### PR TITLE
Add auto merge workflow

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,23 @@
+name: automerge
+on:
+    pull_request:
+        types:
+            - labeled
+    status: {}
+jobs:
+    automerge:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: automerge
+              uses: pascalgn/automerge-action@v0.9.0
+              env:
+                  GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+            - name: Setup Node
+              uses: actions/setup-node@v1
+              with:
+                node-version: '14.x'
+
+            - name: tag release
+              run: git tag $(npm run print-version --silent) && git push --tags

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -22,8 +22,16 @@ jobs:
             - name: Set git user
               run: git config user.name github-action
 
+            - name: Checkout new branch
+              run: git checkout -b version-${{ github.sha }}
+
             - name: Generate version
-              run: npm version prerelease -m "Update version to %s"
+              run: npm --no-git-tag-version version prerelease -m "Update version to %s"
 
             - name: Push new version
-              run: git push && git push --tags
+              run: git push
+
+            - name: Create Pull Request
+              uses: peter-evans/create-pull-request@v3
+              with:
+                    labels: automerge

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test": "jest",
     "lint": "eslint .",
     "deploy-ios": "npm version prerelease && git push && fastlane ios beta",
-    "postversion": "react-native-version"
+    "postversion": "react-native-version",
+    "print-version": "echo $npm_package_version"
   },
   "dependencies": {
     "@react-native-community/async-storage": "^1.11.0",


### PR DESCRIPTION
My first version of this workflow failed because the [github action can't push to master](https://github.com/Expensify/ReactNativeChat/runs/1057869287?check_suite_focus=true), this will resolve that by opening a PR then approving it and merging it if it contains the `automerge` label. Once the PR is merged, then it will be tagged and the deploy scripts will kick off.

This is something similar to what we do in production on Mobile-Expensify for our versioning. This is getting harder and harder to test, so we will have to merge it into master and make sure everything works as expected.