### PR TITLE
Always allow calls to Authenticate to be called (even when request queue is paused)

### DIFF
--- a/src/libs/Network.js
+++ b/src/libs/Network.js
@@ -46,7 +46,9 @@ function processNetworkRequestQueue() {
     _.each(networkRequestQueue, (queuedRequest) => {
         // Some requests must be allowed to run even when the queue is paused e.g. an authentication request
         // that pauses the network queue while authentication happens, then unpauses it when it's done.
-        if (isQueuePaused && queuedRequest.data.forceNetworkRequest !== true) {
+        const shouldSkipRequest = isQueuePaused && queuedRequest.data.forceNetworkRequest !== true;
+
+        if (shouldSkipRequest) {
             return;
         }
 
@@ -56,7 +58,7 @@ function processNetworkRequestQueue() {
 
         // Check to see if the queue has paused again. It's possible that a call to enhanceParameters()
         // has paused the queue and if this is the case we must return.
-        if (isQueuePaused) {
+        if (shouldSkipRequest) {
             return;
         }
 


### PR DESCRIPTION
### Details
We missed this teensy little detail (that entirely breaks the re-authentication flow 😅 ) in https://github.com/Expensify/Expensify.cash/pull/1075/files which ironically was supposed to fix some other sign in bugs. Nice!

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/149497

### Tests
1. Set up quickly expiring authTokens in Auth (5 seconds)
2. Navigate to chrome dev tools Application tab
3. Verify that once you log in your authToken exists
4. Wait until it expires
5. Do something that would trigger a network request like mount a new chat
6. Verify the authToken updates indicating that it expired and we reauthenticated you

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<Add any necessary screenshots for all platforms if your change added or updated UI>

#### Web
<!-- Insert screenshots of your changes on the web platform or write "no changes"-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser) or write "no changes"-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform or write "no changes"-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform or write "no changes"-->

#### Android
<!-- Insert screenshots of your changes on the Android platform or write "no changes"-->
