### PR TITLE
Update JS-Libs to support `-=+.` in link regex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10831,8 +10831,8 @@
       }
     },
     "expensify-common": {
-      "version": "git+https://github.com/Expensify/expensify-common.git#abf27f7cc163c37256e0bae7a9cbac64853e9073",
-      "from": "git+https://github.com/Expensify/expensify-common.git#abf27f7cc163c37256e0bae7a9cbac64853e9073",
+      "version": "git+https://github.com/Expensify/expensify-common.git#285aeb7f5f327db5d513b44659709980198d1bfc",
+      "from": "git+https://github.com/Expensify/expensify-common.git#285aeb7f5f327db5d513b44659709980198d1bfc",
       "requires": {
         "classnames": "2.2.5",
         "clipboard": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "electron-log": "^4.2.4",
     "electron-serve": "^1.0.0",
     "electron-updater": "^4.3.4",
-    "expensify-common": "git+https://github.com/Expensify/expensify-common.git#abf27f7cc163c37256e0bae7a9cbac64853e9073",
+    "expensify-common": "git+https://github.com/Expensify/expensify-common.git#285aeb7f5f327db5d513b44659709980198d1bfc",
     "file-loader": "^6.0.0",
     "html-entities": "^1.3.1",
     "lodash.get": "^4.4.2",


### PR DESCRIPTION
### Details
Hash bump for [this PR](https://github.com/Expensify/expensify-common/pull/329)

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/153365

### Tests
1. Send the message `[test-=+.](google.com)`
2. Verify it is properly linked
![image](https://user-images.githubusercontent.com/22447860/107295762-e77c9300-6a24-11eb-8cdf-860a9634796e.png)

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

Did not test on other platforms, as this is a regex change and not a UI change
