### PR TITLE
Retry requests that are skipped during re-authentication. Stop logging users out if fetch() fails while re-authenticating.

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -36,6 +36,9 @@ const CONST = {
         GSD: 'gsd',
         DEFAULT: 'default',
     },
+    ERROR: {
+        API_OFFLINE: 'API is offline',
+    },
 };
 
 export default CONST;

--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -400,6 +400,8 @@ function Log(parameters) {
     const commandName = 'Log';
     requireParameters(['message', 'parameters', 'expensifyCashAppVersion'],
         parameters, commandName);
+
+    // Note: We are forcing Log to run since it requires no authToken and should never be queued unless we are offline.
     return request(commandName, {...parameters, forceNetworkRequest: true});
 }
 

--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -400,7 +400,7 @@ function Log(parameters) {
     const commandName = 'Log';
     requireParameters(['message', 'parameters', 'expensifyCashAppVersion'],
         parameters, commandName);
-    return request(commandName, parameters);
+    return request(commandName, {...parameters, forceNetworkRequest: true});
 }
 
 /**

--- a/src/libs/HttpUtils.js
+++ b/src/libs/HttpUtils.js
@@ -1,5 +1,6 @@
 import _ from 'underscore';
 import Onyx from 'react-native-onyx';
+import CONST from '../CONST';
 import CONFIG from '../CONFIG';
 import ONYXKEYS from '../ONYXKEYS';
 import NetworkConnection from './NetworkConnection';
@@ -22,7 +23,9 @@ function processHTTPRequest(url, method = 'get', body = null) {
 
         // This will catch any HTTP network errors (like 404s and such), not to be confused with jsonCode which this
         // does NOT catch
-        .catch(() => {
+        .catch((error) => {
+            console.debug('[HttpUtils] Handled error when calling fetch()', error);
+
             NetworkConnection.setOfflineStatus(true);
 
             // Set an error state and signify we are done loading
@@ -30,7 +33,7 @@ function processHTTPRequest(url, method = 'get', body = null) {
 
             // Throw a new error to prevent any other `then()` in the promise chain from being triggered (until another
             // catch() happens
-            throw new Error('API is offline');
+            throw new Error(CONST.ERROR.API_OFFLINE);
         });
 }
 

--- a/src/libs/Network.js
+++ b/src/libs/Network.js
@@ -1,4 +1,5 @@
 import _ from 'underscore';
+import lodashGet from 'lodash.get';
 import Onyx from 'react-native-onyx';
 import HttpUtils from './HttpUtils';
 import NetworkConnection from './NetworkConnection';
@@ -30,6 +31,54 @@ Onyx.connect({
 });
 
 /**
+ * Checks to see if a request should be made.
+ *
+ * @param {Object} request
+ * @param {Object} request.data
+ * @param {Boolean} request.data.forceNetworkRequest
+ * @return {Boolean}
+ */
+function shouldMakeRequest(request) {
+    // These requests are always made even when the queue is paused
+    if (request.data.forceNetworkRequest === true) {
+        return true;
+    }
+
+    if (isQueuePaused) {
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * Checks to see if a request should be retried when the queue is "paused".
+ *
+ * @param {Object} request
+ * @param {String} request.command
+ * @param {Object} request.data
+ * @param {Boolean} request.data.doNotRetry
+ * @param {String} [request.data.returnValueList]
+ * @return {Boolean}
+ */
+function shouldRetryRequest(request) {
+    const doNotRetry = lodashGet(request, 'data.doNotRetry', false);
+    const logParams = {command: request.command, doNotRetry, isQueuePaused};
+    const returnValueList = lodashGet(request, 'data.returnValueList');
+    if (returnValueList) {
+        logParams.returnValueList = returnValueList;
+    }
+
+    if (doNotRetry) {
+        console.debug('Skipping request that should not be re-tried: ', logParams);
+        return false;
+    }
+
+    console.debug('Skipping request and re-queueing: ', logParams);
+    return true;
+}
+
+/**
  * Process the networkRequestQueue by looping through the queue and attempting to make the requests
  */
 function processNetworkRequestQueue() {
@@ -58,12 +107,16 @@ function processNetworkRequestQueue() {
         return;
     }
 
+    // If a request can't run because the queue is paused then it should end up here so it can be retried.
+    const retryableRequests = [];
+
     _.each(networkRequestQueue, (queuedRequest) => {
         // Some requests must be allowed to run even when the queue is paused e.g. an authentication request
         // that pauses the network queue while authentication happens, then unpauses it when it's done.
-        const shouldSkipRequest = isQueuePaused && queuedRequest.data.forceNetworkRequest !== true;
-
-        if (shouldSkipRequest) {
+        if (!shouldMakeRequest(queuedRequest)) {
+            if (shouldRetryRequest(queuedRequest)) {
+                retryableRequests.push(queuedRequest);
+            }
             return;
         }
 
@@ -78,7 +131,10 @@ function processNetworkRequestQueue() {
 
         // Check to see if the queue has paused again. It's possible that a call to enhanceParameters()
         // has paused the queue and if this is the case we must return.
-        if (shouldSkipRequest) {
+        if (!shouldMakeRequest(queuedRequest)) {
+            if (shouldRetryRequest(queuedRequest)) {
+                retryableRequests.push(queuedRequest);
+            }
             return;
         }
 
@@ -87,7 +143,9 @@ function processNetworkRequestQueue() {
             .catch(queuedRequest.reject);
     });
 
-    networkRequestQueue = [];
+    // We clear the request queue at the end by setting the queue to retryableRequests which will either have some
+    // requests we want to retry or an empty array
+    networkRequestQueue = retryableRequests;
 }
 
 // Process our write queue very often

--- a/src/libs/Network.js
+++ b/src/libs/Network.js
@@ -130,11 +130,9 @@ function processNetworkRequestQueue() {
             : requestData;
 
         // Check to see if the queue has paused again. It's possible that a call to enhanceParameters()
-        // has paused the queue and if this is the case we must return.
+        // has paused the queue and if this is the case we must return. We don't retry these requests
+        // since if a request is made without an authToken we sign out the user.
         if (!shouldMakeRequest(queuedRequest)) {
-            if (shouldRetryRequest(queuedRequest)) {
-                retryableRequests.push(queuedRequest);
-            }
             return;
         }
 

--- a/src/libs/NetworkConnection.js
+++ b/src/libs/NetworkConnection.js
@@ -71,6 +71,7 @@ function listenForReconnect() {
     // every two seconds and if the last time recorded is greater than 4 seconds
     // we know that the computer has been asleep.
     lastTime = (new Date()).getTime();
+    clearInterval(sleepTimer);
     sleepTimer = setInterval(() => {
         const currentTime = (new Date()).getTime();
         const isSkewed = currentTime > (lastTime + 4000);
@@ -87,6 +88,7 @@ function listenForReconnect() {
 function stopListeningForReconnect() {
     logInfo('[NetworkConnection] stopListeningForReconnect called', true);
     clearInterval(sleepTimer);
+    sleepTimer = null;
     if (unsubscribeFromNetInfo) {
         unsubscribeFromNetInfo();
         unsubscribeFromNetInfo = undefined;

--- a/src/libs/Pusher/pusher.js
+++ b/src/libs/Pusher/pusher.js
@@ -385,6 +385,7 @@ function disconnect() {
 function reconnect() {
     if (!socket) {
         console.debug('[Pusher] Unable to reconnect since Pusher instance does not yet exist.');
+        return;
     }
 
     console.debug('[Pusher] Reconnecting to Pusher');

--- a/src/libs/Pusher/pusher.js
+++ b/src/libs/Pusher/pusher.js
@@ -383,6 +383,10 @@ function disconnect() {
  * Disconnect and Re-Connect Pusher
  */
 function reconnect() {
+    if (!socket) {
+        console.debug('[Pusher] Unable to reconnect since Pusher instance does not yet exist.');
+    }
+
     console.debug('[Pusher] Reconnecting to Pusher');
     socket.disconnect();
     socket.connect();

--- a/src/libs/Pusher/pusher.js
+++ b/src/libs/Pusher/pusher.js
@@ -62,23 +62,19 @@ function init(args, params) {
 
         // Listen for connection errors and log them
         socket.connection.bind('error', (error) => {
-            console.debug('[Pusher] error', error);
             callSocketEventCallbacks('error', error);
         });
 
         socket.connection.bind('connected', () => {
-            console.debug('[Pusher] connected');
             callSocketEventCallbacks('connected');
             resolve();
         });
 
         socket.connection.bind('disconnected', () => {
-            console.debug('[Pusher] disconnected');
             callSocketEventCallbacks('disconnected');
         });
 
         socket.connection.bind('state_change', (states) => {
-            console.debug('[Pusher] state changed', states);
             callSocketEventCallbacks('state_change', states);
         });
     });

--- a/src/libs/PusherConnectionManager.js
+++ b/src/libs/PusherConnectionManager.js
@@ -8,7 +8,14 @@ import Log from './Log';
 // subscribe to a bunch of channels at once we will only reauthenticate and force reconnect Pusher once.
 const reauthenticate = _.throttle(() => {
     Log.info('[Pusher] Re-authenticating and then reconnecting', true);
-    API.reauthenticate('Push_Authenticate').then(() => Pusher.reconnect());
+    API.reauthenticate('Push_Authenticate')
+        .then(() => Pusher.reconnect())
+        .catch(() => {
+            console.debug(
+                '[PusherConnectionManager]',
+                'Unable to re-authenticate Pusher because we are offline.',
+            );
+        });
 }, 5000, {trailing: false});
 
 function init() {

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -243,10 +243,6 @@ function removeOptimisticActions(reportID) {
  * @param {Object} reportAction
  */
 function updateReportWithNewAction(reportID, reportAction) {
-    if (!reportAction) {
-        return;
-    }
-
     const newMaxSequenceNumber = reportAction.sequenceNumber;
     const isFromCurrentUser = reportAction.actorAccountID === currentUserAccountID;
 

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -488,7 +488,7 @@ function fetchChatReports() {
             }
 
             // Get all the chat reports if they have any, otherwise create one with concierge
-            if (lodashGet(response, 'response.chatList.length')) {
+            if (lodashGet(response, 'chatList.length')) {
                 fetchChatReportsByIDs(String(response.chatList).split(','));
             } else {
                 fetchOrCreateChatReport([currentUserEmail, 'concierge@expensify.com']);

--- a/tests/unit/NetworkTest.js
+++ b/tests/unit/NetworkTest.js
@@ -1,0 +1,59 @@
+import * as API from '../../src/libs/API';
+import {signInWithTestUser} from '../utils/TestHelper';
+import HttpUtils from '../../src/libs/HttpUtils';
+import waitForPromisesToResolve from '../utils/waitForPromisesToResolve';
+
+// Set up manual mocks for methods used in the actions so our test does not fail.
+jest.mock('../../src/libs/Notification/PushNotification', () => ({
+    // There is no need for a jest.fn() since we don't need to make assertions against it.
+    register: () => {},
+    deregister: () => {},
+}));
+
+test('consecutive API calls eventually succeed when authToken is expired', () => {
+    // Given a test user and set of authToken with subscriptions to session and credentials
+    const TEST_USER_LOGIN = 'test@testguy.com';
+    const TEST_USER_ACCOUNT_ID = 1;
+
+    // When we sign in
+    return signInWithTestUser(TEST_USER_ACCOUNT_ID, TEST_USER_LOGIN)
+        .then(() => {
+            HttpUtils.xhr = jest.fn();
+            HttpUtils.xhr
+
+                // This will make the first call to API.Get() return with an expired session code
+                .mockImplementationOnce(() => Promise.resolve({
+                    jsonCode: 407,
+                }))
+
+                // The next 2 API calls will also fire and also return a 407
+                .mockImplementationOnce(() => Promise.resolve({
+                    jsonCode: 407,
+                }))
+
+                .mockImplementationOnce(() => Promise.resolve({
+                    jsonCode: 407,
+                }))
+
+                // The remaining requests should succeed
+                .mockImplementationOnce(() => Promise.resolve({
+                    jsonCode: 200,
+                    authToken: 'qwerty12345',
+                }))
+
+                .mockImplementation(() => Promise.resolve({
+                    jsonCode: 200,
+                }));
+
+            // And then make 3 API requests in quick succession with an expired authToken
+            API.Get({returnValueList: 'chatList'});
+            API.Get({returnValueList: 'personalDetailsList'});
+            API.Get({returnValueList: 'account'});
+            return waitForPromisesToResolve();
+        })
+        .then(() => {
+            // We should expect to see seven request be made in total. 3 Get requests that initially fail. Then the call
+            // to Authenticate. Followed by 3 requests to Get again.
+            expect(HttpUtils.xhr.mock.calls.length).toBe(7);
+        });
+});

--- a/tests/unit/NetworkTest.js
+++ b/tests/unit/NetworkTest.js
@@ -1,7 +1,10 @@
+import _ from 'underscore';
+import Onyx from 'react-native-onyx';
 import * as API from '../../src/libs/API';
 import {signInWithTestUser} from '../utils/TestHelper';
 import HttpUtils from '../../src/libs/HttpUtils';
 import waitForPromisesToResolve from '../utils/waitForPromisesToResolve';
+import ONYXKEYS from '../../src/ONYXKEYS';
 
 // Set up manual mocks for methods used in the actions so our test does not fail.
 jest.mock('../../src/libs/Notification/PushNotification', () => ({
@@ -10,8 +13,84 @@ jest.mock('../../src/libs/Notification/PushNotification', () => ({
     deregister: () => {},
 }));
 
+jest.useFakeTimers();
+
+test('failing to reauthenticate while offline should not log out user', () => {
+    // Given a test user login and account ID
+    const TEST_USER_LOGIN = 'test@testguy.com';
+    const TEST_USER_ACCOUNT_ID = 1;
+
+    let isOffline;
+
+    Onyx.connect({
+        key: ONYXKEYS.NETWORK,
+        callback: (val) => {
+            isOffline = val && val.isOffline;
+        },
+    });
+
+    // Given a test user login and account ID
+    return signInWithTestUser(TEST_USER_ACCOUNT_ID, TEST_USER_LOGIN)
+        .then(() => {
+            expect(isOffline).toBe(null);
+
+            // Mock fetch() so that it throws a TypeError to simulate a bad network connection
+            global.fetch = jest.fn(() => new Promise((_resolve, reject) => reject(new TypeError('Failed to fetch'))));
+
+            const actualXhr = HttpUtils.xhr;
+            HttpUtils.xhr = jest.fn();
+            HttpUtils.xhr
+                .mockImplementationOnce(() => Promise.resolve({
+                    jsonCode: 407,
+                }))
+
+                // Fail the call to re-authenticate
+                .mockImplementationOnce(actualXhr)
+
+                // The next call should still be using the old authToken
+                .mockImplementationOnce(() => Promise.resolve({
+                    jsonCode: 407,
+                }))
+
+                // Succeed the call to set a new authToken
+                .mockImplementationOnce(() => Promise.resolve({
+                    jsonCode: 200,
+                    authToken: 'qwerty12345',
+                }))
+
+                // All remaining requests should succeed
+                .mockImplementation(() => Promise.resolve({
+                    jsonCode: 200,
+                }));
+
+            // This should first trigger re-authentication and then an API is offline error
+            API.Get({returnValueList: 'chatList'});
+            return waitForPromisesToResolve()
+                .then(() => Onyx.set(ONYXKEYS.NETWORK, {isOffline: false}))
+                .then(() => {
+                    expect(isOffline).toBe(false);
+
+                    // Advance the network request queue by 1 second so that it can realize it's back online
+                    jest.advanceTimersByTime(1000);
+                    return waitForPromisesToResolve();
+                })
+                .then(() => {
+                    // Then we will eventually have 3 calls to chatList and 2 calls to Authenticate
+                    const callsToChatList = _.filter(HttpUtils.xhr.mock.calls, ([command, params]) => (
+                        command === 'Get' && params.returnValueList === 'chatList'
+                    ));
+                    const callsToAuthenticate = _.filter(HttpUtils.xhr.mock.calls, ([command]) => (
+                        command === 'Authenticate'
+                    ));
+
+                    expect(callsToChatList.length).toBe(3);
+                    expect(callsToAuthenticate.length).toBe(2);
+                });
+        });
+});
+
 test('consecutive API calls eventually succeed when authToken is expired', () => {
-    // Given a test user and set of authToken with subscriptions to session and credentials
+    // Given a test user login and account ID
     const TEST_USER_LOGIN = 'test@testguy.com';
     const TEST_USER_ACCOUNT_ID = 1;
 
@@ -54,6 +133,9 @@ test('consecutive API calls eventually succeed when authToken is expired', () =>
         .then(() => {
             // We should expect to see seven request be made in total. 3 Get requests that initially fail. Then the call
             // to Authenticate. Followed by 3 requests to Get again.
-            expect(HttpUtils.xhr.mock.calls.length).toBe(7);
+            const callsToGet = _.filter(HttpUtils.xhr.mock.calls, ([command]) => command === 'Get');
+            const callsToAuthenticate = _.filter(HttpUtils.xhr.mock.calls, ([command]) => command === 'Authenticate');
+            expect(callsToGet.length).toBe(6);
+            expect(callsToAuthenticate.length).toBe(1);
         });
 });

--- a/tests/utils/TestHelper.js
+++ b/tests/utils/TestHelper.js
@@ -14,6 +14,7 @@ import waitForPromisesToResolve from './waitForPromisesToResolve';
  * @return {Promise}
  */
 function signInWithTestUser(accountID, login, password = 'Password1', authToken = 'asdfqwerty') {
+    const originalXhr = HttpUtils.xhr;
     HttpUtils.xhr = jest.fn();
     HttpUtils.xhr.mockImplementation(() => Promise.resolve({
         jsonCode: 200,
@@ -44,7 +45,10 @@ function signInWithTestUser(accountID, login, password = 'Password1', authToken 
                     email: login,
                 }));
             signIn(password);
-            return waitForPromisesToResolve();
+            return waitForPromisesToResolve()
+                .then(() => {
+                    HttpUtils.xhr = originalXhr;
+                });
         });
 }
 


### PR DESCRIPTION
### Details

Reconnection callbacks are failing to fire in the case of an expired `authToken`. This is because another request could essentially get a bunch of requests get 86d due to a race condition...

**How can it happen?**

Turns out pretty easily. If a bunch of JS makes a bunch of API requests in a row while an `authToken` is expired they will all queue, then will all run, and they will all fail. The assumption we were making is that it's fine to do this because the first request that fails will require a new authToken and it will "pause" the request queue. Any requests that run after that while we are authenticating and return 407 will get re-queued. But since the queue is now "paused" we end up just chucking these requests into the ether. In fact, the queue doesn't really "pause" at all. What it really does is skip a request and then clears out all requests at the end so they are lost forever.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/153315
Fixes https://github.com/Expensify/Expensify/issues/154290

### Tests
1. **Pre-requisite:** Set up authToken with [short expiry time in Auth](https://stackoverflow.com/c/expensify/questions/7826) - 10 seconds seems to work best 
1. Boot up iOS or Android app
2. Sign in
3. Background the app and wait about 10 seconds (or however long it will take your authToken to expire)
3. Leave a comment on a report as another user on a report shared with the iOS user
4. Click on the app icon
5. Verify that the LHN shows the chat as unread

Also added an automated test (`NetworkTest`) that can be run against `master` to verify this change fixes the issue.

### Tested On

- [x] Web
- [ ] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
