### PR TITLE
LHN - Get Default Avatar for new chats

### DIFF
--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -160,7 +160,7 @@ function getFromReportParticipants(reports) {
                 if (report.participants.length > 0) {
                     const avatars = _.map(report.participants, dmParticipant => ({
                         firstName: lodashGet(details, [dmParticipant, 'firstName'], ''),
-                        avatar: lodashGet(details, [dmParticipant, 'avatar'], getDefaultAvatar(dmParticipant)),
+                        avatar: lodashGet(details, [dmParticipant, 'avatar'], '') || getDefaultAvatar(dmParticipant),
                     }))
                         .sort((first, second) => first.firstName - second.firstName)
                         .map(item => item.avatar);


### PR DESCRIPTION
### Details
Previously we were not getting a default avatar image if the existing one was an empty string. Rather than relying on` _.get` (which only uses a default value if needle is undefined) we can use `||` because `''` is falsey. 

### Fixed Issues
https://github.com/Expensify/Expensify/issues/153963

### Tests
_From the issue:_

    Action Performed:
    Precondition: Both accounts are new and don't have a profile picture set up. 
    
    1. Go to https://chat.expensify.com and login with account A
    2. Create new chat 
    3. Search for any user (account B) that only has the defaut image (icon) 
    4. Send a message to the account

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

<img width="538" alt="Screen Shot 2021-02-19 at 3 25 42 PM" src="https://user-images.githubusercontent.com/49007721/108572279-cf2f3280-72c6-11eb-94f4-a61226ba7aa4.png">

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

<img width="361" alt="Screen Shot 2021-02-19 at 3 45 53 PM" src="https://user-images.githubusercontent.com/49007721/108573534-b96f3c80-72c9-11eb-9499-8bfcde499e82.png">

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

<img width="1209" alt="Screen Shot 2021-02-19 at 3 48 19 PM" src="https://user-images.githubusercontent.com/49007721/108573791-60ec6f00-72ca-11eb-8158-7508168da67c.png">

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

<img width="339" alt="Screen Shot 2021-02-19 at 3 41 48 PM" src="https://user-images.githubusercontent.com/49007721/108573539-bd02c380-72c9-11eb-8e70-096ebb1bc823.png">

#### Android
<!-- Insert screenshots of your changes on the Android platform-->

<img width="437" alt="Screen Shot 2021-02-19 at 3 52 12 PM" src="https://user-images.githubusercontent.com/49007721/108573843-85e0e200-72ca-11eb-9381-6973ba72b04c.png">

