### PR TITLE
Remove current_report so there is no redundant data being stored

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8836,6 +8836,11 @@
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
+    "lodash.has": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
+      "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI="
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "html-entities": "^1.3.1",
     "jquery": "^3.5.1",
     "lodash.get": "^4.4.2",
+    "lodash.has": "^4.5.2",
     "moment": "^2.27.0",
     "moment-timezone": "^0.5.31",
     "prop-types": "^15.7.2",

--- a/src/components/WithStore.js
+++ b/src/components/WithStore.js
@@ -17,9 +17,6 @@ export default function (mapStoreToStates) {
             this.subscriptionIDs = {};
             this.subscriptionIDsWithPropsData = {};
 
-            this.bind = this.bind.bind(this);
-            this.unbind = this.unbind.bind(this);
-
             // Initialize the state with each of our property names
             this.state = _.reduce(_.keys(mapStoreToStates), (finalResult, propertyName) => ({
                 ...finalResult,
@@ -48,21 +45,6 @@ export default function (mapStoreToStates) {
 
         componentWillUnmount() {
             this.unbind();
-        }
-
-        /**
-         * A method that is convenient to bind the state to the store. Typically used when you can't pass
-         * mapStoreToStates to this HOC. For example: if the key that you want to subscribe to has a piece of
-         * information that can only come from the component's props, then you want to use bind() directly from inside
-         * componentDidMount(). All subscriptions will automatically be unbound when unmounted.
-         *
-         * The options passed to bind are the exact same that you would pass to the HOC.
-         *
-         * @param {object} mapping
-         * @param {object} component
-         */
-        bind(mapping, component) {
-            this.bindStoreToStates(mapping, component);
         }
 
         /**
@@ -149,8 +131,6 @@ export default function (mapStoreToStates) {
                     // eslint-disable-next-line react/jsx-props-no-spreading
                     {...this.state}
                     ref={el => this.wrappedComponent = el}
-                    bind={this.bind}
-                    unbind={this.unbind}
                 />
             );
         }

--- a/src/components/WithStore.js
+++ b/src/components/WithStore.js
@@ -121,7 +121,14 @@ export default function (mapStoreToStates) {
 
             // Load the data from an API request if necessary
             if (loader) {
-                loader(...loaderParams || []);
+                const paramsForLoaderFunction = _.map(loaderParams, (loaderParam) => {
+                    // Some params might com from the props data
+                    if (loaderParam === '%DATAFROMPROPS%') {
+                        return get(this.props, pathForProps);
+                    }
+                    return loaderParam;
+                });
+                loader(...paramsForLoaderFunction || []);
             }
         }
 

--- a/src/page/HomePage/HeaderView.js
+++ b/src/page/HomePage/HeaderView.js
@@ -1,19 +1,64 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import {Button, View, Text} from 'react-native';
+import {withRouter} from '../../lib/Router';
 import {signOut} from '../../store/actions/SessionActions';
 import {fetch as getPersonalDetails} from '../../store/actions/PersonalDetailsActions';
 import styles from '../../style/StyleSheet';
 import STOREKEYS from '../../store/STOREKEYS';
 import WithStore from '../../components/WithStore';
 
+const propTypes = {
+    // These are from WithStore
+    bind: PropTypes.func.isRequired,
+    unbind: PropTypes.func.isRequired,
+
+    // These are from withRouter
+    // eslint-disable-next-line react/forbid-prop-types
+    match: PropTypes.object,
+};
+
+const defaultProps = {
+    match: null,
+};
+
 class HeaderView extends React.Component {
+    componentDidMount() {
+        this.bindToStore();
+    }
+
+    componentDidUpdate(prevProps) {
+        // If the report changed, then we need to re-bind to the store
+        if (prevProps.match.params.reportID !== this.props.match.params.reportID) {
+            this.props.unbind();
+            this.bindToStore();
+        }
+    }
+
+    /**
+     * Bind our state to our store. This can't be done with an HOC because props can't be accessed to make the key
+     */
+    bindToStore() {
+        const key = `${STOREKEYS.REPORT}_${this.props.match.params.reportID}`;
+        this.props.bind({
+            report: {
+                // Bind to only the data for the report (which is why there is a $ at the end)
+                key: `${key}$`,
+
+                // Prefill it with the key of the report exactly
+                // (because prefilling doesn't work with the regex patterns)
+                prefillWithKey: key,
+            }
+        }, this);
+    }
+
     render() {
         return (
             <View style={[styles.nav, styles.flexRow, styles.flexWrap]}>
                 <Text style={styles.brand}>Expensify Chat</Text>
-                {this.state && this.state.currentReportName && (
+                {this.state && this.state.report && (
                     <Text style={[styles.navText, styles.ml1]}>
-                        {this.state.currentReportName}
+                        {this.state.report.reportName}
                     </Text>
                 )}
                 <Text style={styles.flex1} />
@@ -28,7 +73,10 @@ class HeaderView extends React.Component {
     }
 }
 
-export default WithStore({
+HeaderView.propTypes = propTypes;
+HeaderView.defaultProps = defaultProps;
+
+export default withRouter(WithStore({
     // Map this.state.name to the personal details key in the store and bind it to the displayName property
     // and load it with data from getPersonalDetails()
     userDisplayName: {
@@ -37,9 +85,4 @@ export default WithStore({
         loader: getPersonalDetails,
         prefillWithKey: STOREKEYS.MY_PERSONAL_DETAILS,
     },
-    currentReportName: {
-        key: STOREKEYS.CURRENT_REPORT,
-        path: 'reportName',
-        prefillWithKey: STOREKEYS.CURRENT_REPORT,
-    },
-})(HeaderView);
+})(HeaderView));

--- a/src/page/HomePage/Report/ReportHistoryView.js
+++ b/src/page/HomePage/Report/ReportHistoryView.js
@@ -12,10 +12,6 @@ import ReportHistoryItem from './ReportHistoryItem';
 const propTypes = {
     // The ID of the report being looked at
     reportID: PropTypes.string.isRequired,
-
-    // These are from WithStore
-    bind: PropTypes.func.isRequired,
-    unbind: PropTypes.func.isRequired,
 };
 
 class ReportHistoryView extends React.Component {
@@ -23,17 +19,6 @@ class ReportHistoryView extends React.Component {
         super(props);
 
         this.recordlastReadActionID = _.debounce(this.recordlastReadActionID.bind(this), 1000, true);
-    }
-
-    componentDidMount() {
-        this.bindToStore();
-    }
-
-    componentDidUpdate(prevProps) {
-        if (prevProps.reportID !== this.props.reportID) {
-            this.props.unbind();
-            this.bindToStore();
-        }
     }
 
     /**
@@ -46,22 +31,6 @@ class ReportHistoryView extends React.Component {
 
         // Only return comments
         return _.filter(reportHistory, historyItem => historyItem.actionName === 'ADDCOMMENT');
-    }
-
-    /**
-     * Binds this component to the store (needs to be done every time the props change)
-     */
-    bindToStore() {
-        // Bind this.state.reportHistory to the history in the store
-        // and call fetchHistory to load it with data
-        this.props.bind({
-            reportHistory: {
-                key: `${STOREKEYS.REPORT}_${this.props.reportID}_history`,
-                loader: fetchHistory,
-                loaderParams: [this.props.reportID],
-                prefillWithKey: `${STOREKEYS.REPORT}_${this.props.reportID}_history`,
-            }
-        }, this);
     }
 
     /**
@@ -168,4 +137,13 @@ class ReportHistoryView extends React.Component {
 }
 ReportHistoryView.propTypes = propTypes;
 
-export default WithStore()(ReportHistoryView);
+const key = `${STOREKEYS.REPORT}_%DATAFROMPROPS%_history`;
+export default WithStore({
+    reportHistory: {
+        key,
+        loader: fetchHistory,
+        loaderParams: ['%DATAFROMPROPS%'],
+        prefillWithKey: key,
+        pathForProps: 'reportID',
+    },
+})(ReportHistoryView);

--- a/src/page/HomePage/Report/ReportView.js
+++ b/src/page/HomePage/Report/ReportView.js
@@ -2,64 +2,27 @@ import React from 'react';
 import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import {withRouter, Route} from '../../../lib/Router';
-import WithStore from '../../../components/WithStore';
-import STOREKEYS from '../../../store/STOREKEYS';
 import styles from '../../../style/StyleSheet';
 import ReportHistoryView from './ReportHistoryView';
 import ReportHistoryCompose from './ReportHistoryCompose';
 import {addHistoryItem} from '../../../store/actions/ReportActions';
 
 const propTypes = {
-    // These are from WithStore
-    bind: PropTypes.func.isRequired,
-    unbind: PropTypes.func.isRequired,
-
     // These are from withRouter
     // eslint-disable-next-line react/forbid-prop-types
     match: PropTypes.object.isRequired,
 };
 
-class ReportView extends React.Component {
-    componentDidMount() {
-        this.bindToStore();
-    }
+const ReportView = props => (
+    <View style={styles.flex1}>
+        <Route path="/:reportID" exact>
+            <ReportHistoryView reportID={props.match.params.reportID} />
+            <ReportHistoryCompose onSubmit={text => addHistoryItem(props.match.params.reportID, text)} />
+        </Route>
+    </View>
+);
 
-    componentDidUpdate(prevProps) {
-        // If the report changed, then we need to re-bind to the store
-        if (prevProps.match.params.reportID !== this.props.match.params.reportID) {
-            this.props.unbind();
-            this.bindToStore();
-        }
-    }
-
-    /**
-     * Bind our state to our store. This can't be done with an HOC because props can't be accessed to make the key
-     */
-    bindToStore() {
-        const key = `${STOREKEYS.REPORT}_${this.props.match.params.reportID}`;
-        this.props.bind({
-            report: {
-                // Bind to only the data for the report (which is why there is a $ at the end)
-                key: `${key}$`,
-
-                // Prefill it with the key of the report exactly
-                // (because prefilling doesn't work with the regex patterns)
-                prefillWithKey: key,
-            }
-        }, this);
-    }
-
-    render() {
-        return (
-            <View style={styles.flex1}>
-                <Route path="/:reportID" exact>
-                    <ReportHistoryView reportID={this.props.match.params.reportID} />
-                    <ReportHistoryCompose onSubmit={text => addHistoryItem(this.props.match.params.reportID, text)} />
-                </Route>
-            </View>
-        );
-    }
-}
 ReportView.propTypes = propTypes;
+ReportView.displayName = 'ReportView';
 
-export default withRouter(WithStore()(ReportView));
+export default withRouter(ReportView);

--- a/src/page/HomePage/Report/ReportView.js
+++ b/src/page/HomePage/Report/ReportView.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import {View} from 'react-native';
 import PropTypes from 'prop-types';
-import * as Store from '../../../store/Store';
 import {withRouter, Route} from '../../../lib/Router';
 import WithStore from '../../../components/WithStore';
 import STOREKEYS from '../../../store/STOREKEYS';
@@ -51,11 +50,6 @@ class ReportView extends React.Component {
     }
 
     render() {
-        // Update the current report in the store so any other components can update
-        if (this.state && this.state.report) {
-            Store.set(STOREKEYS.CURRENT_REPORT, this.state.report);
-        }
-
         return (
             <View style={styles.flex1}>
                 <Route path="/:reportID" exact>

--- a/src/page/HomePage/SidebarLink.js
+++ b/src/page/HomePage/SidebarLink.js
@@ -13,34 +13,12 @@ const propTypes = {
     // The name of the report to use as the text for this link
     reportName: PropTypes.string.isRequired,
 
-    // These are from WithStore
-    bind: PropTypes.func.isRequired,
-
     // These are from withRouter
     // eslint-disable-next-line react/forbid-prop-types
     match: PropTypes.object.isRequired,
 };
 
 class SidebarLink extends React.Component {
-    constructor(props) {
-        super(props);
-
-        this.state = {
-            isUnread: false,
-        };
-    }
-
-    componentDidMount() {
-        this.props.bind({
-            isUnread: {
-                // Bind to ONLY the report object, not the comments (that's why a $ is added at the end of the key name)
-                key: `${STOREKEYS.REPORT}_${this.props.reportID}$`,
-                path: 'hasUnread',
-                defaultValue: false,
-            },
-        }, this);
-    }
-
     render() {
         const paramsReportID = parseInt(this.props.match.params.reportID, 10);
         const isReportActive = paramsReportID === this.props.reportID;
@@ -52,7 +30,7 @@ class SidebarLink extends React.Component {
                 <Link to={`/${this.props.reportID}`} style={linkActiveStyle}>
                     <View style={[styles.flexRow]}>
                         <Text style={[textActiveStyle, styles.flex1]}>{this.props.reportName}</Text>
-                        {this.state.isUnread && (
+                        {this.state && this.state.isUnread && (
                             <View style={styles.unreadBadge} />
                         )}
                     </View>
@@ -63,4 +41,12 @@ class SidebarLink extends React.Component {
 }
 SidebarLink.propTypes = propTypes;
 
-export default withRouter(WithStore()(SidebarLink));
+export default withRouter(WithStore({
+    isUnread: {
+        // Bind to ONLY the report object, not the comments (that's why a $ is added at the end of the key name)
+        key: `${STOREKEYS.REPORT}_%DATAFROMPROPS%$`,
+        path: 'hasUnread',
+        defaultValue: false,
+        pathForProps: 'reportID',
+    }
+})(SidebarLink));


### PR DESCRIPTION
Here is the improvement we spoke of. This will remove the redundant data in localStorage and bind to the data properly in the header. Ultimately I'm not super excited about the boilerplate required here, so I might take this a step further to make it even easier for other components to do.