### PR TITLE
Standardize use of Dimensions by encouraging use of withWindowDimensions

### DIFF
--- a/src/components/AttachmentModal.js
+++ b/src/components/AttachmentModal.js
@@ -1,7 +1,7 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {
-    View, TouchableOpacity, Text, Dimensions,
+    View, TouchableOpacity, Text,
 } from 'react-native';
 import {withOnyx} from 'react-native-onyx';
 import CONST from '../CONST';
@@ -9,9 +9,10 @@ import ModalWithHeader from './ModalWithHeader';
 import AttachmentView from './AttachmentView';
 import styles from '../styles/styles';
 import themeColors from '../styles/themes/default';
-import variables from '../styles/variables';
 import ONYXKEYS from '../ONYXKEYS';
 import addAuthTokenToURL from '../libs/addAuthTokenToURL';
+import compose from '../libs/compose';
+import withWindowDimensions, {windowDimensionsPropTypes} from './withWindowDimensions';
 
 /**
  * Modal render prop component that exposes modal launching triggers that can be used
@@ -39,6 +40,8 @@ const propTypes = {
     session: PropTypes.shape({
         authToken: PropTypes.string.isRequired,
     }).isRequired,
+
+    ...windowDimensionsPropTypes,
 };
 
 const defaultProps = {
@@ -76,8 +79,7 @@ class AttachmentModal extends Component {
             required: this.props.isAuthTokenRequired,
         });
 
-        const isSmallScreen = Dimensions.get('window').width < variables.mobileResponsiveWidthBreakpoint;
-        const attachmentViewStyles = isSmallScreen
+        const attachmentViewStyles = this.props.isSmallScreenWidth
             ? [styles.imageModalImageCenterContainer]
             : [styles.imageModalImageCenterContainer, styles.p5];
         return (
@@ -135,8 +137,11 @@ class AttachmentModal extends Component {
 
 AttachmentModal.propTypes = propTypes;
 AttachmentModal.defaultProps = defaultProps;
-export default withOnyx({
-    session: {
-        key: ONYXKEYS.SESSION,
-    },
-})(AttachmentModal);
+export default compose(
+    withWindowDimensions,
+    withOnyx({
+        session: {
+            key: ONYXKEYS.SESSION,
+        },
+    }),
+)(AttachmentModal);

--- a/src/components/CreateMenu.js
+++ b/src/components/CreateMenu.js
@@ -1,7 +1,7 @@
 import React, {memo} from 'react';
 import PropTypes from 'prop-types';
 import {
-    View, Text, Pressable, useWindowDimensions,
+    View, Text, Pressable,
 } from 'react-native';
 import Modal from './Modal';
 import styles from '../styles/styles';
@@ -10,7 +10,7 @@ import themeColors from '../styles/themes/default';
 import colors from '../styles/colors';
 import Icon from './Icon';
 import {ChatBubble, Users} from './Icon/Expensicons';
-import variables from '../styles/variables';
+import withWindowDimensions, {windowDimensionsPropTypes} from './withWindowDimensions';
 
 const propTypes = {
     // Callback to fire on request to modal close
@@ -21,11 +21,11 @@ const propTypes = {
 
     // Callback to fire when a CreateMenu item is selected
     onItemSelected: PropTypes.func.isRequired,
+
+    ...windowDimensionsPropTypes,
 };
 
 const CreateMenu = (props) => {
-    const isSmallScreen = useWindowDimensions().width < variables.mobileResponsiveWidthBreakpoint;
-
     // This format allows to set individual callbacks to each item
     // while including mutual callbacks first
     const menuItemData = [
@@ -44,7 +44,7 @@ const CreateMenu = (props) => {
             onClose={props.onClose}
             isVisible={props.isVisible}
             type={
-                isSmallScreen
+                props.isSmallScreenWidth
                     ? CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED
                     : CONST.MODAL.MODAL_TYPE.POPOVER
             }
@@ -74,4 +74,4 @@ const CreateMenu = (props) => {
 
 CreateMenu.propTypes = propTypes;
 CreateMenu.displayName = 'CreateMenu';
-export default memo(CreateMenu);
+export default withWindowDimensions(memo(CreateMenu));

--- a/src/components/ImageView/index.native.js
+++ b/src/components/ImageView/index.native.js
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {View, Dimensions} from 'react-native';
+import {View} from 'react-native';
 import ImageZoom from 'react-native-image-pan-zoom';
 import ImageWithSizeCalculation from '../ImageWithSizeCalculation';
 import styles from '../../styles/styles';
 import variables from '../../styles/variables';
+import withWindowDimensions, {windowDimensionsPropTypes} from '../withWindowDimensions';
 
 /**
  * On the native layer, we use a image library to handle zoom functionality
@@ -12,9 +13,11 @@ import variables from '../../styles/variables';
 const propTypes = {
     // URL to full-sized image
     url: PropTypes.string.isRequired,
+
+    ...windowDimensionsPropTypes,
 };
 
-class ImageView extends React.Component {
+class ImageView extends PureComponent {
     constructor(props) {
         super(props);
 
@@ -26,9 +29,7 @@ class ImageView extends React.Component {
 
     render() {
         // Default windowHeight accounts for the modal header height
-        const windowHeight = Dimensions.get('window').height - variables.contentHeaderHeight;
-        const windowWidth = Dimensions.get('window').width;
-
+        const windowHeight = this.props.windowHeight - variables.contentHeaderHeight;
         return (
             <View
                 style={[
@@ -40,7 +41,7 @@ class ImageView extends React.Component {
                 ]}
             >
                 <ImageZoom
-                    cropWidth={windowWidth}
+                    cropWidth={this.props.windowWidth}
                     cropHeight={windowHeight}
                     imageWidth={this.state.imageWidth}
                     imageHeight={this.state.imageHeight}
@@ -55,8 +56,8 @@ class ImageView extends React.Component {
                             let imageWidth = width;
                             let imageHeight = height;
 
-                            if (width > windowWidth || height > windowHeight) {
-                                const scaleFactor = Math.max(width / windowWidth, height / windowHeight);
+                            if (width > this.props.windowWidth || height > windowHeight) {
+                                const scaleFactor = Math.max(width / this.props.windowWidth, height / windowHeight);
                                 imageHeight = height / scaleFactor;
                                 imageWidth = width / scaleFactor;
                             }
@@ -73,4 +74,4 @@ class ImageView extends React.Component {
 ImageView.propTypes = propTypes;
 ImageView.displayName = 'ImageView';
 
-export default ImageView;
+export default withWindowDimensions(ImageView);

--- a/src/components/KeyboardSpacer/index.ios.js
+++ b/src/components/KeyboardSpacer/index.ios.js
@@ -4,16 +4,30 @@
  */
 import ReactNativeKeyboardSpacer from 'react-native-keyboard-spacer';
 import React from 'react';
-import {Dimensions} from 'react-native';
+import withWindowDimensions, {windowDimensionsPropTypes} from '../withWindowDimensions';
 
-function hasSafeAreas() {
-    const dims = Dimensions.get('window');
-    const heightsIphonesWithNotches = [812, 896, 844, 926];
-    return (heightsIphonesWithNotches.includes(dims.height) || heightsIphonesWithNotches.includes(dims.width));
-}
+const propTypes = {
+    ...windowDimensionsPropTypes,
+};
 
-const KeyboardSpacer = () => (
-    <ReactNativeKeyboardSpacer topSpacing={hasSafeAreas() ? -30 : 0} />
-);
+const KeyboardSpacer = (props) => {
+    /**
+     * Checks to see if the iOS device has safe areas or not
+     *
+     * @param {Number} windowWidth
+     * @param {Number} windowHeight
+     * @returns {Boolean}
+     */
+    function hasSafeAreas(windowWidth, windowHeight) {
+        const heightsIphonesWithNotches = [812, 896, 844, 926];
+        return (heightsIphonesWithNotches.includes(windowHeight) || heightsIphonesWithNotches.includes(windowWidth));
+    }
 
-export default KeyboardSpacer;
+    return (
+        <ReactNativeKeyboardSpacer topSpacing={hasSafeAreas(props.windowWidth, props.windowHeight) ? -30 : 0} />
+    );
+};
+
+KeyboardSpacer.propTypes = propTypes;
+KeyboardSpacer.displayName = 'KeyboardSpacer';
+export default withWindowDimensions(KeyboardSpacer);

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -58,7 +58,11 @@ const Modal = (props) => {
         shouldAddTopSafeAreaPadding,
         shouldAddBottomSafeAreaPadding,
         hideBackdrop,
-    } = getModalStyles(props.type, props.windowDimensions);
+    } = getModalStyles(props.type, {
+        windowWidth: props.windowWidth,
+        windowHeight: props.windowHeight,
+        isSmallScreenWidth: props.isSmallScreenWidth,
+    });
     return (
         <ReactNativeModal
             onBackdropPress={props.onClose}

--- a/src/components/PDFView/index.native.js
+++ b/src/components/PDFView/index.native.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {View, Dimensions} from 'react-native';
+import {View} from 'react-native';
 import PDF from 'react-native-pdf';
 import styles from '../../styles/styles';
+import withWindowDimensions, {windowDimensionsPropTypes} from '../withWindowDimensions';
 
 const propTypes = {
     // URL to full-sized image
@@ -11,6 +12,8 @@ const propTypes = {
     // Any additional styles to apply
     // eslint-disable-next-line react/forbid-prop-types
     style: PropTypes.any,
+
+    ...windowDimensionsPropTypes,
 };
 
 const defaultProps = {
@@ -32,8 +35,8 @@ const PDFView = props => (
             style={[
                 styles.imageModalPDF,
                 {
-                    width: Dimensions.get('window').width,
-                    height: Dimensions.get('window').height,
+                    width: props.windowWidth,
+                    height: props.windwoHeight,
                 },
             ]}
         />
@@ -44,4 +47,4 @@ PDFView.propTypes = propTypes;
 PDFView.defaultProps = defaultProps;
 PDFView.displayName = 'PDFView';
 
-export default PDFView;
+export default withWindowDimensions(PDFView);

--- a/src/components/withWindowDimensions.js
+++ b/src/components/withWindowDimensions.js
@@ -5,14 +5,11 @@ import getComponentDisplayName from '../libs/getComponentDisplayName';
 import variables from '../styles/variables';
 
 const windowDimensionsPropTypes = {
-    // via withWindowDimensions
-    windowDimensions: PropTypes.shape({
-        // Width of the window
-        width: PropTypes.number.isRequired,
+    // Width of the window
+    windowWidth: PropTypes.number.isRequired,
 
-        // Height of the window
-        height: PropTypes.number.isRequired,
-    }).isRequired,
+    // Height of the window
+    windowHeight: PropTypes.number.isRequired,
 
     // Is the window width narrow, like on a mobile device?
     isSmallScreenWidth: PropTypes.bool.isRequired,
@@ -25,8 +22,12 @@ export default function (WrappedComponent) {
 
             this.onDimensionChange = this.onDimensionChange.bind(this);
 
+            const initialDimensions = Dimensions.get('window');
+            const isSmallScreenWidth = initialDimensions.width <= variables.mobileResponsiveWidthBreakpoint;
             this.state = {
-                windowDimensions: Dimensions.get('window'),
+                windowHeight: initialDimensions.height,
+                windowWidth: initialDimensions.width,
+                isSmallScreenWidth,
             };
         }
 
@@ -46,7 +47,12 @@ export default function (WrappedComponent) {
          */
         onDimensionChange(newDimensions) {
             const {window} = newDimensions;
-            this.setState({windowDimensions: window});
+            const isSmallScreenWidth = window.width <= variables.mobileResponsiveWidthBreakpoint;
+            this.setState({
+                windowHeight: window.height,
+                windowWidth: window.width,
+                isSmallScreenWidth,
+            });
         }
 
         render() {
@@ -54,8 +60,9 @@ export default function (WrappedComponent) {
                 <WrappedComponent
                     // eslint-disable-next-line react/jsx-props-no-spreading
                     {...this.props}
-                    windowDimensions={this.state.windowDimensions}
-                    isSmallScreenWidth={this.state.windowDimensions.width <= variables.mobileResponsiveWidthBreakpoint}
+                    windowHeight={this.state.windowHeight}
+                    windowWidth={this.state.windowWidth}
+                    isSmallScreenWidth={this.state.isSmallScreenWidth}
                 />
             );
         }

--- a/src/pages/home/HomePage.js
+++ b/src/pages/home/HomePage.js
@@ -67,7 +67,6 @@ class HomePage extends React.Component {
 
         super(props);
 
-        const isSmallScreenWidth = props.windowDimensions.width <= variables.mobileResponsiveWidthBreakpoint;
         this.state = {
             isCreateMenuActive: false,
         };
@@ -80,8 +79,8 @@ class HomePage extends React.Component {
         this.recordTimerAndToggleNavigationMenu = this.recordTimerAndToggleNavigationMenu.bind(this);
         this.navigateToSettings = this.navigateToSettings.bind(this);
 
-        const windowBarSize = isSmallScreenWidth
-            ? -props.windowDimensions.width
+        const windowBarSize = props.isSmallScreenWidth
+            ? -props.windowWidth
             : -variables.sideBarWidth;
         this.animationTranslateX = new Animated.Value(
             !props.isSidebarShown ? windowBarSize : 0,
@@ -118,8 +117,7 @@ class HomePage extends React.Component {
         }, 1000 * 60 * 30);
 
         // Set up the navigationMenu correctly once on init
-        const isSmallScreenWidth = this.props.windowDimensions.width <= variables.mobileResponsiveWidthBreakpoint;
-        if (!isSmallScreenWidth) {
+        if (!this.props.isSmallScreenWidth) {
             showSidebar();
         }
 
@@ -132,15 +130,9 @@ class HomePage extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
-        if (prevProps.windowDimensions.width !== this.props.windowDimensions.width) {
-            const wasPreviouslySmallScreenWidth = prevProps.windowDimensions.width
-                <= variables.mobileResponsiveWidthBreakpoint;
-            const isSmallScreenWidth = this.props.windowDimensions.width <= variables.mobileResponsiveWidthBreakpoint;
-
-            // Always show the sidebar if we are moving from small to large screens
-            if (wasPreviouslySmallScreenWidth && !isSmallScreenWidth) {
-                showSidebar();
-            }
+        // Always show the sidebar if we are moving from small to large screens
+        if (prevProps.isSmallScreenWidth && !this.props.isSmallScreenWidth) {
+            showSidebar();
         }
 
         if (!prevProps.isChatSwitcherActive && this.props.isChatSwitcherActive) {
@@ -206,8 +198,7 @@ class HomePage extends React.Component {
      * Only changes navigationMenu state on small screens (e.g. Mobile and mWeb)
      */
     dismissNavigationMenu() {
-        const isSmallScreenWidth = this.props.windowDimensions.width <= variables.mobileResponsiveWidthBreakpoint;
-        if (!isSmallScreenWidth || !this.props.isSidebarShown) {
+        if (!this.props.isSmallScreenWidth || !this.props.isSidebarShown) {
             return;
         }
 
@@ -233,10 +224,9 @@ class HomePage extends React.Component {
      * @param {Boolean} navigationMenuIsShown
      */
     animateNavigationMenu(navigationMenuIsShown) {
-        const isSmallScreenWidth = this.props.windowDimensions.width <= variables.mobileResponsiveWidthBreakpoint;
-        const windowSideBarSize = isSmallScreenWidth
+        const windowSideBarSize = this.props.isSmallScreenWidth
             ? -variables.sideBarWidth
-            : -this.props.windowDimension.width;
+            : -this.props.windowWidth;
         const animationFinalValue = navigationMenuIsShown ? windowSideBarSize : 0;
 
         setSideBarIsAnimating(true);
@@ -261,9 +251,7 @@ class HomePage extends React.Component {
      * Only changes navigationMenu state on small screens (e.g. Mobile and mWeb)
      */
     toggleNavigationMenu() {
-        const isSmallScreenWidth = this.props.windowDimensions.width <= variables.mobileResponsiveWidthBreakpoint;
-
-        if (!isSmallScreenWidth) {
+        if (!this.props.isSmallScreenWidth) {
             return;
         }
 
@@ -281,7 +269,6 @@ class HomePage extends React.Component {
     }
 
     render() {
-        const isSmallScreenWidth = this.props.windowDimensions.width <= variables.mobileResponsiveWidthBreakpoint;
         return (
             <SafeAreaProvider>
                 <CustomStatusBar />
@@ -297,8 +284,9 @@ class HomePage extends React.Component {
                             <Route path={[ROUTES.REPORT, ROUTES.HOME, ROUTES.SETTINGS, ROUTES.NEW_GROUP]}>
                                 <Animated.View style={[
                                     getNavigationMenuStyle(
-                                        this.props.windowDimensions.width,
+                                        this.props.windowWidth,
                                         this.props.isSidebarShown,
+                                        this.props.isSmallScreenWidth,
                                     ),
                                     {
                                         transform: [{translateX: this.animationTranslateX}],
@@ -317,7 +305,7 @@ class HomePage extends React.Component {
                                     style={[styles.appContent, styles.flex1, styles.flexColumn]}
                                 >
                                     <HeaderView
-                                        shouldShowNavigationMenuButton={isSmallScreenWidth}
+                                        shouldShowNavigationMenuButton={this.props.isSmallScreenWidth}
                                         onNavigationMenuButtonClicked={this.toggleNavigationMenu}
                                         reportID={this.props.currentlyViewedReportID}
                                     />

--- a/src/pages/signin/LoginForm/index.js
+++ b/src/pages/signin/LoginForm/index.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import variables from '../../../styles/variables';
 import LoginFormNarrow from './LoginFormNarrow';
 import LoginFormWide from './LoginFormWide';
 import withWindowDimensions, {windowDimensionsPropTypes} from '../../../components/withWindowDimensions';
@@ -8,8 +7,8 @@ const propTypes = {
     ...windowDimensionsPropTypes,
 };
 
-const LoginForm = ({windowDimensions}) => (
-    windowDimensions.width > variables.mobileResponsiveWidthBreakpoint
+const LoginForm = ({isSmallScreenWidth}) => (
+    !isSmallScreenWidth
         ? <LoginFormWide />
         : <LoginFormNarrow />
 );

--- a/src/pages/signin/SignInPageLayout/index.js
+++ b/src/pages/signin/SignInPageLayout/index.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import variables from '../../../styles/variables';
 import SignInPageLayoutNarrow from './SignInPageLayoutNarrow';
 import SignInPageLayoutWide from './SignInPageLayoutWide';
 import withWindowDimensions, {windowDimensionsPropTypes} from '../../../components/withWindowDimensions';
@@ -9,7 +8,7 @@ const propTypes = {
 };
 
 const SignInPageLayout = props => (
-    props.windowDimensions.width > variables.mobileResponsiveWidthBreakpoint
+    !props.isSmallScreenWidth
         // eslint-disable-next-line react/jsx-props-no-spreading
         ? <SignInPageLayoutWide {...props} />
         // eslint-disable-next-line react/jsx-props-no-spreading

--- a/src/styles/getModalStyles.js
+++ b/src/styles/getModalStyles.js
@@ -4,7 +4,7 @@ import variables from './variables';
 import themeColors from './themes/default';
 
 export default (type, windowDimensions) => {
-    const isSmallScreen = windowDimensions.width < variables.mobileResponsiveWidthBreakpoint;
+    const {isSmallScreenWidth, windowWidth} = windowDimensions;
 
     let modalStyle = {
         margin: 0,
@@ -40,20 +40,20 @@ export default (type, windowDimensions) => {
                 shadowRadius: 5,
 
                 flex: 1,
-                marginTop: isSmallScreen ? 0 : 20,
-                marginBottom: isSmallScreen ? 0 : 20,
-                borderRadius: isSmallScreen ? 0 : 12,
-                borderWidth: isSmallScreen ? 1 : 0,
+                marginTop: isSmallScreenWidth ? 0 : 20,
+                marginBottom: isSmallScreenWidth ? 0 : 20,
+                borderRadius: isSmallScreenWidth ? 0 : 12,
+                borderWidth: isSmallScreenWidth ? 1 : 0,
                 overflow: 'hidden',
-                width: isSmallScreen ? '100%' : windowDimensions.width - 40,
+                width: isSmallScreenWidth ? '100%' : windowWidth - 40,
             };
 
             // The default swipe direction is swipeDown and by
             // setting this to undefined we effectively disable the
             // ability to swipe our modal
             swipeDirection = undefined;
-            animationIn = isSmallScreen ? 'slideInRight' : 'fadeIn';
-            animationOut = isSmallScreen ? 'slideOutRight' : 'fadeOut';
+            animationIn = isSmallScreenWidth ? 'slideInRight' : 'fadeIn';
+            animationOut = isSmallScreenWidth ? 'slideOutRight' : 'fadeOut';
             shouldAddTopSafeAreaPadding = true;
             break;
         case CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED:
@@ -85,7 +85,7 @@ export default (type, windowDimensions) => {
                 ...{
                     alignItems: 'center',
                     justifyContent: 'flex-end',
-                    marginRight: windowDimensions.width - variables.sideBarWidth,
+                    marginRight: windowWidth - variables.sideBarWidth,
                     marginBottom: 100,
                 },
             };
@@ -115,7 +115,7 @@ export default (type, windowDimensions) => {
                 },
             };
             modalContainerStyle = {
-                width: isSmallScreen ? '100%' : variables.sideBarWidth,
+                width: isSmallScreenWidth ? '100%' : variables.sideBarWidth,
                 height: '100%',
                 overflow: 'hidden',
             };

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1112,10 +1112,10 @@ function getSafeAreaMargins(insets) {
  *
  * @param {Number} windowWidth
  * @param {Boolean} isSidebarShown
+ * @param {Boolean} isSmallScreenWidth
  * @returns {Object}
  */
-function getNavigationMenuStyle(windowWidth, isSidebarShown) {
-    const isSmallScreenWidth = windowWidth <= variables.mobileResponsiveWidthBreakpoint;
+function getNavigationMenuStyle(windowWidth, isSidebarShown, isSmallScreenWidth) {
     return isSmallScreenWidth
         ? {
             ...styles.navigationMenuOpenAbsolute,


### PR DESCRIPTION
### Details
Checking the window dimensions via `Dimensions` is causing many different ways to check window width. This PR attempts to standardize on just using `withWindowDimensions` instead.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/153073

### Tests
1. There should be no changed behaviors from these changes. But we should make sure there are no regressions. Specifically in things that we expect to be "responsive" when the window size changes.
2. Check various modals to make sure they are resizing properly on all platforms

### Tested On

- [x] Web
- [x] Mobile Web (iOS Safari) - yes, but looks weird tbh. Doesn't seem like `Dimensions` works very well on `master`
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
❌ 