### PR TITLE
Added charset meta tag to document template

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <meta charset="utf-8" />
     <title>Expensify.cash</title>
     <style>
         @font-face {


### PR DESCRIPTION
### Details

Adds the meta charset document tag to resolve browser errors from not specifying how to parse the document.

### Fixed Issues

Fixes #1148 

### Tests

There should be no errors relating to character parsing in Dev Tools.

### Tested On

- [x] Web
- [x] Mobile Web

### Screenshots

n/a
