### PR TITLE
fixed padding issue for  textInputCompose on Android

### DIFF
--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -193,7 +193,7 @@ class ReportActionCompose extends React.Component {
                                         displayFileInModal({file});
                                         this.setState({isDraggingOver: false});
                                     }}
-                                    style={[styles.textInput, styles.textInputCompose, styles.flex4]}
+                                    style={[styles.textInputCompose, styles.flex4]}
                                     defaultValue={this.props.comment}
                                     maxLines={16} // This is the same that slack has
                                     onFocus={() => this.setIsFocused(true)}

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -761,14 +761,23 @@ const styles = {
     },
 
     textInputCompose: addOutlineWidth({
+        backgroundColor: themeColors.componentBG,
+        borderColor: themeColors.border,
+        color: themeColors.text,
+        fontFamily: fontFamily.GTA,
+        fontSize: variables.fontSizeNormal,
         borderWidth: 0,
         borderRadius: 0,
         height: 'auto',
-        minHeight: 38,
-        paddingTop: 10,
-        paddingRight: 8,
-        paddingBottom: 10,
-        paddingLeft: 8,
+    
+        // On Android, multiline TextInput with height: 'auto' will show extra padding unless they are configured with
+        // paddingVertical: 0, alignSelf: 'center', and textAlignVertical: 'center'
+    
+        paddingHorizontal: 8,
+        marginVertical: 5,
+        paddingVertical: 0,
+        alignSelf: 'center',
+        textAlignVertical: 'center',
     }, 0),
 
     chatItemSubmitButton: {

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -769,10 +769,10 @@ const styles = {
         borderWidth: 0,
         borderRadius: 0,
         height: 'auto',
-    
+
         // On Android, multiline TextInput with height: 'auto' will show extra padding unless they are configured with
         // paddingVertical: 0, alignSelf: 'center', and textAlignVertical: 'center'
-    
+
         paddingHorizontal: 8,
         marginVertical: 5,
         paddingVertical: 0,


### PR DESCRIPTION
<If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit.>

### Details
Centred the submit button on the chat box.

### Fixed Issues
<Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing>
Fixes #1002 

### Tests
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->
1. Open the Expensify.cash app
2.  Log in
3. Tap the hamburger menu button( ☰ ) in the top-left
4. Start a new DM (or select an existing DM)
You will notice that the submit button has some reasoned padding from the top and bottom.


### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
![104854528-d4880e80-590f-11eb-9daf-5d04bd070adb](https://user-images.githubusercontent.com/4520893/105512419-bf2d2e80-5cd9-11eb-9967-419a31cab524.png)


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
![104854500-b6221300-590f-11eb-881b-b29b221f8630](https://user-images.githubusercontent.com/4520893/105512439-c5230f80-5cd9-11eb-86a6-b4b230adabae.png)
#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
![104854493-a9052400-590f-11eb-8e3f-21246c14d50c](https://user-images.githubusercontent.com/4520893/105512462-ce13e100-5cd9-11eb-9ae5-54db73350cb0.png)

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
![104854486-9d196200-590f-11eb-8102-4ad328d65877](https://user-images.githubusercontent.com/4520893/105512487-d409c200-5cd9-11eb-8d0f-eae1761163ab.png)

@marcaaron @Julesssss I have created a new pull because the previous one #1101 was automatically closed when I tried to clear all the unverified commit messages.  hope that is fine with you. 
