### PR TITLE
Setup expensify.cash.dev to work with the webpack dev server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,10 @@
  * Rename this file to `.env` and put your local config in here
  */
 EXPENSIFY_URL_COM=https://www.expensify.com.dev/
-EXPENSIFY_URL_CASH=https://expensify.cash/
+EXPENSIFY_URL_CASH=https://expensify.cash.dev/
 EXPENSIFY_PARTNER_NAME=android
 EXPENSIFY_PARTNER_PASSWORD=c3a9ac418ea3f152aae2
 PUSHER_APP_KEY=ac6d22b891daae55283a
 NGROK_URL=https://expensify-user.ngrok.io/
 USE_NGROK=false
+USE_WEB_PROXY=false

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,7 @@ fastlane/screenshots
 
 # Local DEV config
 /.env
+
+# Local DEV SSL certs
+expensify.cash.dev.pem
+expensify.cash.dev-key.pem

--- a/README.md
+++ b/README.md
@@ -70,6 +70,18 @@ You can use any IDE or code editing tool for developing on any platform. Use you
 ## Running the web app 🕸
 Contributors who don't have full-access to Expensify's development environment will need to run the app against the production API.
 * In the `.env` file set the `USE_WEB_PROXY` environment variable to `true` to indicate the proxy should be used
+* Add `127.0.0.1 expensify.cash.dev` to your hosts file (We recommend using [Gas Mask](https://github.com/2ndalpha/gasmask) to manage your hosts file)
+* Generate SSL certs for `expensify.cash.dev` by running the following:
+
+```
+brew install mkcert
+brew install nss
+mkcert -install
+mkcert expensify.cash.dev
+```
+
+**Note:** If you are using an operating system other than macOS please follow the `mkcert` installation instructions [here](https://github.com/FiloSottile/mkcert#installation)
+
 * To run the web app, run the **Development Server**: `npm run proxy`
 * Changes applied to Javascript will be applied automatically via WebPack as configured in `webpack.dev.js`
 

--- a/config/webpack/webpack.dev.js
+++ b/config/webpack/webpack.dev.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const path = require('path');
 const webpack = require('webpack');
 const {merge} = require('webpack-merge');
@@ -25,6 +26,10 @@ module.exports = (parameters = {}) => {
         devServer: {
             contentBase: path.join(__dirname, '../dist'),
             hot: true,
+            host: 'expensify.cash.dev',
+            https: true,
+            key: fs.readFileSync(path.resolve(__dirname, '../../expensify.cash.dev-key.pem')),
+            cert: fs.readFileSync(path.resolve(__dirname, '../../expensify.cash.dev.pem')),
             ...proxySettings,
         },
         plugins: [

--- a/config/webpack/webpack.dev.js
+++ b/config/webpack/webpack.dev.js
@@ -26,7 +26,9 @@ module.exports = (parameters = {}) => {
         devServer: {
             contentBase: path.join(__dirname, '../dist'),
             hot: true,
-            host: 'expensify.cash.dev',
+            public: 'expensify.cash.dev',
+            host: '0.0.0.0',
+            port: 443,
             https: true,
             key: fs.readFileSync(path.resolve(__dirname, '../../expensify.cash.dev-key.pem')),
             cert: fs.readFileSync(path.resolve(__dirname, '../../expensify.cash.dev.pem')),


### PR DESCRIPTION
### Details
Runs the website from `https://expensify.cash.dev` instead of `localhost`

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/148887

### Tests
1. Follow the new instructions in the readme for `npm run proxy` (remember to set `USE_WEB_PROXY=true`)
2. Also verify that `npm run web` works normally by setting `USE_WEB_PROXY=false`

### Tested On

- [x] Web
- [ ] Mobile Web
- [x] Desktop - NOT APPLICABLE
- [x] iOS - NOT APPLICABLE
- [x] Android - NOT APPLICABLE

### Screenshots
<Add any necessary screenshots for all platforms if your change added or updated UI>

#### Web
<!-- Insert screenshots of your changes on the web platform or write "no changes"-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser) or write "no changes"-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform or write "no changes"-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform or write "no changes"-->

#### Android
<!-- Insert screenshots of your changes on the Android platform or write "no changes"-->
