### PR TITLE
Don't retry request to check online status and update online status in Ion when request succeeds

### DIFF
--- a/src/lib/Network.js
+++ b/src/lib/Network.js
@@ -233,7 +233,8 @@ function processNetworkRequestQueue() {
         // 2. Getting a 200 response back from the API (happens right below)
 
         // Make a simple request every second to see if the API is online again
-        request('Get', null)
+        request('Get', {doNotRetry: true})
+            .then(() => Ion.merge(IONKEYS.NETWORK, {isOffline: false}))
             .then(() => isAppOffline = false);
         return;
     }


### PR DESCRIPTION
- Fixes the offline problem, which is, when you turn off wifi, requests start failing, but then a TON of them fire off and fail, like hundreds
- I noticed that the request that get multiplied were simply `command=Get` with no params which is the one we use to check if we're online (via xhr, not pusher)
- Adding `doNotRetry: true` should fix that
- I also noticed that we added `Ion.merge(IONKEYS.NETWORK, {isOffline: true});` in the catch block of `xhr` but didn't add the one in this PR

**Note: I couldn't repro on dev, hence the HOLD**