### PR TITLE
Make all text selectable

### DIFF
--- a/src/page/home/report/ReportHistoryItemFragment.js
+++ b/src/page/home/report/ReportHistoryItemFragment.js
@@ -70,14 +70,13 @@ class ReportHistoryItemFragment extends React.PureComponent {
                             alterNode={this.alterNode}
                         />
                     )
-                    : <Text 
-                        selectable
-                        >{Str.htmlDecode(fragment.text)}</Text>;
+                    : <Text selectable>{Str.htmlDecode(fragment.text)}</Text>;
             case 'TEXT':
                 return (
-                    <Text 
+                    <Text
                         selectable
-                        style={[styles.chatItemMessageHeaderSender]}>
+                        style={[styles.chatItemMessageHeaderSender]}
+                    >
                         {Str.htmlDecode(fragment.text)}
                     </Text>
                 );

--- a/src/page/home/report/ReportHistoryItemFragment.js
+++ b/src/page/home/report/ReportHistoryItemFragment.js
@@ -70,10 +70,14 @@ class ReportHistoryItemFragment extends React.PureComponent {
                             alterNode={this.alterNode}
                         />
                     )
-                    : <Text>{Str.htmlDecode(fragment.text)}</Text>;
+                    : <Text 
+                        selectable
+                        >{Str.htmlDecode(fragment.text)}</Text>;
             case 'TEXT':
                 return (
-                    <Text style={[styles.chatItemMessageHeaderSender]}>
+                    <Text 
+                        selectable
+                        style={[styles.chatItemMessageHeaderSender]}>
                         {Str.htmlDecode(fragment.text)}
                     </Text>
                 );

--- a/src/page/home/report/ReportHistoryItemFragment.js
+++ b/src/page/home/report/ReportHistoryItemFragment.js
@@ -61,6 +61,7 @@ class ReportHistoryItemFragment extends React.PureComponent {
                 return fragment.html !== fragment.text
                     ? (
                         <HTML
+                            textSelectable
                             renderers={this.customRenderers}
                             baseFontStyle={webViewStyles.baseFontStyle}
                             tagsStyles={webViewStyles.tagStyles}


### PR DESCRIPTION
Fixes: https://github.com/Expensify/ReactNativeChat/issues/260

- Make HTML comments selectable on all platforms to allow copy/paste.
- Make regular text comments selectable on mobile