### PR TITLE
Update Example ENV for Expensify Employees to use their local API 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,4 @@ EXPENSIFY_PARTNER_PASSWORD=c3a9ac418ea3f152aae2
 PUSHER_APP_KEY=ac6d22b891daae55283a
 NGROK_URL=https://expensify-user.ngrok.io/
 USE_NGROK=false
+USE_WEB_PROXY=false

--- a/ios/ReactNativeChat.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ios/ReactNativeChat.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ios/ReactNativeChat.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ios/ReactNativeChat.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>IDEDidComputeMac32BitWarning</key>
-	<true/>
-</dict>
-</plist>


### PR DESCRIPTION
### Details
Expensify Employees could no longer set up their e.cash using the instructions because it would point them to production. This fixes that. 

### Fixed Issues
https://expensify.slack.com/archives/C011W8BJ9L6/p1609798628298400

### Tests
1. Pull this branch
2. Copy `.env.example` to `.env`
3. Create a new account on e.com.dev that does not exist on e.com
4. Validate the account
5. Log in with the new account on e.cash
6. Make sure it lets you log in with whatever your dev environment default password is

### Tested On

- [x] Web
If it doesn't break on web, it's not going to break anywhere
