### PR TITLE
Trigger Reconnect Callbacks When App returns from background

### DIFF
--- a/src/lib/API.js
+++ b/src/lib/API.js
@@ -1,5 +1,4 @@
 import _ from 'underscore';
-import {AppState} from 'react-native';
 import Ion from './Ion';
 import IONKEYS from '../IONKEYS';
 import {xhr, setOfflineStatus} from './Network';
@@ -10,6 +9,7 @@ import Str from './Str';
 import Guid from './Guid';
 import redirectToSignIn from './actions/SignInRedirect';
 import {redirect} from './actions/App';
+import Activity from './Activity';
 
 // Holds all of the callbacks that need to be triggered when the network reconnects
 const reconnectionCallbacks = [];
@@ -53,10 +53,12 @@ Ion.connect({
 // for a few minutes, but eventually disconnects causing a delay when the app
 // returns from the background. So, if we are returning from the background
 // and we are online we should trigger our reconnection callbacks.
-AppState.addEventListener('change', (state) => {
-    if (state === 'active' && !isOffline) {
-        triggerReconnectionCallbacks();
+Activity.registerOnAppBecameActiveCallback(() => {
+    if (isOffline) {
+        return;
     }
+
+    triggerReconnectionCallbacks();
 });
 
 // When the user authenticates for the first time we create a login and store credentials in Ion.

--- a/src/lib/API.js
+++ b/src/lib/API.js
@@ -28,6 +28,13 @@ Ion.connect({
     callback: val => authToken = val ? val.authToken : null,
 });
 
+/**
+ * Loop over all reconnection callbacks and fire each one
+ */
+function triggerReconnectionCallbacks() {
+    _.each(reconnectionCallbacks, callback => callback());
+}
+
 // We subscribe to changes to the online/offline status of the network to determine when we should fire off API calls
 // vs queueing them for later. When reconnecting, ie, going from offline to online, all the reconnection callbacks
 // are triggered (this is usually Actions that need to re-download data from the server)
@@ -36,7 +43,7 @@ Ion.connect({
     key: IONKEYS.NETWORK,
     callback: (val) => {
         if (isOffline && !val.isOffline) {
-            _.each(reconnectionCallbacks, callback => callback());
+            triggerReconnectionCallbacks();
         }
         isOffline = val && val.isOffline;
     }
@@ -48,7 +55,7 @@ Ion.connect({
 // and we are online we should trigger our reconnection callbacks.
 AppState.addEventListener('change', (state) => {
     if (state === 'active' && !isOffline) {
-        _.each(reconnectionCallbacks, callback => callback());
+        triggerReconnectionCallbacks();
     }
 });
 

--- a/src/lib/API.js
+++ b/src/lib/API.js
@@ -1,4 +1,5 @@
 import _ from 'underscore';
+import {AppState} from 'react-native';
 import Ion from './Ion';
 import IONKEYS from '../IONKEYS';
 import {xhr, setOfflineStatus} from './Network';
@@ -38,6 +39,16 @@ Ion.connect({
             _.each(reconnectionCallbacks, callback => callback());
         }
         isOffline = val && val.isOffline;
+    }
+});
+
+// When the app is in the background Pusher can still receive realtime updates
+// for a few minutes, but eventually disconnects causing a delay when the app
+// returns from the background. So, if we are returning from the background
+// and we are online we should trigger our reconnection callbacks.
+AppState.addEventListener('change', (state) => {
+    if (state === 'active' && !isOffline) {
+        _.each(reconnectionCallbacks, callback => callback());
     }
 });
 

--- a/src/lib/Activity/index.js
+++ b/src/lib/Activity/index.js
@@ -1,0 +1,7 @@
+/**
+ * On web/desktop we don't really care if the app becomes
+ * active or inactive as long as Pusher is always connected
+ */
+export default {
+    registerOnAppBecameActiveCallback: () => {},
+};

--- a/src/lib/Activity/index.native.js
+++ b/src/lib/Activity/index.native.js
@@ -6,7 +6,7 @@ AppState.addEventListener('change', (state) => {
     if (state === 'active') {
         onAppBecameActiveCallback();
     }
-})
+});
 
 /**
  * Register active state change callback

--- a/src/lib/Activity/index.native.js
+++ b/src/lib/Activity/index.native.js
@@ -1,0 +1,22 @@
+import {AppState} from 'react-native';
+
+let onAppBecameActiveCallback;
+
+AppState.addEventListener('change', (state) => {
+    if (state === 'active') {
+        onAppBecameActiveCallback();
+    }
+})
+
+/**
+ * Register active state change callback
+ *
+ * @param {Function} callback
+ */
+function registerOnAppBecameActiveCallback(callback) {
+    onAppBecameActiveCallback = callback;
+}
+
+export default {
+    registerOnAppBecameActiveCallback,
+};

--- a/src/page/home/report/ReportActionsView.js
+++ b/src/page/home/report/ReportActionsView.js
@@ -56,7 +56,8 @@ class ReportActionsView extends React.Component {
         if (_.size(prevProps.reportActions) !== _.size(this.props.reportActions)) {
             // If a new comment is added and it's from the current user scroll to the bottom otherwise
             // leave the user positioned where they are now in the list.
-            if (lastItem(this.props.reportActions).actorEmail === this.props.session.email) {
+            const lastAction = lastItem(this.props.reportActions);
+            if (lastAction && (lastAction.actorEmail === this.props.session.email)) {
                 this.scrollToListBottom();
             }
 


### PR DESCRIPTION
**Fixes:** https://github.com/Expensify/Expensify/issues/141960

The above bug is a little tricky to reproduce since you have to wait for Pusher to timeout while the app is in the background, but goes something like this...

1. App moves from active to inactive/background
1. App disconnects from Pusher after several minutes while being in the background
1. New comment is left on a report
1. App becomes active
1. Pusher reconnects but doesn't recover any messages that were missed, we never moved from online to offline, and so reconnection callbacks do not fire so any events we missed are just gone for good.

Long term, I imagine that we'll fix this with silent device notifications (via Airship), but for now this should create a more reliable experience when moving from `background` to `active` state.