### PR TITLE
Split homepage into web and mobile so that we can add AudioEye script

### DIFF
--- a/src/pages/home/HomePage/index.js
+++ b/src/pages/home/HomePage/index.js
@@ -9,44 +9,44 @@ import {
 } from 'react-native';
 import {SafeAreaInsetsContext} from 'react-native-safe-area-context';
 import {withOnyx} from 'react-native-onyx';
-import {Route} from '../../libs/Router';
-import styles, {getSafeAreaPadding, getNavigationMenuStyle} from '../../styles/styles';
-import variables from '../../styles/variables';
-import HeaderView from './HeaderView';
-import Sidebar from './sidebar/SidebarView';
-import MainView from './MainView';
-import NewGroupPage from '../NewGroupPage';
-import NewChatPage from '../NewChatPage';
-import SettingsPage from '../SettingsPage';
-import SearchPage from '../SearchPage';
+import {Route} from '../../../libs/Router';
+import styles, {getSafeAreaPadding, getNavigationMenuStyle} from '../../../styles/styles';
+import variables from '../../../styles/variables';
+import HeaderView from '../HeaderView';
+import Sidebar from '../sidebar/SidebarView';
+import MainView from '../MainView';
+import NewGroupPage from '../../NewGroupPage';
+import NewChatPage from '../../NewChatPage';
+import SettingsPage from '../../SettingsPage';
+import SearchPage from '../../SearchPage';
 import {
     hide as hideSidebar,
     show as showSidebar,
     setIsAnimating as setSideBarIsAnimating,
-} from '../../libs/actions/Sidebar';
+} from '../../../libs/actions/Sidebar';
 import {
     subscribeToReportCommentEvents,
     fetchAll as fetchAllReports,
-} from '../../libs/actions/Report';
-import * as PersonalDetails from '../../libs/actions/PersonalDetails';
-import * as Pusher from '../../libs/Pusher/pusher';
-import PusherConnectionManager from '../../libs/PusherConnectionManager';
-import UnreadIndicatorUpdater from '../../libs/UnreadIndicatorUpdater';
-import ROUTES from '../../ROUTES';
-import ONYXKEYS from '../../ONYXKEYS';
-import Timing from '../../libs/actions/Timing';
-import NetworkConnection from '../../libs/NetworkConnection';
-import CONFIG from '../../CONFIG';
-import CustomStatusBar from '../../components/CustomStatusBar';
-import CONST from '../../CONST';
-import {fetchCountryCodeByRequestIP} from '../../libs/actions/GeoLocation';
-import KeyboardShortcut from '../../libs/KeyboardShortcut';
-import {redirect} from '../../libs/actions/App';
-import RightDockedModal from '../../components/RightDockedModal';
-import withWindowDimensions, {windowDimensionsPropTypes} from '../../components/withWindowDimensions';
-import compose from '../../libs/compose';
-import {getBetas} from '../../libs/actions/User';
-import Account from '../../libs/actions/Account';
+} from '../../../libs/actions/Report';
+import * as PersonalDetails from '../../../libs/actions/PersonalDetails';
+import * as Pusher from '../../../libs/Pusher/pusher';
+import PusherConnectionManager from '../../../libs/PusherConnectionManager';
+import UnreadIndicatorUpdater from '../../../libs/UnreadIndicatorUpdater';
+import ROUTES from '../../../ROUTES';
+import ONYXKEYS from '../../../ONYXKEYS';
+import Timing from '../../../libs/actions/Timing';
+import NetworkConnection from '../../../libs/NetworkConnection';
+import CONFIG from '../../../CONFIG';
+import CustomStatusBar from '../../../components/CustomStatusBar';
+import CONST from '../../../CONST';
+import {fetchCountryCodeByRequestIP} from '../../../libs/actions/GeoLocation';
+import KeyboardShortcut from '../../../libs/KeyboardShortcut';
+import {redirect} from '../../../libs/actions/App';
+import RightDockedModal from '../../../components/RightDockedModal';
+import withWindowDimensions, {windowDimensionsPropTypes} from '../../../components/withWindowDimensions';
+import compose from '../../../libs/compose';
+import {getBetas} from '../../../libs/actions/User';
+import Account from '../../../libs/actions/Account';
 
 const propTypes = {
     isSidebarShown: PropTypes.bool,

--- a/src/pages/home/HomePage/index.js
+++ b/src/pages/home/HomePage/index.js
@@ -126,6 +126,11 @@ class HomePage extends Component {
         KeyboardShortcut.subscribe('K', () => {
             redirect(ROUTES.SEARCH);
         }, ['meta'], true);
+
+        const script = document.createElement('script');
+        script.type = 'text/javascript';
+        script.text = '!function(){var t=function(){var t=document.createElement("script");t.src="https://ws.audioeye.com/ae.js",t.type="text/javascript",t.setAttribute("async",""),document.getElementsByTagName("body")[0].appendChild(t)};"complete"!==document.readyState?window.addEventListener?window.addEventListener("load",t):window.attachEvent&&window.attachEvent("onload",t):t()}()';
+        document.body.appendChild(script);
     }
 
     shouldComponentUpdate(nextProps, nextState) {

--- a/src/pages/home/HomePage/index.native.js
+++ b/src/pages/home/HomePage/index.native.js
@@ -126,11 +126,6 @@ class HomePage extends Component {
         KeyboardShortcut.subscribe('K', () => {
             redirect(ROUTES.SEARCH);
         }, ['meta'], true);
-
-        const script = document.createElement('script');
-        script.type = 'text/javascript';
-        script.text = '!function(){var t=function(){var t=document.createElement("script");t.src="https://ws.audioeye.com/ae.js",t.type="text/javascript",t.setAttribute("async",""),document.getElementsByTagName("body")[0].appendChild(t)};"complete"!==document.readyState?window.addEventListener?window.addEventListener("load",t):window.attachEvent&&window.attachEvent("onload",t):t()}()';
-        document.body.appendChild(script);
     }
 
     shouldComponentUpdate(nextProps, nextState) {

--- a/src/pages/home/MainView.js
+++ b/src/pages/home/MainView.js
@@ -72,8 +72,8 @@ class MainView extends Component {
 
         const reportsToDisplay = _.filter(this.props.reports, report => (
             report.isPinned
-            || report.unreadActionCount > 0
-            || report.reportID === activeReportID
+                || report.unreadActionCount > 0
+                || report.reportID === activeReportID
         ));
         return (
             <>


### PR DESCRIPTION
### Details
We are currently looking at a couple of accessibility vendors including this one, AudioEye. This PR includes their "AI" in our JS ([these lines](https://github.com/Expensify/Expensify.cash/pull/1487/files#diff-b43699280e5ff3c9488da6770baf253583fb23466c2587aca93f3dd5ff71370eR130-R133)) which will go through our website and generate a report on what we need to change. The usefulness of this report will determine whether we want to move forward with them or not

### Fixed Issues
None. Check out #accessibility in slack

### Tests
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
Mobile and desktop all look the same.
Web looks like this:
![2021-02-16_15-05-28](https://user-images.githubusercontent.com/42391420/108128187-9ba39c80-7069-11eb-8588-f9afbe3ed475.png)

