### PR TITLE
Add a focused style to the composer box

### DIFF
--- a/src/components/TextInputFocusable/index.js
+++ b/src/components/TextInputFocusable/index.js
@@ -43,8 +43,6 @@ class TextInputFocusable extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
-        this.focusInput();
-
         if (prevProps.defaultValue !== this.props.defaultValue) {
             this.updateNumberOfLines();
         }

--- a/src/page/home/report/ReportActionCompose.js
+++ b/src/page/home/report/ReportActionCompose.js
@@ -144,7 +144,12 @@ class ReportActionCompose extends React.Component {
     render() {
         return (
             <View style={[styles.chatItemCompose]}>
-                <View style={[this.state.isFocused ? styles.chatItemComposeBoxFocused : styles.chatItemComposeBox, styles.flexRow]}>
+                <View style={[
+                    this.state.isFocused ? styles.chatItemComposeBoxFocusedColour : styles.chatItemComposeBoxColour,
+                    styles.chatItemComposeBox,
+                    styles.flexRow
+                ]}
+                >
                     <TouchableOpacity
                         onPress={this.showAttachmentPicker}
                         style={[styles.chatItemAttachButton]}

--- a/src/page/home/report/ReportActionCompose.js
+++ b/src/page/home/report/ReportActionCompose.js
@@ -36,7 +36,9 @@ class ReportActionCompose extends React.Component {
         this.triggerSubmitShortcut = this.triggerSubmitShortcut.bind(this);
         this.submitForm = this.submitForm.bind(this);
         this.showAttachmentPicker = this.showAttachmentPicker.bind(this);
+        this.focusTextInput = this.focusTextInput.bind(this);
         this.comment = '';
+        this.state = {isFocused: false};
     }
 
     componentDidUpdate(prevProps) {
@@ -45,6 +47,10 @@ class ReportActionCompose extends React.Component {
         if (this.props.comment && prevProps.comment === '' && prevProps.comment !== this.props.comment) {
             this.comment = this.props.comment;
         }
+    }
+
+    focusTextInput(shouldHighlight) {
+        this.setState({isFocused: shouldHighlight});
     }
 
     /**
@@ -138,7 +144,7 @@ class ReportActionCompose extends React.Component {
     render() {
         return (
             <View style={[styles.chatItemCompose]}>
-                <View style={[styles.chatItemComposeBox, styles.flexRow]}>
+                <View style={[this.state.isFocused ? styles.chatItemComposeBoxFocused : styles.chatItemComposeBox, styles.flexRow]}>
                     <TouchableOpacity
                         onPress={this.showAttachmentPicker}
                         style={[styles.chatItemAttachButton]}
@@ -161,6 +167,8 @@ class ReportActionCompose extends React.Component {
                         style={[styles.textInput, styles.textInputCompose, styles.flex4]}
                         defaultValue={this.props.comment || ''}
                         maxLines={16} // This is the same that slack has
+                        onFocus={() => this.focusTextInput(true)}
+                        onBlur={() => this.focusTextInput(false)}
                     />
                     <TouchableOpacity
                         style={[styles.chatItemSubmitButton, styles.buttonSuccess]}

--- a/src/page/home/report/ReportActionCompose.js
+++ b/src/page/home/report/ReportActionCompose.js
@@ -150,7 +150,7 @@ class ReportActionCompose extends React.Component {
         return (
             <View style={[styles.chatItemCompose]}>
                 <View style={[
-                    this.state.isFocused ? styles.chatItemComposeBoxFocusedColour : styles.chatItemComposeBoxColor,
+                    this.state.isFocused ? styles.chatItemComposeBoxFocusedColor : styles.chatItemComposeBoxColor,
                     styles.chatItemComposeBox,
                     styles.flexRow
                 ]}

--- a/src/page/home/report/ReportActionCompose.js
+++ b/src/page/home/report/ReportActionCompose.js
@@ -49,6 +49,11 @@ class ReportActionCompose extends React.Component {
         }
     }
 
+    /**
+     * updates the Highlight state of the composer
+     *
+     * @param {boolean} shouldHighlight
+     */
     focusTextInput(shouldHighlight) {
         this.setState({isFocused: shouldHighlight});
     }

--- a/src/page/home/report/ReportActionCompose.js
+++ b/src/page/home/report/ReportActionCompose.js
@@ -36,7 +36,7 @@ class ReportActionCompose extends React.Component {
         this.triggerSubmitShortcut = this.triggerSubmitShortcut.bind(this);
         this.submitForm = this.submitForm.bind(this);
         this.showAttachmentPicker = this.showAttachmentPicker.bind(this);
-        this.focusTextInput = this.focusTextInput.bind(this);
+        this.setIsFocused = this.setIsFocused.bind(this);
         this.comment = '';
         this.state = {isFocused: false};
     }
@@ -54,7 +54,7 @@ class ReportActionCompose extends React.Component {
      *
      * @param {boolean} shouldHighlight
      */
-    focusTextInput(shouldHighlight) {
+    setIsFocused(shouldHighlight) {
         this.setState({isFocused: shouldHighlight});
     }
 
@@ -177,8 +177,8 @@ class ReportActionCompose extends React.Component {
                         style={[styles.textInput, styles.textInputCompose, styles.flex4]}
                         defaultValue={this.props.comment || ''}
                         maxLines={16} // This is the same that slack has
-                        onFocus={() => this.focusTextInput(true)}
-                        onBlur={() => this.focusTextInput(false)}
+                        onFocus={() => this.setIsFocused(true)}
+                        onBlur={() => this.setIsFocused(false)}
                     />
                     <TouchableOpacity
                         style={[styles.chatItemSubmitButton, styles.buttonSuccess]}

--- a/src/page/home/report/ReportActionCompose.js
+++ b/src/page/home/report/ReportActionCompose.js
@@ -50,7 +50,7 @@ class ReportActionCompose extends React.Component {
     }
 
     /**
-     * updates the Highlight state of the composer
+     * Updates the Highlight state of the composer
      *
      * @param {boolean} shouldHighlight
      */
@@ -150,7 +150,7 @@ class ReportActionCompose extends React.Component {
         return (
             <View style={[styles.chatItemCompose]}>
                 <View style={[
-                    this.state.isFocused ? styles.chatItemComposeBoxFocusedColour : styles.chatItemComposeBoxColour,
+                    this.state.isFocused ? styles.chatItemComposeBoxFocusedColour : styles.chatItemComposeBoxColor,
                     styles.chatItemComposeBox,
                     styles.flexRow
                 ]}

--- a/src/style/StyleSheet.js
+++ b/src/style/StyleSheet.js
@@ -544,6 +544,14 @@ const styles = {
         minHeight: 40,
     },
 
+    chatItemComposeBoxFocused: {
+        backgroundColor: colors.componentBG,
+        borderWidth: 1,
+        borderColor: colors.blue,
+        borderRadius: 8,
+        minHeight: 40,
+    },
+
     textInputCompose: {
         borderWidth: 0,
         borderRadius: 0,

--- a/src/style/StyleSheet.js
+++ b/src/style/StyleSheet.js
@@ -536,18 +536,17 @@ const styles = {
         display: 'flex',
     },
 
+    chatItemComposeBoxColour: {
+        borderColor: colors.border,
+    },
+
+    chatItemComposeBoxFocusedColour: {
+        borderColor: colors.blue,
+    },
+
     chatItemComposeBox: {
         backgroundColor: colors.componentBG,
         borderWidth: 1,
-        borderColor: colors.border,
-        borderRadius: 8,
-        minHeight: 40,
-    },
-
-    chatItemComposeBoxFocused: {
-        backgroundColor: colors.componentBG,
-        borderWidth: 1,
-        borderColor: colors.blue,
         borderRadius: 8,
         minHeight: 40,
     },

--- a/src/style/StyleSheet.js
+++ b/src/style/StyleSheet.js
@@ -540,7 +540,7 @@ const styles = {
         borderColor: colors.border,
     },
 
-    chatItemComposeBoxFocusedColour: {
+    chatItemComposeBoxFocusedColor: {
         borderColor: colors.blue,
     },
 
@@ -659,7 +659,6 @@ const styles = {
     chatSwitcherItemText: {
         color: colors.text,
     },
-    ReportActionCompose.js
     chatSwitcherItemFocused: {
         backgroundColor: colors.blue,
         borderRadius: 8,

--- a/src/style/StyleSheet.js
+++ b/src/style/StyleSheet.js
@@ -536,7 +536,7 @@ const styles = {
         display: 'flex',
     },
 
-    chatItemComposeBoxColour: {
+    chatItemComposeBoxColor: {
         borderColor: colors.border,
     },
 
@@ -659,7 +659,7 @@ const styles = {
     chatSwitcherItemText: {
         color: colors.text,
     },
-
+    ReportActionCompose.js
     chatSwitcherItemFocused: {
         backgroundColor: colors.blue,
         borderRadius: 8,

--- a/src/style/StyleSheet.js
+++ b/src/style/StyleSheet.js
@@ -659,6 +659,7 @@ const styles = {
     chatSwitcherItemText: {
         color: colors.text,
     },
+    
     chatSwitcherItemFocused: {
         backgroundColor: colors.blue,
         borderRadius: 8,

--- a/src/style/StyleSheet.js
+++ b/src/style/StyleSheet.js
@@ -659,7 +659,7 @@ const styles = {
     chatSwitcherItemText: {
         color: colors.text,
     },
-    
+
     chatSwitcherItemFocused: {
         backgroundColor: colors.blue,
         borderRadius: 8,


### PR DESCRIPTION
fixes: https://github.com/Expensify/Expensify/issues/141643

### Problem
the composer text input should have a focused style

### Tests

1. Tap the composer and verify that it becomes Blue
1. Tap outside the composer and verify that it unfocus and it becomes grey
1. Make sure to test the native Android and iOS as well.