### PR TITLE
Bump react-native-web to 0.14.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21337,9 +21337,9 @@
       }
     },
     "react-native-web": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.14.0.tgz",
-      "integrity": "sha512-jz7li7lgjZ2rJeH9HLBpAtLDzD1LHfK7TcmsrBes3za4hl5+Qn3UtlKbhiT/lcNGd2IDCP13Gj9DEWTRg/auNA==",
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.14.10.tgz",
+      "integrity": "sha512-YTvYnUUPnOjU50GiXk90cm6atk714vF8p7HhBlqHtLtftHk9xQRwgxXzoMHiKf0Bx20Dyo2SGvv4XrPxcmEheQ==",
       "requires": {
         "array-find-index": "^1.0.2",
         "create-react-class": "^15.6.2",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "react-native-render-html": "^6.0.0-alpha.10",
     "react-native-safe-area-context": "^3.1.4",
     "react-native-svg": "^12.1.0",
-    "react-native-web": "^0.14.0",
+    "react-native-web": "^0.14.1",
     "react-native-web-webview": "^1.0.2",
     "react-native-webview": "^11.0.2",
     "react-router-dom": "^5.2.0",

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -371,7 +371,6 @@ const styles = {
         borderRadius: 999,
         alignItems: 'center',
         justifyContent: 'center',
-        cursor: 'pointer',
     },
 
     sidebarFooterUsername: {


### PR DESCRIPTION
### Details
Ran into an issue where `Pressable` does not have a `cursor: pointer` and discovered the latest version of `react-native-web` should fix that issue.

### Fixed Issues
None

### Tests
1. Make sure the app runs on all platforms

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
N/A