### PR TITLE
Remove exitTo feature from Expensify.cash

### DIFF
--- a/src/Expensify.js
+++ b/src/Expensify.js
@@ -129,7 +129,7 @@ class Expensify extends PureComponent {
 
                     <Route path={[ROUTES.SET_PASSWORD]} component={SetPasswordPage} />
                     <Route path={[ROUTES.NOT_FOUND]} component={NotFoundPage} />
-                    <Route path={[ROUTES.SIGNIN_WITH_EXITTO, ROUTES.SIGNIN]} component={SignInPage} />
+                    <Route path={[ROUTES.SIGNIN]} component={SignInPage} />
                     <Route
                         path={[ROUTES.HOME, ROUTES.ROOT]}
                         render={() => (

--- a/src/ROUTES.js
+++ b/src/ROUTES.js
@@ -12,7 +12,5 @@ export default {
     SEARCH: '/search',
     SET_PASSWORD: '/setpassword/:validateCode',
     SIGNIN: '/signin',
-    SIGNIN_WITH_EXITTO: '/signIn/exitTo/:exitTo*',
-    getSigninWithExitToRoute: exitTo => `/signin/exitTo${exitTo}`,
     NOT_FOUND: '/404',
 };

--- a/src/libs/actions/Session.js
+++ b/src/libs/actions/Session.js
@@ -19,15 +19,12 @@ Onyx.connect({
  * Sets API data in the store when we make a successful "Authenticate"/"CreateLogin" request
  *
  * @param {Object} data
- * @param {String} exitTo
  */
-function setSuccessfulSignInData(data, exitTo) {
+function setSuccessfulSignInData(data) {
     PushNotification.register(data.accountID);
-
-    const redirectURL = exitTo ? Str.normalizeUrl(exitTo) : ROUTES.ROOT;
     Onyx.multiSet({
         [ONYXKEYS.SESSION]: _.pick(data, 'authToken', 'accountID', 'email'),
-        [ONYXKEYS.APP_REDIRECT_TO]: redirectURL,
+        [ONYXKEYS.APP_REDIRECT_TO]: ROUTES.ROOT,
     });
 }
 
@@ -112,10 +109,9 @@ function fetchAccountDetails(login) {
  * after an authToken expires.
  *
  * @param {String} password
- * @param {String} exitTo
  * @param {String} [twoFactorAuthCode]
  */
-function signIn(password, exitTo, twoFactorAuthCode) {
+function signIn(password, twoFactorAuthCode) {
     Onyx.merge(ONYXKEYS.ACCOUNT, {error: '', loading: true});
 
     API.Authenticate({
@@ -143,7 +139,7 @@ function signIn(password, exitTo, twoFactorAuthCode) {
                         throw new Error(createLoginResponse.message);
                     }
 
-                    setSuccessfulSignInData(createLoginResponse, exitTo);
+                    setSuccessfulSignInData(createLoginResponse);
 
                     // If we have an old generated login for some reason
                     // we should delete it before storing the new details
@@ -232,7 +228,7 @@ function setPassword(password, validateCode) {
         .then((response) => {
             if (response.jsonCode === 200) {
                 Onyx.merge(ONYXKEYS.CREDENTIALS, {password});
-                setSuccessfulSignInData(response, '/home/');
+                setSuccessfulSignInData(response);
                 return;
             }
 

--- a/src/libs/actions/SignInRedirect.js
+++ b/src/libs/actions/SignInRedirect.js
@@ -19,7 +19,7 @@ Onyx.connect({
 });
 
 /**
- * Clears the Onyx store, redirects to the sign in page and handles adding any exitTo params to the URL.
+ * Clears the Onyx store and redirects to the sign in page.
  * Normally this method would live in Session.js, but that would cause a circular dependency with Network.js.
  *
  * @param {String} [errorMessage] error message to be displayed on the sign in page
@@ -34,20 +34,15 @@ function redirectToSignIn(errorMessage) {
         return;
     }
 
-    // If there is already an exitTo, or has the URL of signin, don't redirect
-    if (currentURL.indexOf('exitTo') !== -1 || currentURL.indexOf('signin') !== -1) {
+    // If we are already on the signin page, don't redirect
+    if (currentURL.indexOf('signin') !== -1) {
         return;
     }
 
     // Save the reportID before calling redirect or otherwise when clear
     // is finished the value saved here will already be null
     const reportID = currentlyViewedReportID;
-
-    // When the URL is at the root of the site, go to sign-in, otherwise add the exitTo
-    const urlWithExitTo = currentURL === ROUTES.ROOT
-        ? ROUTES.SIGNIN
-        : ROUTES.getSigninWithExitToRoute(currentURL);
-    redirect(urlWithExitTo);
+    redirect(ROUTES.SIGNIN);
     Onyx.clear().then(() => {
         if (errorMessage) {
             Onyx.set(ONYXKEYS.SESSION, {error: errorMessage});

--- a/src/pages/signin/PasswordForm.js
+++ b/src/pages/signin/PasswordForm.js
@@ -4,20 +4,14 @@ import {
 } from 'react-native';
 import PropTypes from 'prop-types';
 import {withOnyx} from 'react-native-onyx';
-import {withRouter} from '../../libs/Router';
 import styles from '../../styles/styles';
 import ButtonWithLoader from '../../components/ButtonWithLoader';
 import themeColors from '../../styles/themes/default';
 import {signIn} from '../../libs/actions/Session';
-import compose from '../../libs/compose';
 import ONYXKEYS from '../../ONYXKEYS';
 import ChangeExpensifyLoginLink from './ChangeExpensifyLoginLink';
 
 const propTypes = {
-    // These are from withRouter
-    // eslint-disable-next-line react/forbid-prop-types
-    match: PropTypes.object.isRequired,
-
     /* Onyx Props */
 
     // The details about the account that the user is signing in with
@@ -68,7 +62,7 @@ class PasswordForm extends React.Component {
             formError: null,
         });
 
-        signIn(this.state.password, this.props.match.params.exitTo, this.state.twoFactorAuthCode);
+        signIn(this.state.password, this.state.twoFactorAuthCode);
     }
 
     render() {
@@ -121,9 +115,6 @@ class PasswordForm extends React.Component {
 PasswordForm.propTypes = propTypes;
 PasswordForm.defaultProps = defaultProps;
 
-export default compose(
-    withRouter,
-    withOnyx({
-        account: {key: ONYXKEYS.ACCOUNT},
-    }),
-)(PasswordForm);
+export default withOnyx({
+    account: {key: ONYXKEYS.ACCOUNT},
+})(PasswordForm);


### PR DESCRIPTION
### Details
It was discussed that there is no clear reason why we would want a user to be redirected to sign in with an "exitTo" and the only other option would be to send them to sign in with an "exitTo" via a deep link. Since we have no deep links this feature doesn't really serve any purpose and should be removed.

When we add deep links we can think about the best way to drive some post sign in activity.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/154193

### Tests
1. Sign in
2. Visit `/settings` by clicking on the avatar
3. Sign out
4. Sign in again
5. Verify you are not brought back to settings

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
