### PR TITLE
Removed comments from .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,3 @@
-/**
- * Rename this file to `.env` and put your local config in here
- */
 EXPENSIFY_URL_COM=https://www.expensify.com.dev/
 EXPENSIFY_URL_CASH=https://expensify.cash/
 EXPENSIFY_PARTNER_NAME=android


### PR DESCRIPTION
### Fixed Issues
<Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing>
Fixes https://github.com/Expensify/Expensify/issues/152515

### Tests
Tried building the iOS app without this change (in my .env) and it failed. Made the change, fixed. Make no mistake, this is a workaround, but I think it's necessary for the time being. More context here: https://expensify.slack.com/archives/C011W8BJ9L6/p1611595751212300?thread_ts=1611089375.212800&cid=C011W8BJ9L6

### Tested On
- [x] iOS
