### PR TITLE
Optimize Options Re-render to smooth out right docked modal animations

### DIFF
--- a/src/pages/home/sidebar/OptionRow.js
+++ b/src/pages/home/sidebar/OptionRow.js
@@ -158,4 +158,34 @@ OptionRow.defaultProps = defaultProps;
 OptionRow.displayName = 'OptionRow';
 
 // It it very important to use React.memo here so SectionList items will not unnecessarily re-render
-export default memo(OptionRow);
+export default memo(OptionRow, (prevProps, nextProps) => {
+    if (prevProps.optionIsFocused !== nextProps.optionIsFocused) {
+        return false;
+    }
+
+    if (prevProps.isSelected !== nextProps.isSelected) {
+        return false;
+    }
+
+    if (prevProps.option.isUnread !== nextProps.option.isUnread) {
+        return false;
+    }
+
+    if (prevProps.option.isUnread !== nextProps.option.isUnread) {
+        return false;
+    }
+
+    if (prevProps.option.alternateText !== nextProps.option.alternateText) {
+        return false;
+    }
+
+    if (prevProps.option.hasDraftComment !== nextProps.option.hasDraftComment) {
+        return false;
+    }
+
+    if (prevProps.option.isPinned !== nextProps.option.isPinned) {
+        return false;
+    }
+
+    return true;
+});

--- a/src/pages/home/sidebar/OptionRow.js
+++ b/src/pages/home/sidebar/OptionRow.js
@@ -187,5 +187,9 @@ export default memo(OptionRow, (prevProps, nextProps) => {
         return false;
     }
 
+    if (!_.isEqual(prevProps.option.icons, nextProps.option.icons)) {
+        return false;
+    }
+
     return true;
 });


### PR DESCRIPTION
### Details
Options in the LHN re-rendering is causing animation performance issues. This PR set us up so we are only re-rendering in certain circumstances. Might update this to pass not so deeply nested props in `option` as an alternative fix but this is proof of concept.

### Fixed Issues (Related to)
https://github.com/Expensify/Expensify.cash/issues/1358
https://github.com/Expensify/Expensify/issues/152627
And also a follow up of sorts to https://github.com/Expensify/Expensify.cash/pull/1367

### Tests

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
