### PR TITLE
Fix chat switcher enter keypress

### DIFF
--- a/src/page/home/sidebar/ChatSwitcherView.js
+++ b/src/page/home/sidebar/ChatSwitcherView.js
@@ -152,11 +152,13 @@ class ChatSwitcherView extends React.Component {
      */
     handleKeyPress(e) {
         let newFocusedIndex;
+        let option;
 
         switch (e.key) {
             case 'Enter':
-                // Select the focused option
-                this.fetchChatReportAndRedirect(this.state.options[this.state.focusedIndex]);
+                // Call the selected option's callback and pass the option itself
+                option = this.state.options[this.state.focusedIndex];
+                option.callback(option);
                 e.preventDefault();
                 break;
 

--- a/src/page/home/sidebar/ChatSwitcherView.js
+++ b/src/page/home/sidebar/ChatSwitcherView.js
@@ -318,8 +318,7 @@ export default withIon({
         key: IONKEYS.PERSONAL_DETAILS,
     },
     reports: {
-        key: `${IONKEYS.REPORT}_[0-9]+$`,
-        indexBy: 'reportID',
+        key: IONKEYS.COLLECTION.REPORT
     },
     session: {
         key: IONKEYS.SESSION,


### PR DESCRIPTION
Coming from https://github.com/Expensify/ReactNativeChat/pull/439#issuecomment-697022266

This pr updates the enter keypress to use the option's callback instead of fetchChatReportAndReDirect which no longer exists.
It also updates the key in withIon to correctly get the reports prop

Tested by making sure that chat rooms were showing up in the switcher, and that I could use the enter key for both types of rooms without errors