### PR TITLE
Fix LHN showing unread chats from current user

### DIFF
--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -181,13 +181,15 @@ function fetchChatReportsByIDs(chatList) {
  */
 function updateReportWithNewAction(reportID, reportAction) {
     const newMaxSequenceNumber = reportAction.sequenceNumber;
+    const isFromCurrentUser = reportAction.actorAccountID === currentUserAccountID;
+    const unreadActionCount = isFromCurrentUser ? 0 : newMaxSequenceNumber - (lastReadActionIDs[reportID] || 0);
 
     // Always merge the reportID into Ion
     // If the report doesn't exist in Ion yet, then all the rest of the data will be filled out
     // by handleReportChanged
     Ion.merge(`${IONKEYS.COLLECTION.REPORT}${reportID}`, {
         reportID,
-        unreadActionCount: newMaxSequenceNumber - (lastReadActionIDs[reportID] || 0),
+        unreadActionCount,
         maxSequenceNumber: reportAction.sequenceNumber,
     });
 
@@ -202,7 +204,7 @@ function updateReportWithNewAction(reportID, reportAction) {
     }
 
     // If this comment is from the current user we don't want to parrot whatever they wrote back to them.
-    if (reportAction.actorAccountID === currentUserAccountID) {
+    if (isFromCurrentUser) {
         console.debug('[LOCAL_NOTIFICATION] No notification because comment is from the currently logged in user');
         return;
     }

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -174,6 +174,24 @@ function fetchChatReportsByIDs(chatList) {
 }
 
 /**
+ * Update the lastReadActionID in Ion and local memory.
+ *
+ * @param {Number} reportID
+ * @param {Number} sequenceNumber
+ */
+function setLocalLastReadActionID(reportID, sequenceNumber) {
+    lastReadActionIDs[reportID] = sequenceNumber;
+
+    // Update the lastReadActionID on the report optimistically
+    Ion.merge(`${IONKEYS.COLLECTION.REPORT}${reportID}`, {
+        unreadActionCount: 0,
+        reportNameValuePairs: {
+            [`lastReadActionID_${currentUserAccountID}`]: sequenceNumber,
+        }
+    });
+}
+
+/**
  * Updates a report in the store with a new report action
  *
  * @param {number} reportID
@@ -182,14 +200,20 @@ function fetchChatReportsByIDs(chatList) {
 function updateReportWithNewAction(reportID, reportAction) {
     const newMaxSequenceNumber = reportAction.sequenceNumber;
     const isFromCurrentUser = reportAction.actorAccountID === currentUserAccountID;
-    const unreadActionCount = isFromCurrentUser ? 0 : newMaxSequenceNumber - (lastReadActionIDs[reportID] || 0);
+
+    // When handling an action from the current users we can assume that their
+    // last read actionID has been updated in the server but not necessarily reflected
+    // locally so we must first update it and then calculate the unread (which should be 0)
+    if (isFromCurrentUser) {
+        setLocalLastReadActionID(reportID, newMaxSequenceNumber);
+    }
 
     // Always merge the reportID into Ion
     // If the report doesn't exist in Ion yet, then all the rest of the data will be filled out
     // by handleReportChanged
     Ion.merge(`${IONKEYS.COLLECTION.REPORT}${reportID}`, {
         reportID,
-        unreadActionCount,
+        unreadActionCount: newMaxSequenceNumber - (lastReadActionIDs[reportID] || 0),
         maxSequenceNumber: reportAction.sequenceNumber,
     });
 
@@ -500,15 +524,7 @@ function updateLastReadActionID(reportID, sequenceNumber) {
         return;
     }
 
-    lastReadActionIDs[reportID] = sequenceNumber;
-
-    // Update the lastReadActionID on the report optimistically
-    Ion.merge(`${IONKEYS.COLLECTION.REPORT}${reportID}`, {
-        unreadActionCount: 0,
-        reportNameValuePairs: {
-            [`lastReadActionID_${currentUserAccountID}`]: sequenceNumber,
-        }
-    });
+    setLocalLastReadActionID(reportID, sequenceNumber);
 
     // Mark the report as not having any unread items
     API.setLastReadActionID({


### PR DESCRIPTION
<Assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit.>

<Explanation of the change or anything fishy that is going on>

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/142727

### Tests
1. Log into two separate incognito windows with the same account
1. Start a chat with any user in **Window 1**
1. Make sure the chat is visible on **Window 1** and absent from the LHN on **Window 2**. If the chat is pinned on **Window 2** then unpin the chat
1. Send several messages
1. Verify the chat does NOT appear in the LHN for **Window 2**

cc @mallenexpensify 

### Screenshots
❌ 