### PR TITLE
Change back to path-to-document

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -18,7 +18,8 @@ jobs:
                   PERSONAL_ACCESS_TOKEN : ${{ secrets.BOTIFY_TOKEN }}
               with:
                   path-to-signatures: '${{ github.repository }}/cla.json'
-                  path-to-cla-document: 'https://github.com/${{ github.repository }}/blob/master/CLA.md'
+                  path-to-document: 'https://github.com/${{ github.repository }}/blob/master/CLA.md'
                   branch: 'master'
                   remote-organization-name: 'Expensify'
                   remote-repository-name: 'CLA'
+                  allowlist: botify


### PR DESCRIPTION
@Jag96 - Please review

Once again trying to fix the path to the CLA document. In addition, I added botify to the allowlist so that the bot can merge PRs without the need to sign the CLA as seen here: https://github.com/Expensify/ReactNativeChat/runs/1552791965

### Tests
1. @Jag96 is going to merge this into `master`
2. @Jag96 is going to make a PR
3. We are going to verify the link works
4. I will verify that the version is built without error from botify
