### PR TITLE
Prevent iOS white screen on sign-in

### DIFF
--- a/src/lib/DateUtils.js
+++ b/src/lib/DateUtils.js
@@ -1,8 +1,5 @@
 import moment from 'moment';
-
-// We have to import moment-timezone, but don't access it directly because all it's functionality is added to moment
-// eslint-disable-next-line no-unused-vars
-import momentTimzone from 'moment-timezone';
+import 'moment-timezone';
 import Str from './Str';
 import Ion from './Ion';
 import IONKEYS from '../IONKEYS';


### PR DESCRIPTION
@AndrewGable please review this

This PR fixes an issue where iOS would white screen after sign in, preventing the user from taking any actions. After investigating, @AndrewGable and I discovered the issue, which lead us to [this fix](https://stackoverflow.com/a/37728479/2509962).

```
2020-09-29 16:47:24.206310-0700 Chat[42394:4777500] [javascript] TypeError: undefined is not an object (evaluating 'n.format')

This error is located at:
    in ReportActionItemDate
```

### Tests
1. Build the RNC app to your device, confirm that after signing in you don't get a white screen
2. Run the app on web, confirm that the dates for chats are correct
