### PR TITLE
Remove isOffline reliability on Pusher and Remove accountID race condition

### DIFF
--- a/src/lib/API.js
+++ b/src/lib/API.js
@@ -309,32 +309,11 @@ Pusher.registerCustomAuthorizer((channel, {authEndpoint}) => ({
  * @params {object} data
  */
 Pusher.registerSocketEventCallback((eventName, data) => {
-    let isCurrentlyOffline = false;
     switch (eventName) {
-        case 'connected':
-            isCurrentlyOffline = false;
-            break;
-        case 'disconnected':
-            isCurrentlyOffline = true;
-            break;
-        case 'state_change':
-            if (data.current === 'failed') {
-                // WebSockets are not natively available. In this case,
-                // we should not let Pusher influence the offline state of the app.
-                return;
-            }
-
-            if (data.current === 'disconnected' || data.current === 'connecting' || data.current === 'unavailable') {
-                isCurrentlyOffline = true;
-            }
-            break;
         case 'error':
             reconnectToPusher();
             break;
-        default:
-            break;
     }
-    setOfflineStatus(isCurrentlyOffline);
 });
 
 /**

--- a/src/lib/API.js
+++ b/src/lib/API.js
@@ -8,7 +8,6 @@ import ROUTES from '../ROUTES';
 import Str from './Str';
 import Guid from './Guid';
 import redirectToSignIn from './actions/SignInRedirect';
-import {redirect} from './actions/App';
 
 // Holds all of the callbacks that need to be triggered when the network reconnects
 const reconnectionCallbacks = [];
@@ -112,8 +111,10 @@ function setSuccessfulSignInData(data, exitTo) {
     } else {
         redirectTo = ROUTES.HOME;
     }
-    redirect(redirectTo);
-    Ion.merge(IONKEYS.SESSION, _.pick(data, 'authToken', 'accountID', 'email'));
+    Ion.multiSet({
+        [IONKEYS.SESSION]: _.pick(data, 'authToken', 'accountID', 'email'),
+        [IONKEYS.APP_REDIRECT_TO]: redirectTo
+    });
 }
 
 /**

--- a/src/lib/API.js
+++ b/src/lib/API.js
@@ -312,6 +312,8 @@ Pusher.registerSocketEventCallback((eventName) => {
         case 'error':
             reconnectToPusher();
             break;
+        default:
+            break;
     }
 });
 

--- a/src/lib/API.js
+++ b/src/lib/API.js
@@ -102,15 +102,8 @@ function queueRequest(command, data) {
  * @param {string} exitTo
  */
 function setSuccessfulSignInData(data, exitTo) {
-    let redirectTo;
+    const redirectTo = exitTo ? Str.normalizeUrl(exitTo) : ROUTES.HOME;
 
-    if (exitTo && exitTo[0] === '/') {
-        redirectTo = exitTo;
-    } else if (exitTo) {
-        redirectTo = `/${exitTo}`;
-    } else {
-        redirectTo = ROUTES.HOME;
-    }
     Ion.multiSet({
         [IONKEYS.SESSION]: _.pick(data, 'authToken', 'accountID', 'email'),
         [IONKEYS.APP_REDIRECT_TO]: redirectTo

--- a/src/lib/API.js
+++ b/src/lib/API.js
@@ -305,10 +305,9 @@ Pusher.registerCustomAuthorizer((channel, {authEndpoint}) => ({
  * Events that happen on the pusher socket are used to determine if the app is online or offline. The offline setting
  * is stored in Ion so the rest of the app has access to it.
  *
- * @params {string} eventName,
- * @params {object} data
+ * @params {string} eventName
  */
-Pusher.registerSocketEventCallback((eventName, data) => {
+Pusher.registerSocketEventCallback((eventName) => {
     switch (eventName) {
         case 'error':
             reconnectToPusher();

--- a/src/lib/Str.js
+++ b/src/lib/Str.js
@@ -78,13 +78,23 @@ const Str = {
      *
      * @param {String} haystack  The full string to be searched
      * @param {String} needle    The case-sensitive string to search for
-     * @return {Boolean} Retruns true if the haystack starts with the needle.
+     * @returns {Boolean} Returns true if the haystack starts with the needle.
      */
     startsWith(haystack, needle) {
         return _.isString(haystack)
             && _.isString(needle)
             && haystack.substring(0, needle.length) === needle;
     },
+
+    /**
+     * Takes in a URL and returns it with a leading '/'
+     *
+     * @param {mixed} url The URL to be formatted
+     * @returns {String} The formatted URL
+     */
+    normalizeUrl(url) {
+        return (typeof url === 'string' && url.startsWith('/')) ? url : `/${url}`;
+    }
 };
 
 export default Str;

--- a/src/lib/actions/App.js
+++ b/src/lib/actions/App.js
@@ -1,6 +1,6 @@
 import Ion from '../Ion';
 import IONKEYS from '../../IONKEYS';
-import Str from '../Str'
+import Str from '../Str';
 
 let currentRedirectTo;
 Ion.connect({

--- a/src/lib/actions/App.js
+++ b/src/lib/actions/App.js
@@ -1,5 +1,6 @@
 import Ion from '../Ion';
 import IONKEYS from '../../IONKEYS';
+import Str from '../Str'
 
 let currentRedirectTo;
 Ion.connect({
@@ -14,7 +15,7 @@ Ion.connect({
  * @param {mixed} url
  */
 function redirect(url) {
-    const formattedURL = (typeof url === 'string' && url.startsWith('/')) ? url : `/${url}`;
+    const formattedURL = Str.normalizeUrl(url);
     Ion.merge(IONKEYS.APP_REDIRECT_TO, formattedURL);
 }
 

--- a/src/lib/actions/Report.js
+++ b/src/lib/actions/Report.js
@@ -23,6 +23,7 @@ Ion.connect({
         if (val) {
             currentUserEmail = val.email;
             currentUserAccountID = val.accountID;
+            Pusher.init().then(subscribeToReportCommentEvents);
         }
     }
 });
@@ -220,6 +221,11 @@ function updateReportWithNewAction(reportID, reportAction) {
  * Initialize our pusher subscriptions to listen for new report comments
  */
 function subscribeToReportCommentEvents() {
+    // If we don't have the user's accountID yet we can't subscribe so return early
+    if (!currentUserAccountID) {
+        return;
+    }
+
     const pusherChannelName = `private-user-accountID-${currentUserAccountID}`;
     if (Pusher.isSubscribed(pusherChannelName) || Pusher.isAlreadySubscribing(pusherChannelName)) {
         return;

--- a/src/lib/actions/Report.js
+++ b/src/lib/actions/Report.js
@@ -210,6 +210,11 @@ function updateReportWithNewAction(reportID, reportAction) {
  * Initialize our pusher subscriptions to listen for new report comments
  */
 function subscribeToReportCommentEvents() {
+    // If we don't have the user's accountID yet we can't subscribe so return early
+    if (!currentUserAccountID) {
+        return;
+    }
+
     const pusherChannelName = `private-user-accountID-${currentUserAccountID}`;
     if (Pusher.isSubscribed(pusherChannelName) || Pusher.isAlreadySubscribing(pusherChannelName)) {
         return;

--- a/src/lib/actions/Report.js
+++ b/src/lib/actions/Report.js
@@ -16,6 +16,16 @@ import Visibility from '../Visibility';
 
 let currentUserEmail;
 let currentUserAccountID;
+Ion.connect({
+    key: IONKEYS.SESSION,
+    callback: (val) => {
+        // When signed out, val is undefined
+        if (val) {
+            currentUserEmail = val.email;
+            currentUserAccountID = val.accountID;
+        }
+    }
+});
 
 let currentURL;
 Ion.connect({
@@ -224,18 +234,6 @@ function subscribeToReportCommentEvents() {
         updateReportWithNewAction(pushJSON.reportID, pushJSON.reportAction);
     });
 }
-
-Ion.connect({
-    key: IONKEYS.SESSION,
-    callback: (val) => {
-        // When signed out, val is undefined
-        if (val) {
-            currentUserEmail = val.email;
-            currentUserAccountID = val.accountID;
-            Pusher.init().then(subscribeToReportCommentEvents);
-        }
-    }
-});
 
 /**
  * Get all chat reports and provide the proper report name

--- a/src/lib/actions/Report.js
+++ b/src/lib/actions/Report.js
@@ -16,17 +16,6 @@ import Visibility from '../Visibility';
 
 let currentUserEmail;
 let currentUserAccountID;
-Ion.connect({
-    key: IONKEYS.SESSION,
-    callback: (val) => {
-        // When signed out, val is undefined
-        if (val) {
-            currentUserEmail = val.email;
-            currentUserAccountID = val.accountID;
-            Pusher.init().then(subscribeToReportCommentEvents);
-        }
-    }
-});
 
 let currentURL;
 Ion.connect({
@@ -221,11 +210,6 @@ function updateReportWithNewAction(reportID, reportAction) {
  * Initialize our pusher subscriptions to listen for new report comments
  */
 function subscribeToReportCommentEvents() {
-    // If we don't have the user's accountID yet we can't subscribe so return early
-    if (!currentUserAccountID) {
-        return;
-    }
-
     const pusherChannelName = `private-user-accountID-${currentUserAccountID}`;
     if (Pusher.isSubscribed(pusherChannelName) || Pusher.isAlreadySubscribing(pusherChannelName)) {
         return;
@@ -235,6 +219,18 @@ function subscribeToReportCommentEvents() {
         updateReportWithNewAction(pushJSON.reportID, pushJSON.reportAction);
     });
 }
+
+Ion.connect({
+    key: IONKEYS.SESSION,
+    callback: (val) => {
+        // When signed out, val is undefined
+        if (val) {
+            currentUserEmail = val.email;
+            currentUserAccountID = val.accountID;
+            Pusher.init().then(subscribeToReportCommentEvents);
+        }
+    }
+});
 
 /**
  * Get all chat reports and provide the proper report name

--- a/src/page/home/HomePage.js
+++ b/src/page/home/HomePage.js
@@ -12,8 +12,9 @@ import styles, {getSafeAreaPadding} from '../../style/StyleSheet';
 import Header from './HeaderView';
 import Sidebar from './sidebar/SidebarView';
 import Main from './MainView';
-import {fetchAll as fetchAllReports} from '../../lib/actions/Report';
+import {subscribeToReportCommentEvents, fetchAll as fetchAllReports} from '../../lib/actions/Report';
 import {fetch as fetchPersonalDetails} from '../../lib/actions/PersonalDetails';
+import * as Pusher from '../../lib/Pusher/pusher';
 
 const windowSize = Dimensions.get('window');
 const widthBreakPoint = 1000;
@@ -35,6 +36,8 @@ export default class App extends React.Component {
     }
 
     componentDidMount() {
+        Pusher.init().then(subscribeToReportCommentEvents);
+
         // Fetch all the personal details
         fetchPersonalDetails();
 

--- a/src/page/home/HomePage.js
+++ b/src/page/home/HomePage.js
@@ -36,8 +36,6 @@ export default class App extends React.Component {
     }
 
     componentDidMount() {
-        Pusher.init().then(subscribeToReportCommentEvents);
-
         // Fetch all the personal details
         fetchPersonalDetails();
 

--- a/src/page/home/HomePage.js
+++ b/src/page/home/HomePage.js
@@ -12,9 +12,8 @@ import styles, {getSafeAreaPadding} from '../../style/StyleSheet';
 import Header from './HeaderView';
 import Sidebar from './sidebar/SidebarView';
 import Main from './MainView';
-import {subscribeToReportCommentEvents, fetchAll as fetchAllReports} from '../../lib/actions/Report';
+import {fetchAll as fetchAllReports} from '../../lib/actions/Report';
 import {fetch as fetchPersonalDetails} from '../../lib/actions/PersonalDetails';
-import * as Pusher from '../../lib/Pusher/pusher';
 
 const windowSize = Dimensions.get('window');
 const widthBreakPoint = 1000;


### PR DESCRIPTION
Fixes https://github.com/Expensify/Expensify/issues/141565

We were accidentally DOSing ourselves via the chat app because we were calling [fetchAll](https://github.com/Expensify/ReactNativeChat/blob/a8582686093ca14e0745859901dab450fa22e844/src/lib/actions/Report.js#L273) a bunch of times. This function gets called any time we're going from offline -> online. We managed to reproduce the issue by deleting all local storage and then refreshing and logging in. This would put us into an infinite loop of `get` calls because pusher was throwing errors that said `Auth info required to subscribe to private-user-accountID-undefined`. When we got an error we would call `Pusher.reconnect()` which really just calls `disconnect();` and then `reconnect()`. This put our app into offline, and then online, (which calls `fetchAll` and then we would get an error and the process would repeat.

To fix this I did 2 things:
1. Remove everything relating to the `isOffline` state of our app that relies on pusher. We already have 2 other things that tell us if the app is offline, so it was just causing bugs.
2. Fix the race condition that was causing us to not have the user's accountID when we tried to subscribe to the pusher channel