### PR TITLE
Default to target=_blank for report comment links

### DIFF
--- a/src/components/AnchorForCommentsOnly/index.js
+++ b/src/components/AnchorForCommentsOnly/index.js
@@ -10,12 +10,6 @@ const propTypes = {
     // The URL to open
     href: PropTypes.string,
 
-    // What headers to send to the linked page (usually noopener and noreferrer)
-    rel: PropTypes.string,
-
-    // Used to determine where to open a link ("_blank" is passed for a new tab)
-    target: PropTypes.string,
-
     // Any children to display
     children: PropTypes.node,
 
@@ -26,16 +20,12 @@ const propTypes = {
 
 const defaultProps = {
     href: '',
-    rel: '',
-    target: '',
     children: null,
     style: {},
 };
 
 const AnchorForCommentsOnly = ({
     href,
-    rel,
-    target,
     children,
     style,
     ...props
@@ -43,8 +33,8 @@ const AnchorForCommentsOnly = ({
     <a
         style={StyleSheet.flatten(style)}
         href={href}
-        rel={rel}
-        target={target}
+        rel="noopener noreferrer"
+        target="_blank"
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...props}
     >

--- a/src/components/AnchorForCommentsOnly/index.js
+++ b/src/components/AnchorForCommentsOnly/index.js
@@ -10,6 +10,12 @@ const propTypes = {
     // The URL to open
     href: PropTypes.string,
 
+    // What headers to send to the linked page (usually noopener and noreferrer)
+    rel: PropTypes.string,
+
+    // Used to determine where to open a link ("_blank" is passed for a new tab)
+    target: PropTypes.string,
+
     // Any children to display
     children: PropTypes.node,
 
@@ -20,12 +26,16 @@ const propTypes = {
 
 const defaultProps = {
     href: '',
+    rel: '',
+    target: '',
     children: null,
     style: {},
 };
 
 const AnchorForCommentsOnly = ({
     href,
+    rel,
+    target,
     children,
     style,
     ...props
@@ -33,8 +43,8 @@ const AnchorForCommentsOnly = ({
     <a
         style={StyleSheet.flatten(style)}
         href={href}
-        rel="noopener noreferrer"
-        target="_blank"
+        rel={rel}
+        target={target}
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...props}
     >

--- a/src/page/home/report/ReportActionItemFragment.js
+++ b/src/page/home/report/ReportActionItemFragment.js
@@ -35,6 +35,13 @@ class ReportActionItemFragment extends React.PureComponent {
             a: (htmlAttribs, children, convertedCSSStyles, passProps) => (
                 <AnchorForCommentsOnly
                     href={htmlAttribs.href}
+
+                    // Unless otherwise specified open all links in
+                    // a new window. On Desktop this means that we will
+                    // skip the default Save As... download prompt
+                    // and defer to whatever browser the user has.
+                    target={htmlAttribs.target || '_blank'}
+                    rel={htmlAttribs.rel || 'noopener noreferrer'}
                     style={passProps.style}
                     key={passProps.key}
                 >

--- a/src/page/home/report/ReportActionItemFragment.js
+++ b/src/page/home/report/ReportActionItemFragment.js
@@ -35,8 +35,6 @@ class ReportActionItemFragment extends React.PureComponent {
             a: (htmlAttribs, children, convertedCSSStyles, passProps) => (
                 <AnchorForCommentsOnly
                     href={htmlAttribs.href}
-                    target={htmlAttribs.target}
-                    rel={htmlAttribs.rel}
                     style={passProps.style}
                     key={passProps.key}
                 >


### PR DESCRIPTION
cc @Jag96 

Quick fix here. Couldn't think of any reason why we'd need to open a report comment link in app for now so providing defaults for now to prevent people from getting stuck viewing files in the desktop app. Discussed with @Jag96 and the only reason we could think of is that file downloads will bypass the default "Save as..." prompt that shows in Electron. But there's no clear reason why it's better to do that than just opening these links in Chrome for now.

This logic might need to change if we have report comments that are intended to deep link to various places in the app. But that seems like a future problem.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/142225

### Tests
1. Send yourself a `.zip` attachment and a `.txt` attachment
1. Attempt to open both in web and desktop platforms
1. Verify they always open in a new external browser window

### Screenshots
❌ 