### PR TITLE
Fix issue where flexGrow change was ignored

### DIFF
--- a/src/pages/home/sidebar/SidebarLinks.js
+++ b/src/pages/home/sidebar/SidebarLinks.js
@@ -86,9 +86,14 @@ const SidebarLinks = (props) => {
     const sidebarLinksStyle = !props.isChatSwitcherActive
         ? [styles.sidebarListContainer]
         : [styles.sidebarListContainer, styles.dNone];
+
+    const chatSwitcherStyle = props.isChatSwitcherActive
+        ? [styles.sidebarHeader, styles.flexGrow1]
+        : [styles.sidebarHeader, styles.flexGrow0];
+
     return (
         <View style={[styles.flex1, {marginTop: props.insets.top}]}>
-            <View style={[styles.sidebarHeader]}>
+            <View style={[chatSwitcherStyle]}>
                 <ChatSwitcherView
                     onLinkClick={props.onLinkClick}
                     isChatSwitcherActive={props.isChatSwitcherActive}

--- a/src/styles/StyleSheet.js
+++ b/src/styles/StyleSheet.js
@@ -138,6 +138,10 @@ const styles = {
         flexWrap: 'wrap',
     },
 
+    flexGrow0: {
+        flexGrow: 0,
+    },
+
     flexGrow1: {
         flexGrow: 1,
     },
@@ -404,8 +408,6 @@ const styles = {
         paddingRight: 12,
         paddingBottom: 16,
         paddingLeft: 12,
-        flex: 1,
-        flexGrow: 0,
     },
 
     sidebarHeaderLogo: {


### PR DESCRIPTION
Fixes issue where chat switcher search results would not display. Mobile apps did not like the use of both `flex` and `flexBox`. 

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/148241

### Tests

- Open LHN
- Tap the chat switcher to gain focus
- Enter some text
- Results should appear
- Tap the x button to loose focus
- Tap the chat switcher again to gain focus
- Enter some text
- Results should appear

### Screenshots
N/A
