### PR TITLE
Move the user typing indicator to be below the compose box

### DIFF
--- a/src/components/KeyboardSpacer/index.ios.js
+++ b/src/components/KeyboardSpacer/index.ios.js
@@ -6,7 +6,7 @@ import ReactNativeKeyboardSpacer from 'react-native-keyboard-spacer';
 import React from 'react';
 
 const KeyboardSpacer = () => (
-    <ReactNativeKeyboardSpacer topSpacing={-36} />
+    <ReactNativeKeyboardSpacer topSpacing={-30} />
 );
 
 export default KeyboardSpacer;

--- a/src/pages/home/HeaderView.js
+++ b/src/pages/home/HeaderView.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import _ from 'underscore';
 import {View, Image, TouchableOpacity} from 'react-native';
 import PropTypes from 'prop-types';
 import Text from '../../components/Text';
@@ -8,7 +7,6 @@ import IONKEYS from '../../IONKEYS';
 import withIon from '../../components/withIon';
 import {withRouter} from '../../libs/Router';
 import LHNToggle from '../../../assets/images/icon-menu-toggle.png';
-import {getDisplayName} from '../../libs/actions/PersonalDetails';
 import pinEnabled from '../../../assets/images/pin-enabled.png';
 import pinDisabled from '../../../assets/images/pin-disabled.png';
 import compose from '../../libs/compose';
@@ -33,96 +31,59 @@ const propTypes = {
         // Value indicating if the report is pinned or not
         isPinned: PropTypes.bool,
     }),
-
-    // Key-value pairs of user logins and whether or not they are typing. Keys are logins.
-    userTypingStatuses: PropTypes.objectOf(PropTypes.bool),
 };
 
 const defaultProps = {
     report: null,
-    userTypingStatuses: {},
 };
 
-const HeaderView = (props) => {
-    /**
-     * Retrieves the text to display if users are typing.
-     *
-     * @returns {string}
-     */
-    function getUsersTypingText() {
-        // Filter only to users that are typing.
-        const usersTyping = Object.keys(props.userTypingStatuses || {})
-            .filter(login => props.userTypingStatuses[login] === true);
-
-        if (_.size(usersTyping) === 1) {
-            const displayName = getDisplayName(usersTyping[0]);
-            return `${displayName} is typing...`;
-        }
-
-        if (_.size(usersTyping) > 1) {
-            return 'Multiple users are typing...';
-        }
-
-        return '';
-    }
-
-    return (
-        <View style={[styles.appContentHeader]}>
-            <View style={[styles.appContentHeaderTitle]}>
-                {props.shouldShowHamburgerButton && (
-                    <TouchableOpacity
-                        onPress={props.onHamburgerButtonClicked}
-                        style={[styles.LHNToggle]}
-                    >
-                        <Image
-                            resizeMode="contain"
-                            style={[styles.LHNToggleIcon]}
-                            source={LHNToggle}
-                        />
-                    </TouchableOpacity>
-                )}
-                {props.report && props.report.reportName ? (
-                    <View style={[
-                        styles.dFlex,
-                        styles.flexRow,
-                        styles.alignItemsCenter,
-                        styles.flexGrow1,
-                        styles.flexJustifySpaceBetween
-                    ]}
-                    >
-                        <View>
-                            <Text numberOfLines={1} style={[styles.navText]}>
-                                {props.report.reportName}
-                            </Text>
-                            {
-                                !_.isEmpty(getUsersTypingText())
-                                && (
-                                    <Text style={[styles.navSubText]}>
-                                        {getUsersTypingText()}
-                                    </Text>
-                                )
-                            }
-
-                        </View>
-
-                        <View style={[styles.reportOptions, styles.flexRow]}>
-                            <TouchableOpacity
-                                onPress={() => togglePinnedState(parseInt(props.report.reportID, 10))}
-                                style={[styles.touchableButtonImage, styles.mr0]}
-                            >
-                                <Image
-                                    resizeMode="contain"
-                                    source={props.report.isPinned ? pinEnabled : pinDisabled}
-                                    style={[styles.reportPinIcon]}
-                                />
-                            </TouchableOpacity>
-                        </View>
+const HeaderView = props => (
+    <View style={[styles.appContentHeader]}>
+        <View style={[styles.appContentHeaderTitle]}>
+            {props.shouldShowHamburgerButton && (
+                <TouchableOpacity
+                    onPress={props.onHamburgerButtonClicked}
+                    style={[styles.LHNToggle]}
+                >
+                    <Image
+                        resizeMode="contain"
+                        style={[styles.LHNToggleIcon]}
+                        source={LHNToggle}
+                    />
+                </TouchableOpacity>
+            )}
+            {props.report && props.report.reportName ? (
+                <View style={[
+                    styles.dFlex,
+                    styles.flexRow,
+                    styles.alignItemsCenter,
+                    styles.flexGrow1,
+                    styles.flexJustifySpaceBetween
+                ]}
+                >
+                    <View>
+                        <Text numberOfLines={1} style={[styles.navText]}>
+                            {props.report.reportName}
+                        </Text>
                     </View>
-                ) : null}
-            </View>
+
+                    <View style={[styles.reportOptions, styles.flexRow]}>
+                        <TouchableOpacity
+                            onPress={() => togglePinnedState(parseInt(props.report.reportID, 10))}
+                            style={[styles.touchableButtonImage, styles.mr0]}
+                        >
+                            <Image
+                                resizeMode="contain"
+                                source={props.report.isPinned ? pinEnabled : pinDisabled}
+                                style={[styles.reportPinIcon]}
+                            />
+                        </TouchableOpacity>
+                    </View>
+                </View>
+            ) : null}
         </View>
-    );
-};
+    </View>
+);
 
 HeaderView.propTypes = propTypes;
 HeaderView.displayName = 'HeaderView';
@@ -134,8 +95,5 @@ export default compose(
         report: {
             key: ({match}) => `${IONKEYS.COLLECTION.REPORT}${match.params.reportID}`,
         },
-        userTypingStatuses: {
-            key: ({match}) => `${IONKEYS.COLLECTION.REPORT_USER_IS_TYPING}${match.params.reportID}`,
-        }
     }),
 )(HeaderView);

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -9,12 +9,7 @@ import IONKEYS from '../../../IONKEYS';
 import paperClipIcon from '../../../../assets/images/icon-paper-clip.png';
 import ImagePicker from '../../../libs/ImagePicker';
 import withIon from '../../../components/withIon';
-import {
-    addAction,
-    saveReportComment,
-    broadcastUserIsTyping,
-    subscribeToReportTypingEvents, unsubscribeToReportTypingEvents
-} from '../../../libs/actions/Report';
+import {addAction, saveReportComment, broadcastUserIsTyping} from '../../../libs/actions/Report';
 import ReportTypingIndicator from './ReportTypingIndicator';
 
 const propTypes = {
@@ -48,23 +43,11 @@ class ReportActionCompose extends React.Component {
         this.state = {isFocused: false};
     }
 
-    componentDidMount() {
-        if (this.props.reportID) {
-            subscribeToReportTypingEvents(this.props.reportID);
-        }
-    }
-
     componentDidUpdate(prevProps) {
         // The first time the component loads the props is empty and the next time it may contain value.
         // If it does let's update this.comment so that it matches the defaultValue that we show in textInput.
         if (this.props.comment && prevProps.comment === '' && prevProps.comment !== this.props.comment) {
             this.comment = this.props.comment;
-        }
-    }
-
-    componentWillUnmount() {
-        if (this.props.reportID) {
-            unsubscribeToReportTypingEvents(this.props.reportID);
         }
     }
 

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -10,6 +10,7 @@ import paperClipIcon from '../../../../assets/images/icon-paper-clip.png';
 import ImagePicker from '../../../libs/ImagePicker';
 import withIon from '../../../components/withIon';
 import {addAction, saveReportComment, broadcastUserIsTyping} from '../../../libs/actions/Report';
+import ReportTypingIndicator from './ReportTypingIndicator';
 
 const propTypes = {
     // A method to call when the form is submitted
@@ -194,6 +195,7 @@ class ReportActionCompose extends React.Component {
                         />
                     </TouchableOpacity>
                 </View>
+                <ReportTypingIndicator reportID={this.props.reportID} />
             </View>
         );
     }

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -9,7 +9,12 @@ import IONKEYS from '../../../IONKEYS';
 import paperClipIcon from '../../../../assets/images/icon-paper-clip.png';
 import ImagePicker from '../../../libs/ImagePicker';
 import withIon from '../../../components/withIon';
-import {addAction, saveReportComment, broadcastUserIsTyping} from '../../../libs/actions/Report';
+import {
+    addAction,
+    saveReportComment,
+    broadcastUserIsTyping,
+    subscribeToReportTypingEvents, unsubscribeToReportTypingEvents
+} from '../../../libs/actions/Report';
 import ReportTypingIndicator from './ReportTypingIndicator';
 
 const propTypes = {
@@ -43,11 +48,23 @@ class ReportActionCompose extends React.Component {
         this.state = {isFocused: false};
     }
 
+    componentDidMount() {
+        if (this.props.reportID) {
+            subscribeToReportTypingEvents(this.props.reportID);
+        }
+    }
+
     componentDidUpdate(prevProps) {
         // The first time the component loads the props is empty and the next time it may contain value.
         // If it does let's update this.comment so that it matches the defaultValue that we show in textInput.
         if (this.props.comment && prevProps.comment === '' && prevProps.comment !== this.props.comment) {
             this.comment = this.props.comment;
+        }
+    }
+
+    componentWillUnmount() {
+        if (this.props.reportID) {
+            unsubscribeToReportTypingEvents(this.props.reportID);
         }
     }
 

--- a/src/pages/home/report/ReportTypingIndicator.js
+++ b/src/pages/home/report/ReportTypingIndicator.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Text} from 'react-native';
+import {View, Text} from 'react-native';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
 import compose from '../../../libs/compose';
@@ -57,7 +57,7 @@ const ReportTypingIndicator = ({userTypingStatuses}) => {
     const usersTyping = getUsersTyping();
     const usersTypingText = getUsersTypingText(usersTyping);
     return (
-        <Text style={[styles.typingIndicator]}>
+        <View style={[styles.typingIndicator]}>
             {!_.isEmpty(usersTyping) && (
                 <Text style={[styles.typingIndicatorSubText]}>
                     {usersTypingText}
@@ -65,7 +65,7 @@ const ReportTypingIndicator = ({userTypingStatuses}) => {
                     typing...
                 </Text>
             )}
-        </Text>
+        </View>
     );
 };
 

--- a/src/pages/home/report/ReportTypingIndicator.js
+++ b/src/pages/home/report/ReportTypingIndicator.js
@@ -1,0 +1,83 @@
+import React from 'react';
+import {Text} from 'react-native';
+import PropTypes from 'prop-types';
+import _ from 'underscore';
+import compose from '../../../libs/compose';
+import withIon from '../../../components/withIon';
+import IONKEYS from '../../../IONKEYS';
+import styles from '../../../styles/StyleSheet';
+import {getDisplayName} from '../../../libs/actions/PersonalDetails';
+
+const propTypes = {
+    // Key-value pairs of user logins and whether or not they are typing. Keys are logins.
+    userTypingStatuses: PropTypes.objectOf(PropTypes.bool),
+};
+
+const defaultProps = {
+    userTypingStatuses: {},
+};
+
+const ReportTypingIndicator = ({userTypingStatuses}) => {
+    /**
+     * Get an array with the logins of the users that are currently typing.
+     *
+     * @returns {string[]}
+     */
+    function getUsersTyping() {
+        return Object.keys(userTypingStatuses || {})
+            .filter(login => userTypingStatuses[login] === true);
+    }
+
+    /**
+     * Get the Text element that will hold the display for the users that are typing.
+     *
+     * @returns {JSX.Element}
+     */
+    function getUsersTypingText() {
+        const usersTyping = getUsersTyping();
+
+        if (_.size(usersTyping) === 1) {
+            return <Text style={[styles.textStrong]}>{getDisplayName(usersTyping[0])}</Text>;
+        }
+
+        if (_.size(usersTyping) === 2) {
+            return (
+                <Text>
+                    <Text style={[styles.textStrong]}>{getDisplayName(usersTyping[0])}</Text>
+                    {' and '}
+                    <Text style={[styles.textStrong]}>{getDisplayName(usersTyping[1])}</Text>
+                </Text>
+            );
+        }
+
+        if (_.size(usersTyping) > 2) {
+            return <Text style={[styles.textStrong]}>Multiple users</Text>;
+        }
+    }
+
+    const usersTyping = getUsersTyping();
+    const usersTypingText = getUsersTypingText();
+    return (
+        <Text style={[styles.typingIndicator]}>
+            {!_.isEmpty(usersTyping) && (
+                <Text style={[styles.typingIndicatorSubText]}>
+                    {usersTypingText}
+                    {_.size(usersTyping) > 1 ? ' are ' : ' is '}
+                    typing...
+                </Text>
+            )}
+        </Text>
+    );
+};
+
+ReportTypingIndicator.propTypes = propTypes;
+ReportTypingIndicator.defaultProps = defaultProps;
+ReportTypingIndicator.displayName = 'ReportTypingIndicator';
+
+export default compose(
+    withIon({
+        userTypingStatuses: {
+            key: ({reportID}) => `${IONKEYS.COLLECTION.REPORT_USER_IS_TYPING}${reportID}`,
+        }
+    }),
+)(ReportTypingIndicator);

--- a/src/pages/home/report/ReportTypingIndicator.js
+++ b/src/pages/home/report/ReportTypingIndicator.js
@@ -41,39 +41,40 @@ class ReportTypingIndicator extends React.Component {
     render() {
         const numUsersTyping = _.size(this.state.usersTyping);
 
-        // Return an empty view if no one is typing.
-        if (numUsersTyping === 0) {
-            return <View style={[styles.typingIndicator]} />;
-        }
-
-        // Decide on the Text element that will hold the display for the users that are typing.
-        let usersTypingText;
+        // Decide on the Text element that will hold the display based on the number of users that are typing.
         switch (numUsersTyping) {
+            case 0:
+                return <View style={[styles.typingIndicator]} />;
             case 1:
-                usersTypingText = <Text style={[styles.textStrong]}>{getDisplayName(this.state.usersTyping[0])}</Text>;
-                break;
-            case 2:
-                usersTypingText = (
-                    <Text>
-                        <Text style={[styles.textStrong]}>{getDisplayName(this.state.usersTyping[0])}</Text>
-                        {' and '}
-                        <Text style={[styles.textStrong]}>{getDisplayName(this.state.usersTyping[1])}</Text>
-                    </Text>
+                return (
+                    <View style={[styles.typingIndicator]}>
+                        <Text style={[styles.typingIndicatorSubText]}>
+                            <Text style={[styles.textStrong]}>{getDisplayName(this.state.usersTyping[0])}</Text>
+                            {' is typing...'}
+                        </Text>
+                    </View>
                 );
-                break;
+            case 2:
+                return (
+                    <View style={[styles.typingIndicator]}>
+                        <Text style={[styles.typingIndicatorSubText]}>
+                            <Text style={[styles.textStrong]}>{getDisplayName(this.state.usersTyping[0])}</Text>
+                            {' and '}
+                            <Text style={[styles.textStrong]}>{getDisplayName(this.state.usersTyping[1])}</Text>
+                            {' are typing...'}
+                        </Text>
+                    </View>
+                );
             default:
-                usersTypingText = <Text style={[styles.textStrong]}>Multiple users</Text>;
+                return (
+                    <View style={[styles.typingIndicator]}>
+                        <Text style={[styles.typingIndicatorSubText]}>
+                            <Text style={[styles.textStrong]}>Multiple users</Text>
+                            {' are typing...'}
+                        </Text>
+                    </View>
+                );
         }
-
-        return (
-            <View style={[styles.typingIndicator]}>
-                <Text style={[styles.typingIndicatorSubText]}>
-                    {usersTypingText}
-                    {numUsersTyping > 1 ? ' are ' : ' is '}
-                    typing...
-                </Text>
-            </View>
-        );
     }
 }
 

--- a/src/pages/home/report/ReportTypingIndicator.js
+++ b/src/pages/home/report/ReportTypingIndicator.js
@@ -18,53 +18,42 @@ const defaultProps = {
 };
 
 const ReportTypingIndicator = ({userTypingStatuses}) => {
-    /**
-     * Get an array with the logins of the users that are currently typing.
-     *
-     * @returns {string[]}
-     */
-    function getUsersTyping() {
-        return Object.keys(userTypingStatuses || {})
-            .filter(login => userTypingStatuses[login] === true);
+    // Get an array with the logins of the users that are currently typing.
+    const usersTyping = Object.keys(userTypingStatuses || {})
+        .filter(login => userTypingStatuses[login] === true);
+    const numUsersTyping = _.size(usersTyping);
+
+    // Return an empty view if no one is typing.
+    if (numUsersTyping === 0) {
+        return <View style={[styles.typingIndicator]} />;
     }
 
-    /**
-     * Get the Text element that will hold the display for the users that are typing.
-     *
-     * @param {string[]} usersTyping
-     * @returns {JSX.Element}
-     */
-    function getUsersTypingText(usersTyping) {
-        if (_.size(usersTyping) === 1) {
-            return <Text style={[styles.textStrong]}>{getDisplayName(usersTyping[0])}</Text>;
-        }
-
-        if (_.size(usersTyping) === 2) {
-            return (
+    // Decide on the Text element that will hold the display for the users that are typing.
+    let usersTypingText;
+    switch (numUsersTyping) {
+        case 1:
+            usersTypingText = <Text style={[styles.textStrong]}>{getDisplayName(usersTyping[0])}</Text>;
+            break;
+        case 2:
+            usersTypingText = (
                 <Text>
                     <Text style={[styles.textStrong]}>{getDisplayName(usersTyping[0])}</Text>
                     {' and '}
                     <Text style={[styles.textStrong]}>{getDisplayName(usersTyping[1])}</Text>
                 </Text>
             );
-        }
-
-        if (_.size(usersTyping) > 2) {
-            return <Text style={[styles.textStrong]}>Multiple users</Text>;
-        }
+            break;
+        default:
+            usersTypingText = <Text style={[styles.textStrong]}>Multiple users</Text>;
     }
 
-    const usersTyping = getUsersTyping();
-    const usersTypingText = getUsersTypingText(usersTyping);
     return (
         <View style={[styles.typingIndicator]}>
-            {!_.isEmpty(usersTyping) && (
-                <Text style={[styles.typingIndicatorSubText]}>
-                    {usersTypingText}
-                    {_.size(usersTyping) > 1 ? ' are ' : ' is '}
-                    typing...
-                </Text>
-            )}
+            <Text style={[styles.typingIndicatorSubText]}>
+                {usersTypingText}
+                {_.size(usersTyping) > 1 ? ' are ' : ' is '}
+                typing...
+            </Text>
         </View>
     );
 };

--- a/src/pages/home/report/ReportTypingIndicator.js
+++ b/src/pages/home/report/ReportTypingIndicator.js
@@ -31,11 +31,10 @@ const ReportTypingIndicator = ({userTypingStatuses}) => {
     /**
      * Get the Text element that will hold the display for the users that are typing.
      *
+     * @param {string[]} usersTyping
      * @returns {JSX.Element}
      */
-    function getUsersTypingText() {
-        const usersTyping = getUsersTyping();
-
+    function getUsersTypingText(usersTyping) {
         if (_.size(usersTyping) === 1) {
             return <Text style={[styles.textStrong]}>{getDisplayName(usersTyping[0])}</Text>;
         }
@@ -56,7 +55,7 @@ const ReportTypingIndicator = ({userTypingStatuses}) => {
     }
 
     const usersTyping = getUsersTyping();
-    const usersTypingText = getUsersTypingText();
+    const usersTypingText = getUsersTypingText(usersTyping);
     return (
         <Text style={[styles.typingIndicator]}>
             {!_.isEmpty(usersTyping) && (

--- a/src/pages/home/report/ReportTypingIndicator.js
+++ b/src/pages/home/report/ReportTypingIndicator.js
@@ -17,46 +17,65 @@ const defaultProps = {
     userTypingStatuses: {},
 };
 
-const ReportTypingIndicator = ({userTypingStatuses}) => {
-    // Get an array with the logins of the users that are currently typing.
-    const usersTyping = Object.keys(userTypingStatuses || {})
-        .filter(login => userTypingStatuses[login] === true);
-    const numUsersTyping = _.size(usersTyping);
+class ReportTypingIndicator extends React.Component {
+    constructor(props) {
+        super(props);
 
-    // Return an empty view if no one is typing.
-    if (numUsersTyping === 0) {
-        return <View style={[styles.typingIndicator]} />;
+        const usersTyping = Object.keys(props.userTypingStatuses || {})
+            .filter(login => props.userTypingStatuses[login]);
+        this.state = {usersTyping};
     }
 
-    // Decide on the Text element that will hold the display for the users that are typing.
-    let usersTypingText;
-    switch (numUsersTyping) {
-        case 1:
-            usersTypingText = <Text style={[styles.textStrong]}>{getDisplayName(usersTyping[0])}</Text>;
-            break;
-        case 2:
-            usersTypingText = (
-                <Text>
-                    <Text style={[styles.textStrong]}>{getDisplayName(usersTyping[0])}</Text>
-                    {' and '}
-                    <Text style={[styles.textStrong]}>{getDisplayName(usersTyping[1])}</Text>
+    componentDidUpdate(prevProps) {
+        // Make sure we only update the state if there's been a change in who's typing.
+        if (!_.isEqual(prevProps.userTypingStatuses, this.props.userTypingStatuses)) {
+            const usersTyping = Object.keys(this.props.userTypingStatuses || {})
+                .filter(login => this.props.userTypingStatuses[login]);
+
+            // Suppressing because this is within a conditional, and hence we won't run into an infinite loop
+            // eslint-disable-next-line react/no-did-update-set-state
+            this.setState({usersTyping});
+        }
+    }
+
+    render() {
+        const numUsersTyping = _.size(this.state.usersTyping);
+
+        // Return an empty view if no one is typing.
+        if (numUsersTyping === 0) {
+            return <View style={[styles.typingIndicator]} />;
+        }
+
+        // Decide on the Text element that will hold the display for the users that are typing.
+        let usersTypingText;
+        switch (numUsersTyping) {
+            case 1:
+                usersTypingText = <Text style={[styles.textStrong]}>{getDisplayName(this.state.usersTyping[0])}</Text>;
+                break;
+            case 2:
+                usersTypingText = (
+                    <Text>
+                        <Text style={[styles.textStrong]}>{getDisplayName(this.state.usersTyping[0])}</Text>
+                        {' and '}
+                        <Text style={[styles.textStrong]}>{getDisplayName(this.state.usersTyping[1])}</Text>
+                    </Text>
+                );
+                break;
+            default:
+                usersTypingText = <Text style={[styles.textStrong]}>Multiple users</Text>;
+        }
+
+        return (
+            <View style={[styles.typingIndicator]}>
+                <Text style={[styles.typingIndicatorSubText]}>
+                    {usersTypingText}
+                    {numUsersTyping > 1 ? ' are ' : ' is '}
+                    typing...
                 </Text>
-            );
-            break;
-        default:
-            usersTypingText = <Text style={[styles.textStrong]}>Multiple users</Text>;
+            </View>
+        );
     }
-
-    return (
-        <View style={[styles.typingIndicator]}>
-            <Text style={[styles.typingIndicatorSubText]}>
-                {usersTypingText}
-                {_.size(usersTyping) > 1 ? ' are ' : ' is '}
-                typing...
-            </Text>
-        </View>
-    );
-};
+}
 
 ReportTypingIndicator.propTypes = propTypes;
 ReportTypingIndicator.defaultProps = defaultProps;

--- a/src/pages/home/report/ReportView.js
+++ b/src/pages/home/report/ReportView.js
@@ -3,7 +3,7 @@ import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import ReportActionView from './ReportActionsView';
 import ReportActionCompose from './ReportActionCompose';
-import {addAction} from '../../../libs/actions/Report';
+import {addAction, subscribeToReportTypingEvents, unsubscribeToReportTypingEvents} from '../../../libs/actions/Report';
 import KeyboardSpacer from '../../../components/KeyboardSpacer';
 import styles from '../../../styles/StyleSheet';
 
@@ -18,6 +18,18 @@ const propTypes = {
 // This is a PureComponent so that it only re-renders when the reportID changes or when the report changes from
 // active to inactive (or vice versa). This should greatly reduce how often comments are re-rendered.
 class ReportView extends React.PureComponent {
+    componentDidMount() {
+        if (this.props.reportID) {
+            subscribeToReportTypingEvents(this.props.reportID);
+        }
+    }
+
+    componentWillUnmount() {
+        if (this.props.reportID) {
+            unsubscribeToReportTypingEvents(this.props.reportID);
+        }
+    }
+
     render() {
         // Only display the compose form for the active report because the form needs to get focus and
         // calling focus() on 42 different forms doesn't work

--- a/src/pages/home/report/ReportView.js
+++ b/src/pages/home/report/ReportView.js
@@ -3,7 +3,7 @@ import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import ReportActionView from './ReportActionsView';
 import ReportActionCompose from './ReportActionCompose';
-import {addAction, subscribeToReportTypingEvents, unsubscribeToReportTypingEvents} from '../../../libs/actions/Report';
+import {addAction} from '../../../libs/actions/Report';
 import KeyboardSpacer from '../../../components/KeyboardSpacer';
 import styles from '../../../styles/StyleSheet';
 
@@ -18,18 +18,6 @@ const propTypes = {
 // This is a PureComponent so that it only re-renders when the reportID changes or when the report changes from
 // active to inactive (or vice versa). This should greatly reduce how often comments are re-rendered.
 class ReportView extends React.PureComponent {
-    componentDidMount() {
-        if (this.props.reportID) {
-            subscribeToReportTypingEvents(this.props.reportID);
-        }
-    }
-
-    componentWillUnmount() {
-        if (this.props.reportID) {
-            unsubscribeToReportTypingEvents(this.props.reportID);
-        }
-    }
-
     render() {
         // Only display the compose form for the active report because the form needs to get focus and
         // calling focus() on 42 different forms doesn't work

--- a/src/styles/StyleSheet.js
+++ b/src/styles/StyleSheet.js
@@ -148,6 +148,11 @@ const styles = {
         fontSize: 11,
     },
 
+    textStrong: {
+        fontFamily: fontFamily.GTA_BOLD,
+        fontWeight: '600',
+    },
+
     colorReversed: {
         color: colors.textReversed,
     },
@@ -189,9 +194,14 @@ const styles = {
         fontWeight: '700'
     },
 
-    navSubText: {
+    typingIndicator: {
+        height: 25,
+    },
+
+    typingIndicatorSubText: {
         color: colors.textSupporting,
         fontSize: 11,
+        paddingLeft: 10,
     },
 
     // Actions
@@ -551,7 +561,7 @@ const styles = {
 
     chatItemCompose: {
         minHeight: 65,
-        paddingBottom: 20,
+        marginBottom: 5,
         paddingLeft: 20,
         paddingRight: 20,
         display: 'flex',

--- a/src/styles/StyleSheet.js
+++ b/src/styles/StyleSheet.js
@@ -195,14 +195,16 @@ const styles = {
     },
 
     typingIndicator: {
-        height: 25,
+        height: 15,
+        marginBottom: 5,
+        marginTop: 5,
     },
 
     typingIndicatorSubText: {
         color: colors.textSupporting,
         fontFamily: fontFamily.GTA,
         fontSize: 11,
-        marginLeft: 45,
+        marginLeft: 48,
     },
 
     // Actions

--- a/src/styles/StyleSheet.js
+++ b/src/styles/StyleSheet.js
@@ -200,8 +200,9 @@ const styles = {
 
     typingIndicatorSubText: {
         color: colors.textSupporting,
+        fontFamily: fontFamily.GTA,
         fontSize: 11,
-        paddingLeft: 10,
+        marginLeft: 45,
     },
 
     // Actions


### PR DESCRIPTION
@marcaaron will you please review?
cc @shawnborton @michelle-thompson for design input

Move the user typing indicator to be below the compose box

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/142357

### Tests
- Have two open sessions (I did this using one browser and one desktop app client, both logged into different accounts)
- Start typing in one of the sessions, make sure that you see `[User] is typing...` below the compose input box in the chat in the other session.
- Do the same from the other session,  make sure that you see `[User] is typing...` below the compose input box in the chat of the previous session.

### Screenshots
![Kapture 2020-10-22 at 16 33 27](https://user-images.githubusercontent.com/4741899/96940391-78cef600-1484-11eb-9c52-6e8fcdc5092f.gif)

![Kapture 2020-10-22 at 16 35 04](https://user-images.githubusercontent.com/4741899/96940438-92703d80-1484-11eb-9943-65d1205ce7e6.gif)


