### PR TITLE
Fix continuous deploy

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,5 +1,6 @@
 name: Build and Deploy Android
 
+# This workflow is run when any tag is published
 on:
     push:
         tags:

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,9 +1,11 @@
 name: automerge
+
 on:
     pull_request:
         types:
             - labeled
     status: {}
+
 jobs:
     automerge:
         runs-on: ubuntu-latest

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,5 +1,6 @@
 name: automerge
 
+# This workflow is triggered by a pull request that is labeled
 on:
     pull_request:
         types:

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -1,5 +1,6 @@
 name: Build and Deploy Desktop
 
+# This workflow is run when any tag is published
 on:
     push:
         tags:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,13 @@
 name: eslint
 
-on: push
+# Only lint on branches that aren't related to master and the deploy process
+on:
+    push:
+        branches-ignore:
+            - 'master'
+            - 'bump-version-*'
+        tags-ignore:
+            - '*'
 
 jobs:
     build:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on:
     push:
         branches-ignore:
             - 'master'
-            - 'bump-version-*'
+            - 'version-bump-*'
         tags-ignore:
             - '*'
 

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,8 +1,6 @@
 name: Create a new version
 
-on:
-    push:
-        branches: [master]
+on: push
 
 jobs:
     build:
@@ -23,7 +21,7 @@ jobs:
               run: npm install
 
             - name: Set git user
-              run: git config user.name github-action
+              run: git config user.name botify
 
             - name: Checkout new branch
               run: git checkout -b version-bump-${{ github.sha }}
@@ -33,6 +31,8 @@ jobs:
 
             - name: Push new version
               run: git push --set-upstream origin version-bump-${{ github.sha }}
+              with:
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: tag release
               run: git tag $(npm run print-version --silent) && git push --tags

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -11,6 +11,7 @@ jobs:
               with:
                   fetch-depth: 0
                   ref: master
+                  token: ${{ secrets.BOTIFY_TOKEN }}
 
             - name: Setup Node
               uses: actions/setup-node@v1
@@ -31,8 +32,6 @@ jobs:
 
             - name: Push new version
               run: git push --set-upstream origin version-bump-${{ github.sha }}
-              with:
-                  github_token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: tag release
               run: git tag $(npm run print-version --silent) && git push --tags

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,6 +1,8 @@
 name: Create a new version
 
-on: push
+on:
+    push:
+        branches: [master]
 
 jobs:
     build:

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -10,7 +10,6 @@ jobs:
             - uses: actions/checkout@v2
               with:
                   fetch-depth: 0
-                  ref: master
                   token: ${{ secrets.BOTIFY_TOKEN }}
 
             - name: Setup Node
@@ -21,28 +20,28 @@ jobs:
             - name: Install dependenices
               run: npm install
 
-            - name: Set git user
+            - name: Set up git
               run: |
                 git fetch
+                git checkout master
                 git config user.name botify
 
             - name: Checkout new branch
               run: git checkout -b version-bump-${{ github.sha }}
 
             - name: Generate version
-              run: npm --no-git-tag-version version prerelease -m "Update version to %s"
+              run: npm version prerelease -m "Update version to %s"
 
             - name: Push new version
               run: git push --set-upstream origin version-bump-${{ github.sha }}
 
-            - name: tag release
-              run: git tag $(npm run print-version --silent) && git push --tags
+            - name: Push tags
+              run: git push --tags
 
             - name: Create Pull Request
               uses: repo-sync/pull-request@v2
               with:
                     source_branch: version-bump-${{ github.sha }}
                     destination_branch: "master"
-                    pr_title: "Auto Version PR"
                     pr_label: "automerge"
                     github_token: ${{ secrets.BOTIFY_TOKEN }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -22,7 +22,9 @@ jobs:
               run: npm install
 
             - name: Set git user
-              run: git config user.name botify
+              run: |
+                git fetch
+                git config user.name botify
 
             - name: Checkout new branch
               run: git checkout -b version-bump-${{ github.sha }}

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -1,5 +1,6 @@
 name: Build and Deploy Web
 
+# This workflow is run when any tag is published
 on:
     push:
         tags:


### PR DESCRIPTION
Finally got all these actions worked as we wanted! The final fix was 00963a5 which basically makes botify the author for all git actions, so it can create tags which will trigger actions. The rest is clean up of code. Once we merge this PR we will see:

1. A tag created with the latest version
2. A PR created with the latest version (e.g https://github.com/Expensify/ReactNativeChat/pull/377)
3. Three deploy scripts kick off to deploy web, android, and desktop with the latest version
