### PR TITLE
adding-self-to-chat-group

### DIFF
--- a/src/pages/home/sidebar/ChatSwitcherView.js
+++ b/src/pages/home/sidebar/ChatSwitcherView.js
@@ -481,7 +481,7 @@ class ChatSwitcherView extends React.Component {
                     onConfirmUsers={this.startGroupChat}
                 />
 
-                {this.state.usersToStartGroupReportWith.length === MAX_GROUP_DM_LENGTH
+                {this.state.usersToStartGroupReportWith.filter(v => v.login !== this.props.session.email).length === MAX_GROUP_DM_LENGTH
                     ? (
                         <View style={[styles.chatSwitcherMessage]}>
                             <Text style={[styles.h4, styles.mb1]}>


### PR DESCRIPTION
<If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit.>

### Details
<Explanation of the change or anything fishy that is going on>
Per Lauren Reid via upwork: 
We have a bug in our cross-platform React Native application on all platforms (web, iOS, Android, desktop) where a user is able to add themselves to a group. Doing so, and adding other members to the chat as well, results in the max number of group participants being reached one user too early (as your 'own' user should not count towards this limit).

Per the code, the limit is 8

### Fixed Issues
[985](https://github.com/Expensify/Expensify.cash/issues/985)

Removed self from the length of state variable usersToStartGroupReportWith 

### Tests
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->
Mocked a state usersToStartGroupReportWith on component ChatSwitcherView with a length of 8
Add another unique user and verified the "Maximum participants reached" appears
Add self and verified the "Maximum participants reached" did not appear

### Screenshots
<Add any necessary screenshots for all platforms if your change added or updated UI>
