### PR TITLE
Add missing library to fix Pusher on Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,6 +6,7 @@ buildscript {
         minSdkVersion = 16
         compileSdkVersion = 29
         targetSdkVersion = 29
+        androidXCore = "1.0.2"
     }
     repositories {
         google()


### PR DESCRIPTION
Fixes https://github.com/AndrewGable/ReactNativeChat/issues/169
Fixes https://github.com/AndrewGable/ReactNativeChat/issues/167

When I installed Pusher on Android I didn't follow the install instructions mentioned on a dependency needed: https://github.com/react-native-community/react-native-netinfo#using-react-native--060

This adds the missing library and fixes Pusher.

## Tests
1. Run Android & Web
2. Add a comment on web
3. Verify the LHN bolds the report
4. Verify real time comments work