### PR TITLE
Do not take the user to the sign in page if an authToken is present

### DIFF
--- a/src/pages/SignInPage.js
+++ b/src/pages/SignInPage.js
@@ -13,7 +13,8 @@ import PropTypes from 'prop-types';
 import _ from 'underscore';
 import CONFIG from '../CONFIG';
 import compose from '../libs/compose';
-import {withRouter} from '../libs/Router';
+import {withRouter, Redirect} from '../libs/Router';
+import ROUTES from '../ROUTES';
 import {signIn} from '../libs/actions/Session';
 import IONKEYS from '../IONKEYS';
 import withIon from '../components/withIon';
@@ -71,7 +72,15 @@ class App extends Component {
     }
 
     render() {
-        const isLoading = this.props.session && this.props.session.loading;
+        const session = this.props.session || {};
+
+        // If we end up on the sign in page and have an authToken then
+        // we are signed in and should be brought back to the site root
+        if (session.authToken) {
+            return <Redirect to={ROUTES.ROOT} />;
+        }
+
+        const isLoading = session.loading;
         return (
             <>
                 <StatusBar />


### PR DESCRIPTION
### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/143847

### Tests
1. Sign in
1. Manually navigate to `/#/signin`
1. Verify you are redirected to the `HomePage` because you have an `authToken`
1. Sign out
1. Verify you are brought to `SignIn` and have no issues seeing this page

### Screenshots
❌ 