### PR TITLE
Bump JS-Libs version for PR #282

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10693,8 +10693,8 @@
       }
     },
     "js-libs": {
-      "version": "git+ssh://git@github.com/Expensify/JS-Libs.git#c2a2bb1b0b725b9b0681e71cb99123f9e711ec20",
-      "from": "git+ssh://git@github.com/Expensify/JS-Libs.git#c2a2bb1b0b725b9b0681e71cb99123f9e711ec20",
+      "version": "git+ssh://git@github.com/Expensify/JS-Libs.git#804bdb252b4db2967aa2113c4024dd6068d1eb32",
+      "from": "git+ssh://git@github.com/Expensify/JS-Libs.git#804bdb252b4db2967aa2113c4024dd6068d1eb32",
       "requires": {
         "classnames": "2.2.5",
         "clipboard": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "electron-updater": "^4.3.4",
     "file-loader": "^6.0.0",
     "html-entities": "^1.3.1",
-    "js-libs": "git+https://git@github.com:Expensify/JS-Libs.git#c2a2bb1b0b725b9b0681e71cb99123f9e711ec20",
+    "js-libs": "git+https://git@github.com:Expensify/JS-Libs.git#804bdb252b4db2967aa2113c4024dd6068d1eb32",
     "lodash.get": "^4.4.2",
     "lodash.has": "^4.5.2",
     "lodash.orderby": "^4.6.0",


### PR DESCRIPTION
Updating to changes from https://github.com/Expensify/JS-Libs/pull/282

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/143244

### Tests
1. Send messages inside an inline code block using backticks with other syntax inside of it. Examples:

```
`_italics_`

`*bold*`

`~strikethrough~`

`[link](https://github.com/Expensify/Expensify/issues/143244)`

`https://github.com/Expensify/Expensify/issues/143244`
```

2. Ensure the formatting rules are not applied:

![Screen Shot 2020-10-15 at 3 21 55 PM](https://user-images.githubusercontent.com/12268372/96235924-6ea48780-0fac-11eb-924d-e7b3c74f7f0c.png)
