### PR TITLE
Patched the Expensify-common

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "electron-log": "^4.2.4",
     "electron-serve": "^1.0.0",
     "electron-updater": "^4.3.4",
-    "expensify-common": "git+https://github.com/Expensify/expensify-common.git#d1bfacca6fb92f7e89a2a9cdf0863fad6481c0f2",
+    "expensify-common": "git+https://github.com/Expensify/expensify-common.git#abf27f7cc163c37256e0bae7a9cbac64853e9073",
     "file-loader": "^6.0.0",
     "html-entities": "^1.3.1",
     "lodash.get": "^4.4.2",


### PR DESCRIPTION
fixes the code formatting issue

@kadiealexander @stephanieelliott Please review it. I have submitted the PR to Expensify-common  https://github.com/Expensify/expensify-common/pull/316 which is approved and merged by @marcaaron. This PR patches the lib version here.

### Details
After testing I found out the using `&nbsp;` chars instead of spaces are creating one big line which as a result will break into new lines on the browser or rendering engine's mercy. Usually, the result would be that words will break into multiple lines. So I have replaced the `&nbsp;` to `&#32;` on  ExpensiMark.js which Preserves the backward compatibility for other apps and resolve this issue.

### Fixed Issues

Fixes Expensify/Expensify.cash#993

### Tests
Go to the chat screen and add any report comment enclosed between (framed by ```\n) . The word should wrap to the next line properly. 
for example - 
_Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent viverra feugiat ipsum sit amet dapibus. Donec eu euismod metus, viverra tempor lacus. In semper, magna vel eleifend ultrices, nisi turpis facilisis metus, ac tristique nisi sem non est. Quisque tempus turpis vitae lectus maximus tincidunt. Fusce tempor nisl et condimentum lacinia. Sed tellus arcu, commodo vitae lorem et, tincidunt porttitor -- magna. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum sem tellus, tempus in vulputate a, tempor eleifend massa. Morbi a dolor ut est tincidunt consectetur non at justo. Nullam sem erat, gravida in ipsum ac, facilisis faucibus ex. Morbi venenatis turpis justo, vitae interdum sapien venenatis quis. Duis dictum ornare -- massa, ac mollis quam sagittis non. Vivamus metus tellus, ultricies eu metus vel, pharetra vulputate nunc. Nulla nec ex ac orci dignissim imperdiet._

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

![Screenshot_2020-12-31 Expensify cash](https://user-images.githubusercontent.com/24370807/103447837-72e06700-4cb6-11eb-8f3b-79b251c1dad6.png)

Similiar results on other platforms.
