### PR TITLE
Fix exitTo regression

### DIFF
--- a/src/lib/Network.js
+++ b/src/lib/Network.js
@@ -137,9 +137,9 @@ function setSuccessfulSignInData(data, exitTo) {
     let redirectTo;
 
     if (exitTo && exitTo[0] === '/') {
-        redirectTo = exitTo.substring(1);
-    } else if (exitTo) {
         redirectTo = exitTo;
+    } else if (exitTo) {
+        redirectTo = `/${exitTo}`;
     } else {
         redirectTo = ROUTES.HOME;
     }


### PR DESCRIPTION
**Fixes:** https://github.com/Expensify/ReactNativeChat/issues/309

**Tests:**

1. Go to chat.expensify.com/#/signin/exitTo/64218473
1. Enter your credentials
1. Submit
1. Get redirected to correct report