### PR TITLE
fix: pod install and updated react-native-render-html changes

### DIFF
--- a/ios/ExpensifyCash.xcodeproj/project.pbxproj
+++ b/ios/ExpensifyCash.xcodeproj/project.pbxproj
@@ -510,6 +510,10 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
+			inputPaths = (
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}",
+				"$(SRCROOT)/$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)",
+			);
 			name = "[CP-User] [RNFB] Crashlytics Configuration";
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
-  - Airship (14.2.0):
-    - Airship/Automation (= 14.2.0)
-    - Airship/Core (= 14.2.0)
-    - Airship/ExtendedActions (= 14.2.0)
-    - Airship/MessageCenter (= 14.2.0)
-  - Airship/Automation (14.2.0):
+  - Airship (14.2.1):
+    - Airship/Automation (= 14.2.1)
+    - Airship/Core (= 14.2.1)
+    - Airship/ExtendedActions (= 14.2.1)
+    - Airship/MessageCenter (= 14.2.1)
+  - Airship/Automation (14.2.1):
     - Airship/Core
-  - Airship/Core (14.2.0)
-  - Airship/ExtendedActions (14.2.0):
+  - Airship/Core (14.2.1)
+  - Airship/ExtendedActions (14.2.1):
     - Airship/Core
-  - Airship/MessageCenter (14.2.0):
+  - Airship/MessageCenter (14.2.1):
     - Airship/Core
   - boost-for-react-native (1.63.0)
   - CocoaAsyncSocket (7.6.5)
@@ -320,15 +320,15 @@ PODS:
     - React-cxxreact (= 0.63.3)
     - React-jsi (= 0.63.3)
   - React-jsinspector (0.63.3)
-  - react-native-config (1.4.1):
-    - react-native-config/App (= 1.4.1)
-  - react-native-config/App (1.4.1):
+  - react-native-config (1.4.2):
+    - react-native-config/App (= 1.4.2)
+  - react-native-config/App (1.4.2):
     - React-Core
-  - react-native-document-picker (4.0.0):
+  - react-native-document-picker (4.2.0):
     - React-Core
-  - react-native-image-picker (2.3.4):
-    - React-Core
-  - react-native-netinfo (5.9.7):
+  - react-native-image-picker (2.4.0):
+    - React
+  - react-native-netinfo (5.9.10):
     - React-Core
   - react-native-pdf (6.2.2):
     - React-Core
@@ -336,9 +336,9 @@ PODS:
     - React
   - react-native-progress-view (1.2.3):
     - React
-  - react-native-safe-area-context (3.1.8):
+  - react-native-safe-area-context (3.1.9):
     - React-Core
-  - react-native-webview (11.0.2):
+  - react-native-webview (11.2.1):
     - React-Core
   - React-RCTActionSheet (0.63.3):
     - React-Core/RCTActionSheetHeaders (= 0.63.3)
@@ -404,21 +404,21 @@ PODS:
     - React-Core
   - RNCAsyncStorage (1.12.1):
     - React-Core
-  - RNFBAnalytics (7.6.8):
+  - RNFBAnalytics (7.6.10):
     - Firebase/Analytics (~> 6.34.0)
     - React-Core
     - RNFBApp
-  - RNFBApp (8.4.6):
+  - RNFBApp (8.4.7):
     - Firebase/CoreOnly (~> 6.34.0)
     - React-Core
-  - RNFBCrashlytics (8.4.10):
+  - RNFBCrashlytics (8.5.2):
     - Firebase/Crashlytics (~> 6.34.0)
     - React-Core
     - RNFBApp
   - RNSVG (12.1.0):
     - React
-  - urbanairship-react-native (10.0.0):
-    - Airship (= 14.2.0)
+  - urbanairship-react-native (10.0.1):
+    - Airship (= 14.2.1)
     - React-Core
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
@@ -603,7 +603,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  Airship: 02ad73780f9eed21870e36b0aaab327acda6a102
+  Airship: 9d2bfec2bd9586ddee5d1dbeb15cf4fdbababf85
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
@@ -641,15 +641,15 @@ SPEC CHECKSUMS:
   React-jsi: df07aa95b39c5be3e41199921509bfa929ed2b9d
   React-jsiexecutor: b56c03e61c0dd5f5801255f2160a815f4a53d451
   React-jsinspector: 8e68ffbfe23880d3ee9bafa8be2777f60b25cbe2
-  react-native-config: d8b45133fd13d4f23bd2064b72f6e2c08b2763ed
-  react-native-document-picker: b3e78a8f7fef98b5cb069f20fc35797d55e68e28
-  react-native-image-picker: 32d1ad2c0024ca36161ae0d5c2117e2d6c441f11
-  react-native-netinfo: e36c1bb6df27ab84aa933679b3f5bbf9d180b18f
+  react-native-config: c98128a72bc2c3a1ca72caec0b021f0fa944aa29
+  react-native-document-picker: 44ecae7103090b6789cca010f06f5205fd1cb66e
+  react-native-image-picker: 4e63090db19a528e36c0cc07d1423c8c0cb4c4ef
+  react-native-netinfo: 30fb89fa913c342be82a887b56e96be6d71201dd
   react-native-pdf: 4b5a9e4465a6a3b399e91dc4838eb44ddf716d1f
-  react-native-progress-bar-android: ce95a69f11ac580799021633071368d08aaf9ad8
-  react-native-progress-view: 5816e8a6be812c2b122c6225a2a3db82d9008640
-  react-native-safe-area-context: 01158a92c300895d79dee447e980672dc3fb85a6
-  react-native-webview: b2542d6fd424bcc3e3b2ec5f854f0abb4ec86c87
+  react-native-progress-bar-android: be43138ab7da30d51fc038bafa98e9ed594d0c40
+  react-native-progress-view: 21b1e29e70c7559c16c9e0a04c4adc19fce6ede2
+  react-native-safe-area-context: b6e0e284002381d2ff29fa4fff42b4d8282e3c94
+  react-native-webview: a4751ec8f0a6a397026f22ed54c1efeec4540555
   React-RCTActionSheet: 53ea72699698b0b47a6421cb1c8b4ab215a774aa
   React-RCTAnimation: 1befece0b5183c22ae01b966f5583f42e69a83c2
   React-RCTBlob: 0b284339cbe4b15705a05e2313a51c6d8b51fa40
@@ -661,12 +661,12 @@ SPEC CHECKSUMS:
   React-RCTVibration: 8e9fb25724a0805107fc1acc9075e26f814df454
   ReactCommon: 4167844018c9ed375cc01a843e9ee564399e53c3
   rn-fetch-blob: f065bb7ab7fb48dd002629f8bdcb0336602d3cba
-  RNCAsyncStorage: cb9a623793918c6699586281f0b51cbc38f046f9
-  RNFBAnalytics: 2dc4dd9e2445faffca041b10447a23a71dcdabf8
-  RNFBApp: 7eacc7da7ab19f96c05e434017d44a9f09410da8
-  RNFBCrashlytics: 4870c14cf8833053b6b5648911abefe1923854d2
+  RNCAsyncStorage: b03032fdbdb725bea0bd9e5ec5a7272865ae7398
+  RNFBAnalytics: 6414e9fe1f36c3074f39cd6265b3def777dbfbdb
+  RNFBApp: 804b98033f45c3a3e35b56de8c894f85ef5e4388
+  RNFBCrashlytics: 501d01e5dd0cd6affedba60762b9b8d7d579cea8
   RNSVG: ce9d996113475209013317e48b05c21ee988d42e
-  urbanairship-react-native: dfb6dc22b2f41ccaadd636b73d51b448cd1b2bbc
+  urbanairship-react-native: 55f29ff21b5732ee3cacbcaa42b76e489465abea
   Yoga: 7d13633d129fd179e01b8953d38d47be90db185a
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/src/components/RenderHTML.js
+++ b/src/components/RenderHTML.js
@@ -168,7 +168,7 @@ const RenderHTML = ({html, debug = false}) => {
                 width: MAX_IMG_DIMENSIONS,
                 height: MAX_IMG_DIMENSIONS,
             }}
-            html={html}
+            source={{html}}
             debug={debug}
         />
     );


### PR DESCRIPTION
<If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit.>

### Details

It fixes Airship issue on pod install 
It updates "react-native-render-html": "^6.0.0-alpha.10" API changes
![Screen Shot 2021-02-02 at 11 14 54 AM](https://user-images.githubusercontent.com/13379067/106556652-16d46100-6548-11eb-90c9-54286247efca.png)
<img width="1022" alt="Screen Shot 2021-02-02 at 11 09 30 AM" src="https://user-images.githubusercontent.com/13379067/106556713-32d80280-6548-11eb-9611-ff3bbc217c70.png">


### Fixed Issues
<Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing>
Fixes GH_LINK

### Tests
1. Install fresh project
2. Navigate to chat screen

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [X] iOS
- [ ] Android

### Screenshots
#### Web
#### Mobile Web
#### Desktop
#### iOS
#### Android
