### PR TITLE
[HOLD] Submit or close modal based on keyboard events

### DIFF
--- a/src/components/AttachmentModal/AttachmentModalBase.js
+++ b/src/components/AttachmentModal/AttachmentModalBase.js
@@ -55,6 +55,8 @@ class AttachmentModalBase extends Component {
         super(props);
 
         this.updateImageDimensions = this.updateImageDimensions.bind(this);
+        this.confirmAndClose = this.confirmAndClose.bind(this);
+        this.close = this.close.bind(this);
 
         // If pinToEdges is false, the default modal size will be slightly smaller than full screen
         this.modalWidth = Dimensions.get('window').width - 40;
@@ -95,6 +97,15 @@ class AttachmentModalBase extends Component {
         }
 
         this.setState({imageWidth, imageHeight});
+    }
+
+    close() {
+        this.setState({isModalOpen: false});
+    }
+
+    confirmAndClose() {
+        this.props.onConfirm(this.state.file);
+        this.close();
     }
 
     render() {
@@ -138,10 +149,7 @@ class AttachmentModalBase extends Component {
                             <TouchableOpacity
                                 style={[styles.button, styles.buttonSuccess, styles.buttonConfirm]}
                                 underlayColor={colors.componentBG}
-                                onPress={() => {
-                                    this.props.onConfirm(this.state.file);
-                                    this.setState({isModalOpen: false});
-                                }}
+                                onPress={this.confirmAndClose}
                             >
                                 <Text
                                     style={[

--- a/src/components/AttachmentModal/index.js
+++ b/src/components/AttachmentModal/index.js
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import React from 'react';
 import AttachmentModalBase from './AttachmentModalBase';
 import propTypes from './attachmentModalPropTypes';
 
@@ -7,46 +7,14 @@ const defaultProps = {
     isAuthTokenRequired: false,
 };
 
-class AttachmentModal extends Component {
-    constructor(props) {
-        super(props);
-        this.modalRef = React.createRef();
-
-        this.handleKeyboardEvent = this.handleKeyboardEvent.bind(this);
-    }
-
-    componentDidMount() {
-        document.onkeyup = this.handleKeyboardEvent;
-    }
-
-    handleKeyboardEvent(e) {
-        if (!e) {
-            return;
-        }
-
-        e.preventDefault();
-
-        if (e.key === 'Enter') {
-            this.modalRef.current.confirmAndClose();
-        }
-
-        if (e.key === 'Escape') {
-            this.modalRef.current.close();
-        }
-    }
-
-    render() {
-        return (
-            <AttachmentModalBase
-                // eslint-disable-next-line react/jsx-props-no-spreading
-                {...this.props}
-                ref={this.modalRef}
-            >
-                {this.props.children}
-            </AttachmentModalBase>
-        );
-    }
-}
+const AttachmentModal = props => (
+    <AttachmentModalBase
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...props}
+    >
+        {props.children}
+    </AttachmentModalBase>
+);
 
 AttachmentModal.propTypes = propTypes;
 AttachmentModal.defaultProps = defaultProps;

--- a/src/components/AttachmentModal/index.js
+++ b/src/components/AttachmentModal/index.js
@@ -7,14 +7,15 @@ const defaultProps = {
     isAuthTokenRequired: false,
 };
 
-const AttachmentModal = props => (
+const AttachmentModal = React.forwardRef((props, ref) => (
     <AttachmentModalBase
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...props}
+        ref={ref}
     >
         {props.children}
     </AttachmentModalBase>
-);
+));
 
 AttachmentModal.propTypes = propTypes;
 AttachmentModal.defaultProps = defaultProps;

--- a/src/components/AttachmentModal/index.js
+++ b/src/components/AttachmentModal/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {Component} from 'react';
 import AttachmentModalBase from './AttachmentModalBase';
 import propTypes from './attachmentModalPropTypes';
 
@@ -7,14 +7,46 @@ const defaultProps = {
     isAuthTokenRequired: false,
 };
 
-const AttachmentModal = props => (
-    <AttachmentModalBase
-        // eslint-disable-next-line react/jsx-props-no-spreading
-        {...props}
-    >
-        {props.children}
-    </AttachmentModalBase>
-);
+class AttachmentModal extends Component {
+    constructor(props) {
+        super(props);
+        this.modalRef = React.createRef();
+
+        this.handleKeyboardEvent = this.handleKeyboardEvent.bind(this);
+    }
+
+    componentDidMount() {
+        document.onkeyup = this.handleKeyboardEvent;
+    }
+
+    handleKeyboardEvent(e) {
+        if (!e) {
+            return;
+        }
+
+        e.preventDefault();
+
+        if (e.key === 'Enter') {
+            this.modalRef.current.confirmAndClose();
+        }
+
+        if (e.key === 'Escape') {
+            this.modalRef.current.close();
+        }
+    }
+
+    render() {
+        return (
+            <AttachmentModalBase
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                {...this.props}
+                ref={this.modalRef}
+            >
+                {this.props.children}
+            </AttachmentModalBase>
+        );
+    }
+}
 
 AttachmentModal.propTypes = propTypes;
 AttachmentModal.defaultProps = defaultProps;

--- a/src/components/AttachmentModal/index.native.js
+++ b/src/components/AttachmentModal/index.native.js
@@ -6,15 +6,16 @@ const defaultProps = {
     sourceURL: null,
 };
 
-const AttachmentModal = props => (
+const AttachmentModal = React.forwardRef((props, ref) => (
     <AttachmentModalBase
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...props}
+        ref={ref}
         pinToEdges
     >
         {props.children}
     </AttachmentModalBase>
-);
+));
 
 AttachmentModal.propTypes = propTypes;
 AttachmentModal.defaultProps = defaultProps;

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -102,9 +102,21 @@ class ReportActionCompose extends React.Component {
      * @param {Object} e
      */
     triggerSubmitShortcut(e) {
-        if (e && e.key === 'Enter' && !e.shiftKey) {
+        if (!e) {
+            return;
+        }
+
+        const modalIsOpen = lodashGet(this, ['modalRef', 'current', 'state', 'isModalOpen']);
+        if (e.key === 'Enter' && !e.shiftKey) {
             e.preventDefault();
-            this.submitForm();
+            if (modalIsOpen) {
+                this.modalRef.current.confirmAndClose();
+            } else {
+                this.submitForm();
+            }
+        } else if (e.key === 'Escape' && modalIsOpen) {
+            e.preventDefault();
+            this.modalRef.current.close();
         }
     }
 

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -159,7 +159,7 @@ class ReportActionCompose extends React.Component {
                                                 openPicker({
                                                     onPicked: (file) => {
                                                         displayFileInModal({file});
-                                                        this.modalRef.focus();
+                                                        this.textInput.focus();
                                                     },
                                                 });
                                             }}

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -41,6 +41,7 @@ class ReportActionCompose extends React.Component {
         this.submitForm = this.submitForm.bind(this);
         this.setIsFocused = this.setIsFocused.bind(this);
         this.comment = props.comment;
+        this.modalRef = React.createRef();
         this.state = {
             isFocused: false,
             textInputShouldClear: false
@@ -146,6 +147,7 @@ class ReportActionCompose extends React.Component {
                             addAction(this.props.reportID, '', file);
                             this.setTextInputShouldClear(true);
                         }}
+                        ref={this.modalRef}
                     >
                         {({displayFileInModal}) => (
                             <>
@@ -157,6 +159,7 @@ class ReportActionCompose extends React.Component {
                                                 openPicker({
                                                     onPicked: (file) => {
                                                         displayFileInModal({file});
+                                                        this.modalRef.focus();
                                                     },
                                                 });
                                             }}


### PR DESCRIPTION
There is a bug in this as-is where after the file input is closed the button that was last clicked (the paperclip) has the focus instead of the modal. I tried focusing the modal element but I'm not sure it is focusable. Not sure what the workaround here should be.

**NOTE:** This PR is held on [this one](https://github.com/Expensify/react-native-onyx/pull/24), because `withOnyx` needs to forward refs for this to work.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/148091#event-4101474960

### Tests

#### Web/Desktop
1) Open a chat.
2) Type a text message, hit `Return` to send it. Make sure that it sends.
3) Click on the paperclip to upload an attachment.
4) Choose an attachment, and hit enter or use the button to confirm your selection.
5) Immediately hit `Escape`, and verify that the modal is closed and the attachment is _not_ uploaded.
6) Repeat steps 3 and 4
7) Hit `Return` and make sure the attachment is uploaded and sent.

#### iOS/Android/mWeb
1) Open a chat.
2) Type a text message and send it. Make sure that it sends.
3) Tap the paperclip to upload an attachment.
4) Choose an attachment and send it. Make sure that it sends.

### Tested on:
- [x] Web
- [x] Desktop
- [x] iOS
- [x] Android
- [x] mWeb
