### PR TITLE
Allow users to search for group DM participants by email

### DIFF
--- a/src/pages/home/sidebar/ChatSwitcherView.js
+++ b/src/pages/home/sidebar/ChatSwitcherView.js
@@ -359,7 +359,9 @@ class ChatSwitcherView extends React.Component {
             .map(report => ({
                 text: report.reportName,
                 alternateText: report.reportName,
-                searchText: report.reportName ?? '',
+                searchText: report.participants.length < 10
+                    ? `${report.reportName} ${report.participants.join(' ')}`
+                    : report.reportName ?? '',
                 reportID: report.reportID,
                 type: OPTION_TYPE.REPORT,
                 participants: report.participants,


### PR DESCRIPTION

Allows users to search for members of a group DM by email 

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/146733

### Tests
1. Add 2 or more people to a group DM 
1. Try to search for the group DM participants by email 
1. Ensure you can do so 

### Screenshots
#### Example user who is in a group DM
![Screen Shot 2020-12-03 at 5 33 15 PM](https://user-images.githubusercontent.com/16747822/101099876-928b4f00-3593-11eb-9a69-1110948cb2cc.png)

#### Searching for group DM by email (OLD) 
![Screen Shot 2020-12-03 at 5 33 21 PM](https://user-images.githubusercontent.com/16747822/101099909-9d45e400-3593-11eb-92ed-8e364860658a.png)

#### Searching for group DM by email (NEW)
![Screen Shot 2020-12-03 at 5 52 30 PM](https://user-images.githubusercontent.com/16747822/101099922-a33bc500-3593-11eb-80a1-040e277c3baf.png)

