### PR TITLE
Fix keyboard focus for the compose comment form

### DIFF
--- a/src/page/home/MainView.js
+++ b/src/page/home/MainView.js
@@ -36,11 +36,19 @@ class MainView extends React.Component {
 
         // The styles for each of our reports. Basically, they are all hidden except for the one matching the
         // reportID in the URL
+        let activeReportID;
         const reportStyles = _.reduce(this.props.reports, (memo, report) => {
+            const isActiveReport = reportIDInURL === report.reportID;
             const finalData = {...memo};
-            const reportStyle = reportIDInURL === report.reportID
-                ? [styles.dFlex, styles.flex1]
-                : [styles.dNone];
+            let reportStyle;
+
+            if (isActiveReport) {
+                activeReportID = report.reportID;
+                reportStyle = [styles.dFlex, styles.flex1];
+            } else {
+                reportStyle = [styles.dNone];
+            }
+
             finalData[report.reportID] = [reportStyle];
             return finalData;
         }, {});
@@ -52,7 +60,10 @@ class MainView extends React.Component {
                         key={report.reportID}
                         style={reportStyles[report.reportID]}
                     >
-                        <ReportView reportID={report.reportID} />
+                        <ReportView
+                            reportID={report.reportID}
+                            isActiveReport={report.reportID === activeReportID}
+                        />
                     </View>
                 ))}
             </>

--- a/src/page/home/report/ReportView.js
+++ b/src/page/home/report/ReportView.js
@@ -15,8 +15,8 @@ const propTypes = {
     isActiveReport: PropTypes.bool.isRequired,
 };
 
-// This is a PureComponent so that it only re-renders when the reportID changes or the report is active
-// or not. This should greatly reduce how often comments are re-rendered.
+// This is a PureComponent so that it only re-renders when the reportID changes or when the report changes from
+// active to inactive (or vice versa). This should greatly reduce how often comments are re-rendered.
 class ReportView extends React.PureComponent {
     render() {
         // Only display the compose form for the active report because the form needs to get focus and

--- a/src/page/home/report/ReportView.js
+++ b/src/page/home/report/ReportView.js
@@ -19,7 +19,7 @@ const propTypes = {
 // or not. This should greatly reduce how often comments are re-rendered.
 class ReportView extends React.PureComponent {
     render() {
-        // Only display the compose form for the active report because the form needs to get focus and */}
+        // Only display the compose form for the active report because the form needs to get focus and
         // calling focus() on 42 different forms doesn't work
         const shouldShowComposeForm = this.props.isActiveReport;
         return (

--- a/src/page/home/report/ReportView.js
+++ b/src/page/home/report/ReportView.js
@@ -10,19 +10,29 @@ import styles from '../../../style/StyleSheet';
 const propTypes = {
     // The ID of the report actions will be created for
     reportID: PropTypes.number.isRequired,
+
+    // Whether or not this report is the one that is currently being viewed
+    isActiveReport: PropTypes.bool.isRequired,
 };
 
-// This is a PureComponent so that it only re-renders when the reportID changes (and it never should change, so once
-// rendered, always rendered)
+// This is a PureComponent so that it only re-renders when the reportID changes or the report is active
+// or not. This should greatly reduce how often comments are re-rendered.
 class ReportView extends React.PureComponent {
     render() {
+        // Only display the compose form for the active report because the form needs to get focus and */}
+        // calling focus() on 42 different forms doesn't work
+        const shouldShowComposeForm = this.props.isActiveReport;
         return (
             <View style={[styles.chatContent]}>
                 <ReportHistoryView reportID={this.props.reportID} />
-                <ReportHistoryCompose
-                    reportID={this.props.reportID}
-                    onSubmit={addHistoryItem}
-                />
+
+                {shouldShowComposeForm && (
+                    <ReportHistoryCompose
+                        reportID={this.props.reportID}
+                        onSubmit={addHistoryItem}
+                    />
+                )}
+
                 <KeyboardSpacer />
             </View>
         );


### PR DESCRIPTION
The focus of the input was actually broken because we are rendering all the reports at once (and then just hiding/showing them via styles), it means that we were calling `focus()` on `n` compose forms. This code should ensure that there is only a single compose form, and therefore the focus stuff will work again and fix https://github.com/Expensify/ReactNativeChat/issues/326.

# Tests
1. Go to a chat
1. Refresh the page
1. Verify that the compose form gets focus
1. Open a chat from the chat switcher
1. Verify that the compose form gets focus