### PR TITLE
Improve search functions to match multiple names

### DIFF
--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -125,15 +125,11 @@ Onyx.connect({
  * @returns {Boolean}
  */
 function isSearchStringMatch(searchValue, searchText) {
-    const matchRegexes = [
-        new RegExp(`^${Str.escapeForRegExp(searchValue)}$`, 'i'),
-        new RegExp(`^${Str.escapeForRegExp(searchValue)}`, 'i'),
-        new RegExp(Str.escapeForRegExp(searchValue), 'i'),
-    ];
-
-    return _.some(matchRegexes, (regex) => {
+    const searchWords = searchValue.split(' ');
+    return _.every(searchWords, (word) => {
+        const matchRegex = new RegExp(Str.escapeForRegExp(word), 'i');
         const valueToSearch = searchText && searchText.replace(new RegExp(/&nbsp;/g), '');
-        return regex.test(valueToSearch);
+        return matchRegex.test(valueToSearch);
     });
 }
 
@@ -317,6 +313,7 @@ function getSearchOptions(
         showChatPreviewLine: true,
         showReportsWithNoComments: true,
         includePersonalDetails: true,
+        sortByLastMessageTimestamp: true,
     });
 }
 


### PR DESCRIPTION
### Details
- Splitted search value into the words.
- Test regex for each word.
- Removed redundant regex patterns.
- Added sortByLastMessageTimestamp to search options.

### Fixed Issues
Fixes #1283

### Tests
- Click seach icon
- Enter "test1 test7" value to search input box
- Make sure the group with test1@example.com and test7@example.com is listed
- Verified that search results are ordered by last message timestamp
 
### Tested On

- [X] Web
- [X] Mobile Web
- [X] Desktop
- [X] iOS
- [X] Android

### Screenshots

#### Web
<img width="420" alt="107883605-cc5bc880-6ee7-11eb-858a-d797b6c1e5d4" src="https://user-images.githubusercontent.com/3853003/108547340-41614080-72e2-11eb-8689-82556d97be86.png">
<img width="420" alt="107883611-d251a980-6ee7-11eb-8629-e9f9df015720" src="https://user-images.githubusercontent.com/3853003/108547345-432b0400-72e2-11eb-9c91-3a140bfebda0.png">

#### Desktop
<img width="1198" alt="Screenshot 2021-02-19 at 20 14 07" src="https://user-images.githubusercontent.com/3853003/108556602-2e08a200-72ef-11eb-8036-a894ec37a994.png">

#### iOS
<img width="280" alt="107883804-11342f00-6ee9-11eb-9dc6-2d2020571326" src="https://user-images.githubusercontent.com/3853003/108547356-47efb800-72e2-11eb-992e-f8476faee855.png">
<img width="280" alt="107883809-16917980-6ee9-11eb-9f57-c4715b6caa07" src="https://user-images.githubusercontent.com/3853003/108547362-4920e500-72e2-11eb-9882-49d2e7ac687a.png">

#### Android
<img width="280" alt="107883809-16917980-6ee9-11eb-9f57-c4715b6caa07" src="https://user-images.githubusercontent.com/3853003/108557310-4b8a3b80-72f0-11eb-9938-9891f20eca8a.png">
