### PR TITLE
Toggle Hamburger menu after selecting chat in Switcher View

### DIFF
--- a/src/pages/home/sidebar/ChatSwitcherView.js
+++ b/src/pages/home/sidebar/ChatSwitcherView.js
@@ -30,6 +30,9 @@ const propTypes = {
     // A method that is triggered when the TextInput loses focus
     onBlur: PropTypes.func.isRequired,
 
+    // Toggles the hamburger menu open and closed
+    onLinkClick: PropTypes.func.isRequired,
+
     /* Ion Props */
 
     // All of the personal details for everyone
@@ -99,6 +102,7 @@ class ChatSwitcherView extends React.Component {
      */
     selectUser(option) {
         fetchOrCreateChatReport([this.props.session.email, option.login]);
+        this.props.onLinkClick();
         this.reset();
     }
 
@@ -110,6 +114,7 @@ class ChatSwitcherView extends React.Component {
      */
     selectReport(option) {
         redirect(ROUTES.getReportRoute(option.reportID));
+        this.props.onLinkClick();
         this.reset();
     }
 

--- a/src/pages/home/sidebar/SidebarLinks.js
+++ b/src/pages/home/sidebar/SidebarLinks.js
@@ -84,6 +84,7 @@ class SidebarLinks extends React.Component {
                             this.setState({areReportLinksVisible: false});
                             this.props.onChatSwitcherFocus();
                         }}
+                        onLinkClick={onLinkClick}
                     />
                 </View>
                 <View style={sidebarLinksStyle}>


### PR DESCRIPTION
@stitesExpensify please review

Toggle the hamburger menu after selecting a chat in the switcher view. This prevents us from having to double click on the chat again.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/143744

### Tests
- On each of the 3 platforms (for desktop/web shrink the width of the app so that the LHN shows after clicking the Hamburger menu), search for a chat in the chat switcher.
- Click that chat
- Make sure that the hamburger menu toggles off and you are now right in the chat:

### Screenshots
![Kapture 2020-10-19 at 21 18 07](https://user-images.githubusercontent.com/4741899/96539728-9e73b980-1250-11eb-9951-9ea6741c367f.gif)