### PR TITLE
Added Sidebar CreateMenu Drawer

### DIFF
--- a/assets/images/chatbubble.svg
+++ b/assets/images/chatbubble.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 24.3.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 20 20" style="enable-background:new 0 0 20 20;" xml:space="preserve">
+<path d="M18.8,9.8c0-4-3.9-7.2-8.8-7.2S1.2,5.8,1.2,9.8S5.1,17,10,17c0.9,0,1.8-0.1,2.5-0.2l2.9,1.4c0.4,0.2,0.9-0.1,0.9-0.5v-2.8
+	C17.8,13.6,18.8,11.8,18.8,9.8z"/>
+</svg>

--- a/assets/images/users.svg
+++ b/assets/images/users.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 24.3.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 20 20" style="enable-background:new 0 0 20 20;" xml:space="preserve">
+<style type="text/css">
+	.st0{clip-path:url(#SVGID_2_);}
+</style>
+<g>
+	<defs>
+		<rect id="SVGID_1_" width="20" height="20"/>
+	</defs>
+	<clipPath id="SVGID_2_">
+		<use xlink:href="#SVGID_1_"  style="overflow:visible;"/>
+	</clipPath>
+	<g class="st0">
+		<path d="M10.8,5.8c0-0.2-0.1-0.5-0.2-0.8C10.6,5.4,10.8,5.5,10.8,5.8z"/>
+		<path d="M13.6,1.2c-1.2,0-2.5,0.8-2.9,1.9c0.9,0.8,1.4,1.9,1.4,3.1c0,0.2,0,0.5-0.1,0.8c0.5,0.5,1.1,0.6,1.6,0.6
+			c1.8,0,3.1-1.4,3.1-3.1C16.9,2.8,15.4,1.2,13.6,1.2z"/>
+		<path d="M7.8,9.5c1.7,0,3.1-1.4,3.1-3.1S9.5,3.3,7.8,3.3S4.6,4.6,4.6,6.4S6,9.5,7.8,9.5z"/>
+		<path d="M13.6,9c-1.4,0-2.5,0.4-3.5,1.1c2.8,0.9,4.8,3.4,5.1,6.2H19c0.6,0,1-0.5,1-1C20,11.8,17.1,9,13.6,9z"/>
+		<path d="M13,18.2H2.4c-0.6,0-1-0.5-1-1c0-3.5,2.9-6.4,6.4-6.4s6.4,2.9,6.4,6.4C14,17.9,13.6,18.2,13,18.2z"/>
+	</g>
+</g>
+</svg>

--- a/src/CONST.js
+++ b/src/CONST.js
@@ -12,6 +12,7 @@ const CONST = {
     MODAL: {
         MODAL_TYPE: {
             CENTERED: 'centered',
+            BOTTOM_DOCKED: 'bottom_docked',
         },
     },
     TIMING: {

--- a/src/components/CreateMenu.js
+++ b/src/components/CreateMenu.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {memo} from 'react';
 import PropTypes from 'prop-types';
 import {View, Text, Pressable} from 'react-native';
 import Modal from './Modal';
@@ -6,6 +6,7 @@ import styles from '../styles/styles';
 import CONST from '../CONST';
 import themeColors from '../styles/themes/default';
 import colors from '../styles/colors';
+import {ChatBubbleIcon, UsersIcon} from './Expensicons';
 
 const propTypes = {
     // Callback to fire on request to modal close
@@ -14,48 +15,53 @@ const propTypes = {
     // State that determines whether to display the create menu or not
     isVisible: PropTypes.bool.isRequired,
 
-    // The data array containing the icon, text and callback information of each item
-    menuItemData: PropTypes.arrayOf(PropTypes.shape({
-        // The icon component of the item
-        icon: PropTypes.func.isRequired,
-
-        // The text content of the item
-        text: PropTypes.string.isRequired,
-
-        // Callback to fire on item press
-        onPress: PropTypes.func.isRequired,
-    })).isRequired,
+    // Callback to fire when a CreateMenu item is selected
+    onItemSelected: PropTypes.func.isRequired,
 };
 
-const CreateMenu = props => (
-    <Modal
-        onClose={props.onClose}
-        isVisible={props.isVisible}
-        type={CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED}
-    >
-        {props.menuItemData.map(item => (
-            <Pressable
-                key={item.text}
-                onPress={item.onPress}
-                style={({hovered}) => ([
-                    styles.sidebarCreateMenuItem,
-                    {backgroundColor: hovered ? themeColors.buttonHoveredBG : colors.transparent},
-                ])}
-            >
-                <View style={styles.sidebarCreateMenuIcon}>
-                    <item.icon width={24} height={24} />
-                </View>
-                <View style={styles.justifyContentCenter}>
-                    <Text style={[styles.sidebarCreateMenuText, styles.ml3]}>
-                        {item.text}
-                    </Text>
+const CreateMenu = (props) => {
+    // This format allows to set individual callbacks to each item
+    // while including mutual callbacks first
+    const menuItemData = [
+        {IconComponent: ChatBubbleIcon, text: 'New Chat', onPress: () => {}},
+        {IconComponent: UsersIcon, text: 'New Group', onPress: () => {}},
+    ].map(item => ({
+        ...item,
+        onPress: () => {
+            props.onItemSelected();
+            item.onPress();
+        },
+    }));
 
-                </View>
-            </Pressable>
-        ))}
-    </Modal>
-);
+    return (
+        <Modal
+            onClose={props.onClose}
+            isVisible={props.isVisible}
+            type={CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED}
+        >
+            {menuItemData.map(({IconComponent, text, onPress}) => (
+                <Pressable
+                    key={text}
+                    onPress={onPress}
+                    style={({hovered}) => ([
+                        styles.createMenuItem,
+                        {backgroundColor: hovered ? themeColors.buttonHoveredBG : colors.transparent},
+                    ])}
+                >
+                    <View style={styles.createMenuIcon}>
+                        <IconComponent width={24} height={24} />
+                    </View>
+                    <View style={styles.justifyContentCenter}>
+                        <Text style={[styles.createMenuText, styles.ml3]}>
+                            {text}
+                        </Text>
+                    </View>
+                </Pressable>
+            ))}
+        </Modal>
+    );
+};
 
 CreateMenu.propTypes = propTypes;
 CreateMenu.displayName = 'CreateMenu';
-export default CreateMenu;
+export default memo(CreateMenu);

--- a/src/components/CreateMenu.js
+++ b/src/components/CreateMenu.js
@@ -33,23 +33,26 @@ const CreateMenu = props => (
         isVisible={props.isVisible}
         type={CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED}
     >
-        <View style={styles.sidebarCreateMenuContainer}>
-            {props.menuItemData.map(item => (
-                <Pressable
-                    key={item.text}
-                    onPress={item.onPress}
-                    style={({hovered}) => ([
-                        styles.sidebarCreateMenuItem,
-                        {backgroundColor: hovered ? themeColors.buttonDisabledBG : colors.transparent},
-                    ])}
-                >
-                    <item.icon />
+        {props.menuItemData.map(item => (
+            <Pressable
+                key={item.text}
+                onPress={item.onPress}
+                style={({hovered}) => ([
+                    styles.sidebarCreateMenuItem,
+                    {backgroundColor: hovered ? themeColors.buttonHoveredBG : colors.transparent},
+                ])}
+            >
+                <View style={styles.sidebarCreateMenuIcon}>
+                    <item.icon width={24} height={24} />
+                </View>
+                <View style={styles.justifyContentCenter}>
                     <Text style={[styles.sidebarCreateMenuText, styles.ml3]}>
                         {item.text}
                     </Text>
-                </Pressable>
-            ))}
-        </View>
+
+                </View>
+            </Pressable>
+        ))}
     </Modal>
 );
 

--- a/src/components/CreateMenu.js
+++ b/src/components/CreateMenu.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {View, Text, Pressable} from 'react-native';
+import Modal from './Modal';
+import styles from '../styles/styles';
+import CONST from '../CONST';
+import themeColors from '../styles/themes/default';
+import colors from '../styles/colors';
+
+const propTypes = {
+    // Callback to fire on request to modal close
+    onClose: PropTypes.func.isRequired,
+
+    // State that determines whether to display the create menu or not
+    isVisible: PropTypes.bool.isRequired,
+
+    // The data array containing the icon, text and callback information of each item
+    menuItemData: PropTypes.arrayOf(PropTypes.shape({
+        // The icon component of the item
+        icon: PropTypes.func.isRequired,
+
+        // The text content of the item
+        text: PropTypes.string.isRequired,
+
+        // Callback to fire on item press
+        onPress: PropTypes.func.isRequired,
+    })).isRequired,
+};
+
+const CreateMenu = props => (
+    <Modal
+        onClose={props.onClose}
+        isVisible={props.isVisible}
+        type={CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED}
+    >
+        <View style={styles.sidebarCreateMenuContainer}>
+            {props.menuItemData.map(item => (
+                <Pressable
+                    key={item.text}
+                    onPress={item.onPress}
+                    style={({hovered}) => ([
+                        styles.sidebarCreateMenuItem,
+                        {backgroundColor: hovered ? themeColors.buttonDisabledBG : colors.transparent},
+                    ])}
+                >
+                    <item.icon />
+                    <Text style={[styles.sidebarCreateMenuText, styles.ml3]}>
+                        {item.text}
+                    </Text>
+                </Pressable>
+            ))}
+        </View>
+    </Modal>
+);
+
+CreateMenu.propTypes = propTypes;
+CreateMenu.displayName = 'CreateMenu';
+export default CreateMenu;

--- a/src/components/Expensicons/ChatBubbleIcon.js
+++ b/src/components/Expensicons/ChatBubbleIcon.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ChatBubbleSvg from '../../../assets/images/chatbubble.svg';
+import themeColors from '../../styles/themes/default';
+
+const propTypes = {
+    // Width of the icon
+    width: PropTypes.number,
+
+    // Height of the icon
+    height: PropTypes.number,
+
+    // Fill of the icon
+    fill: PropTypes.string,
+};
+
+const defaultProps = {
+    width: 20,
+    height: 20,
+    fill: themeColors.icon,
+};
+
+const ChatBubbleIcon = props => (
+    <ChatBubbleSvg
+        width={props.width}
+        height={props.height}
+        fill={props.fill}
+    />
+);
+
+ChatBubbleIcon.propTypes = propTypes;
+ChatBubbleIcon.defaultProps = defaultProps;
+
+export default ChatBubbleIcon;

--- a/src/components/Expensicons/UsersIcon.js
+++ b/src/components/Expensicons/UsersIcon.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import UsersSvg from '../../../assets/images/users.svg';
+import themeColors from '../../styles/themes/default';
+
+const propTypes = {
+    // Width of the icon
+    width: PropTypes.number,
+
+    // Height of the icon
+    height: PropTypes.number,
+
+    // Fill of the icon
+    fill: PropTypes.string,
+};
+
+const defaultProps = {
+    width: 20,
+    height: 20,
+    fill: themeColors.icon,
+};
+
+const UsersIcon = props => (
+    <UsersSvg
+        width={props.width}
+        height={props.height}
+        fill={props.fill}
+    />
+);
+
+UsersIcon.propTypes = propTypes;
+UsersIcon.defaultProps = defaultProps;
+
+export default UsersIcon;

--- a/src/components/Expensicons/index.js
+++ b/src/components/Expensicons/index.js
@@ -1,9 +1,13 @@
 import ExpensifyCashLogoIcon from './ExpensifyCashLogoIcon';
 import PinIcon from './PinIcon';
 import PlusIcon from './PlusIcon';
+import UsersIcon from './UsersIcon';
+import ChatBubbleIcon from './ChatBubbleIcon';
 
 export {
     ExpensifyCashLogoIcon,
     PinIcon,
     PlusIcon,
+    UsersIcon,
+    ChatBubbleIcon,
 };

--- a/src/components/FAB.js
+++ b/src/components/FAB.js
@@ -14,13 +14,6 @@ const propTypes = {
 
     // Current state (active or not active) of the component
     isActive: PropTypes.bool.isRequired,
-
-    // Temporary prop to be able to test the component before implementing it
-    isHidden: PropTypes.bool,
-};
-
-const defaultProps = {
-    isHidden: true,
 };
 
 class FAB extends React.Component {
@@ -66,10 +59,6 @@ class FAB extends React.Component {
             outputRange: [themeColors.componentBG, themeColors.icon],
         });
 
-        if (this.props.isHidden) {
-            return null;
-        }
-
         return (
             <AnimatedPressable
                 onPress={this.props.onPress}
@@ -84,6 +73,5 @@ class FAB extends React.Component {
     }
 }
 
-FAB.defaultProps = defaultProps;
 FAB.propTypes = propTypes;
 export default FAB;

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -22,6 +22,7 @@ const propTypes = {
     // Style of modal to display
     type: PropTypes.oneOf([
         CONST.MODAL.MODAL_TYPE.CENTERED,
+        CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED,
     ]),
 };
 

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -53,6 +53,8 @@ const Modal = (props) => {
             style={modalStyle}
             animationIn={animationIn}
             animationOut={animationOut}
+            useNativeDriver
+            useNativeDriverForBackdrop
         >
             <CustomStatusBar />
             <SafeAreaInsetsContext.Consumer>

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -53,8 +53,6 @@ const Modal = (props) => {
             style={modalStyle}
             animationIn={animationIn}
             animationOut={animationOut}
-            useNativeDriver
-            useNativeDriverForBackdrop
         >
             <CustomStatusBar />
             <SafeAreaInsetsContext.Consumer>

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -61,13 +61,13 @@ const Modal = (props) => {
                     return (
                         <View
                             style={{
-                                ...styles.defaultModalContainer,
-                                paddingBottom,
-                                ...modalContainerStyle,
-
                                 // This padding is based on the insets and could not neatly be
                                 // returned by getModalStyles to avoid passing this inline.
                                 paddingTop: needsSafeAreaPadding ? paddingTop : 20,
+
+                                ...styles.defaultModalContainer,
+                                paddingBottom,
+                                ...modalContainerStyle,
                             }}
                         >
                             {props.children}

--- a/src/pages/home/HomePage.js
+++ b/src/pages/home/HomePage.js
@@ -37,7 +37,6 @@ import CONFIG from '../../CONFIG';
 import CustomStatusBar from '../../components/CustomStatusBar';
 import CONST from '../../CONST';
 import {fetchCountryCodeByRequestIP} from '../../libs/actions/GeoLocation';
-import {ChatBubbleIcon, UsersIcon} from '../../components/Expensicons';
 import KeyboardShortcut from '../../libs/KeyboardShortcut';
 import * as ChatSwitcher from '../../libs/actions/ChatSwitcher';
 
@@ -65,6 +64,7 @@ class App extends React.Component {
             isCreateMenuActive: false,
         };
 
+        this.onCreateMenuItemSelected = this.onCreateMenuItemSelected.bind(this);
         this.toggleCreateMenu = this.toggleCreateMenu.bind(this);
         this.toggleHamburger = this.toggleHamburger.bind(this);
         this.dismissHamburger = this.dismissHamburger.bind(this);
@@ -75,20 +75,6 @@ class App extends React.Component {
         this.animationTranslateX = new Animated.Value(
             !props.isSidebarShown ? -variables.sideBarWidth : 0,
         );
-
-        // This format allows to set individual callbacks to each item
-        // while including mutual callbacks first
-        this.menuItemData = [
-            {icon: ChatBubbleIcon, text: 'New Chat', onPress: () => {}},
-            {icon: UsersIcon, text: 'New Group', onPress: () => {}},
-        ].map(item => ({
-            ...item,
-            onPress: () => {
-                this.toggleCreateMenu();
-                ChatSwitcher.show();
-                item.onPress();
-            },
-        }));
     }
 
     componentDidMount() {
@@ -134,6 +120,14 @@ class App extends React.Component {
     componentWillUnmount() {
         Dimensions.removeEventListener('change', this.toggleHamburgerBasedOnDimensions);
         KeyboardShortcut.unsubscribe('K');
+    }
+
+    /**
+     * Method called when a Create Menu item is selected.
+     */
+    onCreateMenuItemSelected() {
+        this.toggleCreateMenu();
+        ChatSwitcher.show();
     }
 
     /**
@@ -290,9 +284,10 @@ class App extends React.Component {
                                     <Sidebar
                                         insets={insets}
                                         onLinkClick={this.recordTimerAndToggleHamburger}
+                                        isChatSwitcherActive={this.props.isChatSwitcherActive}
                                         isCreateMenuActive={this.state.isCreateMenuActive}
                                         toggleCreateMenu={this.toggleCreateMenu}
-                                        menuItemData={this.menuItemData}
+                                        onCreateMenuItemSelected={this.onCreateMenuItemSelected}
                                     />
                                 </Animated.View>
                                 {/* The following pressable allows us to click outside the LHN to close it,

--- a/src/pages/home/sidebar/ChatSwitcherView.js
+++ b/src/pages/home/sidebar/ChatSwitcherView.js
@@ -59,6 +59,8 @@ const propTypes = {
     countryCodeByIP: PropTypes.number,
 
     isSidebarAnimating: PropTypes.bool,
+
+    // Current state of the chat switcher (active of inactive)
     isChatSwitcherActive: PropTypes.bool,
 };
 const defaultProps = {
@@ -106,6 +108,13 @@ class ChatSwitcherView extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
+        // Checks if the isChatSwitcherActive prop changed from false to true
+        // If the change happens, update the search value and focus on the input
+        if (!prevProps.isChatSwitcherActive && this.props.isChatSwitcherActive) {
+            this.updateSearch(this.state.search);
+            this.textInput.focus();
+        }
+
         // Check if the sidebar was animating but is no longer animating and
         // if the chat switcher is active then focus the input
         if (prevProps.isSidebarAnimating
@@ -319,7 +328,6 @@ class ChatSwitcherView extends React.Component {
      */
     triggerOnFocusCallback() {
         ChatSwitcher.show();
-        this.updateSearch(this.state.search);
     }
 
     /**
@@ -557,5 +565,9 @@ export default withOnyx({
     },
     countryCodeByIP: {
         key: ONYXKEYS.COUNTRY_CODE,
+    },
+    isChatSwitcherActive: {
+        key: ONYXKEYS.IS_CHAT_SWITCHER_ACTIVE,
+        initWithStoredValues: false,
     },
 })(ChatSwitcherView);

--- a/src/pages/home/sidebar/SidebarLinks.js
+++ b/src/pages/home/sidebar/SidebarLinks.js
@@ -41,6 +41,7 @@ const propTypes = {
     // List of draft comments. We don't know the shape, since the keys include the report numbers
     comments: PropTypes.objectOf(PropTypes.string),
 
+    // Current state of the chat switcher (active of inactive)
     isChatSwitcherActive: PropTypes.bool,
 
     // List of users' personal details
@@ -117,7 +118,6 @@ const SidebarLinks = (props) => {
             <View style={[chatSwitcherStyle]}>
                 <ChatSwitcherView
                     onLinkClick={props.onLinkClick}
-                    isChatSwitcherActive={props.isChatSwitcherActive}
                 />
             </View>
             <View style={[
@@ -195,6 +195,10 @@ export default compose(
         },
         network: {
             key: ONYXKEYS.NETWORK,
+        },
+        isChatSwitcherActive: {
+            key: ONYXKEYS.IS_CHAT_SWITCHER_ACTIVE,
+            initWithStoredValues: false,
         },
     }),
 )(SidebarLinks);

--- a/src/pages/home/sidebar/SidebarView.js
+++ b/src/pages/home/sidebar/SidebarView.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import {View} from 'react-native';
 import PropTypes from 'prop-types';
-import {withOnyx} from 'react-native-onyx';
-import ONYXKEYS from '../../../ONYXKEYS';
 import styles from '../../../styles/styles';
 import SidebarBottom from './SidebarBottom';
 import SidebarLinks from './SidebarLinks';
@@ -21,27 +19,17 @@ const propTypes = {
     isChatSwitcherActive: PropTypes.bool,
 
     // Current state of the CreateMenu component (active or inactive)
-    isCreateMenuActive: PropTypes.bool,
+    isCreateMenuActive: PropTypes.bool.isRequired,
 
     // Callback to fire on request to toggle the CreateMenu
     toggleCreateMenu: PropTypes.func.isRequired,
 
-    // The data array containing the icon, text and callback information of each item
-    menuItemData: PropTypes.arrayOf(PropTypes.shape({
-        // The icon component of the item
-        icon: PropTypes.func.isRequired,
-
-        // The text content of the item
-        text: PropTypes.string.isRequired,
-
-        // Callback to fire on item press
-        onPress: PropTypes.func.isRequired,
-    })).isRequired,
+    // Callback to fire when a CreateMenu item is selected
+    onCreateMenuItemSelected: PropTypes.func.isRequired,
 };
 
 const defaultProps = {
     isChatSwitcherActive: false,
-    isCreateMenuActive: false,
 };
 
 const SidebarView = props => (
@@ -62,7 +50,7 @@ const SidebarView = props => (
         <CreateMenu
             onClose={props.toggleCreateMenu}
             isVisible={props.isCreateMenuActive}
-            menuItemData={props.menuItemData}
+            onItemSelected={props.onCreateMenuItemSelected}
         />
     </>
 );
@@ -70,11 +58,4 @@ const SidebarView = props => (
 SidebarView.propTypes = propTypes;
 SidebarView.defaultProps = defaultProps;
 SidebarView.displayName = 'SidebarView';
-export default withOnyx(
-    {
-        isChatSwitcherActive: {
-            key: ONYXKEYS.IS_CHAT_SWITCHER_ACTIVE,
-            initWithStoredValues: false,
-        },
-    },
-)(SidebarView);
+export default SidebarView;

--- a/src/pages/home/sidebar/SidebarView.js
+++ b/src/pages/home/sidebar/SidebarView.js
@@ -1,9 +1,12 @@
 import React from 'react';
 import {View} from 'react-native';
 import PropTypes from 'prop-types';
+import {withOnyx} from 'react-native-onyx';
+import ONYXKEYS from '../../../ONYXKEYS';
 import styles from '../../../styles/styles';
 import SidebarBottom from './SidebarBottom';
 import SidebarLinks from './SidebarLinks';
+import CreateMenu from '../../../components/CreateMenu';
 import SafeAreaInsetPropTypes from '../../SafeAreaInsetPropTypes';
 import FAB from '../../../components/FAB';
 
@@ -14,39 +17,64 @@ const propTypes = {
     // Safe area insets required for mobile devices margins
     insets: SafeAreaInsetPropTypes.isRequired,
 
-    // when the chat switcher is selected
+    // Current state of the chat switcher (active of inactive)
     isChatSwitcherActive: PropTypes.bool,
 
-    // Current state (active or not active) of the FAB
-    isFloatingActionButtonActive: PropTypes.bool.isRequired,
+    // Current state of the CreateMenu component (active or inactive)
+    isCreateMenuActive: PropTypes.bool,
 
-    // Callback to fire on request to toggle the FAB
-    onFloatingActionButtonPress: PropTypes.func.isRequired,
+    // Callback to fire on request to toggle the CreateMenu
+    toggleCreateMenu: PropTypes.func.isRequired,
+
+    // The data array containing the icon, text and callback information of each item
+    menuItemData: PropTypes.arrayOf(PropTypes.shape({
+        // The icon component of the item
+        icon: PropTypes.func.isRequired,
+
+        // The text content of the item
+        text: PropTypes.string.isRequired,
+
+        // Callback to fire on item press
+        onPress: PropTypes.func.isRequired,
+    })).isRequired,
 };
 
 const defaultProps = {
     isChatSwitcherActive: false,
+    isCreateMenuActive: false,
 };
 
 const SidebarView = props => (
-    <View style={[styles.flex1, styles.sidebar]}>
-        <SidebarLinks
-            onLinkClick={props.onLinkClick}
-            insets={props.insets}
-            isChatSwitcherActive={props.isChatSwitcherActive}
-        />
-        {!props.isChatSwitcherActive && (
+    <>
+        <View style={[styles.flex1, styles.sidebar]}>
+            <SidebarLinks
+                onLinkClick={props.onLinkClick}
+                insets={props.insets}
+            />
+            {!props.isChatSwitcherActive && (
             <SidebarBottom insets={props.insets} />
-        )}
-        <FAB
-            isActive={props.isFloatingActionButtonActive}
-            onPress={props.onFloatingActionButtonPress}
-            isHidden
+            )}
+            <FAB
+                isActive={props.isCreateMenuActive}
+                onPress={props.toggleCreateMenu}
+            />
+        </View>
+        <CreateMenu
+            onClose={props.toggleCreateMenu}
+            isVisible={props.isCreateMenuActive}
+            menuItemData={props.menuItemData}
         />
-    </View>
+    </>
 );
 
 SidebarView.propTypes = propTypes;
 SidebarView.defaultProps = defaultProps;
 SidebarView.displayName = 'SidebarView';
-export default SidebarView;
+export default withOnyx(
+    {
+        isChatSwitcherActive: {
+            key: ONYXKEYS.IS_CHAT_SWITCHER_ACTIVE,
+            initWithStoredValues: false,
+        },
+    },
+)(SidebarView);

--- a/src/styles/getModalStyles.js
+++ b/src/styles/getModalStyles.js
@@ -60,6 +60,9 @@ export default (type, windowDimensions) => {
                 width: isSmallScreen ? '100%' : variables.sideBarWidth,
                 borderTopLeftRadius: 16,
                 borderTopRightRadius: 16,
+                paddingTop: 12,
+                paddingBottom: 12,
+                justifyContent: 'center',
                 overflow: 'hidden',
             };
 

--- a/src/styles/getModalStyles.js
+++ b/src/styles/getModalStyles.js
@@ -49,6 +49,25 @@ export default (type, windowDimensions) => {
             animationOut = isSmallScreen ? 'slideOutRight' : 'fadeOut';
             needsSafeAreaPadding = true;
             break;
+        case CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED:
+            modalStyle = {
+                margin: 0,
+                alignItems: 'center',
+                justifyContent: 'flex-end',
+                marginRight: isSmallScreen ? 0 : windowDimensions.width - variables.sideBarWidth,
+            };
+            modalContainerStyle = {
+                width: isSmallScreen ? '100%' : variables.sideBarWidth,
+                borderTopLeftRadius: 16,
+                borderTopRightRadius: 16,
+                overflow: 'hidden',
+            };
+
+            swipeDirection = undefined;
+            animationIn = 'slideInUp';
+            animationOut = 'slideOutDown';
+            needsSafeAreaPadding = false;
+            break;
         default:
             modalStyle = {};
             modalContainerStyle = {};

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -423,6 +423,7 @@ const styles = {
         fontFamily: fontFamily.GTA_BOLD,
         fontSize: variables.fontSizeLabel,
         fontWeight: fontWeightBold,
+        color: themeColors.heading,
         lineHeight: 20,
     },
 

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -406,21 +406,21 @@ const styles = {
         textDecorationLine: 'none',
     },
 
-    sidebarCreateMenuItem: {
+    createMenuItem: {
         flexDirection: 'row',
         borderRadius: 0,
         paddingHorizontal: 20,
         paddingVertical: 12,
     },
 
-    sidebarCreateMenuIcon: {
+    createMenuIcon: {
         width: 40,
         height: 40,
         justifyContent: 'center',
         alignItems: 'center',
     },
 
-    sidebarCreateMenuText: {
+    createMenuText: {
         fontFamily: fontFamily.GTA_BOLD,
         fontSize: variables.fontSizeNormal,
         fontWeight: fontWeightBold,

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -406,25 +406,25 @@ const styles = {
         textDecorationLine: 'none',
     },
 
-    sidebarCreateMenuContainer: {
-        paddingTop: 12,
-        paddingBottom: 20,
-        justifyContent: 'center',
-    },
-
     sidebarCreateMenuItem: {
         flexDirection: 'row',
         borderRadius: 0,
-        paddingHorizontal: 32,
-        paddingVertical: 16,
+        paddingHorizontal: 20,
+        paddingVertical: 12,
+    },
+
+    sidebarCreateMenuIcon: {
+        width: 40,
+        height: 40,
+        justifyContent: 'center',
+        alignItems: 'center',
     },
 
     sidebarCreateMenuText: {
         fontFamily: fontFamily.GTA_BOLD,
-        fontSize: variables.fontSizeLabel,
+        fontSize: variables.fontSizeNormal,
         fontWeight: fontWeightBold,
         color: themeColors.heading,
-        lineHeight: 20,
     },
 
     chatLinkRowPressable: {

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -406,6 +406,27 @@ const styles = {
         textDecorationLine: 'none',
     },
 
+    sidebarCreateMenuContainer: {
+        paddingTop: 12,
+        paddingBottom: 20,
+        justifyContent: 'center',
+    },
+
+    sidebarCreateMenuItem: {
+        flexDirection: 'row',
+        cursor: 'pointer',
+        borderRadius: 0,
+        paddingHorizontal: 32,
+        paddingVertical: 16,
+    },
+
+    sidebarCreateMenuText: {
+        fontFamily: fontFamily.GTA_BOLD,
+        fontSize: variables.fontSizeLabel,
+        fontWeight: fontWeightBold,
+        lineHeight: 20,
+    },
+
     chatLinkRowPressable: {
         minWidth: 0,
         textDecorationLine: 'none',

--- a/src/styles/themes/default.js
+++ b/src/styles/themes/default.js
@@ -24,4 +24,5 @@ export default {
     modalBackdrop: colors.gray3,
     pillBG: colors.gray2,
     buttonDisabledBG: colors.gray2,
+    buttonHoveredBG: colors.gray1,
 };

--- a/src/styles/utilities/spacing.js
+++ b/src/styles/utilities/spacing.js
@@ -33,6 +33,10 @@ export default {
         marginLeft: 8,
     },
 
+    ml3: {
+        marginLeft: 12,
+    },
+
     mt1: {
         marginTop: 4,
     },


### PR DESCRIPTION
@marcaaron 

### Details
Created a CreateMenu Modal. it should be displayed when the floating action button is pressed and should animate from the bottom of the sidebar. 

The modal closes either when the user press one of its items, or press anywhere outside of it on the screen.

When the user presses one of the modal's items, it closes the modal, and activates the chat switcher (mirrors the action when pressing on the search icon on the top of the sidebar).

#### Problem found and how I fixed

**_This problem was fixed with other commits on the `master branch`, the trick below is not needed anymore and was fixed_**

As I mentioned on the [issue page](https://github.com/Expensify/Expensify.cash/issues/1240), there was a problem when calling the `ChatSwitcher.show()` (when pressing one of the modal's items). From my debugging, for the desired result to occur, the app also needs to call a couple of functions declared on the `src/pages/home/sidebar/ChatSwitcherView.js`. It needed to call both `updateSearch()` and `textInput.focus()`.

What I did was: I added (on the file cited above) a check for change on the `isChatSwitcherActive`, checking for a change from false to true. This check happens on `componentDidUpdate()`. If it is true, `updateSearch()` and `textInput.focus()` are called. 

#### Divergences from the initial proposal

I said first that the `CreateMenu` component would be called on the `HomePage.js` file. Decided to change it and call it on the `SidebarView.js` file. It is cleaner this way in my opinion.

#### Not really a problem but I changed

When I was debugging the first problem, I noticed the the `isChatSwitcherActive` prop was being passed down all the way from the `HomePage`. I don't believe these variables stored in Onyx should be passed down this way, I think it is much cleaner to always add it to the `withOnyx` HOF to access it. 

When I got to the `src/pages/home/sidebar/ChatSwitcherView.js` file I actually thought other files could be passing it down wrong and this could be the cause of the problem. After going all the way up to `HomePage` I realized it was correct.

What I mean is, when you see the prop is being accessed via `withOnyx()`, you know it could not be the issue, and you are not sure otherwise.

I changed the `isChatSwitcherActive` be accessed with `withOnyx` on the files I worked with, but did not looked much further to see if it happens in other locations.

If the way it was is the desired way, not a problem. I can undo the changes I made in an instant.


### Fixed Issues
Fixes #1240 

### Tests
1. Click on the floating action button
2. Verify a modal opens with a menu animating from the bottom. The menu must contain 2 items with icon and text
3. When clicking any of the menu's items, it should activate the chat switcher (action should be the same as when clicking the 'search' icon on the top of the sidebar), and the modal should close
4. If clicking anywhere on the screen outside the menu, the modal should close

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->


#### Web
![web](https://i.ibb.co/YQvLVLW/web.gif)

#### Mobile Web
![mobile web](https://i.ibb.co/FDpm4qm/mobile-web.gif)

#### Desktop
![desktop](https://i.ibb.co/GRPzqbD/desktop.gif)

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
![android](https://i.ibb.co/t3d6nsM/android.jpg)
