### PR TITLE
Fix loading screen background

### DIFF
--- a/src/style/StyleSheet.js
+++ b/src/style/StyleSheet.js
@@ -222,6 +222,7 @@ const styles = {
 
     genericView: {
         backgroundColor: colors.heading,
+        height: '100%',
     },
 
     signInPageInner: {


### PR DESCRIPTION
We added an interstitial background page but it shows up as white since it has no height. This PR just adds height to it.

Fixes: https://github.com/Expensify/ReactNativeChat/issues/229

Test
1. Log out
1. Navigate to the site root
1. Verify the page that briefly shows before the Sign In form is not white and matches the background of the sign in page