### PR TITLE
Fix unregistered handler issue which blocks signin

### DIFF
--- a/src/libs/NetworkConnection.js
+++ b/src/libs/NetworkConnection.js
@@ -4,10 +4,9 @@ import NetInfo from '@react-native-community/netinfo';
 import Onyx from 'react-native-onyx';
 import ONYXKEYS from '../ONYXKEYS';
 
-// NetInfo.addEventListener() returns a function used to unsubscribe the listener. We must hold a reference to it and
-// other callback functions in order to unsubscribe them. Additionally, they are used to check initialization state.
+// NetInfo.addEventListener() returns a function used to unsubscribe the
+// listener so we must create a reference to it and call it in stopListeningForReconnect()
 let unsubscribeFromNetInfo;
-let appStateChangeCallback;
 let sleepTimer;
 let lastTime;
 let isActive = false;
@@ -42,6 +41,21 @@ function setOfflineStatus(isCurrentlyOffline) {
 }
 
 /**
+ * @param {String} state
+ */
+function setAppState(state) {
+    console.debug('[AppState] state changed:', state);
+    const nextStateIsActive = state === 'active';
+
+    // We are moving from not active to active and we are online so fire callbacks
+    if (!isOffline && nextStateIsActive && !isActive) {
+        triggerReconnectionCallbacks();
+    }
+
+    isActive = nextStateIsActive;
+}
+
+/**
  * Set up the event listener for NetInfo to tell whether the user has
  * internet connectivity or not. This is more reliable than the Pusher
  * `disconnected` event which takes about 10-15 seconds to emit.
@@ -58,18 +72,7 @@ function listenForReconnect() {
     // for a few minutes, but eventually disconnects causing a delay when the app
     // returns from the background. So, if we are returning from the background
     // and we are online we should trigger our reconnection callbacks.
-    appStateChangeCallback = function (state) {
-        console.debug('[AppState] state changed:', state);
-        const nextStateIsActive = state === 'active';
-
-        // We are moving from not active to active and we are online so fire callbacks
-        if (!isOffline && nextStateIsActive && !isActive) {
-            triggerReconnectionCallbacks();
-        }
-
-        isActive = nextStateIsActive;
-    };
-    AppState.addEventListener('change', appStateChangeCallback);
+    AppState.addEventListener('change', setAppState);
 
     // When a device is put to sleep, NetInfo is not always able to detect
     // when connectivity has been lost. As a failsafe we will capture the time
@@ -93,10 +96,7 @@ function stopListeningForReconnect() {
     if (unsubscribeFromNetInfo) {
         unsubscribeFromNetInfo();
     }
-    if (appStateChangeCallback) {
-        AppState.removeEventListener('change', appStateChangeCallback);
-        appStateChangeCallback = null;
-    }
+    AppState.removeEventListener('change', setAppState);
 }
 
 /**

--- a/src/libs/NetworkConnection.js
+++ b/src/libs/NetworkConnection.js
@@ -11,6 +11,7 @@ let sleepTimer;
 let lastTime;
 let isActive = false;
 let isOffline = false;
+let isListeningToAppStateChanges = false;
 
 // Holds all of the callbacks that need to be triggered when the network reconnects
 const reconnectionCallbacks = [];
@@ -73,6 +74,7 @@ function listenForReconnect() {
     // returns from the background. So, if we are returning from the background
     // and we are online we should trigger our reconnection callbacks.
     AppState.addEventListener('change', setAppState);
+    isListeningToAppStateChanges = true;
 
     // When a device is put to sleep, NetInfo is not always able to detect
     // when connectivity has been lost. As a failsafe we will capture the time
@@ -96,7 +98,9 @@ function stopListeningForReconnect() {
     if (unsubscribeFromNetInfo) {
         unsubscribeFromNetInfo();
     }
-    AppState.removeEventListener('change', setAppState);
+    if (isListeningToAppStateChanges) {
+        AppState.removeEventListener('change', setAppState);
+    }
 }
 
 /**

--- a/src/libs/NetworkConnection.js
+++ b/src/libs/NetworkConnection.js
@@ -58,7 +58,7 @@ function listenForReconnect() {
     // for a few minutes, but eventually disconnects causing a delay when the app
     // returns from the background. So, if we are returning from the background
     // and we are online we should trigger our reconnection callbacks.
-    appStateChangeCallback = (state) => {
+    appStateChangeCallback = function (state) {
         console.debug('[AppState] state changed:', state);
         const nextStateIsActive = state === 'active';
 

--- a/src/libs/NetworkConnection.js
+++ b/src/libs/NetworkConnection.js
@@ -58,7 +58,7 @@ function listenForReconnect() {
     // for a few minutes, but eventually disconnects causing a delay when the app
     // returns from the background. So, if we are returning from the background
     // and we are online we should trigger our reconnection callbacks.
-    appStateChangeCallback = function (state) {
+    appStateChangeCallback = (state) => {
         console.debug('[AppState] state changed:', state);
         const nextStateIsActive = state === 'active';
 


### PR DESCRIPTION
CC @marcaaron @tgolen -- I'll hang around for a code review to ensure this gets merged. There are a few ways of holding the callback reference, so please let me know if you see any changes or improvements to this solution.

A request was being made at app start with an empty auth token under certain conditions (possibly a combination of incomplete report data and a disconnection event). This underlying issue has [caused other issues in the past](https://github.com/Expensify/ReactNativeChat/pull/761) and should be fixed.

A side effect of the above issue is that we were attempting to remove a callback here which had never been set, blocking sign in attempts. To fix this, we now hold a reference to the callback and only attempt to unregister it if it has been initialised and registered. 

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/147292

### Tests
- Sign out
- Apply the diff below
- You should be able to sign in and use the app as expected

**DIFF**
This will make an API request at app start which does not contain an authToken, triggering the secondary issue.
```
diff --git a/src/Expensify.js b/src/Expensify.js
index a3fa6704..f1ef0118 100644
--- a/src/Expensify.js
+++ b/src/Expensify.js
@@ -8,6 +8,7 @@ import HomePage from './pages/home/HomePage';
 import listenToStorageEvents from './libs/listenToStorageEvents';
 import * as ActiveClientManager from './libs/ActiveClientManager';
 import ONYXKEYS from './ONYXKEYS';
+import NetworkConnection from './libs/NetworkConnection';
 
 import styles from './styles/StyleSheet';
 import Log from './libs/Log';
@@ -73,6 +74,8 @@ class Expensify extends Component {
             key: ONYXKEYS.SESSION,
             callback: this.removeLoadingState,
         });
+
+        NetworkConnection.stopListeningForReconnect();
     }
 
     componentDidUpdate(prevProps, prevState) {

```

### Screenshots
N/A
