### PR TITLE
Hide typing indicator if the current user is typing on another platform

### DIFF
--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -394,6 +394,11 @@ function subscribeToReportTypingEvents(reportID) {
             return;
         }
 
+        // Don't show the typing indicator if a user is typing on another platform
+        if (login === currentUserEmail) {
+            return;
+        }
+
         // Use a combo of the reportID and the login as a key for holding our timers.
         const reportUserIdentifier = `${reportID}-${login}`;
         clearTimeout(typingWatchTimers[reportUserIdentifier]);


### PR DESCRIPTION
### Details
User's are being shown that they are typing on one platform when typing on another.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/153104

### Tests
1. Open a report on 2 different platforms e.g. web and iOS or web and another web session in an incognito window
2. Open the same report on each platform
3. Begin typing
4. Verify you do not see any indicator that you are typing below the text input

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
