### PR TITLE
Rename ModalHeader to HeaderWithCloseButton Refactor

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -7,10 +7,10 @@ import styles from '../styles/styles';
 import exitIcon from '../../assets/images/icon-x--20x20.png';
 
 const propTypes = {
-    // Title of the modal
+    // Title of the Header
     title: PropTypes.string,
 
-    // Method to trigger when pressing close button of the modal
+    // Method to trigger when pressing close button of the header
     onCloseButtonPress: PropTypes.func,
 };
 
@@ -19,8 +19,8 @@ const defaultProps = {
     onCloseButtonPress: () => {},
 };
 
-const ModalHeader = props => (
-    <View style={styles.modalHeaderBar}>
+const Header = props => (
+    <View style={styles.headerBar}>
         <View style={[
             styles.dFlex,
             styles.flexRow,
@@ -51,8 +51,8 @@ const ModalHeader = props => (
     </View>
 );
 
-ModalHeader.propTypes = propTypes;
-ModalHeader.defaultProps = defaultProps;
-ModalHeader.displayName = 'ModalHeader';
+Header.propTypes = propTypes;
+Header.defaultProps = defaultProps;
+Header.displayName = 'Header';
 
-export default ModalHeader;
+export default Header;

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -11,7 +11,7 @@ const propTypes = {
 
 const Header = props => (
     <View style={[styles.flex1]}>
-        <Text numberOfLines={1} style={[styles.headerText]}>
+        <Text numberOfLines={2} style={[styles.headerText]}>
             {props.title}
         </Text>
     </View>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,58 +1,21 @@
 import React from 'react';
+import {View, Text} from 'react-native';
 import PropTypes from 'prop-types';
-import {
-    View, Image, TouchableOpacity, Text,
-} from 'react-native';
 import styles from '../styles/styles';
-import exitIcon from '../../assets/images/icon-x--20x20.png';
 
 const propTypes = {
-    // Title of the Header
-    title: PropTypes.string,
-
-    // Method to trigger when pressing close button of the header
-    onCloseButtonPress: PropTypes.func,
-};
-
-const defaultProps = {
-    title: '',
-    onCloseButtonPress: () => {},
+    /** Title of the Header */
+    title: PropTypes.string.isRequired,
 };
 
 const Header = props => (
-    <View style={styles.headerBar}>
-        <View style={[
-            styles.dFlex,
-            styles.flexRow,
-            styles.alignItemsCenter,
-            styles.flexGrow1,
-            styles.justifyContentBetween,
-            styles.overflowHidden,
-        ]}
-        >
-            <View style={[styles.flex1]}>
-                <Text numberOfLines={1} style={[styles.navText]}>
-                    {props.title}
-                </Text>
-            </View>
-            <View style={[styles.reportOptions, styles.flexRow]}>
-                <TouchableOpacity
-                    onPress={props.onCloseButtonPress}
-                    style={[styles.touchableButtonImage]}
-                >
-                    <Image
-                        resizeMode="contain"
-                        style={[styles.attachmentCloseIcon]}
-                        source={exitIcon}
-                    />
-                </TouchableOpacity>
-            </View>
-        </View>
+    <View style={[styles.flex1]}>
+        <Text numberOfLines={1} style={[styles.navText]}>
+            {props.title}
+        </Text>
     </View>
 );
 
-Header.propTypes = propTypes;
-Header.defaultProps = defaultProps;
 Header.displayName = 'Header';
-
+Header.propTypes = propTypes;
 export default Header;

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,7 +1,8 @@
 import React from 'react';
-import {View, Text} from 'react-native';
+import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import styles from '../styles/styles';
+import Text from './Text';
 
 const propTypes = {
     /** Title of the Header */
@@ -10,7 +11,7 @@ const propTypes = {
 
 const Header = props => (
     <View style={[styles.flex1]}>
-        <Text numberOfLines={1} style={[styles.navText]}>
+        <Text numberOfLines={1} style={[styles.headerText]}>
             {props.title}
         </Text>
     </View>

--- a/src/components/HeaderWithCloseButton.js
+++ b/src/components/HeaderWithCloseButton.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+    View, Image, TouchableOpacity,
+} from 'react-native';
+import styles from '../styles/styles';
+import exitIcon from '../../assets/images/icon-x--20x20.png';
+import Header from './Header';
+
+const propTypes = {
+    /** Title of the Header */
+    title: PropTypes.string,
+
+    /** Method to trigger when pressing close button of the header */
+    onCloseButtonPress: PropTypes.func,
+};
+
+const defaultProps = {
+    title: '',
+    onCloseButtonPress: () => {},
+};
+
+const HeaderWithCloseButton = props => (
+    <View style={styles.headerBar}>
+        <View style={[
+            styles.dFlex,
+            styles.flexRow,
+            styles.alignItemsCenter,
+            styles.flexGrow1,
+            styles.justifyContentBetween,
+            styles.overflowHidden,
+        ]}
+        >
+            <Header title={props.title} />
+            <View style={[styles.reportOptions, styles.flexRow]}>
+                <TouchableOpacity
+                    onPress={props.onCloseButtonPress}
+                    style={[styles.touchableButtonImage]}
+                >
+                    <Image
+                        resizeMode="contain"
+                        style={[styles.attachmentCloseIcon]}
+                        source={exitIcon}
+                    />
+                </TouchableOpacity>
+            </View>
+        </View>
+    </View>
+);
+
+HeaderWithCloseButton.propTypes = propTypes;
+HeaderWithCloseButton.defaultProps = defaultProps;
+HeaderWithCloseButton.displayName = 'HeaderWithCloseButton';
+
+export default HeaderWithCloseButton;

--- a/src/components/ModalWithHeader.js
+++ b/src/components/ModalWithHeader.js
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {View} from 'react-native';
 import Modal from './Modal';
-import Header from './Header';
 import styles from '../styles/styles';
+import HeaderWithCloseButton from './HeaderWithCloseButton';
 
 const propTypes = {
     // Title for modal header
@@ -22,7 +22,7 @@ const ModalWithHeader = props => (
         {...props}
     >
         <View style={[styles.modalViewContainer]}>
-            <Header
+            <HeaderWithCloseButton
                 title={props.title}
                 onCloseButtonPress={props.onClose}
             />

--- a/src/components/ModalWithHeader.js
+++ b/src/components/ModalWithHeader.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {View} from 'react-native';
 import Modal from './Modal';
-import ModalHeader from './ModalHeader';
+import Header from './Header';
 import styles from '../styles/styles';
 
 const propTypes = {
@@ -22,7 +22,7 @@ const ModalWithHeader = props => (
         {...props}
     >
         <View style={[styles.modalViewContainer]}>
-            <ModalHeader
+            <Header
                 title={props.title}
                 onCloseButtonPress={props.onClose}
             />

--- a/src/pages/home/HeaderView.js
+++ b/src/pages/home/HeaderView.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {View, Image, TouchableOpacity} from 'react-native';
 import PropTypes from 'prop-types';
 import {withOnyx} from 'react-native-onyx';
-import Text from '../../components/Text';
+import Header from '../../components/Header';
 import styles from '../../styles/styles';
 import ONYXKEYS from '../../ONYXKEYS';
 import {withRouter} from '../../libs/Router';
@@ -59,12 +59,7 @@ const HeaderView = props => (
                     styles.justifyContentBetween,
                 ]}
                 >
-                    <View style={[styles.flex1]}>
-                        <Text numberOfLines={1} style={[styles.navText]}>
-                            {props.report.reportName}
-                        </Text>
-                    </View>
-
+                    <Header title={props.report.reportName} />
                     <View style={[styles.reportOptions, styles.flexRow]}>
                         <TouchableOpacity
                             onPress={() => togglePinnedState(props.report)}

--- a/src/pages/home/HomePage.js
+++ b/src/pages/home/HomePage.js
@@ -13,7 +13,6 @@ import {withOnyx} from 'react-native-onyx';
 import {Route} from '../../libs/Router';
 import styles, {getSafeAreaPadding} from '../../styles/styles';
 import variables from '../../styles/variables';
-import Header from './HeaderView';
 import Sidebar from './sidebar/SidebarView';
 import Main from './MainView';
 import {
@@ -37,6 +36,7 @@ import CONFIG from '../../CONFIG';
 import CustomStatusBar from '../../components/CustomStatusBar';
 import CONST from '../../CONST';
 import {fetchCountryCodeByRequestIP} from '../../libs/actions/GeoLocation';
+import HeaderWithCloseButton from '../../components/HeaderWithCloseButton';
 
 const windowSize = Dimensions.get('window');
 
@@ -266,7 +266,7 @@ class App extends React.Component {
                                     <View
                                         style={[styles.appContent, styles.flex1, styles.flexColumn]}
                                     >
-                                        <Header
+                                        <HeaderWithCloseButton
                                             shouldShowHamburgerButton={this.state.isHamburgerEnabled}
                                             onHamburgerButtonClicked={this.toggleHamburger}
                                         />

--- a/src/pages/home/HomePage.js
+++ b/src/pages/home/HomePage.js
@@ -13,6 +13,7 @@ import {withOnyx} from 'react-native-onyx';
 import {Route} from '../../libs/Router';
 import styles, {getSafeAreaPadding} from '../../styles/styles';
 import variables from '../../styles/variables';
+import HeaderView from './HeaderView';
 import Sidebar from './sidebar/SidebarView';
 import Main from './MainView';
 import {
@@ -36,7 +37,6 @@ import CONFIG from '../../CONFIG';
 import CustomStatusBar from '../../components/CustomStatusBar';
 import CONST from '../../CONST';
 import {fetchCountryCodeByRequestIP} from '../../libs/actions/GeoLocation';
-import HeaderWithCloseButton from '../../components/HeaderWithCloseButton';
 
 const windowSize = Dimensions.get('window');
 
@@ -266,7 +266,7 @@ class App extends React.Component {
                                     <View
                                         style={[styles.appContent, styles.flex1, styles.flexColumn]}
                                     >
-                                        <HeaderWithCloseButton
+                                        <HeaderView
                                             shouldShowHamburgerButton={this.state.isHamburgerEnabled}
                                             onHamburgerButtonClicked={this.toggleHamburger}
                                         />

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -164,7 +164,7 @@ const styles = {
         height: 12,
     },
 
-    navText: {
+    headerText: {
         fontFamily: fontFamily.GTA,
         color: themeColors.heading,
         fontSize: variables.fontSizeNormal,

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -830,7 +830,7 @@ const styles = {
         flex: 1,
     },
 
-    modalHeaderBar: {
+    headerBar: {
         overflow: 'hidden',
         justifyContent: 'center',
         display: 'flex',


### PR DESCRIPTION
### Details
There's no issue here just doing some quick cleanup to make Consumer UI Refresh instructions easier to communicate.

cc @shawnborton 

### Fixed Issues

### Tests
❌ 

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
There should be no changes but posting to verify that I tested on all platforms.

#### Web
![Screen Shot 2021-01-11 at 4 58 24 PM](https://user-images.githubusercontent.com/32969087/104264235-57e8c200-542f-11eb-8ff1-5d495b751f1c.png)

#### Mobile Web
![Screen Shot 2021-01-11 at 4 58 13 PM](https://user-images.githubusercontent.com/32969087/104264263-6505b100-542f-11eb-8099-2e8ebe488061.png)

#### Desktop
![2021-01-11_17-09-06](https://user-images.githubusercontent.com/32969087/104264449-bca41c80-542f-11eb-9442-ddff03cb6da7.png)
![2021-01-11_17-08-21](https://user-images.githubusercontent.com/32969087/104264452-be6de000-542f-11eb-997c-730d9b754ea2.png)

#### iOS
![2021-01-11_17-05-13](https://user-images.githubusercontent.com/32969087/104264473-c6c61b00-542f-11eb-8a43-3436fe187d37.png)
![2021-01-11_17-02-34](https://user-images.githubusercontent.com/32969087/104264478-c9c10b80-542f-11eb-9160-bffdeb047726.png)

#### Android
![2021-01-11_17-07-16](https://user-images.githubusercontent.com/32969087/104264486-cf1e5600-542f-11eb-9848-4499708fee29.png)
![2021-01-11_17-07-06](https://user-images.githubusercontent.com/32969087/104264490-d2b1dd00-542f-11eb-97aa-eb5b15a6179e.png)
