### PR TITLE
Prevent sidebarHeader from growing slightly

### DIFF
--- a/src/styles/StyleSheet.js
+++ b/src/styles/StyleSheet.js
@@ -404,6 +404,7 @@ const styles = {
         paddingBottom: 16,
         paddingLeft: 12,
         flex: 1,
+        flexGrow: 0,
     },
 
     sidebarHeaderLogo: {


### PR DESCRIPTION
This puts `flexGrow: 0` on the `sidebarHeader` to prevent it from slightly growing depending on how large the chats list is.  

### Fixed Issues
N/A

### Tests
1. Open RNC on both web and mobile, and make sure the sidebarHeader area stays the same height no matter how many chats are in the list. 

### Screenshots
Before:
Notice that the sidebarHeader height is 76.36px tall:
<img width="1449" alt="Screen Shot 2020-12-11 at 10 05 19 AM" src="https://user-images.githubusercontent.com/2319350/101938591-7477ad00-3b98-11eb-9023-cb90a4e4ccae.png">


After:
Notice that the sidebarHeader height is correctly at 72px:
<img width="1454" alt="Screen Shot 2020-12-11 at 10 03 40 AM" src="https://user-images.githubusercontent.com/2319350/101938436-29f63080-3b98-11eb-94aa-7480e05d8b0c.png">

<img width="584" alt="Screen Shot 2020-12-11 at 10 03 57 AM" src="https://user-images.githubusercontent.com/2319350/101938458-34182f00-3b98-11eb-8e76-212eddc4fe63.png">

