### PR TITLE
Update popover modal type

### DIFF
--- a/src/components/CreateMenu.js
+++ b/src/components/CreateMenu.js
@@ -80,11 +80,7 @@ class CreateMenu extends PureComponent {
                     this.onModalHide();
                     this.resetOnModalHide();
                 }}
-                type={
-                    this.props.isSmallScreenWidth
-                        ? CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED
-                        : CONST.MODAL.MODAL_TYPE.POPOVER
-                }
+                type={CONST.MODAL.MODAL_TYPE.POPOVER}
                 popoverAnchorPosition={styles.createMenuPosition}
             >
                 {menuItemData.map(({icon, text, onPress}) => (

--- a/src/components/CreateMenu.js
+++ b/src/components/CreateMenu.js
@@ -3,9 +3,8 @@ import PropTypes from 'prop-types';
 import {
     View, Text, Pressable,
 } from 'react-native';
-import Modal from './Modal';
+import Popover from './Popover';
 import styles from '../styles/styles';
-import CONST from '../CONST';
 import themeColors from '../styles/themes/default';
 import Icon from './Icon';
 import {ChatBubble, Users} from './Icon/Expensicons';
@@ -73,15 +72,14 @@ class CreateMenu extends PureComponent {
         }));
 
         return (
-            <Modal
+            <Popover
                 onClose={this.props.onClose}
                 isVisible={this.props.isVisible}
                 onModalHide={() => {
                     this.onModalHide();
                     this.resetOnModalHide();
                 }}
-                type={CONST.MODAL.MODAL_TYPE.POPOVER}
-                popoverAnchorPosition={styles.createMenuPosition}
+                anchorPosition={styles.createMenuPosition}
             >
                 {menuItemData.map(({icon, text, onPress}) => (
                     <Pressable
@@ -102,7 +100,7 @@ class CreateMenu extends PureComponent {
                         </View>
                     </Pressable>
                 ))}
-            </Modal>
+            </Popover>
         );
     }
 }

--- a/src/components/CreateMenu.js
+++ b/src/components/CreateMenu.js
@@ -85,6 +85,7 @@ class CreateMenu extends PureComponent {
                         ? CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED
                         : CONST.MODAL.MODAL_TYPE.POPOVER
                 }
+                popoverAnchorPosition={styles.createMenuPosition}
             >
                 {menuItemData.map(({icon, text, onPress}) => (
                     <Pressable

--- a/src/components/Modal/BaseModal.js
+++ b/src/components/Modal/BaseModal.js
@@ -26,11 +26,15 @@ const BaseModal = (props) => {
         shouldAddTopSafeAreaPadding,
         shouldAddBottomSafeAreaPadding,
         hideBackdrop,
-    } = getModalStyles(props.type, {
-        windowWidth: props.windowWidth,
-        windowHeight: props.windowHeight,
-        isSmallScreenWidth: props.isSmallScreenWidth,
-    });
+    } = getModalStyles(
+        props.type,
+        {
+            windowWidth: props.windowWidth,
+            windowHeight: props.windowHeight,
+            isSmallScreenWidth: props.isSmallScreenWidth,
+        },
+        props.popoverAnchorPosition,
+    );
     return (
         <ReactNativeModal
             onBackdropPress={props.onClose}

--- a/src/components/Modal/BaseModal.js
+++ b/src/components/Modal/BaseModal.js
@@ -5,15 +5,8 @@ import {SafeAreaInsetsContext} from 'react-native-safe-area-context';
 import KeyboardShortcut from '../../libs/KeyboardShortcut';
 import styles, {getSafeAreaPadding} from '../../styles/styles';
 import themeColors from '../../styles/themes/default';
-import modalPropTypes from './ModalPropTypes';
+import {propTypes, defaultProps} from './ModalPropTypes';
 import getModalStyles from '../../styles/getModalStyles';
-
-
-const defaultProps = {
-    onSubmit: null,
-    type: '',
-    onModalHide: () => { },
-};
 
 const BaseModal = (props) => {
     const subscribeToKeyEvents = () => {
@@ -90,7 +83,7 @@ const BaseModal = (props) => {
     );
 };
 
-BaseModal.propTypes = modalPropTypes;
+BaseModal.propTypes = propTypes;
 BaseModal.defaultProps = defaultProps;
 BaseModal.displayName = 'BaseModal';
 export default memo(BaseModal);

--- a/src/components/Modal/ModalPropTypes.js
+++ b/src/components/Modal/ModalPropTypes.js
@@ -25,6 +25,15 @@ const propTypes = {
         CONST.MODAL.MODAL_TYPE.POPOVER,
         CONST.MODAL.MODAL_TYPE.RIGHT_DOCKED,
     ]),
+
+    // The anchor position of a popover modal. Has no effect on other modal types.
+    popoverAnchorPosition: PropTypes.shape({
+        top: PropTypes.number,
+        right: PropTypes.number,
+        bottom: PropTypes.number,
+        left: PropTypes.number,
+    }),
+
     ...windowDimensionsPropTypes,
 };
 
@@ -32,6 +41,7 @@ const defaultProps = {
     onSubmit: null,
     type: '',
     onModalHide: () => {},
+    popoverAnchorPosition: null,
 };
 
 export {propTypes, defaultProps};

--- a/src/components/Modal/ModalPropTypes.js
+++ b/src/components/Modal/ModalPropTypes.js
@@ -41,7 +41,7 @@ const defaultProps = {
     onSubmit: null,
     type: '',
     onModalHide: () => {},
-    popoverAnchorPosition: null,
+    popoverAnchorPosition: {},
 };
 
 export {propTypes, defaultProps};

--- a/src/components/Modal/ModalPropTypes.js
+++ b/src/components/Modal/ModalPropTypes.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import CONST from '../../CONST';
 import {windowDimensionsPropTypes} from '../withWindowDimensions';
 
-const modalPropTypes = {
+const propTypes = {
     // Callback method fired when the user requests to close the modal
     onClose: PropTypes.func.isRequired,
 
@@ -28,4 +28,10 @@ const modalPropTypes = {
     ...windowDimensionsPropTypes,
 };
 
-export default modalPropTypes;
+const defaultProps = {
+    onSubmit: null,
+    type: '',
+    onModalHide: () => {},
+};
+
+export {propTypes, defaultProps};

--- a/src/components/Modal/index.android.js
+++ b/src/components/Modal/index.android.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import withWindowDimensions from '../withWindowDimensions';
 import BaseModal from './BaseModal';
-import modalPropTypes from './ModalPropTypes';
+import {propTypes, defaultProps} from './ModalPropTypes';
 
 // Only want to use useNativeDriver on Android. It has strange flashes issue on IOS
 // https://github.com/react-native-modal/react-native-modal#the-modal-flashes-in-a-weird-way-when-animating
@@ -14,6 +14,8 @@ const Modal = props => (
         {props.children}
     </BaseModal>
 );
-Modal.propTypes = modalPropTypes;
+
+Modal.propTypes = propTypes;
+Modal.defaultProps = defaultProps;
 Modal.displayName = 'Modal';
 export default withWindowDimensions(Modal);

--- a/src/components/Modal/index.android.js
+++ b/src/components/Modal/index.android.js
@@ -8,7 +8,7 @@ import {propTypes, defaultProps} from './ModalPropTypes';
 const Modal = props => (
     <BaseModal
         useNativeDriver
-               // eslint-disable-next-line react/jsx-props-no-spreading
+        // eslint-disable-next-line react/jsx-props-no-spreading
         {...props}
     >
         {props.children}

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -1,11 +1,7 @@
 import React from 'react';
 import withWindowDimensions from '../withWindowDimensions';
 import BaseModal from './BaseModal';
-import modalPropTypes from './ModalPropTypes';
-
-const defaultProps = {
-    type: '',
-};
+import {propTypes, defaultProps} from './ModalPropTypes';
 
 const Modal = props => (
     // eslint-disable-next-line react/jsx-props-no-spreading
@@ -14,7 +10,7 @@ const Modal = props => (
     </BaseModal>
 );
 
-Modal.propTypes = modalPropTypes;
+Modal.propTypes = propTypes;
 Modal.defaultProps = defaultProps;
 Modal.displayName = 'Modal';
 export default withWindowDimensions(Modal);

--- a/src/components/Popover.js
+++ b/src/components/Popover.js
@@ -1,0 +1,42 @@
+import _ from 'underscore';
+import React from 'react';
+import PropTypes from 'prop-types';
+import CONST from '../CONST';
+import {propTypes as modalPropTypes, defaultProps as defaultModalProps} from './Modal/ModalPropTypes';
+import Modal from './Modal';
+import withWindowDimensions from './withWindowDimensions';
+
+const propTypes = {
+    ...(_.omit(modalPropTypes, 'type', 'popoverAnchorPosition')),
+
+    // The anchor position of the popover
+    anchorPosition: PropTypes.shape({
+        top: PropTypes.number,
+        right: PropTypes.number,
+        bottom: PropTypes.number,
+        left: PropTypes.number,
+    }).isRequired,
+};
+
+const defaultProps = {
+    ...(_.omit(defaultModalProps, 'type', 'popoverAnchorPosition')),
+};
+
+/*
+ * This is a convenience wrapper around the Modal component for a responsive Popover.
+ * On small screen widths, it uses BottomDocked modal type, and a Popover on wide screen widths.
+ */
+const Popover = props => (
+    <Modal
+        type={props.isSmallScreenWidth ? CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED : CONST.MODAL.MODAL_TYPE.POPOVER}
+        popoverAnchorPosition={props.anchorPosition}
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...props}
+    />
+);
+
+Popover.propTypes = propTypes;
+Popover.defaultProps = defaultProps;
+Popover.displayName = 'Popover';
+
+export default withWindowDimensions(Popover);

--- a/src/styles/getModalStyles.js
+++ b/src/styles/getModalStyles.js
@@ -18,12 +18,7 @@ export default (type, windowDimensions, popoverAnchorPosition = {}) => {
     let shouldAddBottomSafeAreaPadding = false;
     let shouldAddTopSafeAreaPadding = false;
 
-    // On smaller screen widths, the Popover modal becomes a BottomDocked modal
-    const screenWidthAdjustedType = windowDimensions.isSmallScreenWidth && type === CONST.MODAL.MODAL_TYPE.POPOVER
-        ? CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED
-        : type;
-
-    switch (screenWidthAdjustedType) {
+    switch (type) {
         case CONST.MODAL.MODAL_TYPE.CENTERED:
             // A centered modal is one that has a visible backdrop
             // and can be dismissed by clicking outside of the modal.

--- a/src/styles/getModalStyles.js
+++ b/src/styles/getModalStyles.js
@@ -18,11 +18,11 @@ export default (type, windowDimensions, popoverAnchorPosition = {}) => {
     let shouldAddBottomSafeAreaPadding = false;
     let shouldAddTopSafeAreaPadding = false;
 
-    const platformAdjustedType = windowDimensions.isSmallScreenWidth && type === CONST.MODAL.MODAL_TYPE.POPOVER
+    const screenWidthAdjustedType = windowDimensions.isSmallScreenWidth && type === CONST.MODAL.MODAL_TYPE.POPOVER
         ? CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED
         : type;
 
-    switch (platformAdjustedType) {
+    switch (screenWidthAdjustedType) {
         case CONST.MODAL.MODAL_TYPE.CENTERED:
             // A centered modal is one that has a visible backdrop
             // and can be dismissed by clicking outside of the modal.

--- a/src/styles/getModalStyles.js
+++ b/src/styles/getModalStyles.js
@@ -18,6 +18,7 @@ export default (type, windowDimensions, popoverAnchorPosition = {}) => {
     let shouldAddBottomSafeAreaPadding = false;
     let shouldAddTopSafeAreaPadding = false;
 
+    // On smaller screen widths, the Popover modal becomes a BottomDocked modal
     const screenWidthAdjustedType = windowDimensions.isSmallScreenWidth && type === CONST.MODAL.MODAL_TYPE.POPOVER
         ? CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED
         : type;

--- a/src/styles/getModalStyles.js
+++ b/src/styles/getModalStyles.js
@@ -18,7 +18,11 @@ export default (type, windowDimensions, popoverAnchorPosition = {}) => {
     let shouldAddBottomSafeAreaPadding = false;
     let shouldAddTopSafeAreaPadding = false;
 
-    switch (type) {
+    const platformAdjustedType = windowDimensions.isSmallScreenWidth && type === CONST.MODAL.MODAL_TYPE.POPOVER
+        ? CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED
+        : type;
+
+    switch (platformAdjustedType) {
         case CONST.MODAL.MODAL_TYPE.CENTERED:
             // A centered modal is one that has a visible backdrop
             // and can be dismissed by clicking outside of the modal.

--- a/src/styles/getModalStyles.js
+++ b/src/styles/getModalStyles.js
@@ -3,7 +3,7 @@ import colors from './colors';
 import variables from './variables';
 import themeColors from './themes/default';
 
-export default (type, windowDimensions) => {
+export default (type, windowDimensions, popoverAnchorPosition = {}) => {
     const {isSmallScreenWidth, windowWidth} = windowDimensions;
 
     let modalStyle = {
@@ -83,11 +83,11 @@ export default (type, windowDimensions) => {
         case CONST.MODAL.MODAL_TYPE.POPOVER:
             modalStyle = {
                 ...modalStyle,
+                ...popoverAnchorPosition,
                 ...{
+                    position: 'absolute',
                     alignItems: 'center',
                     justifyContent: 'flex-end',
-                    marginRight: windowWidth - variables.sideBarWidth,
-                    marginBottom: 100,
                 },
             };
             modalContainerStyle = {

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -413,6 +413,11 @@ const styles = {
         textDecorationLine: 'none',
     },
 
+    createMenuPosition: {
+        left: 18,
+        bottom: 100,
+    },
+
     createMenuItem: {
         flexDirection: 'row',
         borderRadius: 0,


### PR DESCRIPTION
### Details
There's a bit of history to this PR. Basically, I'm:

1) Extracting some changes to simplify [this PR](https://github.com/Expensify/Expensify.cash/pull/1469/files), and
2) Taking a conclusion from [this slack thread](https://expensify.slack.com/archives/C011W8BJ9L6/p1613725676116500), namely "we have a separate, established rule for popovers. If the screen is small (mobile), the popover is bottom-docked. If the screen is wide, launch popover near where the click/press event happened", and put it into code.

Ultimately this is a prep step for the ReportActionContextMenu. 

### Fixed Issues (parital)
https://github.com/Expensify/Expensify/issues/147472

### Tests
For now, we're just going to perform a regression test of the existing popover modal.

1. Run the app.
2. Click on the global create floating action button
3. Ensure that the _correct type_ of popover modal appears.

On wide screens, it should look like this (image taken from production):

<img src="https://user-images.githubusercontent.com/47436092/108781116-427eb180-751e-11eb-8287-aef5572274f5.png" alt="" width="350px" />

On narrow screens, it should look like this (image taken from production):

<img src="https://user-images.githubusercontent.com/47436092/108781274-78bc3100-751e-11eb-831c-902c77173848.png" alt="" width="350px" />

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

|Platform|Wide|Narrow|
|---|---|---|
|Web|![image](https://user-images.githubusercontent.com/47436092/108781343-938ea580-751e-11eb-864d-b58b5d53b6f6.png)|![image](https://user-images.githubusercontent.com/47436092/108781391-a1442b00-751e-11eb-916a-b0ad10c85d4c.png)|
|mWeb|n/a|![image](https://user-images.githubusercontent.com/47436092/108782038-b2da0280-751f-11eb-8457-aadec077b11d.png)|
|Desktop|![image](https://user-images.githubusercontent.com/47436092/108781589-fda74a80-751e-11eb-8ba1-d179f838ef4e.png)|![image](https://user-images.githubusercontent.com/47436092/108781638-0f88ed80-751f-11eb-8986-24d9ef2f75d2.png)|
|iOS|n/a|![image](https://user-images.githubusercontent.com/47436092/108782524-94283b80-7520-11eb-95da-9a828e187cbd.png)|
|Android|n/a|![image](https://user-images.githubusercontent.com/47436092/108782853-36e0ba00-7521-11eb-9b8e-d60fb38a1225.png)|

