### PR TITLE
Fix keyboard dismiss when toggling hamburger menu

### DIFF
--- a/src/pages/home/HomePage.js
+++ b/src/pages/home/HomePage.js
@@ -175,6 +175,9 @@ class App extends React.Component {
             return;
         }
 
+        // Dismiss keyboard before toggling sidebar
+        Keyboard.dismiss();
+
         // If the hamburger currently is not shown, we want to make it visible before the animation
         if (!this.props.isSidebarShown) {
             showSidebar();
@@ -182,7 +185,6 @@ class App extends React.Component {
         }
 
         // Otherwise, we want to hide it after the animation
-        Keyboard.dismiss();
         this.animateHamburger(true);
     }
 


### PR DESCRIPTION
Previously the flow of toggle hamburger function was linear, so keyboard was always dismissed on click:

```javascript
        const hamburgerIsShown = this.state.hamburgerShown;

        // If the hamburger currently is not shown, we want to immediately make it visible for the animation
        if (!hamburgerIsShown) {
            this.setState({hamburgerShown: true});
        }
        Keyboard.dismiss();
        this.animateHamburger(hamburgerIsShown);
```

But later the logic was changed and early return was added. So keyboard was dismissed only during sidebar hiding.

```javascript
        // If the hamburger currently is not shown, we want to make it visible before the animation
        if (!this.props.isSidebarShown) {
            showSidebar();
            return;
        }

        // Otherwise, we want to hide it after the animation
        Keyboard.dismiss();
        this.animateHamburger(true);
```

This pull request moves `Keyboard.dismiss()` to the top, so dismiss would happen in any case.

### Fixed Issues
Fixes #937  

### Tests

Build to iOS and Android. On each platform:

1. Start the app
2. Open a chat with someone (for example, tap the hamburger menu, type in `concierge@` in the text box, and tap on the `Concierge` user)
3. Tap inside the message compose textbox, confirm the keyboard appears
4. Click hamburger menu
5. Confirm the keyboard is dismissed

### Screenshots

**Issue:**

![issue](https://user-images.githubusercontent.com/130532/102209525-8e3b2c00-3ed9-11eb-85c9-98d0c56f9014.gif)

**Fixed:**

iOS
![fixed_ios](https://user-images.githubusercontent.com/130532/102209853-11f51880-3eda-11eb-8a44-ed91d5de28bd.gif)

Android
![fixed_android](https://user-images.githubusercontent.com/130532/102210607-0d7d2f80-3edb-11eb-957a-f91995acdc5b.gif)
