### PR TITLE
chat clip alignment fix

### DIFF
--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -711,6 +711,7 @@ const styles = {
     chatItemSubmitButtonIcon: {
         height: 20,
         width: 20,
+        margin: 'auto',
     },
 
     reportPinIcon: {


### PR DESCRIPTION
<If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit.>

### Details
icon is displayed off-center when it should be centered. This occurs on initial load of the application but disappears upon refresh

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/941

### Screencast

Sharing the screencast which shows the fix.

In the recording, you'll observe that I first run the code locally in Incognito Browser, login and see the misaligned clip icon issue. Then I pause the recording, add the fix to the code, resume recording and run the code in a new instance of Incognito Browser. Post login you can see that the clip icon is properly centered.

https://user-images.githubusercontent.com/5907784/102803813-d9c06f00-43de-11eb-8161-951d50c942e2.mp4


