### PR TITLE
Update names of events to be a little less specific

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -17,8 +17,8 @@ const CONST = {
         HOMEPAGE_INITIAL_RENDER: 'homepage_initial_render',
         HOMEPAGE_REPORTS_LOADED: 'homepage_reports_loaded',
         SWITCH_REPORT: 'switch_report',
-        PINNED: 'pinned',
-        UNPINNED: 'unpinned'
+        HOT: 'hot',
+        COLD: 'cold'
     }
 };
 

--- a/src/pages/home/report/ReportView.js
+++ b/src/pages/home/report/ReportView.js
@@ -23,12 +23,12 @@ class ReportView extends React.PureComponent {
     componentDidMount() {
         subscribeToReportTypingEvents(this.props.reportID);
 
-        Timing.end(CONST.TIMING.SWITCH_REPORT, CONST.TIMING.UNPINNED);
+        Timing.end(CONST.TIMING.SWITCH_REPORT, CONST.TIMING.COLD);
     }
 
     componentDidUpdate(props) {
         if (!props.isActiveReport) {
-            Timing.end(CONST.TIMING.SWITCH_REPORT, CONST.TIMING.PINNED);
+            Timing.end(CONST.TIMING.SWITCH_REPORT, CONST.TIMING.HOT);
         }
     }
 


### PR DESCRIPTION
These names probably better reflect what we care about. We care if the report was in the DOM already (and it is quick to switch to) or it was not in the DOM (and slow to switch to)

### Fixed Issues
From [this slack thread](https://expensify.slack.com/archives/C011W8BJ9L6/p1608326431327600)

### Tests
1. Log into the chat app
2. Switch between chats that are either pinned or unpinned
3. Verify the events are logged to the API
