### PR TITLE
Add a GH action to check for unsigned commits

### DIFF
--- a/.github/workflows/signing.sh
+++ b/.github/workflows/signing.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+git fetch -q origin master:master
+
 commit_list=$(git rev-list master..)
 declare -r commit_list
 

--- a/.github/workflows/signing.sh
+++ b/.github/workflows/signing.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+commit_list=$(git rev-list master..)
+declare -r commit_list
+
+unsigned_commit=false
+for commit in $commit_list; do
+    if ! git verify-commit "$commit" 2>&1 | grep -q "Signature"; then
+        echo "Commit $commit not signed"
+        unsigned_commit=true
+    fi
+done
+
+if [[ $unsigned_commit == true ]]; then
+    exit 1
+fi

--- a/.github/workflows/signing.yml
+++ b/.github/workflows/signing.yml
@@ -1,0 +1,14 @@
+name: Check for unsigned commits
+
+on:
+    pull_request:
+        types: [opened, synchronize]
+
+jobs:
+    lint:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+
+            - name: Run check
+              run: ./.github/workflows/signing.sh

--- a/.github/workflows/signing.yml
+++ b/.github/workflows/signing.yml
@@ -5,10 +5,12 @@ on:
         types: [opened, synchronize]
 
 jobs:
-    lint:
+    check:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
+              with:
+                  fetch-depth: 0
 
             - name: Run check
               run: ./.github/workflows/signing.sh


### PR DESCRIPTION
### Details
We want to [make it mandatory](https://github.com/Expensify/Expensify.cash/pull/1171/files) to have signed commits and instead of manually checking whether some commits are missing signing, let's do that in a GH action. 

### Fixed Issues
N/A

### Tests
Tested with an unsigned commit, got this : 
<img width="980" alt="Screen Shot 2021-01-06 at 10 05 50" src="https://user-images.githubusercontent.com/1805746/103750436-160ee480-5007-11eb-9a84-52138c1490d8.png">

For signed commits, you can see that this PR works.
