### PR TITLE
Chat / Cycle attachments when the user presses the left/right keys #1038

### DIFF
--- a/src/components/AttachmentModal.js
+++ b/src/components/AttachmentModal.js
@@ -1,9 +1,10 @@
-import React, { Component } from 'react';
+import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {
     View, TouchableOpacity, Text, Dimensions,
 } from 'react-native';
-import { withOnyx } from 'react-native-onyx';
+import {withOnyx} from 'react-native-onyx';
+import lodashGet from 'lodash.get';
 import CONST from '../CONST';
 import ModalWithHeader from './ModalWithHeader';
 import AttachmentView from './AttachmentView';
@@ -12,7 +13,6 @@ import themeColors from '../styles/themes/default';
 import variables from '../styles/variables';
 import ONYXKEYS from '../ONYXKEYS';
 import addAuthTokenToURL from '../libs/addAuthTokenToURL';
-import lodashGet from 'lodash.get';
 import ReportActionPropTypes from '../pages/home/report/ReportActionPropTypes';
 
 /**
@@ -28,7 +28,7 @@ const propTypes = {
     // If not passed in via props must be specified when modal is opened.
     sourceURL: PropTypes.string,
 
-    file: PropTypes.shape({ name: PropTypes.string }),
+    file: PropTypes.shape({name: PropTypes.string}),
 
     // A function to get the next attachement based on the current attachment and the
     // direction (to the right or to the left) indicated
@@ -83,18 +83,18 @@ class AttachmentModal extends Component {
 
     componentDidUpdate(prevProps) {
         if (prevProps.sourceURL !== this.props.sourceURL) {
-            console.log(this.props.currentAction)
+            console.log(this.props.currentAction);
             this.setState({
                 sourceURL: this.props.sourceURL,
                 file: this.props.file,
                 isAuthTokenRequired: this.props.currentAction.isAttachment,
                 isModalOpen: true
-            })
+            });
         }
         if (this.state.isModalOpen) {
-            document.addEventListener("keydown", this.handleKeyPress, false);
+            document.addEventListener('keydown', this.handleKeyPress, false);
         } else {
-            document.removeEventListener("keydown", this.handleKeyPress, false);
+            document.removeEventListener('keydown', this.handleKeyPress, false);
         }
     }
 
@@ -105,7 +105,7 @@ class AttachmentModal extends Component {
         while ((img = imgRex.exec(htmlString))) {
             images.push(img[1]);
         }
-        return images[0]
+        return images[0];
     }
 
     getAttachmentSource(htmlString) {
@@ -115,18 +115,18 @@ class AttachmentModal extends Component {
         while ((img = imgRex.exec(htmlString))) {
             images.push(img[1]);
         }
-        return images[0]
+        return images[0];
     }
 
     handleKeyPress = (event) => {
         if (event.key === 'ArrowRight' || event.key === 'ArrowLeft') {
             event.stopPropagation();
-            const nextAttachment = this.props.getNextAttachment(this.props.currentAction, event.key === 'ArrowRight' ? true : false)
+            const nextAttachment = this.props.getNextAttachment(this.props.currentAction, event.key === 'ArrowRight');
             if (nextAttachment) {
                 const html = lodashGet(nextAttachment.action, ['message', 0, 'html'], '');
-                const newSourceURL = this.getAttachmentThumbnail(html)
-                const newSource = this.getAttachmentSource(html)
-                this.props.setAttachmentModalData({ currentAction: nextAttachment.action, sourceURL: newSourceURL, file: { name: newSource } })
+                const newSourceURL = this.getAttachmentThumbnail(html);
+                const newSource = this.getAttachmentSource(html);
+                this.props.setAttachmentModalData({currentAction: nextAttachment.action, sourceURL: newSourceURL, file: {name: newSource}});
             }
         }
     }
@@ -146,7 +146,7 @@ class AttachmentModal extends Component {
             <>
                 <ModalWithHeader
                     type={CONST.MODAL.MODAL_TYPE.CENTERED}
-                    onClose={() => this.setState({ isModalOpen: false })}
+                    onClose={() => this.setState({isModalOpen: false})}
                     isVisible={this.state.isModalOpen}
                     title={this.props.title}
                     backgroundColor={themeColors.componentBG}
@@ -164,7 +164,7 @@ class AttachmentModal extends Component {
                             underlayColor={themeColors.componentBG}
                             onPress={() => {
                                 this.props.onConfirm(this.state.file);
-                                this.props.setAttachmentModalData({ isModalOpen: false })
+                                this.props.setAttachmentModalData({isModalOpen: false});
                             }}
                         >
                             <Text
@@ -180,22 +180,22 @@ class AttachmentModal extends Component {
                     )}
                 </ModalWithHeader>
                 {this.props.children ? this.props.children({
-                    displayFileInModal: ({ file }) => {
+                    displayFileInModal: ({file}) => {
                         if (file instanceof File) {
                             const source = URL.createObjectURL(file);
                             this.setState({
                                 isModalOpen: true, sourceURL: source, file, isAuthTokenRequired: false
-                            })
+                            });
                         } else {
                             this.setState({
                                 isModalOpen: true, sourceURL: source, file, isAuthTokenRequired: false
-                            })
+                            });
                         }
                     },
                     show: () => {
                         this.setState({
                             isModalOpen: true
-                        })
+                        });
                     },
                 }) : null}
             </>

--- a/src/components/AttachmentModal.js
+++ b/src/components/AttachmentModal.js
@@ -38,9 +38,6 @@ const propTypes = {
     // ReportActionsView
     setAttachmentModalData: PropTypes.func,
 
-    // A boolean indicating if the modal is currently being diplayed
-    isModalOpen: PropTypes.bool,
-
     // The current action that the modal is currently displaying
     currentAction: PropTypes.shape(ReportActionPropTypes),
 
@@ -50,23 +47,21 @@ const propTypes = {
     // A function as a child to pass modal launching methods to
     children: PropTypes.func,
 
-    // Do the urls require an authToken?
-    isAuthTokenRequired: PropTypes.bool,
-
     // Current user session
     session: PropTypes.shape({
         authToken: PropTypes.string.isRequired,
     }).isRequired,
-
-
 };
 
 const defaultProps = {
     title: '',
     sourceURL: null,
+    file: {name: null},
     onConfirm: null,
-    isAuthTokenRequired: false,
-    isModalOpen: false,
+    currentAction: {
+        actionName: '', person: [], sequenceNumber: 0, timestamp: 0, message: []
+    },
+    children: null,
     setAttachmentModalData: () => { },
     getNextAttachment: () => { }
 };
@@ -83,13 +78,7 @@ class AttachmentModal extends Component {
 
     componentDidUpdate(prevProps) {
         if (prevProps.sourceURL !== this.props.sourceURL) {
-            console.log(this.props.currentAction);
-            this.setState({
-                sourceURL: this.props.sourceURL,
-                file: this.props.file,
-                isAuthTokenRequired: this.props.currentAction.isAttachment,
-                isModalOpen: true
-            });
+            this.setCurrentModalData(this.props);
         }
         if (this.state.isModalOpen) {
             document.addEventListener('keydown', this.handleKeyPress, false);
@@ -98,24 +87,25 @@ class AttachmentModal extends Component {
         }
     }
 
+    setCurrentModalData(props) {
+        this.setState({
+            sourceURL: props.sourceURL,
+            file: props.file,
+            isAuthTokenRequired: props.currentAction.isAttachment,
+            isModalOpen: true
+        });
+    }
+
     getAttachmentThumbnail(htmlString) {
-        const imgRex = /<img.*?src="(.*?)"[^>]+>/g;
-        const images = [];
-        let img;
-        while ((img = imgRex.exec(htmlString))) {
-            images.push(img[1]);
-        }
-        return images[0];
+        const imgRegx = /<img.*?src="(.*?)"[^>]+>/g;
+        const imageGroup = imgRegx.exec(htmlString);
+        return imageGroup[1];
     }
 
     getAttachmentSource(htmlString) {
-        const imgRex = /<img.*?data-expensify-source="(.*?)"[^>]+>/g;
-        const images = [];
-        let img;
-        while ((img = imgRex.exec(htmlString))) {
-            images.push(img[1]);
-        }
-        return images[0];
+        const imgRegx = /<img.*?data-expensify-source="(.*?)"[^>]+>/g;
+        const imageGroup = imgRegx.exec(htmlString);
+        return imageGroup[1];
     }
 
     handleKeyPress = (event) => {
@@ -188,7 +178,7 @@ class AttachmentModal extends Component {
                             });
                         } else {
                             this.setState({
-                                isModalOpen: true, sourceURL: source, file, isAuthTokenRequired: false
+                                isModalOpen: true, sourceURL: file.uri, file, isAuthTokenRequired: false
                             });
                         }
                     },

--- a/src/components/AttachmentModal.js
+++ b/src/components/AttachmentModal.js
@@ -1,9 +1,9 @@
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import {
     View, TouchableOpacity, Text, Dimensions,
 } from 'react-native';
-import {withOnyx} from 'react-native-onyx';
+import { withOnyx } from 'react-native-onyx';
 import CONST from '../CONST';
 import ModalWithHeader from './ModalWithHeader';
 import AttachmentView from './AttachmentView';
@@ -12,6 +12,8 @@ import themeColors from '../styles/themes/default';
 import variables from '../styles/variables';
 import ONYXKEYS from '../ONYXKEYS';
 import addAuthTokenToURL from '../libs/addAuthTokenToURL';
+import lodashGet from 'lodash.get';
+import ReportActionPropTypes from '../pages/home/report/ReportActionPropTypes';
 
 /**
  * Modal render prop component that exposes modal launching triggers that can be used
@@ -26,11 +28,27 @@ const propTypes = {
     // If not passed in via props must be specified when modal is opened.
     sourceURL: PropTypes.string,
 
+    file: PropTypes.shape({ name: PropTypes.string }),
+
+    // A function to get the next attachement based on the current attachment and the
+    // direction (to the right or to the left) indicated
+    getNextAttachment: PropTypes.func,
+
+    // A function to set the attachment data that this modal receives as a prop from
+    // ReportActionsView
+    setAttachmentModalData: PropTypes.func,
+
+    // A boolean indicating if the modal is currently being diplayed
+    isModalOpen: PropTypes.bool,
+
+    // The current action that the modal is currently displaying
+    currentAction: PropTypes.shape(ReportActionPropTypes),
+
     // Optional callback to fire when we want to preview an image and approve it for use.
     onConfirm: PropTypes.func,
 
     // A function as a child to pass modal launching methods to
-    children: PropTypes.func.isRequired,
+    children: PropTypes.func,
 
     // Do the urls require an authToken?
     isAuthTokenRequired: PropTypes.bool,
@@ -39,6 +57,8 @@ const propTypes = {
     session: PropTypes.shape({
         authToken: PropTypes.string.isRequired,
     }).isRequired,
+
+
 };
 
 const defaultProps = {
@@ -46,12 +66,14 @@ const defaultProps = {
     sourceURL: null,
     onConfirm: null,
     isAuthTokenRequired: false,
+    isModalOpen: false,
+    setAttachmentModalData: () => { },
+    getNextAttachment: () => { }
 };
 
 class AttachmentModal extends Component {
     constructor(props) {
         super(props);
-
         this.state = {
             isModalOpen: false,
             file: null,
@@ -59,13 +81,63 @@ class AttachmentModal extends Component {
         };
     }
 
+    componentDidUpdate(prevProps) {
+        if (prevProps.sourceURL !== this.props.sourceURL) {
+            console.log(this.props.currentAction)
+            this.setState({
+                sourceURL: this.props.sourceURL,
+                file: this.props.file,
+                isAuthTokenRequired: this.props.currentAction.isAttachment,
+                isModalOpen: true
+            })
+        }
+        if (this.state.isModalOpen) {
+            document.addEventListener("keydown", this.handleKeyPress, false);
+        } else {
+            document.removeEventListener("keydown", this.handleKeyPress, false);
+        }
+    }
+
+    getAttachmentThumbnail(htmlString) {
+        const imgRex = /<img.*?src="(.*?)"[^>]+>/g;
+        const images = [];
+        let img;
+        while ((img = imgRex.exec(htmlString))) {
+            images.push(img[1]);
+        }
+        return images[0]
+    }
+
+    getAttachmentSource(htmlString) {
+        const imgRex = /<img.*?data-expensify-source="(.*?)"[^>]+>/g;
+        const images = [];
+        let img;
+        while ((img = imgRex.exec(htmlString))) {
+            images.push(img[1]);
+        }
+        return images[0]
+    }
+
+    handleKeyPress = (event) => {
+        if (event.key === 'ArrowRight' || event.key === 'ArrowLeft') {
+            event.stopPropagation();
+            const nextAttachment = this.props.getNextAttachment(this.props.currentAction, event.key === 'ArrowRight' ? true : false)
+            if (nextAttachment) {
+                const html = lodashGet(nextAttachment.action, ['message', 0, 'html'], '');
+                const newSourceURL = this.getAttachmentThumbnail(html)
+                const newSource = this.getAttachmentSource(html)
+                this.props.setAttachmentModalData({ currentAction: nextAttachment.action, sourceURL: newSourceURL, file: { name: newSource } })
+            }
+        }
+    }
+
+
     render() {
         const sourceURL = addAuthTokenToURL({
             url: this.state.sourceURL,
             authToken: this.props.session.authToken,
-            required: this.props.isAuthTokenRequired,
+            required: this.state.isAuthTokenRequired,
         });
-
         const isSmallScreen = Dimensions.get('window').width < variables.mobileResponsiveWidthBreakpoint;
         const attachmentViewStyles = isSmallScreen
             ? [styles.imageModalImageCenterContainer]
@@ -74,7 +146,7 @@ class AttachmentModal extends Component {
             <>
                 <ModalWithHeader
                     type={CONST.MODAL.MODAL_TYPE.CENTERED}
-                    onClose={() => this.setState({isModalOpen: false})}
+                    onClose={() => this.setState({ isModalOpen: false })}
                     isVisible={this.state.isModalOpen}
                     title={this.props.title}
                     backgroundColor={themeColors.componentBG}
@@ -92,7 +164,7 @@ class AttachmentModal extends Component {
                             underlayColor={themeColors.componentBG}
                             onPress={() => {
                                 this.props.onConfirm(this.state.file);
-                                this.setState({isModalOpen: false});
+                                this.props.setAttachmentModalData({ isModalOpen: false })
                             }}
                         >
                             <Text
@@ -107,19 +179,25 @@ class AttachmentModal extends Component {
                         </TouchableOpacity>
                     )}
                 </ModalWithHeader>
-                {this.props.children({
-                    displayFileInModal: ({file}) => {
+                {this.props.children ? this.props.children({
+                    displayFileInModal: ({ file }) => {
                         if (file instanceof File) {
                             const source = URL.createObjectURL(file);
-                            this.setState({isModalOpen: true, sourceURL: source, file});
+                            this.setState({
+                                isModalOpen: true, sourceURL: source, file, isAuthTokenRequired: false
+                            })
                         } else {
-                            this.setState({isModalOpen: true, sourceURL: file.uri, file});
+                            this.setState({
+                                isModalOpen: true, sourceURL: source, file, isAuthTokenRequired: false
+                            })
                         }
                     },
                     show: () => {
-                        this.setState({isModalOpen: true});
+                        this.setState({
+                            isModalOpen: true
+                        })
                     },
-                })}
+                }) : null}
             </>
         );
     }

--- a/src/components/RenderHTML.js
+++ b/src/components/RenderHTML.js
@@ -12,7 +12,6 @@ import {webViewStyles} from '../styles/styles';
 import fontFamily from '../styles/fontFamily';
 import AnchorForCommentsOnly from './AnchorForCommentsOnly';
 import InlineCodeBlock from './InlineCodeBlock';
-import AttachmentModal from './AttachmentModal';
 import ThumbnailImage from './ThumbnailImage';
 
 const MAX_IMG_DIMENSIONS = 512;

--- a/src/components/RenderHTML.js
+++ b/src/components/RenderHTML.js
@@ -1,14 +1,14 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useWindowDimensions, TouchableOpacity } from 'react-native';
+import {useWindowDimensions, TouchableOpacity} from 'react-native';
 import HTML, {
     defaultHTMLElementModels,
     TNodeChildrenRenderer,
     splitBoxModelStyle,
 } from 'react-native-render-html';
 import Config from '../CONFIG';
-import { webViewStyles } from '../styles/styles';
+import {webViewStyles} from '../styles/styles';
 import fontFamily from '../styles/fontFamily';
 import AnchorForCommentsOnly from './AnchorForCommentsOnly';
 import InlineCodeBlock from './InlineCodeBlock';
@@ -39,17 +39,18 @@ function computeImagesMaxWidth(contentWidth) {
 }
 
 
-
 const propTypes = {
     html: PropTypes.string.isRequired,
     debug: PropTypes.bool,
 };
 
-const RenderHTML = React.memo(({ action, html, debug = false, setAttachmentModalData }) => {
-    const { width } = useWindowDimensions();
+const RenderHTML = React.memo(({
+    action, html, debug = false, setAttachmentModalData
+}) => {
+    const {width} = useWindowDimensions();
     const containerWidth = width * 0.8;
 
-    const AnchorRenderer = ({ tnode, key, style }) => {
+    const AnchorRenderer = ({tnode, key, style}) => {
         const htmlAttribs = tnode.attributes;
         return (
             <AnchorForCommentsOnly
@@ -68,14 +69,14 @@ const RenderHTML = React.memo(({ action, html, debug = false, setAttachmentModal
                 <TNodeChildrenRenderer tnode={tnode} />
             </AnchorForCommentsOnly>
         );
-    }
+    };
 
     const CodeRenderer = ({
         key, style, TDefaultRenderer, ...defaultRendererProps
     }) => {
         // We split wrapper and inner styles
         // "boxModelStyle" corresponds to border, margin, padding and backgroundColor
-        const { boxModelStyle, otherStyle: textStyle } = splitBoxModelStyle(style);
+        const {boxModelStyle, otherStyle: textStyle} = splitBoxModelStyle(style);
         return (
             <InlineCodeBlock
                 TDefaultRenderer={TDefaultRenderer}
@@ -85,9 +86,9 @@ const RenderHTML = React.memo(({ action, html, debug = false, setAttachmentModal
                 key={key}
             />
         );
-    }
+    };
 
-    const ImgRenderer = ({ tnode }) => {
+    const ImgRenderer = ({tnode}) => {
         const htmlAttribs = tnode.attributes;
 
         // There are two kinds of images that need to be displayed:
@@ -126,7 +127,9 @@ const RenderHTML = React.memo(({ action, html, debug = false, setAttachmentModal
         return (
             <TouchableOpacity
                 onPress={() => {
-                    setAttachmentModalData({ currentAction: action, sourceURL: previewSource, file: { name: source }, isModalOpen: true })
+                    setAttachmentModalData({
+                        currentAction: action, sourceURL: previewSource, file: {name: source}, isModalOpen: true
+                    });
                 }}
             >
                 <ThumbnailImage
@@ -136,7 +139,7 @@ const RenderHTML = React.memo(({ action, html, debug = false, setAttachmentModal
                 />
             </TouchableOpacity>
         );
-    }
+    };
 
     // Define default element models for these renderers.
     AnchorRenderer.model = defaultHTMLElementModels.a;
@@ -168,9 +171,7 @@ const RenderHTML = React.memo(({ action, html, debug = false, setAttachmentModal
             debug={debug}
         />
     );
-}, (prevProps, nextProps) => {
-    return prevProps.html === nextProps.html
-});
+}, (prevProps, nextProps) => prevProps.html === nextProps.html);
 
 RenderHTML.displayName = 'RenderHTML';
 RenderHTML.propTypes = propTypes;

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { View, Image, TouchableOpacity } from 'react-native';
+import {View, Image, TouchableOpacity} from 'react-native';
 import _ from 'underscore';
 import lodashGet from 'lodash.get';
-import { withOnyx } from 'react-native-onyx';
+import {withOnyx} from 'react-native-onyx';
 import styles from '../../../styles/styles';
 import themeColors from '../../../styles/themes/default';
 import TextInputFocusable from '../../../components/TextInputFocusable';
@@ -11,7 +11,7 @@ import sendIcon from '../../../../assets/images/icon-send.png';
 import ONYXKEYS from '../../../ONYXKEYS';
 import paperClipIcon from '../../../../assets/images/icon-paper-clip.png';
 import AttachmentPicker from '../../../components/AttachmentPicker';
-import { addAction, saveReportComment, broadcastUserIsTyping } from '../../../libs/actions/Report';
+import {addAction, saveReportComment, broadcastUserIsTyping} from '../../../libs/actions/Report';
 import ReportTypingIndicator from './ReportTypingIndicator';
 import AttachmentModal from '../../../components/AttachmentModal';
 
@@ -62,7 +62,7 @@ class ReportActionCompose extends React.Component {
      * @param {Boolean} shouldHighlight
      */
     setIsFocused(shouldHighlight) {
-        this.setState({ isFocused: shouldHighlight });
+        this.setState({isFocused: shouldHighlight});
     }
 
     /**
@@ -71,7 +71,7 @@ class ReportActionCompose extends React.Component {
      * @param {Boolean} shouldClear
      */
     setTextInputShouldClear(shouldClear) {
-        this.setState({ textInputShouldClear: shouldClear });
+        this.setState({textInputShouldClear: shouldClear});
     }
 
     /**
@@ -150,16 +150,16 @@ class ReportActionCompose extends React.Component {
                         isModalOpen={this.props.isModalOpen}
                         setAttachmentModalData={this.setAttachmentModalData}
                     >
-                        {({ displayFileInModal }) => (
+                        {({displayFileInModal}) => (
                             <>
                                 <AttachmentPicker>
-                                    {({ openPicker }) => (
+                                    {({openPicker}) => (
                                         <TouchableOpacity
                                             onPress={(e) => {
                                                 e.preventDefault();
                                                 openPicker({
                                                     onPicked: (file) => {
-                                                        displayFileInModal({ file });
+                                                        displayFileInModal({file});
                                                     },
                                                 });
                                             }}
@@ -182,8 +182,8 @@ class ReportActionCompose extends React.Component {
                                     placeholderTextColor={themeColors.textSupporting}
                                     onChangeText={this.updateComment}
                                     onKeyPress={this.triggerSubmitShortcut}
-                                    onDragEnter={() => this.setState({ isDraggingOver: true })}
-                                    onDragLeave={() => this.setState({ isDraggingOver: false })}
+                                    onDragEnter={() => this.setState({isDraggingOver: true})}
+                                    onDragLeave={() => this.setState({isDraggingOver: false})}
                                     onDrop={(e) => {
                                         e.preventDefault();
 
@@ -192,15 +192,15 @@ class ReportActionCompose extends React.Component {
                                             return;
                                         }
 
-                                        displayFileInModal({ file });
-                                        this.setState({ isDraggingOver: false });
+                                        displayFileInModal({file});
+                                        this.setState({isDraggingOver: false});
                                     }}
                                     style={[styles.textInput, styles.textInputCompose, styles.flex4]}
                                     defaultValue={this.props.comment}
                                     maxLines={16} // This is the same that slack has
                                     onFocus={() => this.setIsFocused(true)}
                                     onBlur={() => this.setIsFocused(false)}
-                                    onPasteFile={file => displayFileInModal({ file })}
+                                    onPasteFile={file => displayFileInModal({file})}
                                     shouldClear={this.state.textInputShouldClear}
                                     onClear={() => this.setTextInputShouldClear(false)}
                                 />
@@ -231,6 +231,6 @@ ReportActionCompose.defaultProps = defaultProps;
 
 export default withOnyx({
     comment: {
-        key: ({ reportID }) => `${ONYXKEYS.COLLECTION.REPORT_DRAFT_COMMENT}${reportID}`,
+        key: ({reportID}) => `${ONYXKEYS.COLLECTION.REPORT_DRAFT_COMMENT}${reportID}`,
     },
 })(ReportActionCompose);

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {View, Image, TouchableOpacity} from 'react-native';
+import { View, Image, TouchableOpacity } from 'react-native';
 import _ from 'underscore';
 import lodashGet from 'lodash.get';
-import {withOnyx} from 'react-native-onyx';
+import { withOnyx } from 'react-native-onyx';
 import styles from '../../../styles/styles';
 import themeColors from '../../../styles/themes/default';
 import TextInputFocusable from '../../../components/TextInputFocusable';
@@ -11,7 +11,7 @@ import sendIcon from '../../../../assets/images/icon-send.png';
 import ONYXKEYS from '../../../ONYXKEYS';
 import paperClipIcon from '../../../../assets/images/icon-paper-clip.png';
 import AttachmentPicker from '../../../components/AttachmentPicker';
-import {addAction, saveReportComment, broadcastUserIsTyping} from '../../../libs/actions/Report';
+import { addAction, saveReportComment, broadcastUserIsTyping } from '../../../libs/actions/Report';
 import ReportTypingIndicator from './ReportTypingIndicator';
 import AttachmentModal from '../../../components/AttachmentModal';
 
@@ -62,7 +62,7 @@ class ReportActionCompose extends React.Component {
      * @param {Boolean} shouldHighlight
      */
     setIsFocused(shouldHighlight) {
-        this.setState({isFocused: shouldHighlight});
+        this.setState({ isFocused: shouldHighlight });
     }
 
     /**
@@ -71,7 +71,7 @@ class ReportActionCompose extends React.Component {
      * @param {Boolean} shouldClear
      */
     setTextInputShouldClear(shouldClear) {
-        this.setState({textInputShouldClear: shouldClear});
+        this.setState({ textInputShouldClear: shouldClear });
     }
 
     /**
@@ -147,17 +147,19 @@ class ReportActionCompose extends React.Component {
                             addAction(this.props.reportID, '', file);
                             this.setTextInputShouldClear(false);
                         }}
+                        isModalOpen={this.props.isModalOpen}
+                        setAttachmentModalData={this.setAttachmentModalData}
                     >
-                        {({displayFileInModal}) => (
+                        {({ displayFileInModal }) => (
                             <>
                                 <AttachmentPicker>
-                                    {({openPicker}) => (
+                                    {({ openPicker }) => (
                                         <TouchableOpacity
                                             onPress={(e) => {
                                                 e.preventDefault();
                                                 openPicker({
                                                     onPicked: (file) => {
-                                                        displayFileInModal({file});
+                                                        displayFileInModal({ file });
                                                     },
                                                 });
                                             }}
@@ -180,8 +182,8 @@ class ReportActionCompose extends React.Component {
                                     placeholderTextColor={themeColors.textSupporting}
                                     onChangeText={this.updateComment}
                                     onKeyPress={this.triggerSubmitShortcut}
-                                    onDragEnter={() => this.setState({isDraggingOver: true})}
-                                    onDragLeave={() => this.setState({isDraggingOver: false})}
+                                    onDragEnter={() => this.setState({ isDraggingOver: true })}
+                                    onDragLeave={() => this.setState({ isDraggingOver: false })}
                                     onDrop={(e) => {
                                         e.preventDefault();
 
@@ -190,15 +192,15 @@ class ReportActionCompose extends React.Component {
                                             return;
                                         }
 
-                                        displayFileInModal({file});
-                                        this.setState({isDraggingOver: false});
+                                        displayFileInModal({ file });
+                                        this.setState({ isDraggingOver: false });
                                     }}
                                     style={[styles.textInput, styles.textInputCompose, styles.flex4]}
                                     defaultValue={this.props.comment}
                                     maxLines={16} // This is the same that slack has
                                     onFocus={() => this.setIsFocused(true)}
                                     onBlur={() => this.setIsFocused(false)}
-                                    onPasteFile={file => displayFileInModal({file})}
+                                    onPasteFile={file => displayFileInModal({ file })}
                                     shouldClear={this.state.textInputShouldClear}
                                     onClear={() => this.setTextInputShouldClear(false)}
                                 />
@@ -229,6 +231,6 @@ ReportActionCompose.defaultProps = defaultProps;
 
 export default withOnyx({
     comment: {
-        key: ({reportID}) => `${ONYXKEYS.COLLECTION.REPORT_DRAFT_COMMENT}${reportID}`,
+        key: ({ reportID }) => `${ONYXKEYS.COLLECTION.REPORT_DRAFT_COMMENT}${reportID}`,
     },
 })(ReportActionCompose);

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -24,10 +24,14 @@ const propTypes = {
 
     // The ID of the report actions will be created for
     reportID: PropTypes.number.isRequired,
+
+    // Boolean indicating if the modal is currently open
+    isModalOpen: PropTypes.bool,
 };
 
 const defaultProps = {
     comment: '',
+    isModalOpen: false
 };
 
 class ReportActionCompose extends React.Component {
@@ -148,7 +152,6 @@ class ReportActionCompose extends React.Component {
                             this.setTextInputShouldClear(false);
                         }}
                         isModalOpen={this.props.isModalOpen}
-                        setAttachmentModalData={this.setAttachmentModalData}
                     >
                         {({displayFileInModal}) => (
                             <>

--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -15,8 +15,8 @@ const propTypes = {
 const ReportActionItem = props => (
     <>
         {!props.displayAsGroup
-            ? <ReportActionItemSingle action={props.action} />
-            : <ReportActionItemGrouped action={props.action} />}
+            ? <ReportActionItemSingle action={props.action} setAttachmentModalData={props.setAttachmentModalData} />
+            : <ReportActionItemGrouped action={props.action} setAttachmentModalData={props.setAttachmentModalData} />}
     </>
 );
 

--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -10,6 +10,9 @@ const propTypes = {
 
     // Should the comment have the appearance of being grouped with the previous comment?
     displayAsGroup: PropTypes.bool.isRequired,
+
+    // Allows setting of attachment modal data
+    setAttachmentModalData: PropTypes.func.isRequired
 };
 
 const ReportActionItem = props => (

--- a/src/pages/home/report/ReportActionItemFragment.js
+++ b/src/pages/home/report/ReportActionItemFragment.js
@@ -3,6 +3,7 @@ import {ActivityIndicator, View} from 'react-native';
 import PropTypes from 'prop-types';
 import Str from 'expensify-common/lib/str';
 import ReportActionFragmentPropTypes from './ReportActionFragmentPropTypes';
+import ReportActionPropTypes from './ReportActionPropTypes';
 import styles from '../../../styles/styles';
 import themeColors from '../../../styles/themes/default';
 import RenderHTML from '../../../components/RenderHTML';
@@ -17,6 +18,12 @@ const propTypes = {
 
     // Does this fragment belong to a reportAction that has not yet loaded?
     loading: PropTypes.bool,
+
+    // Allows setting of attachment modal data
+    setAttachmentModalData: PropTypes.func.isRequired,
+
+    // The current action for the fragment
+    action: PropTypes.shape(ReportActionPropTypes).isRequired
 };
 
 const defaultProps = {

--- a/src/pages/home/report/ReportActionItemFragment.js
+++ b/src/pages/home/report/ReportActionItemFragment.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ActivityIndicator, View } from 'react-native';
+import {ActivityIndicator, View} from 'react-native';
 import PropTypes from 'prop-types';
 import Str from 'expensify-common/lib/str';
 import ReportActionFragmentPropTypes from './ReportActionFragmentPropTypes';
@@ -26,7 +26,7 @@ const defaultProps = {
 
 class ReportActionItemFragment extends React.PureComponent {
     render() {
-        const { fragment, setAttachmentModalData, action } = this.props;
+        const {fragment, setAttachmentModalData, action} = this.props;
         switch (fragment.type) {
             case 'COMMENT':
                 // If this is an attachment placeholder, return the placeholder component
@@ -46,8 +46,8 @@ class ReportActionItemFragment extends React.PureComponent {
                 return fragment.html !== fragment.text ? (
                     <RenderHTML action={action} html={fragment.html} debug={false} setAttachmentModalData={setAttachmentModalData} />
                 ) : (
-                        <Text selectable>{Str.htmlDecode(fragment.text)}</Text>
-                    );
+                    <Text selectable>{Str.htmlDecode(fragment.text)}</Text>
+                );
             case 'TEXT':
                 return (
                     <Text

--- a/src/pages/home/report/ReportActionItemFragment.js
+++ b/src/pages/home/report/ReportActionItemFragment.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {ActivityIndicator, View} from 'react-native';
+import { ActivityIndicator, View } from 'react-native';
 import PropTypes from 'prop-types';
 import Str from 'expensify-common/lib/str';
 import ReportActionFragmentPropTypes from './ReportActionFragmentPropTypes';
@@ -26,7 +26,7 @@ const defaultProps = {
 
 class ReportActionItemFragment extends React.PureComponent {
     render() {
-        const {fragment} = this.props;
+        const { fragment, setAttachmentModalData, action } = this.props;
         switch (fragment.type) {
             case 'COMMENT':
                 // If this is an attachment placeholder, return the placeholder component
@@ -44,10 +44,10 @@ class ReportActionItemFragment extends React.PureComponent {
 
                 // Only render HTML if we have html in the fragment
                 return fragment.html !== fragment.text ? (
-                    <RenderHTML html={fragment.html} debug={false} />
+                    <RenderHTML action={action} html={fragment.html} debug={false} setAttachmentModalData={setAttachmentModalData} />
                 ) : (
-                    <Text selectable>{Str.htmlDecode(fragment.text)}</Text>
-                );
+                        <Text selectable>{Str.htmlDecode(fragment.text)}</Text>
+                    );
             case 'TEXT':
                 return (
                     <Text

--- a/src/pages/home/report/ReportActionItemGrouped.js
+++ b/src/pages/home/report/ReportActionItemGrouped.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View} from 'react-native';
+import { View } from 'react-native';
 import PropTypes from 'prop-types';
 import ReportActionPropTypes from './ReportActionPropTypes';
 import ReportActionItemMessage from './ReportActionItemMessage';
@@ -10,10 +10,10 @@ const propTypes = {
     action: PropTypes.shape(ReportActionPropTypes).isRequired,
 };
 
-const ReportActionItemGrouped = ({action}) => (
+const ReportActionItemGrouped = ({ action, setAttachmentModalData }) => (
     <View style={[styles.chatItem]}>
         <View style={[styles.chatItemRightGrouped]}>
-            <ReportActionItemMessage action={action} />
+            <ReportActionItemMessage action={action} setAttachmentModalData={setAttachmentModalData} />
         </View>
     </View>
 );

--- a/src/pages/home/report/ReportActionItemGrouped.js
+++ b/src/pages/home/report/ReportActionItemGrouped.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View } from 'react-native';
+import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import ReportActionPropTypes from './ReportActionPropTypes';
 import ReportActionItemMessage from './ReportActionItemMessage';
@@ -10,7 +10,7 @@ const propTypes = {
     action: PropTypes.shape(ReportActionPropTypes).isRequired,
 };
 
-const ReportActionItemGrouped = ({ action, setAttachmentModalData }) => (
+const ReportActionItemGrouped = ({action, setAttachmentModalData}) => (
     <View style={[styles.chatItem]}>
         <View style={[styles.chatItemRightGrouped]}>
             <ReportActionItemMessage action={action} setAttachmentModalData={setAttachmentModalData} />

--- a/src/pages/home/report/ReportActionItemGrouped.js
+++ b/src/pages/home/report/ReportActionItemGrouped.js
@@ -8,6 +8,9 @@ import styles from '../../../styles/styles';
 const propTypes = {
     // All the data of the action
     action: PropTypes.shape(ReportActionPropTypes).isRequired,
+
+    // Allows setting of attachment modal data
+    setAttachmentModalData: PropTypes.func.isRequired
 };
 
 const ReportActionItemGrouped = ({action, setAttachmentModalData}) => (

--- a/src/pages/home/report/ReportActionItemMessage.js
+++ b/src/pages/home/report/ReportActionItemMessage.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View } from 'react-native';
+import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
 import styles from '../../../styles/styles';
@@ -11,7 +11,7 @@ const propTypes = {
     action: PropTypes.shape(ReportActionPropTypes).isRequired,
 };
 
-const ReportActionItemMessage = ({ action, setAttachmentModalData }) => (
+const ReportActionItemMessage = ({action, setAttachmentModalData}) => (
     <View style={[styles.chatItemMessage]}>
         {_.map(_.compact(action.message), (fragment, index) => (
             <ReportActionItemFragment

--- a/src/pages/home/report/ReportActionItemMessage.js
+++ b/src/pages/home/report/ReportActionItemMessage.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View} from 'react-native';
+import { View } from 'react-native';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
 import styles from '../../../styles/styles';
@@ -11,14 +11,16 @@ const propTypes = {
     action: PropTypes.shape(ReportActionPropTypes).isRequired,
 };
 
-const ReportActionItemMessage = ({action}) => (
+const ReportActionItemMessage = ({ action, setAttachmentModalData }) => (
     <View style={[styles.chatItemMessage]}>
         {_.map(_.compact(action.message), (fragment, index) => (
             <ReportActionItemFragment
                 key={`actionFragment-${action.sequenceNumber}-${index}`}
+                action={action}
                 fragment={fragment}
                 isAttachment={action.isAttachment}
                 loading={action.loading}
+                setAttachmentModalData={setAttachmentModalData}
             />
         ))}
     </View>

--- a/src/pages/home/report/ReportActionItemMessage.js
+++ b/src/pages/home/report/ReportActionItemMessage.js
@@ -9,6 +9,9 @@ import ReportActionPropTypes from './ReportActionPropTypes';
 const propTypes = {
     // The report action
     action: PropTypes.shape(ReportActionPropTypes).isRequired,
+
+    // Allows setting of attachment modal data
+    setAttachmentModalData: PropTypes.func.isRequired
 };
 
 const ReportActionItemMessage = ({action, setAttachmentModalData}) => (

--- a/src/pages/home/report/ReportActionItemSingle.js
+++ b/src/pages/home/report/ReportActionItemSingle.js
@@ -13,6 +13,9 @@ import Avatar from '../../../components/Avatar';
 const propTypes = {
     // All the data of the action
     action: PropTypes.shape(ReportActionPropTypes).isRequired,
+
+    // Allows setting of attachment modal data
+    setAttachmentModalData: PropTypes.func.isRequired
 };
 
 const ReportActionItemSingle = ({action, setAttachmentModalData}) => {

--- a/src/pages/home/report/ReportActionItemSingle.js
+++ b/src/pages/home/report/ReportActionItemSingle.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View} from 'react-native';
+import { View } from 'react-native';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
 import ReportActionPropTypes from './ReportActionPropTypes';
@@ -15,7 +15,7 @@ const propTypes = {
     action: PropTypes.shape(ReportActionPropTypes).isRequired,
 };
 
-const ReportActionItemSingle = ({action}) => {
+const ReportActionItemSingle = ({ action, setAttachmentModalData }) => {
     const avatarUrl = action.automatic
         ? `${CONST.CLOUDFRONT_URL}/images/icons/concierge_2019.svg`
         : action.avatar;
@@ -29,13 +29,15 @@ const ReportActionItemSingle = ({action}) => {
                 <View style={[styles.chatItemMessageHeader]}>
                     {_.map(action.person, (fragment, index) => (
                         <ReportActionItemFragment
+                            action={action}
                             key={`person-${action.sequenceNumber}-${index}`}
                             fragment={fragment}
+                            setAttachmentModalData={setAttachmentModalData}
                         />
                     ))}
                     <ReportActionItemDate timestamp={action.timestamp} />
                 </View>
-                <ReportActionItemMessage action={action} />
+                <ReportActionItemMessage action={action} setAttachmentModalData={setAttachmentModalData} />
             </View>
         </View>
     );

--- a/src/pages/home/report/ReportActionItemSingle.js
+++ b/src/pages/home/report/ReportActionItemSingle.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View } from 'react-native';
+import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
 import ReportActionPropTypes from './ReportActionPropTypes';
@@ -15,7 +15,7 @@ const propTypes = {
     action: PropTypes.shape(ReportActionPropTypes).isRequired,
 };
 
-const ReportActionItemSingle = ({ action, setAttachmentModalData }) => {
+const ReportActionItemSingle = ({action, setAttachmentModalData}) => {
     const avatarUrl = action.automatic
         ? `${CONST.CLOUDFRONT_URL}/images/icons/concierge_2019.svg`
         : action.avatar;

--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -132,6 +132,46 @@ class ReportActionsView extends React.Component {
     }
 
     /**
+     * Gets the next attachment based on the current action passed into the function
+     * and the direction being moved (to he left or to the right)
+     *
+     * @param {ReportActionPropTypes} action
+     * @param {Boolean} toRight
+     *
+     * @returns {ReportActionPropTypes}
+     */
+    getNextAttachment(action, toRight) {
+        const actions = Object.values(this.sortedReportActions).reverse();
+        const sequenceNumber = action.sequenceNumber;
+        const actionsToSearch = toRight ? actions.slice(sequenceNumber) : actions.slice(0, sequenceNumber !== 0 ? sequenceNumber - 1 : 0).reverse();
+        const nextAttachment = actionsToSearch.find(actionResult => actionResult.action.isAttachment);
+        if (nextAttachment) {
+            return nextAttachment;
+        }
+        const actionsToSearchFromBeginning = toRight ? actions : [...actions].reverse();
+        const nextAttachmentAfterLoop = actionsToSearchFromBeginning.find(actionResult => actionResult.action.isAttachment);
+        return nextAttachmentAfterLoop;
+    }
+
+    /**
+     * Sets the data needed for the modal in the state object
+     *
+     * @param {Object} args
+     * @param {ReportActionPropTypes} args.currentAction
+     * @param {String} args.sourceURL
+     * @param {Object} args.file
+     * @param {String} args.file.name
+     * @param {Boolean} args.isModalOpen
+     */
+    setAttachmentModalData({
+        currentAction, sourceURL, file, isModalOpen
+    }) {
+        this.setState({
+            currentAction, sourceURL, file, isModalOpen
+        });
+    }
+
+    /**
      * Updates and sorts the report actions by sequence number
      */
     updateSortedReportActions() {
@@ -227,45 +267,6 @@ class ReportActionsView extends React.Component {
                 setAttachmentModalData={this.setAttachmentModalData}
             />
         );
-    }
-
-    /**
-     * Sets the data needed for the modal in the state object
-     *
-     * @param {Object} args
-     * @param {ReportActionPropTypes} args.currentAction
-     * @param {String} args.sourceURL
-     * @param {Object} args.file
-     * @param {String} args.file.name
-     * @param {Boolean} args.isModalOpen
-     */
-    setAttachmentModalData(modalData) {
-        this.setState({
-            ...modalData
-        });
-    }
-
-    /**
-     * Gets the next attachment based on the current action passed into the function
-     * and the direction being moved (to he left or to the right)
-     *
-     * @param {ReportActionPropTypes} args.action
-     * @param {Boolean} args.toRight
-     *
-     * @returns {ReportActionPropTypes}
-     */
-    getNextAttachment(action, toRight) {
-        const actions = Object.values(this.sortedReportActions).reverse();
-        const sequenceNumber = action.sequenceNumber;
-        const actionsToSearch = toRight ? actions.slice(sequenceNumber) : actions.slice(0, sequenceNumber !== 0 ? sequenceNumber - 1 : 0).reverse();
-        const nextAttachment = actionsToSearch.find(action => action.action.isAttachment);
-        if (nextAttachment) {
-            return nextAttachment;
-        } else {
-            const actionsToSearch = toRight ? actions : [...actions].reverse();
-            const nextAttachmentAfterLoop = actionsToSearch.find(action => action.action.isAttachment);
-            return nextAttachmentAfterLoop;
-        }
     }
 
     render() {

--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -1,17 +1,17 @@
 import React from 'react';
-import { View, Keyboard, AppState } from 'react-native';
+import {View, Keyboard, AppState} from 'react-native';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
 import lodashGet from 'lodash.get';
-import { withOnyx } from 'react-native-onyx';
+import {withOnyx} from 'react-native-onyx';
 import Text from '../../../components/Text';
-import { fetchActions, updateLastReadActionID } from '../../../libs/actions/Report';
+import {fetchActions, updateLastReadActionID} from '../../../libs/actions/Report';
 import ONYXKEYS from '../../../ONYXKEYS';
 import ReportActionItem from './ReportActionItem';
 import styles from '../../../styles/styles';
 import ReportActionPropTypes from './ReportActionPropTypes';
 import InvertedFlatList from '../../../components/InvertedFlatList';
-import { lastItem } from '../../../libs/CollectionUtils';
+import {lastItem} from '../../../libs/CollectionUtils';
 import Visibility from '../../../libs/Visibility';
 import AttachmentModal from '../../../components/AttachmentModal';
 
@@ -53,7 +53,7 @@ class ReportActionsView extends React.Component {
         this.state = {
             refetchNeeded: true,
             sourceURL: null,
-            file: { name: null },
+            file: {name: null},
             isAttachment: null,
             isModalOpen: false
         };
@@ -128,7 +128,7 @@ class ReportActionsView extends React.Component {
      * @param {Boolean} refetchNeeded
      */
     setRefetchNeeded(refetchNeeded) {
-        this.setState({ refetchNeeded });
+        this.setState({refetchNeeded});
     }
 
     /**
@@ -138,7 +138,7 @@ class ReportActionsView extends React.Component {
         this.sortedReportActions = _.chain(this.props.reportActions)
             .sortBy('sequenceNumber')
             .filter(action => action.actionName === 'ADDCOMMENT')
-            .map((item, index) => ({ action: item, index }))
+            .map((item, index) => ({action: item, index}))
             .value()
             .reverse();
     }
@@ -193,7 +193,7 @@ class ReportActionsView extends React.Component {
      */
     scrollToListBottom() {
         if (this.actionListElement) {
-            this.actionListElement.scrollToIndex({ animated: false, index: 0 });
+            this.actionListElement.scrollToIndex({animated: false, index: 0});
         }
         this.recordMaxAction();
     }
@@ -242,7 +242,7 @@ class ReportActionsView extends React.Component {
     setAttachmentModalData(modalData) {
         this.setState({
             ...modalData
-        })
+        });
     }
 
     /**
@@ -314,7 +314,7 @@ ReportActionsView.defaultProps = defaultProps;
 
 export default withOnyx({
     reportActions: {
-        key: ({ reportID }) => `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`,
+        key: ({reportID}) => `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`,
         canEvict: props => !props.isActiveReport,
     },
     session: {

--- a/src/pages/home/report/ReportView.js
+++ b/src/pages/home/report/ReportView.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import {View} from 'react-native';
+import { View } from 'react-native';
 import PropTypes from 'prop-types';
-import ReportActionView from './ReportActionsView';
+import ReportActionsView from './ReportActionsView';
 import ReportActionCompose from './ReportActionCompose';
-import {addAction, subscribeToReportTypingEvents, unsubscribeFromReportChannel} from '../../../libs/actions/Report';
+import { addAction, subscribeToReportTypingEvents, unsubscribeFromReportChannel } from '../../../libs/actions/Report';
 import KeyboardSpacer from '../../../components/KeyboardSpacer';
 import Timing from '../../../libs/actions/Timing';
 import CONST from '../../../CONST';
@@ -42,7 +42,7 @@ class ReportView extends React.PureComponent {
         const shouldShowComposeForm = this.props.isActiveReport;
         return (
             <View style={[styles.chatContent]}>
-                <ReportActionView
+                <ReportActionsView
                     reportID={this.props.reportID}
                     isActiveReport={this.props.isActiveReport}
                 />

--- a/src/pages/home/report/ReportView.js
+++ b/src/pages/home/report/ReportView.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import { View } from 'react-native';
+import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import ReportActionsView from './ReportActionsView';
 import ReportActionCompose from './ReportActionCompose';
-import { addAction, subscribeToReportTypingEvents, unsubscribeFromReportChannel } from '../../../libs/actions/Report';
+import {addAction, subscribeToReportTypingEvents, unsubscribeFromReportChannel} from '../../../libs/actions/Report';
 import KeyboardSpacer from '../../../components/KeyboardSpacer';
 import Timing from '../../../libs/actions/Timing';
 import CONST from '../../../CONST';


### PR DESCRIPTION
Implemented functionality to achieve following statement:
"The attachments present in the chat should cycle when the user is viewing the modal and presses the left/right arrows on their keyboard"

### Details
Refactored code and moved Attachment modal so only one is created for ReportActionsView and one for the ReportActionCompose view. Then setAttachmentModalData sets modal data in higher component and is passed down to Attachmentmodal.

Also wrote getNextAttachment function which retrieves the next attachment using the current action and a boolean value indicating whether to move to the right or left of the current action.

### Fixed Issues
Implements #1038 

### Tests

1. Upload multiple attachments (Images and PDFs)
2. Once they have been uploaded, use the left and right arrow keys to move between all of them.
3. Go to the last attachment and confirm that moving to the right of the last attachment takes you to the first attachment in a cyclical manner.

1. Test that uploading attachments still works (Images, PDFs .etc)

### Tested On
- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots

#### Web
<img width="2048" alt="Screenshot 2020-12-31 at 19 33 10" src="https://user-images.githubusercontent.com/13122879/103423562-25bda180-4b9f-11eb-9b68-22d2b26b6795.png">
<img width="2048" alt="Screenshot 2020-12-31 at 19 33 27" src="https://user-images.githubusercontent.com/13122879/103423566-2a825580-4b9f-11eb-9328-d3f53a567e82.png">

#### Mobile Web
no changes

#### Desktop
no changes

#### iOS
no changes

#### Android
no changes