### PR TITLE
Use setInterval instead of setTimeout that calls itself agian

### DIFF
--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -178,9 +178,11 @@ function getFromReportParticipants(reports) {
 // When the app reconnects from being offline, fetch all of the personal details
 NetworkConnection.onReconnect(fetch);
 
-// Refresh the personal details and timezone every 30 minutes because there is no
+// Refresh the personal details and timezone now and then every 30 minutes because there is no
 // pusher event that sends updated personal details data yet
 // See https://github.com/Expensify/ReactNativeChat/issues/468
+fetch();
+fetchTimezone();
 setInterval(() => {
     if (isOffline) {
         return;

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -20,6 +20,12 @@ Onyx.connect({
     callback: val => personalDetails = val,
 });
 
+let isOffline;
+Onyx.connect({
+    key: ONYXKEYS.NETWORK,
+    callback: val => isOffline = val && val.isOffline,
+});
+
 /**
  * Helper method to return a default avatar
  *
@@ -101,6 +107,9 @@ function formatPersonalDetails(personalDetailsList) {
  * Get the timezone of the logged in user
  */
 function fetchTimezone() {
+    if (isOffline) {
+        return;
+    }
     API.Get({
         returnValueList: 'nameValuePairs',
         name: 'timeZone',
@@ -115,6 +124,9 @@ function fetchTimezone() {
  * Get the personal details for our organization
  */
 function fetch() {
+    if (isOffline) {
+        return;
+    }
     API.Get({
         returnValueList: 'personalDetailsList',
     })
@@ -127,9 +139,6 @@ function fetch() {
 
             // Set my personal details so they can be easily accessed and subscribed to on their own key
             Onyx.merge(ONYXKEYS.MY_PERSONAL_DETAILS, myPersonalDetails);
-
-            // Get the timezone and put it in Onyx
-            fetchTimezone();
         })
         .catch(error => console.debug('Error fetching personal details', error));
 }

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -109,9 +109,6 @@ function fetchTimezone() {
             const timezone = lodashGet(data, 'nameValuePairs.timeZone.selected', 'America/Los_Angeles');
             Onyx.merge(ONYXKEYS.MY_PERSONAL_DETAILS, {timezone});
         });
-
-    // Refresh the timezone every 30 minutes
-    setTimeout(fetchTimezone, 1000 * 60 * 30);
 }
 
 /**
@@ -135,11 +132,6 @@ function fetch() {
             fetchTimezone();
         })
         .catch(error => console.debug('Error fetching personal details', error));
-
-    // Refresh the personal details every 30 minutes because there is no
-    // pusher event that sends updated personal details data yet
-    // See https://github.com/Expensify/ReactNativeChat/issues/468
-    setTimeout(fetch, 1000 * 60 * 30);
 }
 
 /**
@@ -182,6 +174,14 @@ function getFromReportParticipants(reports) {
 
 // When the app reconnects from being offline, fetch all of the personal details
 NetworkConnection.onReconnect(fetch);
+
+// Refresh the personal details every 30 minutes because there is no
+// pusher event that sends updated personal details data yet
+// See https://github.com/Expensify/ReactNativeChat/issues/468
+setInterval(fetch, 1000 * 60 * 30);
+
+// Refresh the timezone every 30 minutes
+setInterval(fetchTimezone, 1000 * 60 * 30);
 
 export {
     fetch,

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -107,9 +107,6 @@ function formatPersonalDetails(personalDetailsList) {
  * Get the timezone of the logged in user
  */
 function fetchTimezone() {
-    if (isOffline) {
-        return;
-    }
     API.Get({
         returnValueList: 'nameValuePairs',
         name: 'timeZone',
@@ -124,9 +121,6 @@ function fetchTimezone() {
  * Get the personal details for our organization
  */
 function fetch() {
-    if (isOffline) {
-        return;
-    }
     API.Get({
         returnValueList: 'personalDetailsList',
     })
@@ -184,13 +178,16 @@ function getFromReportParticipants(reports) {
 // When the app reconnects from being offline, fetch all of the personal details
 NetworkConnection.onReconnect(fetch);
 
-// Refresh the personal details every 30 minutes because there is no
+// Refresh the personal details and timezone every 30 minutes because there is no
 // pusher event that sends updated personal details data yet
 // See https://github.com/Expensify/ReactNativeChat/issues/468
-setInterval(fetch, 1000 * 60 * 30);
-
-// Refresh the timezone every 30 minutes
-setInterval(fetchTimezone, 1000 * 60 * 30);
+setInterval(() => {
+    if (isOffline) {
+        return;
+    }
+    fetch();
+    fetchTimezone();
+}, 1000 * 60 * 30);
 
 export {
     fetch,

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -178,11 +178,9 @@ function getFromReportParticipants(reports) {
 // When the app reconnects from being offline, fetch all of the personal details
 NetworkConnection.onReconnect(fetch);
 
-// Refresh the personal details and timezone now and then every 30 minutes because there is no
+// Refresh the personal details and timezone every 30 minutes because there is no
 // pusher event that sends updated personal details data yet
 // See https://github.com/Expensify/ReactNativeChat/issues/468
-fetch();
-fetchTimezone();
 setInterval(() => {
     if (isOffline) {
         return;

--- a/src/pages/home/HomePage.js
+++ b/src/pages/home/HomePage.js
@@ -25,7 +25,7 @@ import {
     subscribeToReportCommentEvents,
     fetchAll as fetchAllReports,
 } from '../../libs/actions/Report';
-import {fetch as fetchPersonalDetails} from '../../libs/actions/PersonalDetails';
+import * as PersonalDetails from '../../libs/actions/PersonalDetails';
 import * as Pusher from '../../libs/Pusher/pusher';
 import PusherConnectionManager from '../../libs/PusherConnectionManager';
 import UnreadIndicatorUpdater from '../../libs/UnreadIndicatorUpdater';
@@ -83,15 +83,12 @@ class App extends React.Component {
             authEndpoint: `${CONFIG.EXPENSIFY.URL_API_ROOT}api?command=Push_Authenticate`,
         }).then(subscribeToReportCommentEvents);
 
-        // Fetch all the personal details
-        fetchPersonalDetails();
-
+        // Fetch some data we need on initialization
+        PersonalDetails.fetch();
+        PersonalDetails.fetchTimezone();
         fetchAllReports(true, false, true);
-
         fetchCountryCodeByRequestIP();
-
         UnreadIndicatorUpdater.listenForReportChanges();
-
         Dimensions.addEventListener('change', this.toggleHamburgerBasedOnDimensions);
 
         // Set up the hamburger correctly once on init


### PR DESCRIPTION
### Details
Each time [we reconnect, we call fetch](https://github.com/Expensify/Expensify.cash/blob/82bceb7f36bb090bfaafc3917f6a48b8e3d71c0c/src/libs/actions/PersonalDetails.js#L184) (we also do it when the app state changes) and when we do that we queue a setTimeout call for 30 minutes later to call itself, so after each reconnection we have an additional setTimeout to call the same method. Then fetch also calls fetchTimezone which does the same thing.
As a solution I made them just one call to setInterval is setup only once.

### Fixed Issues
https://github.com/Expensify/Expensify/issues/151292

### Tests
- Change the interval to 10s instead of 30m
- Set a breakpoint in the fetch method of personal details
- Check it stops there only every 10s
- Disconnect/reconnect to internet
- Check it stops there after reconnection (there's a [different bug](https://github.com/Expensify/Expensify/issues/151303) that is triggering some calls that should happen only when going online when going offline too)
- Check it still stops there every 10s (Doing the same test before this change I would see it triggers twice every 10s)
- Comment [this code](https://github.com/Expensify/Expensify.cash/blob/f423958339219e6d16ae2810f327675f8ce5ac23/src/libs/Network.js#L36-L37) so I can test this properly on dev (see https://github.com/Expensify/Expensify/issues/151303)
- Disconnect wifi
- Wait 30s
- Reconnect from wifi, check we did not do 3 calls to fetch the personaldetails/timezone at the same time


### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
No changes

