### PR TITLE
[WIP] Adds Naive Pagination to Report Action Views

### DIFF
--- a/src/components/InvertedFlatList/BaseInvertedFlatList.js
+++ b/src/components/InvertedFlatList/BaseInvertedFlatList.js
@@ -137,8 +137,8 @@ class BaseInvertedFlatList extends Component {
                 renderItem={this.renderItem}
                 getItemLayout={this.getItemLayout}
                 bounces={false}
-                maxToRenderPerBatch={15}
-                updateCellsBatchingPeriod={40}
+                // maxToRenderPerBatch={15}
+                // updateCellsBatchingPeriod={40}
 
                 // Setting removeClippedSubviews will break text selection on Android
                 removeClippedSubviews={false}

--- a/src/components/InvertedFlatList/BaseInvertedFlatList.js
+++ b/src/components/InvertedFlatList/BaseInvertedFlatList.js
@@ -17,6 +17,9 @@ const propTypes = {
     // if this is inaccurate.
     initialRowHeight: PropTypes.number.isRequired,
 
+    // Should we calculate the item layouts or not
+    shouldGetItemLayout: PropTypes.bool,
+
     // Passed via forwardRef so we can access the FlatList ref
     innerRef: PropTypes.oneOfType([
         PropTypes.func,
@@ -26,6 +29,7 @@ const propTypes = {
 
 const defaultProps = {
     data: [],
+    shouldGetItemLayout: true,
 };
 
 class BaseInvertedFlatList extends Component {
@@ -120,11 +124,15 @@ class BaseInvertedFlatList extends Component {
      * @return {React.Component}
      */
     renderItem({item, index}) {
-        return (
-            <View onLayout={({nativeEvent}) => this.measureItemLayout(nativeEvent, index)}>
-                {this.props.renderItem({item, index})}
-            </View>
-        );
+        if (this.props.shouldGetItemLayout) {
+            return (
+                <View onLayout={({nativeEvent}) => this.measureItemLayout(nativeEvent, index)}>
+                    {this.props.renderItem({item, index})}
+                </View>
+            );
+        }
+
+        return this.props.renderItem({item, index});
     }
 
     render() {
@@ -135,13 +143,13 @@ class BaseInvertedFlatList extends Component {
                 ref={this.props.innerRef}
                 inverted
                 renderItem={this.renderItem}
-                getItemLayout={this.getItemLayout}
-                bounces={false}
-                // maxToRenderPerBatch={15}
-                // updateCellsBatchingPeriod={40}
 
-                // Setting removeClippedSubviews will break text selection on Android
-                removeClippedSubviews={false}
+                // iOS scrolling skips in a bad way after a certain number of items
+                // enters the list and should not use getItemLayout as implemented here
+                getItemLayout={this.props.shouldGetItemLayout ? this.getItemLayout : undefined}
+                bounces={false}
+                maxToRenderPerBatch={15}
+                updateCellsBatchingPeriod={40}
             />
         );
     }

--- a/src/components/InvertedFlatList/BaseInvertedFlatList.js
+++ b/src/components/InvertedFlatList/BaseInvertedFlatList.js
@@ -18,7 +18,7 @@ const propTypes = {
     initialRowHeight: PropTypes.number.isRequired,
 
     // Should we calculate the item layouts or not
-    shouldGetItemLayout: PropTypes.bool,
+    shouldMeasureItems: PropTypes.bool,
 
     // Passed via forwardRef so we can access the FlatList ref
     innerRef: PropTypes.oneOfType([
@@ -29,7 +29,7 @@ const propTypes = {
 
 const defaultProps = {
     data: [],
-    shouldGetItemLayout: true,
+    shouldMeasureItems: true,
 };
 
 class BaseInvertedFlatList extends Component {
@@ -124,7 +124,7 @@ class BaseInvertedFlatList extends Component {
      * @return {React.Component}
      */
     renderItem({item, index}) {
-        if (this.props.shouldGetItemLayout) {
+        if (this.props.shouldMeasureItems) {
             return (
                 <View onLayout={({nativeEvent}) => this.measureItemLayout(nativeEvent, index)}>
                     {this.props.renderItem({item, index})}
@@ -146,7 +146,7 @@ class BaseInvertedFlatList extends Component {
 
                 // iOS scrolling skips in a bad way after a certain number of items
                 // enters the list and should not use getItemLayout as implemented here
-                getItemLayout={this.props.shouldGetItemLayout ? this.getItemLayout : undefined}
+                getItemLayout={this.props.shouldMeasureItems ? this.getItemLayout : undefined}
                 bounces={false}
                 maxToRenderPerBatch={15}
                 updateCellsBatchingPeriod={40}

--- a/src/components/InvertedFlatList/index.android.js
+++ b/src/components/InvertedFlatList/index.android.js
@@ -1,0 +1,19 @@
+import BaseInvertedFlatList from './BaseInvertedFlatList';
+import React, {forwardRef} from 'react';
+
+const InvertedFlatList = forwardRef((props, ref) => (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <BaseInvertedFlatList
+        {...props}
+        ref={ref}
+
+        // Setting removeClippedSubviews will break text selection on Android
+        removeClippedSubviews={false}
+        onEndReached={() => {
+            props.onScrollToTop();
+        }}
+    />
+));
+
+InvertedFlatList.displayName = 'InvertedFlatList';
+export default InvertedFlatList;

--- a/src/components/InvertedFlatList/index.android.js
+++ b/src/components/InvertedFlatList/index.android.js
@@ -1,9 +1,14 @@
-import BaseInvertedFlatList from './BaseInvertedFlatList';
 import React, {forwardRef} from 'react';
+import PropTypes from 'prop-types';
+import BaseInvertedFlatList from './BaseInvertedFlatList';
+
+const propTypes = {
+    onScrollToTop: PropTypes.func.isRequired,
+};
 
 const InvertedFlatList = forwardRef((props, ref) => (
-    // eslint-disable-next-line react/jsx-props-no-spreading
     <BaseInvertedFlatList
+        // eslint-disable-next-line react/jsx-props-no-spreading
         {...props}
         ref={ref}
 
@@ -16,4 +21,5 @@ const InvertedFlatList = forwardRef((props, ref) => (
 ));
 
 InvertedFlatList.displayName = 'InvertedFlatList';
+InvertedFlatList.propTypes = propTypes;
 export default InvertedFlatList;

--- a/src/components/InvertedFlatList/index.ios.js
+++ b/src/components/InvertedFlatList/index.ios.js
@@ -6,7 +6,7 @@ const InvertedFlatList = forwardRef((props, ref) => (
     <BaseInvertedFlatList
         {...props}
         ref={ref}
-        shouldGetItemLayout={false}
+        shouldMeasureItems={false}
         onEndReachedThreshold={0.5}
         onEndReached={() => {
             props.onScrollToTop();

--- a/src/components/InvertedFlatList/index.ios.js
+++ b/src/components/InvertedFlatList/index.ios.js
@@ -1,9 +1,14 @@
-import BaseInvertedFlatList from './BaseInvertedFlatList';
 import React, {forwardRef} from 'react';
+import PropTypes from 'prop-types';
+import BaseInvertedFlatList from './BaseInvertedFlatList';
+
+const propTypes = {
+    onScrollToTop: PropTypes.func.isRequired,
+};
 
 const InvertedFlatList = forwardRef((props, ref) => (
-    // eslint-disable-next-line react/jsx-props-no-spreading
     <BaseInvertedFlatList
+        // eslint-disable-next-line react/jsx-props-no-spreading
         {...props}
         ref={ref}
         shouldMeasureItems={false}
@@ -15,4 +20,5 @@ const InvertedFlatList = forwardRef((props, ref) => (
 ));
 
 InvertedFlatList.displayName = 'InvertedFlatList';
+InvertedFlatList.propTypes = propTypes;
 export default InvertedFlatList;

--- a/src/components/InvertedFlatList/index.ios.js
+++ b/src/components/InvertedFlatList/index.ios.js
@@ -6,19 +6,11 @@ const InvertedFlatList = forwardRef((props, ref) => (
     <BaseInvertedFlatList
         {...props}
         ref={ref}
+        shouldGetItemLayout={false}
         onEndReachedThreshold={0.5}
-        initialNumToRender={20}
         onEndReached={() => {
-            console.log('end reached');
-            // props.onScrollToTop();
+            props.onScrollToTop();
         }}
-        // onScroll={({nativeEvent}) => {
-        //     const scrollTop = (nativeEvent.contentOffset.y + nativeEvent.layoutMeasurement.height);
-        //     if (scrollTop === nativeEvent.contentSize.height) {
-        //         console.log('top reached')
-        //         props.onScrollToTop();
-        //     }
-        // }}
     />
 ));
 

--- a/src/components/InvertedFlatList/index.js
+++ b/src/components/InvertedFlatList/index.js
@@ -63,7 +63,7 @@ const InvertedFlatList = (props) => {
             onScroll={({nativeEvent}) => {
                 const scrollTop = (nativeEvent.contentOffset.y + nativeEvent.layoutMeasurement.height);
                 if (scrollTop === nativeEvent.contentSize.height) {
-                    this.props.onScrollToTop();
+                    props.onScrollToTop();
                 }
             }}
         />

--- a/src/components/InvertedFlatList/index.js
+++ b/src/components/InvertedFlatList/index.js
@@ -10,6 +10,12 @@ import BaseInvertedFlatList from './BaseInvertedFlatList';
 const propTypes = {
     // Passed via forwardRef so we can access the FlatList ref
     innerRef: PropTypes.func.isRequired,
+
+    onScrollToTop: PropTypes.func,
+};
+
+const defaultProps = {
+    onScrollToTop: () => {},
 };
 
 // This is copied from https://codesandbox.io/s/react-native-dsyse
@@ -54,11 +60,18 @@ const InvertedFlatList = (props) => {
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...props}
             ref={ref}
+            onScroll={({nativeEvent}) => {
+                const scrollTop = (nativeEvent.contentOffset.y + nativeEvent.layoutMeasurement.height);
+                if (scrollTop === nativeEvent.contentSize.height) {
+                    this.props.onScrollToTop();
+                }
+            }}
         />
     );
 };
 
 InvertedFlatList.propTypes = propTypes;
+InvertedFlatList.defaultProps = defaultProps;
 
 export default forwardRef((props, ref) => (
     // eslint-disable-next-line react/jsx-props-no-spreading

--- a/src/components/InvertedFlatList/index.native.js
+++ b/src/components/InvertedFlatList/index.native.js
@@ -1,4 +1,26 @@
 import BaseInvertedFlatList from './BaseInvertedFlatList';
+import React, {forwardRef} from 'react';
 
-BaseInvertedFlatList.displayName = 'InvertedFlatList';
-export default BaseInvertedFlatList;
+const InvertedFlatList = forwardRef((props, ref) => (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <BaseInvertedFlatList
+        {...props}
+        ref={ref}
+        onEndReachedThreshold={0.5}
+        initialNumToRender={20}
+        onEndReached={() => {
+            console.log('end reached');
+            // props.onScrollToTop();
+        }}
+        // onScroll={({nativeEvent}) => {
+        //     const scrollTop = (nativeEvent.contentOffset.y + nativeEvent.layoutMeasurement.height);
+        //     if (scrollTop === nativeEvent.contentSize.height) {
+        //         console.log('top reached')
+        //         props.onScrollToTop();
+        //     }
+        // }}
+    />
+));
+
+InvertedFlatList.displayName = 'InvertedFlatList';
+export default InvertedFlatList;

--- a/src/libs/CollectionUtils.js
+++ b/src/libs/CollectionUtils.js
@@ -13,6 +13,14 @@ export function lastItem(object = {}) {
     return object[lastKey];
 }
 
+/**
+ * All collection keys have IDs built into the
+ * key. This is a simple tool to separate that ID
+ * from the key.
+ *
+ * @param {String} key
+ * @return {String}
+ */
 export function getIDFromKey(key) {
     return _.last(key.split('_'));
 }

--- a/src/libs/CollectionUtils.js
+++ b/src/libs/CollectionUtils.js
@@ -13,6 +13,11 @@ export function lastItem(object = {}) {
     return object[lastKey];
 }
 
+export function getIDFromKey(key) {
+    return _.last(key.split('_'));
+}
+
 export default {
     lastItem,
+    getIDFromKey,
 };

--- a/src/libs/Ion.js
+++ b/src/libs/Ion.js
@@ -94,14 +94,15 @@ function keyChanged(key, data) {
  * @param {string} [config.statePropertyName]
  * @param {function} [config.callback]
  * @param {*|null} val
+ * @param {String} [key]
  */
-function sendDataToConnection(config, val) {
+function sendDataToConnection(config, val, key) {
     if (config.withIonInstance) {
         config.withIonInstance.setState({
             [config.statePropertyName]: val,
         });
     } else if (_.isFunction(config.callback)) {
-        config.callback(val);
+        config.callback(val, key);
     }
 }
 
@@ -152,7 +153,7 @@ function connect(mapping) {
                     .then(val => sendDataToConnection(mapping, val));
             } else {
                 _.each(matchingKeys, (key) => {
-                    get(key).then(val => sendDataToConnection(mapping, val));
+                    get(key).then(val => sendDataToConnection(mapping, val, key));
                 });
             }
         });

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -269,20 +269,16 @@ function fetchActions(reportID) {
             }
 
             const previousOffset = reportActionOffsets[reportID] || 0;
-            const actionSubSet = data.history.slice(previousOffset, previousOffset + 50);
+            const newOffset = previousOffset + 50;
+            const actionSubSet = data.history.slice(previousOffset, newOffset);
             const indexedData = _.indexBy(actionSubSet, 'sequenceNumber');
             const maxSequenceNumber = _.chain(actionSubSet)
                 .pluck('sequenceNumber')
                 .max()
                 .value();
 
-            const offset = _.chain(actionSubSet)
-                .pluck('sequenceNumber')
-                .min()
-                .value();
-
             Ion.merge(`${IONKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`, {actions: indexedData, loading: false});
-            Ion.merge(`${IONKEYS.COLLECTION.REPORT}${reportID}`, {maxSequenceNumber, offset});
+            Ion.merge(`${IONKEYS.COLLECTION.REPORT}${reportID}`, {maxSequenceNumber, offset: newOffset});
         });
 }
 

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -270,7 +270,7 @@ function fetchActions(reportID) {
             }
 
             const previousOffset = reportActionOffsets[reportID] || 0;
-            const newOffset = previousOffset + 50;
+            const newOffset = previousOffset + 20;
             const actionSubSet = data.history.slice(previousOffset, newOffset);
             const indexedData = _.indexBy(actionSubSet, 'sequenceNumber');
             const maxSequenceNumber = _.chain(actionSubSet)

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -270,7 +270,7 @@ function fetchActions(reportID) {
             }
 
             const previousOffset = reportActionOffsets[reportID] || 0;
-            const newOffset = previousOffset + 20;
+            const newOffset = previousOffset + 50;
             const actionSubSet = data.history.slice(previousOffset, newOffset);
             const indexedData = _.indexBy(actionSubSet, 'sequenceNumber');
             const maxSequenceNumber = _.chain(actionSubSet)

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -188,7 +188,9 @@ function updateReportWithNewAction(reportID, reportAction) {
 
     // Add the action into Ion
     Ion.merge(`${IONKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`, {
-        [reportAction.sequenceNumber]: reportAction,
+        actions: {
+            [reportAction.sequenceNumber]: reportAction,
+        },
     });
 
     if (!ActiveClientManager.isClientTheLeader()) {
@@ -279,7 +281,7 @@ function fetchActions(reportID) {
                 .min()
                 .value();
 
-            Ion.merge(`${IONKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`, {...indexedData, loading: false});
+            Ion.merge(`${IONKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`, {actions: indexedData, loading: false});
             Ion.merge(`${IONKEYS.COLLECTION.REPORT}${reportID}`, {maxSequenceNumber, offset});
         });
 }
@@ -384,32 +386,34 @@ function addAction(reportID, text, file) {
 
     // Optimistically add the new comment to the store before waiting to save it to the server
     Ion.merge(actionKey, {
-        [newSequenceNumber]: {
-            actionName: 'ADDCOMMENT',
-            actorEmail: currentUserEmail,
-            person: [
-                {
-                    style: 'strong',
-                    text: myPersonalDetails.displayName || currentUserEmail,
-                    type: 'TEXT'
-                }
-            ],
-            automatic: false,
-            sequenceNumber: ++highestSequenceNumber,
-            avatar: myPersonalDetails.avatarURL,
-            timestamp: moment().unix(),
-            message: [
-                {
-                    type: 'COMMENT',
-                    html: isAttachment ? 'Uploading Attachment...' : htmlComment,
+        actions: {
+            [newSequenceNumber]: {
+                actionName: 'ADDCOMMENT',
+                actorEmail: currentUserEmail,
+                person: [
+                    {
+                        style: 'strong',
+                        text: myPersonalDetails.displayName || currentUserEmail,
+                        type: 'TEXT'
+                    }
+                ],
+                automatic: false,
+                sequenceNumber: ++highestSequenceNumber,
+                avatar: myPersonalDetails.avatarURL,
+                timestamp: moment().unix(),
+                message: [
+                    {
+                        type: 'COMMENT',
+                        html: isAttachment ? 'Uploading Attachment...' : htmlComment,
 
-                    // Remove HTML from text when applying optimistic offline comment
-                    text: isAttachment ? 'Uploading Attachment...'
-                        : htmlComment.replace(/<[^>]*>?/gm, ''),
-                }
-            ],
-            isFirstItem: false,
-            isAttachment,
+                        // Remove HTML from text when applying optimistic offline comment
+                        text: isAttachment ? 'Uploading Attachment...'
+                            : htmlComment.replace(/<[^>]*>?/gm, ''),
+                    }
+                ],
+                isFirstItem: false,
+                isAttachment,
+            },
         }
     });
 

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -261,6 +261,11 @@ function fetchActions(reportID) {
     Ion.merge(`${IONKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`, {loading: true});
     API.getReportHistory({reportID})
         .then((data) => {
+            if (!data.history) {
+                Ion.merge(`${IONKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`, {loading: false});
+                return;
+            }
+
             const previousOffset = reportActionOffsets[reportID] || 0;
             const actionSubSet = data.history.slice(previousOffset, previousOffset + 50);
             const indexedData = _.indexBy(actionSubSet, 'sequenceNumber');

--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -63,10 +63,11 @@ class ReportActionsView extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
-        if (_.size(prevProps.reportActions.actions) !== _.size(this.props.reportActions.actions)) {
+        const actions = lodashGet(this.props, 'reportActions.actions');
+        if (_.size(lodashGet(prevProps, 'reportActions.actions')) !== _.size(actions)) {
             // If a new comment is added and it's from the current user scroll to the bottom otherwise
             // leave the user positioned where they are now in the list.
-            const lastAction = lastItem(this.props.reportActions.actions);
+            const lastAction = lastItem(actions);
             if (lastAction && (lastAction.actorEmail === this.props.session.email)) {
                 this.scrollToListBottom();
             }
@@ -240,7 +241,7 @@ class ReportActionsView extends React.Component {
                     // Add some padding here so that the scroll position
                     // doesn't retrigger the loadMore method
                     return (
-                        <View style={{height: 32}} />
+                        <View style={{height: 36}} />
                     );
                 }}
                 onScroll={({nativeEvent}) => {

--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -66,9 +66,12 @@ class ReportActionsView extends React.Component {
         const actions = lodashGet(this.props, 'reportActions.actions');
         if (_.size(lodashGet(prevProps, 'reportActions.actions')) !== _.size(actions)) {
             // If a new comment is added and it's from the current user scroll to the bottom otherwise
-            // leave the user positioned where they are now in the list.
+            // leave the user positioned where they are now in the list. We also make an exception for
+            // right after we update with a new action from a fetch since we are paginating or there
+            // was a background update and we should not shift the scroll position.
             const lastAction = lastItem(actions);
-            if (lastAction && (lastAction.actorEmail === this.props.session.email)) {
+            const didFetchActions = prevProps.reportActions.loading && !this.props.reportActions.loading;
+            if (!didFetchActions && lastAction && (lastAction.actorEmail === this.props.session.email)) {
                 this.scrollToListBottom();
             }
 
@@ -244,11 +247,8 @@ class ReportActionsView extends React.Component {
                         <View style={{height: 36}} />
                     );
                 }}
-                onScroll={({nativeEvent}) => {
-                    const scrollTop = (nativeEvent.contentOffset.y + nativeEvent.layoutMeasurement.height);
-                    if (scrollTop === nativeEvent.contentSize.height) {
-                        this.debouncedLoadMore();
-                    }
+                onScrollToTop={() => {
+                    this.debouncedLoadMore();
                 }}
             />
         );

--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View, Keyboard} from 'react-native';
+import {View, Keyboard, ActivityIndicator} from 'react-native';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
 import lodashGet from 'lodash.get';
@@ -8,7 +8,7 @@ import withIon from '../../../components/withIon';
 import {fetchActions, updateLastReadActionID} from '../../../libs/actions/Report';
 import IONKEYS from '../../../IONKEYS';
 import ReportActionItem from './ReportActionItem';
-import styles from '../../../styles/StyleSheet';
+import styles, {colors} from '../../../styles/StyleSheet';
 import ReportActionPropTypes from './ReportActionPropTypes';
 import InvertedFlatList from '../../../components/InvertedFlatList';
 import {lastItem} from '../../../libs/CollectionUtils';
@@ -154,6 +154,15 @@ class ReportActionsView extends React.Component {
         this.recordMaxAction();
     }
 
+    loadMore() {
+        if (this.props.reportActions.loading) {
+            return;
+        }
+
+        // Load the next set of report actions
+        fetchActions(this.props.reportID);
+    }
+
     /**
      * Do not move this or make it an anonymous function it is a method
      * so it will not be recreated each time we render an item
@@ -208,6 +217,24 @@ class ReportActionsView extends React.Component {
                 contentContainerStyle={[styles.chatContentScrollView]}
                 keyExtractor={item => `${item.action.sequenceNumber}`}
                 initialRowHeight={32}
+                ListFooterComponent={() => {
+                    if (this.props.reportActions.loading) {
+                        return (
+                            <ActivityIndicator
+                                size="large"
+                                color={colors.textSupporting}
+                            />
+                        );
+                    }
+
+                    return null;
+                }}
+                onScroll={({nativeEvent}) => {
+                    const scrollTop = (nativeEvent.contentOffset.y + nativeEvent.layoutMeasurement.height);
+                    if (scrollTop === nativeEvent.contentSize.height) {
+                        this.loadMore();
+                    }
+                }}
             />
         );
     }


### PR DESCRIPTION
So, this is not a "real" pagination since the report history API is still not optimized for chat and some of the changes @cead22 will propose in his doc will make the actual work of adding pagination easier.

**What can we do for now?**

- We simulate fetching the next page of results from the API in the front end in a naive way. Which means each time we call the API we'll actually get all the report actions, but we'll pretend like we actually only asked for a range and set that into storage.

- When a user scrolls to the top of a chat we'll show a loading spinner, call the API again, get all the actions again, but this time only set the next range of actions.

This is less optimized for the API (which we can optimize later) and more optimized for keeping the front end lean.

**Why do this via multiple API calls instead of caching on subsequent calls?**

Because we _should_ eventually build this at the API level and this is just a step in the right direction. We could try to cache the entire result of `Report_GetHistory` when it comes back and then use it instead of calling the API again. But it doesn't really matter that much if we call the API again or not. And "real" pagination will call the API for the next set of results anyway.

**Take aways**

This considerably reduces the amount of data fetching report actions takes up on a cold boot of the app. e.g. the account I am testing with in the storage eviction PR has total report actions that add up to about `9mb` - in this PR those same actions only add up to `800kb` on cold boot (which makes sense because we are only storing the first 50 actions).

Thoughts? @cead22 @iwiznia 

### Fixed Issues (Partial Fix)
https://github.com/Expensify/Expensify/issues/143175

### Tests
1. Create a DM report with a user and add a large number of comments (several hundred or more) via `clitools generator:reportcomment`
1. Login to e.cash as this user and pull up the chat
1. Scroll to the top of the chat and verify that a loading spinner appears and more comments are revealed
1. Scroll again and verify even more comments are revealed
1. Verify that eventually no more comments will appear
1. Make sure the comments are correctly displayed.

### Screenshots
![Screenshot 1484](https://user-images.githubusercontent.com/32969087/96183438-b7483c00-0eeb-11eb-982b-80d4a85f6ab7.png)