### PR TITLE
Fix web deploy issues w/ python/pip

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -27,7 +27,7 @@ jobs:
             - name: Setup Cloudflare CLI
               run: |
                    # Pip 21 doesn't support python 3.5, so use the version before it
-                   sudo python3 -m pip install --upgrade "pip < 21.0"
+                   sudo python3 -m pip install --upgrade pip==20.3.4
                    pip3 install wheel # need wheel before cloudflare, this is the only way to ensure order.
                    pip3 install cloudflare
 

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -26,7 +26,8 @@ jobs:
             # Installs Cloudflare CLI, after installing/upgrading dependencies
             - name: Setup Cloudflare CLI
               run: |
-                   pip3 install --upgrade pip3
+                   # Pip 21 doesn't support python 3.5, so use the version before it
+                   sudo python3 -m pip install --upgrade "pip < 21.0"
                    pip3 install wheel # need wheel before cloudflare, this is the only way to ensure order.
                    pip3 install cloudflare
 


### PR DESCRIPTION
### Details
This PR fixes an issue where Web deploys were failing. The fix here was to update our pip version to 20.3.4, keeping it below v21, since python3.5 is not compatible with that version ([docs](https://pip.pypa.io/en/stable/news/#id1)).

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/152233

### Tests
I tested this on a separate branch by modifying the web.yml workflow so it ran with every push event. The successful test run can be seen in these runs:
- https://github.com/Expensify/Expensify.cash/runs/1765485898?check_suite_focus=true
- https://github.com/Expensify/Expensify.cash/runs/1765547039?check_suite_focus=true

Once this is merged I'll confirm this works when the deploy runs