### PR TITLE
Convert comments to HTML before sending to the API

### DIFF
--- a/src/components/webView/index.js
+++ b/src/components/webView/index.js
@@ -5,10 +5,8 @@
 import {Text} from 'react-native';
 import React from 'react';
 import PropTypes from 'prop-types';
-import ExpensiMark from '../../lib/ExpensiMark';
 import styles from '../../style/StyleSheet';
 
-const parser = new ExpensiMark();
 const propTypes = {
     html: PropTypes.string,
 };
@@ -19,7 +17,7 @@ const defaultProps = {
 const WebView = ({html}) => (
     <Text style={[styles.chatItemMessage]}>
         {/* eslint-disable-next-line react/no-danger */}
-        <span dangerouslySetInnerHTML={{__html: parser.replace(html)}} />
+        <span dangerouslySetInnerHTML={{__html: html}} />
     </Text>
 );
 

--- a/src/lib/actions/ActionsReport.js
+++ b/src/lib/actions/ActionsReport.js
@@ -6,6 +6,7 @@ import IONKEYS from '../../IONKEYS';
 import CONFIG from '../../CONFIG';
 import * as pusher from '../Pusher/pusher';
 import promiseAllSettled from '../promiseAllSettled';
+import ExpensiMark from '../ExpensiMark';
 
 /**
  * Updates a report in the store with a new report action
@@ -154,6 +155,10 @@ function fetchHistory(reportID) {
 function addHistoryItem(reportID, reportComment) {
     const historyKey = `${IONKEYS.REPORT_HISTORY}_${reportID}`;
 
+    // Convert the comment from MD into HTML because that's how it is stored in the database
+    const parser = new ExpensiMark();
+    const htmlComment = parser.replace(reportComment);
+
     return Ion.multiGet([historyKey, IONKEYS.SESSION, IONKEYS.PERSONAL_DETAILS])
         .then((values) => {
             const reportHistory = values[historyKey];
@@ -187,8 +192,8 @@ function addHistoryItem(reportID, reportComment) {
                     message: [
                         {
                             type: 'COMMENT',
-                            html: reportComment,
-                            text: reportComment,
+                            html: htmlComment,
+                            text: htmlComment,
                         }
                     ],
                     isFirstItem: false,
@@ -198,7 +203,7 @@ function addHistoryItem(reportID, reportComment) {
         })
         .then(() => delayedWrite('Report_AddComment', {
             reportID,
-            reportComment,
+            reportComment: htmlComment,
         }));
 }
 

--- a/src/lib/actions/ActionsSignInRedirect.js
+++ b/src/lib/actions/ActionsSignInRedirect.js
@@ -11,7 +11,7 @@ import ROUTES from '../../ROUTES';
 function redirectToSignIn() {
     return Ion.get(IONKEYS.CURRENT_URL)
         .then((url) => {
-            const urlWithExitTo = url !== '/'
+            const urlWithExitTo = url && url !== '/'
                 ? `${ROUTES.SIGNIN}/exitTo${url}`
                 : ROUTES.SIGNIN;
             return Ion.set(IONKEYS.APP_REDIRECT_TO, urlWithExitTo);


### PR DESCRIPTION
I won't really know if this works until it's deployed and can look at the comments that came from email replies. 

Fixes https://github.com/AndrewGable/ReactNativeChat/issues/164

### Tests
1. Add a comment with markdown styling
1. Verify that the formatting of the new comment is proper