### PR TITLE
Fix output path for webpack

### DIFF
--- a/config/webpack/webpack.common.js
+++ b/config/webpack/webpack.common.js
@@ -16,7 +16,7 @@ module.exports = {
     },
     output: {
         filename: '[name]-[hash].bundle.js',
-        path: path.resolve(__dirname, '../dist'),
+        path: path.resolve(__dirname, '../../dist'),
     },
     plugins: [
         new CleanWebpackPlugin(),


### PR DESCRIPTION
We changed the location of the config file, but not the output path so builds broke

cc: @tgolen @AndrewGable @roryabraham 

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/146500

### Tests
1. run `npm run build`
1. _verify_ the output is placed in `ReactNativeChat/dist`

### Screenshots
n/a