### PR TITLE
Changed CreateMenu modal for larger screens

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -12,7 +12,8 @@ const CONST = {
     MODAL: {
         MODAL_TYPE: {
             CENTERED: 'centered',
-            CREATE_MENU: 'create_menu',
+            BOTTOM_DOCKED: 'bottom_docked',
+            POPOVER: 'popover',
         },
     },
     TIMING: {

--- a/src/CONST.js
+++ b/src/CONST.js
@@ -12,7 +12,7 @@ const CONST = {
     MODAL: {
         MODAL_TYPE: {
             CENTERED: 'centered',
-            BOTTOM_DOCKED: 'bottom_docked',
+            CREATE_MENU: 'create_menu',
         },
     },
     TIMING: {

--- a/src/components/CreateMenu.js
+++ b/src/components/CreateMenu.js
@@ -1,12 +1,15 @@
 import React, {memo} from 'react';
 import PropTypes from 'prop-types';
-import {View, Text, Pressable} from 'react-native';
+import {
+    View, Text, Pressable, useWindowDimensions,
+} from 'react-native';
 import Modal from './Modal';
 import styles from '../styles/styles';
 import CONST from '../CONST';
 import themeColors from '../styles/themes/default';
 import colors from '../styles/colors';
 import {ChatBubbleIcon, UsersIcon} from './Expensicons';
+import variables from '../styles/variables';
 
 const propTypes = {
     // Callback to fire on request to modal close
@@ -20,6 +23,8 @@ const propTypes = {
 };
 
 const CreateMenu = (props) => {
+    const isSmallScreen = useWindowDimensions().width < variables.mobileResponsiveWidthBreakpoint;
+
     // This format allows to set individual callbacks to each item
     // while including mutual callbacks first
     const menuItemData = [
@@ -37,7 +42,11 @@ const CreateMenu = (props) => {
         <Modal
             onClose={props.onClose}
             isVisible={props.isVisible}
-            type={CONST.MODAL.MODAL_TYPE.CREATE_MENU}
+            type={
+                isSmallScreen
+                    ? CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED
+                    : CONST.MODAL.MODAL_TYPE.POPOVER
+            }
         >
             {menuItemData.map(({IconComponent, text, onPress}) => (
                 <Pressable

--- a/src/components/CreateMenu.js
+++ b/src/components/CreateMenu.js
@@ -37,7 +37,7 @@ const CreateMenu = (props) => {
         <Modal
             onClose={props.onClose}
             isVisible={props.isVisible}
-            type={CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED}
+            type={CONST.MODAL.MODAL_TYPE.CREATE_MENU}
         >
             {menuItemData.map(({IconComponent, text, onPress}) => (
                 <Pressable

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -22,7 +22,7 @@ const propTypes = {
     // Style of modal to display
     type: PropTypes.oneOf([
         CONST.MODAL.MODAL_TYPE.CENTERED,
-        CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED,
+        CONST.MODAL.MODAL_TYPE.CREATE_MENU,
     ]),
 };
 
@@ -38,6 +38,7 @@ const Modal = (props) => {
         animationIn,
         animationOut,
         needsSafeAreaPadding,
+        hideBackdrop,
     } = getModalStyles(props.type, useWindowDimensions());
 
     return (
@@ -48,7 +49,7 @@ const Modal = (props) => {
             swipeDirection={swipeDirection}
             isVisible={props.isVisible}
             backdropColor={themeColors.modalBackdrop}
-            backdropOpacity={0.5}
+            backdropOpacity={hideBackdrop ? 0 : 0.5}
             backdropTransitionOutTiming={0}
             style={modalStyle}
             animationIn={animationIn}

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -22,7 +22,8 @@ const propTypes = {
     // Style of modal to display
     type: PropTypes.oneOf([
         CONST.MODAL.MODAL_TYPE.CENTERED,
-        CONST.MODAL.MODAL_TYPE.CREATE_MENU,
+        CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED,
+        CONST.MODAL.MODAL_TYPE.POPOVER,
     ]),
 };
 

--- a/src/styles/getModalStyles.js
+++ b/src/styles/getModalStyles.js
@@ -10,6 +10,7 @@ export default (type, windowDimensions) => {
     let swipeDirection;
     let animationIn;
     let animationOut;
+    let hideBackdrop = false;
     let needsSafeAreaPadding = false;
 
     switch (type) {
@@ -49,27 +50,33 @@ export default (type, windowDimensions) => {
             animationOut = isSmallScreen ? 'slideOutRight' : 'fadeOut';
             needsSafeAreaPadding = true;
             break;
-        case CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED:
+        case CONST.MODAL.MODAL_TYPE.CREATE_MENU:
             modalStyle = {
                 margin: 0,
                 alignItems: 'center',
                 justifyContent: 'flex-end',
                 marginRight: isSmallScreen ? 0 : windowDimensions.width - variables.sideBarWidth,
+                marginBottom: isSmallScreen ? 0 : 82,
             };
             modalContainerStyle = {
-                width: isSmallScreen ? '100%' : variables.sideBarWidth,
-                borderTopLeftRadius: 16,
-                borderTopRightRadius: 16,
+                width: isSmallScreen ? '100%' : variables.sideBarWidth - 40,
+                borderTopLeftRadius: isSmallScreen ? 20 : 12,
+                borderTopRightRadius: isSmallScreen ? 20 : 12,
+                borderBottomLeftRadius: isSmallScreen ? 0 : 12,
+                borderBottomRightRadius: isSmallScreen ? 0 : 12,
+                borderWidth: isSmallScreen ? 0 : 1,
+                borderColor: '#ECECEC',
                 paddingTop: 12,
                 paddingBottom: 12,
                 justifyContent: 'center',
                 overflow: 'hidden',
+                boxShadow: isSmallScreen ? 'none' : '0px 0px 10px 0px rgba(0, 0, 0, 0.025)',
             };
 
+            hideBackdrop = !isSmallScreen;
             swipeDirection = undefined;
-            animationIn = 'slideInUp';
-            animationOut = 'slideOutDown';
-            needsSafeAreaPadding = false;
+            animationIn = isSmallScreen ? 'slideInUp' : 'fadeInLeft';
+            animationOut = isSmallScreen ? 'slideOutDown' : 'fadeOutLeft';
             break;
         default:
             modalStyle = {};
@@ -86,5 +93,6 @@ export default (type, windowDimensions) => {
         animationIn,
         animationOut,
         needsSafeAreaPadding,
+        hideBackdrop,
     };
 };

--- a/src/styles/getModalStyles.js
+++ b/src/styles/getModalStyles.js
@@ -1,6 +1,7 @@
 import CONST from '../CONST';
 import colors from './colors';
 import variables from './variables';
+import themeColors from './themes/default';
 
 export default (type, windowDimensions) => {
     const isSmallScreen = windowDimensions.width < variables.mobileResponsiveWidthBreakpoint;
@@ -50,33 +51,50 @@ export default (type, windowDimensions) => {
             animationOut = isSmallScreen ? 'slideOutRight' : 'fadeOut';
             needsSafeAreaPadding = true;
             break;
-        case CONST.MODAL.MODAL_TYPE.CREATE_MENU:
+        case CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED:
             modalStyle = {
                 margin: 0,
                 alignItems: 'center',
                 justifyContent: 'flex-end',
-                marginRight: isSmallScreen ? 0 : windowDimensions.width - variables.sideBarWidth,
-                marginBottom: isSmallScreen ? 0 : 82,
             };
             modalContainerStyle = {
-                width: isSmallScreen ? '100%' : variables.sideBarWidth - 40,
-                borderTopLeftRadius: isSmallScreen ? 20 : 12,
-                borderTopRightRadius: isSmallScreen ? 20 : 12,
-                borderBottomLeftRadius: isSmallScreen ? 0 : 12,
-                borderBottomRightRadius: isSmallScreen ? 0 : 12,
-                borderWidth: isSmallScreen ? 0 : 1,
-                borderColor: '#ECECEC',
+                width: '100%',
+                borderTopLeftRadius: 20,
+                borderTopRightRadius: 20,
                 paddingTop: 12,
                 paddingBottom: 12,
                 justifyContent: 'center',
                 overflow: 'hidden',
-                boxShadow: isSmallScreen ? 'none' : '0px 0px 10px 0px rgba(0, 0, 0, 0.025)',
             };
 
-            hideBackdrop = !isSmallScreen;
             swipeDirection = undefined;
-            animationIn = isSmallScreen ? 'slideInUp' : 'fadeInLeft';
-            animationOut = isSmallScreen ? 'slideOutDown' : 'fadeOutLeft';
+            animationIn = 'slideInUp';
+            animationOut = 'slideOutDown';
+            break;
+        case CONST.MODAL.MODAL_TYPE.POPOVER:
+            modalStyle = {
+                margin: 0,
+                alignItems: 'center',
+                justifyContent: 'flex-end',
+                marginRight: windowDimensions.width - variables.sideBarWidth,
+                marginBottom: 82,
+            };
+            modalContainerStyle = {
+                width: variables.sideBarWidth - 40,
+                borderRadius: 12,
+                borderWidth: 1,
+                borderColor: themeColors.border,
+                paddingTop: 12,
+                paddingBottom: 12,
+                justifyContent: 'center',
+                overflow: 'hidden',
+                boxShadow: '0px 0px 10px 0px rgba(0, 0, 0, 0.025)',
+            };
+
+            hideBackdrop = true;
+            swipeDirection = undefined;
+            animationIn = 'fadeInLeft';
+            animationOut = 'fadeOutLeft';
             break;
         default:
             modalStyle = {};


### PR DESCRIPTION
@marcaaron @shawnborton 

### Details
Changed the CreateMenu modal for larger screens. The breakpoint is calculated as:
`isSmallScreen = windowDimensions.width < variables.mobileResponsiveWidthBreakpoint`
For small screens, the modal animation stays the same. I did change one (really) small thing on small screens. I changed the menu's border radius from `16` to `20`, as seen on the Figma file.

For the animation I used `fadeInLeft` and `fadeOutLeft`. I liked it because follows the floating action button movement (like it is pushing the menu), and does not need weird modification on the modal component (this would be the case if we wanted to change the origin of the animation).

#### Important changes from the issue deliverable description

**_Edit: Changed my mind on this issue. I like the initially proposed way better. Changed it back._**

The issue page (and my initial proposal over there) suggests creating a new type of modal, probably following the pattern of:
- Create a new type constant on `src/CONST.js`;
- Use it to create a new modal type on `src/styles/getModalStyles.js;
- Conditionally render the different types on the `CreateMenu` component.

I decided to go in a different direction, which I found much cleaner. I wanted to leave all the logic inside the `getModalStyles` file.
For that, I just altered the existing type, which was already being used, and used plenty of `isSmallScreen` verifications to get the styles on both screen sizes correct.

I know it diverges from the way the code was probably trying to go, creating very generic and reusable types of modals, but I believe the advantages of creating this specific modal are greater than creating two generic types. This way we can keep the `CreateMenu` component free of any logic relating to the menu style.

Because it created a very specific and not really reusable modal style, I changed the type name from `BOTTOM_DOCKED` to just `CREATE_MENU`.


#### Cursor issue discussion

On the issue page, there was a discussion relating to "losing" the cursor functionality on the screen space outside the `CreateMenu` when the component is open, as it usually is with a modal.
I did some tests, which are described on the issue page, but could not get a solution to work with the use of the Modal. Any other solution would be a little more complicated, but I am up to try it if you don't like this one.


### Fixed Issues
Fixes [#1267](https://github.com/Expensify/Expensify.cash/issues/1267)

### Tests
On large screens
1. Click the floating action button;
2. Verify the menu fades in from the left of the screen, its bottom height must be a few pixels above the FAB;
3. If you click anywhere else on the screen, the menu closes fading out from the left of the screen;
4. If you click one of the items, it should activate the chat switcher (action should be the same as when clicking the 'search' icon on the top of the sidebar), and the modal should close.

On small screens
1. Verify the CreateMenu animation does not change from the current one when opening / closing, and the click item action still works.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [ ] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
![web](https://i.ibb.co/sPJMKV6/web.gif)

#### Mobile Web
![mobile web](https://i.ibb.co/yNbwsx6/mobile-web.gif)

#### Desktop
![desktop](https://i.ibb.co/bPRD5gT/desktop.gif)

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
![android](https://i.ibb.co/4g0mhfh/android.jpg)
