### PR TITLE
Use relative path for action (not workflow)

### DIFF
--- a/.github/actions/bumpVersion/action.yml
+++ b/.github/actions/bumpVersion/action.yml
@@ -2,4 +2,4 @@ name: 'Bump npm version'
 description: 'Increase the npm build version of the ReactNativeChat application'
 runs:
     using: 'node12'
-    main: 'Expensify/Expensify.cash/.github/actions/bumpVersion/index.js'
+    main: './index.js'


### PR DESCRIPTION


### Details
GH Actions want relative paths, but workflows want absolute paths (including org, repo name, and branch ref)

### Fixed Issues
n/a, just [this build failure](https://github.com/Expensify/Expensify.cash/actions/runs/479112902)

### Tests
Can only be tested by being merged