### PR TITLE
Add loading indicator

### DIFF
--- a/src/lib/API.js
+++ b/src/lib/API.js
@@ -364,6 +364,7 @@ function getAuthToken() {
  * @returns {Promise}
  */
 function authenticate(parameters) {
+    Ion.merge(IONKEYS.SESSION, {loading: true, error: ''});
     return queueRequest('Authenticate', {
         // When authenticating for the first time, we pass useExpensifyLogin as true so we check for credentials for
         // the expensify partnerID to let users authenticate with their expensify user and password.
@@ -379,6 +380,8 @@ function authenticate(parameters) {
             console.error(err);
             console.debug('[SIGNIN] Request error');
             Ion.merge(IONKEYS.SESSION, {error: err.message});
+        }).finally(() => {
+            Ion.merge(IONKEYS.SESSION, {loading: false});
         });
 }
 

--- a/src/lib/Ion.js
+++ b/src/lib/Ion.js
@@ -85,13 +85,6 @@ function keyChanged(key, data) {
 }
 
 /**
- * Initialize the store with actions and listening for storage events
- */
-function init() {
-    addStorageEventHandler((key, newValue) => keyChanged(key, newValue));
-}
-
-/**
  * Sends the data obtained from the keys to the connection. It either:
  *     - sets state on the withIonInstances
  *     - triggers the callback function
@@ -264,6 +257,14 @@ function merge(key, val) {
         .then(() => {
             keyChanged(key, val);
         });
+}
+
+/**
+ * Initialize the store with actions and listening for storage events
+ */
+function init() {
+    merge(IONKEYS.SESSION, {loading: false});
+    addStorageEventHandler((key, newValue) => keyChanged(key, newValue));
 }
 
 const Ion = {

--- a/src/lib/Ion.js
+++ b/src/lib/Ion.js
@@ -263,7 +263,8 @@ function merge(key, val) {
  * Initialize the store with actions and listening for storage events
  */
 function init() {
-    merge(IONKEYS.SESSION, {loading: false});
+    // Clear any loading and error messages so they do not appear on app startup
+    merge(IONKEYS.SESSION, {loading: false, error: ''});
     addStorageEventHandler((key, newValue) => keyChanged(key, newValue));
 }
 

--- a/src/lib/Network.js
+++ b/src/lib/Network.js
@@ -43,6 +43,9 @@ function xhr(command, data, type = 'post') {
         .catch(() => {
             setOfflineStatus(true);
 
+            // Set an error state and signify we are done loading
+            Ion.merge(IONKEYS.SESSION, {loading: false, error: 'Cannot connect to server'});
+
             // Throw a new error to prevent any other `then()` in the promise chain from being triggered (until another
             // catch() happens
             throw new Error('API is offline');

--- a/src/page/SignInPage.js
+++ b/src/page/SignInPage.js
@@ -32,7 +32,7 @@ const propTypes = {
         // Error to display when there is a session error returned
         error: PropTypes.string,
 
-        // Stores if we are currently making a authentication request
+        // Stores if we are currently making an authentication request
         loading: PropTypes.bool,
     }),
 };
@@ -71,6 +71,7 @@ class App extends Component {
     }
 
     render() {
+        const isLoading = this.props.session && this.props.session.loading;
         return (
             <>
                 <StatusBar />
@@ -122,9 +123,9 @@ class App extends Component {
                                 style={[styles.button, styles.buttonSuccess, styles.mb4]}
                                 onPress={this.submitForm}
                                 underlayColor={colors.componentBG}
-                                disabled={this.props.session && this.props.session.loading}
+                                disabled={isLoading}
                             >
-                                {this.props.session && this.props.session.loading === true ? (
+                                {isLoading ? (
                                     <ActivityIndicator color={colors.textReversed} />
                                 ) : (
                                     <Text style={[styles.buttonText, styles.buttonSuccessText]}>Log In</Text>

--- a/src/page/SignInPage.js
+++ b/src/page/SignInPage.js
@@ -7,8 +7,10 @@ import {
     TextInput,
     Image,
     View,
+    ActivityIndicator,
 } from 'react-native';
 import PropTypes from 'prop-types';
+import _ from 'underscore';
 import CONFIG from '../CONFIG';
 import compose from '../lib/compose';
 import {withRouter} from '../lib/Router';
@@ -29,6 +31,9 @@ const propTypes = {
     session: PropTypes.shape({
         // Error to display when there is a session error returned
         error: PropTypes.string,
+
+        // Stores if we are currently making a authentication request
+        loading: PropTypes.bool,
     }),
 };
 
@@ -59,6 +64,9 @@ class App extends Component {
      * Sign into the application when the form is submitted
      */
     submitForm() {
+        if (this.props.session.loading) {
+            return;
+        }
         signIn(this.state.login, this.state.password, this.state.twoFactorAuthCode, this.props.match.params.exitTo);
     }
 
@@ -114,10 +122,15 @@ class App extends Component {
                                 style={[styles.button, styles.buttonSuccess, styles.mb4]}
                                 onPress={this.submitForm}
                                 underlayColor={colors.componentBG}
+                                disabled={this.props.session && this.props.session.loading}
                             >
-                                <Text style={[styles.buttonText, styles.buttonSuccessText]}>Log In</Text>
+                                {this.props.session && this.props.session.loading === true ? (
+                                    <ActivityIndicator color={colors.textReversed} />
+                                ) : (
+                                    <Text style={[styles.buttonText, styles.buttonSuccessText]}>Log In</Text>
+                                )}
                             </TouchableOpacity>
-                            {this.props.session && this.props.session.error && (
+                            {this.props.session && !_.isEmpty(this.props.session.error) && (
                                 <Text style={[styles.formError]}>
                                     {this.props.session.error}
                                 </Text>

--- a/src/page/SignInPage.js
+++ b/src/page/SignInPage.js
@@ -64,7 +64,7 @@ class App extends Component {
      * Sign into the application when the form is submitted
      */
     submitForm() {
-        if (this.props.session.loading) {
+        if (this.props.session && this.props.session.loading) {
             return;
         }
         signIn(this.state.login, this.state.password, this.state.twoFactorAuthCode, this.props.match.params.exitTo);


### PR DESCRIPTION
@roryabraham will you review please?

cc: @marcaaron 

# Fixed issues
$ https://github.com/Expensify/Expensify/issues/141725

## Tests / QA
1. Attempt to sign in with a login that will not work
1. _Verify_ that you get a loading indicator
1. After the signin attempt has finished, _verify_ that you receive an error message
1. Attempt to sign in with valid credentials.
1. _Verify_ the error message disappears, and that you get a loading indicator
1. _Verify_ you are signed in
1. Sign out
1. Turn off your local nginx
1. Attempt to sign in
1. _Verify_ the loading indicator stops, and you get the following error
![image](https://user-images.githubusercontent.com/22447860/94587138-024d2880-0237-11eb-9e30-a24626871bd1.png)

## Screenshots
IOS
![image](https://user-images.githubusercontent.com/22447860/94498782-d6d32b00-01af-11eb-8c5d-c155cebc621a.png)

Android
![image](https://user-images.githubusercontent.com/22447860/94498938-41846680-01b0-11eb-9d4d-dac97f45a773.png)

Web
![image](https://user-images.githubusercontent.com/22447860/94499033-80b2b780-01b0-11eb-8545-3b97a85e3bd3.png)

Desktop
![image](https://user-images.githubusercontent.com/22447860/94499323-37af3300-01b1-11eb-84e6-8f93987d0eb9.png)
