### PR TITLE
Wrap modal with SafeAreaView when pinToEdges is true

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -642,14 +642,14 @@ SPEC CHECKSUMS:
   React-jsiexecutor: b56c03e61c0dd5f5801255f2160a815f4a53d451
   React-jsinspector: 8e68ffbfe23880d3ee9bafa8be2777f60b25cbe2
   react-native-config: 9a061347e0136fdb32d43a34d60999297d672361
-  react-native-document-picker: 0bba80cc56caab1f67dbaa81ff557e3a9b7f2b9f
-  react-native-image-picker: c6d75c4ab2cf46f9289f341242b219cb3c1180d3
-  react-native-netinfo: 250dc0ca126512f618a8a2ca6a936577e1f66586
+  react-native-document-picker: b3e78a8f7fef98b5cb069f20fc35797d55e68e28
+  react-native-image-picker: 32d1ad2c0024ca36161ae0d5c2117e2d6c441f11
+  react-native-netinfo: e36c1bb6df27ab84aa933679b3f5bbf9d180b18f
   react-native-pdf: 4b5a9e4465a6a3b399e91dc4838eb44ddf716d1f
-  react-native-progress-bar-android: be43138ab7da30d51fc038bafa98e9ed594d0c40
-  react-native-progress-view: 21b1e29e70c7559c16c9e0a04c4adc19fce6ede2
-  react-native-safe-area-context: 79fea126c6830c85f65947c223a5e3058a666937
-  react-native-webview: 73e409ecc987c189772bda27ba7f0e2f3dcd2e81
+  react-native-progress-bar-android: ce95a69f11ac580799021633071368d08aaf9ad8
+  react-native-progress-view: 5816e8a6be812c2b122c6225a2a3db82d9008640
+  react-native-safe-area-context: 01158a92c300895d79dee447e980672dc3fb85a6
+  react-native-webview: 2e330b109bfd610e9818bf7865d1979f898960a7
   React-RCTActionSheet: 53ea72699698b0b47a6421cb1c8b4ab215a774aa
   React-RCTAnimation: 1befece0b5183c22ae01b966f5583f42e69a83c2
   React-RCTBlob: 0b284339cbe4b15705a05e2313a51c6d8b51fa40
@@ -661,12 +661,12 @@ SPEC CHECKSUMS:
   React-RCTVibration: 8e9fb25724a0805107fc1acc9075e26f814df454
   ReactCommon: 4167844018c9ed375cc01a843e9ee564399e53c3
   rn-fetch-blob: f065bb7ab7fb48dd002629f8bdcb0336602d3cba
-  RNCAsyncStorage: b03032fdbdb725bea0bd9e5ec5a7272865ae7398
-  RNCPushNotificationIOS: 346c804c13fb99e644c996d1af5175a35452b2cb
+  RNCAsyncStorage: cb9a623793918c6699586281f0b51cbc38f046f9
+  RNCPushNotificationIOS: cfc6e1821f1af1874741d9b7055b75c0f8fa8a7d
   RNFBAnalytics: 2dc4dd9e2445faffca041b10447a23a71dcdabf8
   RNFBApp: 7eacc7da7ab19f96c05e434017d44a9f09410da8
   RNFBCrashlytics: 4870c14cf8833053b6b5648911abefe1923854d2
-  urbanairship-react-native: 87a82abfbc182a854f66eb7fd25198ce62e95a54
+  urbanairship-react-native: fa123940041a6a13ab7dac192e32833c53754f00
   Yoga: 7d13633d129fd179e01b8953d38d47be90db185a
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/src/components/ModalView.js
+++ b/src/components/ModalView.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-    View, TouchableOpacity, Dimensions, TouchableWithoutFeedback
+    View, SafeAreaView, TouchableOpacity, Dimensions, TouchableWithoutFeedback
 } from 'react-native';
 import BaseModalHeader from './BaseModalHeader';
 import styles from '../styles/StyleSheet';
@@ -43,13 +43,13 @@ const defaultProps = {
 const ModalView = props => (
     <>
         {props.pinToEdges ? (
-            <View style={styles.modalViewContainer}>
+            <SafeAreaView style={styles.modalViewContainer}>
                 <BaseModalHeader
                     title="Attachment"
                     onCloseButtonPress={props.onCloseButtonPress}
                 />
                 {props.children}
-            </View>
+            </SafeAreaView>
         ) : (
             <TouchableOpacity
                 style={styles.modalCenterContentContainer}


### PR DESCRIPTION
cc @Luke9389 @thienlnam 

Simple, just wrap the modal with a `SafeAreaView` instead of a `View`

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/146498

### Tests
1) Open a full-screen image modal on iOS
2) Ensure that the modal header isn't hidden behind the status bar.
3) Ensure that you can close and reopen the modal.

### Screenshots

**Note:** Full-Screen image loading appears to be failing on master

On master:

<img src="https://user-images.githubusercontent.com/47436092/99750647-9c8e5780-2a95-11eb-8bc9-6efac588ae31.png" alt="" width="400px" />

On this branch:

<img src="https://user-images.githubusercontent.com/47436092/99750903-0c9cdd80-2a96-11eb-9e59-46f385223c7c.png" alt="" width="400px" />
