### PR TITLE
Update to XCode 12.3 for iOS build and deploy workflow

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -6,6 +6,9 @@ on:
         tags:
             - '*'
 
+env:
+  DEVELOPER_DIR: /Applications/Xcode_12.3.app/Contents/Developer
+
 jobs:
     build:
         runs-on: macos-latest

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -320,10 +320,10 @@ PODS:
     - React-cxxreact (= 0.63.3)
     - React-jsi (= 0.63.3)
   - React-jsinspector (0.63.3)
-  - react-native-config (1.3.3):
-    - react-native-config/App (= 1.3.3)
-  - react-native-config/App (1.3.3):
-    - React
+  - react-native-config (1.4.1):
+    - react-native-config/App (= 1.4.1)
+  - react-native-config/App (1.4.1):
+    - React-Core
   - react-native-document-picker (4.0.0):
     - React-Core
   - react-native-image-picker (2.3.4):
@@ -641,7 +641,7 @@ SPEC CHECKSUMS:
   React-jsi: df07aa95b39c5be3e41199921509bfa929ed2b9d
   React-jsiexecutor: b56c03e61c0dd5f5801255f2160a815f4a53d451
   React-jsinspector: 8e68ffbfe23880d3ee9bafa8be2777f60b25cbe2
-  react-native-config: 9a061347e0136fdb32d43a34d60999297d672361
+  react-native-config: d8b45133fd13d4f23bd2064b72f6e2c08b2763ed
   react-native-document-picker: b3e78a8f7fef98b5cb069f20fc35797d55e68e28
   react-native-image-picker: 32d1ad2c0024ca36161ae0d5c2117e2d6c441f11
   react-native-netinfo: e36c1bb6df27ab84aa933679b3f5bbf9d180b18f


### PR DESCRIPTION
Please review @roryabraham 

### Details
Updates the iOS workflow to match the e2e workflow and use XCode 12.3 to build the iOS app.

### Fixed Issues
Fixes [broken iOS builds ](https://github.com/Expensify/Expensify.cash/actions?query=workflow%3A%22Build+and+Deploy+iOS%22)hopefully 🤞 

### Tests
1. Merge this PR
2. Verify that the iOS workflow succeeds

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [X] iOS
- [ ] Android
