### PR TITLE
Force our static links to open in a new tab on desktop and web

### DIFF
--- a/src/components/Anchor/index.js
+++ b/src/components/Anchor/index.js
@@ -5,6 +5,10 @@ import {Text} from 'react-native';
 
 /**
  * Text based component that is passed a URL to open onPress
+ *
+ * This file is for web and desktop.
+ * It is different from the native version because it uses javascript to manually force a new window to open.
+ * This is required because Linking.openURL (used in native) does not allow for links to open in new tabs/windows
  */
 
 const propTypes = {

--- a/src/components/Anchor/index.js
+++ b/src/components/Anchor/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
-import {Linking, Text} from 'react-native';
+import {Text} from 'react-native';
 
 /**
  * Text based component that is passed a URL to open onPress
@@ -38,7 +38,7 @@ const Anchor = ({
 
     return (
         // eslint-disable-next-line react/jsx-props-no-spreading
-        <Text style={mergedStyles} onPress={() => Linking.openURL(href)} {...props}>
+        <Text style={mergedStyles} onPress={() => {debugger; window.open(href, '_blank');}} {...props}>
             {children}
         </Text>
     );

--- a/src/components/Anchor/index.js
+++ b/src/components/Anchor/index.js
@@ -38,7 +38,7 @@ const Anchor = ({
 
     return (
         // eslint-disable-next-line react/jsx-props-no-spreading
-        <Text style={mergedStyles} onPress={() => {debugger; window.open(href, '_blank');}} {...props}>
+        <Text style={mergedStyles} onPress={() => window.open(href, '_blank')} {...props}>
             {children}
         </Text>
     );

--- a/src/components/Anchor/index.native.js
+++ b/src/components/Anchor/index.native.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import _ from 'underscore';
+import {Linking, Text} from 'react-native';
+
+/**
+ * Text based component that is passed a URL to open onPress
+ */
+
+const propTypes = {
+    // The URL to open
+    href: PropTypes.string.isRequired,
+
+    // Any children to display
+    children: PropTypes.node,
+
+    // Any additional styles to apply
+    // eslint-disable-next-line react/forbid-prop-types
+    style: PropTypes.any,
+};
+
+const defaultProps = {
+    children: null,
+    style: {},
+};
+
+const Anchor = ({
+                   href,
+                   children,
+                   style,
+                   ...props
+               }) => {
+    // If the style prop is an array of styles, we need to mix them all together
+    const mergedStyles = !_.isArray(style) ? style : _.reduce(style, (finalStyles, s) => ({
+        ...finalStyles,
+        ...s
+    }), {});
+
+    return (
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        <Text style={mergedStyles} onPress={() => Linking.openURL(href)} {...props}>
+            {children}
+        </Text>
+    );
+};
+
+Anchor.propTypes = propTypes;
+Anchor.defaultProps = defaultProps;
+Anchor.displayName = 'Anchor';
+
+export default Anchor;

--- a/src/components/Anchor/index.native.js
+++ b/src/components/Anchor/index.native.js
@@ -25,11 +25,11 @@ const defaultProps = {
 };
 
 const Anchor = ({
-                   href,
-                   children,
-                   style,
-                   ...props
-               }) => {
+    href,
+    children,
+    style,
+    ...props
+}) => {
     // If the style prop is an array of styles, we need to mix them all together
     const mergedStyles = !_.isArray(style) ? style : _.reduce(style, (finalStyles, s) => ({
         ...finalStyles,

--- a/src/components/Anchor/index.native.js
+++ b/src/components/Anchor/index.native.js
@@ -5,6 +5,10 @@ import {Linking, Text} from 'react-native';
 
 /**
  * Text based component that is passed a URL to open onPress
+ *
+ * This file is for iOS and Android.
+ * It is different from the web/desktop version because it uses the built in react-native Linking.openURL
+ * This is required because Linking.openURL provides the correct functionality for mobile, but not web/desktop
  */
 
 const propTypes = {


### PR DESCRIPTION
https://github.com/Expensify/ReactNativeChat/issues/286

This PR separates the Anchor component to have one for web and one for native. Native continues to use `Linking.openURL` but web and desktop now use `window.open`. The reason for this is that `Linking.openURL` has _no_ way to force links to open in a new tab/browser. While researching I found [this PR](https://github.com/necolas/react-native-web/pull/1432) that attempted to add new tab functionality to `Linking.openURL` but it was denied and the only useful comment had platform specific `if/else` statements which we want to avoid

### Tests
1. Run `npm run web`
2. Click "iOS" in the bottom left of the nav bar
3. Make sure a new tab opens
--------
1. Run `npm run desktop`
2. Click "iOS" in the bottom left of the nav bar
3. Make sure your default browser opens with the new tab
---------
1. Run `npm run ios`
2. Click any of the buttons in the bottom left of the nav bar
3. Make sure the link opens in app
