### PR TITLE
Replace pathForProps by giving `key` a function option

### DIFF
--- a/src/components/withIon.js
+++ b/src/components/withIon.js
@@ -5,8 +5,6 @@
  */
 import React from 'react';
 import _ from 'underscore';
-import lodashGet from 'lodash.get';
-import lodashHas from 'lodash.has';
 import Ion from '../lib/Ion';
 
 /**

--- a/src/components/withIon.js
+++ b/src/components/withIon.js
@@ -65,6 +65,8 @@ export default function (mapIonToState) {
              * Takes a single mapping and binds the state of the component to the store
              *
              * @param {object} mapping
+             * @param {string|function} mapping.key key to connect to. can be a string or a function that takes this.props
+             * as an argument and returns a string
              * @param {string} statePropertyName the name of the state property that Ion will add the data to
              * @param {string} [mapping.indexBy] the name of the ID property to use for the collection
              * @param {boolean} [mapping.initWithStoredValues] If set to false, then no data will be prefilled into the

--- a/src/page/home/HeaderView.js
+++ b/src/page/home/HeaderView.js
@@ -59,12 +59,9 @@ export default compose(
     withIon({
         // Map this.props.reportName to the data for a specific report in the store,
         // and bind it to the reportName property.
-        // It uses the data returned from the props path (ie. the reportID) to replace %DATAFROMPROPS% in the key it
-        // binds to
         reportName: {
-            key: `${IONKEYS.REPORT}_%DATAFROMPROPS%`,
+            key: ({match}) => `${IONKEYS.REPORT}_${match.params.reportID}`,
             path: 'reportName',
-            pathForProps: 'match.params.reportID',
         },
     }),
 )(HeaderView);

--- a/src/page/home/report/ReportActionCompose.js
+++ b/src/page/home/report/ReportActionCompose.js
@@ -129,7 +129,7 @@ ReportActionCompose.defaultProps = defaultProps;
 
 export default withIon({
     comment: {
-        key: `${IONKEYS.REPORT_DRAFT_COMMENT}_%DATAFROMPROPS%`,
+        key: ({reportID}) => `${IONKEYS.REPORT_DRAFT_COMMENT}_${reportID}`,
         pathForProps: 'reportID',
     },
 })(ReportActionCompose);

--- a/src/page/home/report/ReportActionCompose.js
+++ b/src/page/home/report/ReportActionCompose.js
@@ -130,6 +130,5 @@ ReportActionCompose.defaultProps = defaultProps;
 export default withIon({
     comment: {
         key: ({reportID}) => `${IONKEYS.REPORT_DRAFT_COMMENT}_${reportID}`,
-        pathForProps: 'reportID',
     },
 })(ReportActionCompose);

--- a/src/page/home/report/ReportActionsView.js
+++ b/src/page/home/report/ReportActionsView.js
@@ -180,15 +180,11 @@ class ReportActionsView extends React.Component {
 ReportActionsView.propTypes = propTypes;
 ReportActionsView.defaultProps = defaultProps;
 
-const key = `${IONKEYS.REPORT_ACTIONS}_%DATAFROMPROPS%`;
 export default compose(
     withRouter,
     withIon({
         reportActions: {
-            key,
-            loader: fetchActions,
-            loaderParams: ['%DATAFROMPROPS%'],
-            pathForProps: 'reportID',
+            key: ({reportID}) => `${IONKEYS.REPORT_ACTIONS}_${reportID}`,
         },
     }),
 )(ReportActionsView);

--- a/src/page/home/sidebar/SidebarLink.js
+++ b/src/page/home/sidebar/SidebarLink.js
@@ -64,10 +64,9 @@ export default compose(
     withRouter,
     withIon({
         isUnread: {
-            key: `${IONKEYS.REPORT}_%DATAFROMPROPS%`,
+            key: ({reportID}) => `${IONKEYS.REPORT}_${reportID}`,
             path: 'hasUnread',
             defaultValue: false,
-            pathForProps: 'reportID',
         }
     }),
 )(SidebarLink);


### PR DESCRIPTION
Small improvement to simplify `withIon` and allowing the `key` config option to be a function

This isn't urgent and can wait.

The main motivation here is that it would be best to pass as few options to `withIon` as possible. Using a function that returns a string feels more intuitive than the `pathForProps/%DATAFROMPROPS%`. It achieves the same thing but in a slightly clearer way.

cc @tgolen 