### PR TITLE
Fix native attachments due to prop change

### DIFF
--- a/src/components/ImageView/index.native.js
+++ b/src/components/ImageView/index.native.js
@@ -43,9 +43,10 @@ const ImageView = (props) => {
                 imageHeight={props.height}
             >
                 <ImageWithSizeCalculation
-                    style={{width: props.width, height: props.height}}
                     url={props.url}
                     onMeasure={props.onMeasure}
+                    width={props.width}
+                    height={props.height}
                 />
             </ImgZoom>
         </View>


### PR DESCRIPTION
Think we might have missed this while testing https://github.com/Expensify/ReactNativeChat/pull/685

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/148107

### Tests
1. Open the app and login
1. Search for users and add one of the member
1. Click on attachment icon and take a picture
1. Click on use photo
1. Verify the photo is visible in the modal

### Screenshots
![Screen Shot 2020-12-11 at 10 46 26 AM](https://user-images.githubusercontent.com/32969087/101953311-3a110e80-3b9e-11eb-8671-8c9feb9c306a.png)
