### PR TITLE
Browser notification fix

### DIFF
--- a/src/lib/ActiveClientManager.js
+++ b/src/lib/ActiveClientManager.js
@@ -29,8 +29,10 @@ function removeClient() {
  * @returns {Promise}
  */
 function isClientTheLeader() {
+    // At the moment activeClients only has 1 value i.e., the latest clientID so let's compare if
+    // the latest matches the current browsers clientID.
     return Ion.get(IONKEYS.ACTIVE_CLIENTS)
-        .then(activeClientIDs => _.first(activeClientIDs) === clientID);
+        .then(activeClients => activeClients.clientID === clientID);
 }
 
 export {

--- a/src/lib/Notification/BrowserNotifications.js
+++ b/src/lib/Notification/BrowserNotifications.js
@@ -22,7 +22,7 @@ function canUseBrowserNotifications() {
         // Check if they previously granted or denied us access to send a notification
         const permissionGranted = Notification.permission === 'granted';
 
-        if (permissionGranted || Notification.permisson === 'denied') {
+        if (permissionGranted || Notification.permission === 'denied') {
             return resolve(permissionGranted);
         }
 


### PR DESCRIPTION
Discussed 1:1 with tim. This is a hacky solution so that browser notification works for us this friday.

Meanwhile i'll work on tim's refactoring behavior to update the way notifications work.

# Fixes issues,
https://github.com/Expensify/ReactNativeChat/issues/433

# Tests
1. Open chat in browser1 and browser2 (browser2 is incognito). Sign into different users on the same domain.
1. Have user2 send user1 a message. Confirm you get a desktop notification, clear it.
1. In browser1 open another chat for the user1. Have user2 send in DM to user1. 
1. Confirm you got just one browser notification for this new message and not two.