### PR TITLE
Use medium weight for bold fonts

### DIFF
--- a/src/style/StyleSheet.js
+++ b/src/style/StyleSheet.js
@@ -539,6 +539,10 @@ const webViewStyles = {
             textDecorationStyle: 'solid'
         },
 
+        strong: {
+            fontWeight: '600',
+        },
+
         a: {
             color: colors.blue
         }


### PR DESCRIPTION
@marcaaron will you review please? This uses the proper `600` weight for "bold" text:

![image](https://user-images.githubusercontent.com/2319350/91358729-8af82500-e7b0-11ea-9bab-53b587cef945.png)
