### PR TITLE
Improve the loading of all reports

### DIFF
--- a/src/lib/actions/Report.js
+++ b/src/lib/actions/Report.js
@@ -235,7 +235,7 @@ function fetchAll() {
         shouldLoadOptionalKeys: true,
     }));
 
-    // Chat reports need to be fetched separately then the reports hard-coded in the config
+    // Chat reports need to be fetched separately than the reports hard-coded in the config
     // files. The promise for fetching them is added to the array of promises here so
     // that both types of reports (chat reports and hard-coded reports) are fetched in
     // parallel

--- a/src/lib/actions/Report.js
+++ b/src/lib/actions/Report.js
@@ -235,6 +235,12 @@ function fetchAll() {
         shouldLoadOptionalKeys: true,
     }));
 
+    // Chat reports need to be fetched separately then the reports hard-coded in the config
+    // files. The promise for fetching them is added to the array of promises here so
+    // that both types of reports (chat reports and hard-coded reports) are fetched in
+    // parallel
+    reportFetchPromises.push(fetchChatReports());
+
     return promiseAllSettled(reportFetchPromises)
         .then(data => fetchedReports = _.compact(_.map(data, (promiseResult) => {
             // Grab the report from the promise result which stores it in the `value` key
@@ -431,7 +437,6 @@ export {
     fetchAll,
     fetchHistory,
     fetchChatReport,
-    fetchChatReports,
     addHistoryItem,
     updateLastReadActionID,
     subscribeToReportCommentEvents,

--- a/src/page/home/report/ReportHistoryView.js
+++ b/src/page/home/report/ReportHistoryView.js
@@ -71,6 +71,8 @@ class ReportHistoryView extends React.Component {
         const previousAction = reportHistory[historyItemIndex - 1];
         const currentAction = reportHistory[historyItemIndex];
 
+        // It's OK for there to be no previous action, and in that case, false will be returned
+        // so that the comment isn't grouped
         if (!currentAction || !previousAction) {
             return false;
         }

--- a/src/page/home/sidebar/SidebarLinks.js
+++ b/src/page/home/sidebar/SidebarLinks.js
@@ -7,7 +7,7 @@ import Text from '../../../components/Text';
 import SidebarLink from './SidebarLink';
 import withIon from '../../../components/withIon';
 import IONKEYS from '../../../IONKEYS';
-import {fetchAll, fetchChatReports} from '../../../lib/actions/Report';
+import {fetchAll} from '../../../lib/actions/Report';
 import Ion from '../../../lib/Ion';
 import PageTitleUpdater from '../../../lib/PageTitleUpdater/index.native';
 import ChatSwitcherView from './ChatSwitcherView';
@@ -110,8 +110,6 @@ export default withIon({
                     Ion.set(IONKEYS.APP_REDIRECT_TO, `/${firstReportID}`);
                 }
             });
-
-            fetchChatReports();
         }),
     },
 })(SidebarLinks);


### PR DESCRIPTION
This PR has a few benefits:

1. Now all reports are loaded in parallel, so the LHN populates faster 
2. Previously, since `fetchAll()` was separate from `fetchChatReports`, the chat reports were excluded from the "download all information again on reconnect". Now, they will be automatically included in the reports that are refreshed after a network reconnect happens.