### PR TITLE
Use valid accessibility role in SignIn form

### DIFF
--- a/src/pages/SignInPage.js
+++ b/src/pages/SignInPage.js
@@ -86,7 +86,7 @@ class App extends Component {
             <>
                 <CustomStatusBar />
                 <SafeAreaView style={[styles.signInPage]}>
-                    <View style={[styles.signInPageInner]} accessibilityRole="form">
+                    <View style={[styles.signInPageInner]} accessibilityRole="menu">
                         <View style={[styles.signInPageLogo]}>
                             <Image
                                 resizeMode="contain"


### PR DESCRIPTION
cc @AndrewGable 

### Details
There was an invalid `accessibilityRole` provided to a component that causes a breaking change on iOS:

![image](https://user-images.githubusercontent.com/47436092/102828461-a3accc00-4399-11eb-9a4b-2db0b2c7b889.png)

Replaced with a valid one from [this list](https://reactnative.dev/docs/view#accessibilityrole)

### Fixed Issues
N/A

### Tests
Run the application, and make sure you don't see that error ^.

#### Tested on:

- [x] iOS
- [x] Web
- [ ] Android
- [x] Desktop
- [x] mWeb 
