### PR TITLE
Allow users to search for chats by email 

### DIFF
--- a/src/pages/home/sidebar/ChatSwitcherView.js
+++ b/src/pages/home/sidebar/ChatSwitcherView.js
@@ -163,8 +163,8 @@ class ChatSwitcherView extends React.Component {
                 return {
                     text: report.reportName,
                     alternateText: isSingleUserDM ? login : report.reportName,
-                    searchText: report.participants < 10
-                        ? `${report.reportName} ${report.participants.join(' ')}`
+                    searchText: participants.length < 10
+                        ? `${report.reportName} ${participants.join(' ')}`
                         : report.reportName ?? '',
                     reportID: report.reportID,
                     participants,


### PR DESCRIPTION
cc: @chiragsalian this was introduced in https://github.com/Expensify/Expensify.cash/pull/759 just FYI 

### Details
Ensures we can search for chats by email address instead of just display name

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/148728

### Tests
1. Create a user with a different display name than their email address 
2. Create a DM with that user
3. Create a group message with that user
4. Search for the user's email in your search bar and confirm you can see all of the relevant chats populated. 

![Screen Shot 2020-12-21 at 12 13 31 PM](https://user-images.githubusercontent.com/16747822/102804395-b3231980-4387-11eb-84a1-537eaf516126.png)
