### PR TITLE
Upload attachment on `Enter` keypress

### DIFF
--- a/src/components/AttachmentModal.js
+++ b/src/components/AttachmentModal.js
@@ -57,6 +57,16 @@ class AttachmentModal extends Component {
             file: null,
             sourceURL: props.sourceURL,
         };
+
+        this.submitAndClose = this.submitAndClose.bind(this);
+    }
+
+    /**
+     * Execute the onConfirm callback and close the modal.
+     */
+    submitAndClose() {
+        this.props.onConfirm(this.state.file);
+        this.setState({isModalOpen: false});
     }
 
     render() {
@@ -74,6 +84,7 @@ class AttachmentModal extends Component {
             <>
                 <ModalWithHeader
                     type={CONST.MODAL.MODAL_TYPE.CENTERED}
+                    onSubmit={this.submitAndClose}
                     onClose={() => this.setState({isModalOpen: false})}
                     isVisible={this.state.isModalOpen}
                     title={this.props.title}
@@ -90,10 +101,7 @@ class AttachmentModal extends Component {
                         <TouchableOpacity
                             style={[styles.button, styles.buttonSuccess, styles.buttonConfirm]}
                             underlayColor={themeColors.componentBG}
-                            onPress={() => {
-                                this.props.onConfirm(this.state.file);
-                                this.setState({isModalOpen: false});
-                            }}
+                            onPress={this.submitAndClose}
                         >
                             <Text
                                 style={[

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -21,6 +21,9 @@ const propTypes = {
     // Modal contents
     children: PropTypes.node.isRequired,
 
+    // Callback method fired when the user requests to submit the modal content.
+    onSubmit: PropTypes.func,
+
     // Style of modal to display
     type: PropTypes.oneOf([
         CONST.MODAL.MODAL_TYPE.CENTERED,
@@ -33,10 +36,19 @@ const propTypes = {
 };
 
 const defaultProps = {
+    onSubmit: null,
     type: '',
 };
 
 const Modal = (props) => {
+    const subscribeToKeyEvents = () => {
+        KeyboardShortcut.subscribe('Escape', props.onClose, [], true);
+        KeyboardShortcut.subscribe('Enter', props.onSubmit, [], true);
+    };
+    const unsubscribeFromKeyEvents = () => {
+        KeyboardShortcut.unsubscribe('Escape');
+        KeyboardShortcut.unsubscribe('Enter');
+    };
     const {
         modalStyle,
         modalContainerStyle,
@@ -50,8 +62,8 @@ const Modal = (props) => {
         <ReactNativeModal
             onBackdropPress={props.onClose}
             onBackButtonPress={props.onClose}
-            onModalShow={() => KeyboardShortcut.subscribe('Escape', props.onClose, [], true)}
-            onModalHide={() => KeyboardShortcut.unsubscribe('Escape')}
+            onModalShow={subscribeToKeyEvents}
+            onModalHide={unsubscribeFromKeyEvents}
             onSwipeComplete={props.onClose}
             swipeDirection={swipeDirection}
             isVisible={props.isVisible}

--- a/src/libs/KeyboardShortcut/index.js
+++ b/src/libs/KeyboardShortcut/index.js
@@ -74,10 +74,14 @@ const KeyboardShortcut = {
     getKeyCode(key) {
         // For keys that have longer names we must catch and return the correct key key.charCodeAt(0) would return the
         // key code for 'E' (the letter at index 0 in the string) not 'Escape'
-        if (key === 'Escape') {
-            return 27;
+        switch (key) {
+            case 'Enter':
+                return 13;
+            case 'Escape':
+                return 27;
+            default:
+                return key.charCodeAt(0);
         }
-        return key.charCodeAt(0);
     },
 
     /**

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -159,11 +159,15 @@ class ReportActionCompose extends React.Component {
                                         <TouchableOpacity
                                             onPress={(e) => {
                                                 e.preventDefault();
-                                                openPicker({
-                                                    onPicked: (file) => {
-                                                        displayFileInModal({file});
-                                                    },
-                                                });
+
+                                                // Do not open attachment picker from keypress event
+                                                if (!e.key) {
+                                                    openPicker({
+                                                        onPicked: (file) => {
+                                                            displayFileInModal({file});
+                                                        },
+                                                    });
+                                                }
                                             }}
                                             style={[styles.chatItemAttachButton]}
                                             underlayColor={themeColors.componentBG}


### PR DESCRIPTION
### Details
Submit the attachment modal when the user hits the `Enter` key.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/148091

### Tests

#### Web/desktop
1. Click the paperclip to upload an attachment.
2. Choose an attachment.
3. Hit `ESC` to close the attachment. Verify the modal closes and nothing sends.
4. Repeat steps 1 and 2.
5. Click the submit button in the modal to send the attachment. Verify the modal closes and the attachment sends.
6. Repeat steps 1 and 2.
7. Hit `Enter`/`Return`. Verify that the modal closes and the attachment sends.

#### iOS/Android/mWeb
1. Click the paperclip to upload an attachment.
2. Choose an attachment.
3. Submit the modal.
4. Verify that the modal closes and the attachment sends.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android
