### PR TITLE
Fix chat jumper list on mobile Web (mobile Safari)

### DIFF
--- a/src/pages/home/sidebar/SidebarLinks.js
+++ b/src/pages/home/sidebar/SidebarLinks.js
@@ -91,7 +91,7 @@ const SidebarLinks = (props) => {
         : [styles.sidebarHeader];
 
     return (
-        <View style={[styles.flex1, {marginTop: props.insets.top}]}>
+        <View style={[styles.flex1, styles.height100percent, {marginTop: props.insets.top}]}>
             <View style={[chatSwitcherStyle]}>
                 <ChatSwitcherView
                     onLinkClick={props.onLinkClick}

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -176,6 +176,10 @@ const styles = {
         overflow: 'hidden',
     },
 
+    height100percent: {
+        height: '100%',
+    },
+
     h4: {
         fontFamily: fontFamily.GTA_BOLD,
         fontSize: variables.fontSizeLabel,
@@ -406,6 +410,7 @@ const styles = {
     // Sidebar Styles
     sidebar: {
         backgroundColor: themeColors.sidebar,
+        height: '100%',
     },
 
     sidebarHeader: {


### PR DESCRIPTION
This is a quick fix to fix the chat jumper from making the entire app body overflow when viewed in a mobile web browser. 

Note: I am currently having trouble running the native mobile apps locally, so whoever goes to review this PR, I am hoping you can help me test this. 

cc @jboniface 




### Fixed Issues
$ https://github.com/Expensify/Expensify.cash/issues/989
$ https://github.com/Expensify/Expensify/issues/145533

### Tests
1. Run the Expensify.cash app in mobile Safari. You can do this via the Simulator by launching Safari and navigating to the app from there. 
1. Use the chat switcher and make sure you can scroll down the list without the entire app body moving around

### Screenshots
Before:
![102403636-92884780-3fb4-11eb-9a76-4f44bcac5ecb](https://user-images.githubusercontent.com/2319350/102421565-936fa800-3fb9-11eb-9665-9efafc3666e3.gif)



After:
![HR4HRnQa9C](https://user-images.githubusercontent.com/2319350/102421570-98345c00-3fb9-11eb-89b2-c02a653adf79.gif)
