### PR TITLE
Add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+<Assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit.>
+
+<Explanation of the change or anything fishy that is going on>
+
+### Fixed Issues
+Fixes GH_LINK
+
+### Tests
+<Tests you performed on all platforms that validates your changed worked>
+
+### Screenshots
+<Add any necessary screenshots for all platforms if your change added or updated UI>


### PR DESCRIPTION
@AndrewGable @cead22 will you please review this?

This PR adds a PR template to the React Native codebase, similar to the one we have for [Web-Expensify](https://raw.githubusercontent.com/Expensify/Web-Expensify/0f135a84386d8af289389d8ccc9d5aeb7be0d489/.github/PULL_REQUEST_TEMPLATE.md?token=AA6L6LRGBHP52UMJINDOO427PSU4K).

### Tests
None

### Screenshots
None
