### PR TITLE
[WIP] Fix issue where input focus is lost after adding attachment

### DIFF
--- a/src/components/TextInputFocusable/index.js
+++ b/src/components/TextInputFocusable/index.js
@@ -12,9 +12,6 @@ const propTypes = {
     // If the input should clear, it actually gets intercepted instead of .clear()
     shouldClear: PropTypes.bool,
 
-    // Should the TextInput field be in focused state
-    shouldFocus: PropTypes.bool,
-
     // When the input has cleared whoever owns this input should know about it
     onClear: PropTypes.func,
 };
@@ -22,7 +19,6 @@ const propTypes = {
 const defaultProps = {
     maxLines: -1,
     shouldClear: false,
-    shouldFocus: false,
     onClear: () => {},
 };
 
@@ -49,11 +45,6 @@ class TextInputFocusable extends React.Component {
             this.setState({numberOfLines: 1});
             this.props.onClear();
         }
-
-        if (this.props.shouldFocus) {
-            this.focusInput();
-        }
-
         if (prevProps.defaultValue !== this.props.defaultValue) {
             this.updateNumberOfLines();
         }

--- a/src/components/TextInputFocusable/index.js
+++ b/src/components/TextInputFocusable/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {TextInput} from 'react-native';
 import PropTypes from 'prop-types';
+import _ from 'underscore';
 
 const propTypes = {
     // Maximum number of lines in the text input
@@ -8,6 +9,9 @@ const propTypes = {
 
     // The default value of the comment box
     defaultValue: PropTypes.string.isRequired,
+
+    // A ref to forward to the text input
+    forwardedRef: PropTypes.func.isRequired,
 
     // If the input should clear, it actually gets intercepted instead of .clear()
     shouldClear: PropTypes.bool,
@@ -36,6 +40,9 @@ class TextInputFocusable extends React.Component {
 
     componentDidMount() {
         this.focusInput();
+        if (this.props.forwardedRef && _.isFunction(this.props.forwardedRef)) {
+            this.props.forwardedRef(this.textInput);
+        }
     }
 
     componentDidUpdate(prevProps) {
@@ -107,4 +114,8 @@ class TextInputFocusable extends React.Component {
 
 TextInputFocusable.propTypes = propTypes;
 TextInputFocusable.defaultProps = defaultProps;
-export default TextInputFocusable;
+
+export default React.forwardRef((props, ref) => (
+    /* eslint-disable-next-line react/jsx-props-no-spreading */
+    <TextInputFocusable {...props} forwardedRef={ref} />
+));

--- a/src/components/TextInputFocusable/index.js
+++ b/src/components/TextInputFocusable/index.js
@@ -12,6 +12,9 @@ const propTypes = {
     // If the input should clear, it actually gets intercepted instead of .clear()
     shouldClear: PropTypes.bool,
 
+    // Should the TextInput field be in focused state
+    shouldFocus: PropTypes.bool,
+
     // When the input has cleared whoever owns this input should know about it
     onClear: PropTypes.func,
 };
@@ -19,6 +22,7 @@ const propTypes = {
 const defaultProps = {
     maxLines: -1,
     shouldClear: false,
+    shouldFocus: false,
     onClear: () => {},
 };
 
@@ -45,6 +49,11 @@ class TextInputFocusable extends React.Component {
             this.setState({numberOfLines: 1});
             this.props.onClear();
         }
+
+        if (this.props.shouldFocus) {
+            this.focusInput();
+        }
+
         if (prevProps.defaultValue !== this.props.defaultValue) {
             this.updateNumberOfLines();
         }

--- a/src/components/TextInputFocusable/index.native.js
+++ b/src/components/TextInputFocusable/index.native.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {TextInput} from 'react-native';
 import PropTypes from 'prop-types';
+import _ from 'underscore';
 
 /**
  * On native layers we like to have the Text Input not focused so the user can read new chats without they keyboard in
@@ -10,6 +11,9 @@ import PropTypes from 'prop-types';
 const propTypes = {
     // If the input should clear, it actually gets intercepted instead of .clear()
     shouldClear: PropTypes.bool,
+
+    // A ref to forward to the text input
+    forwardedRef: PropTypes.func.isRequired,
 
     // When the input has cleared whoever owns this input should know about it
     onClear: PropTypes.func,
@@ -21,6 +25,12 @@ const defaultProps = {
 };
 
 class TextInputFocusable extends React.Component {
+    componentDidMount() {
+        if (this.props.forwardedRef && _.isFunction(this.props.forwardedRef)) {
+            this.props.forwardedRef(this.textInput);
+        }
+    }
+
     componentDidUpdate(prevProps) {
         if (!prevProps.shouldClear && this.props.shouldClear) {
             this.textInput.clear();
@@ -43,4 +53,8 @@ class TextInputFocusable extends React.Component {
 TextInputFocusable.displayName = 'TextInputFocusable';
 TextInputFocusable.propTypes = propTypes;
 TextInputFocusable.defaultProps = defaultProps;
-export default TextInputFocusable;
+
+export default React.forwardRef((props, ref) => (
+    /* eslint-disable-next-line react/jsx-props-no-spreading */
+    <TextInputFocusable {...props} forwardedRef={ref} />
+));

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -166,6 +166,7 @@ class ReportActionCompose extends React.Component {
                     </TouchableOpacity>
                     <TextInputFocusable
                         multiline
+                        ref={el => this.textInput = el}
                         textAlignVertical="top"
                         placeholder="Write something..."
                         placeholderTextColor={colors.textSupporting}

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -177,7 +177,6 @@ class ReportActionCompose extends React.Component {
                         onFocus={() => this.setIsFocused(true)}
                         onBlur={() => this.setIsFocused(false)}
                         shouldClear={this.state.textInputShouldClear}
-                        shouldFocus={this.state.isFocused}
                         onClear={() => this.setTextInputShouldClear(false)}
                     />
                     <TouchableOpacity

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -177,6 +177,7 @@ class ReportActionCompose extends React.Component {
                         onFocus={() => this.setIsFocused(true)}
                         onBlur={() => this.setIsFocused(false)}
                         shouldClear={this.state.textInputShouldClear}
+                        shouldFocus={this.state.isFocused}
                         onClear={() => this.setTextInputShouldClear(false)}
                     />
                     <TouchableOpacity


### PR DESCRIPTION
CC @iwiznia - FYI as you worked on adding re-focus behaviour
CC @sketchydroide, @marcaaron - You both discussed the `shouldClear` implementation which I'm attempting to follow.

Further information [here](https://github.com/Expensify/Expensify/issues/143309#issuecomment-720595720)

I fixed [this crash](https://github.com/Expensify/ReactNativeChat/pull/733), by removing an outdated focus request. This also caused a regression: TextInput no longer gains focus after adding an attachment. I split the solution out to unblock the crash as there are some complications that should be discussed further. 

This solution was to pass `shouldFocus` state to the child `TextInputFocusable` component and to handle this new state from within the component. Similar behaviour was used for `shouldClear.` The problem with this solution is that it fixes web, desktop and Android, but not iOS. 


### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/143309

### Tests

**1) Adding attachment should not cause crash!**  
- Add an attachment 
- Attachment will begin to upload
- App should not crash

**2) Input focus state should remain after adding attachment**  
_This works for Desktop, Web, Android, but **not iOS**_
- Tap attachment button, select document, take a photo or choose from gallery
- Attachment will begin to upload
- Input field focus state should remain focused

### Screenshots
N/A
