### PR TITLE
Use draft comment to initialize comment field of ReportActionCompose

### DIFF
--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -38,7 +38,7 @@ class ReportActionCompose extends React.Component {
         this.triggerSubmitShortcut = this.triggerSubmitShortcut.bind(this);
         this.submitForm = this.submitForm.bind(this);
         this.setIsFocused = this.setIsFocused.bind(this);
-        this.comment = '';
+        this.comment = props.comment;
         this.state = {
             isFocused: false,
             textInputShouldClear: false


### PR DESCRIPTION
PBing: @MariaHCD 

What was happening here is that when we leave a report with a draft comment, then come back to it, the `ReportActionCompose` component is unmounted and re-constructed. When it's re-rendered, the draft comment is provided as a prop because it is bound with `withOnyx` to the draft comment in the store. But in the constructor, we initialized `this.comment` to an empty string, and because the underlying data hasn't changed, `withOnyx` doesn't update the component, so `componentDidUpdate` isn't called. So all we need to do to fix this is grab the  draft comment from the initial props and use it to initialize `this.comment` in the constructor.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/147434

### Tests
1) Write a draft message, but do not send it.
2) Leave the report, then come back
3) Immediately hit the `enter` key on web/desktop or the `send` button on mobile
4) Ensure that your draft message is sent.

### Tested on:

- [x] Web
- [x] Desktop
- [ ] iOS
- [ ] Android
- [ ] mWeb