### PR TITLE
Only group if they are both comments

### DIFF
--- a/src/page/home/report/ReportHistoryView.js
+++ b/src/page/home/report/ReportHistoryView.js
@@ -77,6 +77,11 @@ class ReportHistoryView extends React.Component {
             return false;
         }
 
+        // Only comments that follow other comments are consecutive
+        if (previousAction.actionName !== 'ADDCOMMENT' || currentAction.actionName !== 'ADDCOMMENT') {
+            return false;
+        }
+
         // Comments are only grouped if they happen within 5 minutes of each other
         if (currentAction.timestamp - previousAction.timestamp > 300) {
             return false;


### PR DESCRIPTION
fixes: https://github.com/Expensify/ReactNativeChat/issues/371

### Problem
If the previous history item was not a comment `ADDCOMMENT` it would still be used to see if the comment should be grouped, since this are not shown in chats it looks like the comment is part of someone else conversation.

### Tests:
1. Create a report and share/submit it to another user on Web. Add a couple of comments and actions from each user that looks like this
- User 1: comment 1
- User 1: comment 2
- User 2: action 
- User 2: comment 3
- User 2: comment 4
2. Verify that in the ReactNative chat version of this report `comment 3` is **NOT** grouped to the comments of `User 1` right after `comment 2`. Verify that `comment 3` is grouped with `comment 4`
