### PR TITLE
fix email link rendering bug

### DIFF
--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -500,7 +500,6 @@ function addAction(reportID, text, file) {
         replacement: '<a href="mailto:$2">$2</a>'
     });
     parser.rules.join();
-    
 
     const htmlComment = parser.replace(text);
     const isAttachment = _.isEmpty(text) && file !== undefined;

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -485,7 +485,7 @@ function addAction(reportID, text, file) {
     const actionKey = `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`;
 
     // Convert the comment from MD into HTML because that's how it is stored in the database
-    let parser = new ExpensiMark();
+    const parser = new ExpensiMark();
 
     // Insert Email rule to ExpensMark rules
     parser.rules.splice(2, 0, {

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -490,13 +490,13 @@ function addAction(reportID, text, file) {
     // Insert Email rule to ExpensMark rules
     parser.rules.splice(2, 0, {
         name: 'MD-Email', // For Markdown Email Link
-        regex: /\[([\w\\s\\d!?&#;]+)\]\((([a-zA-Z0-9\-\_\.])+@[a-zA-Z\_]+?(\.[a-zA-Z]{2,6})+)\)/gim,
+        regex: /\[([\w\\s\\d!?&#;]+)\]\((([a-zA-Z0-9\-])+@[a-zA-Z]+?(\.[a-zA-Z]{2,6})+)\)/gim,
         replacement: '<a href="mailto:$2">$1</a>'
     });
     parser.rules.join();
     parser.rules.splice(3, 0, {
-        name: 'Email',  // For General Email Link
-        regex: /(?![^<]*>|[^<>]*<\\)([_*~]*?)(([a-zA-Z0-9\-\_\.])+@[a-zA-Z\_]+?(\.[a-zA-Z]{2,6})+)(?![^<]*(<\\pre>|<\\code>))/gim,
+        name: 'Email', // For General Email Link
+        regex: /(?![^<]*>|[^<>]*<\\)([_*~]*?)(([a-zA-Z0-9\-])+@[a-zA-Z]+?(\.[a-zA-Z]{2,6})+)(?![^<]*(<\\pre>|<\\code>))/gim,
         replacement: '<a href="mailto:$2">$2</a>'
     });
     parser.rules.join();

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -485,7 +485,23 @@ function addAction(reportID, text, file) {
     const actionKey = `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`;
 
     // Convert the comment from MD into HTML because that's how it is stored in the database
-    const parser = new ExpensiMark();
+    let parser = new ExpensiMark();
+
+    // Insert Email rule to ExpensMark rules
+    parser.rules.splice(2, 0, {
+        name: 'MD-Email', // For Markdown Email Link
+        regex: /\[([\w\\s\\d!?&#;]+)\]\((([a-zA-Z0-9\-\_\.])+@[a-zA-Z\_]+?(\.[a-zA-Z]{2,6})+)\)/gim,
+        replacement: '<a href="mailto:$2">$1</a>'
+    });
+    parser.rules.join();
+    parser.rules.splice(3, 0, {
+        name: 'Email',  // For General Email Link
+        regex: /(?![^<]*>|[^<>]*<\\)([_*~]*?)(([a-zA-Z0-9\-\_\.])+@[a-zA-Z\_]+?(\.[a-zA-Z]{2,6})+)(?![^<]*(<\\pre>|<\\code>))/gim,
+        replacement: '<a href="mailto:$2">$2</a>'
+    });
+    parser.rules.join();
+    
+
     const htmlComment = parser.replace(text);
     const isAttachment = _.isEmpty(text) && file !== undefined;
 


### PR DESCRIPTION

### Details
The app doesn't render email link correctly.  
### Fixed Issues
Fixed this issue  -  https://github.com/Expensify/Expensify.cash/issues/990
### Tests
Write some emails and click send button :  For example,  test@test.com

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<Add any necessary screenshots for all platforms if your change added or updated UI>

#### Web
![image_2020_12_28T08_12_32_148Z](https://user-images.githubusercontent.com/76614790/103200184-aa9e8600-4927-11eb-8a68-6e6dd4172a9a.png)


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser) or write "no changes"-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform or write "no changes"-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform or write "no changes"-->

#### Android
<!-- Insert screenshots of your changes on the Android platform or write "no changes"-->
