### PR TITLE
Cleaning up Settings page styles

### DIFF
--- a/src/components/AvatarWithIndicator.js
+++ b/src/components/AvatarWithIndicator.js
@@ -27,16 +27,16 @@ const AvatarWithIndicator = ({
     size,
 }) => {
     const indicatorStyles = [
-        size === 'large' ? styles.largeStatusIndicator : styles.statusIndicator,
+        size === 'large' ? styles.statusIndicatorLarge : styles.statusIndicator,
         isActive ? styles.statusIndicatorOnline : styles.statusIndicatorOffline,
     ];
 
     return (
         <View
-            style={[size === 'large' ? styles.largeAvatar : styles.sidebarAvatar]}
+            style={[size === 'large' ? styles.avatarLarge : styles.sidebarAvatar]}
         >
             <Avatar
-                style={[size === 'large' ? styles.largeAvatar : null]}
+                style={[size === 'large' ? styles.avatarLarge : null]}
                 source={source}
             />
             <View style={StyleSheet.flatten(indicatorStyles)} />

--- a/src/pages/SettingsPage.js
+++ b/src/pages/SettingsPage.js
@@ -79,7 +79,7 @@ const SettingsPage = ({
                 />
                 <View style={styles.settingsWrapper}>
                     <View
-                        style={[styles.largeAvatar, styles.mb3, styles.mt3]}
+                        style={[styles.largeAvatar, styles.mb3]}
                     >
                         <AvatarWithIndicator
                             size="large"
@@ -97,7 +97,7 @@ const SettingsPage = ({
                     )}
                     <TouchableOpacity
                         onPress={signOut}
-                        style={[styles.signOutButton, styles.mt5]}
+                        style={[styles.button, styles.w100, styles.mt5]}
                     >
                         <Text style={[styles.buttonText]}>
                             Sign Out

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -347,7 +347,7 @@ const styles = {
 
     statusIndicator: {
         borderColor: themeColors.sidebar,
-        borderRadius: 5,
+        borderRadius: 6,
         borderWidth: 2,
         position: 'absolute',
         right: -1,

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -82,16 +82,17 @@ const styles = {
     },
 
     button: {
-        borderColor: themeColors.border,
+        backgroundColor: themeColors.buttonDefaultBG,
         borderRadius: variables.componentBorderRadius,
-        borderWidth: 1,
         height: variables.componentSizeNormal,
         justifyContent: 'center',
+        paddingHorizontal: 12,
     },
 
     buttonText: {
-        color: themeColors.text,
+        color: themeColors.heading,
         fontFamily: fontFamily.GTA_BOLD,
+        fontSize: variables.fontSizeLabel,
         fontWeight: fontWeightBold,
         textAlign: 'center',
     },
@@ -346,13 +347,13 @@ const styles = {
 
     statusIndicator: {
         borderColor: themeColors.sidebar,
-        borderRadius: 7,
+        borderRadius: 5,
         borderWidth: 2,
         position: 'absolute',
-        right: -6,
-        bottom: 3,
-        height: 14,
-        width: 14,
+        right: -1,
+        bottom: -1,
+        height: 12,
+        width: 12,
         zIndex: 10,
     },
     statusIndicatorOnline: {
@@ -948,16 +949,6 @@ const styles = {
         borderColor: colors.transparent,
     },
 
-    signOutButton: {
-        width: '95%',
-        alignSelf: 'center',
-        justifyContent: 'center',
-        alignItems: 'center',
-        backgroundColor: themeColors.sidebarButtonBG,
-        borderRadius: variables.componentBorderRadius,
-        height: variables.componentSizeLarge,
-    },
-
     settingsPageBackground: {
         flexDirection: 'column',
         width: '100%',
@@ -980,32 +971,32 @@ const styles = {
         width: '100%',
     },
 
-    largeAvatar: {
+    avatarLarge: {
         width: 80,
         height: 80,
     },
 
-    largeStatusIndicator: {
+    statusIndicatorLarge: {
         borderColor: themeColors.componentBG,
-        borderRadius: 14,
+        borderRadius: 8,
         borderWidth: 2,
         position: 'absolute',
-        right: 8,
+        right: 4,
         bottom: 4,
-        height: 14,
-        width: 14,
+        height: 16,
+        width: 16,
         zIndex: 10,
     },
 
     settingsDisplayName: {
-        fontSize: 17,
+        fontSize: variables.fontSizeLarge,
         fontFamily: fontFamily.GTA_BOLD,
+        fontWeight: fontWeightBold,
         color: themeColors.heading,
     },
 
-
     settingsLoginName: {
-        fontSize: 13,
+        fontSize: variables.fontSizeLabel,
         fontFamily: fontFamily.GTA,
         color: themeColors.textSupporting,
     },
@@ -1013,6 +1004,7 @@ const styles = {
     settingsWrapper: {
         width: '100%',
         alignItems: 'center',
+        padding: 20,
     },
 };
 

--- a/src/styles/themes/default.js
+++ b/src/styles/themes/default.js
@@ -17,6 +17,7 @@ export default {
     textBackground: colors.gray1,
     textReversed: colors.white,
     textMutedReversed: colors.gray3,
+    buttonDefaultBG: colors.gray2,
     buttonSuccessBG: colors.green,
     online: colors.green,
     offline: colors.gray3,


### PR DESCRIPTION
@marcaaron will you please review?

### Details
This cleans up styles for the Settings page:
- uses a default button style for the Sign Out button
- Make the display name use a bold weight
- Fixes some design weirdness with the online indicator
- Adds a 20px padding around the Settings page content

### Fixed Issues
N/A

### Tests
For example:
1. View the home screen (Left hand navigation) of the Expensify.cash app
2. Click on your avatar in the top right to launch the Settings page
3. Verify that the settings page has the changes listed above


### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
@marcaaron I might need some help testing this as I don't have Android or the Desktop app set up to run locally. 

#### Web
![image](https://user-images.githubusercontent.com/2319350/105380183-e61e2e80-5c0d-11eb-9efe-031b2989b3af.png)



#### Mobile Web
![image](https://user-images.githubusercontent.com/2319350/105372198-a2bfc200-5c05-11eb-88ea-b11158888d36.png)


#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
![image](https://user-images.githubusercontent.com/2319350/105380038-c2f37f00-5c0d-11eb-9e44-8079e045a31c.png)


#### Android
<!-- Insert screenshots of your changes on the Android platform-->
