### PR TITLE
Update DSYM path for Crashlytics upload

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -105,7 +105,7 @@ platform :ios do
     )
 
     upload_symbols_to_crashlytics(
-      dsym_path: "./ios/Chat.app.dSYM",
+      dsym_path: "./Chat.app.dSYM",
       gsp_path: "./ios/GoogleService-Info.plist"
     )
   end


### PR DESCRIPTION
@timszot will you please review this

The DSYM upload is failing because the path in the Fastfile is incorrect. The error is [here](https://github.com/Expensify/ReactNativeChat/runs/1266261362?check_suite_focus=true#step:11:41693), which shows that the current path has an unnecessary `iOS` in the path. Removing this should fix the build.

### Tests
Not sure how to test this since the path is different on dev.
