### PR TITLE
Dismiss keyboard when opening Chat Switcher

### DIFF
--- a/src/pages/home/HomePage.js
+++ b/src/pages/home/HomePage.js
@@ -4,7 +4,8 @@ import {
     View,
     Dimensions,
     Animated,
-    Easing
+    Easing,
+    Keyboard
 } from 'react-native';
 import {SafeAreaInsetsContext, SafeAreaProvider} from 'react-native-safe-area-context';
 import {Route} from '../../libs/Router';
@@ -137,7 +138,7 @@ export default class App extends React.Component {
         if (!hamburgerIsShown) {
             this.setState({hamburgerShown: true});
         }
-
+        Keyboard.dismiss();
         this.animateHamburger(hamburgerIsShown);
     }
 


### PR DESCRIPTION
### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/143842

### Tests
Run on iOS / Android
1. Open a chat
2. Tap the text field
1. _Verify_ that the software keyboard opens (iOS simulator: press command+k to open it)
1. Tap the chat switcher hamburger.
1. _Verify_ the chat switcher opens and the keyboard closes
1. Close the chat switcher
1. Tap the text field
1. _Verify_ the keyboard opens.

Run on Web / Desktop
1. Open a chat
1. Type a message and send it
1. _Verify_ the message sent with no issues.

### Screenshots
<Add any necessary screenshots for all platforms if your change added or updated UI>
