### PR TITLE
Add default avatar to my personal details

### DIFF
--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -111,8 +111,10 @@ function fetch() {
             const allPersonalDetails = formatPersonalDetails(data.personalDetailsList);
             Ion.merge(IONKEYS.PERSONAL_DETAILS, allPersonalDetails);
 
+            const myPersonalDetails = allPersonalDetails[currentUserEmail] || {avatarURL: getAvatar(undefined, currentUserEmail)};
+
             // Set my personal details so they can be easily accessed and subscribed to on their own key
-            Ion.merge(IONKEYS.MY_PERSONAL_DETAILS, allPersonalDetails[currentUserEmail] || {});
+            Ion.merge(IONKEYS.MY_PERSONAL_DETAILS, myPersonalDetails);
 
             // Get the timezone and put it in Ion
             fetchTimezone();

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -111,7 +111,8 @@ function fetch() {
             const allPersonalDetails = formatPersonalDetails(data.personalDetailsList);
             Ion.merge(IONKEYS.PERSONAL_DETAILS, allPersonalDetails);
 
-            const myPersonalDetails = allPersonalDetails[currentUserEmail] || {avatarURL: getAvatar(undefined, currentUserEmail)};
+            const myPersonalDetails = allPersonalDetails[currentUserEmail]
+                || {avatarURL: getAvatar(undefined, currentUserEmail)};
 
             // Set my personal details so they can be easily accessed and subscribed to on their own key
             Ion.merge(IONKEYS.MY_PERSONAL_DETAILS, myPersonalDetails);


### PR DESCRIPTION
Users that do not have avatars are not seeing a placeholder avatar this adds one.

### Fixed Issues
Fixes No issue just something I came across while working on another PR

### Tests
1. Create a new account with no avatar and log in
1. Leave a comment on a report and verify that an avatar is immediately shown

### Screenshots
❌ 