### PR TITLE
Protect from un-initialised Pusher crash

### DIFF
--- a/src/libs/Pusher/pusher.js
+++ b/src/libs/Pusher/pusher.js
@@ -358,12 +358,13 @@ function registerCustomAuthorizer(authorizer) {
  * Disconnect from Pusher
  */
 function disconnect() {
-    if (socket) {
-        socket.disconnect();
-        socket = null;
-    } else {
+    if (!socket) {
         console.error('[Pusher] Attempting to disconnect from Pusher before initialisation has occured, ignoring.');
+        return;
     }
+
+    socket.disconnect();
+    socket = null;
 }
 
 /**

--- a/src/libs/Pusher/pusher.js
+++ b/src/libs/Pusher/pusher.js
@@ -358,8 +358,12 @@ function registerCustomAuthorizer(authorizer) {
  * Disconnect from Pusher
  */
 function disconnect() {
-    socket.disconnect();
-    socket = null;
+    if (socket) {
+        socket.disconnect();
+        socket = null;
+    } else {
+        console.error('[Pusher] Attempting to disconnect from Pusher before initialisation has occured, ignoring.');
+    }
 }
 
 /**


### PR DESCRIPTION
CC @marcaaron 


- A repeating crash was occurring at the authentication page, triggered by unconfirmed conditions (our best guess is a combination of incomplete report data [here](https://github.com/Expensify/ReactNativeChat/blob/bd9f4620f1b02761747902da5f7a2ee4224a99d1/src/libs/actions/Report.js#L218-L222) and a disconnection event). 
- The actual crash occurs due to Ion data triggering an API request which fails (due to a missing authToken), which in turn calls Pusher.disconnect prior to initialisation
- We discussed [many solutions here](https://expensify.slack.com/archives/C03TQ48KC/p1604507253220700), but decided to go with the simple option of protecting from an undefined socket reference and logging an error.


### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/144286

### Tests

I was lucky (unlucky?) enough to have the conditions occur accidentally for me. I had a go at trying to create an incomplete report in Ion, but wasn't able to work our reproducible steps. 

Instead, I recommend that we leave the issue open, and I will monitor this [Firebase crash report](https://console.firebase.google.com/project/expensify-chat/crashlytics/app/android:com.expensify.chat/issues/f52ddfb8306449bd3b645e8fe47460aa?time=last-seven-days&sessionEventKey=5F94B4510154000111013ECD646C28C5_1465773583181442659) and ask Applause if they are able to reproduce (they have been able to reproduce this on a most of the recent builds).
