### PR TITLE
Make sure searchText is always populated in the chatSwitcher

### DIFF
--- a/src/pages/home/sidebar/ChatSwitcherView.js
+++ b/src/pages/home/sidebar/ChatSwitcherView.js
@@ -359,7 +359,7 @@ class ChatSwitcherView extends React.Component {
             .map(report => ({
                 text: report.reportName,
                 alternateText: report.reportName,
-                searchText: report.reportName,
+                searchText: report.reportName ?? '',
                 reportID: report.reportID,
                 type: OPTION_TYPE.REPORT,
                 participants: report.participants,


### PR DESCRIPTION
<Assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit.>

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/146032

### Tests
- Have a nameless report in Dev
- Open chatswitcher and search for something. It should work fine.
