### PR TITLE
Do not toggle sidebar menu if window width hasn't changed

### DIFF
--- a/src/pages/home/HomePage.js
+++ b/src/pages/home/HomePage.js
@@ -56,6 +56,7 @@ class App extends React.Component {
         super(props);
 
         this.state = {
+            windowWidth: windowSize.width,
             isHamburgerEnabled: windowSize.width <= variables.mobileResponsiveWidthBreakpoint,
         };
 
@@ -123,7 +124,16 @@ class App extends React.Component {
      * @param {Object} changedWindow
      */
     toggleHamburgerBasedOnDimensions({window: changedWindow}) {
-        this.setState({isHamburgerEnabled: changedWindow.width <= variables.mobileResponsiveWidthBreakpoint});
+        if (this.state.windowWidth === changedWindow.width) {
+            // Window width hasn't changed, don't toggle sidebar
+            return;
+        }
+
+        this.setState({
+            windowWidth: changedWindow.width,
+            isHamburgerEnabled: changedWindow.width <= variables.mobileResponsiveWidthBreakpoint
+        });
+
         if (!this.props.isSidebarShown && changedWindow.width > variables.mobileResponsiveWidthBreakpoint) {
             showSidebar();
         } else if (this.props.isSidebarShown && changedWindow.width < variables.mobileResponsiveWidthBreakpoint) {


### PR DESCRIPTION
### Details

The root cause of the issue is `toggleHamburgerBasedOnDimensions` function.

```javascript
    /**
     * Fired when the windows dimensions changes
     * @param {Object} changedWindow
     */
    toggleHamburgerBasedOnDimensions({window: changedWindow}) {
        this.setState({isHamburgerEnabled: changedWindow.width <= variables.mobileResponsiveWidthBreakpoint});
        if (!this.props.isSidebarShown && changedWindow.width > variables.mobileResponsiveWidthBreakpoint) {
            showSidebar();
        } else if (this.props.isSidebarShown && changedWindow.width < variables.mobileResponsiveWidthBreakpoint) {
            hideSidebar();
        }
    }
```

On each dimensions change it checks if current window width is less then mobile breakpoint, and if it is, then it hides the sidebar.

This is what's happening here:

1. In mobile browser user has keyboard on screen. `Window height` equals `screen height` minus `keyboard height`.
2. User clicks Hamburger menu.
3. Sidebar is opening, and it hides the keyboard.
4. Now `window height` equals just `screen height`. It triggers `Dimensions change` event.
5. `toggleHamburgerBasedOnDimensions` is triggered. It checks if width is below breakpoint, and hides the sidebar, which had just appeared.

For more fun try to open sidebar and focus on the search input. And then try to open sidebar again.

It doesn't happen in native apps, because keyboard appearing/disappearing doesn't change window height. It doesn't happen in desktop browsers for obvious reasons.

The simplest fix would be to check if width has changed, and toggle sidebar only if it has. Unfortunately, `Dimensions change` event passes only current window sizes, so it's not `prevProps !== nextProps` case.

The solution: we should save initial window width in the state, compare it with value passed by `Dimensions change`, ignore the change if width is the same (or toggle sidebar if it isn't, and then save the new width in the state).

### Fixed Issues
Fixes #998 
Fixes #1001

### Tests

1. Run the web app.
2. Open web app in the browser on mobile.
3. Log in. If input is not focused on login, click on the input and wait for keyboard to appear.
4. Click on hamburger menu.
5. Verify that keyboard disappears, sidebar appears and stays on screen.
6. Click on chat search box.
7. Verify that keyboard appears, but sidebar stays on screen and search box is usable.

### Screenshots

**Issue:**
![menu-flash-issue](https://user-images.githubusercontent.com/130532/103045735-5a719d80-458e-11eb-8591-cb2c199ccbbd.gif)

**Fixed:**

Android
![menu-flash-fixed-android](https://user-images.githubusercontent.com/130532/103045770-7a08c600-458e-11eb-9ab3-e6834e3b8e71.gif)

iOS
![menu-flash-fixed-ios](https://user-images.githubusercontent.com/130532/103045788-8725b500-458e-11eb-9663-6a9fa3b879df.gif)
