### PR TITLE
Fix mobile styling (a bit)

### DIFF
--- a/src/page/HomePage/HeaderView.js
+++ b/src/page/HomePage/HeaderView.js
@@ -9,7 +9,7 @@ import WithStore from '../../components/WithStore';
 class HeaderView extends React.Component {
     render() {
         return (
-            <View style={[styles.nav, styles.flexRow]}>
+            <View style={[styles.nav, styles.flexRow, styles.flexWrap]}>
                 <Text style={styles.brand}>Expensify Chat</Text>
                 {this.state && this.state.currentReportName && (
                     <Text style={[styles.navText, styles.ml1]}>

--- a/src/style/StyleSheet.js
+++ b/src/style/StyleSheet.js
@@ -24,6 +24,9 @@ const styles = {
     flexColumn: {
         flexDirection: 'column',
     },
+    flexWrap: {
+        flexWrap: 'wrap'
+    },
     flexGrow1: {
         flexGrow: 1,
     },
@@ -42,18 +45,21 @@ const styles = {
         padding: 8,
     },
     sidebarLink: {
-        // TODO: Mobile does not support rem values
-        // padding: '.5rem 1rem',
+        paddingTop: 4,
+        paddingRight: 8,
+        paddingBottom: 4,
+        paddingLeft: 8,
         textDecorationLine: 'none',
     },
     sidebarLinkActive: {
         backgroundColor: '#007bff',
-        // TODO: Mobile does not support rem values
-        // borderRadius: '.25rem',
+        borderRadius: 4,
     },
     sidebarLinkActiveAnchor: {
-        // TODO: Mobile does not support rem values
-        // padding: '.5rem 1rem',
+        paddingTop: 4,
+        paddingRight: 8,
+        paddingBottom: 4,
+        paddingLeft: 8,
         textDecorationLine: 'none',
     },
     sidebarLinkText: {


### PR DESCRIPTION
Basic style fixes for mobile because it doesn't support `rem`.

💻 | ☎️ 
---|---
<img width="1600" alt="Screen Shot 2020-08-09 at 5 24 37 PM" src="https://user-images.githubusercontent.com/2838819/89744804-4dcc2d00-da65-11ea-827d-a0dc24e5d0fb.png"> | <img width="540" alt="Screen Shot 2020-08-09 at 5 24 21 PM" src="https://user-images.githubusercontent.com/2838819/89744807-50c71d80-da65-11ea-85b4-a78173c1fb36.png">
