### PR TITLE
Only run CLA on PR comments, not on issue comments

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -9,6 +9,8 @@ on:
 jobs:
     CLA:
         runs-on: ubuntu-latest
+        # This job only runs for pull request comments
+        if: ${{ github.event.issue.pull_request }}
         steps:
             - uses: actions-ecosystem/action-regex-match@9c35fe9ac1840239939c59e5db8839422eed8a73
               id: sign


### PR DESCRIPTION
### Details
Adds a check to only have CLA assistant run on PR comments, and not on issue comments.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/154742

### Tests
1. Verify the CLA bot passes on this pull request (meaning it is still run on PRs correctly)
2. Verify that after we merge this PR, a new issue comment does not trigger CLA bot
