### PR TITLE
Fix ChatSwitcher input that will not gain focus when using keyboard shortcut / fix up focus callback props

### DIFF
--- a/src/IONKEYS.js
+++ b/src/IONKEYS.js
@@ -28,6 +28,8 @@ export default {
     // Information about the current session (authToken, accountID, email, loading, error)
     SESSION: 'session',
     IS_SIDEBAR_SHOWN: 'isSidebarShown',
+    IS_CHAT_SWITCHER_ACTIVE: 'isChatSwitcherActive',
+    IS_SIDEBAR_ANIMATING: 'isSidebarAnimating',
 
     // Collection Keys
     COLLECTION: {

--- a/src/libs/actions/ChatSwitcher.js
+++ b/src/libs/actions/ChatSwitcher.js
@@ -1,0 +1,21 @@
+import Ion from '../Ion';
+import IONKEYS from '../../IONKEYS';
+
+/**
+ * Hide the Chat Switcher
+ */
+function hide() {
+    Ion.set(IONKEYS.IS_CHAT_SWITCHER_ACTIVE, false);
+}
+
+/**
+ * Show the Chat Switcher
+ */
+function show() {
+    Ion.set(IONKEYS.IS_CHAT_SWITCHER_ACTIVE, true);
+}
+
+export {
+    hide,
+    show,
+};

--- a/src/libs/actions/Sidebar.js
+++ b/src/libs/actions/Sidebar.js
@@ -15,6 +15,11 @@ function show() {
     Ion.set(IONKEYS.IS_SIDEBAR_SHOWN, true);
 }
 
+/**
+ * Tracks the animating state of the Sidebar.
+ *
+ * @param {Boolean} isAnimating
+ */
 function setIsAnimating(isAnimating) {
     Ion.set(IONKEYS.IS_SIDEBAR_ANIMATING, isAnimating);
 }

--- a/src/libs/actions/Sidebar.js
+++ b/src/libs/actions/Sidebar.js
@@ -15,7 +15,12 @@ function show() {
     Ion.set(IONKEYS.IS_SIDEBAR_SHOWN, true);
 }
 
+function setIsAnimating(isAnimating) {
+    Ion.set(IONKEYS.IS_SIDEBAR_ANIMATING, isAnimating);
+}
+
 export {
     hide,
     show,
+    setIsAnimating,
 };

--- a/src/pages/home/HomePage.js
+++ b/src/pages/home/HomePage.js
@@ -15,7 +15,11 @@ import styles, {getSafeAreaPadding} from '../../styles/StyleSheet';
 import Header from './HeaderView';
 import Sidebar from './sidebar/SidebarView';
 import Main from './MainView';
-import {hide as hideSidebar, show as showSidebar} from '../../libs/actions/Sidebar';
+import {
+    hide as hideSidebar,
+    show as showSidebar,
+    setIsAnimating as setSideBarIsAnimating,
+} from '../../libs/actions/Sidebar';
 import {
     subscribeToReportCommentEvents,
     fetchAll as fetchAllReports,
@@ -33,9 +37,11 @@ const widthBreakPoint = 1000;
 
 const propTypes = {
     isSidebarShown: PropTypes.bool,
+    isChatSwitcherActive: PropTypes.bool,
 };
 const defaultProps = {
     isSidebarShown: true,
+    isChatSwitcherActive: false,
 };
 
 class App extends React.Component {
@@ -77,6 +83,10 @@ class App extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
+        if (!prevProps.isChatSwitcherActive && this.props.isChatSwitcherActive) {
+            this.showHamburger();
+        }
+
         if (this.props.isSidebarShown === prevProps.isSidebarShown) {
             // Nothing changed, don't trigger animation or re-render
             return;
@@ -135,6 +145,7 @@ class App extends React.Component {
     animateHamburger(hamburgerIsShown) {
         const animationFinalValue = hamburgerIsShown ? -300 : 0;
 
+        setSideBarIsAnimating(true);
         Animated.timing(this.animationTranslateX, {
             toValue: animationFinalValue,
             duration: 200,
@@ -143,6 +154,10 @@ class App extends React.Component {
         }).start(({finished}) => {
             if (finished && hamburgerIsShown) {
                 hideSidebar();
+            }
+
+            if (finished) {
+                setSideBarIsAnimating(false);
             }
         });
     }
@@ -197,7 +212,7 @@ class App extends React.Component {
                                     <Sidebar
                                         insets={insets}
                                         onLinkClick={this.toggleHamburger}
-                                        onChatSwitcherFocus={this.showHamburger}
+                                        isChatSwitcherActive={this.props.isChatSwitcherActive}
                                     />
                                 </Animated.View>
                                 <View
@@ -226,6 +241,10 @@ export default withIon(
     {
         isSidebarShown: {
             key: IONKEYS.IS_SIDEBAR_SHOWN
+        },
+        isChatSwitcherActive: {
+            key: IONKEYS.IS_CHAT_SWITCHER_ACTIVE,
+            initWithStoredValues: false,
         },
     },
 )(App);

--- a/src/pages/home/HomePage.js
+++ b/src/pages/home/HomePage.js
@@ -6,7 +6,8 @@ import {
     Dimensions,
     Animated,
     Easing,
-    Keyboard
+    Keyboard,
+    Pressable,
 } from 'react-native';
 import _ from 'underscore';
 import {SafeAreaInsetsContext, SafeAreaProvider} from 'react-native-safe-area-context';
@@ -117,7 +118,7 @@ class App extends React.Component {
      * Only changes hamburger state on small screens (e.g. Mobile and mWeb)
      */
     dismissHamburger() {
-        if (!this.props.isSidebarShown) {
+        if (!this.state.isHamburgerEnabled || !this.props.isSidebarShown) {
             return;
         }
 
@@ -215,16 +216,20 @@ class App extends React.Component {
                                         isChatSwitcherActive={this.props.isChatSwitcherActive}
                                     />
                                 </Animated.View>
-                                <View
-                                    onTouchStart={this.dismissHamburger}
-                                    style={[styles.appContent, appContentStyle, styles.flex1, styles.flexColumn]}
+                                <Pressable
+                                    style={[styles.flex1]}
+                                    onPress={this.dismissHamburger}
                                 >
-                                    <Header
-                                        shouldShowHamburgerButton={this.state.isHamburgerEnabled}
-                                        onHamburgerButtonClicked={this.toggleHamburger}
-                                    />
-                                    <Main />
-                                </View>
+                                    <View
+                                        style={[styles.appContent, appContentStyle, styles.flex1, styles.flexColumn]}
+                                    >
+                                        <Header
+                                            shouldShowHamburgerButton={this.state.isHamburgerEnabled}
+                                            onHamburgerButtonClicked={this.toggleHamburger}
+                                        />
+                                        <Main />
+                                    </View>
+                                </Pressable>
                             </Route>
                         </View>
                     )}

--- a/src/pages/home/sidebar/ChatSwitcherView.js
+++ b/src/pages/home/sidebar/ChatSwitcherView.js
@@ -56,12 +56,15 @@ const propTypes = {
         email: PropTypes.string.isRequired,
     }),
 
-    sideBarIsAnimating: PropTypes.bool,
+    isSidebarAnimating: PropTypes.bool,
+    isChatSwitcherActive: PropTypes.bool,
 };
 const defaultProps = {
     personalDetails: {},
     reports: {},
     session: null,
+    isSidebarAnimating: false,
+    isChatSwitcherActive: false,
 };
 
 class ChatSwitcherView extends React.Component {
@@ -98,10 +101,6 @@ class ChatSwitcherView extends React.Component {
         }, ['meta'], true);
     }
 
-    componentWillUnmount() {
-        KeyboardShortcut.unsubscribe('K');
-    }
-
     componentDidUpdate(prevProps) {
         // Check if the sidebar was animating but is no longer animating and
         // if the chat switcher is active then focus the input
@@ -111,6 +110,10 @@ class ChatSwitcherView extends React.Component {
         ) {
             this.textInput.focus();
         }
+    }
+
+    componentWillUnmount() {
+        KeyboardShortcut.unsubscribe('K');
     }
 
     /**

--- a/src/pages/home/sidebar/SidebarLinks.js
+++ b/src/pages/home/sidebar/SidebarLinks.js
@@ -18,12 +18,6 @@ const propTypes = {
     // eslint-disable-next-line react/forbid-prop-types
     match: PropTypes.object.isRequired,
 
-    // A function to call when the chat switcher is blurred
-    onChatSwitcherBlur: PropTypes.func.isRequired,
-
-    // A function to call when the chat switcher gets focus
-    onChatSwitcherFocus: PropTypes.func.isRequired,
-
     // Toggles the hamburger menu open and closed
     onLinkClick: PropTypes.func.isRequired,
 
@@ -38,20 +32,15 @@ const propTypes = {
         reportName: PropTypes.string,
         unreadActionCount: PropTypes.number,
     })),
+
+    isChatSwitcherActive: PropTypes.bool,
 };
 const defaultProps = {
     reports: {},
+    isChatSwitcherActive: false,
 };
 
 class SidebarLinks extends React.Component {
-    constructor(props) {
-        super(props);
-
-        this.state = {
-            areReportLinksVisible: true,
-        };
-    }
-
     render() {
         const {onLinkClick} = this.props;
         const reportIDInUrl = parseInt(this.props.match.params.reportID, 10);
@@ -68,23 +57,15 @@ class SidebarLinks extends React.Component {
         const reportsToDisplay = _.filter(sortedReports, report => (report.isPinned || (report.unreadActionCount > 0) || report.reportID === reportIDInUrl));
 
         // Update styles to hide the report links if they should not be visible
-        const sidebarLinksStyle = this.state.areReportLinksVisible
+        const sidebarLinksStyle = !this.props.isChatSwitcherActive
             ? [styles.sidebarListContainer]
             : [styles.sidebarListContainer, styles.dNone];
-
         return (
             <View style={[styles.flex1, {marginTop: this.props.insets.top}]}>
                 <View style={[styles.sidebarHeader]}>
                     <ChatSwitcherView
-                        onBlur={() => {
-                            this.setState({areReportLinksVisible: true});
-                            this.props.onChatSwitcherBlur();
-                        }}
-                        onFocus={() => {
-                            this.setState({areReportLinksVisible: false});
-                            this.props.onChatSwitcherFocus();
-                        }}
                         onLinkClick={onLinkClick}
+                        isChatSwitcherActive={this.props.isChatSwitcherActive}
                     />
                 </View>
                 <ScrollView
@@ -125,6 +106,6 @@ export default compose(
     withIon({
         reports: {
             key: IONKEYS.COLLECTION.REPORT,
-        }
+        },
     }),
 )(SidebarLinks);

--- a/src/pages/home/sidebar/SidebarLinks.js
+++ b/src/pages/home/sidebar/SidebarLinks.js
@@ -40,66 +40,65 @@ const defaultProps = {
     isChatSwitcherActive: false,
 };
 
-class SidebarLinks extends React.Component {
-    render() {
-        const {onLinkClick} = this.props;
-        const reportIDInUrl = parseInt(this.props.match.params.reportID, 10);
-        const sortedReports = lodashOrderby(this.props.reports, [
-            'isPinned',
-            'reportName'
-        ], [
-            'desc',
-            'asc'
-        ]);
+const SidebarLinks = props => {
+    const {onLinkClick} = props;
+    const reportIDInUrl = parseInt(props.match.params.reportID, 10);
+    const sortedReports = lodashOrderby(props.reports, [
+        'isPinned',
+        'reportName'
+    ], [
+        'desc',
+        'asc'
+    ]);
 
-        // Filter the reports so that the only reports shown are pinned, unread, and the one matching the URL
-        // eslint-disable-next-line max-len
-        const reportsToDisplay = _.filter(sortedReports, report => (report.isPinned || (report.unreadActionCount > 0) || report.reportID === reportIDInUrl));
+    // Filter the reports so that the only reports shown are pinned, unread, and the one matching the URL
+    // eslint-disable-next-line max-len
+    const reportsToDisplay = _.filter(sortedReports, report => (report.isPinned || (report.unreadActionCount > 0) || report.reportID === reportIDInUrl));
 
-        // Update styles to hide the report links if they should not be visible
-        const sidebarLinksStyle = !this.props.isChatSwitcherActive
-            ? [styles.sidebarListContainer]
-            : [styles.sidebarListContainer, styles.dNone];
-        return (
-            <View style={[styles.flex1, {marginTop: this.props.insets.top}]}>
-                <View style={[styles.sidebarHeader]}>
-                    <ChatSwitcherView
-                        onLinkClick={onLinkClick}
-                        isChatSwitcherActive={this.props.isChatSwitcherActive}
-                    />
-                </View>
-                <ScrollView
-                    style={sidebarLinksStyle}
-                    bounces={false}
-                    indicatorStyle="white"
-                    stickyHeaderIndices={[0]}
-                >
-                    <View style={[styles.sidebarListItem]}>
-                        <Text style={[styles.sidebarListHeader]}>
-                            Chats
-                        </Text>
-                    </View>
-                    {/* A report will not have a report name if it hasn't been fetched from the server yet */}
-                    {/* so nothing is rendered */}
-                    {_.map(reportsToDisplay, report => report.reportName && (
-                        <SidebarLink
-                            key={report.reportID}
-                            reportID={report.reportID}
-                            reportName={report.reportName}
-                            isUnread={report.unreadActionCount > 0}
-                            onLinkClick={onLinkClick}
-                            isActiveReport={report.reportID === reportIDInUrl}
-                            isPinned={report.isPinned}
-                        />
-                    ))}
-                </ScrollView>
+    // Update styles to hide the report links if they should not be visible
+    const sidebarLinksStyle = !props.isChatSwitcherActive
+        ? [styles.sidebarListContainer]
+        : [styles.sidebarListContainer, styles.dNone];
+    return (
+        <View style={[styles.flex1, {marginTop: props.insets.top}]}>
+            <View style={[styles.sidebarHeader]}>
+                <ChatSwitcherView
+                    onLinkClick={onLinkClick}
+                    isChatSwitcherActive={props.isChatSwitcherActive}
+                />
             </View>
-        );
-    }
+            <ScrollView
+                style={sidebarLinksStyle}
+                bounces={false}
+                indicatorStyle="white"
+                stickyHeaderIndices={[0]}
+            >
+                <View style={[styles.sidebarListItem]}>
+                    <Text style={[styles.sidebarListHeader]}>
+                        Chats
+                    </Text>
+                </View>
+                {/* A report will not have a report name if it hasn't been fetched from the server yet */}
+                {/* so nothing is rendered */}
+                {_.map(reportsToDisplay, report => report.reportName && (
+                    <SidebarLink
+                        key={report.reportID}
+                        reportID={report.reportID}
+                        reportName={report.reportName}
+                        isUnread={report.unreadActionCount > 0}
+                        onLinkClick={onLinkClick}
+                        isActiveReport={report.reportID === reportIDInUrl}
+                        isPinned={report.isPinned}
+                    />
+                ))}
+            </ScrollView>
+        </View>
+    );
 }
 
 SidebarLinks.propTypes = propTypes;
 SidebarLinks.defaultProps = defaultProps;
+SidebarLinks.displayName = 'SidebarLinks';
 
 export default compose(
     withRouter,

--- a/src/pages/home/sidebar/SidebarLinks.js
+++ b/src/pages/home/sidebar/SidebarLinks.js
@@ -94,7 +94,7 @@ const SidebarLinks = (props) => {
             </ScrollView>
         </View>
     );
-}
+};
 
 SidebarLinks.propTypes = propTypes;
 SidebarLinks.defaultProps = defaultProps;

--- a/src/pages/home/sidebar/SidebarLinks.js
+++ b/src/pages/home/sidebar/SidebarLinks.js
@@ -40,7 +40,7 @@ const defaultProps = {
     isChatSwitcherActive: false,
 };
 
-const SidebarLinks = props => {
+const SidebarLinks = (props) => {
     const {onLinkClick} = props;
     const reportIDInUrl = parseInt(props.match.params.reportID, 10);
     const sortedReports = lodashOrderby(props.reports, [

--- a/src/pages/home/sidebar/SidebarView.js
+++ b/src/pages/home/sidebar/SidebarView.js
@@ -36,4 +36,5 @@ const SidebarView = props => (
 
 SidebarView.propTypes = propTypes;
 SidebarView.defaultProps = defaultProps;
+SidebarView.displayName = 'SidebarView';
 export default SidebarView;

--- a/src/pages/home/sidebar/SidebarView.js
+++ b/src/pages/home/sidebar/SidebarView.js
@@ -17,23 +17,23 @@ const propTypes = {
     isChatSwitcherActive: PropTypes.bool,
 };
 
-class SidebarView extends React.Component {
-    render() {
-        return (
-            <View style={[styles.flex1, styles.sidebar]}>
-                <SidebarLinks
-                    onLinkClick={this.props.onLinkClick}
-                    insets={this.props.insets}
-                    isChatSwitcherActive={this.props.isChatSwitcherActive}
-                />
-                {!this.props.isChatSwitcherActive && (
-                    <SidebarBottom insets={this.props.insets} />
-                )}
-            </View>
-        );
-    }
-}
+const defaultProps = {
+    isChatSwitcherActive: false,
+};
+
+const SidebarView = props => (
+    <View style={[styles.flex1, styles.sidebar]}>
+        <SidebarLinks
+            onLinkClick={props.onLinkClick}
+            insets={props.insets}
+            isChatSwitcherActive={props.isChatSwitcherActive}
+        />
+        {!props.isChatSwitcherActive && (
+            <SidebarBottom insets={props.insets} />
+        )}
+    </View>
+);
 
 SidebarView.propTypes = propTypes;
-
+SidebarView.defaultProps = defaultProps;
 export default SidebarView;

--- a/src/pages/home/sidebar/SidebarView.js
+++ b/src/pages/home/sidebar/SidebarView.js
@@ -14,39 +14,21 @@ const propTypes = {
     insets: SafeAreaInsetPropTypes.isRequired,
 
     // when the chat switcher is selected
-    onChatSwitcherFocus: PropTypes.func.isRequired,
+    isChatSwitcherActive: PropTypes.bool,
 };
 
 class SidebarView extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            isSidebarBottomVisible: true,
-        };
-
-        this.setIsFocused = this.setIsFocused.bind(this);
-    }
-
-    /**
-    * @param {boolean} isFocused
-    * */
-    setIsFocused(isFocused) {
-        this.setState({isSidebarBottomVisible: !isFocused});
-        if (isFocused) {
-            this.props.onChatSwitcherFocus();
-        }
-    }
-
     render() {
         return (
             <View style={[styles.flex1, styles.sidebar]}>
                 <SidebarLinks
                     onLinkClick={this.props.onLinkClick}
                     insets={this.props.insets}
-                    onChatSwitcherFocus={() => this.setIsFocused(true)}
-                    onChatSwitcherBlur={() => this.setIsFocused(false)}
+                    isChatSwitcherActive={this.props.isChatSwitcherActive}
                 />
-                {this.state.isSidebarBottomVisible && <SidebarBottom insets={this.props.insets} />}
+                {!this.props.isChatSwitcherActive && (
+                    <SidebarBottom insets={this.props.insets} />
+                )}
             </View>
         );
     }


### PR DESCRIPTION
Two birds with one stone since these have very similar test steps

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/144641
Fixes https://github.com/Expensify/Expensify/issues/144639

### Tests (web, ios, android, desktop)
1. Log into chat on web
1. Modify the window width so that the sidebar hides
1. `command + k` verify the sidebar opens and focuses inside the chat switcher
1. Click outside of the sidebar and verify it closes again 

### Screenshots
❌ 