### PR TITLE
Add our custom monospace font to web

### DIFF
--- a/assets/css/fonts.css
+++ b/assets/css/fonts.css
@@ -61,6 +61,13 @@
     src: url("https://www.expensify.com/font/GT-America-Standard-Bold-Italic.eot") format("embedded-opentype"), url("https://www.expensify.com/font/GT-America-Standard-Bold-Italic.woff") format("woff"), url("https://www.expensify.com/font/GT-America-Standard-Bold-Italic.woff2") format("woff2");
 }
 
+@font-face {
+    font-family: GTAmericaExpMono-Rg;
+    font-weight: 400;
+    font-style: normal;
+    src: url('https://www.expensify.com/font/GT-America-Exp-Mono-Regular.eot') format('embedded-opentype'), url('https://www.expensify.com/font/GT-America-Exp-Mono-Regular.woff') format('woff'), url('https://www.expensify.com/font/GT-America-Exp-Mono-Regular.woff2') format('woff2');
+}
+
 * {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;

--- a/src/styles/fontFamily/index.js
+++ b/src/styles/fontFamily/index.js
@@ -1,11 +1,10 @@
-import monospace from './monospace';
 import bold from '../bold';
 
 const fontFamily = {
     GTA_ITALIC: 'GTAmericaExp-RgIt',
     GTA_BOLD: bold,
     GTA: 'GTAmericaExp-Regular',
-    MONOSPACE: monospace,
+    MONOSPACE: 'GTAmericaExpMono-Rg',
     SYSTEM: 'System',
 };
 

--- a/src/styles/fontFamily/monospace/index.js
+++ b/src/styles/fontFamily/monospace/index.js
@@ -1,1 +1,0 @@
-export default 'monospace';

--- a/src/styles/fontFamily/monospace/index.native.js
+++ b/src/styles/fontFamily/monospace/index.native.js
@@ -1,1 +1,0 @@
-export default 'GTAmericaExpMono-Rg';


### PR DESCRIPTION
### Details
Just adding the monospace font to web

### Fixed Issues
https://github.com/Expensify/Expensify/issues/148502

### Tests
1. Write anything you want in the code style (Surround it with `)
2. Make sure it looks like this (the g's and r's are the most distinguishing to me)
![2021-02-01_17-17-14](https://user-images.githubusercontent.com/42391420/106534631-c4486580-64b1-11eb-981a-1a0e67351d91.png)


### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [ ] Android

### Screenshots
![2021-02-01_19-14-53](https://user-images.githubusercontent.com/42391420/106542866-da5e2200-64c1-11eb-9bb0-636d07a47dca.png)
![2021-02-01_17-22-25](https://user-images.githubusercontent.com/42391420/106542868-dc27e580-64c1-11eb-98dc-1b76877fb4da.png)
![2021-02-01_19-18-40](https://user-images.githubusercontent.com/42391420/106543101-5193b600-64c2-11eb-92a2-7ae0bd3ab43e.png)
