### PR TITLE
Fixed MultipleAvatars

### DIFF
--- a/src/components/MultipleAvatars.js
+++ b/src/components/MultipleAvatars.js
@@ -16,42 +16,42 @@ const defaultProps = {
     optionIsFocused: false,
 };
 
-const MultiAvatar = props => (
+const MultipleAvatars = props => (
     <>
         {props.avatarImageURLs !== undefined && (
             <>
                 <View
                     style={[
                         props.avatarImageURLs.length > 1
-                            ? [styles.chatSwitcherSingleAvatar, styles.chatSwitcherAvatar1]
-                            : [styles.chatSwitcherBigAvatar, styles.chatSwitcherEmptyAvatar1],
+                            ? [styles.singleAvatar, styles.singleLeftAvatar]
+                            : [styles.bigAvatar, styles.emptyAvatar],
                     ]}
                 >
                     <Image
                         source={{uri: props.avatarImageURLs[0]}}
                         style={
                             props.avatarImageURLs.length > 1
-                                ? styles.chatSwitcherSingleAvatar
-                                : styles.chatSwitcherBigAvatar
+                                ? styles.singleAvatar
+                                : styles.bigAvatar
                         }
                     />
                 </View>
                 {props.avatarImageURLs.length > 1 && (
                     <View
                         style={[
-                            styles.chatSwitcherSingleAvatar,
-                            props.avatarImageURLs.length > 1 ? styles.chatSwitcherAvatar2 : null,
-                            props.optionIsFocused ? styles.chatSwitcherFocusedAvatar : styles.chatSwitcherAvatar,
+                            styles.singleAvatar,
+                            props.avatarImageURLs.length > 1 ? styles.singleRightAvatar : null,
+                            props.optionIsFocused ? styles.focusedAvatar : styles.avatar,
                         ]}
                     >
                         {props.avatarImageURLs.length > 2 && (
                             <View
                                 style={[
-                                    styles.chatSwitcherAvatarText,
-                                    styles.chatSwitcherAvatarSpace,
+                                    styles.avatarText,
+                                    styles.avatarSpace,
                                 ]}
                             >
-                                <Text style={styles.chatSwitcherAvatarInnerText}>
+                                <Text style={styles.avatarInnerText}>
                                     {props.avatarImageURLs.length}
                                 </Text>
                             </View>
@@ -60,8 +60,8 @@ const MultiAvatar = props => (
                             <Image
                                 source={{uri: props.avatarImageURLs[1]}}
                                 style={[
-                                    styles.chatSwitcherSingleAvatar,
-                                    styles.chatSwitcherAvatarSpace,
+                                    styles.singleAvatar,
+                                    styles.avatarSpace,
                                 ]}
                             />
                         )}
@@ -72,6 +72,6 @@ const MultiAvatar = props => (
     </>
 );
 
-MultiAvatar.defaultProps = defaultProps;
-MultiAvatar.propTypes = propTypes;
-export default memo(MultiAvatar);
+MultipleAvatars.defaultProps = defaultProps;
+MultipleAvatars.propTypes = propTypes;
+export default memo(MultipleAvatars);

--- a/src/components/MultipleAvatars.js
+++ b/src/components/MultipleAvatars.js
@@ -24,7 +24,7 @@ const MultipleAvatars = props => (
                     style={[
                         props.avatarImageURLs.length > 1
                             ? [styles.singleAvatar, styles.singleLeftAvatar]
-                            : [styles.bigAvatar, styles.emptyAvatar],
+                            : [styles.avatarNormal, styles.emptyAvatar],
                     ]}
                 >
                     <Image
@@ -32,7 +32,7 @@ const MultipleAvatars = props => (
                         style={
                             props.avatarImageURLs.length > 1
                                 ? styles.singleAvatar
-                                : styles.bigAvatar
+                                : styles.avatarNormal
                         }
                     />
                 </View>

--- a/src/components/MultipleAvatars.js
+++ b/src/components/MultipleAvatars.js
@@ -52,7 +52,7 @@ const MultipleAvatars = props => (
                                 ]}
                             >
                                 <Text style={styles.avatarInnerText}>
-                                    {props.avatarImageURLs.length}
+                                    {props.avatarImageURLs.length - 1}
                                 </Text>
                             </View>
                         )}

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -167,15 +167,14 @@ function getFromReportParticipants(reports) {
             // report and based on the participants we'll link up their avatars to report icons.
             _.each(reports, (report) => {
                 if (report.participants.length > 0) {
-                    const avatars = report.participants
-                        .map(dmParticipant => ({
-                            firstName: lodashGet(details, [dmParticipant, 'firstName'], ''),
-                            avatar: lodashGet(details, [dmParticipant, 'avatar'], getDefaultAvatar(dmParticipant)),
-                        }))
+                    const avatars = _.map(report.participants, dmParticipant => ({
+                        firstName: lodashGet(details, [dmParticipant, 'firstName'], ''),
+                        avatar: lodashGet(details, [dmParticipant, 'avatar'], getDefaultAvatar(dmParticipant)),
+                    }))
                         .sort((first, second) => first.firstName - second.firstName)
                         .map(item => item.avatar);
 
-                    Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`, {icon: avatars});
+                    Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`, {icons: avatars});
                 }
             });
         });

--- a/src/pages/home/sidebar/ChatLinkRow.js
+++ b/src/pages/home/sidebar/ChatLinkRow.js
@@ -11,7 +11,7 @@ import {
 import styles from '../../../styles/styles';
 import ChatSwitcherOptionPropTypes from './ChatSwitcherOptionPropTypes';
 import pencilIcon from '../../../../assets/images/icon-pencil.png';
-import MultiAvatar from '../../../components/MultiAvatar';
+import MultipleAvatars from '../../../components/MultipleAvatars';
 
 const propTypes = {
     // Option to allow the user to choose from can be type 'report' or 'user'
@@ -74,10 +74,10 @@ const ChatLinkRow = ({
                     ]}
                 >
                     {
-                        !_.isEmpty(option.icon)
+                        !_.isEmpty(option.icons)
                         && (
-                            <MultiAvatar
-                                avatarImageURLs={option.icon}
+                            <MultipleAvatars
+                                avatarImageURLs={option.icons}
                                 optionIsFocused={optionIsFocused}
                             />
                         )

--- a/src/pages/home/sidebar/ChatSwitcherView.js
+++ b/src/pages/home/sidebar/ChatSwitcherView.js
@@ -428,7 +428,7 @@ class ChatSwitcherView extends React.Component {
                 alternateText: personalDetail.login,
                 searchText: personalDetail.displayName === personalDetail.login ? personalDetail.login
                     : `${personalDetail.displayName} ${personalDetail.login}`,
-                icons: _.isArray(personalDetail.avatarURL) ? personalDetail.avatarURL : [personalDetail.avatarURL],
+                icons: [personalDetail.avatarURL],
                 login: personalDetail.login,
                 type: CONST.OPTION_TYPE.PERSONAL_DETAIL,
                 keyForList: personalDetail.login,

--- a/src/pages/home/sidebar/ChatSwitcherView.js
+++ b/src/pages/home/sidebar/ChatSwitcherView.js
@@ -173,7 +173,7 @@ class ChatSwitcherView extends React.Component {
                         : report.reportName ?? '',
                     reportID: report.reportID,
                     participants,
-                    icon: report.icon,
+                    icons: report.icons,
                     login,
                     singleUserDM: isSingleUserDM,
                     type: CONST.OPTION_TYPE.REPORT,
@@ -428,7 +428,7 @@ class ChatSwitcherView extends React.Component {
                 alternateText: personalDetail.login,
                 searchText: personalDetail.displayName === personalDetail.login ? personalDetail.login
                     : `${personalDetail.displayName} ${personalDetail.login}`,
-                icon: Array.isArray(personalDetail.avatarURL) ? personalDetail.avatarURL : [personalDetail.avatarURL],
+                icons: _.isArray(personalDetail.avatarURL) ? personalDetail.avatarURL : [personalDetail.avatarURL],
                 login: personalDetail.login,
                 type: CONST.OPTION_TYPE.PERSONAL_DETAIL,
                 keyForList: personalDetail.login,

--- a/src/pages/home/sidebar/SidebarLinks.js
+++ b/src/pages/home/sidebar/SidebarLinks.js
@@ -123,7 +123,7 @@ const SidebarLinks = (props) => {
 
                                 // The icon for the row is set when we fetch personal details via
                                 // PersonalDetails.getFromReportParticipants()
-                                icon: report.icon,
+                                icons: report.icons,
                                 login,
                                 reportID: report.reportID,
                                 isUnread: report.unreadActionCount > 0,

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -189,11 +189,6 @@ const styles = {
         marginRight: 8,
     },
 
-    avatarNormal: {
-        height: variables.componentSizeNormal,
-        width: variables.componentSizeNormal,
-    },
-
     textInput: {
         backgroundColor: themeColors.componentBG,
         borderRadius: variables.componentBorderRadius,
@@ -761,7 +756,7 @@ const styles = {
         borderRadius: variables.avatarSizeNormal,
     },
 
-    bigAvatar: {
+    avatarNormal: {
         height: variables.componentSizeNormal,
         width: variables.componentSizeNormal,
         borderRadius: variables.componentSizeNormal,

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -755,24 +755,24 @@ const styles = {
         borderRightWidth: 0,
     },
 
-    chatSwitcherSingleAvatar: {
+    singleAvatar: {
         height: variables.avatarSizeNormal,
         width: variables.avatarSizeNormal,
         borderRadius: variables.avatarSizeNormal,
     },
 
-    chatSwitcherBigAvatar: {
+    bigAvatar: {
         height: variables.componentSizeNormal,
         width: variables.componentSizeNormal,
         borderRadius: variables.componentSizeNormal,
     },
 
-    chatSwitcherAvatar1: {
+    singleLeftAvatar: {
         marginTop: -variables.componentSizeNormal / 2,
         borderRadius: variables.avatarSizeNormal,
     },
 
-    chatSwitcherAvatar2: {
+    singleRightAvatar: {
         marginTop: variables.avatarSizeNormal / 2,
         height: variables.avatarSizeNormal + 6,
         width: variables.avatarSizeNormal + 6,
@@ -780,7 +780,7 @@ const styles = {
         left: -variables.avatarSizeNormal / 2,
     },
 
-    chatSwitcherAvatarText: {
+    avatarText: {
         backgroundColor: themeColors.icon,
         justifyContent: 'center',
         alignItems: 'center',
@@ -789,30 +789,27 @@ const styles = {
         width: variables.avatarSizeNormal,
     },
 
-    chatSwitcherAvatarInnerText: {
+    avatarInnerText: {
         color: themeColors.textReversed,
         fontSize: variables.fontSizeSmall,
+        lineHeight: variables.avatarSizeNormal,
     },
 
-    chatSwitcherAvatarSpace: {
+    avatarSpace: {
         top: 3,
         left: 3,
     },
 
-    chatSwitcherAvatar: {
+    avatar: {
         backgroundColor: themeColors.sidebar,
     },
 
-    chatSwitcherFocusedAvatar: {
+    focusedAvatar: {
         backgroundColor: themeColors.border,
     },
 
-    chatSwitcherEmptyAvatar1: {
+    emptyAvatar: {
         marginRight: variables.componentSizeNormal - variables.avatarSizeNormal,
-    },
-
-    chatSwitcherItemText: {
-        color: themeColors.text,
     },
 
     chatSwitcherItemAvatarNameWrapper: {

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -751,9 +751,9 @@ const styles = {
     },
 
     singleAvatar: {
-        height: variables.avatarSizeNormal,
-        width: variables.avatarSizeNormal,
-        borderRadius: variables.avatarSizeNormal,
+        height: 24,
+        width: 24,
+        borderRadius: 24,
     },
 
     avatarNormal: {
@@ -764,30 +764,29 @@ const styles = {
 
     singleLeftAvatar: {
         marginTop: -variables.componentSizeNormal / 2,
-        borderRadius: variables.avatarSizeNormal,
+        borderRadius: 24,
     },
 
     singleRightAvatar: {
-        marginTop: variables.avatarSizeNormal / 2,
-        height: variables.avatarSizeNormal + 6,
-        width: variables.avatarSizeNormal + 6,
-        borderRadius: variables.avatarSizeNormal + 6,
-        left: -variables.avatarSizeNormal / 2,
+        marginTop: 12,
+        height: 30,
+        width: 30,
+        borderRadius: 30,
+        left: -12,
     },
 
     avatarText: {
         backgroundColor: themeColors.icon,
-        justifyContent: 'center',
-        alignItems: 'center',
-        borderRadius: variables.avatarSizeNormal,
-        height: variables.avatarSizeNormal,
-        width: variables.avatarSizeNormal,
+        borderRadius: 24,
+        height: 24,
+        width: 24,
     },
 
     avatarInnerText: {
         color: themeColors.textReversed,
         fontSize: variables.fontSizeSmall,
-        lineHeight: variables.avatarSizeNormal,
+        lineHeight: 24,
+        textAlign: 'center',
     },
 
     avatarSpace: {
@@ -804,7 +803,7 @@ const styles = {
     },
 
     emptyAvatar: {
-        marginRight: variables.componentSizeNormal - variables.avatarSizeNormal,
+        marginRight: variables.componentSizeNormal - 24,
     },
 
     chatSwitcherItemAvatarNameWrapper: {

--- a/src/styles/variables.js
+++ b/src/styles/variables.js
@@ -1,5 +1,4 @@
 export default {
-    avatarSizeNormal: 24,
     contentHeaderHeight: 65,
     componentSizeSmall: 28,
     componentSizeNormal: 40,


### PR DESCRIPTION
Please review my update. @roryabraham @marcaaron @shawnborton 

### Details

- Updated code style
- Fixed line-height of avatar text

### Fixed Issues

Fixes [1064](https://github.com/Expensify/Expensify.cash/issues/1064)

### Tests

Once you are logged in, you can chat with other participants (2+).
When a chat has 2 participants (me and another participant), showed the single avatar (40X40) of another user.
When a chat has 3 participants, showed the avatars (24X24) of the 2 other participants.
When a chat has 4 or more participants, showed the avatar (24X24) of the user whose username comes first alphabetically, and showed a circular (24X24) counter for the number of chat participants.
The font size of number is 11 (variables.fontSizeSmall) and background color is themeColors.textReversed.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
## iOS
![iOS](https://user-images.githubusercontent.com/59010279/103617303-b6490880-4f36-11eb-83e2-b9675a2022d7.png)

## Android
![android](https://user-images.githubusercontent.com/59010279/103619462-797f1080-4f3a-11eb-85b0-e1cad36daeaf.png)

## Web
![web](https://user-images.githubusercontent.com/59010279/103617349-c82aab80-4f36-11eb-8fb7-8cac4aeb77c1.JPG)

## mobile web
![mobile web](https://user-images.githubusercontent.com/59010279/103617388-d4af0400-4f36-11eb-9552-3e660ff30bc3.JPG)

## mac desktop
![desktop](https://user-images.githubusercontent.com/59010279/103617463-f6a88680-4f36-11eb-8dcb-5afad415cc02.JPG)