### PR TITLE
Fix to show email in chat switcher

### DIFF
--- a/src/pages/home/sidebar/ChatSwitcherView.js
+++ b/src/pages/home/sidebar/ChatSwitcherView.js
@@ -162,7 +162,7 @@ class ChatSwitcherView extends React.Component {
                 const login = isSingleUserDM ? report.participants[0] : '';
                 return {
                     text: report.reportName,
-                    alternateText: report.reportName,
+                    alternateText: isSingleUserDM ? login : report.reportName,
                     searchText: report.participants < 10
                         ? `${report.reportName} ${report.participants.join(' ')}`
                         : report.reportName ?? '',


### PR DESCRIPTION
### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/148109

### Tests
1. Click on chat search
1. Confirm emails show up if they exist
![image](https://user-images.githubusercontent.com/14356145/102124786-8d34cc80-3dfd-11eb-9e16-ad0e739a5f7b.png)
1. Type a user and confirm the email still shows
![image](https://user-images.githubusercontent.com/14356145/102124849-a178c980-3dfd-11eb-97cd-b8e09e2172ab.png)

Can't take mobile screenshots at the moment since chat switcher is broken on mobile ([context](https://expensify.slack.com/archives/C011W8BJ9L6/p1607964078411900))