### PR TITLE
cleared onyx storage when logout and initialized account storage with…

### DIFF
--- a/src/libs/actions/Session.js
+++ b/src/libs/actions/Session.js
@@ -70,8 +70,9 @@ function signOut() {
         partnerName: CONFIG.EXPENSIFY.PARTNER_NAME,
         partnerPassword: CONFIG.EXPENSIFY.PARTNER_PASSWORD,
         doNotRetry: true,
-    })
-        .catch(error => Onyx.merge(ONYXKEYS.SESSION, {error: error.message}));
+    }).then(() => {
+        Onyx.clear();
+    }).catch(error => Onyx.merge(ONYXKEYS.SESSION, {error: error.message}));
 }
 
 /**
@@ -80,7 +81,7 @@ function signOut() {
  * @param {String} login
  */
 function fetchAccountDetails(login) {
-    Onyx.merge(ONYXKEYS.ACCOUNT, {error: '', loading: true});
+    Onyx.set(ONYXKEYS.ACCOUNT, {error: '', loading: true});
 
     API.GetAccountStatus({email: login, isViaExpensifyCash: true})
         .then((response) => {

--- a/src/libs/actions/Session.js
+++ b/src/libs/actions/Session.js
@@ -70,9 +70,8 @@ function signOut() {
         partnerName: CONFIG.EXPENSIFY.PARTNER_NAME,
         partnerPassword: CONFIG.EXPENSIFY.PARTNER_PASSWORD,
         doNotRetry: true,
-    }).then(() => {
-        Onyx.clear();
-    }).catch(error => Onyx.merge(ONYXKEYS.SESSION, {error: error.message}));
+    })
+        .catch(error => Onyx.merge(ONYXKEYS.SESSION, {error: error.message}));
 }
 
 /**


### PR DESCRIPTION

### Details
Cleared Onyx storage when logout and initialized account storage with Onyx.set() instead Onyx.merge()

Defined with Onyx.set() in case any cookie value is entered incorrectly in the initial state of the account. So when the fetchAccountDetails function runs, clear the account state.

### Fixed Issues
https://github.com/Expensify/Expensify.cash/issues/1118

### Tests
- Safari Version 14.0 (15610.1.28.1.9, 15610) 
- Google Chrome Version 87.0.4280.88 (Official Build) (x86_64)

Action Performed (reproducible steps):
1.   Sign in as normal
2.   Navigate to a report
3.   Click "Sign out"
4.   Note that there is an exitTo in the URL
5.   Enter an email address to sign in
6.   Note that it hangs there forever

I did not get an error when I did the steps specified in the issue. But when I tried again and again I was able to reproduced twice.
Local storage account state include my email while I tried to sign in. It's an infinite loop doing. 
I tested it in two browsers after developments. I did not encounter any problem.


<img width="1680" alt="1" src="https://user-images.githubusercontent.com/30370395/103465672-33198e00-4d4f-11eb-940a-bc597e98bd89.png">
<img width="1679" alt="2" src="https://user-images.githubusercontent.com/30370395/103465673-3c0a5f80-4d4f-11eb-9c96-a3458b3388e0.png">
<img width="1680" alt="3" src="https://user-images.githubusercontent.com/30370395/103465676-42004080-4d4f-11eb-875d-7ae5d8b2c77b.png">



### Tested On
- [ + ] Web
- [ + ] Mobile Web
- [ + ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
no changes

#### Web
no changes

#### Mobile Web
no changes

#### Desktop
no changes

#### iOS
no changes

#### Android
no changes
