### PR TITLE
[HOLD] Add betas to e.cash

### DIFF
--- a/src/ONYXKEYS.js
+++ b/src/ONYXKEYS.js
@@ -39,6 +39,7 @@ export default {
     IS_SIDEBAR_SHOWN: 'isSidebarShown',
     IS_CHAT_SWITCHER_ACTIVE: 'isChatSwitcherActive',
     IS_SIDEBAR_ANIMATING: 'isSidebarAnimating',
+    BETAS: 'betas',
 
     // Collection Keys
     COLLECTION: {

--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -147,7 +147,7 @@ function handleExpiredAuthToken(originalCommand, originalParameters, originalTyp
  *
  * @returns {Promise}
  */
-function request(command, parameters, type = 'post') {
+function request(command, parameters = {}, type = 'post') {
     return new Promise((resolve, reject) => {
         Network.post(command, parameters, type)
             .then((response) => {
@@ -381,7 +381,7 @@ function GetAccountStatus(parameters) {
  */
 function GetRequestCountryCode() {
     const commandName = 'GetRequestCountryCode';
-    return request(commandName, {});
+    return request(commandName);
 }
 
 /**
@@ -528,7 +528,7 @@ function SetPassword(parameters) {
  * @returns {Promise}
  */
 function User_GetBetas() {
-    return request('User_GetBetas', {});
+    return request('User_GetBetas');
 }
 
 export {

--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -524,6 +524,13 @@ function SetPassword(parameters) {
     return request(commandName, parameters);
 }
 
+/**
+ * @returns {Promise}
+ */
+function User_GetBetas() {
+    return request('User_GetBetas', {});
+}
+
 export {
     getAuthToken,
     Authenticate,
@@ -545,5 +552,6 @@ export {
     SetGithubUsername,
     SetPassword,
     User_SignUp,
+    User_GetBetas,
     reauthenticate,
 };

--- a/src/libs/actions/User.js
+++ b/src/libs/actions/User.js
@@ -1,0 +1,12 @@
+import Onyx from 'react-native-onyx';
+import ONYXKEYS from '../../ONYXKEYS';
+import * as API from '../API';
+
+function getBetas() {
+    Onyx.merge(ONYXKEYS.BETAS, []);
+    API.User_GetBetas().then((response) => {
+        Onyx.set(ONYXKEYS.BETAS, response.betas);
+    });
+}
+
+export default getBetas;

--- a/src/libs/actions/User.js
+++ b/src/libs/actions/User.js
@@ -1,12 +1,19 @@
+/* eslint-disable  import/prefer-default-export  */
+
 import Onyx from 'react-native-onyx';
 import ONYXKEYS from '../../ONYXKEYS';
 import * as API from '../API';
 
 function getBetas() {
-    Onyx.merge(ONYXKEYS.BETAS, []);
     API.User_GetBetas().then((response) => {
-        Onyx.set(ONYXKEYS.BETAS, response.betas);
+        if (response.jsonCode === 200) {
+            Onyx.set(ONYXKEYS.BETAS, response.betas);
+        } else {
+            console.error('Could not get betas', response);
+        }
     });
 }
 
-export default getBetas;
+export {
+    getBetas,
+};

--- a/src/pages/home/HomePage.js
+++ b/src/pages/home/HomePage.js
@@ -42,6 +42,7 @@ import {redirect} from '../../libs/actions/App';
 import SettingsModal from '../../components/SettingsModal';
 import withWindowDimensions, {windowDimensionsPropTypes} from '../../components/withWindowDimensions';
 import compose from '../../libs/compose';
+import getBetas from '../../libs/actions/User';
 
 const propTypes = {
     isSidebarShown: PropTypes.bool,
@@ -99,12 +100,13 @@ class HomePage extends React.Component {
         // Fetch some data we need on initialization
         PersonalDetails.fetch();
         PersonalDetails.fetchTimezone();
+        getBetas();
         fetchAllReports(true, false, true);
         fetchCountryCodeByRequestIP();
         UnreadIndicatorUpdater.listenForReportChanges();
 
-        // Refresh the personal details and timezone every 30 minutes because there is no
-        // pusher event that sends updated personal details data yet
+        // Refresh the personal details, timezone and betas every 30 minutes
+        // There is no pusher event that sends updated personal details data yet
         // See https://github.com/Expensify/ReactNativeChat/issues/468
         this.interval = setInterval(() => {
             if (this.props.network.isOffline) {
@@ -112,6 +114,7 @@ class HomePage extends React.Component {
             }
             PersonalDetails.fetch();
             PersonalDetails.fetchTimezone();
+            getBetas();
         }, 1000 * 60 * 30);
 
         // Set up the navigationMenu correctly once on init

--- a/src/pages/home/HomePage.js
+++ b/src/pages/home/HomePage.js
@@ -42,7 +42,7 @@ import {redirect} from '../../libs/actions/App';
 import SettingsModal from '../../components/SettingsModal';
 import withWindowDimensions, {windowDimensionsPropTypes} from '../../components/withWindowDimensions';
 import compose from '../../libs/compose';
-import getBetas from '../../libs/actions/User';
+import {getBetas} from '../../libs/actions/User';
 
 const propTypes = {
     isSidebarShown: PropTypes.bool,


### PR DESCRIPTION
Hold on web PR https://github.com/Expensify/Web-Expensify/pull/30175

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/143385

### Tests
I did a small test of adding the beta subscription to the chats page and made sure it loaded with no betas the first time, then after the api call it had the betas from my account, on reload it rendered directly with the betas in my account. Of course I removed that code since we don't have a use for the betas quite yet (but we will soon).

### Tested On

- [X] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

