### PR TITLE
Fix issue where multiple taps were required to switch chats

### DIFF
--- a/src/pages/home/sidebar/ChatSwitcherList.js
+++ b/src/pages/home/sidebar/ChatSwitcherList.js
@@ -32,6 +32,7 @@ const ChatSwitcherList = ({
     <View style={[styles.flex1]}>
         {options.length > 0 && (
             <FlatList
+                keyboardShouldPersistTaps="always"
                 showsVerticalScrollIndicator={false}
                 data={options}
                 keyExtractor={option => (option.type === 'user' ? option.alternateText : String(option.reportID))}

--- a/src/pages/home/sidebar/SidebarLinks.js
+++ b/src/pages/home/sidebar/SidebarLinks.js
@@ -76,6 +76,7 @@ const SidebarLinks = (props) => {
                 />
             </View>
             <ScrollView
+                keyboardShouldPersistTaps="always"
                 style={sidebarLinksStyle}
                 bounces={false}
                 indicatorStyle="white"


### PR DESCRIPTION
CC @tgolen -- this issue became known after [this PR was merged](https://github.com/Expensify/ReactNativeChat/pull/842) (not necessarily the cause, but FYI) 

When attempting to switch to a different chat from the ChatSwitcher after using a TextInput component, multiple taps were required before the tap was registered. 

This was due to the ScrollView intercepting taps as the user lost focus from an TextInput component. This is a [common problem](https://github.com/facebook/react-native/issues/4087) which was solved with the [`keyboardShouldPersistTaps`](https://reactnative.dev/docs/scrollview#keyboardshouldpersisttaps)  prop. Adding this prop to all ScrollView Components (including subclasses like FlatList) ensures that the parent view will not intercept the tap, allowing the child view to handle the tap as expected.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/146875

### Tests

**Run on both iOS and Android**
- *Ensure a couple of chats are pinned, so that you have the option to switch without searching*
- Open a chat
- Tap in the comment TextInput field, ensure the soft input keyboard is displayed if using a simulator/emulator
- Open the LHN
- Switch to a different chat
- **You should be taken to that chat, on the first tap**
- Tap in the comment TextInput field again, ensuring soft input keyboard is displayed
- Open the LHN
- Search for a user, via the Chat Switcher
- Tap a user result, without adding them to a group chat
- **You should be taken to that chat, on the first tap**

### Screenshots
N/A
