### PR TITLE
Add hotkey navigation of the chat history in desktop

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -54,19 +54,18 @@ const mainWindow = (() => {
             const systemMenu = Menu.getApplicationMenu();
             systemMenu.append(new MenuItem({
                 label: 'History',
-                submenu: [
-                    {
-                        role: 'back',
-                        label: 'Back',
-                        accelerator: process.platform === 'darwin' ? 'Cmd+[' : 'Shift+[',
-                        click: () => {console.log('Going backward!')}
-                    },
-                    {
-                        role: 'forward',
-                        label: 'Forward',
-                        accelerator: process.platform === 'darwin' ? 'Cmd+]' : 'Shift+]',
-                        click: () => {console.log('Going forward!')}
-                    }]
+                submenu: [{
+                    role: 'back',
+                    label: 'Back',
+                    accelerator: process.platform === 'darwin' ? 'Cmd+[' : 'Shift+[',
+                    click: () => { console.log('Going backward!'); }
+                },
+                {
+                    role: 'forward',
+                    label: 'Forward',
+                    accelerator: process.platform === 'darwin' ? 'Cmd+]' : 'Shift+]',
+                    click: () => { console.log('Going forward!'); }
+                }]
             }));
             const windowMenu = systemMenu.items.find(item => item.role === 'windowmenu');
             windowMenu.submenu.append(new MenuItem({type: 'separator'}));

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -52,6 +52,22 @@ const mainWindow = (() => {
 
             // List the Expensify Chat instance under the Window menu, even when it's hidden
             const systemMenu = Menu.getApplicationMenu();
+            systemMenu.append(new MenuItem({
+                label: 'History',
+                submenu: [
+                    {
+                        role: 'back',
+                        label: 'Back',
+                        accelerator: process.platform === 'darwin' ? 'Cmd+[' : 'Shift+[',
+                        click: () => {console.log('Going backward!')}
+                    },
+                    {
+                        role: 'forward',
+                        label: 'Forward',
+                        accelerator: process.platform === 'darwin' ? 'Cmd+]' : 'Shift+]',
+                        click: () => {console.log('Going forward!')}
+                    }]
+            }));
             const windowMenu = systemMenu.items.find(item => item.role === 'windowmenu');
             windowMenu.submenu.append(new MenuItem({type: 'separator'}));
             windowMenu.submenu.append(new MenuItem({

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -52,7 +52,7 @@ const mainWindow = (() => {
 
             // List the Expensify Chat instance under the Window menu, even when it's hidden
             const systemMenu = Menu.getApplicationMenu();
-            systemMenu.append(new MenuItem({
+            systemMenu.insert(4, new MenuItem({
                 label: 'History',
                 submenu: [{
                     role: 'back',

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -58,13 +58,13 @@ const mainWindow = (() => {
                     role: 'back',
                     label: 'Back',
                     accelerator: process.platform === 'darwin' ? 'Cmd+[' : 'Shift+[',
-                    click: () => { console.log('Going backward!'); }
+                    click: () => { browserWindow.webContents.goBack(); }
                 },
                 {
                     role: 'forward',
                     label: 'Forward',
                     accelerator: process.platform === 'darwin' ? 'Cmd+]' : 'Shift+]',
-                    click: () => { console.log('Going forward!'); }
+                    click: () => { browserWindow.webContents.goForward(); }
                 }]
             }));
             const windowMenu = systemMenu.items.find(item => item.role === 'windowmenu');


### PR DESCRIPTION
This PR allows users to navigate their chat history using the **History** menu's **Back ⌘+[** and **Forward ⌘+]** options.

cc @roryabraham @marcaaron 

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/145143

### Tests
1. Launch the desktop app.
1. View conversations between a few other users.
1. Press `CMD+[` till you get back to the first conversation.
1. Press `CMD+]` till you get back to the last coversation.
1. Do the same using the **History > Forward** & **History > Backward** menu options.

### Screenshots
![Screen Shot](https://user-images.githubusercontent.com/766197/99011655-76027680-2501-11eb-9068-ec317106a7fa.png)

![2020-11-18_13-34-44 (1)](https://user-images.githubusercontent.com/766197/99591928-54dbd300-29a4-11eb-8f8e-6c3112db8545.gif)
