### PR TITLE
Fix JS error on personal details

### DIFF
--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -20,12 +20,6 @@ Onyx.connect({
     callback: val => personalDetails = val,
 });
 
-let isOffline;
-Onyx.connect({
-    key: ONYXKEYS.NETWORK,
-    callback: val => isOffline = val && val.isOffline,
-});
-
 /**
  * Helper method to return a default avatar
  *
@@ -178,17 +172,6 @@ function getFromReportParticipants(reports) {
 
 // When the app reconnects from being offline, fetch all of the personal details
 NetworkConnection.onReconnect(fetch);
-
-// Refresh the personal details and timezone every 30 minutes because there is no
-// pusher event that sends updated personal details data yet
-// See https://github.com/Expensify/ReactNativeChat/issues/468
-setInterval(() => {
-    if (isOffline) {
-        return;
-    }
-    fetch();
-    fetchTimezone();
-}, 1000 * 60 * 30);
 
 export {
     fetch,

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -8,10 +8,10 @@ import CONST from '../../CONST';
 import NetworkConnection from '../NetworkConnection';
 import * as API from '../API';
 
-let currentUserEmail;
+let currentUserEmail = '';
 Onyx.connect({
     key: ONYXKEYS.SESSION,
-    callback: val => currentUserEmail = val ? val.email : null,
+    callback: val => currentUserEmail = val ? val.email : '',
 });
 
 let personalDetails;

--- a/src/pages/home/HomePage.js
+++ b/src/pages/home/HomePage.js
@@ -142,10 +142,8 @@ class App extends React.Component {
         Dimensions.removeEventListener('change', this.toggleNavigationMenuBasedOnDimensions);
         KeyboardShortcut.unsubscribe('K');
         NetworkConnection.stopListeningForReconnect();
-        if (this.interval) {
-            clearInterval(this.interval);
-            this.interval = null;
-        }
+        clearInterval(this.interval);
+        this.interval = null;
     }
 
     /**


### PR DESCRIPTION
cc @marcaaron 

### Details
This probably does not fix the underlying issue but at least it would not generate a JS error either

### Fixed Issues
https://expensify.slack.com/archives/C011W8BJ9L6/p1611090981226800?thread_ts=1611073712.193700&cid=C011W8BJ9L6
![image](https://user-images.githubusercontent.com/521248/105205965-1ac6b300-5b46-11eb-9e4e-a9fe578c2b7d.png)

### Tests

- Logged in and out of the app, checked no JS errors were thrown
- Changed the interval to 5 seconds, checked it fires correctly when logged in and that it stops firing after you log out

I have no better ideas for tests, given I am not sure how to reproduce the situation of getting logged out. Let me know if you can think of better tests.

### Tested On

- [X] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

