### PR TITLE
Add slack notifications to entire deploy process

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -35,6 +35,8 @@ jobs:
         - name: Run Fastlane beta
           run: bundle exec fastlane android beta
 
+        # This Slack step is duplicated in all workflows, if you make a change to this step, make sure to update all
+        # the other workflows with the same change
         - uses: 8398a7/action-slack@v3
           name: Job failed Slack notification
           if: ${{ failure() }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -34,3 +34,20 @@ jobs:
 
         - name: Run Fastlane beta
           run: bundle exec fastlane android beta
+
+        - uses: 8398a7/action-slack@v3
+          name: Job failed Slack notification
+          if: ${{ failure() }}
+          with:
+              status: custom
+              fields: workflow, repo
+              custom_payload: |
+                  {
+                    attachments: [{
+                      color: "#DB4545",
+                      text: `💥 ${process.env.AS_REPO} failed on ${process.env.AS_WORKFLOW} workflow 💥`,
+                    }]
+                  }
+          env:
+              GITHUB_TOKEN: ${{ github.token }}
+              SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -23,6 +23,8 @@ jobs:
               env:
                   GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
+            # This Slack step is duplicated in all workflows, if you make a change to this step, make sure to update all
+            # the other workflows with the same change
             - uses: 8398a7/action-slack@v3
               name: Job failed Slack notification
               if: ${{ failure() }}

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -22,3 +22,20 @@ jobs:
               uses: pascalgn/automerge-action@v0.9.0
               env:
                   GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+            - uses: 8398a7/action-slack@v3
+              name: Job failed Slack notification
+              if: ${{ failure() }}
+              with:
+                  status: custom
+                  fields: workflow, repo
+                  custom_payload: |
+                      {
+                        attachments: [{
+                          color: "#DB4545",
+                          text: `💥 ${process.env.AS_REPO} failed on ${process.env.AS_WORKFLOW} workflow 💥`,
+                        }]
+                      }
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -28,9 +28,26 @@ jobs:
             - name: Build desktop app
               run: npm run desktop-build
               env:
-                CSC_LINK: ${{ secrets.CSC_LINK }}
-                CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-                APPLE_ID: ${{ secrets.APPLE_ID }}
-                APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
-                AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  CSC_LINK: ${{ secrets.CSC_LINK }}
+                  CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+                  APPLE_ID: ${{ secrets.APPLE_ID }}
+                  APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+                  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+            - uses: 8398a7/action-slack@v3
+              name: Job failed Slack notification
+              if: ${{ failure() }}
+              with:
+                  status: custom
+                  fields: workflow, repo
+                  custom_payload: |
+                      {
+                        attachments: [{
+                          color: "#DB4545",
+                          text: `💥 ${process.env.AS_REPO} failed on ${process.env.AS_WORKFLOW} workflow 💥`,
+                        }]
+                      }
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -35,6 +35,8 @@ jobs:
                   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
                   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
+            # This Slack step is duplicated in all workflows, if you make a change to this step, make sure to update all
+            # the other workflows with the same change
             - uses: 8398a7/action-slack@v3
               name: Job failed Slack notification
               if: ${{ failure() }}

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -39,3 +39,20 @@ jobs:
               run: bundle exec fastlane ios beta
               env:
                   FASTLANE_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+
+            - uses: 8398a7/action-slack@v3
+              name: Job failed Slack notification
+              if: ${{ failure() }}
+              with:
+                  status: custom
+                  fields: workflow, repo
+                  custom_payload: |
+                      {
+                        attachments: [{
+                          color: "#DB4545",
+                          text: `💥 ${process.env.AS_REPO} failed on ${process.env.AS_WORKFLOW} workflow 💥`,
+                        }]
+                      }
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -40,6 +40,8 @@ jobs:
               env:
                   FASTLANE_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
 
+            # This Slack step is duplicated in all workflows, if you make a change to this step, make sure to update all
+            # the other workflows with the same change
             - uses: 8398a7/action-slack@v3
               name: Job failed Slack notification
               if: ${{ failure() }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,29 +20,17 @@ jobs:
             - run: npm run lint
               env:
                   CI: true
-            - name: Job failed Slack notification
-              uses: rtCamp/action-slack-notify@master
-              env:
-                  SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-                  SLACK_CHANNEL: "#andrew-test"
-                  SLACK_USERNAME: "Botify"
-                  SLACK_ICON: "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2017-07-19/214290201728_e3b6a20b1b2cb3145d6f_72.png"
-                  SLACK_COLOR: "#DB4545"
-                  SLACK_TITLE: 💥 ${{ github.repository }} failed on ${{ github.workflow }} workflow 💥
-                  SLACK_MESSAGE: "_Someone should look into this_"
 
             - uses: 8398a7/action-slack@v3
+              name: Job failed Slack notification
               with:
                    status: custom
-                   fields: workflow,job,commit,repo,ref,author,took
+                   fields: workflow, repo
                    custom_payload: |
                     {
-                      username: 'Botify',
-                      channel: '#andrew-test',
                       attachments: [{
                         color: "#DB4545",
-                        pretext: `${process.env.AS_REPO} failed on ${process.env.AS_WORKFLOW} workflow 💥`,
-                        text: `${process.env.AS_WORKFLOW}\n${process.env.AS_JOB} (${process.env.AS_COMMIT}) of ${process.env.AS_REPO}@${process.env.AS_REF} by ${process.env.AS_AUTHOR} succeeded in ${process.env.AS_TOOK}`,
+                        text: `💥 ${process.env.AS_REPO} failed on ${process.env.AS_WORKFLOW} workflow 💥`,
                       }]
                     }
               env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,7 +41,7 @@ jobs:
                       channel: '#andrew-test',
                       attachments: [{
                         color: "#DB4545",
-                        pretext: `${github.repository} failed on ${github.workflow} workflow 💥`,
+                        pretext: `${process.env.AS_REPO} failed on ${process.env.AS_WORKFLOW} workflow 💥`,
                         text: `${process.env.AS_WORKFLOW}\n${process.env.AS_JOB} (${process.env.AS_COMMIT}) of ${process.env.AS_REPO}@${process.env.AS_REF} by ${process.env.AS_AUTHOR} succeeded in ${process.env.AS_TOOK}`,
                       }]
                     }

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,5 +28,4 @@ jobs:
                   SLACK_USERNAME: "Botify"
                   SLACK_ICON: "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2017-07-19/214290201728_e3b6a20b1b2cb3145d6f_72.png"
                   SLACK_COLOR: "#DB4545"
-                  SLACK_TITLE: $GITHUB_WORKFLOW Failed
-                  SLACK_MESSAGE: "GitHub Action: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/runs/$GITHUB_RUN_NUMBER"
+                  SLACK_TITLE: 💥 ${{ github.repository }} failed to deploy on ${{ github.workflow }} workflow 💥

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,7 +41,7 @@ jobs:
                       channel: '#andrew-test'
                       attachments: [{
                         color: "#DB4545",
-                        pretext: `${github.repository} failed on ${github.workflow} workflow 💥`
+                        pretext: `${github.repository} failed on ${github.workflow} workflow 💥`,
                         text: `${process.env.AS_WORKFLOW}\n${process.env.AS_JOB} (${process.env.AS_COMMIT}) of ${process.env.AS_REPO}@${process.env.AS_REF} by ${process.env.AS_AUTHOR} succeeded in ${process.env.AS_TOOK}`,
                       }]
                     }

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,3 +30,21 @@ jobs:
                   SLACK_COLOR: "#DB4545"
                   SLACK_TITLE: 💥 ${{ github.repository }} failed on ${{ github.workflow }} workflow 💥
                   SLACK_MESSAGE: "_Someone should look into this_"
+
+            - uses: 8398a7/action-slack@v3
+              with:
+                   status: custom
+                   fields: workflow,job,commit,repo,ref,author,took
+                   custom_payload: |
+                    {
+                      username: 'Botify',
+                      channel: '#andrew-test'
+                      attachments: [{
+                        color: "#DB4545",
+                        pretext: `${github.repository} failed on ${github.workflow} workflow 💥`
+                        text: `${process.env.AS_WORKFLOW}\n${process.env.AS_JOB} (${process.env.AS_COMMIT}) of ${process.env.AS_REPO}@${process.env.AS_REF} by ${process.env.AS_AUTHOR} succeeded in ${process.env.AS_TOOK}`,
+                      }]
+                    }
+              env:
+                   GITHUB_TOKEN: ${{ github.token }}
+                   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,7 +38,7 @@ jobs:
                    custom_payload: |
                     {
                       username: 'Botify',
-                      channel: '#andrew-test'
+                      channel: '#andrew-test',
                       attachments: [{
                         color: "#DB4545",
                         pretext: `${github.repository} failed on ${github.workflow} workflow 💥`,

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,3 +20,13 @@ jobs:
             - run: npm run lint
               env:
                   CI: true
+            - name: Job failed Slack notification
+              uses: rtCamp/action-slack-notify@master
+              env:
+                  SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+                  SLACK_CHANNEL: "#andrew-test"
+                  SLACK_USERNAME: "Botify"
+                  SLACK_ICON: "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2017-07-19/214290201728_e3b6a20b1b2cb3145d6f_72.png"
+                  SLACK_COLOR: "#DB4545"
+                  SLACK_TITLE: "$GITHUB_WORKFLOW Failed"
+                  SLACK_MESSAGE: "GitHub Action: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/runs/$GITHUB_RUN_NUMBER"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,4 +28,5 @@ jobs:
                   SLACK_USERNAME: "Botify"
                   SLACK_ICON: "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2017-07-19/214290201728_e3b6a20b1b2cb3145d6f_72.png"
                   SLACK_COLOR: "#DB4545"
-                  SLACK_TITLE: 💥 ${{ github.repository }} failed to deploy on ${{ github.workflow }} workflow 💥
+                  SLACK_TITLE: 💥 ${{ github.repository }} failed on ${{ github.workflow }} workflow 💥
+                  SLACK_MESSAGE: ""

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,5 +28,5 @@ jobs:
                   SLACK_USERNAME: "Botify"
                   SLACK_ICON: "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2017-07-19/214290201728_e3b6a20b1b2cb3145d6f_72.png"
                   SLACK_COLOR: "#DB4545"
-                  SLACK_TITLE: "$GITHUB_WORKFLOW Failed"
+                  SLACK_TITLE: $GITHUB_WORKFLOW Failed
                   SLACK_MESSAGE: "GitHub Action: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/runs/$GITHUB_RUN_NUMBER"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,19 +20,3 @@ jobs:
             - run: npm run lint
               env:
                   CI: true
-
-            - uses: 8398a7/action-slack@v3
-              name: Job failed Slack notification
-              with:
-                   status: custom
-                   fields: workflow, repo
-                   custom_payload: |
-                    {
-                      attachments: [{
-                        color: "#DB4545",
-                        text: `💥 ${process.env.AS_REPO} failed on ${process.env.AS_WORKFLOW} workflow 💥`,
-                      }]
-                    }
-              env:
-                   GITHUB_TOKEN: ${{ github.token }}
-                   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,4 +29,4 @@ jobs:
                   SLACK_ICON: "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2017-07-19/214290201728_e3b6a20b1b2cb3145d6f_72.png"
                   SLACK_COLOR: "#DB4545"
                   SLACK_TITLE: 💥 ${{ github.repository }} failed on ${{ github.workflow }} workflow 💥
-                  SLACK_MESSAGE: ""
+                  SLACK_MESSAGE: "_Someone should look into this_"

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -48,14 +48,19 @@ jobs:
                     pr_label: "automerge"
                     github_token: ${{ secrets.BOTIFY_TOKEN }}
 
-#            - name: Job failed Slack notification
-#              if: ${{ failure() }}
-#              uses: rtCamp/action-slack-notify@master
-#              env:
-#                  SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-#                  SLACK_CHANNEL: "#andrew-test"
-#                  SLACK_USERNAME: "Botify"
-#                  SLACK_ICON: "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2017-07-19/214290201728_e3b6a20b1b2cb3145d6f_72.png"
-#                  SLACK_COLOR: "#DB4545"
-#                  SLACK_TITLE: "$GITHUB_WORKFLOW Failed"
-#                  SLACK_MESSAGE: "GitHub Action: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/runs/$GITHUB_RUN_NUMBER"
+            - uses: 8398a7/action-slack@v3
+              name: Job failed Slack notification
+              if: ${{ failure() }}
+              with:
+                    status: custom
+                    fields: workflow, repo
+                    custom_payload: |
+                        {
+                          attachments: [{
+                            color: "#DB4545",
+                            text: `💥 ${process.env.AS_REPO} failed on ${process.env.AS_WORKFLOW} workflow 💥`,
+                          }]
+                        }
+              env:
+                    GITHUB_TOKEN: ${{ github.token }}
+                    SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -48,6 +48,8 @@ jobs:
                     pr_label: "automerge"
                     github_token: ${{ secrets.BOTIFY_TOKEN }}
 
+            # This Slack step is duplicated in all workflows, if you make a change to this step, make sure to update all
+            # the other workflows with the same change
             - uses: 8398a7/action-slack@v3
               name: Job failed Slack notification
               if: ${{ failure() }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -47,3 +47,15 @@ jobs:
                     destination_branch: "master"
                     pr_label: "automerge"
                     github_token: ${{ secrets.BOTIFY_TOKEN }}
+
+#            - name: Job failed Slack notification
+#              if: ${{ failure() }}
+#              uses: rtCamp/action-slack-notify@master
+#              env:
+#                  SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+#                  SLACK_CHANNEL: "#andrew-test"
+#                  SLACK_USERNAME: "Botify"
+#                  SLACK_ICON: "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2017-07-19/214290201728_e3b6a20b1b2cb3145d6f_72.png"
+#                  SLACK_COLOR: "#DB4545"
+#                  SLACK_TITLE: "$GITHUB_WORKFLOW Failed"
+#                  SLACK_MESSAGE: "GitHub Action: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/runs/$GITHUB_RUN_NUMBER"

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -52,6 +52,8 @@ jobs:
           env:
             CF_API_KEY: ${{ secrets.CLOUDFLARE_TOKEN }}
 
+        # This Slack step is duplicated in all workflows, if you make a change to this step, make sure to update all
+        # the other workflows with the same change
         - uses: 8398a7/action-slack@v3
           name: Job failed Slack notification
           if: ${{ failure() }}

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -51,3 +51,20 @@ jobs:
           run: /home/runner/.local/bin/cli4 --delete hosts=["chat.expensify.com"] /zones/:9ee042e6cfc7fd45e74aa7d2f78d617b/purge_cache
           env:
             CF_API_KEY: ${{ secrets.CLOUDFLARE_TOKEN }}
+
+        - uses: 8398a7/action-slack@v3
+          name: Job failed Slack notification
+          if: ${{ failure() }}
+          with:
+            status: custom
+            fields: workflow, repo
+            custom_payload: |
+                {
+                  attachments: [{
+                    color: "#DB4545",
+                    text: `💥 ${process.env.AS_REPO} failed on ${process.env.AS_WORKFLOW} workflow 💥`,
+                  }]
+                }
+          env:
+            GITHUB_TOKEN: ${{ github.token }}
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
Closes https://github.com/Expensify/Expensify/issues/141786

This will send a slack notification if any of the deploy process fails, so that we don't go a long time with broken builds.

Unfortunately, there is no way to re-use github action code, so I had to copy pasta it on every action used to deploy.

Tested using the eslint workflow in the `andrew-slack` channel

<img width="531" alt="Screen Shot 2020-09-24 at 11 37 45 AM" src="https://user-images.githubusercontent.com/2838819/94185835-ac553b00-fe5a-11ea-9db8-41e0126b6160.png">
