### PR TITLE
Always keep an updated authtoken in the session

### DIFF
--- a/src/lib/Network.js
+++ b/src/lib/Network.js
@@ -246,6 +246,14 @@ function request(command, data, type = 'post') {
                         }));
             }
             return responseData;
+        })
+
+        // Always keep an updated authToken in the session
+        .then((responseData) => {
+            if (responseData.authToken) {
+                Ion.merge(IONKEYS.SESSION, {authToken: responseData.authToken});
+            }
+            return responseData;
         });
 }
 


### PR DESCRIPTION
This will ensure that the authToken in the session is updated on every request. Since the `getPersonalDetails` request is fired off every 30 minutes, it should do a pretty good job of keeping a updated authToken.