### PR TITLE
Adding param to authenticate

### DIFF
--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -226,6 +226,7 @@ function Authenticate(parameters) {
         partnerUserSecret: parameters.partnerUserSecret,
         twoFactorAuthCode: parameters.twoFactorAuthCode,
         doNotRetry: true,
+        isViaExpensifyCash: true,
 
         // Force this request to be made because the network queue is paused when re-authentication is happening
         forceNetworkRequest: true,


### PR DESCRIPTION
### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/147629

### Tests
1. Make sure you have this [Web-E](https://github.com/Expensify/Web-Expensify/pull/29867) and [Auth-PR](https://github.com/Expensify/Auth/pull/5091) code. Run grunt for web-e and make for auth if you haven't.
1. Open chat. Signout if you were signed in.
1. Enter email and password and confirm you see the error message `405 Unauthorized - NVP to access Expensify cash is missing` 
![image](https://user-images.githubusercontent.com/14356145/102142830-e3166e00-3e17-11eb-9fab-81d933a7a02d.png)
(this is because you don't have the NVP the first time)
1. Open sql.sh and run, 
```
insert into nameValuePairs (accountID, name, value, created) values (<your_account_ID>, 'private_canAccessExpensifyCash', 1, '2020-12-14 22:51:34');
```
1. Attempt to sign in again and confirm you are able to without any error.
