### PR TITLE
Remove ActivityIndicator from optimistically added comments

### DIFF
--- a/src/lib/actions/ActionsReport.js
+++ b/src/lib/actions/ActionsReport.js
@@ -4,7 +4,6 @@ import Ion from '../Ion';
 import {request, delayedWrite} from '../Network';
 import IONKEYS from '../../IONKEYS';
 import ExpensiMark from '../ExpensiMark';
-import Guid from '../Guid';
 import CONFIG from '../../CONFIG';
 import * as pusher from '../Pusher/pusher';
 
@@ -199,7 +198,6 @@ function fetchHistory(reportID) {
  */
 function addHistoryItem(reportID, reportComment) {
     const messageParser = new ExpensiMark();
-    const guid = Guid();
     const historyKey = `${IONKEYS.REPORT_HISTORY}_${reportID}`;
 
     return Ion.multiGet([historyKey, IONKEYS.SESSION, IONKEYS.PERSONAL_DETAILS])
@@ -218,7 +216,6 @@ function addHistoryItem(reportID, reportComment) {
             return Ion.set(historyKey, [
                 ...reportHistory,
                 {
-                    tempGuid: guid,
                     actionName: 'ADDCOMMENT',
                     actorEmail: Ion.get(IONKEYS.SESSION, 'email'),
                     person: [

--- a/src/page/HomePage/Report/ReportHistoryCompose.js
+++ b/src/page/HomePage/Report/ReportHistoryCompose.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {View, TextInput, Button} from 'react-native';
+import {View, TextInput} from 'react-native';
 import styles from '../../../style/StyleSheet';
 
 const propTypes = {

--- a/src/page/HomePage/Report/ReportHistoryItem.js
+++ b/src/page/HomePage/Report/ReportHistoryItem.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {ActivityIndicator, View} from 'react-native';
+import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import ReportHistoryItemSingle from './ReportHistoryItemSingle';
 import ReportHistoryPropsTypes from './ReportHistoryPropsTypes';
@@ -17,7 +17,6 @@ const ReportHistoryItem = ({displayAsGroup, historyItem}) => (
     <View>
         {!displayAsGroup && <ReportHistoryItemSingle historyItem={historyItem} />}
         {displayAsGroup && <ReportHistoryItemGrouped historyItem={historyItem} />}
-        {historyItem.tempGuid && <ActivityIndicator type="small" color="#7d8b8f" />}
     </View>
 );
 ReportHistoryItem.propTypes = propTypes;


### PR DESCRIPTION
Fixes https://github.com/AndrewGable/ReactNativeChat/issues/79

### Details
I've also removed the unnecessary tempGuid since we weren't using it anywhere else. I didn't see any other usages of ActivityIndicator in the codebase, and when posting comments there is no longer a spinner.

### Tests
<img src='http://g.recordit.co/DBUPMGMamc.gif' width='300px'/>