### PR TITLE
Fixes Various Safari issues on iOS/mWeb

### DIFF
--- a/src/pages/home/HomePage.js
+++ b/src/pages/home/HomePage.js
@@ -192,13 +192,13 @@ class App extends React.Component {
         return (
             <SafeAreaProvider>
                 <CustomStatusBar />
-                <SafeAreaInsetsContext.Consumer style={[styles.flex1, styles.h100p]}>
+                <SafeAreaInsetsContext.Consumer style={[styles.flex1, styles.vh100]}>
                     {insets => (
                         <View
                             style={[styles.appContentWrapper,
                                 appContentWrapperStyle,
                                 styles.flexRow,
-                                styles.h100p,
+                                styles.vh100,
                                 getSafeAreaPadding(insets)
                             ]}
                         >

--- a/src/pages/home/HomePage.js
+++ b/src/pages/home/HomePage.js
@@ -192,13 +192,13 @@ class App extends React.Component {
         return (
             <SafeAreaProvider>
                 <CustomStatusBar />
-                <SafeAreaInsetsContext.Consumer style={[styles.flex1, styles.vh100]}>
+                <SafeAreaInsetsContext.Consumer style={[styles.flex1]}>
                     {insets => (
                         <View
                             style={[styles.appContentWrapper,
                                 appContentWrapperStyle,
                                 styles.flexRow,
-                                styles.vh100,
+                                styles.flex1,
                                 getSafeAreaPadding(insets)
                             ]}
                         >

--- a/src/pages/home/report/ReportActionItemFragment.js
+++ b/src/pages/home/report/ReportActionItemFragment.js
@@ -119,7 +119,7 @@ class ReportActionItemFragment extends React.PureComponent {
                             <ActivityIndicator
                                 size="large"
                                 color={colors.textSupporting}
-                                style={[styles.h100p]}
+                                style={[styles.flex1]}
                             />
                         </View>
                     );

--- a/src/styles/StyleSheet.js
+++ b/src/styles/StyleSheet.js
@@ -93,6 +93,10 @@ const styles = {
         height: '100%',
     },
 
+    vh100: {
+        height: '100vh',
+    },
+
     flex0: {
         flex: 0,
     },

--- a/src/styles/StyleSheet.js
+++ b/src/styles/StyleSheet.js
@@ -89,14 +89,6 @@ const styles = {
         paddingRight: 8,
     },
 
-    h100p: {
-        height: '100%',
-    },
-
-    vh100: {
-        height: '100vh',
-    },
-
     flex0: {
         flex: 0,
     },


### PR DESCRIPTION
cc @Jag96 @shawnborton 

Seems like Safari doesn't like it when we put `height: 100%` on certain elements. I believe `flex:1` is the preferred solution to expand these elements to their max height. So I got rid of `h100p` entirely and updated a few styles.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/147358
Fixes https://github.com/Expensify/Expensify/issues/147032
Fixes https://github.com/Expensify/Expensify/issues/146696
Fixes https://github.com/Expensify/Expensify/issues/146563
Fixes https://github.com/Expensify/Expensify/issues/146537
Fixes https://github.com/Expensify/Expensify/issues/144306

### Tests
**Safari Desktop**
1. Log in and verify that the app takes up the entire viewable area of the screen (and is not cut off halfway)
1. Verify that a chat can be clicked on and it's contents can be scrolled (via scroll wheel) after clicking into the chat

**Safari iOS**
1. Click into a chat
1. Verify that the app takes up the entire viewable area of the screen (and is not cut off halfway)
1. Verify the chat can be scrolled and other elements (sidebar / compose text input) remain in their correct positions
1. Verify the header remains visible
1. Log out and verify you are brought back to the Sign In page and do not see a blank screen.

### Screenshots
![Screen Shot 2020-12-04 at 9 03 30 AM](https://user-images.githubusercontent.com/32969087/101204163-e8054180-360f-11eb-8f17-9c50775b3162.png)
![Screen Shot 2020-12-04 at 9 03 37 AM](https://user-images.githubusercontent.com/32969087/101204156-e5a2e780-360f-11eb-86df-43173f89b4db.png)

