### PR TITLE
Show open hamburger on initial load

### DIFF
--- a/src/page/HomePage/HomePage.js
+++ b/src/page/HomePage/HomePage.js
@@ -25,7 +25,7 @@ export default class App extends React.Component {
         super(props);
 
         this.state = {
-            hamburgerShown: windowSize.width > widthBreakPoint,
+            hamburgerShown: true,
             isHamburgerEnabled: windowSize.width <= widthBreakPoint,
             animationTranslateX: new Animated.Value(0),
         };


### PR DESCRIPTION
Always shows the hamburger menu on open, and still loads the first report.

Fixes https://github.com/AndrewGable/ReactNativeChat/issues/231