### PR TITLE
Add webpack bundle analyzer to help minimize JS bundle size

### DIFF
--- a/config/webpack/webpack.prod.js
+++ b/config/webpack/webpack.prod.js
@@ -13,7 +13,7 @@ module.exports = merge(common, {
     devtool: 'source-map',
     plugins: [
         // Uncomment this and run `npm run build` to interactively inspect JS bundle contents
-        new BundleAnalyzerPlugin(),
+        // new BundleAnalyzerPlugin(),
         new webpack.DefinePlugin({
             __REACT_WEB_CONFIG__: JSON.stringify(env),
 

--- a/config/webpack/webpack.prod.js
+++ b/config/webpack/webpack.prod.js
@@ -13,7 +13,7 @@ module.exports = merge(common, {
     devtool: 'source-map',
     plugins: [
         // Uncomment this and run `npm run build` to interactively inspect JS bundle contents
-        // new BundleAnalyzerPlugin(),
+        new BundleAnalyzerPlugin(),
         new webpack.DefinePlugin({
             __REACT_WEB_CONFIG__: JSON.stringify(env),
 

--- a/config/webpack/webpack.prod.js
+++ b/config/webpack/webpack.prod.js
@@ -1,6 +1,8 @@
 const path = require('path');
 const webpack = require('webpack');
 const {merge} = require('webpack-merge');
+// eslint-disable-next-line no-unused-vars
+const {BundleAnalyzerPlugin} = require('webpack-bundle-analyzer');
 const dotenv = require('dotenv');
 const common = require('./webpack.common.js');
 
@@ -10,6 +12,8 @@ module.exports = merge(common, {
     mode: 'production',
     devtool: 'source-map',
     plugins: [
+        // Uncomment this and run `npm run build` to interactively inspect JS bundle contents
+        // new BundleAnalyzerPlugin(),
         new webpack.DefinePlugin({
             __REACT_WEB_CONFIG__: JSON.stringify(env),
 

--- a/config/webpack/webpack.prod.js
+++ b/config/webpack/webpack.prod.js
@@ -12,8 +12,8 @@ module.exports = merge(common, {
     mode: 'production',
     devtool: 'source-map',
     plugins: [
-        // Uncomment this and run `npm run build` to interactively inspect JS bundle contents
-        // new BundleAnalyzerPlugin(),
+        // This allows us to interactively inspect JS bundle contents
+        ...(process.env.ANALYZE_BUNDLE === 'true' ? [new BundleAnalyzerPlugin()] : []),
         new webpack.DefinePlugin({
             __REACT_WEB_CONFIG__: JSON.stringify(env),
 

--- a/config/webpack/webpack.prod.js
+++ b/config/webpack/webpack.prod.js
@@ -1,7 +1,6 @@
 const path = require('path');
 const webpack = require('webpack');
 const {merge} = require('webpack-merge');
-// eslint-disable-next-line no-unused-vars
 const {BundleAnalyzerPlugin} = require('webpack-bundle-analyzer');
 const dotenv = require('dotenv');
 const common = require('./webpack.common.js');

--- a/package-lock.json
+++ b/package-lock.json
@@ -3200,6 +3200,12 @@
         "@types/node": ">= 8"
       }
     },
+    "@polka/url": {
+      "version": "1.0.0-next.11",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.11.tgz",
+      "integrity": "sha512-3NsZsJIA/22P3QUyrEDNA2D133H4j224twJrdipXN38dpnIOzAbUDtOwkcJ5pXmn75w7LSQDjA4tO9dm1XlqlA==",
+      "dev": true
+    },
     "@react-native-community/async-storage": {
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/@react-native-community/async-storage/-/async-storage-1.12.1.tgz",
@@ -11873,6 +11879,15 @@
       "dev": true,
       "optional": true
     },
+    "gzip-size": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+      "dev": true,
+      "requires": {
+        "duplexer": "^0.1.2"
+      }
+    },
     "handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -19872,6 +19887,12 @@
       "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
       "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q=="
     },
+    "opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true
+    },
     "opn": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
@@ -22849,6 +22870,25 @@
       "version": "git+https://github.com/Expensify/simply-deferred.git#77a08a95754660c7bd6e0b6979fdf84e8e831bf5",
       "from": "git+https://github.com/Expensify/simply-deferred.git#77a08a95754660c7bd6e0b6979fdf84e8e831bf5"
     },
+    "sirv": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-1.0.11.tgz",
+      "integrity": "sha512-SR36i3/LSWja7AJNRBz4fF/Xjpn7lQFI30tZ434dIy+bitLYSP+ZEenHg36i23V2SGEz+kqjksg0uOGZ5LPiqg==",
+      "dev": true,
+      "requires": {
+        "@polka/url": "^1.0.0-next.9",
+        "mime": "^2.3.1",
+        "totalist": "^1.0.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.0.tgz",
+          "integrity": "sha512-ft3WayFSFUVBuJj7BMLKAQcSlItKtfjsKDDsii3rqFDAZ7t11zRe8ASw/GlmivGwVUYtwkQrxiGGpL6gFvB0ag==",
+          "dev": true
+        }
+      }
+    },
     "sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -24255,6 +24295,12 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
+    "totalist": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-1.1.0.tgz",
+      "integrity": "sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==",
+      "dev": true
+    },
     "tough-cookie": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
@@ -25104,6 +25150,59 @@
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
           "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "dev": true
+        }
+      }
+    },
+    "webpack-bundle-analyzer": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.4.0.tgz",
+      "integrity": "sha512-9DhNa+aXpqdHk8LkLPTBU/dMfl84Y+WE2+KnfI6rSpNRNVKa0VGLjPd2pjFubDeqnWmulFggxmWBxhfJXZnR0g==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.0.4",
+        "acorn-walk": "^8.0.0",
+        "chalk": "^4.1.0",
+        "commander": "^6.2.0",
+        "gzip-size": "^6.0.0",
+        "lodash": "^4.17.20",
+        "opener": "^1.5.2",
+        "sirv": "^1.0.7",
+        "ws": "^7.3.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.0.5",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.0.5.tgz",
+          "integrity": "sha512-v+DieK/HJkJOpFBETDJioequtc3PfxsWMaxIdIwujtF7FEV/MAyDQLlm6/zPvr7Mix07mLh6ccVwIsloceodlg==",
+          "dev": true
+        },
+        "acorn-walk": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.0.2.tgz",
+          "integrity": "sha512-+bpA9MJsHdZ4bgfDcpk0ozQyhhVct7rzOmO0s1IIr0AGGgKBljss8n2zp11rRP2wid5VGeh04CgeKzgat5/25A==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "commander": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+          "dev": true
+        },
+        "ws": {
+          "version": "7.4.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
+          "integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "print-version": "echo $npm_package_version",
     "detox-build": "detox build --configuration ios.sim.debug",
     "detox-test": "detox test --configuration ios.sim.debug",
-    "gh-actions-build": "./.github/scripts/buildActions.sh"
+    "gh-actions-build": "./.github/scripts/buildActions.sh",
+    "analyze-packages": "ANALYZE_BUNDLE=true webpack --config config/webpack/webpack.prod.js"
   },
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.12.1",

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "react-native-version": "^4.0.0",
     "react-test-renderer": "16.13.1",
     "webpack": "^4.44.1",
+    "webpack-bundle-analyzer": "^4.4.0",
     "webpack-cli": "^3.3.12",
     "webpack-dev-server": "^3.11.0",
     "webpack-merge": "^5.1.1"


### PR DESCRIPTION
cc @AndrewGable @Julesssss @tgolen 

### Details

This tool is incredible. 

Separately, it would be interesting to maybe integrate this somehow so that we are pinged when the bundle size increases by a certain amount with a generated image. For now, just want to add it to `devDependencies`.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/153830

### Tests
1. `npm i`
2. Run `npm run analyze-packages`
3. Verify you see the output in your browser that looks like this
![Screen Shot 2021-02-08 at 9 46 21 AM](https://user-images.githubusercontent.com/32969087/107273378-0e21d600-69f3-11eb-9622-d3e5bc9519a1.png)
4. Run `npm run build` and verify you do not see the output and the script terminates after building.

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
