### PR TITLE
Re-add ReactWebConfig to fix broken production config

### DIFF
--- a/ReactWebConfig.js
+++ b/ReactWebConfig.js
@@ -1,0 +1,19 @@
+Object.defineProperty(exports, '__esModule', {
+    value: true
+});
+exports.ReactWebConfig = undefined;
+
+const webpack = require('webpack');
+
+// eslint-disable-next-line no-underscore-dangle
+function interopRequireDefault(obj) { return obj && obj.__esModule ? obj : {default: obj}; }
+
+const webpack2 = interopRequireDefault(webpack);
+const dotenv = require('dotenv');
+
+exports.ReactWebConfig = function ReactWebConfig(path) {
+    const env = (0, dotenv.config)({path}).parsed;
+    return new webpack2.default.DefinePlugin({
+        __REACT_WEB_CONFIG__: JSON.stringify(env)
+    });
+};

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,10 +1,7 @@
-const webpack = require('webpack');
 const path = require('path');
 const {merge} = require('webpack-merge');
-const dotenv = require('dotenv');
 const common = require('./webpack.common.js');
-
-const env = dotenv.config(path.resolve(__dirname, '.env')).parsed;
+const ReactWebConfig = require('./ReactWebConfig').ReactWebConfig;
 
 module.exports = merge(common, {
     mode: 'development',
@@ -14,8 +11,6 @@ module.exports = merge(common, {
         hot: true,
     },
     plugins: [
-        new webpack.DefinePlugin({
-            __REACT_WEB_CONFIG__: JSON.stringify(env),
-        })
+        ReactWebConfig(path.resolve(__dirname, './.env')),
     ]
 });

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,17 +1,12 @@
-const webpack = require('webpack');
 const path = require('path');
 const {merge} = require('webpack-merge');
-const dotenv = require('dotenv');
 const common = require('./webpack.common.js');
-
-const env = dotenv.config(path.resolve(__dirname, '.env.production')).parsed;
+const ReactWebConfig = require('./ReactWebConfig').ReactWebConfig;
 
 module.exports = merge(common, {
     mode: 'production',
     devtool: 'source-map',
     plugins: [
-        new webpack.DefinePlugin({
-            __REACT_WEB_CONFIG__: JSON.stringify(env),
-        })
+        ReactWebConfig(path.resolve(__dirname, './.env.production')),
     ],
 });


### PR DESCRIPTION
### Details
@AndrewGable noticed that the recently deployed web-app was broken, and after looking into it the web app failed to build for the production config. After testing locally, it looks like reverting some of the changes from https://github.com/AndrewGable/ReactNativeChat/pull/144/files fix the issue.

### Tests
1. Open `webpack.dev.js` and change `.env` to `.env.production`
2. Run `npm run web` and open the JS console
3. Confirm that no reports show up in the LHN and that there are errors in the logs because you couldn't fetch the prod reportIDs
4. Change the `webpack.dev.js` value back to `.env` and re-run `npm run web`
5. Confirm the LHN loads w/ the proper reports