### PR TITLE
Enabling iPad

### DIFF
--- a/ios/ReactNativeChat.xcodeproj/project.pbxproj
+++ b/ios/ReactNativeChat.xcodeproj/project.pbxproj
@@ -496,6 +496,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = chat_expensify_appstore;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -522,6 +523,7 @@
 				PRODUCT_NAME = Chat;
 				PROVISIONING_PROFILE_SPECIFIER = chat_expensify_appstore;
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "android": "react-native run-android",
     "ios": "react-native run-ios",
+    "ipad": "react-native run-ios --simulator=\"iPad Pro (12.9-inch) (4th generation)\"",
     "desktop": "webpack --config webpack.dev.js && electron main.js",
     "start": "react-native start",
     "web": "webpack-dev-server --open --config webpack.dev.js",


### PR DESCRIPTION
fixes: https://github.com/Expensify/ReactNativeChat/issues/409

### Enables iPad.

### Tests:
1. run the app from the ios folder by using this script `npm run ipad`
1. Verify that the app takes the entire screen and does not frame an iPhone screen inside the ipad screen.