### PR TITLE
Define base and branch

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -35,3 +35,5 @@ jobs:
               uses: peter-evans/create-pull-request@v3
               with:
                     labels: automerge
+                    branch: version-${{ github.sha }}
+                    base: master


### PR DESCRIPTION
Fixes an issue in https://github.com/Expensify/ReactNativeChat/runs/1058149467?check_suite_focus=true where the defaults didn't pick up the right branch and base for the automatic PR.