### PR TITLE
Allow chat switcher for smaller windows

### DIFF
--- a/src/page/home/HomePage.js
+++ b/src/page/home/HomePage.js
@@ -30,6 +30,7 @@ export default class App extends React.Component {
 
         this.toggleHamburger = this.toggleHamburger.bind(this);
         this.dismissHamburger = this.dismissHamburger.bind(this);
+        this.showHamburger = this.showHamburger.bind(this);
         this.toggleHamburgerBasedOnDimensions = this.toggleHamburgerBasedOnDimensions.bind(this);
         this.animationTranslateX = new Animated.Value(!this.state.hamburgerShown ? -300 : 0);
     }
@@ -73,13 +74,24 @@ export default class App extends React.Component {
      * Only changes hamburger state on small screens (e.g. Mobile and mWeb)
      */
     dismissHamburger() {
-        const hamburgerIsShown = this.state.hamburgerShown;
-
-        if (!hamburgerIsShown) {
+        if (!this.state.hamburgerShown) {
             return;
         }
 
-        this.animateHamburger(hamburgerIsShown);
+        this.animateHamburger(true);
+    }
+
+    /**
+     * Method called when we want to show the hamburger menu,
+     * will not do anything if it already open
+     * Only changes hamburger state on smaller screens (e.g. Mobile and mWeb)
+     */
+    showHamburger() {
+        if (this.state.hamburgerShown) {
+            return;
+        }
+
+        this.toggleHamburger();
     }
 
     /**
@@ -150,7 +162,11 @@ export default class App extends React.Component {
                                         transform: [{translateX: this.animationTranslateX}]
                                     }]}
                                 >
-                                    <Sidebar insets={insets} onLinkClick={this.toggleHamburger} />
+                                    <Sidebar
+                                        insets={insets}
+                                        onLinkClick={this.toggleHamburger}
+                                        onChatSwitcherFocus={this.showHamburger}
+                                    />
                                 </Animated.View>
                                 <View
                                     onTouchStart={this.dismissHamburger}

--- a/src/page/home/sidebar/ChatSwitcherView.js
+++ b/src/page/home/sidebar/ChatSwitcherView.js
@@ -81,6 +81,7 @@ class ChatSwitcherView extends React.Component {
         // Listen for the Command+K key being pressed so the focus can be given to the chat switcher
         KeyboardShortcut.subscribe('K', () => {
             if (this.textInput) {
+                this.props.onFocus();
                 this.textInput.focus();
             }
         }, ['meta'], true);

--- a/src/page/home/sidebar/SidebarLinks.js
+++ b/src/page/home/sidebar/SidebarLinks.js
@@ -31,9 +31,6 @@ const propTypes = {
     // Safe area insets required for mobile devices margins
     insets: SafeAreaInsetPropTypes.isRequired,
 
-    // A function to call when the chat switcher is blurred
-    onChatSwitcherSelected: PropTypes.func.isRequired,
-
     /* Ion Props */
 
     // List of reports

--- a/src/page/home/sidebar/SidebarLinks.js
+++ b/src/page/home/sidebar/SidebarLinks.js
@@ -31,6 +31,9 @@ const propTypes = {
     // Safe area insets required for mobile devices margins
     insets: SafeAreaInsetPropTypes.isRequired,
 
+    // A function to call when the chat switcher is blurred
+    onChatSwitcherSelected: PropTypes.func.isRequired,
+
     /* Ion Props */
 
     // List of reports

--- a/src/page/home/sidebar/SidebarView.js
+++ b/src/page/home/sidebar/SidebarView.js
@@ -12,6 +12,9 @@ const propTypes = {
 
     // Safe area insets required for mobile devices margins
     insets: SafeAreaInsetPropTypes.isRequired,
+
+    // when the chat switcher is selected
+    onChatSwitcherFocus: PropTypes.func.isRequired,
 };
 
 class SidebarView extends React.Component {
@@ -20,6 +23,18 @@ class SidebarView extends React.Component {
         this.state = {
             isSidebarBottomVisible: true,
         };
+
+        this.setIsFocused = this.setIsFocused.bind(this);
+    }
+
+    /**
+    * @param {boolean} isFocused
+    * */
+    setIsFocused(isFocused) {
+        this.setState({isSidebarBottomVisible: !isFocused});
+        if (isFocused) {
+            this.props.onChatSwitcherFocus();
+        }
     }
 
     render() {
@@ -28,8 +43,8 @@ class SidebarView extends React.Component {
                 <SidebarLinks
                     onLinkClick={this.props.onLinkClick}
                     insets={this.props.insets}
-                    onChatSwitcherFocus={() => this.setState({isSidebarBottomVisible: false})}
-                    onChatSwitcherBlur={() => this.setState({isSidebarBottomVisible: true})}
+                    onChatSwitcherFocus={() => this.setIsFocused(true)}
+                    onChatSwitcherBlur={() => this.setIsFocused(false)}
                 />
                 {this.state.isSidebarBottomVisible && <SidebarBottom insets={this.props.insets} />}
             </View>


### PR DESCRIPTION
Fixes: https://github.com/Expensify/Expensify/issues/141709

### Problem
When the screen is smaller, and only shows the chat , and not the burger menu, the chat switcher command `Cmd + K` does not work

### Tests

1. On a bigger window where the LHN is visible, press `Cmd + K` and verify that the chat switcher is selected
1. Change the size of the window so that the LHN hides, and only the Chat is visible.
1. Use the burger menu to open the LHN and verify that it works
1. Select a chat or user and verify that LHN hides
1. Press `Cmd + K` and verify that the LHN animates in, and that the Chat Switcher is selected and you can search for a user.
