### PR TITLE
Prevent self-notifications by Using AccountID instead of Email

### DIFF
--- a/src/lib/API.js
+++ b/src/lib/API.js
@@ -133,7 +133,7 @@ function setSuccessfulSignInData(data, exitTo) {
         redirectTo = ROUTES.HOME;
     }
     redirect(redirectTo);
-    Ion.merge(IONKEYS.SESSION, _.pick(data, 'authToken', 'accountID', 'email'));
+    Ion.merge(IONKEYS.SESSION, _.pick(data, 'authToken', 'accountID', 'email', 'secondaryLogins'));
 }
 
 /**
@@ -210,7 +210,8 @@ function request(command, parameters, type = 'post') {
                     partnerPassword: CONFIG.EXPENSIFY.PARTNER_PASSWORD,
                     partnerUserID: credentials.login,
                     partnerUserSecret: credentials.password,
-                    twoFactorAuthCode: ''
+                    twoFactorAuthCode: '',
+                    includeSecondaryLogins: true,
                 })
                     .then((response) => {
                         reauthenticating = false;
@@ -394,6 +395,7 @@ function authenticate(parameters) {
         partnerUserID: parameters.partnerUserID,
         partnerUserSecret: parameters.partnerUserSecret,
         twoFactorAuthCode: parameters.twoFactorAuthCode,
+        includeSecondaryLogins: true,
         exitTo: parameters.exitTo,
     })
         .catch((err) => {

--- a/src/lib/API.js
+++ b/src/lib/API.js
@@ -125,7 +125,7 @@ function setSuccessfulSignInData(data, exitTo) {
     const redirectTo = exitTo ? Str.normalizeUrl(exitTo) : ROUTES.HOME;
 
     Ion.multiSet({
-        [IONKEYS.SESSION]: _.pick(data, 'authToken', 'accountID', 'email', 'secondaryLogins'),
+        [IONKEYS.SESSION]: _.pick(data, 'authToken', 'accountID', 'email'),
         [IONKEYS.APP_REDIRECT_TO]: redirectTo
     });
 }
@@ -204,8 +204,7 @@ function request(command, parameters, type = 'post') {
                     partnerPassword: CONFIG.EXPENSIFY.PARTNER_PASSWORD,
                     partnerUserID: credentials.login,
                     partnerUserSecret: credentials.password,
-                    twoFactorAuthCode: '',
-                    includeSecondaryLogins: true,
+                    twoFactorAuthCode: ''
                 })
                     .then((response) => {
                         reauthenticating = false;
@@ -369,7 +368,6 @@ function authenticate(parameters) {
         partnerUserID: parameters.partnerUserID,
         partnerUserSecret: parameters.partnerUserSecret,
         twoFactorAuthCode: parameters.twoFactorAuthCode,
-        includeSecondaryLogins: true,
         exitTo: parameters.exitTo,
     })
         .catch((err) => {

--- a/src/lib/actions/Report.js
+++ b/src/lib/actions/Report.js
@@ -16,6 +16,7 @@ import Visibility from '../Visibility';
 
 let currentUserEmail;
 let currentUserAccountID;
+let secondaryLogins;
 Ion.connect({
     key: IONKEYS.SESSION,
     callback: (val) => {
@@ -23,6 +24,7 @@ Ion.connect({
         if (val) {
             currentUserEmail = val.email;
             currentUserAccountID = val.accountID;
+            secondaryLogins = val.secondaryLogins;
         }
     }
 });
@@ -193,7 +195,7 @@ function updateReportWithNewAction(reportID, reportAction) {
     }
 
     // If this comment is from the current user we don't want to parrot whatever they wrote back to them.
-    if (reportAction.actorEmail === currentUserEmail) {
+    if (reportAction.actorEmail === currentUserEmail || _.contains(secondaryLogins, currentUserEmail)) {
         console.debug('[NOTIFICATION] No notification because comment is from the currently logged in user');
         return;
     }

--- a/src/lib/actions/Report.js
+++ b/src/lib/actions/Report.js
@@ -16,7 +16,6 @@ import Visibility from '../Visibility';
 
 let currentUserEmail;
 let currentUserAccountID;
-let secondaryLogins;
 Ion.connect({
     key: IONKEYS.SESSION,
     callback: (val) => {
@@ -24,7 +23,6 @@ Ion.connect({
         if (val) {
             currentUserEmail = val.email;
             currentUserAccountID = val.accountID;
-            secondaryLogins = val.secondaryLogins;
         }
     }
 });
@@ -195,7 +193,7 @@ function updateReportWithNewAction(reportID, reportAction) {
     }
 
     // If this comment is from the current user we don't want to parrot whatever they wrote back to them.
-    if (reportAction.actorEmail === currentUserEmail || _.contains(secondaryLogins, currentUserEmail)) {
+    if (reportAction.actorAccountID === currentUserAccountID) {
         console.debug('[NOTIFICATION] No notification because comment is from the currently logged in user');
         return;
     }


### PR DESCRIPTION
We were relying on email to make sure that we didn't notify users about their own messages. This is unreliable because it's possible a secondary login became primary and sent the message. This update (with help from this [Web PR](https://github.com/Expensify/Web-Expensify/pull/29340) switches our check to use the accountID instead.

### Fixed Issues
Fixes $https://github.com/Expensify/Expensify/issues/141710

### Tests
1. Drop a debugger [here](https://github.com/Expensify/ReactNativeChat/blob/79b4bd3f71202fd2dc80ed0c2126a3947bd5050c/src/lib/actions/Report.js#L194) 
2. Send a message to your account
3. Make sure the `reportAction.actorAccountID` variable is defined