### PR TITLE
Fix bad merge that is breaking small screens

### DIFF
--- a/src/pages/home/HomePage.js
+++ b/src/pages/home/HomePage.js
@@ -305,8 +305,8 @@ class App extends React.Component {
                                     style={[styles.appContent, styles.flex1, styles.flexColumn]}
                                 >
                                     <HeaderView
-                                        shouldShowHamburgerButton={this.state.isHamburgerEnabled}
-                                        onHamburgerButtonClicked={this.toggleHamburger}
+                                        shouldShowNavigationMenuButton={this.state.isSmallScreenWidth}
+                                        onNavigationMenuButtonClicked={this.toggleNavigationMenu}
                                     />
                                     {this.props.currentURL === '/settings' && <SettingsPage />}
                                     <Main />


### PR DESCRIPTION
### Details
Some merge conflicts were not fixed correctly.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/151723

### Tests
1. Run app at a small screen width
2. Verify you can toggle the Left Hand Nav open via the `<` icon

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
![2021-01-19_15-26-32](https://user-images.githubusercontent.com/32969087/105114559-2db88500-5a6b-11eb-9879-aaee9a871dfa.png)

#### Mobile Web
![2021-01-19_15-26-19](https://user-images.githubusercontent.com/32969087/105114537-272a0d80-5a6b-11eb-86d8-95594e136c21.png)
![2021-01-19_15-26-25](https://user-images.githubusercontent.com/32969087/105114535-25f8e080-5a6b-11eb-8e33-ede6820cf979.png)

#### Desktop
![2021-01-19_15-27-10](https://user-images.githubusercontent.com/32969087/105114570-3315cf80-5a6b-11eb-8a11-64a0fb54f542.png)
![2021-01-19_15-27-00](https://user-images.githubusercontent.com/32969087/105114575-33ae6600-5a6b-11eb-8994-4710bc5742f4.png)

#### iOS
![2021-01-19_15-28-04](https://user-images.githubusercontent.com/32969087/105114586-3b6e0a80-5a6b-11eb-9dbf-ad0c5026b54b.png)

#### Android
![2021-01-19_15-28-58](https://user-images.githubusercontent.com/32969087/105114588-3f9a2800-5a6b-11eb-8ae6-68c85a562360.png)
