### PR TITLE
Make polyfill for realpath

### DIFF
--- a/.github/scripts/buildActions.sh
+++ b/.github/scripts/buildActions.sh
@@ -3,8 +3,15 @@
 # Used to precompile all Github Action node.js scripts using ncc.
 # This bundles them with their dependencies into a single executable node.js script.
 
+# This function is a polyfill for GNU's realpath that (hopefully) works on (almost) any shell
+# By default, realpath is not available on macOS w/o first installing coreutils. :(
+realpath_polyfill() {
+    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+
 # In order for this script to be safely run from anywhere, we cannot use the raw relative path '../actions'
-declare -r ACTIONS_DIR="$(dirname "$(dirname "$(realpath "$0")")")/actions"
+declare ACTIONS_DIR
+ACTIONS_DIR="$(dirname "$(dirname "$(realpath_polyfill "$0")")")/actions"
 
 # List of paths to all JS files that implement our GH Actions
 declare -r GITHUB_ACTIONS=(

--- a/.github/scripts/buildActions.sh
+++ b/.github/scripts/buildActions.sh
@@ -3,15 +3,9 @@
 # Used to precompile all Github Action node.js scripts using ncc.
 # This bundles them with their dependencies into a single executable node.js script.
 
-# This function is a polyfill for GNU's realpath that (hopefully) works on (almost) any shell
-# By default, realpath is not available on macOS w/o first installing coreutils. :(
-realpath_polyfill() {
-    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
-}
-
 # In order for this script to be safely run from anywhere, we cannot use the raw relative path '../actions'
 declare ACTIONS_DIR
-ACTIONS_DIR="$(dirname "$(dirname "$(realpath_polyfill "$0")")")/actions"
+ACTIONS_DIR="$(dirname "$(dirname "$0")")/actions"
 
 # List of paths to all JS files that implement our GH Actions
 declare -r GITHUB_ACTIONS=(


### PR DESCRIPTION
### Details
Mac users could not run the `buildActions.sh` script because it used a utility which is not available by default on macOS.

cc @AndrewGable

### Fixed Issues
n/a

### Tests
1. Make a change to `.github/actions/bumpVersion/bumpVersion.js`
2. Run `npm run gh-actions-build`. It should complete without any errors.
3. Run `git diff .github/actions/bumpVersion/index.js`
4. Verify that you see the change you made to `.github/actions/bumpVersion/bumpVersion.js`

### Tested On
- zsh (macOS)
- bash (ubuntu-latest, in the GH actions runner)