### PR TITLE
Move fail notifications for version bump to announce

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -62,8 +62,10 @@ jobs:
                     fields: workflow, repo
                     custom_payload: |
                         {
+                          channel: '#announce',
                           attachments: [{
                             color: "#DB4545",
+                            pretext: `<!here>`,
                             text: `💥 ${process.env.AS_REPO} failed on ${process.env.AS_WORKFLOW} workflow 💥`,
                           }]
                         }


### PR DESCRIPTION
@AndrewGable will you please review this?

This PR moves the failed notification for the version bump to announce. Missed it when I made https://github.com/Expensify/ReactNativeChat/pull/692

### Tests
N/A
