### PR TITLE
Add a custom promise.allSettled implementation for iOS

### DIFF
--- a/src/lib/actions/ActionsReport.js
+++ b/src/lib/actions/ActionsReport.js
@@ -5,6 +5,7 @@ import {request, delayedWrite} from '../Network';
 import IONKEYS from '../../IONKEYS';
 import CONFIG from '../../CONFIG';
 import * as pusher from '../Pusher/pusher';
+import promiseAllSettled from '../promiseAllSettled';
 
 /**
  * Sorts the report actions so that the newest actions are at the bottom
@@ -134,10 +135,10 @@ function fetchAll() {
                 return Ion.merge(`${IONKEYS.REPORT}_${report.reportID}`, newReport);
             });
 
-            return Promise.allSettled(ionPromises);
+            return promiseAllSettled(ionPromises);
         }));
 
-    return Promise.allSettled(reportFetchPromises);
+    return promiseAllSettled(reportFetchPromises);
 }
 
 /**

--- a/src/lib/promiseAllSettled/index.ios.js
+++ b/src/lib/promiseAllSettled/index.ios.js
@@ -1,0 +1,23 @@
+/**
+ * This file implements the idea of Promise.allSettled which isn't supported on IOS. Read more about it here:
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled
+ */
+import _ from 'underscore';
+
+/**
+ * Returns a promise that is resolved when all provided promises are either resolved or rejected
+ *
+ * @param {Promise[]} arrayOfPromises
+ * @returns {Promise}
+ */
+const promiseAllSettled = (arrayOfPromises) => {
+    const mainPromise = new Promise((resolve) => {
+        const done = _.after(arrayOfPromises.length, resolve);
+        _.each(arrayOfPromises, (promise) => {
+            promise.then(done).catch(done);
+        });
+    });
+    return mainPromise;
+};
+
+export default promiseAllSettled;

--- a/src/lib/promiseAllSettled/index.js
+++ b/src/lib/promiseAllSettled/index.js
@@ -1,7 +1,7 @@
 import _ from 'underscore';
 
 /**
- * IOS doesn't support Promise.allSettled, but all modern browsers do so a reference directly to the native
+ * Native devices don't support Promise.allSettled, but all modern browsers do so a reference directly to the native
  * Promise implementation is fine.
  */
 const promiseAllSettled = arrayOfPromises => Promise.allSettled(arrayOfPromises);

--- a/src/lib/promiseAllSettled/index.js
+++ b/src/lib/promiseAllSettled/index.js
@@ -1,0 +1,10 @@
+import _ from 'underscore';
+
+/**
+ * IOS doesn't support Promise.allSettled, but all modern browsers do so a reference directly to the native
+ * Promise implementation is fine.
+ */
+const promiseAllSettled = arrayOfPromises => Promise.allSettled(arrayOfPromises);
+
+
+export default promiseAllSettled;

--- a/src/lib/promiseAllSettled/index.js
+++ b/src/lib/promiseAllSettled/index.js
@@ -1,10 +1,14 @@
-import _ from 'underscore';
-
 /**
  * Native devices don't support Promise.allSettled, but all modern browsers do so a reference directly to the native
  * Promise implementation is fine.
  */
-const promiseAllSettled = arrayOfPromises => Promise.allSettled(arrayOfPromises);
 
+/**
+ * Returns a promise that is resolved when all provided promises are either resolved or rejected
+ *
+ * @param {Promise[]} arrayOfPromises
+ * @returns {Promise}
+ */
+const promiseAllSettled = arrayOfPromises => Promise.allSettled(arrayOfPromises);
 
 export default promiseAllSettled;

--- a/src/lib/promiseAllSettled/index.native.js
+++ b/src/lib/promiseAllSettled/index.native.js
@@ -1,5 +1,5 @@
 /**
- * This file implements the idea of Promise.allSettled which isn't supported on IOS. Read more about it here:
+ * This file implements the idea of Promise.allSettled which isn't supported on native devices. Read more about it here:
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled
  */
 import _ from 'underscore';


### PR DESCRIPTION
Fixes https://github.com/AndrewGable/ReactNativeChat/issues/127

For testing, add a report ID into your local config that you don't have access to (some bogus ID will be fine). Then load the app and verify the reports you DO have access to show up just fine.