### PR TITLE
Refactor AppState to pusher:subscription_succeeded

### DIFF
--- a/src/libs/Network.js
+++ b/src/libs/Network.js
@@ -34,7 +34,8 @@ function processNetworkRequestQueue() {
 
         // Make a simple request every second to see if the API is online again
         HttpUtils.xhr('Get', {doNotRetry: true})
-            .then(() => NetworkConnection.setOfflineStatus(false));
+            .then(() => NetworkConnection.setOfflineStatus(false))
+            .catch(e => console.debug('[Ping] failed', e));
         return;
     }
 

--- a/src/libs/Pusher/pusher.js
+++ b/src/libs/Pusher/pusher.js
@@ -176,12 +176,19 @@ function bindEventToChannel(channel, eventName, eventCallback = () => {}, isChun
  * @param {Boolean} [isChunked] This parameters tells us whether or not we expect the result to come in individual
  * pieces/chunks (because it exceeds
  *  the 10kB limit that pusher has).
+ * @param {Function} [successEventCallback] Callback to be called when reconnection happen
  *
  * @return {Promise}
  *
  * @public
  */
-function subscribe(channelName, eventName, eventCallback = () => {}, isChunked = false) {
+function subscribe(
+    channelName,
+    eventName,
+    eventCallback = () => {},
+    isChunked = false,
+    successEventCallback = () => {},
+) {
     return new Promise((resolve, reject) => {
         // We cannot call subscribe() before init(). Prevent any attempt to do this on dev.
         if (!socket) {
@@ -194,13 +201,17 @@ function subscribe(channelName, eventName, eventCallback = () => {}, isChunked =
 
         if (!channel || !channel.subscribed) {
             channel = socket.subscribe(channelName);
+            let isBound = false;
             channel.bind('pusher:subscription_succeeded', () => {
-                bindEventToChannel(channel, eventName, eventCallback, isChunked);
+                // check so that we do not bind another event with each reconnect attempt
+                if (!isBound) {
+                    bindEventToChannel(channel, eventName, eventCallback, isChunked);
+                    resolve();
+                }
+                isBound = true;
 
-                // Remove this event subscriber so we do not bind another
-                // event with each reconnect attempt
-                channel.unbind('pusher:subscription_succeeded');
-                resolve();
+                // we let this fire for the first time as well as user could wanted to fire something on success
+                successEventCallback();
             });
 
             channel.bind('pusher:subscription_error', (status) => {

--- a/src/libs/Pusher/pusher.js
+++ b/src/libs/Pusher/pusher.js
@@ -203,14 +203,16 @@ function subscribe(
             channel = socket.subscribe(channelName);
             let isBound = false;
             channel.bind('pusher:subscription_succeeded', () => {
-                // check so that we do not bind another event with each reconnect attempt
+                // Check so that we do not bind another event with each reconnect attempt
                 if (!isBound) {
                     bindEventToChannel(channel, eventName, eventCallback, isChunked);
                     resolve();
                 }
                 isBound = true;
 
-                // we let this fire for the first time as well as user could wanted to fire something on success
+                // When subscribing for the first time we can register a success callback that can be
+                // called multiple times when the subscription succeeds again in the future
+                // e.g. as a result of Pusher disconnecting and reconnecting
                 successEventCallback();
             });
 

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -114,7 +114,8 @@ function fetchTimezone() {
         .then((data) => {
             const timezone = lodashGet(data, 'nameValuePairs.timeZone.selected', 'America/Los_Angeles');
             Onyx.merge(ONYXKEYS.MY_PERSONAL_DETAILS, {timezone});
-        });
+        })
+        .catch(error => console.debug('Error fetching user timezone', error));
 }
 
 /**

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -288,6 +288,9 @@ function subscribeToReportCommentEvents() {
 
     Pusher.subscribe(pusherChannelName, 'reportComment', (pushJSON) => {
         updateReportWithNewAction(pushJSON.reportID, pushJSON.reportAction);
+    }, false,
+    () => {
+        NetworkConnection.triggerReconnectionCallbacks();
     });
 
     PushNotification.onReceived(PushNotification.TYPE.REPORT_COMMENT, ({reportID, reportAction}) => {

--- a/src/pages/home/HomePage.js
+++ b/src/pages/home/HomePage.js
@@ -119,6 +119,7 @@ class App extends React.Component {
     componentWillUnmount() {
         Dimensions.removeEventListener('change', this.toggleHamburgerBasedOnDimensions);
         KeyboardShortcut.unsubscribe('K');
+        NetworkConnection.stopListeningForReconnect();
     }
 
     /**


### PR DESCRIPTION
@marcaaron  @tgolen  Please review. I see there could be room for improvements.

### Details
 Due to the AppState switch state many times during the lifecycle of the app, reconnectionCallbacks were firing on every state change even if we never lost connection. So after discussion with @marcaaron and the proposed solution, I have removed the AppState code that was responsible for firing reconnectionCallbacks, instead, we listen for the `pusher:subsription_succeeded` event and then fire the events. This particular event fire only if the app lost the connection to Pusher.
 So we don't need the following check:
 

1. User comes back Online.
2. Laptop comes back from sleep.

### Other Changes
Few catch statements to catch Promise rejection error while offline.

### Fixed Issues

Fixes #1204

### Tests

Various manual tests:
1. Open the app, send some messages from one account to another, now close the internet or other device, and send a message from the first device. Turn the second device's internet back on. You should receive the history messages.
2. Open the app on the browser, now switch tabs reconnectionCallbacks should not fire as we neve lost internet connections and pusher was live.
3. Open the mobile app and put it in the background. Send some messages from the other device. After Some time pull the first app back to the foreground, reconnectioncallbacks should not fire if you never lost the connection to the pusher and all the messages should be there.


### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [ ] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

Not sure how to record this behaviour, Can only be tested manually.
