### PR TITLE
Use the account key instead of a report key

### DIFF
--- a/src/pages/signin/PasswordForm.js
+++ b/src/pages/signin/PasswordForm.js
@@ -118,8 +118,6 @@ PasswordForm.defaultProps = defaultProps;
 export default compose(
     withRouter,
     withOnyx({
-        account: {
-            key: ({match}) => `${ONYXKEYS.COLLECTION.REPORT}${match.params.reportID}`,
-        },
+        account: {key: ONYXKEYS.ACCOUNT},
     }),
 )(PasswordForm);


### PR DESCRIPTION
### Details
Just fixing a key so that we properly get the account information from Onyx
### Fixed Issues
https://github.com/Expensify/Expensify/issues/148721

### Tests
1. Go to e.cash and try to sign into an account that requires 2fa
2. Make sure when you get to the password field there is also a 2fa field
3. Sign in
