### PR TITLE
Update redirects for notifications and channels to go to report/reportID

### DIFF
--- a/src/lib/actions/Report.js
+++ b/src/lib/actions/Report.js
@@ -219,7 +219,7 @@ function updateReportWithNewAction(reportID, reportAction) {
         reportAction,
         onClick: () => {
             // Navigate to this report onClick
-            redirect(reportID);
+            redirect(ROUTES.getReportRoute(reportID));
         }
     });
 }

--- a/src/page/home/sidebar/ChatSwitcherView.js
+++ b/src/page/home/sidebar/ChatSwitcherView.js
@@ -9,6 +9,7 @@ import ChatSwitcherList from './ChatSwitcherList';
 import ChatSwitcherSearchForm from './ChatSwitcherSearchForm';
 import {fetchOrCreateChatReport} from '../../../lib/actions/Report';
 import {redirect} from '../../../lib/actions/App';
+import ROUTES from '../../../ROUTES';
 
 const personalDetailsPropTypes = PropTypes.shape({
     // The login of the person (either email or phone number)
@@ -108,7 +109,7 @@ class ChatSwitcherView extends React.Component {
      * @param {string} option.reportID
      */
     selectReport(option) {
-        redirect(option.reportID);
+        redirect(ROUTES.getReportRoute(option.reportID));
         this.reset();
     }
 


### PR DESCRIPTION
Notifications were breaking people's chats because they were being routed to `#/reportID` instead of `#/report/reportID`. Looks like these redirects were just missed in https://github.com/Expensify/ReactNativeChat/pull/603

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/143035

### Tests
1. Open 2 chat windows, one in chrome, one in incognito
2. Log in on different accounts
3. Send a message from incognito 
4. Click the notification that pops up on normal chrome and make sure you go to the chat

