### PR TITLE
Make the sender name appear in the bold weight font, fix overflow issues

### DIFF
--- a/src/pages/home/sidebar/SidebarBottom.js
+++ b/src/pages/home/sidebar/SidebarBottom.js
@@ -61,7 +61,7 @@ const SidebarBottom = ({myPersonalDetails, network, insets}) => {
             </View>
             <View style={[styles.flexColumn]}>
                 {myPersonalDetails.displayName && (
-                    <Text style={[styles.sidebarFooterUsername]}>
+                    <Text style={[styles.sidebarFooterUsername]} numberOfLines={1}>
                         {myPersonalDetails.displayName}
                     </Text>
                 )}

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -454,6 +454,10 @@ const styles = {
         color: themeColors.heading,
         fontSize: variables.fontSizeLabel,
         fontWeight: '700',
+        width: 200,
+        textOverflow: 'ellipsis',
+        overflow: 'hidden',
+        whiteSpace: 'nowrap',
     },
 
     sidebarFooterLink: {
@@ -632,16 +636,18 @@ const styles = {
         alignItems: 'center',
         display: 'flex',
         flexDirection: 'row',
+        flexWrap: 'wrap',
     },
 
     chatItemMessageHeaderSender: {
         color: themeColors.heading,
+        fontFamily: fontFamily.GTA_BOLD,
         fontSize: variables.fontSizeNormal,
-        height: 24,
+        fontWeight: fontWeightBold,
         lineHeight: 20,
-        fontWeight: '600',
         paddingRight: 5,
         paddingBottom: 4,
+        wordBreak: 'break-word',
     },
 
     chatItemMessageHeaderTimestamp: {


### PR DESCRIPTION
This makes the message sender name appear in the correct bold weight font, and fixes overflow issues in the message sender header as well as the sidebar footer when usernames are super long.


### Fixed Issues
N/A, but relevant discussion here: https://expensify.slack.com/archives/C03U7DCU4/p1608314618489300

### Tests
1. Open up a chat and start sending messages, make sure the sender name appears in bold
2. Sign up with a super long email address and make sure it is truncated properly in the Left Hand Navigation footer, and make sure the sender line with Sender Name + Timestamp breaks to two lines on smaller viewports (mobile).

### Screenshots
![image](https://user-images.githubusercontent.com/2319350/102657677-f0d73680-412a-11eb-8c74-9f474ec994e7.png)

![image](https://user-images.githubusercontent.com/2319350/102657686-f5035400-412a-11eb-8f0b-b470f9f9b41c.png)

![image](https://user-images.githubusercontent.com/2319350/102657805-33007800-412b-11eb-8241-3713264bcb80.png)

![image](https://user-images.githubusercontent.com/2319350/102657873-50cddd00-412b-11eb-8cb7-fb94a39560a9.png)
