### PR TITLE
Fix Prop type error when switching between chats

### DIFF
--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -296,7 +296,7 @@ function unsubscribeToReportTypingEvents(reportID) {
     }
 
     const pusherChannelName = getReportChannelName(reportID);
-    Ion.set(`${IONKEYS.COLLECTION.REPORT_USER_IS_TYPING}${reportID}`, []);
+    Ion.set(`${IONKEYS.COLLECTION.REPORT_USER_IS_TYPING}${reportID}`, {});
     Pusher.unsubscribe(pusherChannelName, 'client-userIsTyping');
 }
 


### PR DESCRIPTION
Pullerbearing (@marcaaron)

Removes small prop type error where we were passing an empty array rather than an object.

### Fixed Issues
None, but saw this out in the wild.

### Tests/QA
- Switch between chats with the JS console open
- Make sure you see no prop type errors about `userTypingStatuses`