### PR TITLE
Disable auto capitalization for login field

### DIFF
--- a/src/page/SignInPage.js
+++ b/src/page/SignInPage.js
@@ -93,6 +93,7 @@ class App extends Component {
                                 textContentType="username"
                                 onChangeText={text => this.setState({login: text})}
                                 onSubmitEditing={this.submitForm}
+                                autoCapitalize="none"
                             />
                         </View>
                         <View style={[styles.mb4]}>


### PR DESCRIPTION
This is either an email or a phone number. Phone numbers aren't capitalized, and emails are not typically capitalized. Disabling auto-capitalization ("sentence" is the default) should make this field more convenient for most users

<Assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit.>

<Explanation of the change or anything fishy that is going on>

### Fixed Issues
https://expensify.slack.com/archives/C011W8BJ9L6/p1602715028102600

### Tests
Built before and after (see screenshots)

### Screenshots
<img width="584" alt="before" src="https://user-images.githubusercontent.com/1058475/96054713-2152d980-0e37-11eb-95db-ab36604ce3d6.png">
<img width="584" alt="after" src="https://user-images.githubusercontent.com/1058475/96054716-231c9d00-0e37-11eb-964c-1aa307879b4e.png">

