### PR TITLE
Listen for the isActiveReport prop to change in ReportActionsView

### DIFF
--- a/src/page/home/report/ReportActionsView.js
+++ b/src/page/home/report/ReportActionsView.js
@@ -58,6 +58,13 @@ class ReportActionsView extends React.Component {
             if (this.props.isActiveReport) {
                 setTimeout(this.recordMaxAction, 3000);
             }
+
+            return;
+        }
+
+        // If we are switching from not active to active report then mark comments as read
+        if (!prevProps.isActiveReport && this.props.isActiveReport) {
+            this.recordMaxAction();
         }
     }
 


### PR DESCRIPTION
cc @AndrewGable This should fix chats showing as unread in the LHN.

In the previous iteration before we merged https://github.com/Expensify/ReactNativeChat/pull/536/ the `onContentSizeChanged` of the `ScrollView` would get triggered whenever we switched chats so this should achieve a similar result.