### PR TITLE
Allow LHN to scroll when many chats are pinned

### DIFF
--- a/src/pages/home/sidebar/SidebarLinks.js
+++ b/src/pages/home/sidebar/SidebarLinks.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View} from 'react-native';
+import {View, ScrollView} from 'react-native';
 import _ from 'underscore';
 import PropTypes from 'prop-types';
 import lodashOrderby from 'lodash.orderby';
@@ -87,7 +87,12 @@ class SidebarLinks extends React.Component {
                         onLinkClick={onLinkClick}
                     />
                 </View>
-                <View style={sidebarLinksStyle}>
+                <ScrollView
+                    style={sidebarLinksStyle}
+                    bounces={false}
+                    indicatorStyle="white"
+                    stickyHeaderIndices={[0]}
+                >
                     <View style={[styles.sidebarListItem]}>
                         <Text style={[styles.sidebarListHeader]}>
                             Chats
@@ -106,7 +111,7 @@ class SidebarLinks extends React.Component {
                             isPinned={report.isPinned}
                         />
                     ))}
-                </View>
+                </ScrollView>
             </View>
         );
     }

--- a/src/styles/StyleSheet.js
+++ b/src/styles/StyleSheet.js
@@ -349,7 +349,6 @@ const styles = {
         flexGrow: 100,
         scrollbarWidth: 'none',
         overflow: 'scroll',
-        paddingTop: 4,
         paddingBottom: 4,
         paddingLeft: 12,
         paddingRight: 12,
@@ -369,6 +368,7 @@ const styles = {
         height: 40,
         justifyContent: 'center',
         textDecorationLine: 'none',
+        backgroundColor: colors.heading,
     },
 
     sidebarLink: {


### PR DESCRIPTION
This just needed a `ScrollView` around it

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/144224

### Tests
1. Pin a ton of chats so they overflow your LHN
1. Verify you can scroll through the list on all platforms and there are no visual bugs

### Screenshots
❌ 