### PR TITLE
Fixed Create Group button showing without selections

### DIFF
--- a/src/pages/NewGroupPage.js
+++ b/src/pages/NewGroupPage.js
@@ -236,21 +236,23 @@ class NewGroupPage extends Component {
                         disableArrowKeysActions
                         hideAdditionalOptionStates
                     />
-                    <View style={[styles.ph5, styles.pb5]}>
-                        <Pressable
-                            onPress={this.createGroup}
-                            style={({hovered}) => [
-                                styles.button,
-                                styles.buttonSuccess,
-                                styles.w100,
-                                hovered && styles.buttonSuccessHovered,
-                            ]}
-                        >
-                            <Text style={[styles.buttonText, styles.buttonSuccessText]}>
-                                Create Group
-                            </Text>
-                        </Pressable>
-                    </View>
+                    {this.state.selectedOptions?.length > 0 && (
+                        <View style={[styles.ph5, styles.pb5]}>
+                            <Pressable
+                                onPress={this.createGroup}
+                                style={({hovered}) => [
+                                    styles.button,
+                                    styles.buttonSuccess,
+                                    styles.w100,
+                                    hovered && styles.buttonSuccessHovered,
+                                ]}
+                            >
+                                <Text style={[styles.buttonText, styles.buttonSuccessText]}>
+                                    Create Group
+                                </Text>
+                            </Pressable>
+                        </View>
+                    )}
                 </View>
                 <KeyboardSpacer />
             </>


### PR DESCRIPTION
@trjExpensify @marcaaron 

### Details
Stopped rendering the `Create Group` button when there is no contact selected.
Left the check for `userLogins.length < 1` in the `createGroup()` function. A cheap double check is never a bad idea.

### Fixed Issues
Fixes #1418 

### Tests
1. Open `New Group` via the `Create Menu`;
2. Check if, when there is no contact selected, the `Create Group` button does not show;
3. Check if the button shows otherwise.

### Tested On

- [x] Web
- [ ] Mobile Web
- [x] Desktop
- [x] iOS
- [ ] Android

### Screenshots

#### Web
![web](https://i.ibb.co/qBXZv0X/web.png)

#### Desktop
![desktop](https://i.ibb.co/8xCHwT2/desktop.gif)

#### iOS
![ios](https://i.ibb.co/yYsHxYR/ios.png)
