### PR TITLE
Update to webfactory/ssh-agent@v0.4.1 to fix cve

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -20,7 +20,7 @@ jobs:
         - name: Install gems
           run: bundle install
 
-        - uses: webfactory/ssh-agent@v0.4.0
+        - uses: webfactory/ssh-agent@v0.4.1
           with:
               ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -17,7 +17,7 @@ jobs:
               with:
                 node-version: '14.x'
 
-            - uses: webfactory/ssh-agent@v0.4.0
+            - uses: webfactory/ssh-agent@v0.4.1
               with:
                   ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -20,7 +20,7 @@ jobs:
             - name: Install gems
               run: bundle install
 
-            - uses: webfactory/ssh-agent@v0.4.0
+            - uses: webfactory/ssh-agent@v0.4.1
               with:
                   ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
               with:
                   node-version: '14.x'
 
-            - uses: webfactory/ssh-agent@v0.4.0
+            - uses: webfactory/ssh-agent@v0.4.1
               with:
                   ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -19,7 +19,7 @@ jobs:
               with:
                   node-version: '14.x'
 
-            - uses: webfactory/ssh-agent@v0.4.0
+            - uses: webfactory/ssh-agent@v0.4.1
               with:
                   ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -38,7 +38,7 @@ jobs:
             aws-region: us-east-1
 
         # Install node modules
-        - uses: webfactory/ssh-agent@v0.4.0
+        - uses: webfactory/ssh-agent@v0.4.1
           with:
               ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 


### PR DESCRIPTION
Updates the ssh-agent to not use a depreciated/possibly insecure way to set env variables.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/145247

### Tests
Verify that the lint workflow passes, then all the other `npm installs` should succeed as well.
