### PR TITLE
Tweak CLA to run on PR comments OR PR target

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -9,8 +9,8 @@ on:
 jobs:
     CLA:
         runs-on: ubuntu-latest
-        # This job only runs for pull request comments
-        if: ${{ github.event.issue.pull_request }}
+        # This job only runs for pull request comments or pull request target events (not issue comments)
+        if: github.event.issue.pull_request || github.event_name == 'pull_request_target'
         steps:
             - uses: actions-ecosystem/action-regex-match@9c35fe9ac1840239939c59e5db8839422eed8a73
               id: sign


### PR DESCRIPTION
### Details
In a previous PR I restricted this CLA workflow only to run on issue comments, which does prevent this from running on issue comments, but we also need to run this on pull request target events as well. 

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/154742

### Tests
1. I edited the logic in [my public test repo here to match the logic in this PR](https://github.com/Andrew-Test-Org/Public-Test-Repo/blob/main/.github/workflows/CLA.yml)
2. I then pushed a [PR that had the CLA run](https://github.com/Andrew-Test-Org/Public-Test-Repo/actions/runs/590183836) ✅
3. I then [left a comment on a PR that ran the CLA](https://github.com/Andrew-Test-Org/Public-Test-Repo/actions/runs/590184939) ✅ 
4. I then [left a comment on an issue and verified the CLA did not run](https://github.com/Andrew-Test-Org/Public-Test-Repo/actions/runs/590202855) ✅ 
