### PR TITLE
Report action fix

### DIFF
--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -122,7 +122,8 @@ function getChatReportName(sharedReportList) {
  * @returns {Object}
  */
 function getSimplifiedReportObject(report) {
-    const lastReportAction = lodashGet(report, ['reportActionList'], []).pop();
+    const reportActionList = lodashGet(report, ['reportActionList'], []);
+    const lastReportAction = !_.isEmpty(reportActionList) ? reportActionList.slice(-1)[0] : null;
     const createTimestamp = lastReportAction ? lastReportAction.created : 0;
     const lastMessageTimestamp = moment.utc(createTimestamp).unix();
     const reportName = lodashGet(report, 'reportNameValuePairs.type') === 'chat'

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -128,7 +128,7 @@ function getChatReportName(sharedReportList) {
  */
 function getSimplifiedReportObject(report) {
     const reportActionList = lodashGet(report, ['reportActionList'], []);
-    const lastReportAction = !_.isEmpty(reportActionList) ? reportActionList.slice(-1)[0] : null;
+    const lastReportAction = !_.isEmpty(reportActionList) ? _.last(reportActionList) : null;
     const createTimestamp = lastReportAction ? lastReportAction.created : 0;
     const lastMessageTimestamp = moment.utc(createTimestamp).unix();
     const reportName = lodashGet(report, 'reportNameValuePairs.type') === 'chat'


### PR DESCRIPTION
### Details
It looks like we were popping for reportActionList which caused us to have incorrect data when it fell into the `getUnreadActionCount` method. This led to a different sequence number being used from the user NVP and the reportActionList.length. The code change should correct that.

### Fixed Issues
<Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing>
Fixes https://github.com/Expensify/Expensify/issues/152483

And most likely https://github.com/Expensify/Expensify/issues/152318

### Tests
1. Open cash in an incognito tab on an account say account2. Have account2 send a message to account1.
2. Open cash in a normal tab and log into account1. Confirm the chat shows up as unread. (assuming you aren't directly loaded into account2's chat)

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
