### PR TITLE
Remove all chats with no messages from the LHN

### DIFF
--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -160,6 +160,13 @@ function getOptions(reports, personalDetails, draftComments, activeReportID, {
             return;
         }
 
+        // Skip this entry if it has no comments and is not the active report. We will only show reports from
+        // people we have sent or recieved at least one message with.
+        const hasNoComments = report.lastMessageTimestamp === 0;
+        if (hasNoComments && report.reportID !== activeReportID) {
+            return;
+        }
+
         const reportPersonalDetails = getPersonalDetailsForLogins(logins, personalDetails);
 
         // Save the report in the map if this is a single participant so we can associate the reportID with the

--- a/tests/unit/OptionsListUtilsTest.js
+++ b/tests/unit/OptionsListUtilsTest.js
@@ -9,7 +9,7 @@ describe('OptionsListUtils', () => {
     const REPORTS = {
         1: {
             lastVisitedTimestamp: 1610666739295,
-            lastMessageTimestamp: 0,
+            lastMessageTimestamp: 1,
             isPinned: false,
             reportID: 1,
             participants: ['tonystark@expensify.com', 'reedrichards@expensify.com'],
@@ -17,7 +17,7 @@ describe('OptionsListUtils', () => {
         },
         2: {
             lastVisitedTimestamp: 1610666739296,
-            lastMessageTimestamp: 0,
+            lastMessageTimestamp: 1,
             isPinned: false,
             reportID: 2,
             participants: ['peterparker@expensify.com'],
@@ -27,7 +27,7 @@ describe('OptionsListUtils', () => {
         // This is the only report we are pinning in this test
         3: {
             lastVisitedTimestamp: 1610666739297,
-            lastMessageTimestamp: 0,
+            lastMessageTimestamp: 1,
             isPinned: true,
             reportID: 3,
             participants: ['reedrichards@expensify.com'],
@@ -35,7 +35,7 @@ describe('OptionsListUtils', () => {
         },
         4: {
             lastVisitedTimestamp: 1610666739298,
-            lastMessageTimestamp: 0,
+            lastMessageTimestamp: 1,
             isPinned: false,
             reportID: 4,
             participants: ['tchalla@expensify.com'],
@@ -43,7 +43,7 @@ describe('OptionsListUtils', () => {
         },
         5: {
             lastVisitedTimestamp: 1610666739299,
-            lastMessageTimestamp: 0,
+            lastMessageTimestamp: 1,
             isPinned: false,
             reportID: 5,
             participants: ['suestorm@expensify.com'],
@@ -51,14 +51,14 @@ describe('OptionsListUtils', () => {
         },
         6: {
             lastVisitedTimestamp: 1610666739300,
-            lastMessageTimestamp: 0,
+            lastMessageTimestamp: 1,
             isPinned: false,
             reportID: 6,
             participants: ['thor@expensify.com'],
             reportName: 'Thor',
         },
 
-        // Note: This is the only report with a lastMessageTimestamp
+        // Note: This report has the largest lastMessageTimestamp
         7: {
             lastVisitedTimestamp: 1610666739301,
             lastMessageTimestamp: 1611282169,
@@ -66,6 +66,16 @@ describe('OptionsListUtils', () => {
             reportID: 7,
             participants: ['steverogers@expensify.com'],
             reportName: 'Captain America',
+        },
+
+        // Note: This report has no lastMessageTimestamp
+        8: {
+            lastVisitedTimestamp: 1610666739301,
+            lastMessageTimestamp: 0,
+            isPinned: false,
+            reportID: 8,
+            participants: ['galactus_herald@expensify.com'],
+            reportName: 'Silver Surfer',
         },
     };
 
@@ -132,8 +142,8 @@ describe('OptionsListUtils', () => {
         // Then all options returned should be recentReports and none should be personalDetails
         expect(results.personalDetails.length).toBe(0);
 
-        // Then all of the reports should be shown
-        expect(results.recentReports.length).toBe(_.size(REPORTS));
+        // Then all of the reports should be shown except the one that has no message on them.
+        expect(results.recentReports.length).toBe(_.size(REPORTS) - 1);
 
         // Then pinned report should be listed first even though it is the oldest
         expect(results.recentReports[0].login).toBe('reedrichards@expensify.com');
@@ -258,8 +268,9 @@ describe('OptionsListUtils', () => {
         // When we call getSidebarOptions() with no search value
         const results = OptionsListUtils.getSidebarOptions(REPORTS, PERSONAL_DETAILS, {}, 0);
 
-        // Then expect all of the reports to be shown both multiple and single participant
-        expect(results.recentReports.length).toBe(_.size(REPORTS));
+        // Then expect all of the reports to be shown both multiple and single participant except the
+        // report that has no lastMessageTimestamp
+        expect(results.recentReports.length).toBe(_.size(REPORTS) - 1);
 
         // That no personalDetails are shown
         expect(results.personalDetails.length).toBe(0);


### PR DESCRIPTION
cc @chiragsalian 

### Details
Removes chats that have no messages from the LHN

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/152005

### Tests
1. Sign out and sign back in
2. Create a chat with a new person you have never chatted with before
3. Switch to another chat
4. Verify that the chat with no messages is no longer in the LHN 

### Tested On

- [x] Web
- [ ] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
