### PR TITLE
Remove AppState listener and trigger reconnection callbacks when Pusher subscription succeeds 

### DIFF
--- a/src/libs/NetworkConnection.js
+++ b/src/libs/NetworkConnection.js
@@ -1,5 +1,4 @@
 import _ from 'underscore';
-import {AppState} from 'react-native';
 import NetInfo from '@react-native-community/netinfo';
 import Onyx from 'react-native-onyx';
 import ONYXKEYS from '../ONYXKEYS';
@@ -9,9 +8,7 @@ import ONYXKEYS from '../ONYXKEYS';
 let unsubscribeFromNetInfo;
 let sleepTimer;
 let lastTime;
-let isActive = false;
 let isOffline = false;
-let isListeningToAppStateChanges = false;
 
 // Holds all of the callbacks that need to be triggered when the network reconnects
 const reconnectionCallbacks = [];
@@ -42,21 +39,6 @@ function setOfflineStatus(isCurrentlyOffline) {
 }
 
 /**
- * @param {String} state
- */
-function setAppState(state) {
-    console.debug('[AppState] state changed:', state);
-    const nextStateIsActive = state === 'active';
-
-    // We are moving from not active to active and we are online so fire callbacks
-    if (!isOffline && nextStateIsActive && !isActive) {
-        triggerReconnectionCallbacks();
-    }
-
-    isActive = nextStateIsActive;
-}
-
-/**
  * Set up the event listener for NetInfo to tell whether the user has
  * internet connectivity or not. This is more reliable than the Pusher
  * `disconnected` event which takes about 10-15 seconds to emit.
@@ -68,13 +50,6 @@ function listenForReconnect() {
         console.debug('[NetInfo] isConnected:', state && state.isConnected);
         setOfflineStatus(!state.isConnected);
     });
-
-    // When the app is in the background Pusher can still receive realtime updates
-    // for a few minutes, but eventually disconnects causing a delay when the app
-    // returns from the background. So, if we are returning from the background
-    // and we are online we should trigger our reconnection callbacks.
-    AppState.addEventListener('change', setAppState);
-    isListeningToAppStateChanges = true;
 
     // When a device is put to sleep, NetInfo is not always able to detect
     // when connectivity has been lost. As a failsafe we will capture the time
@@ -99,10 +74,6 @@ function stopListeningForReconnect() {
         unsubscribeFromNetInfo();
         unsubscribeFromNetInfo = undefined;
     }
-    if (isListeningToAppStateChanges) {
-        AppState.removeEventListener('change', setAppState);
-        isListeningToAppStateChanges = false;
-    }
 }
 
 /**
@@ -119,4 +90,5 @@ export default {
     listenForReconnect,
     stopListeningForReconnect,
     onReconnect,
+    triggerReconnectionCallbacks,
 };

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -293,6 +293,10 @@ function subscribeToReportCommentEvents() {
 
     Pusher.subscribe(pusherChannelName, 'reportComment', (pushJSON) => {
         updateReportWithNewAction(pushJSON.reportID, pushJSON.reportAction);
+    }, false, () => {
+        // When we reconnect to this channel we want to trigger the reconnection callbacks to
+        // catch up on anything that we've missed
+        NetworkConnection.triggerReconnectionCallbacks();
     });
 
     PushNotification.onReceived(PushNotification.TYPE.REPORT_COMMENT, ({reportID, reportAction}) => {


### PR DESCRIPTION
…er reconnects

<If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit.>

### Details
<Explanation of the change or anything fishy that is going on>

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/149966

### Tests
1. Put the web app into the background by minimizing it
2. Verify the reconnection callbacks do not fire
3. Turn off Wi-Fi and wait a few seconds
4. Turn Wi-Fi back on and verify the reconnection callbacks have been triggered.

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<Add any necessary screenshots for all platforms if your change added or updated UI>

#### Web
<!-- Insert screenshots of your changes on the web platform or write "no changes"-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser) or write "no changes"-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform or write "no changes"-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform or write "no changes"-->

#### Android
<!-- Insert screenshots of your changes on the Android platform or write "no changes"-->
