### PR TITLE
Replace isExpensifyCash param for sign up and tweak platform param for graphite timing

### DIFF
--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -168,6 +168,10 @@ function handleExpiredAuthToken(originalCommand, originalParameters, originalTyp
  * @returns {Promise}
  */
 function request(command, parameters, type = 'post') {
+    // Always set referer to https://expensify.cash/
+    // eslint-disable-next-line no-param-reassign
+    parameters.referer = CONFIG.EXPENSIFY.URL_EXPENSIFY_CASH;
+
     return new Promise((resolve, reject) => {
         Network.post(command, parameters, type)
             .then((response) => {

--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -37,13 +37,13 @@ function isAuthTokenRequired(command) {
 }
 
 /**
- * Adds CSRF and AuthToken to our request data
+ * Adds default values to our request data
  *
  * @param {String} command
  * @param {Object} parameters
  * @returns {Object}
  */
-function addAuthTokenToParameters(command, parameters) {
+function addDefaultValuesToParameters(command, parameters) {
     const finalParameters = {...parameters};
 
     if (isAuthTokenRequired(command) && !parameters.authToken) {
@@ -61,6 +61,8 @@ function addAuthTokenToParameters(command, parameters) {
         finalParameters.authToken = authToken;
     }
 
+    // Always set referer to https://expensify.cash/
+    finalParameters.referer = CONFIG.EXPENSIFY.URL_EXPENSIFY_CASH;
 
     // This application does not save its authToken in cookies like the classic Expensify app.
     // Setting api_setCookie to false will ensure that the Expensify API doesn't set any cookies
@@ -70,7 +72,7 @@ function addAuthTokenToParameters(command, parameters) {
 }
 
 // Tie into the network layer to add auth token to the parameters of all requests
-Network.registerParameterEnhancer(addAuthTokenToParameters);
+Network.registerParameterEnhancer(addDefaultValuesToParameters);
 
 /**
  * @throws {Error} If the "parameters" object has a null or undefined value for any of the given parameterNames
@@ -145,7 +147,7 @@ function handleExpiredAuthToken(originalCommand, originalParameters, originalTyp
             Network.unpauseRequestQueue();
 
             // Now that the API is authenticated, make the original request again with the new authToken
-            const params = addAuthTokenToParameters(originalCommand, originalParameters);
+            const params = addDefaultValuesToParameters(originalCommand, originalParameters);
             return Network.post(originalCommand, params, originalType);
         })
 
@@ -168,10 +170,6 @@ function handleExpiredAuthToken(originalCommand, originalParameters, originalTyp
  * @returns {Promise}
  */
 function request(command, parameters, type = 'post') {
-    // Always set referer to https://expensify.cash/
-    // eslint-disable-next-line no-param-reassign
-    parameters.referer = CONFIG.EXPENSIFY.URL_EXPENSIFY_CASH;
-
     return new Promise((resolve, reject) => {
         Network.post(command, parameters, type)
             .then((response) => {

--- a/src/libs/actions/Timing.js
+++ b/src/libs/actions/Timing.js
@@ -30,7 +30,7 @@ function end(eventName, secondaryName) {
         Graphite_Timer({
             name: grafanaEventName,
             value: eventTime,
-            referer: `${getPlatform()}`,
+            platform: `${getPlatform()}`,
         });
 
         delete timestampData[eventName];


### PR DESCRIPTION
Please review @Julesssss / @stitesExpensify 
cc @tgolen 

### Details
Replacing `isExpensifyCash` param with `referer` param, editing the `referer` param in one spot to be `platform`.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/149347
Related API PR: https://github.com/Expensify/Web-Expensify/pull/30044

### Tests
1. Apply same branch on dev API
2. Verify you can sign in on all platforms

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android
