### PR TITLE
Focus app when clicking on notification

### DIFF
--- a/desktop/ELECTRON_EVENTS.js
+++ b/desktop/ELECTRON_EVENTS.js
@@ -1,6 +1,7 @@
 const ELECTRON_EVENTS = {
     REQUEST_UPDATE_BADGE_COUNT: 'requestUpdateBadgeCount',
     REQUEST_VISIBILITY: 'requestVisibility',
+    REQUEST_FOCUS_APP: 'requestFocusApp',
 };
 
 module.exports = ELECTRON_EVENTS;

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -94,6 +94,12 @@ const mainWindow = (() => {
                 event.returnValue = browserWindow.isFocused();
             });
 
+            // This allows the renderer process to bring the app
+            // back into focus if it's minimized or hidden.
+            ipcMain.on(ELECTRON_EVENTS.REQUEST_FOCUS_APP, () => {
+                browserWindow.show();
+            });
+
             // Listen to badge updater event emitted by the render process
             // and update the app badge count (MacOS only)
             ipcMain.on(ELECTRON_EVENTS.REQUEST_UPDATE_BADGE_COUNT, (event, totalCount) => {

--- a/src/libs/Notification/LocalNotification/BrowserNotifications.js
+++ b/src/libs/Notification/LocalNotification/BrowserNotifications.js
@@ -1,6 +1,7 @@
 // Web and desktop implementation only. Do not import for direct use. Use LocalNotification.
 import Str from '../../Str';
 import CONST from '../../../CONST';
+import focusApp from './focusApp';
 
 const EXPENSIFY_ICON_URL = `${CONST.CLOUDFRONT_URL}/images/favicon-2019.png`;
 const DEFAULT_DELAY = 4000;
@@ -82,6 +83,7 @@ function push({
                 onClick();
                 window.parent.focus();
                 window.focus();
+                focusApp();
                 notification.close();
             };
 

--- a/src/libs/Notification/LocalNotification/focusApp/index.desktop.js
+++ b/src/libs/Notification/LocalNotification/focusApp/index.desktop.js
@@ -5,4 +5,3 @@ const ipcRenderer = window.require('electron').ipcRenderer;
 export default () => {
     ipcRenderer.send(ELECTRON_EVENTS.REQUEST_FOCUS_APP);
 };
-

--- a/src/libs/Notification/LocalNotification/focusApp/index.desktop.js
+++ b/src/libs/Notification/LocalNotification/focusApp/index.desktop.js
@@ -1,0 +1,8 @@
+import ELECTRON_EVENTS from '../../../../../desktop/ELECTRON_EVENTS';
+
+const ipcRenderer = window.require('electron').ipcRenderer;
+
+export default () => {
+    ipcRenderer.send(ELECTRON_EVENTS.REQUEST_FOCUS_APP);
+};
+

--- a/src/libs/Notification/LocalNotification/focusApp/index.website.js
+++ b/src/libs/Notification/LocalNotification/focusApp/index.website.js
@@ -1,0 +1,2 @@
+// On web this is up to the browser that shows the notifications
+export default () => {};


### PR DESCRIPTION
### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/144851

### Tests
1. Log in on desktop as User A
1. Start a chat with User B
1. Log in on web as User B
1. Make sure User A is not looking at the chat you started and minimize the desktop app
1. Leave a comment as User B from web
1. Verify the notification appears
1. Click it and verify the desktop app is brought into focus and no longer minimized

### Screenshots
❌ 