### PR TITLE
Try to use ES6 imports instead of CJS

### DIFF
--- a/.github/actions/bumpVersion/bumpVersion.js
+++ b/.github/actions/bumpVersion/bumpVersion.js
@@ -1,67 +1,74 @@
-const {exec} = require('child_process');
-const fs = require('fs');
-const core = require('@actions/core');
-const github = require('@actions/github');
+import {exec} from 'child_process';
+import core from '@actions/core';
+import github from '@actions/github';
 
 // Use Github Actions' default environment variables to get repo information
 // https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables
 const [repoOwner, repoName] = process.env.GITHUB_REPOSITORY.split('/');
+console.log(repoOwner, repoName);
+exec('echo "Hello world!"');
 
-const MAX_RETRIES = 10;
-let errCount = 0;
-let shouldRetry;
+const octokit = github.getOctokit(core.getInput('GITHUB_TOKEN', {required: true}));
+const tags = octokit.repos.listTags({
+    owner: repoOwner,
+    repo: repoName,
+}).then((result) => console.log('Tags:', result));
 
-do {
-    shouldRetry = false;
-    exec('npm version prerelease -m "Update version to %s"', (err, stdout, stderr) => {
-        console.log(stdout);
-        if (err) {
-            console.log(stderr);
-
-            // It's possible that two PRs were merged in rapid succession.
-            // In this case, both PRs will attempt to update to the same npm version.
-            // This will cause the deploy to fail with an exit code 128, saying the git tag for that version already exists.
-            if (errCount < MAX_RETRIES) {
-                console.log(
-                    'Err: npm version conflict, attempting to automatically resolve',
-                    `retryCount: ${++errCount}`,
-                );
-                shouldRetry = true;
-                const {version} = JSON.parse(fs.readFileSync('./package.json'));
-                const currentPatchVersion = `v${version.slice(0, -4)}`
-                console.log('Current patch version:', currentPatchVersion);
-
-                // Get the highest build version git tag from the repo
-                console.log('Fetching tags from github...');
-                const octokit = github.getOctokit(core.getInput('GITHUB_TOKEN', {required: true}));
-                octokit.repos.listTags({
-                    owner: repoOwner,
-                    repo: repoName,
-                })
-                    .then(response => {
-                        const tags = response.data.map(tag => tag.name);
-                        console.log('Tags: ', tags);
-                        const highestBuildNumber = Math.max(
-                            ...(tags
-                                .filter(tag => tag.startsWith(currentPatchVersion))
-                                .map(tag => tag.split('-')[1])
-                            )
-                        );
-                        console.log('Highest build number from current patch version:', highestBuildNumber);
-
-                        const newBuildNumber = `${currentPatchVersion}-${highestBuildNumber + 1}`;
-                        console.log(`Setting npm version for this PR to ${newBuildNumber}`);
-                        exec(`npm version ${newBuildNumber} -m "Update version to ${newBuildNumber}"`, (err, stdout, stderr) => {
-                            console.log(stdout);
-                            if (err) {
-                                console.log(stderr);
-                            }
-                        });
-                    })
-                    .catch(exception => core.setFailed(exception))
-            } else {
-                core.setFailed(err);
-            }
-        }
-    });
-} while (shouldRetry);
+// const MAX_RETRIES = 10;
+// let errCount = 0;
+// let shouldRetry;
+//
+// do {
+//     shouldRetry = false;
+//     exec('npm version prerelease -m "Update version to %s"', (err, stdout, stderr) => {
+//         console.log(stdout);
+//         if (err) {
+//             console.log(stderr);
+//
+//             // It's possible that two PRs were merged in rapid succession.
+//             // In this case, both PRs will attempt to update to the same npm version.
+//             // This will cause the deploy to fail with an exit code 128, saying the git tag for that version already exists.
+//             if (errCount < MAX_RETRIES) {
+//                 console.log(
+//                     'Err: npm version conflict, attempting to automatically resolve',
+//                     `retryCount: ${++errCount}`,
+//                 );
+//                 shouldRetry = true;
+//                 const {version} = JSON.parse(fs.readFileSync('./package.json'));
+//                 const currentPatchVersion = `v${version.slice(0, -4)}`
+//                 console.log('Current patch version:', currentPatchVersion);
+//
+//                 // Get the highest build version git tag from the repo
+//                 console.log('Fetching tags from github...');
+//                 const octokit = github.getOctokit(core.getInput('GITHUB_TOKEN', {required: true}));
+//                 octokit.repos.listTags({
+//                     owner: repoOwner,
+//                     repo: repoName,
+//                 })
+//                     .then(response => {
+//                         const tags = response.data.map(tag => tag.name);
+//                         console.log('Tags: ', tags);
+//                         const highestBuildNumber = Math.max(
+//                             ...(tags
+//                                 .filter(tag => tag.startsWith(currentPatchVersion))
+//                                 .map(tag => tag.split('-')[1])
+//                             )
+//                         );
+//                         console.log('Highest build number from current patch version:', highestBuildNumber);
+//
+//                         const newBuildNumber = `${currentPatchVersion}-${highestBuildNumber + 1}`;
+//                         console.log(`Setting npm version for this PR to ${newBuildNumber}`);
+//                         exec(`npm version ${newBuildNumber} -m "Update version to ${newBuildNumber}"`, (err, stdout, stderr) => {
+//                             console.log(stdout);
+//                             if (err) {
+//                                 console.log(stderr);
+//                             }
+//                         });
+//                     })
+//                     .catch(exception => core.setFailed(exception))
+//             } else {
+//                 core.setFailed(err);
+//             }
+//         }
+//     });
+// } while (shouldRetry);

--- a/.github/actions/bumpVersion/bumpVersion.js
+++ b/.github/actions/bumpVersion/bumpVersion.js
@@ -1,74 +1,67 @@
 import {exec} from 'child_process';
+import * as fs from 'fs';
 import * as core from '@actions/core';
 import * as github from '@actions/github';
 
 // Use Github Actions' default environment variables to get repo information
 // https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables
 const [repoOwner, repoName] = process.env.GITHUB_REPOSITORY.split('/');
-console.log(repoOwner, repoName);
-exec('echo "Hello world!"');
 
-const octokit = github.getOctokit(core.getInput('GITHUB_TOKEN', {required: true}));
-const tags = octokit.repos.listTags({
-    owner: repoOwner,
-    repo: repoName,
-}).then((result) => console.log('Tags:', result));
+const MAX_RETRIES = 10;
+let errCount = 0;
+let shouldRetry;
 
-// const MAX_RETRIES = 10;
-// let errCount = 0;
-// let shouldRetry;
-//
-// do {
-//     shouldRetry = false;
-//     exec('npm version prerelease -m "Update version to %s"', (err, stdout, stderr) => {
-//         console.log(stdout);
-//         if (err) {
-//             console.log(stderr);
-//
-//             // It's possible that two PRs were merged in rapid succession.
-//             // In this case, both PRs will attempt to update to the same npm version.
-//             // This will cause the deploy to fail with an exit code 128, saying the git tag for that version already exists.
-//             if (errCount < MAX_RETRIES) {
-//                 console.log(
-//                     'Err: npm version conflict, attempting to automatically resolve',
-//                     `retryCount: ${++errCount}`,
-//                 );
-//                 shouldRetry = true;
-//                 const {version} = JSON.parse(fs.readFileSync('./package.json'));
-//                 const currentPatchVersion = `v${version.slice(0, -4)}`
-//                 console.log('Current patch version:', currentPatchVersion);
-//
-//                 // Get the highest build version git tag from the repo
-//                 console.log('Fetching tags from github...');
-//                 const octokit = github.getOctokit(core.getInput('GITHUB_TOKEN', {required: true}));
-//                 octokit.repos.listTags({
-//                     owner: repoOwner,
-//                     repo: repoName,
-//                 })
-//                     .then(response => {
-//                         const tags = response.data.map(tag => tag.name);
-//                         console.log('Tags: ', tags);
-//                         const highestBuildNumber = Math.max(
-//                             ...(tags
-//                                 .filter(tag => tag.startsWith(currentPatchVersion))
-//                                 .map(tag => tag.split('-')[1])
-//                             )
-//                         );
-//                         console.log('Highest build number from current patch version:', highestBuildNumber);
-//
-//                         const newBuildNumber = `${currentPatchVersion}-${highestBuildNumber + 1}`;
-//                         console.log(`Setting npm version for this PR to ${newBuildNumber}`);
-//                         exec(`npm version ${newBuildNumber} -m "Update version to ${newBuildNumber}"`, (err, stdout, stderr) => {
-//                             console.log(stdout);
-//                             if (err) {
-//                                 console.log(stderr);
-//                             }
-//                         });
-//                     })
-//                     .catch(exception => core.setFailed(exception))
-//             } else {
-//                 core.setFailed(err);
-//             }
-//         }
-//     });
-// } while (shouldRetry);
+do {
+    shouldRetry = false;
+    exec('npm version prerelease -m "Update version to %s"', (err, stdout, stderr) => {
+        console.log(stdout);
+        if (err) {
+            console.log(stderr);
+
+            // It's possible that two PRs were merged in rapid succession.
+            // In this case, both PRs will attempt to update to the same npm version.
+            // This will cause the deploy to fail with an exit code 128, saying the git tag for that version already exists.
+            if (errCount < MAX_RETRIES) {
+                console.log(
+                    'Err: npm version conflict, attempting to automatically resolve',
+                    `retryCount: ${++errCount}`,
+                );
+                shouldRetry = true;
+                const {version} = JSON.parse(fs.readFileSync('./package.json'));
+                const currentPatchVersion = `v${version.slice(0, -4)}`
+                console.log('Current patch version:', currentPatchVersion);
+
+                // Get the highest build version git tag from the repo
+                console.log('Fetching tags from github...');
+                const octokit = github.getOctokit(core.getInput('GITHUB_TOKEN', {required: true}));
+                octokit.repos.listTags({
+                    owner: repoOwner,
+                    repo: repoName,
+                })
+                    .then(response => {
+                        const tags = response.data.map(tag => tag.name);
+                        console.log('Tags: ', tags);
+                        const highestBuildNumber = Math.max(
+                            ...(tags
+                                .filter(tag => tag.startsWith(currentPatchVersion))
+                                .map(tag => tag.split('-')[1])
+                            )
+                        );
+                        console.log('Highest build number from current patch version:', highestBuildNumber);
+
+                        const newBuildNumber = `${currentPatchVersion}-${highestBuildNumber + 1}`;
+                        console.log(`Setting npm version for this PR to ${newBuildNumber}`);
+                        exec(`npm version ${newBuildNumber} -m "Update version to ${newBuildNumber}"`, (err, stdout, stderr) => {
+                            console.log(stdout);
+                            if (err) {
+                                console.log(stderr);
+                            }
+                        });
+                    })
+                    .catch(exception => core.setFailed(exception))
+            } else {
+                core.setFailed(err);
+            }
+        }
+    });
+} while (shouldRetry);

--- a/.github/actions/bumpVersion/bumpVersion.js
+++ b/.github/actions/bumpVersion/bumpVersion.js
@@ -1,6 +1,6 @@
 import {exec} from 'child_process';
-import core from '@actions/core';
-import github from '@actions/github';
+import * as core from '@actions/core';
+import * as github from '@actions/github';
 
 // Use Github Actions' default environment variables to get repo information
 // https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables

--- a/.github/actions/bumpVersion/index.js
+++ b/.github/actions/bumpVersion/index.js
@@ -16,12 +16,8 @@ __nccwpck_require__.r(__webpack_exports__);
 const external_child_process_namespaceObject = require("child_process");;
 // EXTERNAL MODULE: ./node_modules/@actions/core/lib/core.js
 var core = __nccwpck_require__(2186);
-var core_default = /*#__PURE__*/__nccwpck_require__.n(core);
-
 // EXTERNAL MODULE: ./node_modules/@actions/github/lib/github.js
 var github = __nccwpck_require__(5438);
-var github_default = /*#__PURE__*/__nccwpck_require__.n(github);
-
 // CONCATENATED MODULE: ./.github/actions/bumpVersion/bumpVersion.js
 
 
@@ -33,7 +29,7 @@ const [repoOwner, repoName] = process.env.GITHUB_REPOSITORY.split('/');
 console.log(repoOwner, repoName);
 (0,external_child_process_namespaceObject.exec)('echo "Hello world!"');
 
-const octokit = github_default().getOctokit(core_default().getInput('GITHUB_TOKEN', {required: true}));
+const octokit = github.getOctokit(core.getInput('GITHUB_TOKEN', {required: true}));
 const tags = octokit.repos.listTags({
     owner: repoOwner,
     repo: repoName,
@@ -9282,35 +9278,6 @@ module.exports = require("zlib");;
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/compat get default export */
-/******/ 	(() => {
-/******/ 		// getDefaultExport function for compatibility with non-harmony modules
-/******/ 		__nccwpck_require__.n = (module) => {
-/******/ 			var getter = module && module.__esModule ?
-/******/ 				() => module['default'] :
-/******/ 				() => module;
-/******/ 			__nccwpck_require__.d(getter, { a: getter });
-/******/ 			return getter;
-/******/ 		};
-/******/ 	})();
-/******/ 	
-/******/ 	/* webpack/runtime/define property getters */
-/******/ 	(() => {
-/******/ 		// define getter functions for harmony exports
-/******/ 		__nccwpck_require__.d = (exports, definition) => {
-/******/ 			for(var key in definition) {
-/******/ 				if(__nccwpck_require__.o(definition, key) && !__nccwpck_require__.o(exports, key)) {
-/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-/******/ 				}
-/******/ 			}
-/******/ 		};
-/******/ 	})();
-/******/ 	
-/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
-/******/ 	(() => {
-/******/ 		__nccwpck_require__.o = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop)
-/******/ 	})();
-/******/ 	
 /******/ 	/* webpack/runtime/make namespace object */
 /******/ 	(() => {
 /******/ 		// define __esModule on exports

--- a/.github/actions/bumpVersion/index.js
+++ b/.github/actions/bumpVersion/index.js
@@ -5,76 +5,98 @@ module.exports =
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 2407:
-/***/ ((__unused_webpack_module, __unused_webpack_exports, __nccwpck_require__) => {
+/***/ 674:
+/***/ ((__unused_webpack_module, __webpack_exports__, __nccwpck_require__) => {
 
-const {exec} = __nccwpck_require__(3129);
-const fs = __nccwpck_require__(5747);
-const core = __nccwpck_require__(2186);
-const github = __nccwpck_require__(5438);
+"use strict";
+// ESM COMPAT FLAG
+__nccwpck_require__.r(__webpack_exports__);
+
+// CONCATENATED MODULE: external "child_process"
+const external_child_process_namespaceObject = require("child_process");;
+// EXTERNAL MODULE: ./node_modules/@actions/core/lib/core.js
+var core = __nccwpck_require__(2186);
+var core_default = /*#__PURE__*/__nccwpck_require__.n(core);
+
+// EXTERNAL MODULE: ./node_modules/@actions/github/lib/github.js
+var github = __nccwpck_require__(5438);
+var github_default = /*#__PURE__*/__nccwpck_require__.n(github);
+
+// CONCATENATED MODULE: ./.github/actions/bumpVersion/bumpVersion.js
+
+
+
 
 // Use Github Actions' default environment variables to get repo information
 // https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables
 const [repoOwner, repoName] = process.env.GITHUB_REPOSITORY.split('/');
+console.log(repoOwner, repoName);
+(0,external_child_process_namespaceObject.exec)('echo "Hello world!"');
 
-const MAX_RETRIES = 10;
-let errCount = 0;
-let shouldRetry;
+const octokit = github_default().getOctokit(core_default().getInput('GITHUB_TOKEN', {required: true}));
+const tags = octokit.repos.listTags({
+    owner: repoOwner,
+    repo: repoName,
+}).then((result) => console.log('Tags:', result));
 
-do {
-    shouldRetry = false;
-    exec('npm version prerelease -m "Update version to %s"', (err, stdout, stderr) => {
-        console.log(stdout);
-        if (err) {
-            console.log(stderr);
-
-            // It's possible that two PRs were merged in rapid succession.
-            // In this case, both PRs will attempt to update to the same npm version.
-            // This will cause the deploy to fail with an exit code 128, saying the git tag for that version already exists.
-            if (errCount < MAX_RETRIES) {
-                console.log(
-                    'Err: npm version conflict, attempting to automatically resolve',
-                    `retryCount: ${++errCount}`,
-                );
-                shouldRetry = true;
-                const {version} = JSON.parse(fs.readFileSync('./package.json'));
-                const currentPatchVersion = `v${version.slice(0, -4)}`
-                console.log('Current patch version:', currentPatchVersion);
-
-                // Get the highest build version git tag from the repo
-                console.log('Fetching tags from github...');
-                const octokit = github.getOctokit(core.getInput('GITHUB_TOKEN', {required: true}));
-                octokit.repos.listTags({
-                    owner: repoOwner,
-                    repo: repoName,
-                })
-                    .then(response => {
-                        const tags = response.data.map(tag => tag.name);
-                        console.log('Tags: ', tags);
-                        const highestBuildNumber = Math.max(
-                            ...(tags
-                                .filter(tag => tag.startsWith(currentPatchVersion))
-                                .map(tag => tag.split('-')[1])
-                            )
-                        );
-                        console.log('Highest build number from current patch version:', highestBuildNumber);
-
-                        const newBuildNumber = `${currentPatchVersion}-${highestBuildNumber + 1}`;
-                        console.log(`Setting npm version for this PR to ${newBuildNumber}`);
-                        exec(`npm version ${newBuildNumber} -m "Update version to ${newBuildNumber}"`, (err, stdout, stderr) => {
-                            console.log(stdout);
-                            if (err) {
-                                console.log(stderr);
-                            }
-                        });
-                    })
-                    .catch(exception => core.setFailed(exception))
-            } else {
-                core.setFailed(err);
-            }
-        }
-    });
-} while (shouldRetry);
+// const MAX_RETRIES = 10;
+// let errCount = 0;
+// let shouldRetry;
+//
+// do {
+//     shouldRetry = false;
+//     exec('npm version prerelease -m "Update version to %s"', (err, stdout, stderr) => {
+//         console.log(stdout);
+//         if (err) {
+//             console.log(stderr);
+//
+//             // It's possible that two PRs were merged in rapid succession.
+//             // In this case, both PRs will attempt to update to the same npm version.
+//             // This will cause the deploy to fail with an exit code 128, saying the git tag for that version already exists.
+//             if (errCount < MAX_RETRIES) {
+//                 console.log(
+//                     'Err: npm version conflict, attempting to automatically resolve',
+//                     `retryCount: ${++errCount}`,
+//                 );
+//                 shouldRetry = true;
+//                 const {version} = JSON.parse(fs.readFileSync('./package.json'));
+//                 const currentPatchVersion = `v${version.slice(0, -4)}`
+//                 console.log('Current patch version:', currentPatchVersion);
+//
+//                 // Get the highest build version git tag from the repo
+//                 console.log('Fetching tags from github...');
+//                 const octokit = github.getOctokit(core.getInput('GITHUB_TOKEN', {required: true}));
+//                 octokit.repos.listTags({
+//                     owner: repoOwner,
+//                     repo: repoName,
+//                 })
+//                     .then(response => {
+//                         const tags = response.data.map(tag => tag.name);
+//                         console.log('Tags: ', tags);
+//                         const highestBuildNumber = Math.max(
+//                             ...(tags
+//                                 .filter(tag => tag.startsWith(currentPatchVersion))
+//                                 .map(tag => tag.split('-')[1])
+//                             )
+//                         );
+//                         console.log('Highest build number from current patch version:', highestBuildNumber);
+//
+//                         const newBuildNumber = `${currentPatchVersion}-${highestBuildNumber + 1}`;
+//                         console.log(`Setting npm version for this PR to ${newBuildNumber}`);
+//                         exec(`npm version ${newBuildNumber} -m "Update version to ${newBuildNumber}"`, (err, stdout, stderr) => {
+//                             console.log(stdout);
+//                             if (err) {
+//                                 console.log(stderr);
+//                             }
+//                         });
+//                     })
+//                     .catch(exception => core.setFailed(exception))
+//             } else {
+//                 core.setFailed(err);
+//             }
+//         }
+//     });
+// } while (shouldRetry);
 
 
 /***/ }),
@@ -9124,14 +9146,6 @@ module.exports = require("buffer");;
 
 /***/ }),
 
-/***/ 3129:
-/***/ ((module) => {
-
-"use strict";
-module.exports = require("child_process");;
-
-/***/ }),
-
 /***/ 8614:
 /***/ ((module) => {
 
@@ -9268,12 +9282,52 @@ module.exports = require("zlib");;
 /******/ 	}
 /******/ 	
 /************************************************************************/
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	(() => {
+/******/ 		// getDefaultExport function for compatibility with non-harmony modules
+/******/ 		__nccwpck_require__.n = (module) => {
+/******/ 			var getter = module && module.__esModule ?
+/******/ 				() => module['default'] :
+/******/ 				() => module;
+/******/ 			__nccwpck_require__.d(getter, { a: getter });
+/******/ 			return getter;
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	(() => {
+/******/ 		// define getter functions for harmony exports
+/******/ 		__nccwpck_require__.d = (exports, definition) => {
+/******/ 			for(var key in definition) {
+/******/ 				if(__nccwpck_require__.o(definition, key) && !__nccwpck_require__.o(exports, key)) {
+/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 				}
+/******/ 			}
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	(() => {
+/******/ 		__nccwpck_require__.o = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop)
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/make namespace object */
+/******/ 	(() => {
+/******/ 		// define __esModule on exports
+/******/ 		__nccwpck_require__.r = (exports) => {
+/******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 			}
+/******/ 			Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 		};
+/******/ 	})();
+/******/ 	
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
 /******/ 	__nccwpck_require__.ab = __dirname + "/";/************************************************************************/
 /******/ 	// module exports must be returned from runtime so entry inlining is disabled
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
-/******/ 	return __nccwpck_require__(2407);
+/******/ 	return __nccwpck_require__(674);
 /******/ })()
 ;

--- a/.github/actions/bumpVersion/index.js
+++ b/.github/actions/bumpVersion/index.js
@@ -14,6 +14,8 @@ __nccwpck_require__.r(__webpack_exports__);
 
 // CONCATENATED MODULE: external "child_process"
 const external_child_process_namespaceObject = require("child_process");;
+// EXTERNAL MODULE: external "fs"
+var external_fs_ = __nccwpck_require__(5747);
 // EXTERNAL MODULE: ./node_modules/@actions/core/lib/core.js
 var core = __nccwpck_require__(2186);
 // EXTERNAL MODULE: ./node_modules/@actions/github/lib/github.js
@@ -23,76 +25,69 @@ var github = __nccwpck_require__(5438);
 
 
 
+
 // Use Github Actions' default environment variables to get repo information
 // https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables
 const [repoOwner, repoName] = process.env.GITHUB_REPOSITORY.split('/');
-console.log(repoOwner, repoName);
-(0,external_child_process_namespaceObject.exec)('echo "Hello world!"');
 
-const octokit = github.getOctokit(core.getInput('GITHUB_TOKEN', {required: true}));
-const tags = octokit.repos.listTags({
-    owner: repoOwner,
-    repo: repoName,
-}).then((result) => console.log('Tags:', result));
+const MAX_RETRIES = 10;
+let errCount = 0;
+let shouldRetry;
 
-// const MAX_RETRIES = 10;
-// let errCount = 0;
-// let shouldRetry;
-//
-// do {
-//     shouldRetry = false;
-//     exec('npm version prerelease -m "Update version to %s"', (err, stdout, stderr) => {
-//         console.log(stdout);
-//         if (err) {
-//             console.log(stderr);
-//
-//             // It's possible that two PRs were merged in rapid succession.
-//             // In this case, both PRs will attempt to update to the same npm version.
-//             // This will cause the deploy to fail with an exit code 128, saying the git tag for that version already exists.
-//             if (errCount < MAX_RETRIES) {
-//                 console.log(
-//                     'Err: npm version conflict, attempting to automatically resolve',
-//                     `retryCount: ${++errCount}`,
-//                 );
-//                 shouldRetry = true;
-//                 const {version} = JSON.parse(fs.readFileSync('./package.json'));
-//                 const currentPatchVersion = `v${version.slice(0, -4)}`
-//                 console.log('Current patch version:', currentPatchVersion);
-//
-//                 // Get the highest build version git tag from the repo
-//                 console.log('Fetching tags from github...');
-//                 const octokit = github.getOctokit(core.getInput('GITHUB_TOKEN', {required: true}));
-//                 octokit.repos.listTags({
-//                     owner: repoOwner,
-//                     repo: repoName,
-//                 })
-//                     .then(response => {
-//                         const tags = response.data.map(tag => tag.name);
-//                         console.log('Tags: ', tags);
-//                         const highestBuildNumber = Math.max(
-//                             ...(tags
-//                                 .filter(tag => tag.startsWith(currentPatchVersion))
-//                                 .map(tag => tag.split('-')[1])
-//                             )
-//                         );
-//                         console.log('Highest build number from current patch version:', highestBuildNumber);
-//
-//                         const newBuildNumber = `${currentPatchVersion}-${highestBuildNumber + 1}`;
-//                         console.log(`Setting npm version for this PR to ${newBuildNumber}`);
-//                         exec(`npm version ${newBuildNumber} -m "Update version to ${newBuildNumber}"`, (err, stdout, stderr) => {
-//                             console.log(stdout);
-//                             if (err) {
-//                                 console.log(stderr);
-//                             }
-//                         });
-//                     })
-//                     .catch(exception => core.setFailed(exception))
-//             } else {
-//                 core.setFailed(err);
-//             }
-//         }
-//     });
-// } while (shouldRetry);
+do {
+    shouldRetry = false;
+    (0,external_child_process_namespaceObject.exec)('npm version prerelease -m "Update version to %s"', (err, stdout, stderr) => {
+        console.log(stdout);
+        if (err) {
+            console.log(stderr);
+
+            // It's possible that two PRs were merged in rapid succession.
+            // In this case, both PRs will attempt to update to the same npm version.
+            // This will cause the deploy to fail with an exit code 128, saying the git tag for that version already exists.
+            if (errCount < MAX_RETRIES) {
+                console.log(
+                    'Err: npm version conflict, attempting to automatically resolve',
+                    `retryCount: ${++errCount}`,
+                );
+                shouldRetry = true;
+                const {version} = JSON.parse(external_fs_.readFileSync('./package.json'));
+                const currentPatchVersion = `v${version.slice(0, -4)}`
+                console.log('Current patch version:', currentPatchVersion);
+
+                // Get the highest build version git tag from the repo
+                console.log('Fetching tags from github...');
+                const octokit = github.getOctokit(core.getInput('GITHUB_TOKEN', {required: true}));
+                octokit.repos.listTags({
+                    owner: repoOwner,
+                    repo: repoName,
+                })
+                    .then(response => {
+                        const tags = response.data.map(tag => tag.name);
+                        console.log('Tags: ', tags);
+                        const highestBuildNumber = Math.max(
+                            ...(tags
+                                .filter(tag => tag.startsWith(currentPatchVersion))
+                                .map(tag => tag.split('-')[1])
+                            )
+                        );
+                        console.log('Highest build number from current patch version:', highestBuildNumber);
+
+                        const newBuildNumber = `${currentPatchVersion}-${highestBuildNumber + 1}`;
+                        console.log(`Setting npm version for this PR to ${newBuildNumber}`);
+                        (0,external_child_process_namespaceObject.exec)(`npm version ${newBuildNumber} -m "Update version to ${newBuildNumber}"`, (err, stdout, stderr) => {
+                            console.log(stdout);
+                            if (err) {
+                                console.log(stderr);
+                            }
+                        });
+                    })
+                    .catch(exception => core.setFailed(exception))
+            } else {
+                core.setFailed(err);
+            }
+        }
+    });
+} while (shouldRetry);
 
 
 /***/ }),

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
             - run: npm install
 
             - name: Generate version
-              uses: Expensify/Expensify.cash/.github/actions/bumpVersion@4f086804f613ab6ef578b25b37a8ad6f175fa30e
+              uses: Expensify/Expensify.cash/.github/actions/bumpVersion@77f88b4a059392a972d6a7156f54909eca4d2f60
               with:
                   GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,11 +15,6 @@ jobs:
 
             - run: npm install
 
-            - name: Generate version
-              uses: Expensify/Expensify.cash/.github/actions/bumpVersion@77f88b4a059392a972d6a7156f54909eca4d2f60
-              with:
-                  GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
-
             - run: npm run test
               env:
                   CI: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,11 @@ jobs:
 
             - run: npm install
 
+            - name: Generate version
+              uses: Expensify/Expensify.cash/.github/actions/bumpVersion@master
+              with:
+                  GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+
             - run: npm run test
               env:
                   CI: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
             - run: npm install
 
             - name: Generate version
-              uses: Expensify/Expensify.cash/.github/actions/bumpVersion@master
+              uses: Expensify/Expensify.cash/.github/actions/bumpVersion@4f086804f613ab6ef578b25b37a8ad6f175fa30e
               with:
                   GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 


### PR DESCRIPTION
### Details
We're experimenting here to see if we can use ES6 imports in a Github Action.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/153378

### Tests
This PR _is_ the test 🤯

I tested this by taking away most of the functionality of the `bumpVersion` action (just fetch tags using the github client sdk and then console.log the results) and adding it to the `test` workflow so it triggered whenever I pushed code to this PR. Since that worked with ES6 module imports, it's safe to assume that this will work just the same. But the only way to know for sure is to merge this PR.

### Tested On
- Github