### PR TITLE
Add hack to improve scroll performance on Android

### DIFF
--- a/src/page/home/report/ReportActionItemFragment.js
+++ b/src/page/home/report/ReportActionItemFragment.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import HTML from 'react-native-render-html';
-import {Linking} from 'react-native';
+import {Linking, Platform} from 'react-native';
 import Str from '../../../lib/Str';
 import ReportActionFragmentPropTypes from './ReportActionFragmentPropTypes';
 import styles, {webViewStyles} from '../../../style/StyleSheet';
@@ -61,7 +61,9 @@ class ReportActionItemFragment extends React.PureComponent {
                 return fragment.html !== fragment.text
                     ? (
                         <HTML
-                            textSelectable
+
+                            // HACK - Android selection causes performance issues, temporarily disable it until we fix
+                            textSelectable={Platform.OS !== 'android'}
                             renderers={this.customRenderers}
                             baseFontStyle={webViewStyles.baseFontStyle}
                             tagsStyles={webViewStyles.tagStyles}
@@ -70,11 +72,21 @@ class ReportActionItemFragment extends React.PureComponent {
                             alterNode={this.alterNode}
                         />
                     )
-                    : <Text selectable>{Str.htmlDecode(fragment.text)}</Text>;
+                    : (
+                        <Text
+
+                            // HACK - Android selection causes performance issues, temporarily disable it until we fix
+                            selectable={Platform.OS !== 'android'}
+                        >
+                            {Str.htmlDecode(fragment.text)}
+                        </Text>
+                    );
             case 'TEXT':
                 return (
                     <Text
-                        selectable
+
+                        // HACK - Android selection causes performance issues, temporarily disable it until we fix
+                        selectable={Platform.OS !== 'android'}
                         style={[styles.chatItemMessageHeaderSender]}
                     >
                         {Str.htmlDecode(fragment.text)}


### PR DESCRIPTION
cc @Julesssss - Adding a quick hack to get Android scroll performance working again.

Related https://github.com/Expensify/ReactNativeChat/issues/456

### Tests
1. Run on Android with this branch, verify scrolling on a chat is fast
2. Run on Android with `master`, verify scrolling is very slow