### PR TITLE
Use npm install for desktop builds to temporarily fix recurring build failure

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -22,7 +22,7 @@ jobs:
                   ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
             - name: Install node packages
-              run: npm ci
+              run: npm install
 
             - name: Decrypt Developer ID Certificate
               run: cd desktop && gpg --quiet --batch --yes --decrypt --passphrase="$DEVELOPER_ID_SECRET_PASSPHRASE" --output developer_id.p12 developer_id.p12.gpg


### PR DESCRIPTION
@timszot will you please review this

This PR reverts the update from `npm install` to `npm ci` for desktop.yml. The original change was to fix intermittent build errors for the Build and Deploy Desktop Github Action, however, after updating to `npm ci` the build [always fails](https://github.com/Expensify/Expensify/issues/144368#issuecomment-716868921). While I investigate how to fix this for good, let's revert the desktop build changes so users to avoid notifications in #announce and ensure that users update versions.

### Tests
None, this is a revert of https://github.com/Expensify/ReactNativeChat/pull/712/files#diff-cc0ad60f02c62cee29c07f15d6e7d39332ac4e281f8f993c85dfbaa069f6627cL25
