### PR TITLE
Fixing the LHN width and font sizes

### DIFF
--- a/src/pages/home/sidebar/ChatLinkRow.js
+++ b/src/pages/home/sidebar/ChatLinkRow.js
@@ -93,7 +93,7 @@ const ChatLinkRow = ({
                                     {option.text}
                                 </Text>
                                 <Text
-                                    style={[textStyle, styles.textMicro, styles.chatSwitcherLogin]}
+                                    style={[textStyle, styles.chatSwitcherLogin, styles.mt1]}
                                     numberOfLines={1}
                                 >
                                     {option.alternateText}

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -451,7 +451,7 @@ const styles = {
 
     sidebarLinkText: {
         color: themeColors.text,
-        fontSize: variables.fontSizeLabel,
+        fontSize: variables.fontSizeNormal,
         textDecorationLine: 'none',
         overflow: 'hidden',
     },
@@ -468,7 +468,7 @@ const styles = {
 
     sidebarLinkActiveText: {
         color: themeColors.text,
-        fontSize: variables.fontSizeLabel,
+        fontSize: variables.fontSizeNormal,
         textDecorationLine: 'none',
         overflow: 'hidden',
     },
@@ -483,6 +483,7 @@ const styles = {
     chatSwitcherLogin: {
         color: themeColors.textSupporting,
         fontFamily: fontFamily.GTA,
+        fontSize: variables.fontSizeLabel,
         height: 16,
         lineHeight: 16,
     },

--- a/src/styles/variables.js
+++ b/src/styles/variables.js
@@ -11,5 +11,5 @@ export default {
     fontSizeh1: 19,
     mobileResponsiveWidthBreakpoint: 800,
     safeInsertPercentage: 0.7,
-    sideBarWidth: 300,
+    sideBarWidth: 375,
 };


### PR DESCRIPTION
### Details
This increases the width of the LHN on wider screens to be 375. It also increases the font size of the sender and login in the LHN menu. 

### Fixed Issues
N/A

### Tests
On wider screens (web and desktop platforms) make sure the Left Hand Navigation menu is 375px wide (it should appear wider than it currently is. 

On all platforms, make sure the chat participant names in the LHN are at a font size of 15px. Make sure the login displayed underneath the participant name is at a font size of 13px. 

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
#### Web
![image](https://user-images.githubusercontent.com/2319350/105701862-3d244c00-5f0b-11eb-80c9-4f559281d5af.png)


#### Mobile Web
![image](https://user-images.githubusercontent.com/2319350/105701956-5deca180-5f0b-11eb-9df3-1073c90ee8b9.png)


#### Desktop
![image](https://user-images.githubusercontent.com/2319350/105701794-241b9b00-5f0b-11eb-90c9-9e0b33666e5d.png)


#### iOS
![image](https://user-images.githubusercontent.com/2319350/105701808-2978e580-5f0b-11eb-918c-2deed1acf917.png)


#### Android
![image](https://user-images.githubusercontent.com/2319350/105712616-5680c480-5f1a-11eb-878f-6eaa6ef0bf6d.png)
