### PR TITLE
Implement infinite sessions

### DIFF
--- a/src/CONFIG.js
+++ b/src/CONFIG.js
@@ -1,5 +1,6 @@
-// TODO: Figure out how to determine prod/dev on mobile, etc.
-const IS_IN_PRODUCTION = false;
+import {Platform} from 'react-native';
+
+const IS_IN_PRODUCTION = Platform.OS === 'web' ? process.env.NODE_ENV === 'production' : !__DEV__;
 
 export default {
     PUSHER: {

--- a/src/lib/Network.js
+++ b/src/lib/Network.js
@@ -2,6 +2,7 @@ import * as $ from 'jquery';
 import * as Store from '../store/Store';
 import CONFIG from '../CONFIG';
 import STOREKEYS from '../store/STOREKEYS';
+import _ from 'underscore';
 
 let isAppOffline = false;
 
@@ -30,7 +31,7 @@ function request(command, data, type = 'post') {
                     method: type,
                     body: formData,
                 },
-            )
+            );
         })
         .then(response => response.json())
         .catch(() => isAppOffline = true);

--- a/src/lib/Network.js
+++ b/src/lib/Network.js
@@ -2,7 +2,6 @@ import _ from 'underscore';
 import * as Store from '../store/Store';
 import CONFIG from '../CONFIG';
 import STOREKEYS from '../store/STOREKEYS';
-import _ from 'underscore';
 
 let isAppOffline = false;
 

--- a/src/lib/Str.js
+++ b/src/lib/Str.js
@@ -52,6 +52,11 @@ const Str = {
         return str.replace(/\n/g, '<br />');
     },
 
+    /**
+     * Generates a random device login using Guid
+     *
+     * @returns {string}
+     */
     generateDeviceLoginID() {
         return `React-Native-Chat-${Guid()}`;
     },

--- a/src/lib/Str.js
+++ b/src/lib/Str.js
@@ -1,5 +1,7 @@
 /* globals $, _ */
 
+import Guid from './Guid';
+
 const Str = {
     /**
      * Returns the proper phrase depending on the count that is passed.
@@ -48,6 +50,10 @@ const Str = {
      */
     nl2br(str) {
         return str.replace(/\n/g, '<br />');
+    },
+
+    generateDeviceLoginID() {
+        return `React-Native-Chat-${Guid()}`;
     },
 };
 

--- a/src/page/SignInPage.js
+++ b/src/page/SignInPage.js
@@ -26,13 +26,14 @@ export default class App extends Component {
         this.state = {
             login: '',
             password: '',
-            error: Store.get(STOREKEYS.SESSION, 'error'),
+            error: '',
         };
     }
 
     componentDidMount() {
         // Listen for changes to our session
         Store.subscribe(STOREKEYS.SESSION, this.sessionChanged);
+        Store.get(STOREKEYS.SESSION, 'error').then(error => this.state.error = error);
     }
 
     componentWillUnmount() {
@@ -52,7 +53,7 @@ export default class App extends Component {
      * When the form is submitted, then we trigger our prop callback
      */
     submit() {
-        signIn(this.state.login, this.state.password);
+        signIn(this.state.login, this.state.password, true);
     }
 
     render() {
@@ -79,6 +80,9 @@ export default class App extends Component {
                     </View>
                     <View>
                         <Button onPress={this.submit} title={'Log In'} />
+                    {this.state.error ? <Text style={{color: 'red'}}>
+                        {this.state.error}
+                    </Text> : null}
                     </View>
                 </SafeAreaView>
             </>

--- a/src/page/SignInPage.js
+++ b/src/page/SignInPage.js
@@ -24,9 +24,9 @@ export default class App extends Component {
         this.sessionChanged = this.sessionChanged.bind(this);
 
         this.state = {
-            login: '',
-            password: '',
-            error: '',
+            login: null,
+            password: null,
+            error: null,
         };
     }
 

--- a/src/page/SignInPage.js
+++ b/src/page/SignInPage.js
@@ -24,8 +24,8 @@ export default class App extends Component {
         this.sessionChanged = this.sessionChanged.bind(this);
 
         this.state = {
-            login: null,
-            password: null,
+            login: '',
+            password: '',
             error: null,
         };
     }

--- a/src/page/SignInPage.js
+++ b/src/page/SignInPage.js
@@ -33,7 +33,7 @@ export default class App extends Component {
     componentDidMount() {
         // Listen for changes to our session
         Store.subscribe(STOREKEYS.SESSION, this.sessionChanged);
-        Store.get(STOREKEYS.SESSION, 'error').then(error => this.state.error = error);
+        Store.get(STOREKEYS.SESSION, 'error').then(error => this.setState({error}));
     }
 
     componentWillUnmount() {
@@ -80,9 +80,9 @@ export default class App extends Component {
                     </View>
                     <View>
                         <Button onPress={this.submit} title={'Log In'} />
-                    {this.state.error ? <Text style={{color: 'red'}}>
+                    {this.state.error && <Text style={{color: 'red'}}>
                         {this.state.error}
-                    </Text> : null}
+                    </Text>}
                     </View>
                 </SafeAreaView>
             </>


### PR DESCRIPTION
Implemented infinite sessions:
1. On the sign in page pass `useExpensifyLogin = true` for the first `Authenticate` which will create a new login via `CreateLogin`
2. In `CreateLogin` use `React-Native-Chat-${guid}` for the login name and `${guid}` for the password
3. Store the random login and password 
4. Store the last time we successfully authenticated
5. When calling `verifyAuthToken` check the last time, if it's more than 90 minutes use the random login and password to call authenticate
6. Delete the login we created on sign out