### PR TITLE
Keeping sequenceNumber as numbers

### DIFF
--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -586,8 +586,12 @@ function addAction(reportID, text, file) {
     // Generate a clientID so we can save the optimistic action to storage with the clientID as key. Later, we will
     // remove the optimistic action when we add the real action created in the server. We do this because it's not
     // safe to assume that this will use the very next sequenceNumber. An action created by another can overwrite that
-    // sequenceNumber if it is created before this one.
-    const optimisticReportActionID = Str.guid(`${Date.now()}_`);
+    // sequenceNumber if it is created before this one. We use a combination of current epoch timestamp and a random
+    // number so that the probability of someone else having the same optimisticReportActionID is extremely low even
+    // if they left the comment at the same moment as another user or the same report. The random number is 3 digits
+    // because if we go any higher JS will convert them to 0's in optimisticReportActionID.
+    const randomNumber = Math.floor((Math.random() * (999 - 100)) + 999);
+    const optimisticReportActionID = parseInt(`${Date.now()}${randomNumber}`, 10);
 
     // Store the optimistic action ID on the report the comment was added to. It will be removed later when refetching
     // report actions in order to clear out any stuck actions (i.e. actions where the client never received a Pusher

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -589,7 +589,8 @@ function addAction(reportID, text, file) {
     // sequenceNumber if it is created before this one. We use a combination of current epoch timestamp and a random
     // number so that the probability of someone else having the same optimisticReportActionID is extremely low even
     // if they left the comment at the same moment as another user or the same report. The random number is 3 digits
-    // because if we go any higher JS will convert them to 0's in optimisticReportActionID.
+    // because if we go any higher JS will convert the digits after the 16th position to 0's in
+    // optimisticReportActionID.
     const randomNumber = Math.floor((Math.random() * (999 - 100)) + 100);
     const optimisticReportActionID = parseInt(`${Date.now()}${randomNumber}`, 10);
 

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -585,10 +585,10 @@ function addAction(reportID, text, file) {
     // Generate a clientID so we can save the optimistic action to storage with the clientID as key. Later, we will
     // remove the optimistic action when we add the real action created in the server. We do this because it's not
     // safe to assume that this will use the very next sequenceNumber. An action created by another can overwrite that
-    // sequenceNumber if it is created before this one. We use a combination of current epoch timestamp and a random
-    // number so that the probability of someone else having the same optimisticReportActionID is extremely low even
-    // if they left the comment at the same moment as another user or the same report. The random number is 3 digits
-    // because if we go any higher JS will convert the digits after the 16th position to 0's in
+    // sequenceNumber if it is created before this one. We use a combination of current epoch timestamp (milliseconds)
+    // and a random number so that the probability of someone else having the same optimisticReportActionID is
+    // extremely low even if they left the comment at the same moment as another user on the same report. The random
+    // number is 3 digits because if we go any higher JS will convert the digits after the 16th position to 0's in
     // optimisticReportActionID.
     const randomNumber = Math.floor((Math.random() * (999 - 100)) + 100);
     const optimisticReportActionID = parseInt(`${Date.now()}${randomNumber}`, 10);

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -2,7 +2,6 @@ import moment from 'moment';
 import _ from 'underscore';
 import lodashGet from 'lodash.get';
 import ExpensiMark from 'expensify-common/lib/ExpensiMark';
-import Str from 'expensify-common/lib/str';
 import Onyx from 'react-native-onyx';
 import ONYXKEYS from '../../ONYXKEYS';
 import * as Pusher from '../Pusher/pusher';

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -590,7 +590,7 @@ function addAction(reportID, text, file) {
     // number so that the probability of someone else having the same optimisticReportActionID is extremely low even
     // if they left the comment at the same moment as another user or the same report. The random number is 3 digits
     // because if we go any higher JS will convert them to 0's in optimisticReportActionID.
-    const randomNumber = Math.floor((Math.random() * (999 - 100)) + 999);
+    const randomNumber = Math.floor((Math.random() * (999 - 100)) + 100);
     const optimisticReportActionID = parseInt(`${Date.now()}${randomNumber}`, 10);
 
     // Store the optimistic action ID on the report the comment was added to. It will be removed later when refetching

--- a/src/pages/home/report/ReportActionPropTypes.js
+++ b/src/pages/home/report/ReportActionPropTypes.js
@@ -9,12 +9,8 @@ export default {
     // Person who created the action
     person: PropTypes.arrayOf(ReportActionFragmentPropTypes).isRequired,
 
-    // ID of the report action. Can be either a number or a string since
-    // temporary report action IDs are unique strings generated in the client.
-    sequenceNumber: PropTypes.oneOfType([
-        PropTypes.number,
-        PropTypes.string,
-    ]).isRequired,
+    // ID of the report action
+    sequenceNumber: PropTypes.number.isRequired,
 
     // Unix timestamp
     timestamp: PropTypes.number.isRequired,


### PR DESCRIPTION
Added more context to why i've kept it as numbers [here](https://github.com/Expensify/Expensify/issues/152504#issuecomment-772723387) instead of changing everything to string. Let me know what you think and if you think I have missed something to test.

### Details
<Explanation of the change or anything fishy that is going on>

### Fixed Issues
<Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing>
Fixes https://github.com/Expensify/Expensify/issues/152504

### Tests
1. Have e.cash open in two browsers signed into two different accounts. (one of the browser should be in incognito)
2. Send a message from one user to another.
3. Confirm they are sent a received just fine and are in order.

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
