### PR TITLE
Use absolute dates instead of relative dates

### DIFF
--- a/src/lib/DateUtils.js
+++ b/src/lib/DateUtils.js
@@ -52,9 +52,13 @@ function timestampToDateTime(timestamp, includeTimeZone = false) {
     const date = getLocalMomentFromTimestamp(timestamp);
     const isThisYear = moment().format('YYYY') === date.format('YYYY');
     const isToday = moment().format('D MMM YYYY') === date.format('D MMM YYYY');
+    const yesterday = moment().add(-1, 'day').format('D MMM YYYY');
+    const isYesterday = yesterday === date.format('D MMM YYYY');
 
     let format = 'LT';
-    if (!isToday) {
+    if (isYesterday) {
+        format = `[Yesterday at] ${format}`;
+    } else if (!isToday) {
         format = `MMM D [at] ${format}`;
     } else if (!isThisYear) {
         format = `MMM D, YYYY [at] ${format}`;

--- a/src/lib/DateUtils.js
+++ b/src/lib/DateUtils.js
@@ -50,12 +50,20 @@ function getLocalMomentFromTimestamp(timestamp) {
  */
 function timestampToDateTime(timestamp, includeTimeZone = false) {
     const date = getLocalMomentFromTimestamp(timestamp);
-    let format = moment().year() !== date.get('year')
-        ? 'MMM D, YYYY [at] LT'
-        : 'MMM D [at] LT';
+    const isThisYear = moment().format('YYYY') === date.format('YYYY');
+    const isToday = moment().format('D MMM YYYY') === date.format('D MMM YYYY');
+
+    let format = 'LT';
+    if (!isToday) {
+        format = `MMM D [at] ${format}`;
+    } else if (!isThisYear) {
+        format = `MMM D, YYYY [at] ${format}`;
+    }
+
     if (includeTimeZone) {
         format = `${format} [UTC]Z`;
     }
+
     return date.format(format);
 }
 

--- a/src/page/home/report/ReportHistoryItemDate.js
+++ b/src/page/home/report/ReportHistoryItemDate.js
@@ -11,7 +11,7 @@ const propTypes = {
 
 const ReportHistoryItemDate = props => (
     <Text style={[styles.chatItemMessageHeaderTimestamp]}>
-        {DateUtils.timestampToRelative(props.timestamp)}
+        {DateUtils.timestampToDateTime(props.timestamp)}
     </Text>
 );
 


### PR DESCRIPTION
This was something that @JmillsExpensify asked for. Since the timestamps don't automatically update (and we aren't sure if we want to add that), the most simple solution is to show the times as absolute.

![image](https://user-images.githubusercontent.com/1228807/91741156-8a290f80-eb71-11ea-82cd-fa828072f9e2.png)

# Tests
1. Comment on a report that has comments from more than a day ago
1. Verify that the comments show absolute timestamps and that the month isn't included in comments happening today, and the year isn't included in comments happening this year.