### PR TITLE
[WIP] Use Report_GetHistory offset

### DIFF
--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -380,7 +380,13 @@ function fetchChatReports() {
  * @param {Number} reportID
  */
 function fetchActions(reportID) {
-    API.Report_GetHistory({reportID})
+    API.Report_GetHistory({
+        reportID,
+
+        // Get the most recent action we have and provide this as an offset
+        // to prevent refetching large sets of data we already have
+        offset: reportMaxSequenceNumbers[reportID] || 0,
+    })
         .then((data) => {
             const indexedData = _.indexBy(data.history, 'sequenceNumber');
             const maxSequenceNumber = _.chain(data.history)


### PR DESCRIPTION
### Details
This is how the most basic pagination has been working for realtime report comments for a while. For some reason we never implemented this. We should do so now in an effort to reduce the total data that is processed and merged on reconnection callbacks / when first fetching a chat.

### Fixed Issues (Possibly Related)
Fixes https://github.com/Expensify/Expensify/issues/148102

This isn't going to fix that issue, but might improve it somewhat. I think ideally we will need to consolidate these into fewer API calls since that is the real bottleneck.

### Tests
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### Screenshots
<Add any necessary screenshots for all platforms if your change added or updated UI>
