### PR TITLE
Fixing comment edits when cursor is in the middle

### DIFF
--- a/src/components/TextInputFocusable/index.js
+++ b/src/components/TextInputFocusable/index.js
@@ -6,8 +6,8 @@ const propTypes = {
     // Maximum number of lines in the text input
     maxLines: PropTypes.number,
 
-    // The value of the comment box
-    value: PropTypes.string.isRequired,
+    // The default value of the comment box
+    defaultValue: PropTypes.string.isRequired,
 };
 
 const defaultProps = {
@@ -33,8 +33,13 @@ class TextInputFocusable extends React.Component {
     componentDidUpdate(prevProps) {
         this.focusInput();
 
-        if (prevProps.value !== this.props.value) {
+        if (prevProps.defaultValue !== this.props.defaultValue) {
             this.updateNumberOfLines();
+
+            if (this.props.defaultValue) {
+                this.textInput.selectionStart = this.props.defaultValue.length;
+                this.textInput.selectionEnd = this.props.defaultValue.length;
+            }
         }
     }
 

--- a/src/components/TextInputFocusable/index.js
+++ b/src/components/TextInputFocusable/index.js
@@ -35,11 +35,6 @@ class TextInputFocusable extends React.Component {
 
         if (prevProps.defaultValue !== this.props.defaultValue) {
             this.updateNumberOfLines();
-
-            if (this.props.defaultValue) {
-                this.textInput.selectionStart = this.props.defaultValue.length;
-                this.textInput.selectionEnd = this.props.defaultValue.length;
-            }
         }
     }
 
@@ -81,6 +76,13 @@ class TextInputFocusable extends React.Component {
 
     focusInput() {
         this.textInput.focus();
+    }
+
+    /**
+     * Clears the input
+     */
+    clear() {
+        this.textInput.clear();
     }
 
     render() {

--- a/src/components/TextInputFocusable/index.js
+++ b/src/components/TextInputFocusable/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {TextInput} from 'react-native';
 import PropTypes from 'prop-types';
+import _ from 'underscore';
 
 const propTypes = {
     // A ref to forward to the text input
@@ -31,6 +32,14 @@ class TextInputFocusable extends React.Component {
 
     componentDidMount() {
         this.focusInput();
+
+        // This callback prop is used by the parent component using the constructor to
+        // get a ref to the inner textInput element e.g. if we do
+        // <constructor ref={el => this.textInput = el} /> this will not
+        // return a ref to the component, but rather the HTML element by default
+        if (this.props.forwardedRef && _.isFunction(this.props.forwardedRef)) {
+            this.props.forwardedRef(this.textInput);
+        }
     }
 
     componentDidUpdate(prevProps) {

--- a/src/components/TextInputFocusable/index.js
+++ b/src/components/TextInputFocusable/index.js
@@ -76,10 +76,6 @@ class TextInputFocusable extends React.Component {
 
     focusInput() {
         this.textInput.focus();
-        if (this.props.value) {
-            this.textInput.selectionStart = this.props.value.length;
-            this.textInput.selectionEnd = this.props.value.length;
-        }
     }
 
     render() {

--- a/src/components/TextInputFocusable/index.js
+++ b/src/components/TextInputFocusable/index.js
@@ -3,6 +3,9 @@ import {TextInput} from 'react-native';
 import PropTypes from 'prop-types';
 
 const propTypes = {
+    // A ref to forward to the text input
+    forwardedRef: PropTypes.func.isRequired,
+
     // Maximum number of lines in the text input
     maxLines: PropTypes.number,
 
@@ -78,13 +81,6 @@ class TextInputFocusable extends React.Component {
         this.textInput.focus();
     }
 
-    /**
-     * Clears the input
-     */
-    clear() {
-        this.textInput.clear();
-    }
-
     render() {
         return (
             <TextInput
@@ -103,4 +99,7 @@ class TextInputFocusable extends React.Component {
 TextInputFocusable.propTypes = propTypes;
 TextInputFocusable.defaultProps = defaultProps;
 
-export default TextInputFocusable;
+export default React.forwardRef((props, ref) => (
+    /* eslint-disable-next-line react/jsx-props-no-spreading */
+    <TextInputFocusable {...props} forwardedRef={ref} />
+));

--- a/src/components/TextInputFocusable/index.native.js
+++ b/src/components/TextInputFocusable/index.native.js
@@ -24,11 +24,6 @@ class TextInputFocusable extends React.Component {
     }
 
     render() {
-        console.debug('test1');
-        if (this.textInput) {
-            console.debug(`test2 ${this.textInput.value}`);
-        }
-
         return (
             <TextInput
                 ref={el => this.textInput = el}

--- a/src/components/TextInputFocusable/index.native.js
+++ b/src/components/TextInputFocusable/index.native.js
@@ -1,13 +1,50 @@
 import React from 'react';
 import {TextInput} from 'react-native';
+import PropTypes from 'prop-types';
+import _ from 'underscore';
+
+const propTypes = {
+    // A ref to forward to the text input
+    forwardedRef: PropTypes.func.isRequired,
+};
 
 /**
  * On native layers we like to have the Text Input not focused so the user can read new chats without they keyboard in
  * the way of the view
  */
-// eslint-disable-next-line react/jsx-props-no-spreading
-const TextInputFocusable = props => (<TextInput maxHeight={116} {...props} />);
+class TextInputFocusable extends React.Component {
+    componentDidMount() {
+        // This callback prop is used by the parent component using the constructor to
+        // get a ref to the inner textInput element e.g. if we do
+        // <constructor ref={el => this.textInput = el} /> this will not
+        // return a ref to the component, but rather the HTML element by default
+        if (this.props.forwardedRef && _.isFunction(this.props.forwardedRef)) {
+            this.props.forwardedRef(this.textInput);
+        }
+    }
+
+    render() {
+        console.debug('test1');
+        if (this.textInput) {
+            console.debug(`test2 ${this.textInput.value}`);
+        }
+
+        return (
+            <TextInput
+                ref={el => this.textInput = el}
+                maxHeight={116}
+                /* eslint-disable-next-line react/jsx-props-no-spreading */
+                {...this.props}
+            />
+        );
+    }
+}
 
 TextInputFocusable.displayName = 'TextInputFocusable';
+TextInputFocusable.propTypes = propTypes;
 
-export default TextInputFocusable;
+// export default TextInputFocusable;
+export default React.forwardRef((props, ref) => (
+    /* eslint-disable-next-line react/jsx-props-no-spreading */
+    <TextInputFocusable {...props} forwardedRef={ref} />
+));

--- a/src/page/home/report/ReportActionCompose.js
+++ b/src/page/home/report/ReportActionCompose.js
@@ -89,8 +89,6 @@ class ReportActionCompose extends React.Component {
             e.preventDefault();
         }
 
-        // Let's get the data directly from textInput because saving the data in Ion report comment is asynchronous
-        // so if we refer this.props.comment here we won't get the most recent value if the user types fast.
         const trimmedComment = this.comment.trim();
 
         // Don't submit empty comments

--- a/src/page/home/report/ReportActionCompose.js
+++ b/src/page/home/report/ReportActionCompose.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import _ from 'underscore';
 import {View, Image, TouchableOpacity} from 'react-native';
 import styles, {colors} from '../../../style/StyleSheet';
 import TextInputFocusable from '../../../components/TextInputFocusable';
@@ -35,10 +36,6 @@ class ReportActionCompose extends React.Component {
         this.submitForm = this.submitForm.bind(this);
         this.triggerSubmitShortcut = this.triggerSubmitShortcut.bind(this);
         this.submitForm = this.submitForm.bind(this);
-
-        this.state = {
-            comment: this.props.comment || ''
-        };
     }
 
     /**
@@ -47,8 +44,6 @@ class ReportActionCompose extends React.Component {
      * @param {string} newComment
      */
     updateComment(newComment) {
-        this.moveCursorToEnd = false;
-        this.setState({comment: newComment});
         saveReportComment(this.props.reportID, newComment || '');
     }
 
@@ -89,8 +84,6 @@ class ReportActionCompose extends React.Component {
 
     render() {
         const href = `${CONFIG.PUSHER.AUTH_URL}/report?reportID=${this.props.reportID}&shouldScrollToLastUnread=true`;
-        const check = this.state.comment;
-        const comment = this.props.comment;
         return (
             <View style={[styles.chatItemCompose]}>
                 <View style={[styles.chatItemComposeBox, styles.flexRow]}>
@@ -110,10 +103,10 @@ class ReportActionCompose extends React.Component {
                         textAlignVertical="top"
                         placeholder="Write something..."
                         placeholderTextColor={colors.textSupporting}
-                        onChangeText={this.updateComment}
+                        onChangeText={_.debounce(this.updateComment, 1000)}
                         onKeyPress={this.triggerSubmitShortcut}
                         style={[styles.textInput, styles.textInputCompose, styles.flex4]}
-                        value={comment}
+                        defaultValue={this.props.comment || ''}
                         maxLines={16} // This is the same that slack has
                     />
                     <TouchableOpacity

--- a/src/page/home/report/ReportActionCompose.js
+++ b/src/page/home/report/ReportActionCompose.js
@@ -35,6 +35,10 @@ class ReportActionCompose extends React.Component {
         this.submitForm = this.submitForm.bind(this);
         this.triggerSubmitShortcut = this.triggerSubmitShortcut.bind(this);
         this.submitForm = this.submitForm.bind(this);
+
+        this.state = {
+            comment: this.props.comment || ''
+        };
     }
 
     /**
@@ -43,6 +47,8 @@ class ReportActionCompose extends React.Component {
      * @param {string} newComment
      */
     updateComment(newComment) {
+        this.moveCursorToEnd = false;
+        this.setState({comment: newComment});
         saveReportComment(this.props.reportID, newComment || '');
     }
 
@@ -83,6 +89,8 @@ class ReportActionCompose extends React.Component {
 
     render() {
         const href = `${CONFIG.PUSHER.AUTH_URL}/report?reportID=${this.props.reportID}&shouldScrollToLastUnread=true`;
+        const check = this.state.comment;
+        const comment = this.props.comment;
         return (
             <View style={[styles.chatItemCompose]}>
                 <View style={[styles.chatItemComposeBox, styles.flexRow]}>
@@ -105,7 +113,7 @@ class ReportActionCompose extends React.Component {
                         onChangeText={this.updateComment}
                         onKeyPress={this.triggerSubmitShortcut}
                         style={[styles.textInput, styles.textInputCompose, styles.flex4]}
-                        value={this.props.comment || ''}
+                        value={comment}
                         maxLines={16} // This is the same that slack has
                     />
                     <TouchableOpacity

--- a/src/page/home/report/ReportActionCompose.js
+++ b/src/page/home/report/ReportActionCompose.js
@@ -32,10 +32,28 @@ class ReportActionCompose extends React.Component {
     constructor(props) {
         super(props);
 
-        this.updateComment = _.debounce(this.updateComment.bind(this), 1000, false);
+        this.updateComment = this.updateComment.bind(this);
+        this.debouncedSaveReportComment = _.debounce(this.debouncedSaveReportComment.bind(this), 1000, false);
         this.submitForm = this.submitForm.bind(this);
         this.triggerSubmitShortcut = this.triggerSubmitShortcut.bind(this);
         this.submitForm = this.submitForm.bind(this);
+        this.comment = '';
+    }
+
+    componentDidUpdate(prevProps) {
+        if (this.props.comment && prevProps.comment === '' && prevProps.comment !== this.props.comment) {
+            this.comment = this.props.comment;
+        }
+    }
+
+    /**
+     * Save our report comment in Ion. We debounce this method in the constructor so that it's not called too often
+     * to update Ion and re-render this component.
+     *
+     * @param {string} comment
+     */
+    debouncedSaveReportComment(comment) {
+        saveReportComment(this.props.reportID, comment || '');
     }
 
     /**
@@ -44,7 +62,8 @@ class ReportActionCompose extends React.Component {
      * @param {string} newComment
      */
     updateComment(newComment) {
-        saveReportComment(this.props.reportID, newComment || '');
+        this.comment = newComment;
+        this.debouncedSaveReportComment(newComment);
     }
 
     /**
@@ -72,7 +91,7 @@ class ReportActionCompose extends React.Component {
 
         // Let's get the data directly from textInput because saving the data in Ion report comment is asynchronous
         // so if we refer this.props.comment here we won't get the most recent value if the user types fast.
-        const trimmedComment = this.textInput.value.trim();
+        const trimmedComment = this.comment.trim();
 
         // Don't submit empty comments
         // @TODO show an error in the UI

--- a/src/page/home/report/ReportActionCompose.js
+++ b/src/page/home/report/ReportActionCompose.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {View, Image, TouchableOpacity} from 'react-native';
+import _ from 'underscore';
 import styles, {colors} from '../../../style/StyleSheet';
 import TextInputFocusable from '../../../components/TextInputFocusable';
 import sendIcon from '../../../../assets/images/icon-send.png';

--- a/src/page/home/report/ReportActionCompose.js
+++ b/src/page/home/report/ReportActionCompose.js
@@ -32,7 +32,7 @@ class ReportActionCompose extends React.Component {
     constructor(props) {
         super(props);
 
-        this.updateComment = this.updateComment.bind(this);
+        this.updateComment = _.debounce(this.updateComment.bind(this), 1000, false);
         this.submitForm = this.submitForm.bind(this);
         this.triggerSubmitShortcut = this.triggerSubmitShortcut.bind(this);
         this.submitForm = this.submitForm.bind(this);
@@ -70,11 +70,9 @@ class ReportActionCompose extends React.Component {
             e.preventDefault();
         }
 
-        if (!this.props.comment) {
-            return;
-        }
-
-        const trimmedComment = this.props.comment.trim();
+        // Let's get the data directly from textInput because saving the data in Ion report comment is asynchronous
+        // so if we refer this.props.comment here we won't get the most recent value if the user types fast.
+        const trimmedComment = this.textInput.value.trim();
 
         // Don't submit empty comments
         // @TODO show an error in the UI

--- a/src/page/home/report/ReportActionCompose.js
+++ b/src/page/home/report/ReportActionCompose.js
@@ -41,7 +41,7 @@ class ReportActionCompose extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
-        // The first time the component loads the props is emptry and the next time it may contain value.
+        // The first time the component loads the props is empty and the next time it may contain value.
         // If it does let's update this.comment so that it matches the defaultValue that we show in textInput.
         if (this.props.comment && prevProps.comment === '' && prevProps.comment !== this.props.comment) {
             this.comment = this.props.comment;

--- a/src/page/home/report/ReportActionCompose.js
+++ b/src/page/home/report/ReportActionCompose.js
@@ -70,6 +70,10 @@ class ReportActionCompose extends React.Component {
             e.preventDefault();
         }
 
+        if (!this.props.comment) {
+            return;
+        }
+
         const trimmedComment = this.props.comment.trim();
 
         // Don't submit empty comments
@@ -79,6 +83,7 @@ class ReportActionCompose extends React.Component {
         }
 
         this.props.onSubmit(trimmedComment);
+        this.textInput.clear();
         this.updateComment('');
     }
 
@@ -102,8 +107,9 @@ class ReportActionCompose extends React.Component {
                         multiline
                         textAlignVertical="top"
                         placeholder="Write something..."
+                        ref={el => this.textInput = el}
                         placeholderTextColor={colors.textSupporting}
-                        onChangeText={_.debounce(this.updateComment, 1000)}
+                        onChangeText={this.updateComment}
                         onKeyPress={this.triggerSubmitShortcut}
                         style={[styles.textInput, styles.textInputCompose, styles.flex4]}
                         defaultValue={this.props.comment || ''}

--- a/src/page/home/report/ReportActionCompose.js
+++ b/src/page/home/report/ReportActionCompose.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import _ from 'underscore';
 import {View, Image, TouchableOpacity} from 'react-native';
 import styles, {colors} from '../../../style/StyleSheet';
 import TextInputFocusable from '../../../components/TextInputFocusable';

--- a/src/page/home/report/ReportActionCompose.js
+++ b/src/page/home/report/ReportActionCompose.js
@@ -41,6 +41,8 @@ class ReportActionCompose extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
+        // The first time the component loads the props is emptry and the next time it may contain value.
+        // If it does let's update this.comment so that it matches the defaultValue that we show in textInput.
         if (this.props.comment && prevProps.comment === '' && prevProps.comment !== this.props.comment) {
             this.comment = this.props.comment;
         }


### PR DESCRIPTION
# Fixes
https://github.com/Expensify/ReactNativeChat/issues/457

# Tests
1. Write up a message. Click in the middle of the message. Type out something and confirm the cursor doesn't automatically move to the end.
1. Type out a really long message such that the input box handles multiple lines. Refresh and confirm the message remains and its multiline
1. Type out a message really fast and click send. Confirm it gets sent just fine and the input box is empty.
1. On the mobile app type out a message and confirm you can type quickly.
1. On the mobile app center your cursor in the middle of the text and type out and confirm its working normally.