### PR TITLE
Prompt error on iOS when camera access is disallowed

### DIFF
--- a/src/components/AttachmentPicker/index.native.js
+++ b/src/components/AttachmentPicker/index.native.js
@@ -1,6 +1,7 @@
 /**
  * The react native image/document pickers work for iOS/Android, but we want to wrap them both within AttachmentPicker
  */
+import {Alert, Linking} from 'react-native';
 import RNImagePicker from 'react-native-image-picker';
 import RNDocumentPicker from 'react-native-document-picker';
 import PropTypes from 'prop-types';
@@ -51,6 +52,23 @@ function showDocumentPicker(callback) {
 function show(callback) {
     RNImagePicker.showImagePicker(imagePickerOptions, (response) => {
         if (response.error) {
+            if (response.error === 'Camera permissions not granted') {
+                Alert.alert(
+                    'ExpensifyCash does not have access to your camera. To enable access, tap Settings and turn on Camera.',
+                    '',
+                    [
+                        {
+                            text: 'Cancel',
+                            style: 'cancel',
+                        },
+                        {
+                            text: 'Settings',
+                            onPress: () => Linking.openURL('app-settings:'),
+                        },
+                    ],
+                    {cancelable: false},
+                );
+            }
             console.debug(`Error during attachment selection: ${response.error}`);
         } else if (response.customButton) {
             showDocumentPicker(callback);

--- a/src/components/AttachmentPicker/index.native.js
+++ b/src/components/AttachmentPicker/index.native.js
@@ -54,6 +54,7 @@ function show(callback) {
         if (response.error) {
             if (response.error === 'Camera permissions not granted') {
                 Alert.alert(
+                    // eslint-disable-next-line max-len
                     'ExpensifyCash does not have access to your camera. To enable access, tap Settings and turn on Camera.',
                     '',
                     [


### PR DESCRIPTION
### Details

### Fixed Issues
When tapping "Take Photo", the app should request permission to access the camera.

### Tests
Prerequisite: Allow Expensify.Cash to access: Camera is disabled in device settings
1. Open the app on iOS and log in
2. Tap on the text input field (bottom of screen)
3. Tap the attachment icon (shown as a paperclip)
4. Tap on "Take Photo"

### Screenshots
