### PR TITLE
Close attachment modal on escape

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -93,13 +93,13 @@ class Modal extends Component {
                         return (
                             <View
                                 style={{
-                                    ...styles.defaultModalContainer,
-                                    paddingBottom,
-                                    ...modalContainerStyle,
-
                                     // This padding is based on the insets and could not neatly be
                                     // returned by getModalStyles to avoid passing this inline.
                                     paddingTop: needsSafeAreaPadding ? paddingTop : 20,
+
+                                    ...styles.defaultModalContainer,
+                                    paddingBottom,
+                                    ...modalContainerStyle,
                                 }}
                             >
                                 {this.props.children}

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -9,6 +9,7 @@ import styles, {getSafeAreaPadding} from '../styles/styles';
 import themeColors from '../styles/themes/default';
 import getModalStyles from '../styles/getModalStyles';
 import CONST from '../CONST';
+import withWindowDimensions, {windowDimensionsPropTypes} from './withWindowDimensions';
 
 const propTypes = {
     // Callback method fired when the user requests to close the modal
@@ -27,14 +28,7 @@ const propTypes = {
         CONST.MODAL.MODAL_TYPE.POPOVER,
     ]),
 
-    // via withWindowDimensions
-    windowDimensions: PropTypes.shape({
-        // Width of the window
-        width: PropTypes.number.isRequired,
-
-        // Height of the window
-        height: PropTypes.number.isRequired,
-    }).isRequired,
+    ...windowDimensionsPropTypes,
 };
 
 const defaultProps = {
@@ -95,4 +89,4 @@ const Modal = (props) => {
 Modal.propTypes = propTypes;
 Modal.defaultProps = defaultProps;
 Modal.displayName = 'Modal';
-export default Modal;
+export default withWindowDimensions(Modal);

--- a/src/components/RenderHTML.js
+++ b/src/components/RenderHTML.js
@@ -8,7 +8,7 @@ import HTML, {
     splitBoxModelStyle,
 } from 'react-native-render-html';
 import Config from '../CONFIG';
-import {webViewStyles} from '../styles/styles';
+import styles, {webViewStyles} from '../styles/styles';
 import fontFamily from '../styles/fontFamily';
 import AnchorForCommentsOnly from './AnchorForCommentsOnly';
 import InlineCodeBlock from './InlineCodeBlock';
@@ -120,6 +120,7 @@ function ImgRenderer({tnode}) {
         >
             {({show}) => (
                 <TouchableOpacity
+                    style={styles.noOutline}
                     onPress={() => show()}
                 >
                     <ThumbnailImage

--- a/src/components/withSecondaryInteractionHandler/index.js
+++ b/src/components/withSecondaryInteractionHandler/index.js
@@ -4,16 +4,7 @@
  */
 import React from 'react';
 import {Pressable} from 'react-native';
-
-/**
- * Returns the display name of a component
- *
- * @param {object} component
- * @returns {string}
- */
-function getDisplayName(component) {
-    return component.displayName || component.name || 'Component';
-}
+import getComponentDisplayName from '../../libs/getComponentDisplayName';
 
 export default function (onSecondaryInteraction) {
     function onContextMenu(e) {
@@ -50,7 +41,7 @@ export default function (onSecondaryInteraction) {
         }
 
         withSecondaryInteractionHandler
-            .displayName = `withSecondaryInteractionHandler(${getDisplayName(WrappedComponent)})`;
+            .displayName = `withSecondaryInteractionHandler(${getComponentDisplayName(WrappedComponent)})`;
         return withSecondaryInteractionHandler;
     };
 }

--- a/src/components/withSecondaryInteractionHandler/index.native.js
+++ b/src/components/withSecondaryInteractionHandler/index.native.js
@@ -4,16 +4,7 @@
  */
 import React from 'react';
 import {Pressable} from 'react-native';
-
-/**
- * Returns the display name of a component
- *
- * @param {object} component
- * @returns {string}
- */
-function getDisplayName(component) {
-    return component.displayName || component.name || 'Component';
-}
+import getComponentDisplayName from '../../libs/getComponentDisplayName';
 
 export default function (onSecondaryInteraction) {
     return (WrappedComponent) => {
@@ -29,7 +20,7 @@ export default function (onSecondaryInteraction) {
         );
 
         withSecondaryInteractionHandler
-            .displayName = `withSecondaryInteractionHandler(${getDisplayName(WrappedComponent)})`;
+            .displayName = `withSecondaryInteractionHandler(${getComponentDisplayName(WrappedComponent)})`;
         return withSecondaryInteractionHandler;
     };
 }

--- a/src/components/withWindowDimensions.js
+++ b/src/components/withWindowDimensions.js
@@ -1,5 +1,17 @@
 import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {Dimensions} from 'react-native';
+
+export const windowDimensionsPropTypes = {
+    // via withWindowDimensions
+    windowDimensions: PropTypes.shape({
+        // Width of the window
+        width: PropTypes.number.isRequired,
+
+        // Height of the window
+        height: PropTypes.number.isRequired,
+    }).isRequired,
+};
 
 const withWindowDimensions = WrappedComponent => (
     class WindowDimensions extends Component {

--- a/src/components/withWindowDimensions.js
+++ b/src/components/withWindowDimensions.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {Dimensions} from 'react-native';
 import getComponentDisplayName from '../libs/getComponentDisplayName';
 
-export const windowDimensionsPropTypes = {
+const windowDimensionsPropTypes = {
     // via withWindowDimensions
     windowDimensions: PropTypes.shape({
         // Width of the window
@@ -59,3 +59,7 @@ export default function (WrappedComponent) {
     withWindowDimensions.displayName = `withWindowDimensions(${getComponentDisplayName(WrappedComponent)})`;
     return withWindowDimensions;
 }
+
+export {
+    windowDimensionsPropTypes,
+};

--- a/src/components/withWindowDimensions.js
+++ b/src/components/withWindowDimensions.js
@@ -1,6 +1,7 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {Dimensions} from 'react-native';
+import getComponentDisplayName from '../libs/getComponentDisplayName';
 
 export const windowDimensionsPropTypes = {
     // via withWindowDimensions
@@ -13,8 +14,8 @@ export const windowDimensionsPropTypes = {
     }).isRequired,
 };
 
-const withWindowDimensions = WrappedComponent => (
-    class WindowDimensions extends Component {
+export default function (WrappedComponent) {
+    class withWindowDimensions extends Component {
         constructor(props) {
             super(props);
 
@@ -54,7 +55,7 @@ const withWindowDimensions = WrappedComponent => (
             );
         }
     }
-);
 
-withWindowDimensions.displayName = 'withWindowDimensions';
-export default withWindowDimensions;
+    withWindowDimensions.displayName = `withWindowDimensions(${getComponentDisplayName(WrappedComponent)})`;
+    return withWindowDimensions;
+}

--- a/src/components/withWindowDimensions.js
+++ b/src/components/withWindowDimensions.js
@@ -1,0 +1,48 @@
+import React, {Component} from 'react';
+import {Dimensions} from 'react-native';
+
+const withWindowDimensions = WrappedComponent => (
+    class WindowDimensions extends Component {
+        constructor(props) {
+            super(props);
+
+            this.onDimensionChange = this.onDimensionChange.bind(this);
+
+            this.state = {
+                windowDimensions: Dimensions.get('window'),
+            };
+        }
+
+        componentDidMount() {
+            Dimensions.addEventListener('change', this.onDimensionChange);
+        }
+
+        componentWillUnmount() {
+            Dimensions.removeEventListener('change', this.onDimensionChange);
+        }
+
+        /**
+         * Stores the application window's width and height in a component state variable.
+         * Called each time the application's window dimensions or screen dimensions change.
+         * @link https://reactnative.dev/docs/dimensions
+         * @param {Object} newDimensions Dimension object containing updated window and screen dimensions
+         */
+        onDimensionChange(newDimensions) {
+            const {window} = newDimensions;
+            this.setState({windowDimensions: window});
+        }
+
+        render() {
+            return (
+                <WrappedComponent
+                    // eslint-disable-next-line react/jsx-props-no-spreading
+                    {...this.props}
+                    windowDimensions={this.state.windowDimensions}
+                />
+            );
+        }
+    }
+);
+
+withWindowDimensions.displayName = 'withWindowDimensions';
+export default withWindowDimensions;

--- a/src/libs/KeyboardShortcut/index.js
+++ b/src/libs/KeyboardShortcut/index.js
@@ -67,14 +67,26 @@ document.addEventListener('keydown', bindHandlerToKeyupEvent);
  */
 const KeyboardShortcut = {
     /**
+     * Returns keyCode for a given key
+     * @param {String} key The key to watch, i.e. 'K' or 'Escape'
+     * @returns {Number} The key's keyCode, i.e. 75 or 27
+     */
+    getKeyCode(key) {
+        if (key === 'Escape') {
+            return 27;
+        }
+        return key.charCodeAt(0);
+    },
+
+    /**
      * Subscribes to a keyboard event.
-     * @param {String} key The key code to watch
+     * @param {String} key The key to watch, i.e. 'K' or 'Escape'
      * @param {Function} callback The callback to call
      * @param {String|Array} modifiers Can either be shift or control
      * @param {Boolean} captureOnInputs Should we capture the event on inputs too?
      */
     subscribe(key, callback, modifiers = 'shift', captureOnInputs = false) {
-        const keyCode = key.charCodeAt(0);
+        const keyCode = this.getKeyCode(key);
         if (events[keyCode] === undefined) {
             events[keyCode] = [];
         }
@@ -83,9 +95,10 @@ const KeyboardShortcut = {
 
     /**
      * Unsubscribes to a keyboard event.
-     * @param {Number} keyCode The key code to stop watching
+     * @param {Number} key The key to stop watching
      */
-    unsubscribe(keyCode) {
+    unsubscribe(key) {
+        const keyCode = this.getKeyCode(key);
         delete events[keyCode];
     },
 };

--- a/src/libs/KeyboardShortcut/index.js
+++ b/src/libs/KeyboardShortcut/index.js
@@ -73,7 +73,7 @@ const KeyboardShortcut = {
      */
     getKeyCode(key) {
         // For keys that have longer names we must catch and return the correct key key.charCodeAt(0) would return the
-        // key code for 'E' not 'Escape'
+        // key code for 'E' (the letter at index 0 in the string) not 'Escape'
         if (key === 'Escape') {
             return 27;
         }

--- a/src/libs/KeyboardShortcut/index.js
+++ b/src/libs/KeyboardShortcut/index.js
@@ -72,6 +72,8 @@ const KeyboardShortcut = {
      * @returns {Number} The key's keyCode, i.e. 75 or 27
      */
     getKeyCode(key) {
+        // For keys that have longer names we must catch and return the correct key key.charCodeAt(0) would return the
+        // key code for 'E' not 'Escape'
         if (key === 'Escape') {
             return 27;
         }

--- a/src/libs/getComponentDisplayName.js
+++ b/src/libs/getComponentDisplayName.js
@@ -1,0 +1,9 @@
+/**
+ * Returns the display name of a component
+ *
+ * @param {object} component
+ * @returns {string}
+ */
+export default function getComponentDisplayName(component) {
+    return component.displayName || component.name || 'Component';
+}

--- a/src/pages/home/HomePage.js
+++ b/src/pages/home/HomePage.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
     View,
-    Dimensions,
     Animated,
     Easing,
     Keyboard,
@@ -40,12 +39,15 @@ import {fetchCountryCodeByRequestIP} from '../../libs/actions/GeoLocation';
 import KeyboardShortcut from '../../libs/KeyboardShortcut';
 import * as ChatSwitcher from '../../libs/actions/ChatSwitcher';
 import {redirect} from '../../libs/actions/App';
+import withWindowDimensions, {windowDimensionsPropTypes} from '../../components/withWindowDimensions';
+import compose from '../../libs/compose';
 
 const propTypes = {
     isSidebarShown: PropTypes.bool,
     isChatSwitcherActive: PropTypes.bool,
     currentURL: PropTypes.string,
     network: PropTypes.shape({isOffline: PropTypes.bool}),
+    ...windowDimensionsPropTypes,
 };
 const defaultProps = {
     isSidebarShown: true,
@@ -54,18 +56,15 @@ const defaultProps = {
     network: {isOffline: true},
 };
 
-class App extends React.Component {
+class HomePage extends React.Component {
     constructor(props) {
         Timing.start(CONST.TIMING.HOMEPAGE_INITIAL_RENDER);
         Timing.start(CONST.TIMING.HOMEPAGE_REPORTS_LOADED);
 
         super(props);
 
-        const windowSize = Dimensions.get('window');
-        const isSmallScreenWidth = windowSize.width <= variables.mobileResponsiveWidthBreakpoint;
+        const isSmallScreenWidth = props.windowDimensions.width <= variables.mobileResponsiveWidthBreakpoint;
         this.state = {
-            windowWidth: windowSize.width,
-            isSmallScreenWidth,
             isCreateMenuActive: false,
         };
 
@@ -74,12 +73,11 @@ class App extends React.Component {
         this.toggleNavigationMenu = this.toggleNavigationMenu.bind(this);
         this.dismissNavigationMenu = this.dismissNavigationMenu.bind(this);
         this.showNavigationMenu = this.showNavigationMenu.bind(this);
-        this.toggleNavigationMenuBasedOnDimensions = this.toggleNavigationMenuBasedOnDimensions.bind(this);
         this.recordTimerAndToggleNavigationMenu = this.recordTimerAndToggleNavigationMenu.bind(this);
         this.navigateToSettings = this.navigateToSettings.bind(this);
 
         const windowBarSize = isSmallScreenWidth
-            ? -this.state.windowWidth
+            ? -props.windowDimensions.width
             : -variables.sideBarWidth;
         this.animationTranslateX = new Animated.Value(
             !props.isSidebarShown ? windowBarSize : 0,
@@ -101,7 +99,6 @@ class App extends React.Component {
         fetchAllReports(true, false, true);
         fetchCountryCodeByRequestIP();
         UnreadIndicatorUpdater.listenForReportChanges();
-        Dimensions.addEventListener('change', this.toggleNavigationMenuBasedOnDimensions);
 
         // Refresh the personal details and timezone every 30 minutes because there is no
         // pusher event that sends updated personal details data yet
@@ -115,7 +112,8 @@ class App extends React.Component {
         }, 1000 * 60 * 30);
 
         // Set up the navigationMenu correctly once on init
-        if (!this.state.isSmallScreenWidth) {
+        const isSmallScreenWidth = this.props.windowDimensions.width <= variables.mobileResponsiveWidthBreakpoint;
+        if (!isSmallScreenWidth) {
             showSidebar();
         }
 
@@ -128,6 +126,17 @@ class App extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
+        if (prevProps.windowDimensions.width !== this.props.windowDimensions.width) {
+            const wasPreviouslySmallScreenWidth = prevProps.windowDimensions.width
+                <= variables.mobileResponsiveWidthBreakpoint;
+            const isSmallScreenWidth = this.props.windowDimensions.width <= variables.mobileResponsiveWidthBreakpoint;
+
+            // Always show the sidebar if we are moving from small to large screens
+            if (wasPreviouslySmallScreenWidth && !isSmallScreenWidth) {
+                showSidebar();
+            }
+        }
+
         if (!prevProps.isChatSwitcherActive && this.props.isChatSwitcherActive) {
             this.showNavigationMenu();
         }
@@ -139,7 +148,6 @@ class App extends React.Component {
     }
 
     componentWillUnmount() {
-        Dimensions.removeEventListener('change', this.toggleNavigationMenuBasedOnDimensions);
         KeyboardShortcut.unsubscribe('K');
         NetworkConnection.stopListeningForReconnect();
         clearInterval(this.interval);
@@ -188,35 +196,13 @@ class App extends React.Component {
     }
 
     /**
-     * Fired when the windows dimensions changes
-     * @param {Object} changedWindow
-     */
-    toggleNavigationMenuBasedOnDimensions({window: changedWindow}) {
-        if (this.state.windowWidth === changedWindow.width) {
-            // Window width hasn't changed, don't toggle sidebar
-            return;
-        }
-
-        const isSmallScreenWidth = changedWindow.width <= variables.mobileResponsiveWidthBreakpoint;
-
-        // Always show the sidebar if we are moving from small to large screens
-        if (this.state.isSmallScreenWidth && !isSmallScreenWidth) {
-            showSidebar();
-        }
-
-        this.setState({
-            windowWidth: changedWindow.width,
-            isSmallScreenWidth,
-        });
-    }
-
-    /**
      * Method called when we want to dismiss the navigationMenu,
      * will not do anything if it already closed
      * Only changes navigationMenu state on small screens (e.g. Mobile and mWeb)
      */
     dismissNavigationMenu() {
-        if (!this.state.isSmallScreenWidth || !this.props.isSidebarShown) {
+        const isSmallScreenWidth = this.props.windowDimensions.width <= variables.mobileResponsiveWidthBreakpoint;
+        if (!isSmallScreenWidth || !this.props.isSidebarShown) {
             return;
         }
 
@@ -242,9 +228,10 @@ class App extends React.Component {
      * @param {Boolean} navigationMenuIsShown
      */
     animateNavigationMenu(navigationMenuIsShown) {
-        const windowSideBarSize = this.state.isSmallScreenWidth
+        const isSmallScreenWidth = this.props.windowDimensions.width <= variables.mobileResponsiveWidthBreakpoint;
+        const windowSideBarSize = isSmallScreenWidth
             ? -variables.sideBarWidth
-            : -this.state.windowWidth;
+            : -this.props.windowDimension.width;
         const animationFinalValue = navigationMenuIsShown ? windowSideBarSize : 0;
 
         setSideBarIsAnimating(true);
@@ -269,7 +256,9 @@ class App extends React.Component {
      * Only changes navigationMenu state on small screens (e.g. Mobile and mWeb)
      */
     toggleNavigationMenu() {
-        if (!this.state.isSmallScreenWidth) {
+        const isSmallScreenWidth = this.props.windowDimensions.width <= variables.mobileResponsiveWidthBreakpoint;
+
+        if (!isSmallScreenWidth) {
             return;
         }
 
@@ -287,6 +276,7 @@ class App extends React.Component {
     }
 
     render() {
+        const isSmallScreenWidth = this.props.windowDimensions.width <= variables.mobileResponsiveWidthBreakpoint;
         return (
             <SafeAreaProvider>
                 <CustomStatusBar />
@@ -301,7 +291,10 @@ class App extends React.Component {
                         >
                             <Route path={[ROUTES.REPORT, ROUTES.HOME, ROUTES.SETTINGS]}>
                                 <Animated.View style={[
-                                    getNavigationMenuStyle(this.state.windowWidth, this.props.isSidebarShown),
+                                    getNavigationMenuStyle(
+                                        this.props.windowDimensions.width,
+                                        this.props.isSidebarShown,
+                                    ),
                                     {
                                         transform: [{translateX: this.animationTranslateX}],
                                     }]}
@@ -319,7 +312,7 @@ class App extends React.Component {
                                     style={[styles.appContent, styles.flex1, styles.flexColumn]}
                                 >
                                     <HeaderView
-                                        shouldShowNavigationMenuButton={this.state.isSmallScreenWidth}
+                                        shouldShowNavigationMenuButton={isSmallScreenWidth}
                                         onNavigationMenuButtonClicked={this.toggleNavigationMenu}
                                     />
                                     {this.props.currentURL === '/settings' && <SettingsPage />}
@@ -334,23 +327,26 @@ class App extends React.Component {
     }
 }
 
-App.propTypes = propTypes;
-App.defaultProps = defaultProps;
+HomePage.propTypes = propTypes;
+HomePage.defaultProps = defaultProps;
 
-export default withOnyx(
-    {
-        isSidebarShown: {
-            key: ONYXKEYS.IS_SIDEBAR_SHOWN,
+export default compose(
+    withOnyx(
+        {
+            isSidebarShown: {
+                key: ONYXKEYS.IS_SIDEBAR_SHOWN,
+            },
+            isChatSwitcherActive: {
+                key: ONYXKEYS.IS_CHAT_SWITCHER_ACTIVE,
+                initWithStoredValues: false,
+            },
+            currentURL: {
+                key: ONYXKEYS.CURRENT_URL,
+            },
+            network: {
+                key: ONYXKEYS.NETWORK,
+            },
         },
-        isChatSwitcherActive: {
-            key: ONYXKEYS.IS_CHAT_SWITCHER_ACTIVE,
-            initWithStoredValues: false,
-        },
-        currentURL: {
-            key: ONYXKEYS.CURRENT_URL,
-        },
-        network: {
-            key: ONYXKEYS.NETWORK,
-        },
-    },
-)(App);
+    ),
+    withWindowDimensions,
+)(HomePage);

--- a/src/pages/home/sidebar/ChatSwitcherSearchForm.js
+++ b/src/pages/home/sidebar/ChatSwitcherSearchForm.js
@@ -80,7 +80,7 @@ const ChatSwitcherSearchForm = props => (
                                 ]}
                             >
                                 <TextInputWithFocusStyles
-                                    styleFocusIn={[styles.textInputNoOutline]}
+                                    styleFocusIn={[styles.noOutline]}
                                     ref={props.forwardedRef}
                                     style={[styles.chatSwitcherGroupDMTextInput, styles.mb1]}
                                     value={props.searchValue}

--- a/src/pages/signin/LoginForm/index.js
+++ b/src/pages/signin/LoginForm/index.js
@@ -1,49 +1,20 @@
 import React from 'react';
-import {Dimensions} from 'react-native';
-import _ from 'underscore';
 import variables from '../../../styles/variables';
 import LoginFormNarrow from './LoginFormNarrow';
 import LoginFormWide from './LoginFormWide';
+import withWindowDimensions, {windowDimensionsPropTypes} from '../../../components/withWindowDimensions';
 
-class LoginForm extends React.Component {
-    constructor(props) {
-        super(props);
+const propTypes = {
+    ...windowDimensionsPropTypes,
+};
 
-        this.toggleScreenWidth = _.debounce(this.toggleScreenWidth.bind(this), 1000, true);
+const LoginForm = ({windowDimensions}) => (
+    windowDimensions.width > variables.mobileResponsiveWidthBreakpoint
+        ? <LoginFormWide />
+        : <LoginFormNarrow />
+);
 
-        this.state = {
-            isWideScreen: null,
-        };
-    }
+LoginForm.propTypes = propTypes;
+LoginForm.displayName = 'LoginForm';
 
-    componentDidMount() {
-        Dimensions.addEventListener('change', this.toggleScreenWidth);
-        this.toggleScreenWidth({window: Dimensions.get('window')});
-    }
-
-    componentWillUnmount() {
-        Dimensions.removeEventListener('change', this.toggleScreenWidth);
-    }
-
-    /**
-     * Fired when the windows dimensions changes
-     * @param {Object} changedWindow
-     */
-    toggleScreenWidth({window: changedWindow}) {
-        this.setState({
-            isWideScreen: changedWindow.width > variables.mobileResponsiveWidthBreakpoint,
-        });
-    }
-
-    render() {
-        if (this.state.isWideScreen === null) {
-            return null;
-        }
-
-        return this.state.isWideScreen
-            ? <LoginFormWide />
-            : <LoginFormNarrow />;
-    }
-}
-
-export default LoginForm;
+export default withWindowDimensions(LoginForm);

--- a/src/pages/signin/SignInPageLayout/index.js
+++ b/src/pages/signin/SignInPageLayout/index.js
@@ -1,51 +1,22 @@
 import React from 'react';
-import {Dimensions} from 'react-native';
-import _ from 'underscore';
 import variables from '../../../styles/variables';
 import SignInPageLayoutNarrow from './SignInPageLayoutNarrow';
 import SignInPageLayoutWide from './SignInPageLayoutWide';
+import withWindowDimensions, {windowDimensionsPropTypes} from '../../../components/withWindowDimensions';
 
-class LoginForm extends React.Component {
-    constructor(props) {
-        super(props);
+const propTypes = {
+    ...windowDimensionsPropTypes,
+};
 
-        this.toggleScreenWidth = _.debounce(this.toggleScreenWidth.bind(this), 1000, true);
+const SignInPageLayout = props => (
+    props.windowDimensions.width > variables.mobileResponsiveWidthBreakpoint
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        ? <SignInPageLayoutWide {...props} />
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        : <SignInPageLayoutNarrow {...props} />
+);
 
-        this.state = {
-            isWideScreen: null,
-        };
-    }
+SignInPageLayout.propTypes = propTypes;
+SignInPageLayout.displayName = 'SignInPageLayout';
 
-    componentDidMount() {
-        Dimensions.addEventListener('change', this.toggleScreenWidth);
-        this.toggleScreenWidth({window: Dimensions.get('window')});
-    }
-
-    componentWillUnmount() {
-        Dimensions.removeEventListener('change', this.toggleScreenWidth);
-    }
-
-    /**
-     * Fired when the windows dimensions changes
-     * @param {Object} changedWindow
-     */
-    toggleScreenWidth({window: changedWindow}) {
-        this.setState({
-            isWideScreen: changedWindow.width > variables.mobileResponsiveWidthBreakpoint,
-        });
-    }
-
-    render() {
-        if (this.state.isWideScreen === null) {
-            return null;
-        }
-
-        return this.state.isWideScreen
-            // eslint-disable-next-line react/jsx-props-no-spreading
-            ? <SignInPageLayoutWide {...this.props} />
-            // eslint-disable-next-line react/jsx-props-no-spreading
-            : <SignInPageLayoutNarrow {...this.props} />;
-    }
-}
-
-export default LoginForm;
+export default withWindowDimensions(SignInPageLayout);

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -224,7 +224,7 @@ const styles = {
         borderColor: themeColors.icon,
     },
 
-    textInputNoOutline: addOutlineWidth({}, 0),
+    noOutline: addOutlineWidth({}, 0),
 
     formLabel: {
         color: themeColors.text,


### PR DESCRIPTION
### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/1039

### Tests
1. Click the paperclip icon
2. Select an image to upload
3. Upload the file
4. Click into the image
5. Press escape
6. Observe that the attachment modal closes

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web
no changes

#### Mobile Web
no changes

#### Desktop
no changes

#### iOS
no changes

#### Android
no changes
