### PR TITLE
Make measuring items optional. Fix jank on native platforms.

### DIFF
--- a/src/components/InvertedFlatList/BaseInvertedFlatList.js
+++ b/src/components/InvertedFlatList/BaseInvertedFlatList.js
@@ -22,10 +22,14 @@ const propTypes = {
         PropTypes.func,
         PropTypes.shape({current: PropTypes.instanceOf(FlatList)})
     ]).isRequired,
+
+    // Should we measure these items and call getItemLayout?
+    shouldMeasureItems: PropTypes.bool,
 };
 
 const defaultProps = {
     data: [],
+    shouldMeasureItems: false,
 };
 
 class BaseInvertedFlatList extends Component {
@@ -120,11 +124,15 @@ class BaseInvertedFlatList extends Component {
      * @return {React.Component}
      */
     renderItem({item, index}) {
-        return (
-            <View onLayout={({nativeEvent}) => this.measureItemLayout(nativeEvent, index)}>
-                {this.props.renderItem({item, index})}
-            </View>
-        );
+        if (this.props.shouldMeasureItems) {
+            return (
+                <View onLayout={({nativeEvent}) => this.measureItemLayout(nativeEvent, index)}>
+                    {this.props.renderItem({item, index})}
+                </View>
+            );
+        }
+
+        return this.props.renderItem({item, index});
     }
 
     render() {
@@ -135,7 +143,10 @@ class BaseInvertedFlatList extends Component {
                 ref={this.props.innerRef}
                 inverted
                 renderItem={this.renderItem}
-                getItemLayout={this.getItemLayout}
+
+                // Native platforms do not need to measure items and work fine without this.
+                // Web requires that items be measured or else crazy things happpen when scrolling.
+                getItemLayout={this.props.shouldMeasureItems ? this.getItemLayout : undefined}
                 bounces={false}
                 maxToRenderPerBatch={15}
                 updateCellsBatchingPeriod={40}

--- a/src/components/InvertedFlatList/index.js
+++ b/src/components/InvertedFlatList/index.js
@@ -54,6 +54,7 @@ const InvertedFlatList = (props) => {
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...props}
             ref={ref}
+            shouldMeasureItems
         />
     );
 };


### PR DESCRIPTION
cc @AndrewGable 

I think we are just holding this wrong and measuring the items on the native platforms isn't necessary. It seems to help on web but causes big slow downs on native.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/144060

### Tests
1. Create a report that has 10k comments on it 
1. Try to open the report on iOS and Android
1. Verify performance is improved and there there is no obvious weirdness when scrolling or handling incoming messages
1. Test various UI features like switching between chats, opening and closing the LHN, and verify it is smooth-ish (doesn't take several seconds or anything)

### Screenshots
❌ 