### PR TITLE
Update input field to use font size 15

### DIFF
--- a/src/style/StyleSheet.js
+++ b/src/style/StyleSheet.js
@@ -182,6 +182,7 @@ const styles = {
         borderWidth: 1,
         color: colors.text,
         fontFamily: fontFamily.GTA,
+        fontSize: 15,
         padding: 12,
         textAlignVertical: 'center',
     },
@@ -559,7 +560,6 @@ const styles = {
         paddingRight: 8,
         paddingBottom: 10,
         paddingLeft: 8,
-        fontSize: 15,
     },
 
     chatItemSubmitButton: {

--- a/src/style/StyleSheet.js
+++ b/src/style/StyleSheet.js
@@ -559,6 +559,7 @@ const styles = {
         paddingRight: 8,
         paddingBottom: 10,
         paddingLeft: 8,
+        fontSize: 15,
     },
 
     chatItemSubmitButton: {


### PR DESCRIPTION
Uses the same font size for text input fields that we use for chat messages. 

### Fixed Issues
https://github.com/Expensify/Expensify/issues/143550

### Tests (any platform)
1. Text in all input fields should be size 15 (same as chat messages)
2. Go to the sign in page. See that text is right size when entering on all three input fields
3. Sign in and enter text into the chat switcher. Verify that text is the right size
4. Type a chat message to someone (but don't send). Verify that text in compose box is the right size

### Screenshots
Before: 
![image](https://user-images.githubusercontent.com/1371996/95794527-be820680-0cad-11eb-8209-f51d0e5f8cd4.png)
![image](https://user-images.githubusercontent.com/1371996/95796267-10c52680-0cb2-11eb-94ba-949547fbc499.png)


After: 
![image](https://user-images.githubusercontent.com/1371996/95794534-c2ae2400-0cad-11eb-9554-e66cb3964d81.png)
![image](https://user-images.githubusercontent.com/1371996/95796271-1458ad80-0cb2-11eb-9c99-005ecd365826.png)
