### PR TITLE
Unixon-solutions fixed textbox bug

### DIFF
--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -144,7 +144,7 @@ class ReportActionCompose extends React.Component {
                         title="Upload Attachment"
                         onConfirm={(file) => {
                             addAction(this.props.reportID, '', file);
-                            this.setTextInputShouldClear(true);
+                            //this.setTextInputShouldClear(true);
                         }}
                     >
                         {({displayFileInModal}) => (

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -144,7 +144,6 @@ class ReportActionCompose extends React.Component {
                         title="Upload Attachment"
                         onConfirm={(file) => {
                             addAction(this.props.reportID, '', file);
-                            //this.setTextInputShouldClear(true);
                         }}
                     >
                         {({displayFileInModal}) => (


### PR DESCRIPTION
<Assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit.>

<Explanation of the change or anything fishy that is going on>
@Unixon-solutions  fixed textbox bug, Text in compose box disappears when photo is uploaded


### Fixed Issues
Fixes https://github.com/Expensify/ReactNativeChat/issues/895

### Tests

1. Run the web app
2. Sign in to an account
3. Open the left-hand navigation and search for your test user to chat with. Select the user.
4. Type a message in the compose text box at the bottom of the chat, but do not submit it.
5. Hit the paperclip icon on the left side of the text box and select an image.
6. While the image is uploading, see the text you typed in step 4 not disappearing.

### Gif Link

https://we.tl/t-3jBkqNLk7e
<Add any necessary screenshots for all platforms if your change added or updated UI>