### PR TITLE
Unsubscribe from the report channel not only event

### DIFF
--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -341,14 +341,14 @@ function subscribeToReportTypingEvents(reportID) {
  *
  * @param {number} reportID
  */
-function unsubscribeToReportTypingEvents(reportID) {
+function unsubscribeFromReportChannel(reportID) {
     if (!reportID) {
         return;
     }
 
     const pusherChannelName = getReportChannelName(reportID);
     Ion.set(`${IONKEYS.COLLECTION.REPORT_USER_IS_TYPING}${reportID}`, {});
-    Pusher.unsubscribe(pusherChannelName, 'client-userIsTyping');
+    Pusher.unsubscribe(pusherChannelName);
 }
 
 /**
@@ -650,7 +650,7 @@ export {
     updateLastReadActionID,
     subscribeToReportCommentEvents,
     subscribeToReportTypingEvents,
-    unsubscribeToReportTypingEvents,
+    unsubscribeFromReportChannel,
     saveReportComment,
     broadcastUserIsTyping,
     togglePinnedState,

--- a/src/pages/home/report/ReportView.js
+++ b/src/pages/home/report/ReportView.js
@@ -19,15 +19,11 @@ const propTypes = {
 // active to inactive (or vice versa). This should greatly reduce how often comments are re-rendered.
 class ReportView extends React.PureComponent {
     componentDidMount() {
-        if (this.props.reportID) {
-            subscribeToReportTypingEvents(this.props.reportID);
-        }
+        subscribeToReportTypingEvents(this.props.reportID);
     }
 
     componentWillUnmount() {
-        if (this.props.reportID) {
-            unsubscribeToReportTypingEvents(this.props.reportID);
-        }
+        unsubscribeToReportTypingEvents(this.props.reportID);
     }
 
     render() {

--- a/src/pages/home/report/ReportView.js
+++ b/src/pages/home/report/ReportView.js
@@ -3,7 +3,7 @@ import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import ReportActionView from './ReportActionsView';
 import ReportActionCompose from './ReportActionCompose';
-import {addAction, subscribeToReportTypingEvents, unsubscribeToReportTypingEvents} from '../../../libs/actions/Report';
+import {addAction, subscribeToReportTypingEvents, unsubscribeFromReportChannel} from '../../../libs/actions/Report';
 import KeyboardSpacer from '../../../components/KeyboardSpacer';
 import styles from '../../../styles/StyleSheet';
 
@@ -23,7 +23,7 @@ class ReportView extends React.PureComponent {
     }
 
     componentWillUnmount() {
-        unsubscribeToReportTypingEvents(this.props.reportID);
+        unsubscribeFromReportChannel(this.props.reportID);
     }
 
     render() {


### PR DESCRIPTION
cc @yuwenmemon 

Just trying this to see if it helps fix the linked issue I don't think it should affect your changes but we should be cleanly unsubscribing from the report when it unmounts and by only unsubscribing from the channel we stay occupied in the channel.

# Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/144728

### Tests
1. Test user is typing feature and make sure it works fine.
1. Verify that when a report is out of view (and not pinned) that the channel is no longer occupied 
![Screenshot 1533](https://user-images.githubusercontent.com/32969087/98171517-f38c0e00-1e93-11eb-9ad4-2817a31fd36f.png)

### Screenshots
❌ 