### PR TITLE
Restoring the grouped comments, and fixing the style for it

### DIFF
--- a/src/page/HomePage/Report/ReportHistoryItem.js
+++ b/src/page/HomePage/Report/ReportHistoryItem.js
@@ -34,7 +34,7 @@ class ReportHistoryItem extends React.Component {
         return (
             <View>
                 {!displayAsGroup && (<ReportHistoryItemSingle historyItem={historyItem} authToken={authToken} />)}
-                {displayAsGroup && <ReportHistoryItemGrouped historyItem={historyItem} authToken={authToken} />}
+                {displayAsGroup && (<ReportHistoryItemGrouped historyItem={historyItem} authToken={authToken} />)}
             </View>
         );
     }

--- a/src/page/HomePage/Report/ReportHistoryItem.js
+++ b/src/page/HomePage/Report/ReportHistoryItem.js
@@ -33,8 +33,8 @@ class ReportHistoryItem extends React.Component {
 
         return (
             <View>
-                {!displayAsGroup && (<ReportHistoryItemSingle historyItem={historyItem} authToken={authToken} />)}
-                {displayAsGroup && (<ReportHistoryItemGrouped historyItem={historyItem} authToken={authToken} />)}
+                {!displayAsGroup && <ReportHistoryItemSingle historyItem={historyItem} authToken={authToken} />}
+                {displayAsGroup && <ReportHistoryItemGrouped historyItem={historyItem} authToken={authToken} />}
             </View>
         );
     }

--- a/src/page/HomePage/Report/ReportHistoryItemGrouped.js
+++ b/src/page/HomePage/Report/ReportHistoryItemGrouped.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Text} from 'react-native';
+import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import ReportHistoryPropsTypes from './ReportHistoryPropsTypes';
 import ReportHistoryItemMessage from './ReportHistoryItemMessage';
@@ -8,15 +8,22 @@ import styles from '../../../style/StyleSheet';
 const propTypes = {
     // All the data of the history item
     historyItem: PropTypes.shape(ReportHistoryPropsTypes).isRequired,
+
+    // Current users auth token
+    authToken: PropTypes.string.isRequired,
 };
 
 class ReportHistoryItemGrouped extends React.PureComponent {
     render() {
-        const {historyItem} = this.props;
+        const {historyItem, authToken} = this.props;
         return (
-            <Text style={[styles.historyItemMessageWrapper]}>
-                <ReportHistoryItemMessage historyItem={historyItem} />
-            </Text>
+            <View style={[styles.chatItem]}>
+                <View style={[styles.chatItemRightGrouped]}>
+                    <View style={[styles.chatItemMessage]}>
+                        <ReportHistoryItemMessage historyItem={historyItem} authToken={authToken} />
+                    </View>
+                </View>
+            </View>
         );
     }
 }

--- a/src/page/HomePage/Report/ReportHistoryView.js
+++ b/src/page/HomePage/Report/ReportHistoryView.js
@@ -60,7 +60,6 @@ class ReportHistoryView extends React.Component {
      */
     // eslint-disable-next-line
     isConsecutiveHistoryItemMadeByPreviousActor(historyItemIndex) {
-        // this.getFilteredReportHistory();
         const reportHistory = lodashGet(this.props, 'reportHistory', {});
 
         // This is the created action and the very first action so it cannot be a consecutive comment.

--- a/src/page/HomePage/Report/ReportHistoryView.js
+++ b/src/page/HomePage/Report/ReportHistoryView.js
@@ -60,24 +60,22 @@ class ReportHistoryView extends React.Component {
      */
     // eslint-disable-next-line
     isConsecutiveHistoryItemMadeByPreviousActor(historyItemIndex) {
-        // Disable this for now
-        return false;
+        // this.getFilteredReportHistory();
+        const reportHistory = lodashGet(this.props, 'reportHistory', {});
 
-        // const filteredHistory = this.getFilteredReportHistory();
-        //
-        // // This is the created action and the very first action so it cannot be a consecutive comment.
-        // if (historyItemIndex === 0) {
-        //     return false;
-        // }
-        //
-        // const previousAction = filteredHistory[historyItemIndex - 1];
-        // const currentAction = filteredHistory[historyItemIndex];
-        //
-        // if (currentAction.timestamp - previousAction.timestamp > 300) {
-        //     return false;
-        // }
-        //
-        // return currentAction.actorEmail === previousAction.actorEmail;
+        // This is the created action and the very first action so it cannot be a consecutive comment.
+        if (historyItemIndex === 0) {
+            return false;
+        }
+
+        const previousAction = reportHistory[historyItemIndex - 1];
+        const currentAction = reportHistory[historyItemIndex];
+
+        if (currentAction.timestamp - previousAction.timestamp > 300) {
+            return false;
+        }
+
+        return currentAction.actorEmail === previousAction.actorEmail;
     }
 
     /**

--- a/src/page/HomePage/Report/ReportHistoryView.js
+++ b/src/page/HomePage/Report/ReportHistoryView.js
@@ -71,6 +71,7 @@ class ReportHistoryView extends React.Component {
         const previousAction = reportHistory[historyItemIndex - 1];
         const currentAction = reportHistory[historyItemIndex];
 
+        // Comments are only grouped if they happen within 5 minutes of each other
         if (currentAction.timestamp - previousAction.timestamp > 300) {
             return false;
         }

--- a/src/style/StyleSheet.js
+++ b/src/style/StyleSheet.js
@@ -423,6 +423,14 @@ const styles = {
         marginRight: 8,
     },
 
+    chatItemRightGrouped: {
+        flexGrow: 1,
+        flexShrink: 1,
+        flexBasis: 0,
+        position: 'relative',
+        marginLeft: 48,
+    },
+
     chatItemRight: {
         flexGrow: 1,
         flexShrink: 1,


### PR DESCRIPTION
Fixes https://github.com/Expensify/ReactNativeChat/issues/44

### Tests
1.  Create a series of messages from the same user, verify that they all group accordingly.
1.  Create a series of messages from another different user, verify that they all group accordingly, and none if the previous user group with the ones from this user.
1. Verify that the chat on ReactNativeChat and Web-Expensify group the same way

### Screenshots

| Web | ReactNative |
| - | - |
| ![Screenshot 2020-08-26 at 17 19 19](https://user-images.githubusercontent.com/242568/91329865-96ebe300-e7c0-11ea-89ce-8872c19ec8da.png) | <img width="399" alt="Screenshot 2020-08-26 at 17 19 30" src="https://user-images.githubusercontent.com/242568/91329883-9c492d80-e7c0-11ea-8075-f6eeff68a653.png"> |

