### PR TITLE
Remove padding and border from bottom compose area

### DIFF
--- a/src/page/HomePage/Report/ReportHistoryView.js
+++ b/src/page/HomePage/Report/ReportHistoryView.js
@@ -143,7 +143,7 @@ class ReportHistoryView extends React.Component {
                 onContentSizeChange={this.scrollToListBottom}
                 bounces={false}
                 contentContainerStyle={{
-                    paddingVertical: 8
+                    paddingVertical: 16
                 }}
             >
                 {_.chain(this.props.reportHistory).sortBy('sequenceNumber').map((item, index) => (

--- a/src/style/StyleSheet.js
+++ b/src/style/StyleSheet.js
@@ -213,8 +213,6 @@ const styles = {
 
     sidebarFooter: {
         alignItems: 'center',
-        borderTopWidth: 1,
-        borderTopColor: colors.text,
         display: 'flex',
         flexDirection: 'row',
         height: 85,
@@ -467,10 +465,7 @@ const styles = {
     },
 
     chatItemCompose: {
-        borderTopWidth: 1,
-        borderTopColor: colors.border,
-        minHeight: 85,
-        paddingTop: 20,
+        minHeight: 65,
         paddingBottom: 20,
         paddingLeft: 20,
         paddingRight: 20,


### PR DESCRIPTION
@tgolen This removes the padding and border from the bottom compose area and the bottom left user name area. 

![image](https://user-images.githubusercontent.com/2319350/91236256-b1588a80-e6f4-11ea-9cf1-56d64f9fdb89.png)

![image](https://user-images.githubusercontent.com/2319350/91236418-0eecd700-e6f5-11ea-8595-1b717c9979e8.png)


cc @quinthar 