### PR TITLE
Added LastMessage to chat list on sidebar

### DIFF
--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -82,9 +82,16 @@ function createOption(personalDetailList, report, draftComments, activeReportID)
         && (report.reportID !== activeReportID)
         && lodashGet(draftComments, `${ONYXKEYS.COLLECTION.REPORT_DRAFT_COMMENT}${report.reportID}`, '').length > 0;
 
+    const lastActorDetails = report ? _.find(personalDetailList, {login: report.lastActorEmail}) : null;
+
     return {
         text: report ? report.reportName : personalDetail.displayName,
-        alternateText: (report && hasMultipleParticipants) ? report.reportName : personalDetail.login,
+        alternateText: report
+            ? (hasMultipleParticipants && lastActorDetails
+                ? `${lastActorDetails.displayName}: `
+                : '')
+              + report.lastMessageText
+            : '',
         icons: report ? report.icons : [personalDetail.avatarURL],
 
         // It doesn't make sense to provide a login in the case of a report with multiple participants since

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -138,6 +138,7 @@ function getSimplifiedReportObject(report) {
     const reportName = lodashGet(report, 'reportNameValuePairs.type') === 'chat'
         ? getChatReportName(report.sharedReportList)
         : report.reportName;
+    const lastActorEmail = lodashGet(lastReportAction, 'accountEmail', '');
 
     return {
         reportID: report.reportID,
@@ -153,6 +154,7 @@ function getSimplifiedReportObject(report) {
         ], 0),
         lastMessageTimestamp,
         lastMessageText,
+        lastActorEmail,
     };
 }
 
@@ -260,6 +262,7 @@ function updateReportWithNewAction(reportID, reportAction) {
         maxSequenceNumber: reportAction.sequenceNumber,
         lastMessageTimestamp: reportAction.timestamp,
         lastMessageText: messageText,
+        lastActorEmail: reportAction.actorEmail,
     });
 
     const reportActionsToMerge = {};

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -131,6 +131,7 @@ function getSimplifiedReportObject(report) {
     const lastReportAction = !_.isEmpty(reportActionList) ? _.last(reportActionList) : null;
     const createTimestamp = lastReportAction ? lastReportAction.created : 0;
     const lastMessageTimestamp = moment.utc(createTimestamp).unix();
+    const isLastMessageAttachment = /<img([^>]+)\/>/gi.test(lodashGet(lastReportAction, ['message', 'html'], ''));
 
     // We are removing any html tags from the message html since we cannot access the text version of any comments as
     // the report only has the raw reportActionList and not the processed version returned by Report_GetHistory
@@ -153,7 +154,7 @@ function getSimplifiedReportObject(report) {
             'timestamp',
         ], 0),
         lastMessageTimestamp,
-        lastMessageText,
+        lastMessageText: isLastMessageAttachment ? '[Attachment]' : lastMessageText,
         lastActorEmail,
     };
 }

--- a/src/pages/home/sidebar/OptionRow.js
+++ b/src/pages/home/sidebar/OptionRow.js
@@ -93,23 +93,19 @@ const OptionRow = ({
                         )
                     }
                     <View style={[styles.flex1]}>
-                        {(option.text === option.alternateText || option.alternateText.length === 0) ? (
-                            <Text style={[styles.chatSwitcherDisplayName, textUnreadStyle]} numberOfLines={1}>
-                                {option.text}
+                        <Text style={[styles.chatSwitcherDisplayName, textUnreadStyle]} numberOfLines={1}>
+                            {option.text}
+                        </Text>
+                        {option.alternateText ? (
+                            <Text
+                                style={[textStyle, styles.chatSwitcherLogin, styles.mt1]}
+                                numberOfLines={1}
+                            >
+                                {option.alternateText}
                             </Text>
-                        ) : (
-                            <>
-                                <Text style={[styles.chatSwitcherDisplayName, textUnreadStyle]} numberOfLines={1}>
-                                    {option.text}
-                                </Text>
-                                <Text
-                                    style={[textStyle, styles.chatSwitcherLogin, styles.mt1]}
-                                    numberOfLines={1}
-                                >
-                                    {option.alternateText}
-                                </Text>
-                            </>
-                        )}
+                        )
+                            : null}
+
                     </View>
                     {showSelectedState && (
                         <View

--- a/src/pages/home/sidebar/optionPropTypes.js
+++ b/src/pages/home/sidebar/optionPropTypes.js
@@ -4,7 +4,7 @@ export default PropTypes.shape({
     // The full name of the user if available, otherwise the login (email/phone number) of the user
     text: PropTypes.string.isRequired,
 
-    // The login of the user, or the name of the chat room
+    // Subtitle to show under report displayName, mostly lastMessageText of the report
     alternateText: PropTypes.string.isRequired,
 
     // The array URLs of the person's avatar


### PR DESCRIPTION
Please review @marcaaron.

### Details
Added Las chat message on the report list for LHN views. 
Changes are as follows:
1. Show the last message if any.
2. If the chat is a group chat, then show the participant name who last messaged.
3. Don't show the last message field, if no message.

### Fixed Issues
<Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing>
Fixes #1366 

### Tests
1. Performed Visual tests.
2. Tried various scenarios.

Steps to follow:
1. ~Try searching the contact list and see the search results.~ (Not part of this PR)
2. Send a message in the chat and you should see the last message in the chat list.

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

![Screenshot_2021-02-02 Expensify cash - Chat with friends to send and receive money(2)](https://user-images.githubusercontent.com/24370807/106511411-2fb42680-64f6-11eb-8ab2-ac338797279e.png)
![Screenshot_2021-02-02 Expensify cash - Chat with friends to send and receive money(1)](https://user-images.githubusercontent.com/24370807/106511413-317dea00-64f6-11eb-9b47-91d168858ca3.png)
![Screenshot_2021-02-02 Expensify cash - Chat with friends to send and receive money](https://user-images.githubusercontent.com/24370807/106511415-3347ad80-64f6-11eb-94de-b2f871bfd4d9.png)
