### PR TITLE
Update typingStatus to the same format when the request is coming from e.com

### DIFF
--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -324,6 +324,7 @@ function subscribeToReportTypingEvents(reportID) {
     // Typing status is an object with the shape {[login]: Boolean} (e.g. {yuwen@expensify.com: true}), where the value
     // is whether the user with that login is typing on the report or not.
     Pusher.subscribe(pusherChannelName, 'client-userIsTyping', (typingStatus) => {
+        let userObject = typingStatus;
         let login = _.first(_.keys(typingStatus));
         if (!login) {
             return;
@@ -333,13 +334,13 @@ function subscribeToReportTypingEvents(reportID) {
         // We need to make sure to handle that case or it will say "userLogin is typing..."
         if (login === 'userLogin') {
             login = typingStatus.userLogin;
-            typingStatus = {[typingStatus.userLogin] : true};
+            userObject = {[typingStatus.userLogin]: true};
         }
 
         // Use a combo of the reportID and the login as a key for holding our timers.
         const reportUserIdentifier = `${reportID}-${login}`;
         clearTimeout(typingWatchTimers[reportUserIdentifier]);
-        Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_USER_IS_TYPING}${reportID}`, typingStatus);
+        Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_USER_IS_TYPING}${reportID}`, userObject);
 
         // Wait for 1.5s of no additional typing events before setting the status back to false.
         typingWatchTimers[reportUserIdentifier] = setTimeout(() => {

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -324,9 +324,16 @@ function subscribeToReportTypingEvents(reportID) {
     // Typing status is an object with the shape {[login]: Boolean} (e.g. {yuwen@expensify.com: true}), where the value
     // is whether the user with that login is typing on the report or not.
     Pusher.subscribe(pusherChannelName, 'client-userIsTyping', (typingStatus) => {
-        const login = _.first(_.keys(typingStatus));
+        let login = _.first(_.keys(typingStatus));
         if (!login) {
             return;
+        }
+
+        // If the user is typing on expensify.com (like concierge) the format will actually be [userLogin: Concierge]
+        // We need to make sure to handle that case or it will say "userLogin is typing..."
+        if (login === 'userLogin') {
+            login = typingStatus.userLogin;
+            typingStatus = {[typingStatus.userLogin] : true};
         }
 
         // Use a combo of the reportID and the login as a key for holding our timers.

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -318,13 +318,13 @@ function subscribeToReportCommentEvents() {
  * @returns {Object}
  */
 function getNormalizedTypingStatus(typingStatus) {
-    let userObject = typingStatus;
+    let normalizedTypingStatus = typingStatus;
 
     if (_.first(_.keys(typingStatus)) === 'userLogin') {
-        userObject = {[typingStatus.userLogin]: true};
+        normalizedTypingStatus = {[typingStatus.userLogin]: true};
     }
 
-    return userObject;
+    return normalizedTypingStatus;
 }
 
 /**

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -307,6 +307,27 @@ function subscribeToReportCommentEvents() {
 }
 
 /**
+ * There are 2 possibilities that we can receive via pusher for a user's typing status:
+ * 1. The "new" way from e.cash is passed as {[login]: Boolean} (e.g. {yuwen@expensify.com: true}), where the value
+ * is whether the user with that login is typing on the report or not.
+ * 2. The "old" way from e.com which is passed as {userLogin: login} (e.g. {userLogin: bstites@expensify.com})
+ *
+ * This method makes sure that no matter which we get, we return the "new" format
+ *
+ * @param {Object} typingStatus
+ * @returns {Object}
+ */
+function getNormalizedTypingStatus(typingStatus) {
+    let userObject = typingStatus;
+
+    if (_.first(_.keys(typingStatus)) === 'userLogin') {
+        userObject = {[typingStatus.userLogin]: true};
+    }
+
+    return userObject;
+}
+
+/**
  * Initialize our pusher subscriptions to listen for someone typing in a report.
  *
  * @param {Number} reportID
@@ -320,27 +341,18 @@ function subscribeToReportTypingEvents(reportID) {
     Onyx.set(`${ONYXKEYS.COLLECTION.REPORT_USER_IS_TYPING}${reportID}`, {});
 
     const pusherChannelName = getReportChannelName(reportID);
-
-    // Typing status is an object with the shape {[login]: Boolean} (e.g. {yuwen@expensify.com: true}), where the value
-    // is whether the user with that login is typing on the report or not.
     Pusher.subscribe(pusherChannelName, 'client-userIsTyping', (typingStatus) => {
-        let userObject = typingStatus;
-        let login = _.first(_.keys(typingStatus));
+        const normalizedTypingStatus = getNormalizedTypingStatus(typingStatus);
+        const login = _.first(_.keys(normalizedTypingStatus));
+
         if (!login) {
             return;
-        }
-
-        // If the user is typing on expensify.com (like concierge) the format will actually be [userLogin: Concierge]
-        // We need to make sure to handle that case or it will say "userLogin is typing..."
-        if (login === 'userLogin') {
-            login = typingStatus.userLogin;
-            userObject = {[typingStatus.userLogin]: true};
         }
 
         // Use a combo of the reportID and the login as a key for holding our timers.
         const reportUserIdentifier = `${reportID}-${login}`;
         clearTimeout(typingWatchTimers[reportUserIdentifier]);
-        Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_USER_IS_TYPING}${reportID}`, userObject);
+        Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_USER_IS_TYPING}${reportID}`, normalizedTypingStatus);
 
         // Wait for 1.5s of no additional typing events before setting the status back to false.
         typingWatchTimers[reportUserIdentifier] = setTimeout(() => {


### PR DESCRIPTION
### Details
We built our chat 'isTyping' indicators on e.com significantly before we did for e.cash, and we implemented them differently. On e.com we publish with pusher and the data is in this format: `{userLogin: 'Concierge'}`
On e.cash we publish with pusher and the data is in this format: `{'bstites@expensify.com': true}`

That meant that when we got [here in e.cash](https://github.com/Expensify/Expensify.cash/blob/1acc60f09d90ad6bcf8c85212820901323ee91da/src/libs/actions/Report.js#L342) we were setting the key as `userLogin`. 

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/149072#event-4165894115

### Tests
1. Open multiple chrome windows, one with e.cash, one with e.com logged into concierge, and one incognito of e.cash
2. Send a message to concierge from one of the e.cash windows
3. In concierge get the chat you sent, and start typing a reply
4. Make sure you can see `Concierge is typing` in the e.cash window
5. Send a message from one e.cash to the other
6. Load up the chat in both windows
7. Type on each one and make sure it says `<email1> is typing`

I only tested on web and desktop because this change didn't change any UI elements, only logic. 

### Tested On

- [x] Web
- [x] Desktop

### Screenshots
![2021-01-04_19-20-08](https://user-images.githubusercontent.com/42391420/103599224-e6a28f80-4ec1-11eb-949f-eb7bdd5abc5b.png)
![2021-01-04_19-25-15](https://user-images.githubusercontent.com/42391420/103599547-97109380-4ec2-11eb-84ff-98cc02564716.png)
