### PR TITLE
Fix crash when adding mobile attachment

### DIFF
--- a/src/components/TextInputFocusable/index.js
+++ b/src/components/TextInputFocusable/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {TextInput} from 'react-native';
 import PropTypes from 'prop-types';
+import _ from 'underscore';
 
 const propTypes = {
     // Maximum number of lines in the text input
@@ -8,6 +9,9 @@ const propTypes = {
 
     // The default value of the comment box
     defaultValue: PropTypes.string.isRequired,
+
+    // A ref to forward to the text input
+    forwardedRef: PropTypes.func.isRequired,
 
     // If the input should clear, it actually gets intercepted instead of .clear()
     shouldClear: PropTypes.bool,
@@ -36,6 +40,14 @@ class TextInputFocusable extends React.Component {
 
     componentDidMount() {
         this.focusInput();
+
+        // This callback prop is used by the parent component using the constructor to
+        // get a ref to the inner textInput element e.g. if we do
+        // <constructor ref={el => this.textInput = el} /> this will not
+        // return a ref to the component, but rather the HTML element by default
+        if (this.props.forwardedRef && _.isFunction(this.props.forwardedRef)) {
+            this.props.forwardedRef(this.textInput);
+        }
     }
 
     componentDidUpdate(prevProps) {
@@ -107,4 +119,8 @@ class TextInputFocusable extends React.Component {
 
 TextInputFocusable.propTypes = propTypes;
 TextInputFocusable.defaultProps = defaultProps;
-export default TextInputFocusable;
+
+export default React.forwardRef((props, ref) => (
+    /* eslint-disable-next-line react/jsx-props-no-spreading */
+    <TextInputFocusable {...props} forwardedRef={ref} />
+));

--- a/src/components/TextInputFocusable/index.native.js
+++ b/src/components/TextInputFocusable/index.native.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {TextInput} from 'react-native';
 import PropTypes from 'prop-types';
+import _ from 'underscore';
 
 /**
  * On native layers we like to have the Text Input not focused so the user can read new chats without they keyboard in
@@ -10,6 +11,9 @@ import PropTypes from 'prop-types';
 const propTypes = {
     // If the input should clear, it actually gets intercepted instead of .clear()
     shouldClear: PropTypes.bool,
+
+    // A ref to forward to the text input
+    forwardedRef: PropTypes.func.isRequired,
 
     // When the input has cleared whoever owns this input should know about it
     onClear: PropTypes.func,
@@ -21,6 +25,16 @@ const defaultProps = {
 };
 
 class TextInputFocusable extends React.Component {
+    componentDidMount() {
+        // This callback prop is used by the parent component using the constructor to
+        // get a ref to the inner textInput element e.g. if we do
+        // <constructor ref={el => this.textInput = el} /> this will not
+        // return a ref to the component, but rather the HTML element by default
+        if (this.props.forwardedRef && _.isFunction(this.props.forwardedRef)) {
+            this.props.forwardedRef(this.textInput);
+        }
+    }
+
     componentDidUpdate(prevProps) {
         if (!prevProps.shouldClear && this.props.shouldClear) {
             this.textInput.clear();
@@ -43,4 +57,8 @@ class TextInputFocusable extends React.Component {
 TextInputFocusable.displayName = 'TextInputFocusable';
 TextInputFocusable.propTypes = propTypes;
 TextInputFocusable.defaultProps = defaultProps;
-export default TextInputFocusable;
+
+export default React.forwardRef((props, ref) => (
+    /* eslint-disable-next-line react/jsx-props-no-spreading */
+    <TextInputFocusable {...props} forwardedRef={ref} />
+));

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -140,6 +140,7 @@ class ReportActionCompose extends React.Component {
             console.debug(`Attachment selected: ${response.uri}, ${response.type}, ${response.name}, ${response.size}`);
 
             addAction(this.props.reportID, '', AttachmentPicker.getDataForUpload(response));
+            this.textInput.focus();
         });
     }
 
@@ -165,6 +166,7 @@ class ReportActionCompose extends React.Component {
                     </TouchableOpacity>
                     <TextInputFocusable
                         multiline
+                        ref={el => this.textInput = el}
                         textAlignVertical="top"
                         placeholder="Write something..."
                         placeholderTextColor={colors.textSupporting}

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -140,7 +140,6 @@ class ReportActionCompose extends React.Component {
             console.debug(`Attachment selected: ${response.uri}, ${response.type}, ${response.name}, ${response.size}`);
 
             addAction(this.props.reportID, '', AttachmentPicker.getDataForUpload(response));
-            this.textInput.focus();
         });
     }
 


### PR DESCRIPTION
Fixed a crash when adding mobile attachments, by removing an outdated focus request. 

To maintain existing functionality, we should maintain focus on the text input field after selecting an attachment. I have a commit which fixes this for Desktop, Web and Android, but iOS is not maintaining this focus. For this reason I'm going to reopen the original issue, raise a new PR, request further discussion. This will unblock this crash fix.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/144726

### Tests

**Adding attachment should not cause crash!**  
- Add an attachment 
- Attachment will begin to upload
- App should not crash

### Screenshots
N/A
