### PR TITLE
Extend sleep timer to prevent multiple reconnection callback triggers

### DIFF
--- a/src/libs/NetworkConnection.js
+++ b/src/libs/NetworkConnection.js
@@ -76,12 +76,12 @@ function listenForReconnect() {
 
     // When a device is put to sleep, NetInfo is not always able to detect
     // when connectivity has been lost. As a failsafe we will capture the time
-    // every two seconds and if the last time recorded is greater than 5 seconds
+    // every two seconds and if the last time recorded is greater than 20 seconds
     // we know that the computer has been asleep.
     lastTime = (new Date()).getTime();
     sleepTimer = setInterval(() => {
         const currentTime = (new Date()).getTime();
-        if (currentTime > (lastTime + 5000)) {
+        if (currentTime > (lastTime + 20000)) {
             triggerReconnectionCallbacks();
         }
         lastTime = currentTime;


### PR DESCRIPTION
This is kind of a weird issue but basically on dev I observed that...

1. Enough reconnection callbacks can hang up the JS
1. If those callbacks take longer than 5 seconds then the interval won't reliably tick which will call the callbacks to fire again 

Pretty sure this happens because `setInterval` will _try_ to do what you tell it to but can't actually be trusted see spec [here](https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timers)

### Fixed Issues
Fixes No issue just came across while testing

### Tests
1. Open chat and close laptop
1. Wait a few minutes and reopen the laptop
1. Verify you see the reconnection callbacks fire in the console logs.

### Screenshots
❌ 