### PR TITLE
Make sure the name field is centered with the rest of the header items in order to make it look less naff

### DIFF
--- a/src/pages/home/HeaderView.js
+++ b/src/pages/home/HeaderView.js
@@ -94,9 +94,15 @@ const HeaderView = (props) => {
                             <Text numberOfLines={1} style={[styles.navText]}>
                                 {props.report.reportName}
                             </Text>
-                            <Text numberOfLines={1} style={[styles.navSubText]}>
-                                {getUsersTypingText()}
-                            </Text>
+                            {
+                                !_.isEmpty(getUsersTypingText())
+                                && (
+                                    <Text style={[styles.navSubText]}>
+                                        {getUsersTypingText()}
+                                    </Text>
+                                )
+                            }
+
                         </View>
 
                         <View style={[styles.reportOptions, styles.flexRow]}>


### PR DESCRIPTION
Pullerbearing (@marcaaron)

Make sure that we only render the Text element that contains the typing indicator if there is someone typing. This allows the name to be centered when no one is typing.

### Fixed Issues
For https://github.com/Expensify/Expensify/issues/142357

### Tests/QA
- On each platform, open a chat, make sure the name is centered
- Start typing on another window that is open to the chat from the perspective of the other user
- Made sure that the "typing.." text appears underneath on the original platform

# Screenshots
<img width="451" alt="Screen Shot 2020-10-20 at 6 15 18 PM" src="https://user-images.githubusercontent.com/4741899/96661362-b73ba800-1300-11eb-913d-bc85b8c48c72.png">
<img width="521" alt="Screen Shot 2020-10-20 at 6 15 22 PM" src="https://user-images.githubusercontent.com/4741899/96661366-b86cd500-1300-11eb-9486-ca557d6c4ba2.png">
![Screen Shot 2020-10-20 at 6 15 25 PM](https://user-images.githubusercontent.com/4741899/96661368-b99e0200-1300-11eb-882d-92e371cf49ec.png)
