### PR TITLE
Attachment cycling with onyx

### DIFF
--- a/src/ONYXKEYS.js
+++ b/src/ONYXKEYS.js
@@ -48,5 +48,6 @@ export default {
         REPORT_USER_IS_TYPING: 'reportUserIsTyping_',
     },
 
+    // Stores the information for the current attachment being shown
     ATTACHMENT_MODAL: 'attachmentModalData',
 };

--- a/src/ONYXKEYS.js
+++ b/src/ONYXKEYS.js
@@ -47,4 +47,6 @@ export default {
         REPORT_DRAFT_COMMENT: 'reportDraftComment_',
         REPORT_USER_IS_TYPING: 'reportUserIsTyping_',
     },
+
+    ATTACHMENT_MODAL: 'attachmentModalData',
 };

--- a/src/components/AttachmentModal.js
+++ b/src/components/AttachmentModal.js
@@ -6,8 +6,8 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import lodashGet from 'lodash.get';
 import {withOnyx} from 'react-native-onyx';
+import _ from 'underscore';
 import {clearAttachmentModalData, setAttachmentModalData} from '../libs/actions/Report';
-
 import AttachmentView from './AttachmentView';
 import CONST from '../CONST';
 import ModalWithHeader from './ModalWithHeader';
@@ -71,7 +71,7 @@ class AttachmentModal extends Component {
         const {visibleAttachment: {isModalOpen}} = this.props;
         if (!prevProps.visibleAttachment.isModalOpen && isModalOpen) {
             document.addEventListener('keydown', this.handleKeyPress, false);
-        } else {
+        } else if (!isModalOpen) {
             document.removeEventListener('keydown', this.handleKeyPress, false);
         }
     }
@@ -90,7 +90,7 @@ class AttachmentModal extends Component {
      */
     getNextAttachment = (toRight) => {
         const {sortedReportActions, visibleAttachment: {sourceURL}} = this.props;
-        const attachments = sortedReportActions.filter(sortedReportAction => sortedReportAction.action.isAttachment);
+        const attachments = _.filter(sortedReportActions, sortedReportAction => sortedReportAction.action.isAttachment);
         if (attachments.length <= 1) {
             return;
         }

--- a/src/components/AttachmentModal.js
+++ b/src/components/AttachmentModal.js
@@ -83,7 +83,11 @@ class AttachmentModal extends Component {
         return imageGroup[1];
     }
 
-    // A function to get the next attachment based on the current attachment being show in the report.
+    /**
+     * A function to get the next attachment based on the current attachment being show in the report.
+     *
+     * @param {Boolean} toRight
+     */
     getNextAttachment = (toRight) => {
         const {sortedReportActions, visibleAttachment: {sourceURL}} = this.props;
         const attachments = sortedReportActions.filter(sortedReportAction => sortedReportAction.action.isAttachment);
@@ -96,6 +100,9 @@ class AttachmentModal extends Component {
             const html = lodashGet(attachment, ['action', 'message', 0, 'html'], '');
             return html.includes(sourceURL);
         });
+        if (!currentAttachment) {
+            return;
+        }
         const actions = [...sortedReportActions].reverse();
         const sequenceNumber = currentAttachment.action.sequenceNumber;
         const actionsToSearch = toRight

--- a/src/components/ComposeAttachmentModal.js
+++ b/src/components/ComposeAttachmentModal.js
@@ -1,0 +1,134 @@
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+import {
+    View, TouchableOpacity, Text, Dimensions,
+} from 'react-native';
+import {withOnyx} from 'react-native-onyx';
+import CONST from '../CONST';
+import ModalWithHeader from './ModalWithHeader';
+import AttachmentView from './AttachmentView';
+import styles from '../styles/styles';
+import themeColors from '../styles/themes/default';
+import variables from '../styles/variables';
+import ONYXKEYS from '../ONYXKEYS';
+import addAuthTokenToURL from '../libs/addAuthTokenToURL';
+
+/**
+ * Modal render prop component that exposes modal launching triggers that can be used
+ * to display a full size image or PDF modally with optional confirmation button.
+ */
+
+const propTypes = {
+    // Title of the modal header
+    title: PropTypes.string,
+
+    // Optional source URL for the image shown inside the .
+    // If not passed in via props must be specified when modal is opened.
+    sourceURL: PropTypes.string,
+
+    // Optional callback to fire when we want to preview an image and approve it for use.
+    onConfirm: PropTypes.func,
+
+    // A function as a child to pass modal launching methods to
+    children: PropTypes.func.isRequired,
+
+    // Do the urls require an authToken?
+    isAuthTokenRequired: PropTypes.bool,
+
+    // Current user session
+    session: PropTypes.shape({
+        authToken: PropTypes.string.isRequired,
+    }).isRequired,
+};
+
+const defaultProps = {
+    title: '',
+    sourceURL: null,
+    onConfirm: null,
+    isAuthTokenRequired: false,
+};
+
+class AttachmentModal extends Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            isModalOpen: false,
+            file: null,
+            sourceURL: props.sourceURL,
+        };
+    }
+
+    render() {
+        const sourceURL = addAuthTokenToURL({
+            url: this.state.sourceURL,
+            authToken: this.props.session.authToken,
+            required: this.props.isAuthTokenRequired,
+        });
+
+        const isSmallScreen = Dimensions.get('window').width < variables.mobileResponsiveWidthBreakpoint;
+        const attachmentViewStyles = isSmallScreen
+            ? [styles.imageModalImageCenterContainer]
+            : [styles.imageModalImageCenterContainer, styles.p5];
+        return (
+            <>
+                <ModalWithHeader
+                    type={CONST.MODAL.MODAL_TYPE.CENTERED}
+                    onClose={() => this.setState({isModalOpen: false})}
+                    isVisible={this.state.isModalOpen}
+                    title={this.props.title}
+                    backgroundColor={themeColors.componentBG}
+                >
+                    <View style={attachmentViewStyles}>
+                        {this.state.sourceURL && (
+                            <AttachmentView sourceURL={sourceURL} file={this.state.file} />
+                        )}
+                    </View>
+
+                    {/* If we have an onConfirm method show a confirmation button */}
+                    {this.props.onConfirm && (
+                        <TouchableOpacity
+                            style={[styles.button, styles.buttonSuccess, styles.buttonConfirm]}
+                            underlayColor={themeColors.componentBG}
+                            onPress={() => {
+                                this.props.onConfirm(this.state.file);
+                                this.setState({isModalOpen: false});
+                            }}
+                        >
+                            <Text
+                                style={[
+                                    styles.buttonText,
+                                    styles.buttonSuccessText,
+                                    styles.buttonConfirmText,
+                                ]}
+                            >
+                                Upload
+                            </Text>
+                        </TouchableOpacity>
+                    )}
+                </ModalWithHeader>
+                {this.props.children({
+                    displayFileInModal: ({file}) => {
+                        if (file instanceof File) {
+                            const source = URL.createObjectURL(file);
+                            this.setState({isModalOpen: true, sourceURL: source, file});
+                        } else {
+                            this.setState({isModalOpen: true, sourceURL: file.uri, file});
+                        }
+                    },
+                    show: () => {
+                        this.setState({isModalOpen: true});
+                    },
+                })}
+            </>
+        );
+    }
+}
+
+AttachmentModal.propTypes = propTypes;
+AttachmentModal.defaultProps = defaultProps;
+export default withOnyx({
+    session: {
+        key: ONYXKEYS.SESSION,
+    },
+})(AttachmentModal);

--- a/src/components/RenderHTML.js
+++ b/src/components/RenderHTML.js
@@ -1,19 +1,20 @@
-/* eslint-disable react/prop-types */
-import React from 'react';
-import PropTypes from 'prop-types';
-import {useWindowDimensions, TouchableOpacity} from 'react-native';
 import HTML, {
-    defaultHTMLElementModels,
     TNodeChildrenRenderer,
+    defaultHTMLElementModels,
     splitBoxModelStyle,
 } from 'react-native-render-html';
-import Config from '../CONFIG';
-import {webViewStyles} from '../styles/styles';
-import fontFamily from '../styles/fontFamily';
+import {TouchableOpacity, useWindowDimensions} from 'react-native';
+
+import PropTypes from 'prop-types';
+import React from 'react';
 import AnchorForCommentsOnly from './AnchorForCommentsOnly';
+import Config from '../CONFIG';
 import InlineCodeBlock from './InlineCodeBlock';
-import AttachmentModal from './AttachmentModal';
+/* eslint-disable react/prop-types */
 import ThumbnailImage from './ThumbnailImage';
+import fontFamily from '../styles/fontFamily';
+import {setAttachmentModalData} from '../libs/actions/Report';
+import {webViewStyles} from '../styles/styles';
 
 const MAX_IMG_DIMENSIONS = 512;
 
@@ -113,23 +114,15 @@ function ImgRenderer({tnode}) {
     );
 
     return (
-        <AttachmentModal
-            title="Attachment"
-            sourceURL={source}
-            isAuthTokenRequired={isAttachment}
+        <TouchableOpacity
+            onPress={() => setAttachmentModalData({sourceURL: source, isAttachment, isModalOpen: true})}
         >
-            {({show}) => (
-                <TouchableOpacity
-                    onPress={() => show()}
-                >
-                    <ThumbnailImage
-                        previewSourceURL={previewSource}
-                        style={webViewStyles.tagStyles.img}
-                        isAuthTokenRequired={isAttachment}
-                    />
-                </TouchableOpacity>
-            )}
-        </AttachmentModal>
+            <ThumbnailImage
+                previewSourceURL={previewSource}
+                style={webViewStyles.tagStyles.img}
+                isAuthTokenRequired={isAttachment}
+            />
+        </TouchableOpacity>
     );
 }
 

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -1,22 +1,23 @@
-import moment from 'moment';
-import _ from 'underscore';
-import lodashGet from 'lodash.get';
 import ExpensiMark from 'expensify-common/lib/ExpensiMark';
 import Onyx from 'react-native-onyx';
-import ONYXKEYS from '../../ONYXKEYS';
-import * as Pusher from '../Pusher/pusher';
-import LocalNotification from '../Notification/LocalNotification';
-import PushNotification from '../Notification/PushNotification';
-import * as PersonalDetails from './PersonalDetails';
-import {redirect} from './App';
-import * as ActiveClientManager from '../ActiveClientManager';
-import Visibility from '../Visibility';
-import ROUTES from '../../ROUTES';
-import NetworkConnection from '../NetworkConnection';
-import {hide as hideSidebar} from './Sidebar';
-import Timing from './Timing';
+import _ from 'underscore';
+import lodashGet from 'lodash.get';
+import moment from 'moment';
 import * as API from '../API';
+import * as ActiveClientManager from '../ActiveClientManager';
+import * as PersonalDetails from './PersonalDetails';
+import * as Pusher from '../Pusher/pusher';
+
 import CONST from '../../CONST';
+import LocalNotification from '../Notification/LocalNotification';
+import NetworkConnection from '../NetworkConnection';
+import ONYXKEYS from '../../ONYXKEYS';
+import PushNotification from '../Notification/PushNotification';
+import ROUTES from '../../ROUTES';
+import Timing from './Timing';
+import Visibility from '../Visibility';
+import {hide as hideSidebar} from './Sidebar';
+import {redirect} from './App';
 
 let currentUserEmail;
 let currentUserAccountID;
@@ -649,6 +650,33 @@ function handleReportChanged(report) {
     reportMaxSequenceNumbers[report.reportID] = report.maxSequenceNumber;
 }
 
+/**
+ * Resets the Attachment Modal Data to default values.
+ */
+function clearAttachmentModalData() {
+    Onyx.set(ONYXKEYS.ATTACHMENT_MODAL, {
+        sourceURL: null, isAttachment: null, isModalOpen: false, file: null,
+    });
+}
+
+/**
+ * Sets the data for the attachment modal.
+ *
+ * @param {Object} reportID
+ * @param {String} reportID.sourceURL
+ * @param {Boolean} reportID.isAttachment
+ * @param {Boolean} reportID.isModalOpen
+ * @param {Object} reportID.file
+ * @param {String} reportID.file.name
+ */
+function setAttachmentModalData({
+    sourceURL, isAttachment, isModalOpen, file = null,
+}) {
+    Onyx.set(ONYXKEYS.ATTACHMENT_MODAL, {
+        sourceURL, isAttachment, isModalOpen, file,
+    });
+}
+
 Onyx.connect({
     key: ONYXKEYS.COLLECTION.REPORT,
     callback: handleReportChanged,
@@ -671,4 +699,6 @@ export {
     saveReportComment,
     broadcastUserIsTyping,
     togglePinnedState,
+    setAttachmentModalData,
+    clearAttachmentModalData,
 };

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -667,7 +667,6 @@ function clearAttachmentModalData() {
  * @param {Boolean} reportID.isAttachment
  * @param {Boolean} reportID.isModalOpen
  * @param {Object} reportID.file
- * @param {String} reportID.file.name
  */
 function setAttachmentModalData({
     sourceURL, isAttachment, isModalOpen, file = null,

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -1,19 +1,20 @@
-import React from 'react';
+import {Image, TouchableOpacity, View} from 'react-native';
 import PropTypes from 'prop-types';
-import {View, Image, TouchableOpacity} from 'react-native';
+import React from 'react';
 import _ from 'underscore';
 import lodashGet from 'lodash.get';
 import {withOnyx} from 'react-native-onyx';
+import {addAction, broadcastUserIsTyping, saveReportComment} from '../../../libs/actions/Report';
+
+import AttachmentPicker from '../../../components/AttachmentPicker';
+import ComposeAttachmentModal from '../../../components/ComposeAttachmentModal';
+import ONYXKEYS from '../../../ONYXKEYS';
+import ReportTypingIndicator from './ReportTypingIndicator';
+import TextInputFocusable from '../../../components/TextInputFocusable';
+import paperClipIcon from '../../../../assets/images/icon-paper-clip.png';
+import sendIcon from '../../../../assets/images/icon-send.png';
 import styles from '../../../styles/styles';
 import themeColors from '../../../styles/themes/default';
-import TextInputFocusable from '../../../components/TextInputFocusable';
-import sendIcon from '../../../../assets/images/icon-send.png';
-import ONYXKEYS from '../../../ONYXKEYS';
-import paperClipIcon from '../../../../assets/images/icon-paper-clip.png';
-import AttachmentPicker from '../../../components/AttachmentPicker';
-import {addAction, saveReportComment, broadcastUserIsTyping} from '../../../libs/actions/Report';
-import ReportTypingIndicator from './ReportTypingIndicator';
-import AttachmentModal from '../../../components/AttachmentModal';
 
 const propTypes = {
     // A method to call when the form is submitted
@@ -145,7 +146,7 @@ class ReportActionCompose extends React.Component {
                     styles.flexRow,
                 ]}
                 >
-                    <AttachmentModal
+                    <ComposeAttachmentModal
                         title="Upload Attachment"
                         onConfirm={(file) => {
                             addAction(this.props.reportID, '', file);
@@ -209,7 +210,7 @@ class ReportActionCompose extends React.Component {
 
                             </>
                         )}
-                    </AttachmentModal>
+                    </ComposeAttachmentModal>
                     <TouchableOpacity
                         style={[styles.chatItemSubmitButton,
                             this.state.isCommentEmpty

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -1,20 +1,19 @@
-import {Image, TouchableOpacity, View} from 'react-native';
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
+import {View, Image, TouchableOpacity} from 'react-native';
 import _ from 'underscore';
 import lodashGet from 'lodash.get';
 import {withOnyx} from 'react-native-onyx';
-import {addAction, broadcastUserIsTyping, saveReportComment} from '../../../libs/actions/Report';
-
-import AttachmentPicker from '../../../components/AttachmentPicker';
-import ComposeAttachmentModal from '../../../components/ComposeAttachmentModal';
-import ONYXKEYS from '../../../ONYXKEYS';
-import ReportTypingIndicator from './ReportTypingIndicator';
-import TextInputFocusable from '../../../components/TextInputFocusable';
-import paperClipIcon from '../../../../assets/images/icon-paper-clip.png';
-import sendIcon from '../../../../assets/images/icon-send.png';
 import styles from '../../../styles/styles';
 import themeColors from '../../../styles/themes/default';
+import TextInputFocusable from '../../../components/TextInputFocusable';
+import sendIcon from '../../../../assets/images/icon-send.png';
+import ONYXKEYS from '../../../ONYXKEYS';
+import paperClipIcon from '../../../../assets/images/icon-paper-clip.png';
+import AttachmentPicker from '../../../components/AttachmentPicker';
+import {addAction, saveReportComment, broadcastUserIsTyping} from '../../../libs/actions/Report';
+import ReportTypingIndicator from './ReportTypingIndicator';
+import ComposeAttachmentModal from '../../../components/ComposeAttachmentModal';
 
 const propTypes = {
     // A method to call when the form is submitted

--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -49,6 +49,7 @@ class ReportActionsView extends React.Component {
         this.scrollToListBottom = this.scrollToListBottom.bind(this);
         this.recordMaxAction = this.recordMaxAction.bind(this);
         this.sortedReportActions = this.updateSortedReportActions();
+        this.sortedReportAttachments = this.updateSortedReportAttachments();
         this.timers = [];
 
         this.state = {
@@ -142,6 +143,18 @@ class ReportActionsView extends React.Component {
             .map((item, index) => ({action: item, index}))
             .value()
             .reverse();
+    }
+
+    /**
+     * Updates and sorts the report attachments by sequence number
+     */
+    updateSortedReportAttachments() {
+        this.sortedReportAttachments = _.chain(this.props.reportActions)
+            .sortBy('sequenceNumber')
+            .filter(action => action.actionName === 'ADDCOMMENT')
+            .filter(action => lodashGet(action, ['message', 0, 'text'], '') === '[Attachment]')
+            .map((item, index) => ({action: item, index}))
+            .value();
     }
 
     /**
@@ -245,9 +258,10 @@ class ReportActionsView extends React.Component {
         }
 
         this.updateSortedReportActions();
+        this.updateSortedReportAttachments();
         return (
             <>
-                <AttachmentModal sortedReportActions={this.sortedReportActions} />
+                <AttachmentModal sortedReportAttachments={this.sortedReportAttachments} />
                 <InvertedFlatList
                     ref={el => this.actionListElement = el}
                     data={this.sortedReportActions}

--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -1,18 +1,21 @@
-import React from 'react';
-import {View, Keyboard, AppState} from 'react-native';
+import {AppState, Keyboard, View} from 'react-native';
 import PropTypes from 'prop-types';
+import React from 'react';
 import _ from 'underscore';
 import lodashGet from 'lodash.get';
 import {withOnyx} from 'react-native-onyx';
-import Text from '../../../components/Text';
-import {fetchActions, updateLastReadActionID} from '../../../libs/actions/Report';
+import {fetchActions, updateLastReadActionID, clearAttachmentModalData} from '../../../libs/actions/Report';
+
+import AttachmentModal from '../../../components/AttachmentModal';
+import InvertedFlatList from '../../../components/InvertedFlatList';
 import ONYXKEYS from '../../../ONYXKEYS';
 import ReportActionItem from './ReportActionItem';
-import styles from '../../../styles/styles';
 import ReportActionPropTypes from './ReportActionPropTypes';
-import InvertedFlatList from '../../../components/InvertedFlatList';
-import {lastItem} from '../../../libs/CollectionUtils';
+import Text from '../../../components/Text';
 import Visibility from '../../../libs/Visibility';
+
+import {lastItem} from '../../../libs/CollectionUtils';
+import styles from '../../../styles/styles';
 
 const propTypes = {
     // The ID of the report actions will be created for
@@ -54,6 +57,7 @@ class ReportActionsView extends React.Component {
     }
 
     componentDidMount() {
+        clearAttachmentModalData();
         this.visibilityChangeEvent = AppState.addEventListener('change', () => {
             if (this.props.isActiveReport && Visibility.isVisible()) {
                 this.timers.push(setTimeout(this.recordMaxAction, 3000));
@@ -242,14 +246,17 @@ class ReportActionsView extends React.Component {
 
         this.updateSortedReportActions();
         return (
-            <InvertedFlatList
-                ref={el => this.actionListElement = el}
-                data={this.sortedReportActions}
-                renderItem={this.renderItem}
-                contentContainerStyle={[styles.chatContentScrollView]}
-                keyExtractor={item => `${item.action.sequenceNumber}`}
-                initialRowHeight={32}
-            />
+            <>
+                <AttachmentModal sortedReportActions={this.sortedReportActions} />
+                <InvertedFlatList
+                    ref={el => this.actionListElement = el}
+                    data={this.sortedReportActions}
+                    renderItem={this.renderItem}
+                    contentContainerStyle={[styles.chatContentScrollView]}
+                    keyExtractor={item => `${item.action.sequenceNumber}`}
+                    initialRowHeight={32}
+                />
+            </>
         );
     }
 }


### PR DESCRIPTION
Implemented functionality to achieve the following statement:
"The attachments present in the chat should cycle when the user is viewing the modal and presses the left/right arrows on their keyboard"

### Details
Refactored code and moved Attachment modal so only one is created for ReportActionsView and one for the ReportActionCompose view. AttachmentModal now consumed visibleModal object from Onyx to know what to show and wether to be visible.

Also wrote getNextAttachment function which retrieves the next attachment using the current action and a boolean value indicating whether to move to the right or left of the current action.

### Fixed Issues
Implements #1038 

### Tests

1. Upload multiple attachments (Images and PDFs)
2. Once they have been uploaded, use the left and right arrow keys to move between all of them.
3. Go to the last attachment and confirm that moving to the right of the last attachment takes you to the first attachment in a cyclical manner.

1. Test that uploading attachments still work (Images, PDFs .etc)

### Tested On
- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots

#### Web
<img width="2048" alt="Screenshot 2020-12-31 at 19 33 10" src="https://user-images.githubusercontent.com/13122879/103423562-25bda180-4b9f-11eb-9b68-22d2b26b6795.png">
<img width="2048" alt="Screenshot 2020-12-31 at 19 33 27" src="https://user-images.githubusercontent.com/13122879/103423566-2a825580-4b9f-11eb-9328-d3f53a567e82.png">

#### Mobile Web
no changes

#### Desktop
no changes

#### iOS
no changes

#### Android
no changes