### PR TITLE
Fix ChatSwitcher Android font cut-off

### DIFF
--- a/src/styles/StyleSheet.js
+++ b/src/styles/StyleSheet.js
@@ -770,6 +770,7 @@ const styles = {
         marginTop: 5,
         marginBottom: 5,
         marginLeft: 3,
+        padding: 0,
     },
 
     chatSwticherPillWrapper: {


### PR DESCRIPTION
CC @shawnborton for CSS review

Fixes issue where the Android text input was cutoff, by specifying a padding size of 0. Unlike other platforms, Android was auto-applying padding within a fixed height view, which lead to the font being cut-off. 

(The issue could be reproduced on other platforms by setting a padding of 8 or so)

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/144795

### Tests

Build to Android, iOS, Web, Desktop. On each platform:

1. Open the ChatSwitcher
2. Search for a few users, click add
3. Confirm the user pill displays in the chat input
4. Enter text to search for another user
5. **Confirm the text is not cutoff**


### Screenshots

**Issue**
![Screenshot_1604936498](https://user-images.githubusercontent.com/10736861/98562634-2eca7a80-22a2-11eb-8b00-2d23f123d941.png)


**Fixed**
![Screenshot_1604936213](https://user-images.githubusercontent.com/10736861/98562627-2d994d80-22a2-11eb-8380-5d5de83d371e.png)