### PR TITLE
Fix sign out button, by passing reference when removing event

### DIFF
--- a/src/lib/NetworkConnection.js
+++ b/src/lib/NetworkConnection.js
@@ -27,6 +27,8 @@ const triggerReconnectionCallbacks = _.throttle(() => {
  * for a few minutes, but eventually disconnects causing a delay when the app
  * returns from the background. So, if we are returning from the background
  * and we are online we should trigger our reconnection callbacks.
+ *
+ * @param {AppState} state
  */
 const reconnectListener = (state) => {
     console.debug('[AppState] state changed:', state);


### PR DESCRIPTION
CC @marcaaron

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/143067

Fixes issue where sign out button threw error and did not return user to login page.

![sign-out-blocked](https://user-images.githubusercontent.com/10736861/95342683-99595680-08af-11eb-920a-20175e2e3747.gif)

### Tests (**Desktop and web**)

- Sign in to an account
- Attempt to sign out
- You should be returned to the login page

### Screenshots
N/A
