### PR TITLE
Use compose to chain HOCs

### DIFF
--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -15,6 +15,7 @@ import {addAction, saveReportComment, broadcastUserIsTyping} from '../../../libs
 import ReportTypingIndicator from './ReportTypingIndicator';
 import AttachmentModal from '../../../components/AttachmentModal';
 import withWindowDimensions, {windowDimensionsPropTypes} from '../../../components/withWindowDimensions';
+import compose from '../../../libs/compose';
 
 const propTypes = {
     // A method to call when the form is submitted
@@ -242,11 +243,14 @@ class ReportActionCompose extends React.Component {
 ReportActionCompose.propTypes = propTypes;
 ReportActionCompose.defaultProps = defaultProps;
 
-export default withOnyx({
-    comment: {
-        key: ({reportID}) => `${ONYXKEYS.COLLECTION.REPORT_DRAFT_COMMENT}${reportID}`,
-    },
-    isSidebarShown: {
-        key: ONYXKEYS.IS_SIDEBAR_SHOWN,
-    },
-})(withWindowDimensions(ReportActionCompose));
+export default compose(
+    withOnyx({
+        comment: {
+            key: ({reportID}) => `${ONYXKEYS.COLLECTION.REPORT_DRAFT_COMMENT}${reportID}`,
+        },
+        isSidebarShown: {
+            key: ONYXKEYS.IS_SIDEBAR_SHOWN,
+        },
+    }),
+    withWindowDimensions,
+)(ReportActionCompose);


### PR DESCRIPTION
Just a quick follow-up from https://github.com/Expensify/Expensify.cash/pull/1268 that I remembered after merging it.

### Details
Just use `compose` to chain together HOCs.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/1228

### Tests
1) Run the application.
2) Make sure it compiles and runs without warnings.
3) Complete the QA steps for https://github.com/Expensify/Expensify.cash/pull/1268

### Tested On

- [x] Web
- [x] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android