### PR TITLE
Move local debug log to a remote log

### DIFF
--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -4,6 +4,7 @@ import CONFIG from '../CONFIG';
 import ONYXKEYS from '../ONYXKEYS';
 import redirectToSignIn from './actions/SignInRedirect';
 import * as Network from './Network';
+import Log from './Log';
 
 let isAuthenticating;
 let credentials;
@@ -288,10 +289,8 @@ function reauthenticate(command = '') {
             isAuthenticating = false;
             redirectToSignIn(error.message);
 
-            console.debug('Redirecting to Sign In because we failed to reauthenticate', {
-                command,
-                error: error.message,
-            });
+            Log.info(`Redirecting to Sign In because we failed to reauthenticate. 
+                Command: ${command} Error: ${error.message}`);
         });
 }
 


### PR DESCRIPTION
Please review @marcaaron 

### Details
Moving a local debug log to a remote log to try to track down why a user is being logged out.

### Fixed Issues
Related https://github.com/Expensify/Expensify/issues/154290

### Tests
I believe we will have to wait for this bug to trigger, then we will check the log server, I am not sure there is a way to test this without the error triggering.