### PR TITLE
Navigate history with browser-forward/backward commands

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -100,6 +100,16 @@ const mainWindow = (() => {
                 }
             });
 
+            // Initiating a browser-back or browser-forward with mouse buttons should navigate history.
+            browserWindow.on('app-command', (e, cmd) => {
+                if (cmd === 'browser-backward') {
+                    browserWindow.webContents.goBack();
+                }
+                if (cmd === 'browser-forward') {
+                    browserWindow.webContents.goForward();
+                }
+            });
+
             app.on('before-quit', () => quitting = true);
             app.on('activate', () => browserWindow.show());
 


### PR DESCRIPTION
cc @roryabraham

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/145143

### Tests
Same tests as https://github.com/Expensify/ReactNativeChat/pull/859 with the addition of using the browser navigation buttons on a mouse that has them to navigate forward and backward in the chat history.
