### PR TITLE
Fix switching to a chat with a saved draft

### DIFF
--- a/src/components/TextInputFocusable/index.js
+++ b/src/components/TextInputFocusable/index.js
@@ -56,11 +56,16 @@ class TextInputFocusable extends React.Component {
 
         this.state = {
             numberOfLines: 1,
+            selection: {
+                start: this.props.defaultValue.length,
+                end: this.props.defaultValue.length,
+            },
         };
     }
 
     componentDidMount() {
         this.focusInput();
+        this.updateNumberOfLines();
 
         // This callback prop is used by the parent component using the constructor to
         // get a ref to the inner textInput element e.g. if we do
@@ -164,6 +169,7 @@ class TextInputFocusable extends React.Component {
         return (
             <TextInput
                 ref={el => this.textInput = el}
+                selection={this.state.selection}
                 onChange={() => {
                     this.updateNumberOfLines();
                 }}


### PR DESCRIPTION
@marcaaron @iwiznia @AndrewGable 

### Details

Used selection property of TextInput to set position of the cursor is at the end of the written text.
In order to get the correct size of text box when re-render, It should call `updateNumberOfLines` in componentDidMount to calculate `numberOfLines` by defaultValue from props.

### Fixed Issues

Fixes #1183

### Tests

1. Open a chat
2. Write a very long text that makes the field grow
3. Open another chat
4. Click on the original one that is shown in the sidebar with a pencil icon (indicating you have a draft message)

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots


#### Web
![Screen Shot 2021-01-07 at 3 23 37 PM](https://user-images.githubusercontent.com/74012504/103947828-5bfaa400-50fe-11eb-8d3a-7f04f121eb3c.png)


#### Mobile Web
![Screen Shot 2021-01-07 at 3 38 57 PM](https://user-images.githubusercontent.com/74012504/103947914-7af93600-50fe-11eb-88d0-720b84b80638.png)


#### Desktop
![Screen Shot 2021-01-07 at 3 12 44 PM](https://user-images.githubusercontent.com/74012504/103947938-864c6180-50fe-11eb-8d69-0b2e06ba89bc.png)

#### iOS


#### Android
![Screen Shot 2021-01-07 at 3 39 57 PM](https://user-images.githubusercontent.com/74012504/103947989-9e23e580-50fe-11eb-86fe-5b4871225559.png)

