### PR TITLE
Cancel 404 redirect for now

### DIFF
--- a/src/pages/home/MainView.js
+++ b/src/pages/home/MainView.js
@@ -8,8 +8,6 @@ import ONYXKEYS from '../../ONYXKEYS';
 import styles from '../../styles/styles';
 import {withRouter} from '../../libs/Router';
 import compose from '../../libs/compose';
-import ROUTES from '../../ROUTES';
-import {redirect} from '../../libs/actions/App';
 
 const propTypes = {
     // This comes from withRouter
@@ -29,40 +27,6 @@ const defaultProps = {
 };
 
 class MainView extends Component {
-    componentDidMount() {
-        const reportID = parseInt(this.props.match.params.reportID, 10);
-        this.canViewReport(reportID);
-    }
-
-    componentDidUpdate(prevProps) {
-        const previousReportID = parseInt(prevProps.match.params.reportID, 10);
-        const newReportID = parseInt(this.props.match.params.reportID, 10);
-
-        if (previousReportID !== newReportID) {
-            this.canViewReport(newReportID);
-        }
-    }
-
-    /**
-     * Check to see if this report exists in the report list and if not redirect to 404.
-     *
-     * @param {Number} reportID
-     */
-    canViewReport(reportID) {
-        // If we do not have a valid reportID then we cannot check for access.
-        if (_.isNaN(reportID)) {
-            return;
-        }
-
-        // If the user has this report in their report list then we assume they can access it.
-        if (_.find(this.props.reports, report => report.reportID === reportID)) {
-            return;
-        }
-
-        // Report doesn't exist redirect to /404.
-        redirect(ROUTES.NOT_FOUND);
-    }
-
     render() {
         const reportIDInUrl = parseInt(this.props.match.params.reportID, 10);
 


### PR DESCRIPTION
### Details
There is no practical reason for why we'd need a 404 page yet and the original solution has issues. Mainly, it only works for `exitTo` if the reports load before the App mounts which will never happen

### Fixed Issues
No Issue context here ->

### Tests
1. Log in successfully by any means necessary
2. Log out
3. Log in again while the `exitTo` param is present
4. Verify you are not brought to the 404 page

### Screenshots
❌ 