### PR TITLE
Call isVisible() instead of isVisible

### DIFF
--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -54,7 +54,7 @@ class ReportActionsView extends React.Component {
 
     componentDidMount() {
         this.visibilityChangeEvent = AppState.addEventListener('change', () => {
-            if (this.props.isActiveReport && Visibility.isVisible) {
+            if (this.props.isActiveReport && Visibility.isVisible()) {
                 setTimeout(this.recordMaxAction, 3000);
             }
         });


### PR DESCRIPTION
@marcaaron, can you review? 

The behavior, as far as I can tell, was fine with `isVisible` (As in "it didn't get triggered if the tab was not visible"), but let's change it to function form just in case/for consistency.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/144307

### Tests/QA
Same tests as in https://github.com/Expensify/ReactNativeChat/pull/655

