### PR TITLE
Make unread chats bold in chat switcher

### DIFF
--- a/src/pages/home/sidebar/ChatSwitcherRow.js
+++ b/src/pages/home/sidebar/ChatSwitcherRow.js
@@ -33,6 +33,8 @@ const ChatSwitcherRow = ({
     const textStyle = optionIsFocused
         ? styles.sidebarLinkActiveText
         : styles.sidebarLinkText;
+    const textUnreadStyle = option.isUnread
+        ? [textStyle, styles.sidebarLinkTextUnread] : [textStyle];
     return (
         <View
             style={[
@@ -70,15 +72,15 @@ const ChatSwitcherRow = ({
                     }
                     <View style={[styles.flex1]}>
                         {option.text === option.alternateText ? (
-                            <Text style={[textStyle]} numberOfLines={1}>
+                            <Text style={[textUnreadStyle]} numberOfLines={1}>
                                 {option.alternateText}
                             </Text>
                         ) : (
                             <>
-                                <Text style={[textStyle]} numberOfLines={1}>
+                                <Text style={[textUnreadStyle]} numberOfLines={1}>
                                     {option.text}
                                 </Text>
-                                <Text style={[textStyle, styles.textMicro]} numberOfLines={1}>
+                                <Text style={[textUnreadStyle, styles.textMicro]} numberOfLines={1}>
                                     {option.alternateText}
                                 </Text>
                             </>

--- a/src/pages/home/sidebar/ChatSwitcherRow.js
+++ b/src/pages/home/sidebar/ChatSwitcherRow.js
@@ -72,15 +72,15 @@ const ChatSwitcherRow = ({
                     }
                     <View style={[styles.flex1]}>
                         {option.text === option.alternateText ? (
-                            <Text style={[textUnreadStyle]} numberOfLines={1}>
+                            <Text style={textUnreadStyle} numberOfLines={1}>
                                 {option.alternateText}
                             </Text>
                         ) : (
                             <>
-                                <Text style={[textUnreadStyle]} numberOfLines={1}>
+                                <Text style={textUnreadStyle} numberOfLines={1}>
                                     {option.text}
                                 </Text>
-                                <Text style={[textUnreadStyle, styles.textMicro]} numberOfLines={1}>
+                                <Text style={[...textUnreadStyle, styles.textMicro]} numberOfLines={1}>
                                     {option.alternateText}
                                 </Text>
                             </>

--- a/src/pages/home/sidebar/ChatSwitcherView.js
+++ b/src/pages/home/sidebar/ChatSwitcherView.js
@@ -363,6 +363,7 @@ class ChatSwitcherView extends React.Component {
                 reportID: report.reportID,
                 type: OPTION_TYPE.REPORT,
                 participants: report.participants,
+                isUnread: report.unreadActionCount > 0
             }))
             .value();
 


### PR DESCRIPTION
@chiragsalian can you review please? 

This makes it so that when the chat switcher is being used, if a report that is shown in the search results has unread chats, the row will be bolded. For now, this will only apply to group chats, not individual user rows that show up in the chat switcher results. @chiragsalian's [PR](https://github.com/Expensify/ReactNativeChat/pull/759) to change the order in which the results are shown will make it so that this also gets applied to individual user rows. 

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/144854

### Tests
1. Created a group DM
2. Sent a message from one of the users in the group DM
3. Logged into a different member of the group DM's account 
4. Verified that when using the chat switcher (i.e. typing the first few letters of one of the group members) the row for the group DM indeed was bolded. 

### Screenshots
![image](https://user-images.githubusercontent.com/1371996/98754274-edae9500-238b-11eb-8d3a-0227d4bb35fe.png)
