### PR TITLE
Fix issue where users not displaying in iOS chat switcher

### DIFF
--- a/src/lib/API.js
+++ b/src/lib/API.js
@@ -445,9 +445,9 @@ function get(parameters) {
  * @returns {Promise}
  */
 function getPersonalDetails(parameters) {
-    return queueRequest('Get', {
+    return queueRequest('PersonalDetails_GetForEmails', {
         authToken,
-        emailList: parameters.emailList,
+        emailList: parameters,
     });
 }
 

--- a/src/lib/actions/PersonalDetails.js
+++ b/src/lib/actions/PersonalDetails.js
@@ -131,7 +131,7 @@ function fetch() {
  * @param {String} emailList
  */
 function getForEmails(emailList) {
-    API.getPersonalDetails({emailList})
+    API.getPersonalDetails(emailList)
         .then((data) => {
             const details = _.pick(data, emailList.split(','));
             Ion.merge(IONKEYS.PERSONAL_DETAILS, formatPersonalDetails(details));


### PR DESCRIPTION
CC @cead22 -- I believe this was introduced during the [API refactor](https://github.com/Expensify/ReactNativeChat/pull/563/commits/8c1db8257d04099f89a0d41769a3bf76418f1ae5)

Fixes issue where no users were listed in the chat switcher for iOS. 
- Fix broken personalDetails API request, to prevent empty response from overriding personal user data
- Each platform would receive an empty response and I'm still not sure why this only affected iOS 🤷‍♂️ 

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/142350

### Tests

- Build to iOS
- Wait for [`PersonalDetails_GetForEmails`](https://github.com/Expensify/ReactNativeChat/compare/jules-fix-ios-chat-switcher?expand=1#diff-e3664a95cdd3af4d57ba41eb209b1c3d1ca08bbeb51657644e8353506cffdd9cR448) request to complete
- Open the LHN
- Start typing, you should see users in the list

### Screenshots

**Before**
![Simulator Screen Shot - iPhone 11 - 2020-10-13 at 15 10 22](https://user-images.githubusercontent.com/10736861/95872128-60652a00-0d66-11eb-8233-19cafe53b1dc.png)

**After**
![Simulator Screen Shot - iPhone 11 - 2020-10-13 at 15 10 43](https://user-images.githubusercontent.com/10736861/95872134-622eed80-0d66-11eb-8c80-3715acadb99a.png)

