### PR TITLE
Limit lines of text in HeaderView to 2 (#1065)

### DIFF
--- a/src/pages/home/HeaderView.js
+++ b/src/pages/home/HeaderView.js
@@ -61,7 +61,7 @@ const HeaderView = props => (
                 ]}
                 >
                     <View style={[styles.flex1]}>
-                        <Text numberOfLines={1} style={[styles.navText]}>
+                        <Text numberOfLines={2} style={[styles.navText]}>
                             {props.report.reportName}
                         </Text>
                     </View>


### PR DESCRIPTION
### Details
WIP solution for clamping lines of text in the conversation header. Changing the value for numbersOfLines to > 1 triggers logic in react-native-web to use -webkit-line-clamp and the other properties needed to use it (like display: -webkit-box). This also affects electron version as it also uses a web-based renderer.

### Fixed Issues
Fixes #1065

### Tests
See reproduction steps on linked issue. You may notice that some screenshots show "Concierge" while some show "concierge@expensify.com" - this appears to be down to a delay in usernames being resolved.

Unit tests were not affected by this styling change.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
#### Web
[Windows web screenshots are blocked by #1144]

Firefox (MacOS)
<img width="300" alt="macos firefox screenshot" src="https://user-images.githubusercontent.com/7024578/103392163-720fcf80-4b14-11eb-8372-21ab920ef885.png">


Chrome (MacOS)
<img width="300" alt="macos chrome screenshot" src="https://user-images.githubusercontent.com/7024578/103392123-4856a880-4b14-11eb-9be5-d3ef0e7bce08.png">



#### Mobile Web
Firefox
<img width="300" alt="mobile firefox screenshot" src="https://user-images.githubusercontent.com/7024578/103391858-4a6c3780-4b13-11eb-9ee5-53fad8e4e27f.png">

Chrome
<img width="300" alt="mobile chrome screenshot" src="https://user-images.githubusercontent.com/7024578/103392020-cd8d8d80-4b13-11eb-8e12-5280b22bce0f.png">


#### Desktop
<img width="475" alt="Mac Desktop screenshot" src="https://user-images.githubusercontent.com/7024578/103390451-602a2e80-4b0c-11eb-98fb-7171eeec71af.png">

#### iOS
<img width="475" alt="iOS screenshot" src="https://user-images.githubusercontent.com/7024578/103390346-cebabc80-4b0b-11eb-9d8e-f1800ecac8d2.png">


#### Android
![android](https://user-images.githubusercontent.com/7024578/103389463-d62b9700-4b06-11eb-8121-d79d8dd7cc9d.png)