### PR TITLE
Implemented New Chat Page

### DIFF
--- a/src/ROUTES.js
+++ b/src/ROUTES.js
@@ -5,6 +5,7 @@ export default {
     HOME: '/home',
     SETTINGS: '/settings',
     NEW_GROUP: '/new/group',
+    NEW_CHAT: '/new/chat',
     REPORT: '/r/:reportID',
     getReportRoute: reportID => `/r/${reportID}`,
     ROOT: '/',

--- a/src/components/CreateMenu.js
+++ b/src/components/CreateMenu.js
@@ -37,9 +37,10 @@ class CreateMenu extends PureComponent {
 
     /**
      * Sets a new function to execute when the modal hides
+     * @param {Function} callback The function to be called on modal hide
      */
-    setOnModalHide() {
-        this.onModalHide = () => redirect(ROUTES.NEW_GROUP);
+    setOnModalHide(callback) {
+        this.onModalHide = callback;
     }
 
     /**
@@ -53,11 +54,15 @@ class CreateMenu extends PureComponent {
         // This format allows to set individual callbacks to each item
         // while including mutual callbacks first
         const menuItemData = [
-            {icon: ChatBubble, text: 'New Chat', onPress: () => {}},
+            {
+                icon: ChatBubble,
+                text: 'New Chat',
+                onPress: () => this.setOnModalHide(() => redirect(ROUTES.NEW_CHAT)),
+            },
             {
                 icon: Users,
                 text: 'New Group',
-                onPress: () => this.setOnModalHide(),
+                onPress: () => this.setOnModalHide(() => redirect(ROUTES.NEW_GROUP)),
             },
         ].map(item => ({
             ...item,

--- a/src/pages/NewChatPage.js
+++ b/src/pages/NewChatPage.js
@@ -1,0 +1,180 @@
+import React, {Component} from 'react';
+import {View} from 'react-native';
+import PropTypes from 'prop-types';
+import {withOnyx} from 'react-native-onyx';
+import OptionsSelector from '../components/OptionsSelector';
+import {getNewChatOptions} from '../libs/OptionsListUtils';
+import ONYXKEYS from '../ONYXKEYS';
+import styles from '../styles/styles';
+import {fetchOrCreateChatReport} from '../libs/actions/Report';
+import KeyboardSpacer from '../components/KeyboardSpacer';
+import withWindowDimensions, {windowDimensionsPropTypes} from '../components/withWindowDimensions';
+import {hide as hideSidebar} from '../libs/actions/Sidebar';
+
+const personalDetailsPropTypes = PropTypes.shape({
+    // The login of the person (either email or phone number)
+    login: PropTypes.string.isRequired,
+
+    // The URL of the person's avatar (there should already be a default avatarURL if
+    // the person doesn't have their own avatar uploaded yet)
+    avatarURL: PropTypes.string.isRequired,
+
+    // This is either the user's full name, or their login if full name is an empty string
+    displayName: PropTypes.string.isRequired,
+});
+
+const propTypes = {
+    // All of the personal details for everyone
+    personalDetails: PropTypes.objectOf(personalDetailsPropTypes).isRequired,
+
+    // All reports shared with the user
+    reports: PropTypes.shape({
+        reportID: PropTypes.number,
+        reportName: PropTypes.string,
+    }).isRequired,
+
+    // Session of currently logged in user
+    session: PropTypes.shape({
+        email: PropTypes.string.isRequired,
+    }).isRequired,
+
+    ...windowDimensionsPropTypes,
+};
+
+class NewChatPage extends Component {
+    constructor(props) {
+        super(props);
+
+        this.createNewChat = this.createNewChat.bind(this);
+
+        const {
+            personalDetails,
+            userToInvite,
+        } = getNewChatOptions(
+            props.reports,
+            props.personalDetails,
+            '',
+        );
+
+        this.state = {
+            searchValue: '',
+            personalDetails,
+            userToInvite,
+        };
+    }
+
+    /**
+     * Helper method that returns the text to be used for the header's message and title (if any)
+     *
+     * @return {String}
+     */
+    getHeaderTitleAndMessage() {
+        const hasSelectableOptions = this.state.personalDetails.length !== 0;
+        if (!hasSelectableOptions && !this.state.userToInvite) {
+            return {
+                headerTitle: '',
+                // eslint-disable-next-line max-len
+                headerMessage: 'Don\'t see who you\'re looking for? Type their email or phone number to invite them to chat.',
+            };
+        }
+
+        return {
+            headerTitle: '',
+            headerMessage: '',
+        };
+    }
+
+    /**
+     * Returns the sections needed for the OptionsSelector
+     *
+     * @returns {Array}
+     */
+    getSections() {
+        const sections = [];
+
+        sections.push({
+            title: 'CONTACTS',
+            data: this.state.personalDetails,
+            shouldShow: this.state.personalDetails.length > 0,
+            indexOffset: sections.reduce((prev, {data}) => prev + data.length, 0),
+        });
+
+        if (this.state.userToInvite) {
+            sections.push(({
+                undefined,
+                data: [this.state.userToInvite],
+                shouldShow: true,
+                indexOffset: 0,
+            }));
+        }
+
+        return sections;
+    }
+
+    /**
+     * Creates a new chat with the option
+     * @param {Object} option
+     */
+    createNewChat(option) {
+        if (this.props.isSmallScreenWidth) {
+            hideSidebar();
+        }
+
+        fetchOrCreateChatReport([
+            this.props.session.email,
+            option.login,
+        ]);
+    }
+
+    render() {
+        const sections = this.getSections();
+        const {headerTitle, headerMessage} = this.getHeaderTitleAndMessage();
+
+        return (
+            <>
+                <View style={[styles.flex1, styles.w100]}>
+                    <OptionsSelector
+                        sections={sections}
+                        value={this.state.searchValue}
+                        onSelectRow={this.createNewChat}
+                        onChangeText={(searchValue = '') => {
+                            const {
+                                personalDetails,
+                                userToInvite,
+                            } = getNewChatOptions(
+                                this.props.reports,
+                                this.props.personalDetails,
+                                searchValue,
+                            );
+                            this.setState({
+                                searchValue,
+                                userToInvite,
+                                personalDetails,
+                            });
+                        }}
+                        headerTitle={headerTitle}
+                        headerMessage={headerMessage}
+                        hideSectionHeaders
+                        disableArrowKeysActions
+                        hideAdditionalOptionStates
+                    />
+                </View>
+                <KeyboardSpacer />
+            </>
+        );
+    }
+}
+
+NewChatPage.propTypes = propTypes;
+
+export default withWindowDimensions(withOnyx({
+    reports: {
+        key: ONYXKEYS.COLLECTION.REPORT,
+    },
+    personalDetails: {
+        key: ONYXKEYS.PERSONAL_DETAILS,
+    },
+    session: {
+        key: ONYXKEYS.SESSION,
+    },
+})(NewChatPage));

--- a/src/pages/home/HomePage.js
+++ b/src/pages/home/HomePage.js
@@ -44,6 +44,7 @@ import RightDockedModal from '../../components/RightDockedModal';
 import withWindowDimensions, {windowDimensionsPropTypes} from '../../components/withWindowDimensions';
 import compose from '../../libs/compose';
 import {getBetas} from '../../libs/actions/User';
+import NewChatPage from '../NewChatPage';
 
 const propTypes = {
     isSidebarShown: PropTypes.bool,
@@ -281,7 +282,14 @@ class HomePage extends React.Component {
                                 getSafeAreaPadding(insets),
                             ]}
                         >
-                            <Route path={[ROUTES.REPORT, ROUTES.HOME, ROUTES.SETTINGS, ROUTES.NEW_GROUP]}>
+                            <Route path={[
+                                ROUTES.REPORT,
+                                ROUTES.HOME,
+                                ROUTES.SETTINGS,
+                                ROUTES.NEW_GROUP,
+                                ROUTES.NEW_CHAT,
+                            ]}
+                            >
                                 <Animated.View style={[
                                     getNavigationMenuStyle(
                                         this.props.windowWidth,
@@ -321,6 +329,14 @@ class HomePage extends React.Component {
                                             isVisible={this.props.currentURL === ROUTES.NEW_GROUP}
                                         >
                                             <NewGroupPage />
+                                        </RightDockedModal>
+                                    )}
+                                    {this.props.currentURL === ROUTES.NEW_CHAT && (
+                                        <RightDockedModal
+                                            title="New Chat"
+                                            isVisible={this.props.currentURL === ROUTES.NEW_CHAT}
+                                        >
+                                            <NewChatPage />
                                         </RightDockedModal>
                                     )}
                                     <Main />


### PR DESCRIPTION
@marcaaron 

### Details
Implemented `NewChatPage`, which is a simplified version of the `NewGroupPage`. 
When clicking in `New Chat`, the page shows up with the list of contacts. The user is able to search (for existing or new contacts).
When one contact is pressed or clicked on, a chat starts with the selected contact.

### Fixed Issues
Fixes #1337 

### Tests
1. Press the floating action button, and then on `New Chat`;
2. If on large screens, check if a modal appears from the right. If on small screens, check if a new page shows up, covering the entire screen;
3. Try to search for an existing or a new contact;
4. Click on a contact, check if a new chat starts with him/her.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web
![web](https://i.ibb.co/JnHDrSh/web.gif)

#### Mobile Web
![web mobile](https://i.ibb.co/RgcppFH/web-mobile.gif)

#### Desktop
![desktop](https://i.ibb.co/nbRzhFT/desktop.gif)

#### iOS
![ios](https://i.ibb.co/DgxZb7n/ios.png)

#### Android
![android](https://i.ibb.co/6DxZTc4/android.png)
