### PR TITLE
Reduce performance impacts of reconnection callbacks by optimizing re-renders of Image components with uri source

### DIFF
--- a/src/components/AttachmentView.js
+++ b/src/components/AttachmentView.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {memo} from 'react';
 import {View, Image, Text} from 'react-native';
 import PropTypes from 'prop-types';
 import Str from 'expensify-common/lib/str';
@@ -59,4 +59,4 @@ AttachmentView.propTypes = propTypes;
 AttachmentView.defaultProps = defaultProps;
 AttachmentView.displayName = 'AttachmentView';
 
-export default AttachmentView;
+export default memo(AttachmentView);

--- a/src/components/Avatar.js
+++ b/src/components/Avatar.js
@@ -1,0 +1,30 @@
+import React, {memo} from 'react';
+import {Image} from 'react-native';
+import PropTypes from 'prop-types';
+import styles from '../styles/styles';
+
+const propTypes = {
+    // Url source for the avatar
+    source: PropTypes.string.isRequired,
+
+    // Extra styles to pass
+    style: PropTypes.arrayOf(PropTypes.any),
+};
+
+const defaultProps = {
+    style: [],
+};
+
+const Avatar = ({source, style}) => (
+    <Image
+        source={{uri: source}}
+        style={[
+            styles.avatarNormal,
+            ...style,
+        ]}
+    />
+);
+
+Avatar.defaultProps = defaultProps;
+Avatar.propTypes = propTypes;
+export default memo(Avatar);

--- a/src/components/ImageView/index.js
+++ b/src/components/ImageView/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {memo} from 'react';
 import PropTypes from 'prop-types';
 import {View, Image} from 'react-native';
 import styles from '../../styles/styles';
@@ -28,4 +28,4 @@ const ImageView = props => (
 ImageView.propTypes = propTypes;
 ImageView.displayName = 'ImageView';
 
-export default ImageView;
+export default memo(ImageView);

--- a/src/components/ImageWithSizeCalculation.js
+++ b/src/components/ImageWithSizeCalculation.js
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import React, {PureComponent} from 'react';
 import {Image} from 'react-native';
 import PropTypes from 'prop-types';
 
@@ -25,7 +25,7 @@ const defaultProps = {
  * performing some calculation on a network image after fetching dimensions so
  * it can be appropriately resized.
  */
-class ImageWithSizeCalculation extends Component {
+class ImageWithSizeCalculation extends PureComponent {
     constructor(props) {
         super(props);
         this.isComponentMounted = false;

--- a/src/components/PDFView/index.js
+++ b/src/components/PDFView/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {memo} from 'react';
 import PropTypes from 'prop-types';
 import {WebView} from 'react-native-webview';
 import CONST from '../../CONST';
@@ -35,4 +35,4 @@ PDFView.propTypes = propTypes;
 PDFView.defaultProps = defaultProps;
 PDFView.displayName = 'PDFView';
 
-export default PDFView;
+export default memo(PDFView);

--- a/src/components/ThumbnailImage.js
+++ b/src/components/ThumbnailImage.js
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import React, {PureComponent} from 'react';
 import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import {withOnyx} from 'react-native-onyx';
@@ -28,7 +28,7 @@ const defaultProps = {
     style: {},
 };
 
-class ThumbnailImage extends Component {
+class ThumbnailImage extends PureComponent {
     constructor(props) {
         super(props);
 

--- a/src/pages/home/report/ReportActionItemSingle.js
+++ b/src/pages/home/report/ReportActionItemSingle.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View, Image} from 'react-native';
+import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
 import ReportActionPropTypes from './ReportActionPropTypes';
@@ -8,6 +8,7 @@ import ReportActionItemFragment from './ReportActionItemFragment';
 import styles from '../../../styles/styles';
 import CONST from '../../../CONST';
 import ReportActionItemDate from './ReportActionItemDate';
+import Avatar from '../../../components/Avatar';
 
 const propTypes = {
     // All the data of the action
@@ -20,9 +21,9 @@ const ReportActionItemSingle = ({action}) => {
         : action.avatar;
     return (
         <View style={[styles.chatItem]}>
-            <Image
-                source={{uri: avatarUrl}}
+            <Avatar
                 style={[styles.actionAvatar]}
+                source={avatarUrl}
             />
             <View style={[styles.chatItemRight]}>
                 <View style={[styles.chatItemMessageHeader]}>

--- a/src/pages/home/sidebar/ChatLinkRow.js
+++ b/src/pages/home/sidebar/ChatLinkRow.js
@@ -14,6 +14,7 @@ import ROUTES from '../../../ROUTES';
 import pencilIcon from '../../../../assets/images/icon-pencil.png';
 import PressableLink from '../../../components/PressableLink';
 import CONST from '../../../CONST';
+import Avatar from '../../../components/Avatar';
 
 const propTypes = {
     // Option to allow the user to choose from can be type 'report' or 'user'
@@ -80,10 +81,7 @@ const ChatLinkRow = ({
                         !_.isEmpty(option.icon)
                         && (
                             <View style={[styles.chatSwitcherAvatar, styles.mr3]}>
-                                <Image
-                                    source={{uri: option.icon}}
-                                    style={[styles.chatSwitcherAvatarImage]}
-                                />
+                                <Avatar source={option.icon} />
                             </View>
                         )
                     }

--- a/src/pages/home/sidebar/SidebarBottom.js
+++ b/src/pages/home/sidebar/SidebarBottom.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Image, View, StyleSheet} from 'react-native';
+import {View, StyleSheet} from 'react-native';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
 import {withOnyx} from 'react-native-onyx';
@@ -9,6 +9,7 @@ import AppLinks from './AppLinks';
 import {signOut} from '../../../libs/actions/Session';
 import ONYXKEYS from '../../../ONYXKEYS';
 import SafeAreaInsetPropTypes from '../../SafeAreaInsetPropTypes';
+import Avatar from '../../../components/Avatar';
 
 const propTypes = {
     // Safe area insets required for mobile devices margins
@@ -53,8 +54,8 @@ const SidebarBottom = ({myPersonalDetails, network, insets}) => {
     return (
         <View style={[styles.sidebarFooter, getSafeAreaMargins(insets)]}>
             <View style={[styles.sidebarFooterAvatar]}>
-                <Image
-                    source={{uri: myPersonalDetails.avatarURL}}
+                <Avatar
+                    source={myPersonalDetails.avatarURL}
                     style={[styles.actionAvatar]}
                 />
                 <View style={StyleSheet.flatten(indicatorStyles)} />

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -343,6 +343,9 @@ const styles = {
     actionAvatar: {
         borderRadius: 20,
         marginRight: 8,
+    },
+
+    avatarNormal: {
         height: variables.componentSizeNormal,
         width: variables.componentSizeNormal,
     },
@@ -910,11 +913,6 @@ const styles = {
         borderRadius: 20,
         height: variables.componentSizeNormal,
         overflow: 'hidden',
-        width: variables.componentSizeNormal,
-    },
-
-    chatSwitcherAvatarImage: {
-        height: variables.componentSizeNormal,
         width: variables.componentSizeNormal,
     },
 


### PR DESCRIPTION
cc @Julesssss @tgolen @chiragsalian 

### Details
When the reconnection callbacks fire the `Image` components will re-download all images even if their source has not changed. To prevent this from happening I add to any component that had an `Image` either `PureComponent` or `React.memo`.

### Fixed Issues (Partial)
https://github.com/Expensify/Expensify/issues/148102

### Tests
1. Load a chat with many image attachments
2. Put the app in the background and reopen it
3. Verify via Chrome dev tools that images are not re-downloaded

<img width="1440" alt="2020-12-24_09-12-24" src="https://user-images.githubusercontent.com/32969087/103103888-43e83800-45c8-11eb-9342-7cf7dc97b296.png">

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
❌ 

#### Web
No changes

#### Mobile Web
No changes

#### Desktop
No changes

#### iOS
No changes

#### Android
No changes