### PR TITLE
Fix iOS crash with new URL().hostname

### DIFF
--- a/src/CONFIG.js
+++ b/src/CONFIG.js
@@ -7,7 +7,6 @@ const IS_IN_PRODUCTION = Platform.OS === 'web' ? process.env.NODE_ENV === 'produ
 export default {
     AUTH_TOKEN_EXPIRATION_TIME: 1000 * 60 * 90,
     EXPENSIFY: {
-        HOST_NAME: IS_IN_PRODUCTION ? 'www.expensify.com' : 'www.expensify.com.dev',
         API_ROOT: IS_IN_PRODUCTION ? 'https://www.expensify.com/api?' : 'https://www.expensify.com.dev/api?',
         PARTNER_NAME: IS_IN_PRODUCTION ? 'chat-expensify-com' : 'android',
         PARTNER_PASSWORD: IS_IN_PRODUCTION ? 'e21965746fd75f82bb66' : 'c3a9ac418ea3f152aae2',

--- a/src/page/HomePage/Report/ReportHistoryItemFragment.js
+++ b/src/page/HomePage/Report/ReportHistoryItemFragment.js
@@ -6,7 +6,6 @@ import Str from '../../../lib/Str';
 import ReportHistoryFragmentPropTypes from './ReportHistoryFragmentPropTypes';
 import styles, {webViewStyles} from '../../../style/StyleSheet';
 import Text from '../../../components/Text';
-import CONFIG from '../../../CONFIG';
 
 const propTypes = {
     // The message fragment needing to be displayed

--- a/src/page/HomePage/Report/ReportHistoryItemFragment.js
+++ b/src/page/HomePage/Report/ReportHistoryItemFragment.js
@@ -38,9 +38,7 @@ class ReportHistoryItemFragment extends React.PureComponent {
         const htmlNode = node;
 
         // We only want to attach auth tokens to images that come from Expensify attachments
-        if (htmlNode.name === 'img'
-            && htmlNode.attribs['data-expensify-source']
-            && new URL(htmlNode.attribs['data-expensify-source']).hostname === CONFIG.EXPENSIFY.HOST_NAME) {
+        if (htmlNode.name === 'img' && htmlNode.attribs['data-expensify-source']) {
             htmlNode.attribs.src = `${node.attribs.src}?authToken=${this.props.authToken}`;
             return htmlNode;
         }


### PR DESCRIPTION
Removes a check for the hostname as this was causing a crash on iOS. I think this is fine for the POC, but probably will want to use the "real" way of loading attachments once we are out of POC mode.