### PR TITLE
Make chat switcher text visible

### DIFF
--- a/src/pages/home/sidebar/ChatLinkRow.js
+++ b/src/pages/home/sidebar/ChatLinkRow.js
@@ -61,7 +61,7 @@ const ChatLinkRow = ({
             <PressableLink
                 onClick={() => onSelectRow(option)}
                 to={ROUTES.getReportRoute(option.reportID)}
-                style={styles.textDecorationNoLine}
+                style={styles.chatLinkRowPressable}
             >
                 <TouchableOpacity
                     onPress={() => onSelectRow(option)}
@@ -87,7 +87,7 @@ const ChatLinkRow = ({
                                 </View>
                             )
                         }
-                        <View style={isChatSwitcher ? styles.chatSwitcherUserText : {}}>
+                        <View style={styles.flex1}>
                             {option.text === option.alternateText ? (
                                 <Text style={textUnreadStyle} numberOfLines={1}>
                                     {option.alternateText}

--- a/src/pages/home/sidebar/ChatLinkRow.js
+++ b/src/pages/home/sidebar/ChatLinkRow.js
@@ -86,7 +86,7 @@ const ChatLinkRow = ({
                                 </View>
                             )
                         }
-                        <View style={[styles.flex1]}>
+                        <View>
                             {option.text === option.alternateText ? (
                                 <Text style={textUnreadStyle} numberOfLines={1}>
                                     {option.alternateText}

--- a/src/pages/home/sidebar/ChatLinkRow.js
+++ b/src/pages/home/sidebar/ChatLinkRow.js
@@ -87,7 +87,7 @@ const ChatLinkRow = ({
                                 </View>
                             )
                         }
-                        <View style={styles.chatSwitcherUserText}>
+                        <View style={isChatSwitcher ? styles.chatSwitcherUserText : {}}>
                             {option.text === option.alternateText ? (
                                 <Text style={textUnreadStyle} numberOfLines={1}>
                                     {option.alternateText}

--- a/src/pages/home/sidebar/ChatLinkRow.js
+++ b/src/pages/home/sidebar/ChatLinkRow.js
@@ -97,7 +97,10 @@ const ChatLinkRow = ({
                                     <Text style={textUnreadStyle} numberOfLines={1}>
                                         {option.text}
                                     </Text>
-                                    <Text style={[styles.chatSwitcherLogin, textStyle, styles.textMicro]} numberOfLines={1}>
+                                    <Text
+                                        style={[styles.chatSwitcherLogin, textStyle, styles.textMicro]}
+                                        numberOfLines={1}
+                                    >
                                         {option.alternateText}
                                     </Text>
                                 </>

--- a/src/pages/home/sidebar/ChatLinkRow.js
+++ b/src/pages/home/sidebar/ChatLinkRow.js
@@ -89,7 +89,7 @@ const ChatLinkRow = ({
                         }
                         <View style={[styles.flex1]}>
                             {option.text === option.alternateText ? (
-                                <Text style={[textUnreadStyle]} numberOfLines={1}>
+                                <Text style={[styles.chatSwitcherDisplayName, textUnreadStyle]} numberOfLines={1}>
                                     {option.alternateText}
                                 </Text>
                             ) : (
@@ -97,7 +97,7 @@ const ChatLinkRow = ({
                                     <Text style={textUnreadStyle} numberOfLines={1}>
                                         {option.text}
                                     </Text>
-                                    <Text style={[textStyle, styles.textMicro]} numberOfLines={1}>
+                                    <Text style={[styles.chatSwitcherLogin, textStyle, styles.textMicro]} numberOfLines={1}>
                                         {option.alternateText}
                                     </Text>
                                 </>

--- a/src/pages/home/sidebar/ChatLinkRow.js
+++ b/src/pages/home/sidebar/ChatLinkRow.js
@@ -1,3 +1,4 @@
+import _ from 'underscore';
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
@@ -76,7 +77,7 @@ const ChatLinkRow = ({
                         ]}
                     >
                         {
-                            option.icon
+                            !_.isEmpty(option.icon)
                             && (
                                 <View style={[styles.chatSwitcherAvatar, styles.mr2]}>
                                     <Image

--- a/src/pages/home/sidebar/ChatLinkRow.js
+++ b/src/pages/home/sidebar/ChatLinkRow.js
@@ -86,7 +86,7 @@ const ChatLinkRow = ({
                                 </View>
                             )
                         }
-                        <View>
+                        <View style={styles.chatSwitcherUserText}>
                             {option.text === option.alternateText ? (
                                 <Text style={textUnreadStyle} numberOfLines={1}>
                                     {option.alternateText}

--- a/src/pages/home/sidebar/ChatLinkRow.js
+++ b/src/pages/home/sidebar/ChatLinkRow.js
@@ -87,9 +87,9 @@ const ChatLinkRow = ({
                                 </View>
                             )
                         }
-                        <View style={styles.flex1}>
+                        <View style={[styles.flex1]}>
                             {option.text === option.alternateText ? (
-                                <Text style={textUnreadStyle} numberOfLines={1}>
+                                <Text style={[textUnreadStyle]} numberOfLines={1}>
                                     {option.alternateText}
                                 </Text>
                             ) : (

--- a/src/pages/home/sidebar/SidebarLinks.js
+++ b/src/pages/home/sidebar/SidebarLinks.js
@@ -50,7 +50,6 @@ const defaultProps = {
 };
 
 const SidebarLinks = (props) => {
-    const {onLinkClick} = props;
     const reportIDInUrl = parseInt(props.match.params.reportID, 10);
     const sortedReports = lodashOrderby(props.reports, [
         'isPinned',
@@ -72,7 +71,7 @@ const SidebarLinks = (props) => {
         <View style={[styles.flex1, {marginTop: props.insets.top}]}>
             <View style={[styles.sidebarHeader]}>
                 <ChatSwitcherView
-                    onLinkClick={onLinkClick}
+                    onLinkClick={props.onLinkClick}
                     isChatSwitcherActive={props.isChatSwitcherActive}
                 />
             </View>
@@ -104,7 +103,7 @@ const SidebarLinks = (props) => {
                                 reportID: report.reportID,
                                 isUnread: report.unreadActionCount > 0,
                             }}
-                            onSelectRow={onLinkClick}
+                            onSelectRow={props.onLinkClick}
                             optionIsFocused={report.reportID === reportIDInUrl}
                         />
                     );

--- a/src/styles/StyleSheet.js
+++ b/src/styles/StyleSheet.js
@@ -480,6 +480,11 @@ const styles = {
         backgroundColor: colors.heading,
     },
 
+    chatLinkRowPressable: {
+        minWidth: 0,
+        textDecorationLine: 'none',
+    },
+
     sidebarLink: {
         textDecorationLine: 'none',
     },
@@ -759,10 +764,6 @@ const styles = {
         paddingRight: 3,
         paddingBottom: 0,
         paddingLeft: 5,
-    },
-
-    chatSwitcherUserText: {
-        maxWidth: 180,
     },
 
     chatSwitcherPillsInput: {

--- a/src/styles/StyleSheet.js
+++ b/src/styles/StyleSheet.js
@@ -483,6 +483,7 @@ const styles = {
     chatLinkRowPressable: {
         minWidth: 0,
         textDecorationLine: 'none',
+        flex: 1,
     },
 
     sidebarLink: {

--- a/src/styles/StyleSheet.js
+++ b/src/styles/StyleSheet.js
@@ -761,6 +761,10 @@ const styles = {
         paddingLeft: 5,
     },
 
+    chatSwitcherUserText: {
+        maxWidth: 180,
+    },
+
     chatSwitcherPillsInput: {
         alignItems: 'flex-start',
         alignSelf: 'flex-start',

--- a/src/styles/StyleSheet.js
+++ b/src/styles/StyleSheet.js
@@ -493,7 +493,7 @@ const styles = {
     sidebarLinkInner: {
         alignItems: 'center',
         flexDirection: 'row',
-        height: 44,
+        height: 48,
         paddingTop: 10,
         paddingRight: 8,
         paddingBottom: 10,
@@ -502,6 +502,7 @@ const styles = {
 
     sidebarLinkText: {
         color: colors.icon,
+        fontFamily: fontFamily.GTA,
         fontSize: 13,
         textDecorationLine: 'none',
         overflow: 'hidden',
@@ -512,15 +513,27 @@ const styles = {
         borderRadius: 8,
         textDecorationLine: 'none',
     },
+
     sidebarLinkTextUnread: {
         fontWeight: '600',
         color: colors.textReversed,
     },
+
     sidebarLinkActiveText: {
         color: colors.textReversed,
         fontSize: 13,
         textDecorationLine: 'none',
         overflow: 'hidden',
+    },
+
+    chatSwitcherDisplayName: {
+        height: 16,
+        lineHeight: 16,
+    },
+
+    chatSwitcherLogin: {
+        height: 12,
+        lineHeight: 12,
     },
 
     unreadBadge: {

--- a/src/styles/StyleSheet.js
+++ b/src/styles/StyleSheet.js
@@ -502,7 +502,6 @@ const styles = {
 
     sidebarLinkText: {
         color: colors.icon,
-        fontFamily: fontFamily.GTA,
         fontSize: 13,
         textDecorationLine: 'none',
         overflow: 'hidden',
@@ -527,11 +526,13 @@ const styles = {
     },
 
     chatSwitcherDisplayName: {
+        fontFamily: fontFamily.GTA,
         height: 16,
         lineHeight: 16,
     },
 
     chatSwitcherLogin: {
+        fontFamily: fontFamily.GTA,
         height: 12,
         lineHeight: 12,
     },


### PR DESCRIPTION
Not too sure why, but the flex style on this view was rendering it invisible. Anyways, just took away that one style, the chat text reappeared and looked normal.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/146456

### Tests
- Run the iOS app
- Watch the chat switcher text be invisible as per the issue
- Remove the style and fast-refresh
- Watch the chat switcher text reappear.
- See the screenshot below: everything looks normal

### Screenshots
![image](https://user-images.githubusercontent.com/47436092/99839343-6eedf080-2b1f-11eb-968a-4ba8c0535df1.png)

