### PR TITLE
Refresh attachment authToken when updated

### DIFF
--- a/src/components/BaseImageModal.js
+++ b/src/components/BaseImageModal.js
@@ -42,6 +42,9 @@ const propTypes = {
     session: PropTypes.shape({
         authToken: PropTypes.string.isRequired,
     }).isRequired,
+
+    // Do the urls require an authToken?
+    isAuthTokenRequired: PropTypes.bool.isRequired,
 };
 
 const defaultProps = {
@@ -144,8 +147,8 @@ class BaseImageModal extends React.Component {
      * @returns {String}
      */
     addAuthTokenToURL(url) {
-        return Str.endsWith(url, '?authToken=')
-            ? `${url}${this.props.session.authToken}`
+        return this.props.isAuthTokenRequired
+            ? `${url}?authToken=${this.props.session.authToken}`
             : url;
     }
 

--- a/src/components/BaseImageModal.js
+++ b/src/components/BaseImageModal.js
@@ -4,9 +4,12 @@ import {
     View, Image, TouchableOpacity, Dimensions
 } from 'react-native';
 import Modal from 'react-native-modal';
+import Str from 'expensify-common/lib/str';
 import AttachmentView from './AttachmentView';
 import styles, {webViewStyles} from '../styles/StyleSheet';
 import ModalView from './ModalView';
+import {withOnyx} from 'react-native-onyx';
+import ONYXKEYS from '../ONYXKEYS';
 
 /**
  * Modal component consisting of an image thumbnail which triggers a modal with a larger image display
@@ -129,12 +132,24 @@ class BaseImageModal extends React.Component {
         this.setState({isModalOpen: visibility});
     }
 
+    /**
+     * Add authToken to this attachment URL if necessary
+     *
+     * @param {String} url
+     * @returns {String}
+     */
+    addAuthTokenToURL(url) {
+        return Str.endsWith(url, '?authToken=')
+            ? `${url}${this.props.authToken}`
+            : url;
+    }
+
     render() {
         return (
             <>
                 <TouchableOpacity onPress={() => this.setModalVisiblity(true)}>
                     <Image
-                        source={{uri: this.props.previewSourceURL}}
+                        source={{uri: this.addAuthTokenToURL(this.props.previewSourceURL)}}
                         style={{
                             ...webViewStyles.tagStyles.img,
                             width: this.state.thumbnailWidth,
@@ -158,7 +173,7 @@ class BaseImageModal extends React.Component {
                     >
                         <View style={styles.imageModalImageCenterContainer}>
                             <AttachmentView
-                                sourceURL={this.props.sourceURL}
+                                sourceURL={this.addAuthTokenToURL(this.props.sourceURL)}
                                 imageHeight={this.state.imageHeight}
                                 imageWidth={this.state.imageWidth}
                             />
@@ -173,4 +188,8 @@ class BaseImageModal extends React.Component {
 BaseImageModal.propTypes = propTypes;
 BaseImageModal.defaultProps = defaultProps;
 
-export default BaseImageModal;
+export default withOnyx({
+    session: {
+        key: ONYXKEYS.SESSION,
+    },
+})(BaseImageModal);

--- a/src/components/BaseImageModal.js
+++ b/src/components/BaseImageModal.js
@@ -5,10 +5,10 @@ import {
 } from 'react-native';
 import Modal from 'react-native-modal';
 import Str from 'expensify-common/lib/str';
+import {withOnyx} from 'react-native-onyx';
 import AttachmentView from './AttachmentView';
 import styles, {webViewStyles} from '../styles/StyleSheet';
 import ModalView from './ModalView';
-import {withOnyx} from 'react-native-onyx';
 import ONYXKEYS from '../ONYXKEYS';
 
 /**
@@ -37,6 +37,11 @@ const propTypes = {
 
     // URL to full-sized image
     sourceURL: PropTypes.string,
+
+    // Current user session
+    session: PropTypes.shape({
+        authToken: PropTypes.string.isRequired,
+    }).isRequired,
 };
 
 const defaultProps = {
@@ -140,7 +145,7 @@ class BaseImageModal extends React.Component {
      */
     addAuthTokenToURL(url) {
         return Str.endsWith(url, '?authToken=')
-            ? `${url}${this.props.authToken}`
+            ? `${url}${this.props.session.authToken}`
             : url;
     }
 

--- a/src/components/BaseImageModal.js
+++ b/src/components/BaseImageModal.js
@@ -4,7 +4,6 @@ import {
     View, Image, TouchableOpacity, Dimensions
 } from 'react-native';
 import Modal from 'react-native-modal';
-import Str from 'expensify-common/lib/str';
 import {withOnyx} from 'react-native-onyx';
 import AttachmentView from './AttachmentView';
 import styles, {webViewStyles} from '../styles/StyleSheet';

--- a/src/components/ImageThumbnailWithModal/index.js
+++ b/src/components/ImageThumbnailWithModal/index.js
@@ -18,7 +18,7 @@ const ImageThumbnailWithModal = props => (
         previewSourceURL={props.previewSourceURL}
         sourceURL={props.sourceURL}
         modalTitle="Attachment"
-        isAuthTokenRequired={isAuthTokenRequired}
+        isAuthTokenRequired={props.isAuthTokenRequired}
     />
 );
 

--- a/src/components/ImageThumbnailWithModal/index.js
+++ b/src/components/ImageThumbnailWithModal/index.js
@@ -8,6 +8,9 @@ const propTypes = {
 
     // URL to full-sized image
     sourceURL: PropTypes.string.isRequired,
+
+    // Do the url passed require authToken?
+    isAuthTokenRequired: PropTypes.bool.isRequired,
 };
 
 const ImageThumbnailWithModal = props => (
@@ -15,6 +18,7 @@ const ImageThumbnailWithModal = props => (
         previewSourceURL={props.previewSourceURL}
         sourceURL={props.sourceURL}
         modalTitle="Attachment"
+        isAuthTokenRequired={isAuthTokenRequired}
     />
 );
 

--- a/src/components/ImageThumbnailWithModal/index.native.js
+++ b/src/components/ImageThumbnailWithModal/index.native.js
@@ -13,6 +13,9 @@ const propTypes = {
 
     // URL to full-sized image
     sourceURL: PropTypes.string.isRequired,
+
+    // Do the url passed require authToken?
+    isAuthTokenRequired: PropTypes.bool.isRequired,
 };
 
 const ImageThumbnailWithModal = props => (
@@ -21,6 +24,7 @@ const ImageThumbnailWithModal = props => (
         previewSourceURL={props.previewSourceURL}
         sourceURL={props.sourceURL}
         modalTitle="Attachment"
+        isAuthTokenRequired={props.isAuthTokenRequired}
     />
 );
 

--- a/src/pages/home/report/ReportActionItemFragment.js
+++ b/src/pages/home/report/ReportActionItemFragment.js
@@ -78,15 +78,13 @@ class ReportActionItemFragment extends React.PureComponent {
                 // Chat attachments have both thumbnails and full size source.
                 // The thumbnail source will be under htmlAttribs.src and the
                 // full source is accessed via data-expensify-source.
-                // If the image source has a data-expensify-source attribute this
-                // means that it's a user attachment and that both it's source and
-                // previewSource will require an authToken
-                let previewSource = htmlAttribs['data-expensify-source']
-                    ? `${htmlAttribs.src}?authToken=`
-                    : htmlAttribs.src;
-
-                let source = htmlAttribs['data-expensify-source']
-                    ? `${htmlAttribs['data-expensify-source']}?authToken=`
+                // If the image element has a data-expensify-source attribute this
+                // means that it's an attachment and that both it's source and
+                // previewSource require an authToken.
+                const isAttachment = Boolean(htmlAttribs['data-expensify-source']);
+                let previewSource = htmlAttribs.src;
+                let source = isAttachment
+                    ? htmlAttribs['data-expensify-source']
                     : htmlAttribs.src;
 
                 // Update the image URL so the images can be accessed depending on the config environment
@@ -101,6 +99,7 @@ class ReportActionItemFragment extends React.PureComponent {
 
                 return (
                     <ImageThumbnailWithModal
+                        isAuthTokenRequired={isAttachment}
                         previewSourceURL={previewSource}
                         sourceURL={source}
                         key={passProps.key}

--- a/src/pages/home/report/ReportActionItemFragment.js
+++ b/src/pages/home/report/ReportActionItemFragment.js
@@ -75,12 +75,23 @@ class ReportActionItemFragment extends React.PureComponent {
                 </View>
             ),
             img: (htmlAttribs, children, convertedCSSStyles, passProps) => {
-                // Chat attachments have both thumbnails and full size source.
-                // The thumbnail source will be under htmlAttribs.src and the
-                // full source is accessed via data-expensify-source.
-                // If the image element has a data-expensify-source attribute this
-                // means that it's an attachment and that both it's source and
-                // previewSource require an authToken.
+                // There are two kinds of images that need to be displayed:
+                //
+                //     - Chat Attachment images
+                //
+                //           Images uploaded by the user via the app or email.
+                //           These have a full-sized image `htmlAttribs['data-expensify-source']`
+                //           and a thumbnail `htmlAttribs.src`. Both of these URLs need to have
+                //           an authToken added to them in order to control who
+                //           can see the images.
+                //
+                //     - Non-Attachment Images
+                //
+                //           These could be hosted from anywhere (Expensify or another source)
+                //           and are not protected by any kind of access control e.g. certain
+                //           Concierge responder attachments are uploaded to S3 without any access
+                //           control and thus require no authToken to verify access.
+                //
                 const isAttachment = Boolean(htmlAttribs['data-expensify-source']);
                 let previewSource = htmlAttribs.src;
                 let source = isAttachment

--- a/src/pages/home/report/ReportActionItemFragment.js
+++ b/src/pages/home/report/ReportActionItemFragment.js
@@ -10,7 +10,6 @@ import styles, {webViewStyles, colors} from '../../../styles/StyleSheet';
 import Text from '../../../components/Text';
 import AnchorForCommentsOnly from '../../../components/AnchorForCommentsOnly';
 import InlineCodeBlock from '../../../components/InlineCodeBlock';
-import * as API from '../../../libs/API';
 import ImageThumbnailWithModal from '../../../components/ImageThumbnailWithModal';
 import Config from '../../../CONFIG';
 

--- a/src/pages/home/report/ReportActionItemFragment.js
+++ b/src/pages/home/report/ReportActionItemFragment.js
@@ -78,11 +78,11 @@ class ReportActionItemFragment extends React.PureComponent {
             img: (htmlAttribs, children, convertedCSSStyles, passProps) => {
                 // Attaches authTokens as a URL parameter to load image attachments
                 let previewSource = htmlAttribs['data-expensify-source']
-                    ? `${htmlAttribs.src}?authToken=${API.getAuthToken()}`
+                    ? `${htmlAttribs.src}?authToken=`
                     : htmlAttribs.src;
 
                 let source = htmlAttribs['data-expensify-source']
-                    ? `${htmlAttribs['data-expensify-source']}?authToken=${API.getAuthToken()}`
+                    ? `${htmlAttribs['data-expensify-source']}?authToken=`
                     : htmlAttribs.src;
 
                 // Update the image URL so the images can be accessed depending on the config environment

--- a/src/pages/home/report/ReportActionItemFragment.js
+++ b/src/pages/home/report/ReportActionItemFragment.js
@@ -75,7 +75,12 @@ class ReportActionItemFragment extends React.PureComponent {
                 </View>
             ),
             img: (htmlAttribs, children, convertedCSSStyles, passProps) => {
-                // Attaches authTokens as a URL parameter to load image attachments
+                // Chat attachments have both thumbnails and full size source.
+                // The thumbnail source will be under htmlAttribs.src and the
+                // full source is accessed via data-expensify-source.
+                // If the image source has a data-expensify-source attribute this
+                // means that it's a user attachment and that both it's source and
+                // previewSource will require an authToken
                 let previewSource = htmlAttribs['data-expensify-source']
                     ? `${htmlAttribs.src}?authToken=`
                     : htmlAttribs.src;


### PR DESCRIPTION
cc @thienlnam @tgolen 

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/147177

### Tests
1. Make sure images and PDF attachments are still functioning correctly
1. Load up a chat with several images
1. Invalidate your `authToken` by modifying it directly in localStorage
1. Trigger a reconnect flow by minimizing and maximizing the browser window
1. Verify the images are restored

### Screenshots
❌ 