### PR TITLE
Support for mergeCollection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21038,8 +21038,8 @@
       }
     },
     "react-native-onyx": {
-      "version": "git+https://github.com/Expensify/react-native-onyx.git#4e810bfd30cbb02aaf663ba69456fd233346a774",
-      "from": "git+https://github.com/Expensify/react-native-onyx.git#4e810bfd30cbb02aaf663ba69456fd233346a774",
+      "version": "git+https://github.com/Expensify/react-native-onyx.git#c12a1e7e2dccf06e61e4afb905d85d822521d9ee",
+      "from": "git+https://github.com/Expensify/react-native-onyx.git#c12a1e7e2dccf06e61e4afb905d85d822521d9ee",
       "requires": {
         "@react-native-community/async-storage": "^1.12.1",
         "expensify-common": "git+https://github.com/Expensify/expensify-common.git#cd9f195ed1fd340e7e890c41672a97af4f2956ca",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "react-native-image-picker": "^2.3.3",
     "react-native-keyboard-spacer": "^0.4.1",
     "react-native-modal": "^11.5.6",
-    "react-native-onyx": "git+https://github.com/Expensify/react-native-onyx.git#4e810bfd30cbb02aaf663ba69456fd233346a774",
+    "react-native-onyx": "git+https://github.com/Expensify/react-native-onyx.git#c12a1e7e2dccf06e61e4afb905d85d822521d9ee",
     "react-native-pdf": "^6.2.2",
     "react-native-render-html": "^6.0.0-alpha.10",
     "react-native-safe-area-context": "^3.1.4",

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -168,7 +168,7 @@ function getFromReportParticipants(reports) {
                     reportsToUpdate[`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`] = {icons: avatars};
                 }
             });
-            Onyx.multiMerge(ONYXKEYS.COLLECTION.REPORT, reportsToUpdate);
+            Onyx.mergeCollection(ONYXKEYS.COLLECTION.REPORT, reportsToUpdate);
         });
 }
 

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -168,6 +168,10 @@ function getFromReportParticipants(reports) {
                     reportsToUpdate[`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`] = {icons: avatars};
                 }
             });
+
+            // We use mergeCollection such that it updates ONYXKEYS.COLLECTION.REPORT in one go.
+            // Any withOnyx subscribers to this key will also receive the complete updated props just once
+            // than updating props for each report and re-rendering had merge been used.
             Onyx.mergeCollection(ONYXKEYS.COLLECTION.REPORT, reportsToUpdate);
         });
 }

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -155,6 +155,7 @@ function getFromReportParticipants(reports) {
 
             // The personalDetails of the participants contain their avatar images. Here we'll go over each
             // report and based on the participants we'll link up their avatars to report icons.
+            const reportsToUpdate = {};
             _.each(reports, (report) => {
                 if (report.participants.length > 0) {
                     const avatars = _.map(report.participants, dmParticipant => ({
@@ -164,9 +165,10 @@ function getFromReportParticipants(reports) {
                         .sort((first, second) => first.firstName - second.firstName)
                         .map(item => item.avatar);
 
-                    Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`, {icons: avatars});
+                    reportsToUpdate[`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`] = {icons: avatars};
                 }
             });
+            Onyx.multiMerge(ONYXKEYS.COLLECTION.REPORT, reportsToUpdate);
         });
 }
 

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -172,7 +172,7 @@ function fetchChatReportsByIDs(chatList) {
                 const key = `${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`;
                 simplifiedReports[key] = getSimplifiedReportObject(report);
             });
-            Onyx.multiMerge(ONYXKEYS.COLLECTION.REPORT, simplifiedReports);
+            Onyx.mergeCollection(ONYXKEYS.COLLECTION.REPORT, simplifiedReports);
 
             // Fetch the personal details if there are any
             PersonalDetails.getFromReportParticipants(Object.values(simplifiedReports));

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -172,6 +172,10 @@ function fetchChatReportsByIDs(chatList) {
                 const key = `${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`;
                 simplifiedReports[key] = getSimplifiedReportObject(report);
             });
+
+            // We use mergeCollection such that it updates ONYXKEYS.COLLECTION.REPORT in one go.
+            // Any withOnyx subscribers to this key will also receive the complete updated props just once
+            // than updating props for each report and re-rendering had merge been used.
             Onyx.mergeCollection(ONYXKEYS.COLLECTION.REPORT, simplifiedReports);
 
             // Fetch the personal details if there are any

--- a/src/pages/home/sidebar/SidebarLinks.js
+++ b/src/pages/home/sidebar/SidebarLinks.js
@@ -89,9 +89,6 @@ const SidebarLinks = (props) => {
         ? [styles.sidebarHeader, styles.sidebarHeaderActive]
         : [styles.sidebarHeader];
 
-    if (_.isEmpty(props.reports) || _.isEmpty(props.personalDetails)) {
-        return null;
-    }
     const {recentReports} = getSidebarOptions(props.reports, props.personalDetails, props.draftComments, reportIDInUrl);
 
     const sections = [{

--- a/src/pages/home/sidebar/SidebarLinks.js
+++ b/src/pages/home/sidebar/SidebarLinks.js
@@ -89,6 +89,9 @@ const SidebarLinks = (props) => {
         ? [styles.sidebarHeader, styles.sidebarHeaderActive]
         : [styles.sidebarHeader];
 
+    if (_.isEmpty(props.reports) || _.isEmpty(props.personalDetails)) {
+        return null;
+    }
     const {recentReports} = getSidebarOptions(props.reports, props.personalDetails, props.draftComments, reportIDInUrl);
 
     const sections = [{


### PR DESCRIPTION
### Details
Rather than updating the report collection in a loop which causes a re-render each time we'll use mergeCollection which should do Async.multiMerge to update them in one shot. Then the subscriber will also get notified just one about the collection which results in much less render. 

In my testing,
The number of renders for SideBarLinks went from **175** to **25** on refresh.
The time taking for SideBarLinks to complete its rendering and not render anymore went from **19s** to **5s**.
Because there is a lot less to do it also results in more API commands finishing sooner because it seems like in the past the multiple rerendering of SideBarLinks would have to complete before PersonalDetails_GetForEmails and other requests could continue.

### Fixed Issues
<Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing>
Fixes https://github.com/Expensify/Expensify/issues/152029

### Tests
1. Run `npm i` to get the latest changes.
2. Load expensify chat. Open network tab and refresh the page.
3. The moment the page refreshes continuously scroll the sidebarlinks options. You'll notice that even if it does pause due to a rerender its extremely small and continues to work just fine (on master if you test the same it would be paused for more than 10s sometimes)
4. During this time also check out the network tab. Most requests should finish immediately. There is still a chance of it getting stuck since Auth on dev is a little finicky but its a lot rarer. Especially if you notice PersonalDetails_GetForEmails, it should finish almost instantly (while on master it always gets stuck pending for a number of seconds as SideBarLinks completes all its rerendering iterations)
5. Signout, sign back in. Confirm everything loads just fine. 

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
