### PR TITLE
Use botify to create the PR and start the deploys

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -19,11 +19,3 @@ jobs:
               uses: pascalgn/automerge-action@v0.9.0
               env:
                   GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-
-            - name: Setup Node
-              uses: actions/setup-node@v1
-              with:
-                node-version: '14.x'
-
-            - name: tag release
-              run: git tag $(npm run print-version --silent) && git push --tags

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -32,6 +32,9 @@ jobs:
             - name: Push new version
               run: git push --set-upstream origin version-bump-${{ github.sha }}
 
+            - name: tag release
+              run: git tag $(npm run print-version --silent) && git push --tags
+
             - name: Create Pull Request
               uses: repo-sync/pull-request@v2
               with:

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,8 +1,6 @@
 name: Create a new version
 
-on:
-    push:
-        branches: [master]
+on: push
 
 jobs:
     build:
@@ -10,6 +8,8 @@ jobs:
 
         steps:
             - uses: actions/checkout@v2
+              with:
+                  ref: master
 
             - name: Setup Node
               uses: actions/setup-node@v1

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -24,19 +24,19 @@ jobs:
               run: git config user.name github-action
 
             - name: Checkout new branch
-              run: git checkout -b version-${{ github.sha }}
+              run: git checkout -b version-bump-${{ github.sha }}
 
             - name: Generate version
               run: npm --no-git-tag-version version prerelease -m "Update version to %s"
 
             - name: Push new version
-              run: git push --set-upstream origin version-${{ github.sha }}
+              run: git push --set-upstream origin version-bump-${{ github.sha }}
 
             - name: Create Pull Request
               uses: repo-sync/pull-request@v2
               with:
-                    source_branch: version-${{ github.sha }}
+                    source_branch: version-bump-${{ github.sha }}
                     destination_branch: "master"
                     pr_title: "Auto Version PR"
                     pr_label: "automerge"
-                    github_token: ${{ secrets.GITHUB_TOKEN }}
+                    github_token: ${{ secrets.BOTIFY_TOKEN }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,6 +1,8 @@
 name: Create a new version
 
-on: push
+on:
+    push:
+        branches: [master]
 
 jobs:
     build:

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -9,6 +9,7 @@ jobs:
         steps:
             - uses: actions/checkout@v2
               with:
+                  fetch-depth: 0
                   ref: master
 
             - name: Setup Node


### PR DESCRIPTION
There is a weird quirk that I didn't realize with GitHub actions.. A GitHub action that uses the default auth token cannot create other workflows. @cead22 helped resolve this by adding botify's access token, so it can create the PR, then the default bot can merge PRs.