### PR TITLE
Update JS-Libs hash to fix hyperlinking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15364,8 +15364,8 @@
       }
     },
     "js-libs": {
-      "version": "git+ssh://git@github.com/Expensify/JS-Libs.git#7aead2547a2d27d632cea00a047e527c69c4e6b1",
-      "from": "git+ssh://git@github.com/Expensify/JS-Libs.git#7aead2547a2d27d632cea00a047e527c69c4e6b1",
+      "version": "git+ssh://git@github.com/Expensify/JS-Libs.git#df92effd80acb6f47197d982d357d24f48cd3c98",
+      "from": "git+ssh://git@github.com/Expensify/JS-Libs.git#df92effd80acb6f47197d982d357d24f48cd3c98",
       "requires": {
         "classnames": "2.2.5",
         "clipboard": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "electron-updater": "^4.3.4",
     "file-loader": "^6.0.0",
     "html-entities": "^1.3.1",
-    "js-libs": "git+https://git@github.com:Expensify/JS-Libs.git#7aead2547a2d27d632cea00a047e527c69c4e6b1",
+    "js-libs": "git+https://git@github.com:Expensify/JS-Libs.git#df92effd80acb6f47197d982d357d24f48cd3c98",
     "lodash.get": "^4.4.2",
     "lodash.has": "^4.5.2",
     "lodash.orderby": "^4.6.0",


### PR DESCRIPTION
Updates the JS-Libs hash to include [this fix](https://github.com/Expensify/JS-Libs/pull/291).

### Fixed Issues
None

### Tests
Pasted various links into web and confirmed correct linking:
<img width="918" alt="regex" src="https://user-images.githubusercontent.com/3387421/98306638-117f6e80-1f79-11eb-819b-1fe4a890ac70.png">
