### PR TITLE
Use correct font and weight for the chat header

### DIFF
--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -174,10 +174,10 @@ const styles = {
     },
 
     headerText: {
-        fontFamily: fontFamily.GTA,
         color: themeColors.heading,
+        fontFamily: fontFamily.GTA_BOLD,
         fontSize: variables.fontSizeNormal,
-        fontWeight: '700',
+        fontWeight: fontWeightBold,
     },
 
     reportOptions: {


### PR DESCRIPTION
### Details
This uses the correct font family (GTA Bold) for the header bar on top of chats. 

Previously, Android was showing this header text in the native Android font of Roboto:
![image](https://user-images.githubusercontent.com/2319350/105728229-33f7a700-5f2c-11eb-801a-1c984d06c815.png)



### Fixed Issues
N/A

### Tests
Open up a chat on all platforms, and make sure the top header bar uses the correct font of GTA America Bold.


### Tested On

- [x] Web
- [x] Mobile Web
- [ ] Desktop
- [ ] iOS
- [x] Android

### Screenshots

#### Web
![image](https://user-images.githubusercontent.com/2319350/105725146-e3cb1580-5f28-11eb-8730-c305783be388.png)


#### Mobile Web
![image](https://user-images.githubusercontent.com/2319350/105725197-f2193180-5f28-11eb-8ed1-5ac8f964e1fa.png)


#### Desktop
![image](https://user-images.githubusercontent.com/2319350/105726420-58528400-5f2a-11eb-8fd3-d8aabd6bad7d.png)


#### iOS
![image](https://user-images.githubusercontent.com/2319350/105727995-f1ce6580-5f2b-11eb-9aa3-1b9f935aa528.png)


#### Android
![image](https://user-images.githubusercontent.com/2319350/105724953-aebec300-5f28-11eb-8fb7-dccef3c95878.png)

