### PR TITLE
Use double braces for environment vars

### DIFF
--- a/.github/actions/bumpVersion/action.yml
+++ b/.github/actions/bumpVersion/action.yml
@@ -2,4 +2,4 @@ name: 'Bump npm version'
 description: 'Increase the npm build version of the ReactNativeChat application'
 runs:
     using: 'node12'
-    main: '$GITHUB_REPOSITORY/.github/actions/bumpVersion/index.js'
+    main: ${{ github.repository }}/.github/actions/bumpVersion/index.js

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -33,7 +33,7 @@ jobs:
               run: git checkout -b version-bump-${{ github.sha }}
 
             - name: Generate version
-              uses: $GITHUB_REPOSITORY/.github/actions/bumpVersion
+              uses: ${{ github.repository }}/.github/actions/bumpVersion
 
             - name: Push new version
               run: git push --set-upstream origin version-bump-${{ github.sha }}


### PR DESCRIPTION

### Details
Just trying to get environment variables to expand in order to call a locally-hosted github action in the Expensify.cash repo

### Fixed Issues
n/a, just trying to get https://github.com/Expensify/Expensify.cash/pull/931/files working properly

### Tests
Unfortunately this can only be tested by being merged.
