### PR TITLE
Temporary patch to stop resource hogging by activity indicator

### DIFF
--- a/src/pages/home/report/ReportActionItemFragment.js
+++ b/src/pages/home/report/ReportActionItemFragment.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import HTML from 'react-native-render-html';
 import {
-    Linking, ActivityIndicator, View, Dimensions
+    Linking, View, Dimensions
 } from 'react-native';
 import PropTypes from 'prop-types';
 import Str from '../../../libs/Str';
 import ReportActionFragmentPropTypes from './ReportActionFragmentPropTypes';
-import styles, {webViewStyles, colors} from '../../../styles/StyleSheet';
+import styles, {webViewStyles} from '../../../styles/StyleSheet';
 import Text from '../../../components/Text';
 import AnchorForCommentsOnly from '../../../components/AnchorForCommentsOnly';
 import {getAuthToken} from '../../../libs/API';
@@ -92,11 +92,12 @@ class ReportActionItemFragment extends React.PureComponent {
                 if (this.props.isAttachment && fragment.html === fragment.text) {
                     return (
                         <View style={[styles.chatItemAttachmentPlaceholder]}>
-                            <ActivityIndicator
-                                size="large"
-                                color={colors.textSupporting}
-                                style={[styles.h100p]}
-                            />
+                            {/* <ActivityIndicator */}
+                            {/*    size="large" */}
+                            {/*    color={colors.textSupporting} */}
+                            {/*    style={[styles.h100p]} */}
+                            {/* /> */}
+                            <Text>Uploading Attachment...</Text>
                         </View>
                     );
                 }


### PR DESCRIPTION
@Jag96 Will you please review this?

This is a temporary fix to prevent resource hogging while I work on resolving the real issue.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/142249#issuecomment-714547307

### Tests
Just upload an image and verify that the activity indicator is replaced by the text `Uploading Attachment...`

### Screenshots
![image](https://user-images.githubusercontent.com/47436092/96902151-0260d280-1449-11eb-9d6f-56d3afb2adc7.png)

