### PR TITLE
Include any js files from desktop/ in the electron config

### DIFF
--- a/desktop/electron.config.js
+++ b/desktop/electron.config.js
@@ -23,6 +23,6 @@ module.exports = {
     files: [
         './dist/**/*',
         './main.js',
-        './desktop/ELECTRON_EVENTS.js',
+        './desktop/*.js',
     ]
 };


### PR DESCRIPTION
@AndrewGable @stitesExpensify 

Coming from [this suggestion](https://github.com/Expensify/ReactNativeChat/pull/631#discussion_r507922036)

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/144161

### Tests
We need to test this with a local production build. So,
1) Delete the Chat desktop app 😵
2) make a few temporary changes to `electron.config.js` and `package.json` so that the local build works (at least this is what I had to do to get it to work):
```javascript
module.exports = {
    appId: 'com.expensifyreactnative.chat',
    productName: 'Chat',

    // Comment out notarizing
    // afterSign: 'desktop/notarize.js',
    mac: {
        category: 'public.app-category.finance',
        icon: './android/app/src/main/res/mipmap-xxxhdpi/ic_launcher_round.png',
        hardenedRuntime: true,
        entitlements: 'desktop/entitlements.mac.plist',
        entitlementsInherit: 'desktop/entitlements.mac.plist',
        type: 'distribution'
    },
    dmg: {
        title: 'Chat',
        artifactName: 'Chat.dmg',
        internetEnabled: true
    },
    // Also comment out publishing step
    // publish: [{
    //     provider: 's3',
    //     bucket: 'chat-test-expensify-com',
    //     channel: 'latest'
    // }],
    files: [
        './dist/**/*',
        './main.js',
        './desktop/ELECTRON_EVENTS.js',
    ]
};
```
```json
...
// Temporarily remove --publish always
"desktop-build": "webpack --config webpack.prod.js --platform desktop && electron-builder --config desktop/electron.config.js",
...
```
3) Run `npm run desktop-build`
4) Double click on `dist/Chat.dmg` in finder, install Chat, replacing old installation.
5) Open chat, no errors! 🎉 