### PR TITLE
Add reconnect logic for Pusher

### DIFF
--- a/src/lib/API.js
+++ b/src/lib/API.js
@@ -263,6 +263,16 @@ function processNetworkRequestQueue() {
 setInterval(processNetworkRequestQueue, 1000);
 
 /**
+ * Pusher.reconnect() calls disconnect and connect on the
+ * Pusher socket. In some cases, the authorizer might fail
+ * or an error will be returned due to an out of date authToken.
+ * Reconnect will preserve our existing subscriptions and retry
+ * connecting until it succeeds. We're throttling this call so
+ * that we retry as few times as possible.
+ */
+const reconnectToPusher = _.throttle(Pusher.reconnect, 1000);
+
+/**
  * When authTokens expire they will automatically be refreshed.
  * The authorizer helps make sure that we are always passing the
  * current valid token to generate the signed auth response
@@ -284,6 +294,7 @@ Pusher.registerCustomAuthorizer((channel, {authEndpoint}) => ({
             .then(authResponse => authResponse.json())
             .then(data => callback(null, data))
             .catch((err) => {
+                reconnectToPusher();
                 console.debug('[Network] Failed to authorize Pusher');
                 callback(new Error(`Error calling auth endpoint: ${err}`));
             });
@@ -310,6 +321,9 @@ Pusher.registerSocketEventCallback((eventName, data) => {
             if (data.current === 'connecting' || data.current === 'unavailable') {
                 isCurrentlyOffline = true;
             }
+            break;
+        case 'error':
+            reconnectToPusher();
             break;
         default:
             break;

--- a/src/lib/Pusher/pusher.js
+++ b/src/lib/Pusher/pusher.js
@@ -354,6 +354,14 @@ function disconnect() {
     socket = null;
 }
 
+/**
+ * Disconnect and Re-Connect Pusher
+ */
+function reconnect() {
+    socket.disconnect();
+    socket.connect();
+}
+
 if (window) {
     /**
      * Pusher socket for debugging purposes
@@ -376,4 +384,5 @@ export {
     registerSocketEventCallback,
     registerCustomAuthorizer,
     disconnect,
+    reconnect,
 };


### PR DESCRIPTION
cc @tgolen @chiragsalian 

Fixes: https://github.com/Expensify/ReactNativeChat/issues/465

I think this should fix just about every possible Pusher failure to subscribe or connect scenario when there is or will eventually be a good `authToken`.

**Tests**
1. Set up 5 second authTokens to simulate expiry
1. Log into RNC and verify you are able to subscribe `window.getPusherInstance()` look at channels etc
1. Turn off WiFi
1. Wait until you see the Pusher errors and see the state change to "unavailable"
1. Turn on WiFi
1. Wait until you are successfully re-authenticated and errors stop streaming the logs
1. Check the Pusher instance again and verify you are subscribed.