### PR TITLE
Fix bad boolean check to restore chat

### DIFF
--- a/src/CONFIG.js
+++ b/src/CONFIG.js
@@ -14,7 +14,7 @@ if (_.isString(Config.EXPENSIFY_URL_COM) && !Config.EXPENSIFY_URL_COM.endsWith('
     Config.EXPENSIFY_URL_COM += '/';
 }
 
-const expensifyCom = Config.USE_WEB_PROXY ? '/' : Config.EXPENSIFY_URL_COM;
+const expensifyCom = Config.USE_WEB_PROXY === 'true' ? '/' : Config.EXPENSIFY_URL_COM;
 
 // Ngrok helps us avoid many of our cross-domain issues with connecting to our API
 // and is reqired for viewing images on mobile and for developing on android


### PR DESCRIPTION
### Details
`Expensify.cash` is down since some `.production.env` variables changed and we are not correctly checking them. 
We need to explicitly check for `true` as the existing check will return true when the value is a string of `'false'`

### Fixed Issues
https://expensify.slack.com/archives/C011W8BJ9L6/p1608841232445200

### Tests
1. Create a production web build `npm run build`
2. Make sure we are using the correct API endpoint.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web

#### Mobile Web

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform or write "no changes"-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform or write "no changes"-->

#### Android
<!-- Insert screenshots of your changes on the Android platform or write "no changes"-->
