### PR TITLE
The Keyboard spacer needs to check if Safe Areas exist

### DIFF
--- a/src/components/KeyboardSpacer/index.ios.js
+++ b/src/components/KeyboardSpacer/index.ios.js
@@ -4,9 +4,16 @@
  */
 import ReactNativeKeyboardSpacer from 'react-native-keyboard-spacer';
 import React from 'react';
+import {Dimensions} from 'react-native';
+
+function hasSafeAreas() {
+    const dims = Dimensions.get('window');
+    const heightsIphonesWithNotches = [812, 896, 844, 926];
+    return (heightsIphonesWithNotches.includes(dims.height) || heightsIphonesWithNotches.includes(dims.width));
+}
 
 const KeyboardSpacer = () => (
-    <ReactNativeKeyboardSpacer topSpacing={-30} />
+    <ReactNativeKeyboardSpacer topSpacing={hasSafeAreas() ? -30 : 0} />
 );
 
 export default KeyboardSpacer;


### PR DESCRIPTION
The Keyboard spacer needs to check if Safe Areas exist

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/144559

### Tests
1. Run the app on a iPhone 8 Simulator.
1. press the comment bubble on a chat and make sure the keyboard appears
1. Make sure there are is a space between the keyboard and the bubble.
1. Run the app on a iPhone 11 Simulator.
1. press the comment bubble on a chat and make sure the keyboard appears
1. Make sure there are is a space between the keyboard and the bubble. and it's the same height you saw for the iPhone 8.
