### PR TITLE
Add auth token to image URL

### DIFF
--- a/src/components/BaseImageModal.js
+++ b/src/components/BaseImageModal.js
@@ -15,6 +15,9 @@ import ONYXKEYS from '../ONYXKEYS';
  * Used for smaller image previews that also need to be viewed full-sized like in report comments
  */
 
+const DEFUALT_IMAGE_SIZE = 300;
+const DEFUALT_THUMBNAIL_SIZE = 250;
+
 const propTypes = {
     // Should modal go full screen
     pinToEdges: PropTypes.bool,
@@ -66,10 +69,10 @@ class BaseImageModal extends React.Component {
         super(props);
 
         this.state = {
-            imageWidth: 300,
-            imageHeight: 300,
-            thumbnailWidth: 200,
-            thumbnailHeight: 200,
+            imageWidth: DEFUALT_IMAGE_SIZE,
+            imageHeight: DEFUALT_IMAGE_SIZE,
+            thumbnailWidth: DEFUALT_THUMBNAIL_SIZE,
+            thumbnailHeight: DEFUALT_THUMBNAIL_SIZE,
             isModalOpen: false,
         };
 
@@ -89,9 +92,11 @@ class BaseImageModal extends React.Component {
         Image.getSize(this.addAuthTokenToURL(this.props.previewSourceURL), (width, height) => {
             // Width of the thumbnail works better as a constant than it does
             // a percentage of the screen width since it is relative to each screen
-            const thumbnailScreenWidth = 250;
+            const thumbnailScreenWidth = DEFUALT_THUMBNAIL_SIZE;
             const scaleFactor = width / thumbnailScreenWidth;
-            const imageHeight = (height / scaleFactor) || 250;
+
+            // Fall back to default thumbnail size to prevent divide-by-zero error if image fails to load
+            const imageHeight = (height / scaleFactor) || DEFUALT_THUMBNAIL_SIZE;
 
             if (this.isComponentMounted) {
                 this.setState({thumbnailWidth: thumbnailScreenWidth, thumbnailHeight: imageHeight});
@@ -114,8 +119,10 @@ class BaseImageModal extends React.Component {
                 // Resize image to fit within the modal, if necessary
                 if (width > modalWidth || height > modalHeight) {
                     const scaleFactor = Math.max(width / modalWidth, height / modalHeight);
-                    imageHeight = height / scaleFactor || 300;
-                    imageWidth = width / scaleFactor || 300;
+
+                    // Fall back to default size to prevent divide-by-zero error if for some reason the image didn't load
+                    imageHeight = height / scaleFactor || DEFUALT_IMAGE_SIZE;
+                    imageWidth = width / scaleFactor || DEFUALT_IMAGE_SIZE;
                 }
 
                 if (this.isComponentMounted) {

--- a/src/components/BaseImageModal.js
+++ b/src/components/BaseImageModal.js
@@ -15,8 +15,8 @@ import ONYXKEYS from '../ONYXKEYS';
  * Used for smaller image previews that also need to be viewed full-sized like in report comments
  */
 
-const DEFUALT_IMAGE_SIZE = 300;
-const DEFUALT_THUMBNAIL_SIZE = 250;
+const DEFAULT_IMAGE_SIZE = 300;
+const DEFAULT_THUMBNAIL_SIZE = 250;
 
 const propTypes = {
     // Should modal go full screen
@@ -69,10 +69,10 @@ class BaseImageModal extends React.Component {
         super(props);
 
         this.state = {
-            imageWidth: DEFUALT_IMAGE_SIZE,
-            imageHeight: DEFUALT_IMAGE_SIZE,
-            thumbnailWidth: DEFUALT_THUMBNAIL_SIZE,
-            thumbnailHeight: DEFUALT_THUMBNAIL_SIZE,
+            imageWidth: DEFAULT_IMAGE_SIZE,
+            imageHeight: DEFAULT_IMAGE_SIZE,
+            thumbnailWidth: DEFAULT_THUMBNAIL_SIZE,
+            thumbnailHeight: DEFAULT_THUMBNAIL_SIZE,
             isModalOpen: false,
         };
 
@@ -92,11 +92,11 @@ class BaseImageModal extends React.Component {
         Image.getSize(this.addAuthTokenToURL(this.props.previewSourceURL), (width, height) => {
             // Width of the thumbnail works better as a constant than it does
             // a percentage of the screen width since it is relative to each screen
-            const thumbnailScreenWidth = DEFUALT_THUMBNAIL_SIZE;
+            const thumbnailScreenWidth = DEFAULT_THUMBNAIL_SIZE;
             const scaleFactor = width / thumbnailScreenWidth;
 
             // Fall back to default thumbnail size to prevent divide-by-zero error if image fails to load
-            const imageHeight = (height / scaleFactor) || DEFUALT_THUMBNAIL_SIZE;
+            const imageHeight = (height / scaleFactor) || DEFAULT_THUMBNAIL_SIZE;
 
             if (this.isComponentMounted) {
                 this.setState({thumbnailWidth: thumbnailScreenWidth, thumbnailHeight: imageHeight});
@@ -121,8 +121,8 @@ class BaseImageModal extends React.Component {
                     const scaleFactor = Math.max(width / modalWidth, height / modalHeight);
 
                     // Fallback to default size to prevent divide-by-zero error if for some reason the image didn't load
-                    imageHeight = height / scaleFactor || DEFUALT_IMAGE_SIZE;
-                    imageWidth = width / scaleFactor || DEFUALT_IMAGE_SIZE;
+                    imageHeight = height / scaleFactor || DEFAULT_IMAGE_SIZE;
+                    imageWidth = width / scaleFactor || DEFAULT_IMAGE_SIZE;
                 }
 
                 if (this.isComponentMounted) {

--- a/src/components/BaseImageModal.js
+++ b/src/components/BaseImageModal.js
@@ -120,7 +120,7 @@ class BaseImageModal extends React.Component {
                 if (width > modalWidth || height > modalHeight) {
                     const scaleFactor = Math.max(width / modalWidth, height / modalHeight);
 
-                    // Fall back to default size to prevent divide-by-zero error if for some reason the image didn't load
+                    // Fallback to default size to prevent divide-by-zero error if for some reason the image didn't load
                     imageHeight = height / scaleFactor || DEFUALT_IMAGE_SIZE;
                     imageWidth = width / scaleFactor || DEFUALT_IMAGE_SIZE;
                 }

--- a/src/components/BaseImageModal.js
+++ b/src/components/BaseImageModal.js
@@ -86,7 +86,7 @@ class BaseImageModal extends React.Component {
         this.isComponentMounted = true;
 
         // Scale image for thumbnail preview
-        Image.getSize(this.props.previewSourceURL, (width, height) => {
+        Image.getSize(this.addAuthTokenToURL(this.props.previewSourceURL), (width, height) => {
             // Width of the thumbnail works better as a constant than it does
             // a percentage of the screen width since it is relative to each screen
             const thumbnailScreenWidth = 250;
@@ -102,7 +102,7 @@ class BaseImageModal extends React.Component {
     componentDidUpdate() {
         // Only calculate image size if the modal is visible and if we haven't already done this
         if (this.state.isModalOpen && !this.calculatedModalImageSize) {
-            Image.getSize(this.props.sourceURL, (width, height) => {
+            Image.getSize(this.addAuthTokenToURL(this.props.sourceURL), (width, height) => {
                 // Unlike the image width, we do allow the image to span the full modal height
                 const modalHeight = this.props.pinToEdges
                     ? Dimensions.get('window').height

--- a/src/components/BaseImageModal.js
+++ b/src/components/BaseImageModal.js
@@ -114,8 +114,8 @@ class BaseImageModal extends React.Component {
                 // Resize image to fit within the modal, if necessary
                 if (width > modalWidth || height > modalHeight) {
                     const scaleFactor = Math.max(width / modalWidth, height / modalHeight);
-                    imageHeight = height / scaleFactor;
-                    imageWidth = width / scaleFactor;
+                    imageHeight = height / scaleFactor || 300;
+                    imageWidth = width / scaleFactor || 300;
                 }
 
                 if (this.isComponentMounted) {

--- a/src/components/BaseImageModal.js
+++ b/src/components/BaseImageModal.js
@@ -91,7 +91,7 @@ class BaseImageModal extends React.Component {
             // a percentage of the screen width since it is relative to each screen
             const thumbnailScreenWidth = 250;
             const scaleFactor = width / thumbnailScreenWidth;
-            const imageHeight = height / scaleFactor;
+            const imageHeight = (height / scaleFactor) || 250;
 
             if (this.isComponentMounted) {
                 this.setState({thumbnailWidth: thumbnailScreenWidth, thumbnailHeight: imageHeight});

--- a/src/components/BaseImageModal.js
+++ b/src/components/BaseImageModal.js
@@ -90,13 +90,18 @@ class BaseImageModal extends React.Component {
 
         // Scale image for thumbnail preview
         Image.getSize(this.addAuthTokenToURL(this.props.previewSourceURL), (width, height) => {
+            if (!width || !height) {
+                // Image didn't load properly
+                return;
+            }
+
             // Width of the thumbnail works better as a constant than it does
             // a percentage of the screen width since it is relative to each screen
             const thumbnailScreenWidth = DEFAULT_THUMBNAIL_SIZE;
             const scaleFactor = width / thumbnailScreenWidth;
 
             // Fall back to default thumbnail size to prevent divide-by-zero error if image fails to load
-            const imageHeight = (height / scaleFactor) || DEFAULT_THUMBNAIL_SIZE;
+            const imageHeight = height / scaleFactor;
 
             if (this.isComponentMounted) {
                 this.setState({thumbnailWidth: thumbnailScreenWidth, thumbnailHeight: imageHeight});
@@ -108,6 +113,11 @@ class BaseImageModal extends React.Component {
         // Only calculate image size if the modal is visible and if we haven't already done this
         if (this.state.isModalOpen && !this.calculatedModalImageSize) {
             Image.getSize(this.addAuthTokenToURL(this.props.sourceURL), (width, height) => {
+                if (!width || !height) {
+                    // Image didn't load correctly
+                    return;
+                }
+
                 // Unlike the image width, we do allow the image to span the full modal height
                 const modalHeight = this.props.pinToEdges
                     ? Dimensions.get('window').height
@@ -121,8 +131,8 @@ class BaseImageModal extends React.Component {
                     const scaleFactor = Math.max(width / modalWidth, height / modalHeight);
 
                     // Fallback to default size to prevent divide-by-zero error if for some reason the image didn't load
-                    imageHeight = height / scaleFactor || DEFAULT_IMAGE_SIZE;
-                    imageWidth = width / scaleFactor || DEFAULT_IMAGE_SIZE;
+                    imageHeight = height / scaleFactor;
+                    imageWidth = width / scaleFactor;
                 }
 
                 if (this.isComponentMounted) {

--- a/src/components/BaseImageModal.js
+++ b/src/components/BaseImageModal.js
@@ -99,8 +99,6 @@ class BaseImageModal extends React.Component {
             // a percentage of the screen width since it is relative to each screen
             const thumbnailScreenWidth = DEFAULT_THUMBNAIL_SIZE;
             const scaleFactor = width / thumbnailScreenWidth;
-
-            // Fall back to default thumbnail size to prevent divide-by-zero error if image fails to load
             const imageHeight = height / scaleFactor;
 
             if (this.isComponentMounted) {
@@ -129,8 +127,6 @@ class BaseImageModal extends React.Component {
                 // Resize image to fit within the modal, if necessary
                 if (width > modalWidth || height > modalHeight) {
                     const scaleFactor = Math.max(width / modalWidth, height / modalHeight);
-
-                    // Fallback to default size to prevent divide-by-zero error if for some reason the image didn't load
                     imageHeight = height / scaleFactor;
                     imageWidth = width / scaleFactor;
                 }

--- a/src/components/BaseImageModal.js
+++ b/src/components/BaseImageModal.js
@@ -15,9 +15,6 @@ import ONYXKEYS from '../ONYXKEYS';
  * Used for smaller image previews that also need to be viewed full-sized like in report comments
  */
 
-const DEFAULT_IMAGE_SIZE = 300;
-const DEFAULT_THUMBNAIL_SIZE = 250;
-
 const propTypes = {
     // Should modal go full screen
     pinToEdges: PropTypes.bool,
@@ -69,10 +66,10 @@ class BaseImageModal extends React.Component {
         super(props);
 
         this.state = {
-            imageWidth: DEFAULT_IMAGE_SIZE,
-            imageHeight: DEFAULT_IMAGE_SIZE,
-            thumbnailWidth: DEFAULT_THUMBNAIL_SIZE,
-            thumbnailHeight: DEFAULT_THUMBNAIL_SIZE,
+            imageWidth: 300,
+            imageHeight: 300,
+            thumbnailWidth: 200,
+            thumbnailHeight: 200,
             isModalOpen: false,
         };
 
@@ -97,7 +94,7 @@ class BaseImageModal extends React.Component {
 
             // Width of the thumbnail works better as a constant than it does
             // a percentage of the screen width since it is relative to each screen
-            const thumbnailScreenWidth = DEFAULT_THUMBNAIL_SIZE;
+            const thumbnailScreenWidth = 250;
             const scaleFactor = width / thumbnailScreenWidth;
             const imageHeight = height / scaleFactor;
 


### PR DESCRIPTION
I think we just missed a couple places where the image url needs an auth token. Not 100% clear on the cause/effect, but the result was that we were getting weird image formatting where all images were using the default image size (square). Anyways, this seems to fix it 🤷🏼‍♂️

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/146484

### Tests
1) Upload a tall image and a wide image into chat.
2) Make sure the thumbnail preview for each is not square.
3) Click on each, and make sure it scales appropriately (does not become a square) and is not cropped at all.

### Tested on:

- [x] Web
- [x] Desktop
- [x] iOS
- [ ] Android
- [ ] Mobile Web

### Screenshots

![image](https://user-images.githubusercontent.com/47436092/101128494-a8f5d280-35b4-11eb-8652-f657aeb0498d.png)

![image](https://user-images.githubusercontent.com/47436092/101128512-b317d100-35b4-11eb-8123-a65f8e0a7854.png)

![image](https://user-images.githubusercontent.com/47436092/101128555-c4f97400-35b4-11eb-9d87-e2fc19c01bfe.png)


