### PR TITLE
Add background color for avatars so that a "placeholder" appears while the avatar image is loading

### DIFF
--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -780,12 +780,14 @@ const styles = {
     singleAvatar: {
         height: 24,
         width: 24,
+        backgroundColor: themeColors.icon,
         borderRadius: 24,
     },
 
     avatarNormal: {
         height: variables.componentSizeNormal,
         width: variables.componentSizeNormal,
+        backgroundColor: themeColors.icon,
         borderRadius: variables.componentSizeNormal,
     },
 

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -343,7 +343,7 @@ const styles = {
     },
 
     sidebarAvatar: {
-        backgroundColor: themeColors.text,
+        backgroundColor: themeColors.icon,
         borderRadius: 20,
         height: variables.componentSizeNormal,
         width: variables.componentSizeNormal,


### PR DESCRIPTION
### Details
Currently we have no background color set behind an avatar image, so while we are waiting for an avatar image to load, there is a transparent area that feels broken. This just adds a simple background color behind avatar images so that there appears to be a placeholder while images are downloading. 

### Fixed Issues
N/A

### Tests
Load the Expensify.cash app, particularly the Left Hand Navigation menu. While avatar images are downloading, make sure a small gray circle is behind the images. 

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web
![image](https://user-images.githubusercontent.com/2319350/105840277-0f0a3f00-5fd3-11eb-98c6-8cb9f03cabc2.png)


#### Mobile Web
![image](https://user-images.githubusercontent.com/2319350/105840825-edf61e00-5fd3-11eb-8272-89ed18276cb4.png)


#### Desktop
![image](https://user-images.githubusercontent.com/2319350/105840327-2a754a00-5fd3-11eb-8aa1-d7a56a700667.png)


#### iOS
![image](https://user-images.githubusercontent.com/2319350/105840525-70caa900-5fd3-11eb-99cd-a9c20ad29430.png)


#### Android
![image](https://user-images.githubusercontent.com/2319350/105840793-df0f6b80-5fd3-11eb-83e0-0c71b66dcb93.png)

