### PR TITLE
Fix bottom padding on scrollview

### DIFF
--- a/src/page/HomePage/Report/ReportHistoryView.js
+++ b/src/page/HomePage/Report/ReportHistoryView.js
@@ -125,7 +125,9 @@ class ReportHistoryView extends React.Component {
                 }}
                 onContentSizeChange={this.scrollToBottomWhenListSizeChanges}
                 bounces={false}
-                style={[styles.chatContentInner]}
+                contentContainerStyle={{
+                    paddingVertical: 8
+                }}
             >
                 {_.chain(reportHistory).sortBy('sequenceNumber').map((item, index) => (
                     <ReportHistoryItem

--- a/src/style/StyleSheet.js
+++ b/src/style/StyleSheet.js
@@ -361,11 +361,6 @@ const styles = {
         justifyContent: 'flex-end',
     },
 
-    chatContentInner: {
-        paddingTop: 8,
-        paddingBottom: 8,
-    },
-
     chatContentEmpty: {
         paddingTop: 16,
         paddingBottom: 16,


### PR DESCRIPTION
@AndrewGable fixes the missing bottom padding from the ScrollView container on iOS:

![image](https://user-images.githubusercontent.com/2319350/90428903-8b3e4500-e079-11ea-8ad1-44ebf288ec08.png)

Fixes: https://github.com/AndrewGable/ReactNativeChat/issues/152
