### PR TITLE
LastReadActionID cleanup

### DIFF
--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -68,12 +68,10 @@ function getUnreadActionCount(report) {
     // since we migrating our data from lastReadActionID_ value to lastRead_ object.
     const lastReadSequenceNumber = lodashGet(report, [
         'reportNameValuePairs',
-        `lastReadActionID_${currentUserAccountID}`,
-    ]) || lodashGet(report, [
-        'reportNameValuePairs',
         `lastRead_${currentUserAccountID}`,
         'sequenceNumber',
     ]);
+    debugger;
 
     // Save the lastReadActionID locally so we can access this later
     lastReadSequenceNumbers[report.reportID] = lastReadSequenceNumber;

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -64,14 +64,11 @@ const lastReadSequenceNumbers = {};
  * @returns {Boolean}
  */
 function getUnreadActionCount(report) {
-    // @todo remove the first check as part of cleanup https://github.com/Expensify/Expensify/issues/145243
-    // since we migrating our data from lastReadActionID_ value to lastRead_ object.
     const lastReadSequenceNumber = lodashGet(report, [
         'reportNameValuePairs',
         `lastRead_${currentUserAccountID}`,
         'sequenceNumber',
     ]);
-    debugger;
 
     // Save the lastReadActionID locally so we can access this later
     lastReadSequenceNumbers[report.reportID] = lastReadSequenceNumber;


### PR DESCRIPTION
### Details
I made the mistake to not remove this code sooner. We had migrations that should run to delete the old rNVP but the migration did not run for some reason. Maybe it does not run when signed it from chat and not expensify. shall investigate that later. For now you can see the image has the older rNVP which is incorrect so let's remove it.
![image](https://user-images.githubusercontent.com/14356145/104660399-4ac01300-567b-11eb-86d3-7016c6ba26b6.png)

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/145243

### Tests
1. Confirm the account has lastRead and lastReadActionID on a report.
2. Open chat report, pin it and send a message. Switch to another chat.
3. Refresh and confirm the pinned chat that you send a message on earlier does not show up as unread.