### PR TITLE
Bump js-libs to use new link regex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10731,8 +10731,8 @@
       }
     },
     "js-libs": {
-      "version": "git+ssh://git@github.com/Expensify/JS-Libs.git#7b13151f15f631bbf2ef10a7ef57e36f89261b0e",
-      "from": "git+ssh://git@github.com/Expensify/JS-Libs.git#7b13151f15f631bbf2ef10a7ef57e36f89261b0e",
+      "version": "git+ssh://git@github.com/Expensify/JS-Libs.git#7aead2547a2d27d632cea00a047e527c69c4e6b1",
+      "from": "git+ssh://git@github.com/Expensify/JS-Libs.git#7aead2547a2d27d632cea00a047e527c69c4e6b1",
       "requires": {
         "classnames": "2.2.5",
         "clipboard": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "electron-updater": "^4.3.4",
     "file-loader": "^6.0.0",
     "html-entities": "^1.3.1",
-    "js-libs": "git+https://git@github.com:Expensify/JS-Libs.git#7b13151f15f631bbf2ef10a7ef57e36f89261b0e",
+    "js-libs": "git+https://git@github.com:Expensify/JS-Libs.git#7aead2547a2d27d632cea00a047e527c69c4e6b1",
     "lodash.get": "^4.4.2",
     "lodash.has": "^4.5.2",
     "lodash.orderby": "^4.6.0",


### PR DESCRIPTION
### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/144563
Fixes https://github.com/Expensify/Expensify/issues/141678

### Tests
1. In Expensify Chat, try a posting a variety of links that should be auto linked. Some examples are below, but feel free to test more. Verify they are autolinked and point to the correct location.
```
google.com
www.expensify.com
example.army
https://google.com/
http://test.com/test
https://www.google.com
```
1. Post a variety of invalid links that should not be autolinked. Some examples are below. Verify they are not autolinked
```
google.thisisnotarealtld
fake://protocol
test . com
```
1. Post a variety of links. Some examples are below, but feel free to test more. Verify they are linked and point to the correct location.
```
[Expensify!](https://www.expensify.com)
[Expensify](https://www.expensify-test.com)
[Expensify](https://www.expensify.com/settings?param={%22section%22:%22account%22})
[Expensify](expensify.com)
[Expensify](www.expensify.com)
```
1. Post a variety of invalid links. Some examples are below, but feel free to test this more. Verify they are not linked
```
[Google](google.thisisnotarealtld)
[Fake](fake://protocol)
[test](test . com)
```

### Screenshots
N/a, no visual changes.