### PR TITLE
Remove restriction on number of users for searching for chat members by email

### DIFF
--- a/src/pages/home/sidebar/ChatSwitcherView.js
+++ b/src/pages/home/sidebar/ChatSwitcherView.js
@@ -359,9 +359,7 @@ class ChatSwitcherView extends React.Component {
             .map(report => ({
                 text: report.reportName,
                 alternateText: report.reportName,
-                searchText: report.participants.length < 10
-                    ? `${report.reportName} ${report.participants.join(' ')}`
-                    : report.reportName ?? '',
+                searchText: report.participants ? `${report.reportName} ${report.participants.join(' ')}` : report.reportName ?? '',
                 reportID: report.reportID,
                 type: OPTION_TYPE.REPORT,
                 participants: report.participants,

--- a/src/pages/home/sidebar/ChatSwitcherView.js
+++ b/src/pages/home/sidebar/ChatSwitcherView.js
@@ -359,7 +359,9 @@ class ChatSwitcherView extends React.Component {
             .map(report => ({
                 text: report.reportName,
                 alternateText: report.reportName,
-                searchText: report.participants ? `${report.reportName} ${report.participants.join(' ')}` : report.reportName ?? '',
+                searchText: report.participants
+                    ? `${report.reportName} ${report.participants.join(' ')}`
+                    : report.reportName ?? '',
                 reportID: report.reportID,
                 type: OPTION_TYPE.REPORT,
                 participants: report.participants,


### PR DESCRIPTION

Report participants aren't always defined so let's not check the length when they might not exist. Instead for now just check if participants exist and add them to the search text if so 

### Fixed Issues
Fixes https://expensify.slack.com/archives/C011W8BJ9L6/p1607106779200400

### Tests
Same as https://github.com/Expensify/ReactNativeChat/pull/885

