### PR TITLE
Create interface detection library

### DIFF
--- a/src/libs/InterfaceType/INTERFACE_TYPES.js
+++ b/src/libs/InterfaceType/INTERFACE_TYPES.js
@@ -1,0 +1,7 @@
+const interfaceTypes = {
+    TOUCH_ONLY: 'touchOnly',
+    MOUSE_ONLY: 'mouseOnly',
+    HYBRID: 'hybrid',
+};
+
+export default interfaceTypes;

--- a/src/libs/InterfaceType/INTERFACE_TYPES.js
+++ b/src/libs/InterfaceType/INTERFACE_TYPES.js
@@ -1,7 +1,7 @@
-const interfaceTypes = {
+const INTERFACE_TYPES = {
     TOUCH_ONLY: 'touchOnly',
     MOUSE_ONLY: 'mouseOnly',
     HYBRID: 'hybrid',
 };
 
-export default interfaceTypes;
+export default INTERFACE_TYPES;

--- a/src/libs/InterfaceType/index.js
+++ b/src/libs/InterfaceType/index.js
@@ -1,24 +1,34 @@
 import _ from 'underscore';
 import INTERFACE_TYPES from './INTERFACE_TYPES';
 
+/**
+ * Does a window media query.
+ *
+ * @param {String} query
+ * @returns {boolean}
+ */
+function matchMedia(query) {
+    return window.matchMedia(query).matches;
+}
+
 const userAgent = window.navigator.userAgent;
 const hasTouchStartInWindow = _.has(window, 'ontouchstart');
 const supportsTouchEvents = hasTouchStartInWindow
-    || (_.has(window, 'TouchEvent') && window.matchMedia('(any-pointer: coarse)').matches);
+    || (_.has(window, 'TouchEvent') && matchMedia('(any-pointer: coarse)'));
 const hasTouch = (window.navigator.maxTouchPoints || 0) > 0 || supportsTouchEvents;
 
 // iPads now support a mouse that can hover, however the media query interaction
 // feature results always say iPads only have a coarse pointer that can't hover
 // even when a mouse is connected
-const isIPad = window.matchMedia('(pointer: coarse)').matches && /Ipad/.test(userAgent);
+const isIPad = matchMedia('(pointer: coarse)') && /ipad/i.test(userAgent);
 
 // Assume we're dealing with a mouse-only interface
 let interfaceType = INTERFACE_TYPES.MOUSE_ONLY;
 if (hasTouch) {
     if (!hasTouchStartInWindow
-        || !window.matchMedia('(pointer: coarse)').matches
-        || window.matchMedia('(any-pointer: fine)').matches
-        || window.matchMedia('(any-hover: hover)').matches
+        || !matchMedia('(pointer: coarse)')
+        || matchMedia('(any-pointer: fine)')
+        || matchMedia('(any-hover: hover)')
         || isIPad) {
         interfaceType = INTERFACE_TYPES.HYBRID;
     } else {

--- a/src/libs/InterfaceType/index.js
+++ b/src/libs/InterfaceType/index.js
@@ -1,0 +1,32 @@
+import _ from 'underscore';
+import INTERFACE_TYPES from './INTERFACE_TYPES';
+
+const userAgent = window.navigator.userAgent;
+const hasTouchStartInWindow = _.has(window, 'ontouchstart');
+const supportsTouchEvents = hasTouchStartInWindow
+    || (_.has(window, 'TouchEvent') && window.matchMedia('(any-pointer: coarse)').matches);
+const hasTouch = (window.navigator.maxTouchPoints || 0) > 0 || supportsTouchEvents;
+
+// iPads now support a mouse that can hover, however the media query interaction
+// feature results always say iPads only have a coarse pointer that can't hover
+// even when a mouse is connected
+const isIPad = window.matchMedia('(pointer: coarse)').matches && /Ipad/.test(userAgent);
+
+// Assume we're dealing with a mouse-only interface
+let interfaceType = INTERFACE_TYPES.MOUSE_ONLY;
+if (hasTouch) {
+    if (!hasTouchStartInWindow
+        || !window.matchMedia('(pointer: coarse)').matches
+        || window.matchMedia('(any-pointer: fine)').matches
+        || window.matchMedia('(any-hover: hover)').matches
+        || isIPad) {
+        interfaceType = INTERFACE_TYPES.HYBRID;
+    } else {
+        interfaceType = INTERFACE_TYPES.TOUCH_ONLY;
+    }
+}
+
+export default {
+    getInterfaceType: () => interfaceType,
+    interfaceTypes: INTERFACE_TYPES,
+};

--- a/src/libs/InterfaceType/index.native.js
+++ b/src/libs/InterfaceType/index.native.js
@@ -1,3 +1,4 @@
+import {Platform} from 'react-native';
 import INTERFACE_TYPES from './INTERFACE_TYPES';
 
 export default {
@@ -7,6 +8,6 @@ export default {
      *
      * @returns {string}
      */
-    getInterfaceType: () => INTERFACE_TYPES.TOUCH_ONLY,
+    getInterfaceType: () => ((Platform.isPad() || false) ? INTERFACE_TYPES.HYBRID : INTERFACE_TYPES.TOUCH_ONLY),
     interfaceTypes: INTERFACE_TYPES,
 };

--- a/src/libs/InterfaceType/index.native.js
+++ b/src/libs/InterfaceType/index.native.js
@@ -1,0 +1,12 @@
+import INTERFACE_TYPES from './INTERFACE_TYPES';
+
+export default {
+    /**
+     * Determine the interface that the current device offers.
+     * For now, we'll assume that native devices are solely touch-based.
+     *
+     * @returns {string}
+     */
+    getInterfaceType: () => INTERFACE_TYPES.TOUCH_ONLY,
+    interfaceTypes: INTERFACE_TYPES,
+};

--- a/src/libs/InterfaceType/index.native.js
+++ b/src/libs/InterfaceType/index.native.js
@@ -1,4 +1,3 @@
-import {Platform} from 'react-native';
 import INTERFACE_TYPES from './INTERFACE_TYPES';
 
 export default {
@@ -8,6 +7,6 @@ export default {
      *
      * @returns {string}
      */
-    getInterfaceType: () => ((Platform.isPad() || false) ? INTERFACE_TYPES.HYBRID : INTERFACE_TYPES.TOUCH_ONLY),
+    getInterfaceType: () => INTERFACE_TYPES.TOUCH_ONLY,
     interfaceTypes: INTERFACE_TYPES,
 };


### PR DESCRIPTION
Coming from [this slack thread](https://expensify.slack.com/archives/C03TQ48KC/p1607393233000700). I got to thinking about scenarios where we can improve the UX by offering a more tailored experience for different interface types.

For now, we assume all native applications are going to be running on touch-only devices. However, with the web application it is completely feasible that the interface can be one of three types:

1) A mouse-only web interface, such as on a regular macBook
2) A touch-only web interface, such as on a regular iPhone's web browser
3) A hybrid interface, such as on a Microsoft Surface laptop w/ a mouse AND a touchscreen (these are increasingly common).

### Fixed Issues
No particular issue, but it came from https://github.com/Expensify/ReactNativeChat/pull/902 - where I was thinking we could use this kind of paradigm:

- On mouse-only interfaces, listen for right-click but not longPress
- On touch-only interfaces, listen for longPress but not right-click
- On hybrid interfaces, listen for both

### Tests
1) Import the library into the `Expensify` component.
2) Add this code into `componentDidMount`:

    ```javascript
    console.log(InterfaceTypes.getInterfaceType());
    ```
3) Run `npm run web`
4) In another terminal, run `ngrok http --host-header rewrite localhost:8080`
5) Go to `localhost:8080` in the web browser on your mac - see that the console logs `mouseOnly`
6) Go to the ngrok url in the web browser on your phone - see that the console logs `touchOnly`
7) Go to the ngrok url in the web browser an iPad - see that the console logs `hybrid` (because you can connect an Apple magic mouse to an iPad)

Of course, there are many other devices out there, but these were the devices I had on-hand to test with.
