### PR TITLE
Render components only after we have collected the Ion props

### DIFF
--- a/src/components/withIon.js
+++ b/src/components/withIon.js
@@ -60,8 +60,10 @@ export default function (mapIonToState) {
                     }
                 });
 
-                if (this.state.loading && _.every(_.keys(mapIonToState), (key) => this.state[key])) {
-                    // Make sure each Ion key we requested has been set to state with a value of some kind
+                // Make sure each Ion key we requested has been set to state with a value of some kind.
+                // We are doing this so that the wrapped component will only render when all the data
+                // it needs is available to it.
+                if (this.state.loading && _.every(_.keys(mapIonToState), key => this.state[key])) {
                     this.setState({loading: false});
                 }
             }

--- a/src/components/withIon.js
+++ b/src/components/withIon.js
@@ -120,11 +120,9 @@ export default function (mapIonToState) {
                     return null;
                 }
 
-                const stateToPass = {
-                    ...this.state,
-                };
-
-                delete stateToPass.loading;
+                // Remove any internal state properties used by withIon
+                // that should not be passed to a wrapped component.
+                const stateToPass = _.omit(this.state, 'loading');
 
                 // Spreading props and state is necessary in an HOC where the data cannot be predicted
                 return (
@@ -132,7 +130,7 @@ export default function (mapIonToState) {
                         // eslint-disable-next-line react/jsx-props-no-spreading
                         {...this.props}
                         // eslint-disable-next-line react/jsx-props-no-spreading
-                        {...this.state}
+                        {...stateToPass}
                     />
                 );
             }

--- a/src/components/withIon.js
+++ b/src/components/withIon.js
@@ -80,7 +80,7 @@ export default function (mapIonToState) {
                 }
 
                 // Filter all keys by those which we do want to init with stored values
-                // since key's that are configured to not init with stored values will
+                // since keys that are configured to not init with stored values will
                 // never appear on state when the component mounts - only after they update
                 // organically.
                 const requiredKeysForInit = _.chain(mapIonToState)
@@ -93,7 +93,7 @@ export default function (mapIonToState) {
                     .keys()
                     .value();
 
-                // All state keys should must exist and should at least be null
+                // All state keys should exist and at least have a value of null
                 if (_.every(requiredKeysForInit, key => !_.isUndefined(this.state[key]))) {
                     this.setState({loading: false});
                 }
@@ -148,7 +148,7 @@ export default function (mapIonToState) {
                 }
 
                 // Remove any internal state properties used by withIon
-                // that should not be passed to a wrapped component.
+                // that should not be passed to a wrapped component
                 const stateToPass = _.omit(this.state, 'loading');
 
                 // Spreading props and state is necessary in an HOC where the data cannot be predicted

--- a/src/components/withIon.js
+++ b/src/components/withIon.js
@@ -84,12 +84,7 @@ export default function (mapIonToState) {
                 // never appear on state when the component mounts - only after they update
                 // organically.
                 const requiredKeysForInit = _.chain(mapIonToState)
-                    .reduce((prev, curr, key) => {
-                        if (curr.initWithStoredValues === false) {
-                            return prev;
-                        }
-                        return ({...prev, [key]: curr});
-                    }, {})
+                    .omit(config => config.initWithStoredValues === false)
                     .keys()
                     .value();
 

--- a/src/components/withIon.js
+++ b/src/components/withIon.js
@@ -67,10 +67,22 @@ export default function (mapIonToState) {
                 _.each(this.activeConnectionIDsWithPropsData, Ion.disconnect);
             }
 
-            propsDidLoad() {
-                if (_.size(this.actionConnectionIDs) + _.size(this.activeConnectionIDsWithPropsData) === _.size(mapIonToState)) {
-                    this.setState({loading: false});
+            /**
+             * Compares the total number of connections with the total
+             * number of Ion keys mapped to state. When we have them all
+             * we are ready to render the component.
+             */
+            checkAndUpdateLoading() {
+                const totalConnectionSize = _.size({
+                    ...this.actionConnectionIDs,
+                    ...this.activeConnectionIDsWithPropsData
+                });
+
+                if (totalConnectionSize !== _.size(mapIonToState)) {
+                    return;
                 }
+
+                this.setState({loading: false});
             }
 
             /**
@@ -107,15 +119,15 @@ export default function (mapIonToState) {
                     // Store the connectionID with a key that is unique to the data coming from the props which allows
                     // it to be easily reconnected to when the props change
                     Ion.connect(ionConnectionConfig)
-                        .then(connectionID => {
+                        .then((connectionID) => {
                             this.activeConnectionIDsWithPropsData[mapping.pathForProps] = connectionID;
-                            this.propsDidLoad();
+                            this.checkAndUpdateLoading();
                         });
                 } else {
                     Ion.connect(ionConnectionConfig)
-                        .then(connectionID => {
+                        .then((connectionID) => {
                             this.actionConnectionIDs[connectionID] = connectionID;
-                            this.propsDidLoad();
+                            this.checkAndUpdateLoading();
                         });
                 }
             }

--- a/src/components/withIon.js
+++ b/src/components/withIon.js
@@ -75,20 +75,27 @@ export default function (mapIonToState) {
              * it needs is available to it.
              */
             checkAndUpdateLoading() {
-                if (this.state.loading) {
-                    const requiredKeysForInit = _.chain(mapIonToState)
-                        .reduce((prev, curr, key) => {
-                            if (curr.initWithStoredValues === false) {
-                                return prev;
-                            }
-                            return ({...prev, [key]: curr});
-                        }, {})
-                        .keys()
-                        .value();
+                if (!this.state.loading) {
+                    return;
+                }
 
-                    if (_.every(requiredKeysForInit, key => !_.isUndefined(this.state[key]))) {
-                        this.setState({loading: false});
-                    }
+                // Filter all keys by those which we do want to init with stored values
+                // since key's that are configured to not init with stored values will
+                // never appear on state when the component mounts - only after they update
+                // organically.
+                const requiredKeysForInit = _.chain(mapIonToState)
+                    .reduce((prev, curr, key) => {
+                        if (curr.initWithStoredValues === false) {
+                            return prev;
+                        }
+                        return ({...prev, [key]: curr});
+                    }, {})
+                    .keys()
+                    .value();
+
+                // All state keys should must exist and should at least be null
+                if (_.every(requiredKeysForInit, key => !_.isUndefined(this.state[key]))) {
+                    this.setState({loading: false});
                 }
             }
 

--- a/src/lib/Ion.js
+++ b/src/lib/Ion.js
@@ -117,11 +117,11 @@ function connect(mapping) {
     callbackToStateMapping[connectionID] = config;
 
     if (mapping.initWithStoredValues === false) {
-        return Promise.resolve(connectionID);
+        connectionID;
     }
 
     // Get all the data from Ion to initialize the connection with
-    return AsyncStorage.getAllKeys()
+    AsyncStorage.getAllKeys()
         .then((keys) => {
             // Find all the keys matched by the config regex
             const matchingKeys = _.filter(keys, config.regex.test.bind(config.regex));
@@ -139,17 +139,21 @@ function connect(mapping) {
             // React components or callbacks should only have a single data change published
             // to them.
             if (config.indexBy) {
-                return Promise.all(_.map(matchingKeys, key => get(key)))
+                Promise.all(_.map(matchingKeys, key => get(key)))
                     .then(values => _.reduce(values, (finalObject, value) => ({
                         ...finalObject,
                         [value[config.indexBy]]: value,
                     }), {}))
                     .then(val => sendDataToConnection(config, val));
+                return;
             }
 
-            return Promise.all(_.map(matchingKeys, key => get(key).then(val => sendDataToConnection(config, val, key))));
-        })
-        .then(() => connectionID);
+            _.each(matchingKeys, (key) => {
+                get(key).then(val => sendDataToConnection(config, val, key));
+            });
+        });
+
+    return connectionID;
 }
 
 /**

--- a/src/lib/Ion.js
+++ b/src/lib/Ion.js
@@ -117,7 +117,7 @@ function connect(mapping) {
     callbackToStateMapping[connectionID] = config;
 
     if (mapping.initWithStoredValues === false) {
-        connectionID;
+        return connectionID;
     }
 
     // Get all the data from Ion to initialize the connection with
@@ -146,11 +146,11 @@ function connect(mapping) {
                     }), {}))
                     .then(val => sendDataToConnection(config, val));
                 return;
+            } else {
+                _.each(matchingKeys, (key) => {
+                    get(key).then(val => sendDataToConnection(config, val, key));
+                });
             }
-
-            _.each(matchingKeys, (key) => {
-                get(key).then(val => sendDataToConnection(config, val, key));
-            });
         });
 
     return connectionID;

--- a/src/lib/Ion.js
+++ b/src/lib/Ion.js
@@ -145,7 +145,6 @@ function connect(mapping) {
                         [value[config.indexBy]]: value,
                     }), {}))
                     .then(val => sendDataToConnection(config, val));
-                return;
             } else {
                 _.each(matchingKeys, (key) => {
                     get(key).then(val => sendDataToConnection(config, val, key));


### PR DESCRIPTION
This PR is an attempt to solve the problem of all connected React components rendering without any initial data from the Ion. It achieves this without the addition of a memory cache and all other `Ion.connect()` usages and subscribers will remain untouched.

As far as I can tell, there seem to be no performance impact here and there is not much difference between first getting this data from storage and loading it with a single call to render vs. mounting the component and then rendering many times as data is sent back to each connection.

The main change is that a component connected `withIon` will take the Ion props along with it for the first render. I think this is a really important change to make early on because: 

1. Not doing this will cause hacks around `componentDidUpdate()` to replace prop handling logic done in `componentDidMount()` or the `constructor()`
2. We can stop worrying about what props exist or don't exist in components for the first lifecycle method. If the component renders with a `null` prop for any value then there is no key for that value. It won't first render with `undefined` then appear to be `null` so we can get more value out of things like `propTypes` and write less confusing code.

cc @tgolen and cc @chiragsalian who just [ran into an issue related to initial props being unknown](https://github.com/Expensify/ReactNativeChat/blob/ed8551f16a195c82dda7f518394037c637ac55c6/src/page/home/report/ReportActionCompose.js#L43-L49)

Curious to hear everyone's thoughts on this. This is my best attempt at staying respectful of the Ion philosophy while also keeping React best practices in mind.