### PR TITLE
Add to react router history when redirecting

### DIFF
--- a/src/Expensify.js
+++ b/src/Expensify.js
@@ -107,7 +107,7 @@ class Expensify extends Component {
             <Router>
                 {/* If there is ever a property for redirecting, we do the redirect here */}
                 {/* Leave this as a ternary or else iOS throws an error about text not being wrapped in <Text> */}
-                {redirectTo ? <Redirect to={redirectTo} /> : null}
+                {redirectTo ? <Redirect push to={redirectTo} /> : null}
                 <Route path="*" render={recordCurrentRoute} />
                 <Route path={ROUTES.REPORT} exact render={recordCurrentlyViewedReportID} />
 


### PR DESCRIPTION
PBing: @ctkochan22 
cc @deetergp 

Documentation for the change [here](https://reactrouter.com/web/api/Redirect/push-bool)

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/145143

### Tests / QA
Note that for the following steps you can use only 2 or 3 chats, but it's easier to follow the testing steps if you use a different chat for each step/

1. In the chat switcher, start searching for a chat. _Use the mouse_ to click on a chat (call it chat A)
1. In the chat switcher, start searching for a chat. _Use the arrow keys and the enter key_ to switch to a new chat. (call it chat B)
1. Repeat the previous step, except open a third chat (call it chat C)
1. Create a new chat, call it chat D
1. Use the chat switcher and _use the mouse_ to click on another chat (call it E)
1. Use `CMD+[` and `CMD+]` and/or the "back" and "forward" buttons on your web browser to scroll backwards and forwards through your recent chat history. Everything should work as expected.

### Tested on:

- [x] ~ iOS -- History is not relevant but tested for regressions
- [x] ~ Android -- History is not relevant but tested for regressions
- [x] ~ Desktop
- [x] ~ Web
- [x] ~ Mobile Web -- iOS safari running on a simulator
