### PR TITLE
Update report URL routes

### DIFF
--- a/src/ROUTES.js
+++ b/src/ROUTES.js
@@ -3,8 +3,8 @@
  */
 export default {
     HOME: '/home',
-    REPORT: '/report/:reportID',
-    getReportRoute: reportID => `/report/${reportID}`,
+    REPORT: '/r/:reportID',
+    getReportRoute: reportID => `/r/${reportID}`,
     ROOT: '/',
     SIGNIN: '/signin',
     SIGNIN_WITH_EXITTO: '/signIn/exitTo/:exitTo*',


### PR DESCRIPTION
Updates the report routes to from `/report/1234` to `/r/1234`.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/143123

### Tests
`npm run web` and checked URLs for various chats and DMs for dev.

QA: Log into chat.expensify.com and confirm URLs for chats and DMs are in format `https://chat.expensify.com/#/r/12345`

