### PR TITLE
fix some documentation typos and a string

### DIFF
--- a/src/components/OptionsList.js
+++ b/src/components/OptionsList.js
@@ -44,7 +44,7 @@ const propTypes = {
     // Whether to allow option focus or not
     disableFocusOptions: PropTypes.bool,
 
-    // A flag to indicate wheter to show additional optional states, such as pin and draft icons
+    // A flag to indicate whether to show additional optional states, such as pin and draft icons
     hideAdditionalOptionStates: PropTypes.bool,
 
     // Force the text style to be the unread style on all rows
@@ -168,7 +168,7 @@ class OptionsList extends Component {
      * @param {Object} params
      * @param {Object} params.section
      * @param {String} params.section.title
-     * @param {Booolean} params.section.shouldShow
+     * @param {Boolean} params.section.shouldShow
      *
      * @return {Component}
      */

--- a/src/components/OptionsSelector.js
+++ b/src/components/OptionsSelector.js
@@ -54,7 +54,7 @@ const propTypes = {
     // Whether to allow arrow key actions on the list
     disableArrowKeysActions: PropTypes.bool,
 
-    // A flag to indicate wheter to show additional optional states, such as pin and draft icons
+    // A flag to indicate whether to show additional optional states, such as pin and draft icons
     hideAdditionalOptionStates: PropTypes.bool,
 
     // Force the text style to be the unread style on all rows

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -142,7 +142,7 @@ function isSearchStringMatch(searchValue, searchText) {
  *
  * @param {Object} reports
  * @param {Object} personalDetails
- * @param {Obejct} draftComments
+ * @param {Object} draftComments
  * @param {Number} activeReportID
  * @param {Object} options
  * @returns {Object}
@@ -181,7 +181,7 @@ function getOptions(reports, personalDetails, draftComments, activeReportID, {
         }
 
         // Skip this entry if it has no comments and is not the active report. We will only show reports from
-        // people we have sent or recieved at least one message with.
+        // people we have sent or received at least one message with.
         const hasNoComments = report.lastMessageTimestamp === 0;
         if (!showReportsWithNoComments && hasNoComments && report.reportID !== activeReportID) {
             return;
@@ -368,7 +368,7 @@ function getNewGroupOptions(
  * Build the options for the Sidebar a.k.a. LHN
  * @param {Object} reports
  * @param {Object} personalDetails
- * @param {Obejct} draftComments
+ * @param {Object} draftComments
  * @param {Number} activeReportID
  * @returns {Object}
  */

--- a/src/libs/Pusher/pusher.js
+++ b/src/libs/Pusher/pusher.js
@@ -375,7 +375,7 @@ function registerCustomAuthorizer(authorizer) {
  */
 function disconnect() {
     if (!socket) {
-        console.debug('[Pusher] Attempting to disconnect from Pusher before initialisation has occured, ignoring.');
+        console.debug('[Pusher] Attempting to disconnect from Pusher before initialisation has occurred, ignoring.');
         return;
     }
 

--- a/src/libs/actions/Timing.js
+++ b/src/libs/actions/Timing.js
@@ -4,7 +4,7 @@ import {Graphite_Timer} from '../API';
 let timestampData = {};
 
 /**
- * Start a performance timing measurment
+ * Start a performance timing measurement
  *
  * @param {String} eventName
  */

--- a/src/pages/home/sidebar/OptionRow.js
+++ b/src/pages/home/sidebar/OptionRow.js
@@ -29,7 +29,7 @@ const propTypes = {
     // A function that is called when an option is selected. Selected option is passed as a param
     onSelectRow: PropTypes.func.isRequired,
 
-    // A flag to indicate wheter to show additional optional states, such as pin and draft icons
+    // A flag to indicate whether to show additional optional states, such as pin and draft icons
     hideAdditionalOptionStates: PropTypes.bool,
 
     // Whether we should show the selected state


### PR DESCRIPTION
I found a few typos or spelling mistakes in the JDocs and in a console.debug