### PR TITLE
Fix hidden LHN on init bug

### DIFF
--- a/src/pages/home/HomePage.js
+++ b/src/pages/home/HomePage.js
@@ -81,6 +81,9 @@ class App extends React.Component {
         UnreadIndicatorUpdater.listenForReportChanges();
 
         Dimensions.addEventListener('change', this.toggleHamburgerBasedOnDimensions);
+
+        // Set up the hamburger correctly once on init
+        this.toggleHamburgerBasedOnDimensions({window: Dimensions.get('window')});
     }
 
     componentDidUpdate(prevProps) {


### PR DESCRIPTION
### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/142272

### Tests
1. Start with full width chat window so sidebar is visible
1. Minimize chat window so sidebar is not visible
1. Close tab
1. Resize browser window to take up full width of screen
1. Navigate to chat again
1. Verify the sidebar is visible

### Screenshots
❌ 