### PR TITLE
Fix zoom in hotkey on mac

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -67,6 +67,12 @@ const mainWindow = (() => {
                     click: () => { browserWindow.webContents.goForward(); }
                 }]
             }));
+
+            // On mac, pressing cmd++ actually sends a cmd+=. cmd++ is generally the zoom in shortcut, but this is
+            // not properly listened for by electron. Adding in an invisible cmd+= listener fixes this.
+            const viewWindow = systemMenu.items.find(item => item.role === 'viewmenu');
+            viewWindow.submenu.append(new MenuItem({role: 'zoomin', accelerator: 'CommandOrControl+=', visible: false}));
+            
             const windowMenu = systemMenu.items.find(item => item.role === 'windowmenu');
             windowMenu.submenu.append(new MenuItem({type: 'separator'}));
             windowMenu.submenu.append(new MenuItem({

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -71,8 +71,11 @@ const mainWindow = (() => {
             // On mac, pressing cmd++ actually sends a cmd+=. cmd++ is generally the zoom in shortcut, but this is
             // not properly listened for by electron. Adding in an invisible cmd+= listener fixes this.
             const viewWindow = systemMenu.items.find(item => item.role === 'viewmenu');
-            viewWindow.submenu.append(new MenuItem({role: 'zoomin', accelerator: 'CommandOrControl+=', visible: false}));
-            
+            viewWindow.submenu.append(new MenuItem({
+                role: 'zoomin',
+                accelerator: 'CommandOrControl+=',
+                visible: false
+            }));
             const windowMenu = systemMenu.items.find(item => item.role === 'windowmenu');
             windowMenu.submenu.append(new MenuItem({type: 'separator'}));
             windowMenu.submenu.append(new MenuItem({


### PR DESCRIPTION
I hate this fix. Electron has an [open issue](https://github.com/electron/electron/issues/15496), that has not been acted on for months. This solution was brought up in the thread.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/147925

### Tests
Desktop only
1. Press `cmd` and `=`
1. _Verify_ you were zoomed in
1. Press `cmd` `shift` `=`
1. _Verify_ you were zoomed in further
1. Reset your zoom with `cmd` `0`
1. Open the `View` menu
1. _Verify_ there is only 1 shortcut listed for Zoom In
![image](https://user-images.githubusercontent.com/22447860/102155751-039ef200-3e31-11eb-8678-993fcb89cf0d.png)


### Screenshots
Screenshot above