### PR TITLE
Fix modal image height

### DIFF
--- a/src/components/BaseImageModal.js
+++ b/src/components/BaseImageModal.js
@@ -94,7 +94,9 @@ class BaseImageModal extends React.Component {
         if (this.state.isModalOpen && !this.calculatedModalImageSize) {
             Image.getSize(this.props.sourceURL, (width, height) => {
                 // Unlike the image width, we do allow the image to span the full modal height
-                const modalHeight = this.props.pinToEdges ? Dimensions.get('window').height : this.props.modalHeight;
+                const modalHeight = this.props.pinToEdges
+                    ? Dimensions.get('window').height
+                    : this.props.modalHeight - (styles.modalHeaderBar.height || 0);
                 const modalWidth = this.props.pinToEdges ? Dimensions.get('window').width : this.props.modalImageWidth;
                 let imageHeight = height;
                 let imageWidth = width;


### PR DESCRIPTION
PBing: @bondydaa 

The images in modals were scaling to match the image height but not taking into account the height of the header bar. Fortunately, this is hard-coded in the styles, so we can grab the numeric value from there and use it to correct the image scaling.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/146484

### Tests
1) Upload an image whose height is greater than it's width
2) Click on the image to open the modal preview
3) Make sure the full image appears in the modal, taking care to note that no portion of the image is cropped out.

### Screenshots
##### Original Image:
<img src="https://user-images.githubusercontent.com/47436092/100653547-73738f80-32fd-11eb-819a-2af4b64a2401.png" alt="" height="360px" />

##### Before (on master)
<img src="https://user-images.githubusercontent.com/47436092/100653733-b33a7700-32fd-11eb-9c42-88a2ee5203c6.png" alt="" height="360px" />

###### After (on this branch)
<img src="https://user-images.githubusercontent.com/47436092/100653460-4b842c00-32fd-11eb-9520-19c71a3228b1.png" alt="" height="360px" />
