### PR TITLE
Add ELECTRON_EVENTS to electron files

### DIFF
--- a/desktop/electron.config.js
+++ b/desktop/electron.config.js
@@ -22,6 +22,7 @@ module.exports = {
     }],
     files: [
         './dist/**/*',
-        './main.js'
+        './main.js',
+        './desktop/ELECTRON_EVENTS.js',
     ]
 };


### PR DESCRIPTION
@AndrewGable Will you please review this?
cc @marcaaron @mallenexpensify 

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/143354

### Tests
1) Checkout master, verify that npm version is 111
2) Add `./desktop/ELECTRON_EVENTS.js` to electron files in `electron.config.js`
3) Make a few temporary changes to `electron.config.js` and `package.json` so that the local build works for me:
```javascript
module.exports = {
    appId: 'com.expensifyreactnative.chat',
    productName: 'Chat',

    // Comment out notarizing
    // afterSign: 'desktop/notarize.js',
    mac: {
        category: 'public.app-category.finance',
        icon: './android/app/src/main/res/mipmap-xxxhdpi/ic_launcher_round.png',
        hardenedRuntime: true,
        entitlements: 'desktop/entitlements.mac.plist',
        entitlementsInherit: 'desktop/entitlements.mac.plist',
        type: 'distribution'
    },
    dmg: {
        title: 'Chat',
        artifactName: 'Chat.dmg',
        internetEnabled: true
    },
    // Also comment out publishing step
    // publish: [{
    //     provider: 's3',
    //     bucket: 'chat-test-expensify-com',
    //     channel: 'latest'
    // }],
    files: [
        './dist/**/*',
        './main.js',
        './desktop/ELECTRON_EVENTS.js',
    ]
};
```
```json
...
// Temporarily remove --publish always
"desktop-build": "webpack --config webpack.prod.js --platform desktop && electron-builder --config desktop/electron.config.js",
...
```
4) Run `npm run desktop-build`
5) Double click on `dist/Chat.dmg` in finder, install Chat, replacing old installation.
6) Open chat, no errors! 🎉 

**Note:** I think @AndrewGable might still need to test this fix without any other changes in the production build. I'm not 100% sure but I think I was unable to get past the notarization process with my development certs.