### PR TITLE
Prevent duplicate browser notifications

### DIFF
--- a/src/lib/Notification/BrowserNotifications.js
+++ b/src/lib/Notification/BrowserNotifications.js
@@ -105,22 +105,25 @@ export default {
      * @param {Function} params.onClick
      */
     pushReportCommentNotification({reportAction, onClick}) {
-        if (!ActiveClientManager.isClientTheLeader()) {
-            return;
-        }
+        ActiveClientManager.isClientTheLeader()
+            .then((isClientTheLeader) => {
+                if (!isClientTheLeader) {
+                    return;
+                }
 
-        const {person, message} = reportAction;
+                const {person, message} = reportAction;
 
-        const plainTextPerson = Str.htmlDecode(person.map(f => f.text).join());
+                const plainTextPerson = Str.htmlDecode(person.map(f => f.text).join());
 
-        // Specifically target the comment part of the message
-        const plainTextMessage = Str.htmlDecode((message.find(f => f.type === 'COMMENT') || {}).text);
+                // Specifically target the comment part of the message
+                const plainTextMessage = Str.htmlDecode((message.find(f => f.type === 'COMMENT') || {}).text);
 
-        push({
-            title: `New message from ${plainTextPerson}`,
-            body: plainTextMessage,
-            delay: 0,
-            onClick,
-        });
+                push({
+                    title: `New message from ${plainTextPerson}`,
+                    body: plainTextMessage,
+                    delay: 0,
+                    onClick,
+                });
+            });
     },
 };

--- a/src/lib/actions/Report.js
+++ b/src/lib/actions/Report.js
@@ -222,6 +222,10 @@ function subscribeToReportCommentEvents() {
     return Ion.get(IONKEYS.SESSION, 'accountID')
         .then((accountID) => {
             const pusherChannelName = `private-user-accountID-${accountID}`;
+            if (Pusher.isSubscribed(pusherChannelName) || Pusher.isAlreadySubscribing(pusherChannelName)) {
+                return;
+            }
+
             Pusher.subscribe(pusherChannelName, 'reportComment', (pushJSON) => {
                 updateReportWithNewAction(pushJSON.reportID, pushJSON.reportAction);
             });


### PR DESCRIPTION
Fixes: https://github.com/Expensify/ReactNativeChat/issues/333

Addresses two things:

1. In some cases, it might be possible to subscribe more than once to Pusher channels which can lead to multiple duplicate browser notifications

2. `ActiveClientManager.isClientTheLeader()` returns a `Promise` and we were not correctly using it before which is likely what caused the bug in the linked issue.

**Tests:**

1. Create several tabs of ChatDot in your browser while logged in as a single user
1. Make sure they are all on the same report
1. Add a comment to a different report shared with the logged in user as another user to trigger a browser notification
1. Verify that only one browser notification appears