### PR TITLE
List hidden chat window in menu for easy recall

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,6 +1,8 @@
 const {
     app,
     BrowserWindow,
+    Menu,
+    MenuItem,
     shell,
     ipcMain
 } = require('electron');
@@ -50,6 +52,17 @@ const mainWindow = (() => {
                 },
             });
 
+            // List the Expensify Chat instance under the Window menu, even when it's hidden
+            const menu = Menu.getApplicationMenu();
+            windowMenu = menu.items.find((item) => item.role === "windowmenu");
+            windowMenu.submenu.append(new MenuItem({ type: 'separator' }));
+            windowMenu.submenu.append(new MenuItem({
+                label: 'Expensify Chat',
+                accelerator: 'CmdOrCtrl+1',
+                click: () => { browserWindow.show() }
+            }));
+            Menu.setApplicationMenu(menu);
+
             // When the user clicks a link that has target="_blank" (which is all external links)
             // open the default browser instead of a new electron window
             browserWindow.webContents.on('new-window', (e, url) => {
@@ -70,7 +83,7 @@ const mainWindow = (() => {
             browserWindow.on('close', (evt) => {
                 if (!quitting) {
                     evt.preventDefault();
-                    browserWindow.minimize();
+                    browserWindow.hide();
                 }
             });
 

--- a/main.js
+++ b/main.js
@@ -53,15 +53,15 @@ const mainWindow = (() => {
             });
 
             // List the Expensify Chat instance under the Window menu, even when it's hidden
-            const menu = Menu.getApplicationMenu();
-            const windowMenu = menu.items.find(item => item.role === 'windowmenu');
+            const systemMenu = Menu.getApplicationMenu();
+            const windowMenu = systemMenu.items.find(item => item.role === 'windowmenu');
             windowMenu.submenu.append(new MenuItem({type: 'separator'}));
             windowMenu.submenu.append(new MenuItem({
                 label: 'Expensify Chat',
                 accelerator: 'CmdOrCtrl+1',
                 click: () => browserWindow.show()
             }));
-            Menu.setApplicationMenu(menu);
+            Menu.setApplicationMenu(systemMenu);
 
             // When the user clicks a link that has target="_blank" (which is all external links)
             // open the default browser instead of a new electron window

--- a/main.js
+++ b/main.js
@@ -54,12 +54,12 @@ const mainWindow = (() => {
 
             // List the Expensify Chat instance under the Window menu, even when it's hidden
             const menu = Menu.getApplicationMenu();
-            windowMenu = menu.items.find((item) => item.role === "windowmenu");
-            windowMenu.submenu.append(new MenuItem({ type: 'separator' }));
+            const windowMenu = menu.items.find(item => item.role === 'windowmenu');
+            windowMenu.submenu.append(new MenuItem({type: 'separator'}));
             windowMenu.submenu.append(new MenuItem({
                 label: 'Expensify Chat',
                 accelerator: 'CmdOrCtrl+1',
-                click: () => { browserWindow.show() }
+                click: () => browserWindow.show()
             }));
             Menu.setApplicationMenu(menu);
 


### PR DESCRIPTION
Thanks for the review! Let's list the hidden chat window in the system menu (even after it is closed) for easy recall.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/141666

### Tests
1. Close the active chat window with "Command + w"
2. While having the application in focus (only the top system menu should say "Electron", with no app window displayed), hit "Command + 1" and the chat window should be restored 👍 

### Screenshots
<img width="353" alt="Screen Shot 2020-10-22 at 2 04 22 PM" src="https://user-images.githubusercontent.com/2438855/96831760-3996aa00-1470-11eb-8536-b7874b97acab.png">

<img width="557" alt="Screen Shot 2020-10-22 at 2 04 30 PM" src="https://user-images.githubusercontent.com/2438855/96831771-3dc2c780-1470-11eb-8a83-00e2977b7e92.png">

