### PR TITLE
Use types instead of passing callbacks directly in ChatSwitcher

### DIFF
--- a/src/libs/actions/SignInRedirect.js
+++ b/src/libs/actions/SignInRedirect.js
@@ -39,7 +39,8 @@ function redirectToSignIn(errorMessage) {
         return;
     }
 
-    // Save the reportID before calling redirect or otherwise when clear is finished the value saved here will already be null
+    // Save the reportID before calling redirect or otherwise when clear
+    // is finished the value saved here will already be null
     const reportID = currentlyViewedReportID;
 
     // When the URL is at the root of the site, go to sign-in, otherwise add the exitTo

--- a/src/pages/home/sidebar/ChatSwitcherList.js
+++ b/src/pages/home/sidebar/ChatSwitcherList.js
@@ -23,16 +23,16 @@ const propTypes = {
 
         // The URL of the person's avatar
         icon: PropTypes.string,
-
-        // A function that is called when an option is selected. Selected option is passed as a param
-        callback: PropTypes.func.isRequired,
     })),
+
+    // A function that is called when an option is selected. Selected option is passed as a param
+    onSelectRow: PropTypes.func.isRequired,
 };
 const defaultProps = {
     options: [],
 };
 
-const ChatSwitcherList = ({focusedIndex, options}) => (
+const ChatSwitcherList = ({focusedIndex, options, onSelectRow}) => (
     <View style={[styles.chatSwitcherItemList]}>
         {options.length > 0 && _.map(options, (option, i) => {
             const optionIsFocused = i === focusedIndex;
@@ -42,7 +42,7 @@ const ChatSwitcherList = ({focusedIndex, options}) => (
             return (
                 <TouchableOpacity
                     key={option.alternateText}
-                    onPress={() => option.callback(option)}
+                    onPress={() => onSelectRow(option)}
                 >
                     <View
                         style={[

--- a/src/pages/home/sidebar/ChatSwitcherView.js
+++ b/src/pages/home/sidebar/ChatSwitcherView.js
@@ -11,6 +11,11 @@ import {fetchOrCreateChatReport} from '../../../libs/actions/Report';
 import {redirect} from '../../../libs/actions/App';
 import ROUTES from '../../../ROUTES';
 
+const OPTION_TYPE = {
+    USER: 'user',
+    REPORT: 'report',
+};
+
 const personalDetailsPropTypes = PropTypes.shape({
     // The login of the person (either email or phone number)
     login: PropTypes.string.isRequired,
@@ -70,6 +75,7 @@ class ChatSwitcherView extends React.Component {
         this.selectReport = this.selectReport.bind(this);
         this.triggerOnFocusCallback = this.triggerOnFocusCallback.bind(this);
         this.updateSearch = this.updateSearch.bind(this);
+        this.selectRow = this.selectRow.bind(this);
 
         this.state = {
             search: '',
@@ -92,6 +98,23 @@ class ChatSwitcherView extends React.Component {
 
     componentWillUnmount() {
         KeyboardShortcut.unsubscribe('K');
+    }
+
+    /**
+     * Fires the correct method for the option type selected.
+     *
+     * @param {Object} option
+     */
+    selectRow(option) {
+        switch (option.type) {
+            case OPTION_TYPE.USER:
+                this.selectUser(option);
+                break;
+            case OPTION_TYPE.REPORT:
+                this.selectReport(option);
+                break;
+            default:
+        }
     }
 
     /**
@@ -158,13 +181,12 @@ class ChatSwitcherView extends React.Component {
      */
     handleKeyPress(e) {
         let newFocusedIndex;
-        let option;
 
         switch (e.key) {
             case 'Enter':
-                // Call the selected option's callback and pass the option itself
-                option = this.state.options[this.state.focusedIndex];
-                option.callback(option);
+                // Pass the option to the selectRow method which
+                // will fire the correct callback for the option type.
+                this.selectRow(this.state.options[this.state.focusedIndex]);
                 e.preventDefault();
                 break;
 
@@ -240,7 +262,7 @@ class ChatSwitcherView extends React.Component {
                     : `${personalDetail.displayName} ${personalDetail.login}`,
                 icon: personalDetail.avatarURL,
                 login: personalDetail.login,
-                callback: this.selectUser,
+                type: OPTION_TYPE.USER,
             }))
             .value();
 
@@ -255,7 +277,7 @@ class ChatSwitcherView extends React.Component {
                 alternateText: report.reportName,
                 searchText: report.reportName,
                 reportID: report.reportID,
-                callback: this.selectReport,
+                type: OPTION_TYPE.REPORT,
             }))
             .value();
 
@@ -309,6 +331,7 @@ class ChatSwitcherView extends React.Component {
                 <ChatSwitcherList
                     focusedIndex={this.state.focusedIndex}
                     options={this.state.options}
+                    onSelectRow={this.selectRow}
                 />
             </>
         );


### PR DESCRIPTION
cc @stitesExpensify 

This is required for Group DMs as we will need to handle multiple callbacks.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/144290

### Tests
1. Make sure selecting both reports and users from the chat switcher works
1. Test both `Enter` keypress and also tapping on the row directly

### Screenshots
❌ 