### PR TITLE
Clear out the typing indicator before subscribing to typing events

### DIFF
--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -310,6 +310,9 @@ function subscribeToReportTypingEvents(reportID) {
         return;
     }
 
+    // Make sure we have a clean Typing indicator before subscribing to typing events
+    Onyx.set(`${ONYXKEYS.COLLECTION.REPORT_USER_IS_TYPING}${reportID}`, {});
+
     const pusherChannelName = getReportChannelName(reportID);
 
     // Typing status is an object with the shape {[login]: Boolean} (e.g. {yuwen@expensify.com: true}), where the value


### PR DESCRIPTION
Pullerbearing (@madmax330)
also getting @tgolen to take a peek just in case

Onyx would still be holding outdated information about typing status when a user closed out of a window when someone was typing. Since this is realtime information, that's not ideal. This ensures we're always working with a 'clean sheet' before subscribing to typing events.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/146738

### Tests/QA
- Have two different chat sessions open on a different account
- Start typing in one, and while you're still typing in the one session, close the other
- Re-open the session you closed, make sure that it doesn't still show the other user as typing.