### PR TITLE
Undo setting the authToken often to speed up everything / some cleanup

### DIFF
--- a/src/components/AnchorForCommentsOnly/index.js
+++ b/src/components/AnchorForCommentsOnly/index.js
@@ -8,7 +8,7 @@ import {StyleSheet} from 'react-native';
 
 const propTypes = {
     // The URL to open
-    href: PropTypes.string.isRequired,
+    href: PropTypes.string,
 
     // What headers to send to the linked page (usually noopener and noreferrer)
     rel: PropTypes.string,
@@ -25,6 +25,7 @@ const propTypes = {
 };
 
 const defaultProps = {
+    href: '',
     rel: '',
     target: '',
     children: null,

--- a/src/lib/Network.js
+++ b/src/lib/Network.js
@@ -314,14 +314,6 @@ function request(command, data, type = 'post') {
             }
 
             return responseData;
-        })
-
-        // Always keep an updated authToken in the session
-        .then((responseData) => {
-            if (responseData.authToken) {
-                Ion.merge(IONKEYS.SESSION, {authToken: responseData.authToken});
-            }
-            return responseData;
         });
 }
 

--- a/src/lib/actions/Report.js
+++ b/src/lib/actions/Report.js
@@ -114,6 +114,23 @@ function subscribeToReportCommentEvents() {
 }
 
 /**
+ * Returns a generated report title based on the participants
+ *
+ * @param {array} sharedReportList
+ * @param {object} personalDetails
+ * @param {string} currentUserEmail
+ * @return {string}
+ */
+function getChatReportName(sharedReportList, personalDetails, currentUserEmail) {
+    return _.chain(sharedReportList)
+        .map(participant => participant.email)
+        .filter(participant => participant !== currentUserEmail)
+        .map(participant => lodashGet(personalDetails, [participant, 'firstName']) || participant)
+        .value()
+        .join(', ');
+}
+
+/**
  * Get all chat reports and provide the proper report name
  * by fetching sharedReportList and personalDetails
  *
@@ -159,12 +176,11 @@ function fetchChatReports() {
                 const newReport = getSimplifiedReportObject(report, currentUserAccountID);
 
                 if (lodashGet(report, 'reportNameValuePairs.type') === 'chat') {
-                    newReport.reportName = _.chain(report.sharedReportList)
-                        .map(participant => participant.email)
-                        .filter(participant => participant !== currentUserEmail)
-                        .map(participant => lodashGet(personalDetails, [participant, 'firstName'], participant))
-                        .value()
-                        .join(', ');
+                    newReport.reportName = getChatReportName(
+                        report.sharedReportList,
+                        personalDetails,
+                        currentUserEmail
+                    );
                 }
 
                 // Merge the data into Ion. Don't use set() here or multiSet() because then that would
@@ -277,12 +293,7 @@ function fetchChatReport(participants) {
 
             // Store only the absolute bare minimum of data in Ion because space is limited
             const newReport = getSimplifiedReportObject(report, currentUserAccountID);
-            newReport.reportName = _.chain(report.sharedReportList)
-                .map(participant => participant.email)
-                .filter(participant => participant !== currentUserEmail)
-                .map(participant => lodashGet(personalDetails, [participant, 'firstName'], participant))
-                .value()
-                .join(', ');
+            newReport.reportName = getChatReportName(report.sharedReportList, personalDetails, currentUserEmail);
 
             // Merge the data into Ion. Don't use set() here or multiSet() because then that would
             // overwrite any existing data (like if they have unread messages)

--- a/src/page/home/report/ReportHistoryView.js
+++ b/src/page/home/report/ReportHistoryView.js
@@ -168,7 +168,6 @@ export default compose(
         authToken: {
             key: IONKEYS.SESSION,
             path: 'authToken',
-            prefillWithKey: IONKEYS.SESSION,
         },
         reportHistory: {
             key,


### PR DESCRIPTION
Fixes https://github.com/Expensify/ReactNativeChat/issues/314

Long story short we were basically re-rendering a million zillion history items when updating the `authToken` and we were updating it on every request.

This logic determines if a report history item re-renders or not

https://github.com/Expensify/ReactNativeChat/blob/ecfd8c6af402b373f1c89877b87b452b5a6ba628/src/page/home/report/ReportHistoryItem.js#L21-L26

We need the `authToken` to be pretty deeply nested here so that `ReportHistoryItemFragment` can do whatever this is doing...

https://github.com/Expensify/ReactNativeChat/blob/ecfd8c6af402b373f1c89877b87b452b5a6ba628/src/page/home/report/ReportHistoryItemFragment.js#L53-L61

Rather than subscribe in this component and subscribe only when we actually need an `authToken` (e.g. only subscribe when there's an `img` tag) we have every single report comment re-rendering when the `authToken` changes.

Overall, the simplest solution is to not update the `authToken` so that's what I'm proposing we do for now.

Another option would be to render a different kind of `<HTML/>` component that is wrapped in `withIon` when we have an `img` tag so we _only_ update those components. But I think the CYA insurance and aggressive setting of the `authToken` is not needed now that we are handling the token expiring better?

We might run into similar perf issues in the future because we are rendering all of the reports at once and just hiding them. But it works for now.