### PR TITLE
Fix activeClients once more

### DIFF
--- a/src/lib/ActiveClientManager/index.js
+++ b/src/lib/ActiveClientManager/index.js
@@ -9,9 +9,8 @@ const maxClients = 20;
 let activeClients;
 Ion.connect({
     key: IONKEYS.ACTIVE_CLIENTS,
-
-    callback: (val = []) => {
-        activeClients = val;
+    callback: (val) => {
+        activeClients = _.isNull(val) ? [] : val;
         if (activeClients.length >= maxClients) {
             activeClients.shift();
             Ion.set(IONKEYS.ACTIVE_CLIENTS, activeClients);


### PR DESCRIPTION
This fixes an error where we check the length of the `activeClients` key before it gets set in `init`

### Fixed Issues
No issue just something that pops up
![Screenshot 1433](https://user-images.githubusercontent.com/32969087/94854233-73c8da80-03e1-11eb-9c71-1365867fd471.png)

### Tests
I just ran this in the JS console to show that the previous JS logic was wrong and default arguments don't actually work when you pass `null`

![Screenshot 1432](https://user-images.githubusercontent.com/32969087/94854168-5bf15680-03e1-11eb-9b15-cb065b18a2d8.png)

### Screenshots
❌ 