### PR TITLE
Clear store when redirecting to sign in, and don't let the user into the app if CreateLogin fails

### DIFF
--- a/src/lib/API.js
+++ b/src/lib/API.js
@@ -165,7 +165,7 @@ function request(command, parameters, type = 'post') {
                     return createLogin(Str.generateDeviceLoginID(), Guid());
                 }
             })
-            .catch(err => Ion.merge(IONKEYS.SESSION, {error: err}));
+            .catch(err => Ion.merge(IONKEYS.SESSION, {error: err.message}));
     }
 
     // Add authToken automatically to all commands
@@ -294,7 +294,7 @@ Pusher.registerCustomAuthorizer((channel, {authEndpoint}) => ({
             .catch((err) => {
                 reconnectToPusher();
                 console.debug('[Network] Failed to authorize Pusher');
-                callback(new Error(`Error calling auth endpoint: ${err}`));
+                callback(new Error(`Error calling auth endpoint: ${err.message}`));
             });
     },
 }));

--- a/src/lib/API.js
+++ b/src/lib/API.js
@@ -76,7 +76,7 @@ function createLogin(login, password) {
             }
             Ion.merge(IONKEYS.CREDENTIALS, {login, password});
         })
-        .catch(err => Ion.merge(IONKEYS.SESSION, {error: err}));
+        .catch(err => Ion.merge(IONKEYS.SESSION, {error: err.message}));
 }
 
 /**

--- a/src/lib/API.js
+++ b/src/lib/API.js
@@ -72,12 +72,7 @@ function createLogin(login, password) {
     })
         .then((response) => {
             if (response.jsonCode !== 200) {
-                redirectToSignIn();
-
-                // redirectToSignIn clears the Ion store, so we set the error after that call
-                return Ion.multiSet({
-                    [IONKEYS.SESSION]: {error: response.message},
-                });
+                return redirectToSignIn(response.message);
             }
             Ion.merge(IONKEYS.CREDENTIALS, {login, password});
         })
@@ -154,13 +149,7 @@ function request(command, parameters, type = 'post') {
                 // an expensify login or the login credentials we created after the initial authentication.
                 // In both cases, we need the user to sign in again with their expensify credentials
                 if (response.jsonCode !== 200) {
-                    redirectToSignIn();
-
-                    // redirectToSignIn clears the Ion store, so we set the error after that call
-                    return Ion.multiSet({
-                        [IONKEYS.CREDENTIALS]: {},
-                        [IONKEYS.SESSION]: {error: response.message},
-                    });
+                    return redirectToSignIn(response.message);
                 }
 
                 // We need to return the promise from setSuccessfulSignInData to ensure the authToken is updated before
@@ -224,12 +213,7 @@ function request(command, parameters, type = 'post') {
                     .then(() => xhr(command, parametersWithAuthToken, type))
                     .catch((error) => {
                         reauthenticating = false;
-                        redirectToSignIn();
-
-                        // redirectToSignIn clears the Ion store, so we set the error after that call
-                        Ion.multiSet({
-                            [IONKEYS.SESSION]: {error: error.message},
-                        });
+                        redirectToSignIn(error.message);
                         return Promise.reject();
                     });
             }

--- a/src/lib/API.js
+++ b/src/lib/API.js
@@ -76,7 +76,7 @@ function createLogin(login, password) {
             }
             Ion.merge(IONKEYS.CREDENTIALS, {login, password});
         })
-        .catch(err => Ion.merge(IONKEYS.SESSION, {error: err.message}));
+        .catch(error => Ion.merge(IONKEYS.SESSION, {error: error.message}));
 }
 
 /**
@@ -165,7 +165,7 @@ function request(command, parameters, type = 'post') {
                     return createLogin(Str.generateDeviceLoginID(), Guid());
                 }
             })
-            .catch(err => Ion.merge(IONKEYS.SESSION, {error: err.message}));
+            .catch(error => Ion.merge(IONKEYS.SESSION, {error: error.message}));
     }
 
     // Add authToken automatically to all commands
@@ -291,10 +291,10 @@ Pusher.registerCustomAuthorizer((channel, {authEndpoint}) => ({
         })
             .then(authResponse => authResponse.json())
             .then(data => callback(null, data))
-            .catch((err) => {
+            .catch((error) => {
                 reconnectToPusher();
                 console.debug('[Network] Failed to authorize Pusher');
-                callback(new Error(`Error calling auth endpoint: ${err.message}`));
+                callback(new Error(`Error calling auth endpoint: ${error.message}`));
             });
     },
 }));
@@ -373,10 +373,10 @@ function authenticate(parameters) {
         twoFactorAuthCode: parameters.twoFactorAuthCode,
         exitTo: parameters.exitTo,
     })
-        .catch((err) => {
-            console.error(err);
+        .catch((error) => {
+            console.error(error);
             console.debug('[SIGNIN] Request error');
-            Ion.merge(IONKEYS.SESSION, {error: err.message});
+            Ion.merge(IONKEYS.SESSION, {error: error.message});
         });
 }
 
@@ -393,7 +393,7 @@ function deleteLogin(parameters) {
         partnerPassword: CONFIG.EXPENSIFY.PARTNER_PASSWORD,
         doNotRetry: true,
     })
-        .catch(err => Ion.merge(IONKEYS.SESSION, {error: err.message}));
+        .catch(error => Ion.merge(IONKEYS.SESSION, {error: error.message}));
 }
 
 export {

--- a/src/lib/API.js
+++ b/src/lib/API.js
@@ -72,7 +72,7 @@ function createLogin(login, password) {
     })
         .then((response) => {
             if (response.jsonCode !== 200) {
-                throw new Error(response.message);
+                console.debug('Failed creating login, re-authentication will fail');
             }
             Ion.merge(IONKEYS.CREDENTIALS, {login, password});
         });
@@ -153,14 +153,13 @@ function request(command, parameters, type = 'post') {
 
                 // Update the authToken so it's used in the call to  createLogin below
                 authToken = response.authToken;
-                return response;
+                return setSuccessfulSignInData(response, parameters.exitTo);
             })
-            .then((response) => {
+            .then(() => {
                 // If Expensify login, it's the users first time signing in and we need to
                 // create a login for the user
                 if (parameters.useExpensifyLogin) {
-                    return createLogin(Str.generateDeviceLoginID(), Guid())
-                        .then(() => setSuccessfulSignInData(response, parameters.exitTo));
+                    return createLogin(Str.generateDeviceLoginID(), Guid());
                 }
             })
             .catch(error => Ion.merge(IONKEYS.SESSION, {error: error.message}));

--- a/src/lib/actions/Session.js
+++ b/src/lib/actions/Session.js
@@ -32,7 +32,6 @@ function signIn(partnerUserID, partnerUserSecret, twoFactorAuthCode = '', exitTo
  */
 function signOut() {
     redirectToSignIn();
-    Ion.clear();
     Pusher.disconnect();
 
     if (!credentials || !credentials.login) {

--- a/src/lib/actions/Session.js
+++ b/src/lib/actions/Session.js
@@ -2,7 +2,6 @@ import Ion from '../Ion';
 import * as API from '../API';
 import IONKEYS from '../../IONKEYS';
 import redirectToSignIn from './SignInRedirect';
-import * as Pusher from '../Pusher/pusher';
 
 let credentials;
 Ion.connect({
@@ -32,12 +31,9 @@ function signIn(partnerUserID, partnerUserSecret, twoFactorAuthCode = '', exitTo
  */
 function signOut() {
     redirectToSignIn();
-    Pusher.disconnect();
-
     if (!credentials || !credentials.login) {
         return;
     }
-
     API.deleteLogin({
         partnerUserID: credentials.login
     });

--- a/src/lib/actions/SignInRedirect.js
+++ b/src/lib/actions/SignInRedirect.js
@@ -14,12 +14,16 @@ Ion.connect({
  * Clears the Ion store, redirects to the sign in page and handles adding any exitTo params to the URL.
  * Normally this method would live in Session.js, but that would cause a circular dependency with Network.js.
  *
- * @param {String} errorMessage optional error message to be displayed on the sign in page
+ * @param {String} [errorMessage] error message to be displayed on the sign in page
  */
 function redirectToSignIn(errorMessage) {
     Pusher.disconnect();
     Ion.clear()
-        .then(() => Ion.set(IONKEYS.SESSION, {error: errorMessage}));
+        .then(() => {
+            if (errorMessage) {
+                Ion.set(IONKEYS.SESSION, {error: errorMessage})
+            }
+        });
 
     if (!currentURL) {
         return;

--- a/src/lib/actions/SignInRedirect.js
+++ b/src/lib/actions/SignInRedirect.js
@@ -21,7 +21,7 @@ function redirectToSignIn(errorMessage) {
     Ion.clear()
         .then(() => {
             if (errorMessage) {
-                Ion.set(IONKEYS.SESSION, {error: errorMessage})
+                Ion.set(IONKEYS.SESSION, {error: errorMessage});
             }
         });
 

--- a/src/lib/actions/SignInRedirect.js
+++ b/src/lib/actions/SignInRedirect.js
@@ -2,6 +2,7 @@ import Ion from '../Ion';
 import IONKEYS from '../../IONKEYS';
 import ROUTES from '../../ROUTES';
 import {redirect} from './App';
+import * as Pusher from '../Pusher/pusher';
 
 let currentURL;
 Ion.connect({
@@ -16,6 +17,7 @@ Ion.connect({
  * @param {String} errorMessage optional error message to be displayed on the sign in page
  */
 function redirectToSignIn(errorMessage) {
+    Pusher.disconnect();
     Ion.clear()
         .then(() => Ion.set(IONKEYS.SESSION, {error: errorMessage}));
 

--- a/src/lib/actions/SignInRedirect.js
+++ b/src/lib/actions/SignInRedirect.js
@@ -10,10 +10,11 @@ Ion.connect({
 });
 
 /**
- * Redirects to the sign in page and handles adding any exitTo params to the URL.
+ * Clears the Ion store, redirects to the sign in page and handles adding any exitTo params to the URL.
  * Normally this method would live in Session.js, but that would cause a circular dependency with Network.js.
  */
 function redirectToSignIn() {
+    Ion.clear();
     if (!currentURL) {
         return;
     }

--- a/src/lib/actions/SignInRedirect.js
+++ b/src/lib/actions/SignInRedirect.js
@@ -12,9 +12,13 @@ Ion.connect({
 /**
  * Clears the Ion store, redirects to the sign in page and handles adding any exitTo params to the URL.
  * Normally this method would live in Session.js, but that would cause a circular dependency with Network.js.
+ *
+ * @param {String} errorMessage optional error message to be displayed on the sign in page
  */
-function redirectToSignIn() {
-    Ion.clear();
+function redirectToSignIn(errorMessage) {
+    Ion.clear()
+        .then(() => Ion.set(IONKEYS.SESSION, {error: errorMessage}));
+
     if (!currentURL) {
         return;
     }


### PR DESCRIPTION
@marcaaron @stitesExpensify please review
cc @AndrewGable @tgolen 

- Fixes https://github.com/Expensify/Expensify/issues/141696
- Fixes https://github.com/Expensify/Expensify/issues/141695

**Note** the commit https://github.com/Expensify/ReactNativeChat/pull/557/commits/881228c06f9db6bc97a38dc6461d203ecb0bd5cd which I pushed and reverted intentionally, has a slightly different solution: when authenticate succeeds, instead of not letting the user into the app if create login fails, we let the user in knowing that re-authentication will fail, but the user can start using the app, and will be signed out when we try to re-authenticate. The commit if pretty small, so I wanted to share it in case we prefer that solution, but we can also handle that in a separate PR if we feel that's the way to go

# Tests
### 1) Tested hardcoding an error in api.php for Authenticate, tried signing in, confirmed proper error message shows up
```diff

Expensidev/Web-Expensify (master) $ git diff
diff --git a/api.php b/api.php
index 7ff4a5611d..27cca55640 100755
--- a/api.php
+++ b/api.php
@@ -2078,6 +2078,7 @@ try {
         }
         UserAPI::changePrimaryLogin($authToken, $login, $_REQUEST['password'] ?? '');
     } elseif ($command == 'Authenticate') {
+        // throw new ExpError('E5219A50-8EB3-4C1A-BB87-4FAABAE0F063', 'Error authenticating!!', '', [], false);
         Maintenance::blockWithJSONResponse();
         $partnerName = $_REQUEST['partnerName'] ?? null;
         $partnerPassword = $_REQUEST['partnerPassword'] ?? null;
```
![image](https://user-images.githubusercontent.com/165133/94607245-85c74380-0250-11eb-9b1c-17f983617b6c.png)


### 2) Tested hardcoding an error in api.php for CreateLogin, tried signing in, confirmed proper error message shows up
```diff
@@ -2383,7 +2384,8 @@ try {
     } elseif ($command === 'MergeAccountWithSAML') {
         $response = UserAPI::mergeAccountWithSAML($authToken, $_REQUEST['validateCode'] ?? '');
     } elseif ($command === 'CreateLogin') {
-        $response = Auth::createLogin($authToken, $_REQUEST['partnerName'] ?? '', $_REQUEST['partnerPassword'] ?? '', $_REQUEST['partnerUserID'] ?? '', $_REQUEST['partnerUserSecret'] ?? '');
+        // $response = Auth::createLogin($authToken, $_REQUEST['partnerName'] ?? '', $_REQUEST['partnerPassword'] ?? '', $_REQUEST['partnerUserID'] ?? '', $_REQUEST['partnerUserSecret'] ?? '');
+        throw new ExpError('E5219A50-8EB3-4C1A-BB87-4FAABAE0F063', 'Error creating login', '', [], false);
     } elseif ($command === 'TwoFactorAuth_Validate') {
         if (!BetaManager::isInBeta($email, BetaManager::BETA_TWO_FACTOR_AUTH)) {
             throw new ExpError('E5219A50-8EB3-4C1A-BB87-4FAABAE0F063', 'Action not permitted', '', [], false);
```
![image](https://user-images.githubusercontent.com/165133/94607396-b3ac8800-0250-11eb-8bb4-149d12461f83.png)

### 3) I updated auth tokens to expire after 15s
```diff
diff --git a/auth/lib/AuthToken.cpp b/auth/lib/AuthToken.cpp
index 3bdb32a4a..781de493f 100644
--- a/auth/lib/AuthToken.cpp
+++ b/auth/lib/AuthToken.cpp
@@ -907,7 +907,7 @@ string AuthToken::create(int64_t accountID, int64_t partnerID, const bool isVali
     authToken["accountID"] = to_string(accountID);
     authToken["partnerID"] = to_string(partnerID);
     authToken["issued"] = to_string(STimeNow());
-    authToken["expires"] = to_string(STimeNow() + expires);
+    authToken["expires"] = to_string(STimeNow() + 15 * STIME_US_PER_S);
     authToken["type"] = typeStrings[type];
 
     if (requestingAccountID != 0) {
```
- Signed in successfully
- Posted a comment
- Waited 15s
- Posted another comment
- Confirmed re-authentication worked 
- Confirmed comment posted after re-authentication
- Refreshed
- Confirmed the last comment was shown

### Extra) on that commit I mentioned in the **Note** above
- Signed in successfully
- Confirmed warning was logged saying that we failed to create a login and that re-authentication will fail
- Waited 15s
- Posted another comment
- Confirmed re-authentication didn't work and I was signed out 
- **Note** when doing this, I got into a network request loop