### PR TITLE
Use different PR action

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -32,6 +32,10 @@ jobs:
               run: git push --set-upstream origin version-${{ github.sha }}
 
             - name: Create Pull Request
-              uses: peter-evans/create-pull-request@v3
+              uses: repo-sync/pull-request@v2
               with:
-                    labels: automerge
+                    source_branch: version-${{ github.sha }}
+                    destination_branch: "master"
+                    pr_title: "Auto Version PR"
+                    pr_label: "automerge"
+                    github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Uses https://github.com/marketplace/actions/github-pull-request-action to create the PR, which looks closer to what we actually want. The previous action was doing some over complicated things and wasn't creating the PR correctly.