### PR TITLE
Always use the non proxy url when we need a true link back to expensify.com or com.dev

### DIFF
--- a/src/CONFIG.js
+++ b/src/CONFIG.js
@@ -33,6 +33,9 @@ export default {
     AUTH_TOKEN_EXPIRATION_TIME: 1000 * 60 * 90,
     EXPENSIFY: {
         URL_EXPENSIFY_COM: expensifyComWithProxy,
+
+        // This will be exactly what is set for EXPENSIFY_URL_COM whether the proxy is enabled or not.
+        URL_EXPENSIFY_COM_NO_PROXY: expensifyURL,
         URL_EXPENSIFY_CASH: expensifyCashURL,
         URL_API_ROOT: expensifyURLRoot,
         PARTNER_NAME: lodashGet(Config, 'EXPENSIFY_PARTNER_NAME', 'chat-expensify-com'),

--- a/src/CONFIG.js
+++ b/src/CONFIG.js
@@ -32,10 +32,8 @@ export default {
     APP_NAME: 'ExpensifyCash',
     AUTH_TOKEN_EXPIRATION_TIME: 1000 * 60 * 90,
     EXPENSIFY: {
-        URL_EXPENSIFY_COM: expensifyComWithProxy,
-
-        // This will be exactly what is set for EXPENSIFY_URL_COM whether the proxy is enabled or not.
-        URL_EXPENSIFY_COM_NO_PROXY: expensifyURL,
+        // Note: This will be EXACTLY what is set for EXPENSIFY_URL_COM whether the proxy is enabled or not.
+        URL_EXPENSIFY_COM: expensifyURL,
         URL_EXPENSIFY_CASH: expensifyCashURL,
         URL_API_ROOT: expensifyURLRoot,
         PARTNER_NAME: lodashGet(Config, 'EXPENSIFY_PARTNER_NAME', 'chat-expensify-com'),

--- a/src/components/RenderHTML.js
+++ b/src/components/RenderHTML.js
@@ -104,11 +104,11 @@ function ImgRenderer({tnode}) {
 
     // Update the image URL so the images can be accessed depending on the config environment
     previewSource = previewSource.replace(
-        Config.EXPENSIFY.URL_EXPENSIFY_COM,
+        Config.EXPENSIFY.URL_EXPENSIFY_COM_NO_PROXY,
         Config.EXPENSIFY.URL_API_ROOT,
     );
     source = source.replace(
-        Config.EXPENSIFY.URL_EXPENSIFY_COM,
+        Config.EXPENSIFY.URL_EXPENSIFY_COM_NO_PROXY,
         Config.EXPENSIFY.URL_API_ROOT,
     );
 

--- a/src/components/RenderHTML.js
+++ b/src/components/RenderHTML.js
@@ -104,11 +104,11 @@ function ImgRenderer({tnode}) {
 
     // Update the image URL so the images can be accessed depending on the config environment
     previewSource = previewSource.replace(
-        Config.EXPENSIFY.URL_EXPENSIFY_COM_NO_PROXY,
+        Config.EXPENSIFY.URL_EXPENSIFY_COM,
         Config.EXPENSIFY.URL_API_ROOT,
     );
     source = source.replace(
-        Config.EXPENSIFY.URL_EXPENSIFY_COM_NO_PROXY,
+        Config.EXPENSIFY.URL_EXPENSIFY_COM,
         Config.EXPENSIFY.URL_API_ROOT,
     );
 


### PR DESCRIPTION
### Details
Fixes issue causing contributors to not be able to access PDFs

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/154722

### Tests
1. Run the app on web via the proxy
1. Make sure PDFs are visible

### Tested On
This issue only affects web
- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
