### PR TITLE
Fix grouped comment flicker between non grouped and grouped

### DIFF
--- a/src/lib/actions/Report.js
+++ b/src/lib/actions/Report.js
@@ -353,7 +353,7 @@ function addHistoryItem(reportID, reportComment) {
                 ...reportHistory,
                 [newSequenceNumber]: {
                     actionName: 'ADDCOMMENT',
-                    actorEmail: Ion.get(IONKEYS.SESSION, 'email'),
+                    actorEmail: email,
                     person: [
                         {
                             style: 'strong',


### PR DESCRIPTION
### Problem
When entering a new comment on a section of grouped comments from the same user, for a moment that comment would look like not grouped and then after a short time (less than a second) it would assume it's grouped UI look

fixes: https://github.com/Expensify/ReactNativeChat/issues/307

### Tests
1. Write a comment in a chat, and then write a second one.
1. Verify that the new comment is grouped straight away, and the avatar is never shown for the second comment.