### PR TITLE
Fix tooltip after withWindowDimensions update

### DIFF
--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -1,5 +1,4 @@
-import _ from 'underscore';
-import React, {Component} from 'react';
+import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {Animated, Text, View} from 'react-native';
 import Hoverable from './Hoverable';
@@ -30,7 +29,7 @@ const defaultProps = {
     shiftVertical: 0,
 };
 
-class Tooltip extends Component {
+class Tooltip extends PureComponent {
     constructor(props) {
         super(props);
 
@@ -65,18 +64,8 @@ class Tooltip extends Component {
         this.hideTooltip = this.hideTooltip.bind(this);
     }
 
-    shouldComponentUpdate(nextProps, nextState) {
-        /*
-           We only want to re-render if props or state have changed.
-           This prevents an infinite rendering loop with the `onLayout` callback calling setState.
-           Also, we need to do a deep comparison of props using _.isEqual rather than relying on the shallow comparison
-           done by `PureComponent` because a shallow comparison would not catch changes in `props.windowDimensions`.
-         */
-        return !(_.isEqual(this.props, nextProps) && _.isEqual(this.state, nextState));
-    }
-
     componentDidUpdate(prevProps) {
-        if (!_.isEqual(this.props.windowDimensions, prevProps.windowDimensions)) {
+        if (this.props.windowWidth !== prevProps.windowWidth || this.props.windowHeight !== prevProps.windowHeight) {
             this.getWrapperPosition()
                 .then(({x, y}) => {
                     this.setState({xOffset: x, yOffset: y});
@@ -153,7 +142,7 @@ class Tooltip extends Component {
             pointerStyle,
         } = getTooltipStyles(
             this.animation,
-            this.props.windowDimensions.width,
+            this.props.windowWidth,
             this.state.xOffset,
             this.state.yOffset,
             this.state.wrapperWidth,


### PR DESCRIPTION
The `withWindowDimensions` HOC was recently updated, and this component wasn't updated to reflect the changes.

### Details
Tooltip is broken on master because it's using out-of-date `windowDimensionsPropTypes`

### Fixed Issues
n/a – Just extracting changes from another PR that uses Tooltip.

### Tests
1. Wrap the tooltip component around a component.
2. Run the application, verify that the tooltip works and doesn't crash the app.

### Tested On

- [x] Web
- [ ] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android

### Screenshots

#### Web
![image](https://user-images.githubusercontent.com/47436092/106944596-a3fbef00-66db-11eb-9e22-ce0a94eee41d.png)

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
![image](https://user-images.githubusercontent.com/47436092/106944687-c261ea80-66db-11eb-9700-1515f069039e.png)


#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
