### PR TITLE
Fire off network requests as soon as they're queued

### DIFF
--- a/src/lib/Network.js
+++ b/src/lib/Network.js
@@ -61,6 +61,10 @@ function queueRequest(command, data) {
             data,
             callback: resolve,
         });
+
+        // Try to fire off the request as soon as it's queued so we don't add a delay to every queued command
+        // eslint-disable-next-line no-use-before-define
+        processNetworkRequestQueue();
     });
 }
 
@@ -220,9 +224,9 @@ function request(command, data, type = 'post') {
 }
 
 /**
- * Process the write queue by looping through the queue and attempting to make the requests
+ * Process the networkRequestQueue by looping through the queue and attempting to make the requests
  */
-function processWriteQueue() {
+function processNetworkRequestQueue() {
     if (isAppOffline) {
         // Two things will bring the app online again...
         // 1. Pusher reconnecting (see registerSocketEventCallback at the top of this file)
@@ -248,7 +252,7 @@ function processWriteQueue() {
 }
 
 // Process our write queue very often
-setInterval(processWriteQueue, 1000);
+setInterval(processNetworkRequestQueue, 1000);
 
 export {
     request,

--- a/src/lib/Network.js
+++ b/src/lib/Network.js
@@ -142,7 +142,11 @@ function createLogin(login, password) {
 }
 
 /**
- * Make an XHR to the server
+ * Makes an API request.
+ *
+ * For most API commands if we get a 407 jsonCode in the response, which means the authToken
+ * expired, this function automatically makes an API call to Authenticate and get a fresh authToken, and retries the
+ * original API command
  *
  * @param {string} command
  * @param {mixed} data

--- a/src/lib/Network.js
+++ b/src/lib/Network.js
@@ -47,7 +47,7 @@ registerSocketEventCallback((eventName, data) => {
 });
 
 /**
- * Make an XHR to the server
+ * Adds a request to networkRequestQueue
  *
  * @param {string} command
  * @param {mixed} data

--- a/src/lib/actions/ActionsPersonalDetails.js
+++ b/src/lib/actions/ActionsPersonalDetails.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 import Ion from '../Ion';
-import {delayedWrite} from '../Network';
+import {queueRequest} from '../Network';
 import IONKEYS from '../../IONKEYS';
 import md5 from '../md5';
 import CONST from '../../CONST';
@@ -38,7 +38,7 @@ function fetch() {
             }
 
             currentLogin = login;
-            return delayedWrite('Get', {
+            return queueRequest('Get', {
                 returnValueList: 'personalDetailsList',
             });
         })
@@ -92,7 +92,7 @@ function fetch() {
  * @returns {Promise}
  */
 function fetchTimezone() {
-    const requestPromise = delayedWrite('Get', {
+    const requestPromise = queueRequest('Get', {
         returnValueList: 'nameValuePairs',
         name: 'timeZone',
     })

--- a/src/lib/actions/ActionsReport.js
+++ b/src/lib/actions/ActionsReport.js
@@ -2,7 +2,7 @@ import moment from 'moment';
 import _ from 'underscore';
 import get from 'lodash.get';
 import Ion from '../Ion';
-import {delayedWrite} from '../Network';
+import {queueRequest} from '../Network';
 import IONKEYS from '../../IONKEYS';
 import CONFIG from '../../CONFIG';
 import * as pusher from '../Pusher/pusher';
@@ -101,7 +101,7 @@ function fetchAll() {
     let fetchedReports;
 
     // Request each report one at a time to allow individual reports to fail if access to it is prevents by Auth
-    const reportFetchPromises = _.map(CONFIG.REPORT_IDS.split(','), reportID => delayedWrite('Get', {
+    const reportFetchPromises = _.map(CONFIG.REPORT_IDS.split(','), reportID => queueRequest('Get', {
         returnValueList: 'reportStuff',
         reportIDList: reportID,
         shouldLoadOptionalKeys: true,
@@ -144,7 +144,7 @@ function fetchAll() {
  * @returns {Promise}
  */
 function fetchHistory(reportID) {
-    return delayedWrite('Report_GetHistory', {
+    return queueRequest('Report_GetHistory', {
         reportID,
         offset: 0,
     })
@@ -212,7 +212,7 @@ function addHistoryItem(reportID, reportComment) {
                 }
             });
         })
-        .then(() => delayedWrite('Report_AddComment', {
+        .then(() => queueRequest('Report_AddComment', {
             reportID,
             reportComment: htmlComment,
         }));
@@ -237,7 +237,7 @@ function updateLastReadActionID(accountID, reportID, sequenceNumber) {
     })
 
         // Update the lastReadActionID on the report optimistically
-        .then(() => delayedWrite('Report_SetLastReadActionID', {
+        .then(() => queueRequest('Report_SetLastReadActionID', {
             accountID,
             reportID,
             sequenceNumber,


### PR DESCRIPTION
- The only change is the `processNetworkRequestQueue()` call in the now called `queueRequest`
- I tested before the change posting comments and confirming we only fired off the requests after the delay in the setInterval
- And tested after, by confirming that the request fires off right after it's queued