### PR TITLE
Only fire reconnection callbacks when Pusher re-subscribes not on first subscription

### DIFF
--- a/src/libs/Pusher/pusher.js
+++ b/src/libs/Pusher/pusher.js
@@ -176,7 +176,7 @@ function bindEventToChannel(channel, eventName, eventCallback = () => {}, isChun
  * @param {Boolean} [isChunked] This parameters tells us whether or not we expect the result to come in individual
  * pieces/chunks (because it exceeds
  *  the 10kB limit that pusher has).
- * @param {Function} [successEventCallback] Callback to be called when reconnection happen
+ * @param {Function} [onResubscribe] Callback to be called when reconnection happen
  *
  * @return {Promise}
  *
@@ -187,7 +187,7 @@ function subscribe(
     eventName,
     eventCallback = () => {},
     isChunked = false,
-    successEventCallback = () => {},
+    onResubscribe = () => {},
 ) {
     return new Promise((resolve, reject) => {
         // We cannot call subscribe() before init(). Prevent any attempt to do this on dev.
@@ -207,13 +207,15 @@ function subscribe(
                 if (!isBound) {
                     bindEventToChannel(channel, eventName, eventCallback, isChunked);
                     resolve();
+                    isBound = true;
+                    return;
                 }
-                isBound = true;
 
-                // When subscribing for the first time we can register a success callback that can be
+                // When subscribing for the first time we register a success callback that can be
                 // called multiple times when the subscription succeeds again in the future
-                // e.g. as a result of Pusher disconnecting and reconnecting
-                successEventCallback();
+                // e.g. as a result of Pusher disconnecting and reconnecting. This callback does
+                // not fire on the first subscription_succeeded event.
+                onResubscribe();
             });
 
             channel.bind('pusher:subscription_error', (status) => {


### PR DESCRIPTION
### Details

When we added a way to fire reconnection callbacks on Pusher reconnect we missed that they also are firing on the initial connection. This basically means that each time we refresh we are making all the API calls we normally make and then making them again as soon as Pusher succeeds in subscribing to the `private-user-accountID-*` channel.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/151778

### Tests
1. Start the app
2. Verify you do not immediately see the reconnection callbacks output in the logs
3. Refresh the app
4. Verify you do not see the reconnection callbacks output in the logs

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
