### PR TITLE
Reauthenticate Pusher on Reconnect

### DIFF
--- a/src/lib/Network.js
+++ b/src/lib/Network.js
@@ -1,4 +1,5 @@
 import _ from 'underscore';
+import lodashGet from 'lodash.get';
 import NetInfo from '@react-native-community/netinfo';
 import Ion from './Ion';
 import CONFIG from '../CONFIG';
@@ -100,7 +101,7 @@ function queueRequest(command, data) {
  * @returns {Promise}
  */
 function setSuccessfulSignInData(data, exitTo) {
-    Pusher.updateAuthTokenAndReconnect(_.pick(data, 'authToken'));
+    Pusher.updateAuthTokenAndReconnect(lodashGet(data, 'authToken'));
     return Ion.multiSet({
         // The response from Authenticate includes requestID, jsonCode, etc
         // but we only care about setting these three values in Ion

--- a/src/lib/Network.js
+++ b/src/lib/Network.js
@@ -32,14 +32,17 @@ Pusher.registerCustomAuthorizer((channel, {authEndpoint}) => ({
                     body: formData,
                 });
             })
-            .then((authResponse) => authResponse.json())
-            .then((data) => callback(null, data))
+            .then(authResponse => authResponse.json())
+            .then(data => callback(null, data))
             .catch((err) => {
                 console.debug('[Network] Failed to authorize Pusher');
                 callback(new Error(`Error calling auth endpoint: ${err}`));
             });
     },
 }));
+
+// Initialize the pusher connection
+Pusher.init();
 
 // Indicates if we're in the process of re-authenticating. When an API call returns jsonCode 407 indicating that the
 // authToken expired, we set this to true, pause all API calls, re-authenticate, and then use the authToken fromm the
@@ -134,7 +137,7 @@ function queueRequest(command, data) {
 function setSuccessfulSignInData(data, exitTo) {
     let redirectTo;
 
-    if (exitTo && exit[0] === '/') {
+    if (exitTo && exitTo[0] === '/') {
         redirectTo = exitTo.substring(1);
     } else if (exitTo) {
         redirectTo = exitTo;
@@ -282,18 +285,16 @@ function request(command, data, type = 'post') {
                         partnerUserSecret: password,
                         twoFactorAuthCode: ''
                     }))
-                    .then(response =>
-                        Ion.get(IONKEYS.CURRENT_URL)
-                            .then((exitTo) => {
-                                reauthenticating = false;
+                    .then(response => Ion.get(IONKEYS.CURRENT_URL)
+                        .then((exitTo) => {
+                            reauthenticating = false;
 
-                                if (response.jsonCode !== 200) {
-                                    throw new Error(response.message);
-                                }
+                            if (response.jsonCode !== 200) {
+                                throw new Error(response.message);
+                            }
 
-                                return setSuccessfulSignInData(response, exitTo);
-                            })
-                    )
+                            return setSuccessfulSignInData(response, exitTo);
+                        }))
                     .then(() => xhr(command, data, type))
                     .catch(() => {
                         reauthenticating = false;

--- a/src/lib/Network.js
+++ b/src/lib/Network.js
@@ -201,13 +201,19 @@ function request(command, data, type = 'post') {
                 // trying to authenticate with the login credentials we created after the initial authentication, and
                 // failing, so we need the user to sign in again with their expensify credentials again, which they can
                 // do from the sign in page
-                if (!command.useExpensifyLogin && response.jsonCode !== 200) {
+                if (!data.useExpensifyLogin && response.jsonCode !== 200) {
                     return Ion.multiSet({
                         [IONKEYS.CREDENTIALS]: {},
                         [IONKEYS.SESSION]: {error: response.message},
                     })
                         .then(redirectToSignIn);
                 }
+
+                // Did not authenticate throw something
+                if (response.jsonCode !== 200) {
+                    throw new Error(response.message);
+                }
+
                 return setSuccessfulSignInData(response, data.exitTo);
             })
             .then((response) => {
@@ -238,6 +244,11 @@ function request(command, data, type = 'post') {
                     })
                         .then(response => Ion.get(IONKEYS.CURRENT_URL).then((exitTo) => {
                             reauthenticating = false;
+
+                            if (response.jsonCode !== 200) {
+                                throw new Error(response.message);
+                            }
+
                             return setSuccessfulSignInData(response, exitTo.substring(1));
                         }))
                         .then(() => xhr(command, data, type))

--- a/src/lib/Network.js
+++ b/src/lib/Network.js
@@ -2,7 +2,7 @@ import _ from 'underscore';
 import NetInfo from '@react-native-community/netinfo';
 import Ion from './Ion';
 import CONFIG from '../CONFIG';
-import * as Pusher from '../Pusher/pusher';
+import * as Pusher from './Pusher/pusher';
 import IONKEYS from '../IONKEYS';
 import ROUTES from '../ROUTES';
 import Str from './Str';

--- a/src/lib/Network.js
+++ b/src/lib/Network.js
@@ -279,7 +279,7 @@ function request(command, data, type = 'post') {
                         partnerUserSecret: password,
                         twoFactorAuthCode: ''
                     }))
-                    .then(response => {
+                    .then((response) => {
                         authenticateResponse = response;
                         return Ion.get(IONKEYS.CURRENT_URL);
                     })

--- a/src/lib/Network.js
+++ b/src/lib/Network.js
@@ -311,10 +311,6 @@ function request(command, data, type = 'post') {
  * Process the networkRequestQueue by looping through the queue and attempting to make the requests
  */
 function processNetworkRequestQueue() {
-    if (networkRequestQueue.length === 0) {
-        return;
-    }
-
     Ion.get(IONKEYS.NETWORK, 'isOffline')
         .then((isOffline) => {
             if (isOffline) {
@@ -330,7 +326,7 @@ function processNetworkRequestQueue() {
 
             // Don't make any requests until we're done re-authenticating since we'll use the new authToken
             // from that response for the subsequent network requests
-            if (reauthenticating) {
+            if (reauthenticating || networkRequestQueue.length === 0) {
                 return;
             }
 

--- a/src/lib/Pusher/pusher.js
+++ b/src/lib/Pusher/pusher.js
@@ -164,7 +164,7 @@ function subscribe(channelName, eventName, eventCallback = () => {}, isChunked =
     return new Promise((resolve, reject) => {
     // We cannot call subscribe() before init(). Prevent any attempt to do this on dev.
         if (!socket) {
-            throw new Error(`[Pusher] instance not found. Pusher.subscribe() 
+            throw new Error(`[Pusher] instance not found. Pusher.subscribe()
             most likely has been called before Pusher.init()`);
         }
 
@@ -226,7 +226,7 @@ function unsubscribe(channelName, eventName = '') {
     const channel = getChannel(channelName);
 
     if (!channel) {
-        console.debug(`[Pusher] Attempted to unsubscribe or unbind from a channel, 
+        console.debug(`[Pusher] Attempted to unsubscribe or unbind from a channel,
         but Pusher-JS has no knowledge of it`, 0, {channelName, eventName});
         return;
     }
@@ -237,7 +237,7 @@ function unsubscribe(channelName, eventName = '') {
     } else {
         if (!channel.subscribed) {
             // eslint-disable-next-line no-console
-            console.warn(`[Pusher] Attempted to unsubscribe from channel, 
+            console.warn(`[Pusher] Attempted to unsubscribe from channel,
             but we are not subscribed to begin with`, 0, {channelName});
             return;
         }
@@ -320,6 +320,18 @@ function registerSocketEventCallback(cb) {
     socketEventCallbacks.push(cb);
 }
 
+/**
+ * @param {String} authToken
+ */
+function updateAuthTokenAndReconnect(authToken) {
+    if (!socket) {
+        return;
+    }
+
+    socket.config.auth.params.authToken = authToken;
+    socket.connect();
+}
+
 export {
     init,
     subscribe,
@@ -331,4 +343,5 @@ export {
     sendEvent,
     sendChunkedEvent,
     registerSocketEventCallback,
+    updateAuthTokenAndReconnect,
 };

--- a/src/lib/Pusher/pusher.js
+++ b/src/lib/Pusher/pusher.js
@@ -340,6 +340,13 @@ function registerCustomAuthorizer(authorizer) {
     customAuthorizer = authorizer;
 }
 
+/**
+ * Pusher socket for debugging purposes
+ *
+ * @returns {Function}
+ */
+window.getPusherInstance = () => socket;
+
 export {
     init,
     subscribe,

--- a/src/lib/Pusher/pusher.js
+++ b/src/lib/Pusher/pusher.js
@@ -340,12 +340,14 @@ function registerCustomAuthorizer(authorizer) {
     customAuthorizer = authorizer;
 }
 
-/**
- * Pusher socket for debugging purposes
- *
- * @returns {Function}
- */
-window.getPusherInstance = () => socket;
+if (window) {
+    /**
+     * Pusher socket for debugging purposes
+     *
+     * @returns {Function}
+     */
+    window.getPusherInstance = () => socket;
+}
 
 export {
     init,

--- a/src/lib/Str.js
+++ b/src/lib/Str.js
@@ -59,7 +59,7 @@ const Str = {
      * @returns {string}
      */
     generateDeviceLoginID() {
-        return `React-Native-Chat-${Guid()}`;
+        return `react-native-chat-${Guid()}`;
     },
 };
 

--- a/src/lib/actions/Report.js
+++ b/src/lib/actions/Report.js
@@ -5,7 +5,7 @@ import Ion from '../Ion';
 import {queueRequest, onReconnect} from '../Network';
 import IONKEYS from '../../IONKEYS';
 import CONFIG from '../../CONFIG';
-import * as pusher from '../Pusher/pusher';
+import * as Pusher from '../Pusher/pusher';
 import promiseAllSettled from '../promiseAllSettled';
 import ExpensiMark from '../ExpensiMark';
 
@@ -86,7 +86,7 @@ function initPusher() {
     return Ion.get(IONKEYS.SESSION, 'accountID')
         .then((accountID) => {
             const pusherChannelName = `private-user-accountID-${accountID}`;
-            pusher.subscribe(pusherChannelName, 'reportComment', (pushJSON) => {
+            Pusher.subscribe(pusherChannelName, 'reportComment', (pushJSON) => {
                 updateReportWithNewAction(pushJSON.reportID, pushJSON.reportAction);
             });
         });

--- a/src/lib/actions/Report.js
+++ b/src/lib/actions/Report.js
@@ -78,11 +78,11 @@ function hasUnreadHistoryItems(accountID, report) {
 }
 
 /**
- * Initialize our pusher subscriptions to listen for new report comments
+ * Listen for new report comments via Pusher
  *
  * @returns {Promise}
  */
-function initPusher() {
+function subscribeToReportCommentEvents() {
     return Ion.get(IONKEYS.SESSION, 'accountID')
         .then((accountID) => {
             const pusherChannelName = `private-user-accountID-${accountID}`;
@@ -255,5 +255,5 @@ export {
     fetchHistory,
     addHistoryItem,
     updateLastReadActionID,
-    initPusher,
+    subscribeToReportCommentEvents,
 };

--- a/src/lib/actions/Session.js
+++ b/src/lib/actions/Session.js
@@ -83,7 +83,8 @@ function verifyAuthToken() {
             // have credentials to re-authenticate
             return request('Get', {returnValueList: 'account', doNotRetry: !haveCredentials}).then((data) => {
                 if (data && data.jsonCode === 200) {
-                    return Ion.merge(IONKEYS.SESSION, data);
+                    return Ion.merge(IONKEYS.SESSION, data)
+                        .then(() => Ion.set(IONKEYS.LAST_AUTHENTICATED, new Date().getTime()));
                 }
 
                 // If the auth token is bad and we didn't have credentials saved, we want them to go to the sign in page

--- a/src/lib/actions/Session.js
+++ b/src/lib/actions/Session.js
@@ -77,7 +77,7 @@ function verifyAuthToken() {
 
             if (haveExpiredAuthToken && haveCredentials) {
                 console.debug('Invalid auth token: Token has expired.');
-                return signIn(credentials.login, credentials.password, '', current_url.substring(1), false);
+                return signIn(credentials.login, credentials.password, '', current_url, false);
             }
 
             // We make this request to see if we have a valid authToken, and we only want to retry it if we know we

--- a/src/lib/actions/Session.js
+++ b/src/lib/actions/Session.js
@@ -73,9 +73,7 @@ function verifyAuthToken() {
     return Ion.multiGet([IONKEYS.LAST_AUTHENTICATED, IONKEYS.CREDENTIALS, IONKEYS.CURRENT_URL])
         .then(({last_authenticated, credentials, current_url}) => {
             const haveCredentials = !_.isNull(credentials);
-            // const haveExpiredAuthToken = last_authenticated < new Date().getTime() - CONFIG.AUTH_TOKEN_EXPIRATION_TIME;
-            const haveExpiredAuthToken = last_authenticated < new Date().getTime() - 5000;
-
+            const haveExpiredAuthToken = last_authenticated < new Date().getTime() - CONFIG.AUTH_TOKEN_EXPIRATION_TIME;
 
             if (haveExpiredAuthToken && haveCredentials) {
                 console.debug('Invalid auth token: Token has expired.');

--- a/src/lib/actions/Session.js
+++ b/src/lib/actions/Session.js
@@ -17,7 +17,7 @@ import redirectToSignIn from './SignInRedirect';
  * @returns {Promise}
  */
 function signIn(login, password, twoFactorAuthCode = '', exitTo, useExpensifyLogin = true) {
-    console.debug('[SIGNIN] Authenticating with expensify login');
+    console.debug('[SIGNIN] Authenticating with login type:', useExpensifyLogin ? 'expensify' : 'device');
     return request('Authenticate', {
         // When authenticating for the first time, we pass useExpensifyLogin as true so we check for credentials for
         // the expensify partnerID to let users authenticate with their expensify user and password.

--- a/src/page/HomePage/HomePage.js
+++ b/src/page/HomePage/HomePage.js
@@ -12,10 +12,8 @@ import styles, {getSafeAreaPadding} from '../../style/StyleSheet';
 import Header from './HeaderView';
 import Sidebar from './SidebarView';
 import Main from './MainView';
-import Ion from '../../lib/Ion';
-import IONKEYS from '../../IONKEYS';
 import {initPusher} from '../../lib/actions/Report';
-import * as pusher from '../../lib/Pusher/pusher';
+import * as Pusher from '../../lib/Pusher/pusher';
 
 const windowSize = Dimensions.get('window');
 const widthBreakPoint = 1000;
@@ -35,17 +33,12 @@ export default class App extends React.Component {
     }
 
     componentDidMount() {
-        Ion.get(IONKEYS.SESSION, 'authToken').then((authToken) => {
-            if (authToken) {
-                // Initialize the pusher connection
-                pusher.init(null, {
-                    authToken,
-                });
+        // Initialize the pusher connection
+        Pusher.init();
 
-                // Setup the report action handler to subscribe to pusher
-                initPusher();
-            }
-        });
+        // Setup the report action handler to subscribe to pusher
+        initPusher();
+
         Dimensions.addEventListener('change', this.toggleHamburgerBasedOnDimensions);
 
         StatusBar.setBarStyle('dark-content', true);

--- a/src/page/HomePage/HomePage.js
+++ b/src/page/HomePage/HomePage.js
@@ -12,7 +12,7 @@ import styles, {getSafeAreaPadding} from '../../style/StyleSheet';
 import Header from './HeaderView';
 import Sidebar from './SidebarView';
 import Main from './MainView';
-import {initPusher} from '../../lib/actions/Report';
+import {subscribeToReportCommentEvents} from '../../lib/actions/Report';
 
 const windowSize = Dimensions.get('window');
 const widthBreakPoint = 1000;
@@ -32,8 +32,8 @@ export default class App extends React.Component {
     }
 
     componentDidMount() {
-        // Setup the report action handler to subscribe to pusher
-        initPusher();
+        // Listen for report comment events
+        subscribeToReportCommentEvents();
 
         Dimensions.addEventListener('change', this.toggleHamburgerBasedOnDimensions);
 

--- a/src/page/HomePage/HomePage.js
+++ b/src/page/HomePage/HomePage.js
@@ -13,7 +13,6 @@ import Header from './HeaderView';
 import Sidebar from './SidebarView';
 import Main from './MainView';
 import {initPusher} from '../../lib/actions/Report';
-import * as Pusher from '../../lib/Pusher/pusher';
 
 const windowSize = Dimensions.get('window');
 const widthBreakPoint = 1000;
@@ -33,9 +32,6 @@ export default class App extends React.Component {
     }
 
     componentDidMount() {
-        // Initialize the pusher connection
-        Pusher.init();
-
         // Setup the report action handler to subscribe to pusher
         initPusher();
 


### PR DESCRIPTION
**Fixed issues:** 

- Report view navigating to `/` after reauthenticating with expired `authToken`
- Pusher using old authToken when reconnecting and updating `authToken`
- Network request queue was not emptying all the way
- Network requests queued when authToken expired were never actually getting queued resulting in missing data
- Re-authentication bug prevented us from consistently re-authenticating with stored credentials

**Tests:**

The majority of these tests were performed with an `authToken` that expires every 5 seconds to create a ton of instability. I wanted to make sure that if our `authToken` expires while we step away that everything doesn't go to hell. So to create this situation you'll to make some auth changes on dev by using this diff and rebuilding server-e

```diff
diff --git a/auth/lib/AuthToken.cpp b/auth/lib/AuthToken.cpp
index 0e08652f2..a82240603 100644
--- a/auth/lib/AuthToken.cpp
+++ b/auth/lib/AuthToken.cpp
@@ -776,7 +776,7 @@ string AuthToken::create(int64_t accountID, int64_t partnerID, const bool isVali
     authToken["accountID"] = to_string(accountID);
     authToken["partnerID"] = to_string(partnerID);
     authToken["issued"] = to_string(STimeNow());
-    authToken["expires"] = to_string(STimeNow() + expires);
+    authToken["expires"] = to_string(STimeNow() + 5000000);
     authToken["type"] = typeStrings[type];

     if (requestingAccountID != 0) {
```

clear `localStorage`

**Testing that an authToken can expire while we are in the middle of leaving a comment and we send it like nothing happened**
1. Login with your 5 second `authToken`
1. Wait 5 seconds and leave a comment on a report
1. Dig through the network requests and notice that the initial API requests that failed eventually completed
1. Refresh and verify that the history is now permanent

**Testing that if we refresh the page we can reconnect to Pusher**

This was a weird one because Pusher would intermittently stop working so try to refresh the page many times and with and without reportID in the url

1. Wait 5 seconds
1. Refresh the page
1. Notice that in the debug logs say your `authToken` has expired
1. Use `getPusherInstance()` to inspect the private user channel and see that you are still subscribed

**Testing that when WiFi drops with an expired `authToken` we are still connected to pusher on re-connect**

1. Wait 5 seconds
1. Turn off wifi
1. Wait for Pusher to start throwing errors - 10-15 seconds
1. Turn wifi back on
1. Notice that in the debug logs say your `authToken` has expired
1. Use `getPusherInstance()` to inspect the private user channel and see that you are still subscribed