### PR TITLE
Block requests made without an authToken. Do not fire reconnect callbacks without an authToken.

### DIFF
--- a/src/lib/API.js
+++ b/src/lib/API.js
@@ -53,7 +53,9 @@ Ion.connect({
 // returns from the background. So, if we are returning from the background
 // and we are online we should trigger our reconnection callbacks.
 Activity.registerOnAppBecameActiveCallback(() => {
-    if (isOffline) {
+    // If we know we are offline and we have no authToken then there's
+    // no reason to trigger the reconnection callbacks as they will fail.
+    if (isOffline || !authToken) {
         return;
     }
 
@@ -178,6 +180,16 @@ function request(command, parameters, type = 'post') {
                     createLogin(Str.generateDeviceLoginID(), Guid());
                 }
             });
+    }
+
+    // If we end up here with no authToken it means we are trying to make
+    // an API request before we are signed in. In this case, we should just
+    // cancel this and all other requests and set reauthenticating to false.
+    if (!authToken) {
+        console.error('A request was made without an authToken', {command, parameters});
+        reauthenticating = false;
+        networkRequestQueue = [];
+        return Promise.resolve();
     }
 
     // Add authToken automatically to all commands

--- a/src/lib/API.js
+++ b/src/lib/API.js
@@ -189,6 +189,7 @@ function request(command, parameters, type = 'post') {
         console.error('A request was made without an authToken', {command, parameters});
         reauthenticating = false;
         networkRequestQueue = [];
+        redirectToSignIn();
         return Promise.resolve();
     }
 


### PR DESCRIPTION
The full context and discussion around this solution is [here](https://expensify.slack.com/archives/C03TQ48KC/p1601579127394500)

Ultimately, we all agree that there is probably a better way to do this and discussed a few options, but this is the simplest solution to fix the problem right now. Which is... we are firing reconnect callbacks without an `authToken` so the simple solution is to... stop it !

Better solution which we can follow up with would be more of a `PubSub` or `Ion` integration where `onReconnect` callbacks are hooked into `Ion` and we just let `Ion` know that it needs to update based on an event like the app returning from background or gaining connectivity after it has been lost.
 
### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/142471

### Tests (Android specifically is very broken - apparently iOS as well)
1. Delete app and reinstall
1. Background the app
1. Open the app again
1. Attempt to login
1. Verify you are able to do so

### Screenshots
❌ 