### PR TITLE
Fix addComment bug / Another one related to activeClients

### DIFF
--- a/src/lib/API.js
+++ b/src/lib/API.js
@@ -465,6 +465,7 @@ function createChatReport(parameters) {
  * @param {object} parameters
  * @param {string} parameters.reportComment
  * @param {object} parameters.file
+ * @param {number} parameters.reportID
  * @returns {Promise}
  */
 function addReportComment(parameters) {
@@ -472,6 +473,7 @@ function addReportComment(parameters) {
         authToken,
         reportComment: parameters.reportComment,
         file: parameters.file,
+        reportID: parameters.reportID,
     });
 }
 

--- a/src/lib/ActiveClientManager/index.js
+++ b/src/lib/ActiveClientManager/index.js
@@ -10,7 +10,7 @@ let activeClients;
 Ion.connect({
     key: IONKEYS.ACTIVE_CLIENTS,
 
-    callback: (val) => {
+    callback: (val = []) => {
         activeClients = val;
         if (activeClients.length >= maxClients) {
             activeClients.shift();


### PR DESCRIPTION
We [missed to add a param for `Report_AddComment`](https://github.com/Expensify/ReactNativeChat/pull/563) which broke a few things.

Separately, also noticed that it's possible to have no active clients so defaulted to an empty array in that case to be on the safe side and prevent a JS error I saw pop up.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/142391

### Tests
1. Log in as two separate users
1. Leave a comment on a chat and try to chat back and forth
1. Verify it works as expected

### Screenshots
❌ 