### PR TITLE
Upgrade pip3 during web deploy workflow

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -26,7 +26,7 @@ jobs:
             # Installs Cloudflare CLI, after installing/upgrading dependencies
             - name: Setup Cloudflare CLI
               run: |
-                   pip3 install --upgrade pip
+                   pip3 install --upgrade pip3
                    pip3 install wheel # need wheel before cloudflare, this is the only way to ensure order.
                    pip3 install cloudflare
 


### PR DESCRIPTION
### Details
The web deploy workflow has been failing recently with the following error
```
File "/home/runner/.local/lib/python3.5/site-packages/pip/_internal/cli/main.py", line 60
    sys.stderr.write(f"ERROR: {exc}")
```

We're currently trying to upgrade pip in web.yml, but the output says that we're only at version `8.1.1` when version `21` is available. This PR updates the pip3 install command to specify pip3 to ensure we're updating pip3 and not pip.

### Fixed Issues
Conversation [in slack](https://expensify.slack.com/archives/C03V9A4TB/p1611601967079200)

### Tests
Will merge this and look at deploy output for web.
