### PR TITLE
Scroll up chat history when keyboard opens

### DIFF
--- a/src/lib/actions/ActionsReport.js
+++ b/src/lib/actions/ActionsReport.js
@@ -172,7 +172,7 @@ function addHistoryItem(reportID, reportComment) {
         .then((values) => {
             const reportHistory = values[historyKey];
             const email = values[IONKEYS.SESSION].email || '';
-            const personalDetails = values[IONKEYS.PERSONAL_DETAILS][email];
+            const personalDetails = get(values,[IONKEYS.PERSONAL_DETAILS, email], {});
 
             // The new sequence number will be one higher than the highest
             let highestSequenceNumber = _.chain(reportHistory)

--- a/src/lib/actions/ActionsReport.js
+++ b/src/lib/actions/ActionsReport.js
@@ -172,7 +172,7 @@ function addHistoryItem(reportID, reportComment) {
         .then((values) => {
             const reportHistory = values[historyKey];
             const email = values[IONKEYS.SESSION].email || '';
-            const personalDetails = get(values,[IONKEYS.PERSONAL_DETAILS, email], {});
+            const personalDetails = get(values, [IONKEYS.PERSONAL_DETAILS, email], {});
 
             // The new sequence number will be one higher than the highest
             let highestSequenceNumber = _.chain(reportHistory)

--- a/src/page/HomePage/Report/ReportHistoryView.js
+++ b/src/page/HomePage/Report/ReportHistoryView.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View, ScrollView} from 'react-native';
+import {View, ScrollView, Keyboard} from 'react-native';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
 import lodashGet from 'lodash.get';
@@ -22,7 +22,15 @@ class ReportHistoryView extends React.Component {
         super(props);
 
         this.recordlastReadActionID = _.debounce(this.recordlastReadActionID.bind(this), 1000, true);
-        this.scrollToBottomWhenListSizeChanges = this.scrollToBottomWhenListSizeChanges.bind(this);
+        this.scrollToListBottom = this.scrollToListBottom.bind(this);
+    }
+
+    componentDidMount() {
+        this.keyboardEvent = Keyboard.addListener('keyboardDidShow', this.scrollToListBottom);
+    }
+
+    componentWillUnmount() {
+        this.keyboardEvent.remove();
     }
 
     /**
@@ -97,7 +105,7 @@ class ReportHistoryView extends React.Component {
      * items have been rendered. If the number of items in our history have changed since it was last rendered, then
      * scroll the list to the end.
      */
-    scrollToBottomWhenListSizeChanges() {
+    scrollToListBottom() {
         if (this.historyListElement) {
             this.historyListElement.scrollToEnd({animated: false});
         }

--- a/src/page/HomePage/Report/ReportHistoryView.js
+++ b/src/page/HomePage/Report/ReportHistoryView.js
@@ -131,7 +131,7 @@ class ReportHistoryView extends React.Component {
                 ref={(el) => {
                     this.historyListElement = el;
                 }}
-                onContentSizeChange={this.scrollToBottomWhenListSizeChanges}
+                onContentSizeChange={this.scrollToListBottom}
                 bounces={false}
                 contentContainerStyle={{
                     paddingVertical: 8


### PR DESCRIPTION
**Fixes:** https://github.com/AndrewGable/ReactNativeChat/issues/189

Also fixes a bug where attempting to access personal details that haven't yet been set caused a promise rejection.