### PR TITLE
Overwrite default margin for blockquotes

### DIFF
--- a/src/styles/StyleSheet.js
+++ b/src/styles/StyleSheet.js
@@ -971,6 +971,9 @@ const webViewStyles = {
             paddingLeft: 12,
             marginTop: 4,
             marginBottom: 4,
+
+            // Overwrite default HTML margin for blockquotes
+            marginLeft: 0,
         },
 
         pre: {


### PR DESCRIPTION
### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/147524

### Tests
1. Send a message with a quote in it
```
> test message
```
1. Verify the message is not indented

### Screenshots
Mobile: 
![image](https://user-images.githubusercontent.com/22447860/101220226-2d3e6900-363a-11eb-831e-d4c4cfbd000c.png)
Web / Desktop:
![image](https://user-images.githubusercontent.com/22447860/101220296-4a733780-363a-11eb-8c0c-6e6723dbf637.png)

