### PR TITLE
Update react-native-webview to 11.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19662,9 +19662,9 @@
       }
     },
     "react-native-webview": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-10.10.0.tgz",
-      "integrity": "sha512-T0AnZ0LVhaFBqZpl5attDDYo83zqdFRsFVINbrgHaIm6w5r0d/QK/dJRgXRNyFhn1fSONhe0ejdcnCYCT73B6g==",
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-11.0.2.tgz",
+      "integrity": "sha512-GDyIBRbCZ2wbMUGCxA7LufSEbSoWKOzkFB8YljmAffA15tzN6ccvGEquB/hkk5KhvoYy300kwJyEmyBeG6d/AA==",
       "requires": {
         "escape-string-regexp": "2.0.0",
         "invariant": "2.2.4"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "react-native-safe-area-context": "^3.1.4",
     "react-native-web": "^0.14.0",
     "react-native-web-webview": "^1.0.2",
-    "react-native-webview": "^10.10.0",
+    "react-native-webview": "^11.0.2",
     "react-router-dom": "^5.2.0",
     "react-router-native": "^5.2.0",
     "react-web-config": "^1.0.0",


### PR DESCRIPTION
This patches a `high` security vulnerability in the `react-native-webview` package.

### Fixed Issues
N/A - just an NPM security vulnerability.

### Tests
This package is not used directly by any of our code. The only "breaking change" published in the newer version of the package is that on Android if you click on a link in a webview that opens in a new tab or window, it will prompt to open in the system browser, rather than re-using the current WebView.

I ran the app on Android to make sure everything seemed to work fine (and clicked on the `View in web` link on both platforms). 
