### PR TITLE
Expensify Chat: Minimize window via command + w and close via command + q

### DIFF
--- a/main.js
+++ b/main.js
@@ -62,6 +62,20 @@ const mainWindow = (() => {
                 return shell.openExternal(url);
             });
 
+            // Flag to determine is user is trying to quit the whole application altogether
+            let quitting = false;
+
+            // Closing the chat window should just hide it (vs. fully quitting the application)
+            browserWindow.on("close", (evt) => {
+                if (!quitting) {
+                    evt.preventDefault();
+                    browserWindow.minimize();
+                }
+            });
+
+            app.on('before-quit', () => quitting = true);
+            app.on('activate', () => browserWindow.show());
+
             ipcMain.on('request-visibility', (event) => {
                 // This is how synchronous messages work in Electron
                 // eslint-disable-next-line no-param-reassign

--- a/main.js
+++ b/main.js
@@ -66,7 +66,7 @@ const mainWindow = (() => {
             let quitting = false;
 
             // Closing the chat window should just hide it (vs. fully quitting the application)
-            browserWindow.on("close", (evt) => {
+            browserWindow.on('close', (evt) => {
                 if (!quitting) {
                     evt.preventDefault();
                     browserWindow.minimize();


### PR DESCRIPTION
Let's mirror Slack's behavior! `Command + w` will minimize the chat window instead of closing it, `Command + q` will quit the Expensify Chat app entirely 👍 

Fixes https://github.com/Expensify/Expensify/issues/141666