### PR TITLE
Handle additional Pusher connection state_change events

### DIFF
--- a/src/lib/API.js
+++ b/src/lib/API.js
@@ -318,7 +318,13 @@ Pusher.registerSocketEventCallback((eventName, data) => {
             isCurrentlyOffline = true;
             break;
         case 'state_change':
-            if (data.current === 'connecting' || data.current === 'unavailable') {
+            if (data.current === 'failed') {
+                // WebSockets are not natively available. In this case,
+                // we should not let Pusher influence the offline state of the app.
+                return;
+            }
+
+            if (data.current === 'disconnected' || data.current === 'connecting' || data.current === 'unavailable') {
                 isCurrentlyOffline = true;
             }
             break;


### PR DESCRIPTION
**Fixes:** https://github.com/Expensify/ReactNativeChat/issues/504

**Tests:**

The main test I did here was to just log out when the reconnection callback fire here:

https://github.com/Expensify/ReactNativeChat/blob/12df2846f0954b0456b09a831a0bcf21fe8ff557/src/lib/API.js#L35-L41

1. On `master` add a `console.log` in the place above
1. Put your laptop to sleep by going to ` > Sleep`
1. Wait until the super loud MacBook Pro fan shuts off to indicate that your computer is _really_ asleep
1. Wake up the laptop 
1. Verify that no `console.log` occurred

Retest on this branch and verify the `console.log` does occur proving that we polled for missed data when the computer wakes up.