### PR TITLE
Fix duplicate browser notifications again!

### DIFF
--- a/src/components/withIon.js
+++ b/src/components/withIon.js
@@ -96,8 +96,9 @@ export default function (mapIonToState) {
              * Takes a single mapping and binds the state of the component to the store
              *
              * @param {object} mapping
-             * @param {string|function} mapping.key key to connect to. can be a string or a function that takes this.props
-             * as an argument and returns a string
+             * @param {string|function} mapping.key key to connect to. can be a string or a
+             * function that takes this.props as an argument and returns a string
+             *
              * @param {string} statePropertyName the name of the state property that Ion will add the data to
              * @param {boolean} [mapping.initWithStoredValues] If set to false, then no data will be prefilled into the
              *  component

--- a/src/lib/Pusher/pusher.js
+++ b/src/lib/Pusher/pusher.js
@@ -1,4 +1,5 @@
 import _ from 'underscore';
+import Str from '../Str';
 import Pusher from './library';
 import CONFIG from '../../CONFIG';
 
@@ -358,8 +359,40 @@ function disconnect() {
  * Disconnect and Re-Connect Pusher
  */
 function reconnect() {
+    // A standard disconnect and connect will result in
+    // multiple event callbacks (possible Pusher bug).
+    // In order to re-bind our reportCommment event cleanly
+    // we must save a reference to them then disconnect,
+    // connect, and re-bind them manually.
     socket.disconnect();
+
+    // Find the callback in Pusher's event map and save it
+    let commentCallback;
+    _.each(socket.allChannels(), (channel) => {
+        if (channel.name === Str.startsWith(channel.name, 'private-user-accountID')) {
+            // eslint-disable-next-line no-underscore-dangle
+            const reportCommentCallbacks = channel.callbacks._callbacks._reportComment;
+            if (reportCommentCallbacks) {
+                const [firstReportCommentCallback] = reportCommentCallbacks;
+                commentCallback = firstReportCommentCallback.fn;
+            }
+        }
+    });
+
     socket.connect();
+
+    // If we have a callback saved then we must manually unbind
+    // that event AFTER we have connected. Pusher will create
+    // n duplicate event callbacks for each call to socket.connect().
+    // This seems like a bug with Pusher's library.
+    if (commentCallback) {
+        _.each(socket.allChannels(), (channel) => {
+            if (channel.name === Str.startsWith(channel.name, 'private-user-accountID')) {
+                channel.unbind('reportComment');
+                channel.bind('reportComment', commentCallback);
+            }
+        });
+    }
 }
 
 if (window) {


### PR DESCRIPTION
**Fixes:** https://github.com/Expensify/ReactNativeChat/issues/474

At first I thought Pusher's API was broken, but this is caused by something we did 😅 

**Tests:**

1. `getPusherInstance().disconnect()`
1. `getPusherInstance().connect()`
1. `getPusherInstance().allChannels()[0].callbacks`
1. **_Verify_** `_reportComment` only has one callback (it will have 2 on `master`)

<img width="596" alt="Screenshot 1364" src="https://user-images.githubusercontent.com/32969087/93634518-96043680-f9a5-11ea-8263-f74516478271.png">

