### PR TITLE
Add UserSettings functions to API.js and User.js

### DIFF
--- a/src/ONYXKEYS.js
+++ b/src/ONYXKEYS.js
@@ -47,7 +47,7 @@ export default {
     BETAS: 'betas',
 
     // NVP keys
-    NVP_PAYPALMEADDRESS: 'nvp_paypalMeAddress',
+    NVP_PAYPAL_ME_ADDRESS: 'nvp_paypalMeAddress',
 
     // Collection Keys
     COLLECTION: {

--- a/src/ONYXKEYS.js
+++ b/src/ONYXKEYS.js
@@ -46,12 +46,14 @@ export default {
     IS_SIDEBAR_ANIMATING: 'isSidebarAnimating',
     BETAS: 'betas',
 
+    // NVP keys
+    NVP_PAYPALMEADDRESS: 'nvp_paypalMeAddress',
+
     // Collection Keys
     COLLECTION: {
         REPORT: 'report_',
         REPORT_ACTIONS: 'reportActions_',
         REPORT_DRAFT_COMMENT: 'reportDraftComment_',
         REPORT_USER_IS_TYPING: 'reportUserIsTyping_',
-        NVP: 'nvp_',
     },
 };

--- a/src/ONYXKEYS.js
+++ b/src/ONYXKEYS.js
@@ -37,6 +37,9 @@ export default {
     // an international code
     COUNTRY_CODE: 'countryCode',
 
+    // Contains all the users settings for the Settings page and sub pages
+    USER: 'user',
+
     // Information about the current session (authToken, accountID, email, loading, error)
     SESSION: 'session',
     IS_SIDEBAR_SHOWN: 'isSidebarShown',
@@ -49,5 +52,6 @@ export default {
         REPORT_ACTIONS: 'reportActions_',
         REPORT_DRAFT_COMMENT: 'reportDraftComment_',
         REPORT_USER_IS_TYPING: 'reportUserIsTyping_',
+        NVP: 'nvp_',
     },
 };

--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -442,18 +442,6 @@ function PersonalDetails_GetForEmails(parameters) {
 
 /**
  * @param {Object} parameters
- * @param {Object} parameters.details
- * @returns {Promise}
- */
-function PersonalDetails_Update(parameters) {
-    const commandName = 'PersonalDetails_Update';
-    requireParameters(['details'],
-        parameters, commandName);
-    return request(commandName, parameters);
-}
-
-/**
- * @param {Object} parameters
  * @param {String} parameters.socket_id
  * @param {String} parameters.channel_name
  * @returns {Promise}
@@ -578,18 +566,7 @@ function User_GetBetas() {
  */
 function User_SecondaryLogin_Send(parameters) {
     const commandName = 'User_SecondaryLogin_Send';
-    requireParameters(['email','password'], parameters, commandName);
-    return request(commandName, parameters);
-}
-
-/**
- * @param {Object} parameters
- * @param {String} parameters.base64image
- * @returns {Promise}
- */
-function User_UploadAvatar(parameters) {
-    const commandName = 'User_UploadAvatar';
-    requireParameters(['base64image'], parameters, commandName);
+    requireParameters(['email', 'password'], parameters, commandName);
     return request(commandName, parameters);
 }
 
@@ -618,7 +595,6 @@ export {
     Graphite_Timer,
     Log,
     PersonalDetails_GetForEmails,
-    PersonalDetails_Update,
     Push_Authenticate,
     Report_AddComment,
     Report_GetHistory,
@@ -632,6 +608,5 @@ export {
     User_SignUp,
     User_GetBetas,
     User_SecondaryLogin_Send,
-    User_UploadAvatar,
     reauthenticate,
 };

--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -572,13 +572,13 @@ function User_GetBetas() {
 
 /**
  * @param {Object} parameters
- * @param {String} parameters.login
+ * @param {String} parameters.email
  * @param {String} parameters.password
  * @returns {Promise}
  */
 function User_SecondaryLogin_Send(parameters) {
     const commandName = 'User_SecondaryLogin_Send';
-    requireParameters(['login', 'password'], parameters, commandName);
+    requireParameters(['email','password'], parameters, commandName);
     return request(commandName, parameters);
 }
 

--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -302,7 +302,7 @@ function reauthenticate(command = '') {
  * @returns {Promise}
  */
 function ChangePassword(parameters) {
-    const commandName = 'User_UploadAvatar';
+    const commandName = 'ChangePassword';
     requireParameters(['oldPassword', 'password'], parameters, commandName);
     return request(commandName, parameters);
 }

--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -296,6 +296,18 @@ function reauthenticate(command = '') {
 }
 
 /**
+ * @param {Object} parameters
+ * @param {String} parameters.oldPassword
+ * @param {String} parameters.password
+ * @returns {Promise}
+ */
+function ChangePassword(parameters) {
+    const commandName = 'User_UploadAvatar';
+    requireParameters(['oldPassword', 'password'], parameters, commandName);
+    return request(commandName, parameters);
+}
+
+/**
  * @param {object} parameters
  * @param {string} parameters.emailList
  * @returns {Promise}
@@ -430,6 +442,18 @@ function PersonalDetails_GetForEmails(parameters) {
 
 /**
  * @param {Object} parameters
+ * @param {Object} parameters.details
+ * @returns {Promise}
+ */
+function PersonalDetails_Update(parameters) {
+    const commandName = 'PersonalDetails_Update';
+    requireParameters(['details'],
+        parameters, commandName);
+    return request(commandName, parameters);
+}
+
+/**
+ * @param {Object} parameters
  * @param {String} parameters.socket_id
  * @param {String} parameters.channel_name
  * @returns {Promise}
@@ -529,10 +553,44 @@ function SetPassword(parameters) {
 }
 
 /**
+ * @param {Object} parameters
+ * @param {String} parameters.subscribed
+ * @returns {Promise}
+ */
+function UpdateAccount(parameters) {
+    const commandName = 'UpdateAccount';
+    requireParameters(['subscribed'], parameters, commandName);
+    return request(commandName, parameters);
+}
+
+/**
  * @returns {Promise}
  */
 function User_GetBetas() {
     return request('User_GetBetas');
+}
+
+/**
+ * @param {Object} parameters
+ * @param {String} parameters.login
+ * @param {String} parameters.password
+ * @returns {Promise}
+ */
+function User_SecondaryLogin_Send(parameters) {
+    const commandName = 'User_SecondaryLogin_Send';
+    requireParameters(['login', 'password'], parameters, commandName);
+    return request(commandName, parameters);
+}
+
+/**
+ * @param {Object} parameters
+ * @param {String} parameters.base64image
+ * @returns {Promise}
+ */
+function User_UploadAvatar(parameters) {
+    const commandName = 'User_UploadAvatar';
+    requireParameters(['base64image'], parameters, commandName);
+    return request(commandName, parameters);
 }
 
 /**
@@ -550,6 +608,7 @@ function SetNameValuePair(parameters) {
 export {
     getAuthToken,
     Authenticate,
+    ChangePassword,
     CreateChatReport,
     CreateLogin,
     DeleteLogin,
@@ -559,6 +618,7 @@ export {
     Graphite_Timer,
     Log,
     PersonalDetails_GetForEmails,
+    PersonalDetails_Update,
     Push_Authenticate,
     Report_AddComment,
     Report_GetHistory,
@@ -568,7 +628,10 @@ export {
     SetGithubUsername,
     SetNameValuePair,
     SetPassword,
+    UpdateAccount,
     User_SignUp,
     User_GetBetas,
+    User_SecondaryLogin_Send,
+    User_UploadAvatar,
     reauthenticate,
 };

--- a/src/libs/Network.js
+++ b/src/libs/Network.js
@@ -69,6 +69,8 @@ function processNetworkRequestQueue() {
 
         const requestData = queuedRequest.data;
         const requestEmail = requestData.email ?? '';
+
+        // If we haven't passed an email in the request data, set it to the current user's email
         if (email && _.isEmpty(requestEmail)) {
             requestData.email = email;
         }

--- a/src/libs/Network.js
+++ b/src/libs/Network.js
@@ -68,7 +68,8 @@ function processNetworkRequestQueue() {
         }
 
         const requestData = queuedRequest.data;
-        if (email) {
+        const requestEmail = requestData.email ?? '';
+        if (email && _.isEmpty(requestEmail)) {
             requestData.email = email;
         }
 

--- a/src/libs/actions/User.js
+++ b/src/libs/actions/User.js
@@ -48,7 +48,7 @@ function fetch() {
 
             // Update the nvp_payPalMeAddress NVP
             const payPalMeAddress = lodashGet(response, `nameValuePairs.${payPalNVP}`, '');
-            Onyx.merge(ONYXKEYS.NVP_PAYPALMEADDRESS, payPalMeAddress);
+            Onyx.merge(ONYXKEYS.NVP_PAYPAL_ME_ADDRESS, payPalMeAddress);
         });
 }
 

--- a/src/libs/actions/User.js
+++ b/src/libs/actions/User.js
@@ -16,11 +16,9 @@ import {signIn} from './Session';
  */
 function changePassword(oldPassword, password, twoFactorAuthCode) {
     API.ChangePassword({oldPassword, password}).then((response) => {
-        // If we've successfully authenticated the user, ensure sign them in so they don't get booted out
+        // If we've successfully authenticated the user, ensure we sign them in so they don't get booted out
         if (response.jsonCode === 200) {
             signIn(password, twoFactorAuthCode);
-        } else {
-            console.error('Could not change password', response);
         }
     });
 }
@@ -29,8 +27,6 @@ function getBetas() {
     API.User_GetBetas().then((response) => {
         if (response.jsonCode === 200) {
             Onyx.set(ONYXKEYS.BETAS, response.betas);
-        } else {
-            console.error('Could not get betas', response);
         }
     });
 }
@@ -52,9 +48,8 @@ function fetch() {
 
             // Update the nvp_payPalMeAddress NVP
             const payPalMeAddress = lodashGet(response, `nameValuePairs.${payPalNVP}`, '');
-            Onyx.merge(`${ONYXKEYS.COLLECTION.NVP}payPalMeAddress`, payPalMeAddress);
-        })
-        .catch(error => console.debug('Error fetching user settings', error));
+            Onyx.merge(ONYXKEYS.NVP_PAYPALMEADDRESS, payPalMeAddress);
+        });
 }
 
 /**
@@ -63,11 +58,7 @@ function fetch() {
  * @param {String} email
  */
 function resendValidateCode(email) {
-    API.ResendValidateCode({email}).then((response) => {
-        if (response.jsonCode !== 200) {
-            console.error('Could not resend validate code', response);
-        }
-    });
+    API.ResendValidateCode({email});
 }
 
 /**
@@ -79,8 +70,6 @@ function setExpensifyNewsStatus(subscribed) {
     API.UpdateAccount({subscribed}).then((response) => {
         if (response.jsonCode === 200) {
             Onyx.merge(ONYXKEYS.USER, {expensifyNewsStatus: subscribed});
-        } else {
-            console.error('Could not set Expensify news subscription status', response);
         }
     });
 }
@@ -99,8 +88,6 @@ function setSecondaryLogin(login, password) {
         if (response.jsonCode === 200) {
             const loginList = _.where(response.loginList, {partnerName: 'expensify.com'});
             Onyx.merge(ONYXKEYS.USER, {loginList});
-        } else {
-            console.error('Could not set secondary login', response);
         }
     });
 }

--- a/src/libs/actions/User.js
+++ b/src/libs/actions/User.js
@@ -1,8 +1,29 @@
 /* eslint-disable  import/prefer-default-export  */
 
+import _ from 'underscore';
+import lodashGet from 'lodash.get';
 import Onyx from 'react-native-onyx';
 import ONYXKEYS from '../../ONYXKEYS';
 import * as API from '../API';
+import {signIn} from './Session';
+
+/**
+ * Changes a password for a given account
+ *
+ * @param {String} oldPassword
+ * @param {String} password
+ * @param {String} [twoFactorAuthCode]
+ */
+function changePassword(oldPassword, password, twoFactorAuthCode) {
+    API.ChangePassword({oldPassword, password}).then((response) => {
+        // If we've successfully authenticated the user, ensure sign them in so they don't get booted out
+        if (response.jsonCode === 200) {
+            signIn(password, twoFactorAuthCode);
+        } else {
+            console.error('Could not change password', response);
+        }
+    });
+}
 
 function getBetas() {
     API.User_GetBetas().then((response) => {
@@ -14,6 +35,78 @@ function getBetas() {
     });
 }
 
+/**
+ * Fetches the data needed for user settings
+ */
+function fetch() {
+    const payPalNVP = 'expensify_payPalMeAddress';
+    API.Get({
+        returnValueList: ['account', 'loginList', 'nameValuePairs'],
+        name: payPalNVP,
+    })
+        .then((response) => {
+            // Update the User onyx key
+            const loginList = _.where(response.loginList, {partnerName: 'expensify.com'});
+            const expensifyNewsStatus = lodashGet(response, 'account.subscribed', true);
+            Onyx.merge(ONYXKEYS.USER, {loginList, expensifyNewsStatus});
+
+            // Update the nvp_payPalMeAddress NVP
+            const payPalMeAddress = lodashGet(response, `nameValuePairs.${payPalNVP}`, '');
+            Onyx.merge(`${ONYXKEYS.COLLECTION.NVP}payPalMeAddress`, payPalMeAddress);
+        })
+        .catch(error => console.debug('Error fetching user settings', error));
+}
+
+/**
+ * Resends a validation link to a given login
+ *
+ * @param {String} email
+ */
+function resendValidateCode(email) {
+    API.ResendValidateCode({email}).then((response) => {
+        if (response.jsonCode !== 200) {
+            console.error('Could not resend validate code', response);
+        }
+    });
+}
+
+/**
+ * Sets whether or not the user is subscribed to Expensify news
+ *
+ * @param {Boolean} subscribed
+ */
+function setExpensifyNewsStatus(subscribed) {
+    API.UpdateAccount({subscribed}).then((response) => {
+        if (response.jsonCode === 200) {
+            Onyx.merge(ONYXKEYS.USER, {expensifyNewsStatus: subscribed});
+        } else {
+            console.error('Could not set Expensify news subscription status', response);
+        }
+    });
+}
+
+/**
+ * Adds a secondary login to a user's account
+ *
+ * @param {String} login
+ * @param {String} password
+ */
+function setSecondaryLogin(login, password) {
+    API.User_SecondaryLogin_Send({login, password}).then((response) => {
+        if (response.jsonCode === 200) {
+            const loginList = _.where(response.loginList, {partnerName: 'expensify.com'});
+            Onyx.merge(ONYXKEYS.USER, {loginList});
+        } else {
+            console.error('Could not set secondary login', response);
+        }
+    });
+}
+
 export {
+    changePassword,
     getBetas,
+    fetch,
+    resendValidateCode,
+    setExpensifyNewsStatus,
+    setSecondaryLogin,
 };

--- a/src/libs/actions/User.js
+++ b/src/libs/actions/User.js
@@ -92,7 +92,10 @@ function setExpensifyNewsStatus(subscribed) {
  * @param {String} password
  */
 function setSecondaryLogin(login, password) {
-    API.User_SecondaryLogin_Send({login, password}).then((response) => {
+    API.User_SecondaryLogin_Send({
+        email: login,
+        password,
+    }).then((response) => {
         if (response.jsonCode === 200) {
             const loginList = _.where(response.loginList, {partnerName: 'expensify.com'});
             Onyx.merge(ONYXKEYS.USER, {loginList});


### PR DESCRIPTION

### Details
Adds several new functions to API.js and User.js with the intent to set up things so that contractors could more easily work on the User Settings project 

I.e. do this now so that later we can do the following:
```
Do less: "Write a method that does x and then use it to achieve x"
Do more: "Use this existing method to achieve x"
```

### Fixed Issues
<Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing>
Fixes Expensify/Expensify/issues/154634 (1/2 PRs)

### Tests
1. Add a debug point to `Homepage.js` at the beginning of `componentDidMount()`
2. For each function I refreshed the page, ran `User = _libs_actions_User__WEBPACK_IMPORTED_MODULE_45__;`, then called `User.xyz()` and unpaused the debugger.
3. Tested the following functions to confirm they worked as expected: 
    - `User.fetch()`: Confirmed we requisite `loginList` and `expensifyNewsStatus` were included in the `user` onyx key
        - ![image](https://user-images.githubusercontent.com/16747822/108795352-2b9a8800-753b-11eb-9f22-9a6e736374f0.png)
 
    - `User.setSecondaryLogin()`: Used `nikki@devtool.com` as the the new secondary login to be added and confirmed the onyx key updated as expected.
        - ![image](https://user-images.githubusercontent.com/16747822/108795502-7b794f00-753b-11eb-97bf-2b47165fa822.png)
        - ![image](https://user-images.githubusercontent.com/16747822/108795530-8df38880-753b-11eb-8195-7af22f4cc004.png)
    - `User.resendValidateCode()`: resent a validate code to "nikki@devtool.com" and confirmed it existed if the `notifications` table 
         ```JSON
        sqlite> select * from notifications;
        json = {"accountEmail":"nikki@meep.com","accountID":4,"authToken":"<authtoken>","template":"SecondaryLoginAdd","to":"nikki@devtool.com"}
       priority = 200
       created = 2021-02-23 02:28:17 
      ```
    - `User.setExpensifyNewsStatus()`: Since my `expensifyNewsStatus` was true I tested setting it to false 
        - ![image](https://user-images.githubusercontent.com/16747822/108795934-5802d400-753c-11eb-8ee6-ab35e3b816bf.png)
        - Then tested re-setting it to true, just to be safe
        - ![image](https://user-images.githubusercontent.com/16747822/108795972-79fc5680-753c-11eb-920c-546b16b164b9.png)
    - `User.changePassword()`: I changed my user's password and confirmed that I was re-signed in after the password had been changed. 
        - I enabled 2FA on the account and tried to change the password without including the 2FA code. I then confirmed that I was signed out of the app but that the password did change (2FA is required for the re-authentication, not for the password changing) 
        - I re-ran `User.changePassword` and included the 2FA code. I was able to confirm that the password was changed and I was re-signed into the app. 

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

⬆️  is not applicable to this PR because we're not making any UI changes here. 

### Screenshots
N/A

