### PR TITLE
Trim comment before calling onSubmit handler

### DIFF
--- a/src/page/home/report/ReportHistoryCompose.js
+++ b/src/page/home/report/ReportHistoryCompose.js
@@ -61,13 +61,15 @@ class ReportHistoryCompose extends React.Component {
             e.preventDefault();
         }
 
+        const trimmedComment = this.state.comment.trim();
+
         // Don't submit empty comments
         // @TODO show an error in the UI
-        if (!this.state.comment) {
+        if (!trimmedComment) {
             return;
         }
 
-        this.props.onSubmit(this.props.reportID, this.state.comment);
+        this.props.onSubmit(this.props.reportID, trimmedComment);
         this.setState({
             comment: '',
         });


### PR DESCRIPTION
Fixes #340

### Tests
* Create a comment that has newlines at the beginning or end (Shift+Enter)
* Submit the comment
* Ensure the displayed comment does not have blank lines at the beginning or end