### PR TITLE
[Mobile - HomePage] Added disabled prop to Pressable

### DIFF
--- a/src/pages/home/HomePage.js
+++ b/src/pages/home/HomePage.js
@@ -216,6 +216,7 @@ class App extends React.Component {
                                         isChatSwitcherActive={this.props.isChatSwitcherActive}
                                     />
                                 </Animated.View>
+                                {/* The following pressable allows us to click outside the LHN to close it, and should be enabled only if the LHN is open. */}
                                 <Pressable
                                     disabled={!this.props.isSidebarShown}
                                     style={[styles.flex1]}

--- a/src/pages/home/HomePage.js
+++ b/src/pages/home/HomePage.js
@@ -217,6 +217,7 @@ class App extends React.Component {
                                     />
                                 </Animated.View>
                                 <Pressable
+                                    disabled={!this.props.isSidebarShown}
                                     style={[styles.flex1]}
                                     onPress={this.dismissHamburger}
                                 >

--- a/src/pages/home/HomePage.js
+++ b/src/pages/home/HomePage.js
@@ -216,7 +216,8 @@ class App extends React.Component {
                                         isChatSwitcherActive={this.props.isChatSwitcherActive}
                                     />
                                 </Animated.View>
-                                {/* The following pressable allows us to click outside the LHN to close it, and should be enabled only if the LHN is open. */}
+                                {/* The following pressable allows us to click outside the LHN to close it, and should be enabled only if the LHN is open.
+                                Otherwise, it will capture all onPress events for all of its children, functionally disabling scrolling and other key interactions. */}
                                 <Pressable
                                     disabled={!this.props.isSidebarShown}
                                     style={[styles.flex1]}

--- a/src/pages/home/HomePage.js
+++ b/src/pages/home/HomePage.js
@@ -216,8 +216,9 @@ class App extends React.Component {
                                         isChatSwitcherActive={this.props.isChatSwitcherActive}
                                     />
                                 </Animated.View>
-                                {/* The following pressable allows us to click outside the LHN to close it, and should be enabled only if the LHN is open.
-                                Otherwise, it will capture all onPress events for all of its children, functionally disabling scrolling and other key interactions. */}
+                                {/* The following pressable allows us to click outside the LHN to close it,
+                                and should be enabled only if the LHN is open. Otherwise, it will capture
+                                some onPress events, causing scrolling issues. */}
                                 <Pressable
                                     disabled={!this.props.isSidebarShown}
                                     style={[styles.flex1]}


### PR DESCRIPTION
<Assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit.>

<Explanation of the change or anything fishy that is going on>

This issue was caused by the `Pressable` in the `HomePage.js` file, which was wrapping everything (except the LHN). Its purpose is to allow the user to close the LHN by clicking outside of it, which is why that functionality will be tested below.

### Fixed Issues
https://github.com/Expensify/Expensify/issues/146317

### Tests
<Tests you performed on all platforms that validates your changed worked>

1. Verify that you can scroll whether or not the chat input box is enabled/disabled

1. Make sure you can open the LHN using the hamburger menu button

1. Be sure you can close the LHN by tapping anywhere _outside_ of the LHN. 

### Screenshots
<Add any necessary screenshots for all platforms if your change added or updated UI>

❌