### PR TITLE
Adding isAppInstalled logic

### DIFF
--- a/ios/ExpensifyCash/Info.plist
+++ b/ios/ExpensifyCash/Info.plist
@@ -87,5 +87,9 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false />
+  <key>LSApplicationQueriesSchemes</key>
+  <array>
+      <string>venmo</string>
+  </array>
 </dict>
 </plist>

--- a/src/libs/isAppInstalled/index.js
+++ b/src/libs/isAppInstalled/index.js
@@ -1,0 +1,3 @@
+export default function isAppInstalled() {
+    return false;
+}

--- a/src/libs/isAppInstalled/index.js
+++ b/src/libs/isAppInstalled/index.js
@@ -1,3 +1,10 @@
+/**
+ * Returns always false for other platforms
+ *
+ * @returns {Promise}
+ */
 export default function isAppInstalled() {
-    return false;
+    return new Promise((resolve) => {
+        resolve(false);
+    });
 }

--- a/src/libs/isAppInstalled/index.native.js
+++ b/src/libs/isAppInstalled/index.native.js
@@ -1,0 +1,15 @@
+import {Linking} from 'react-native';
+
+/**
+ * Gets the URLSchema and check the existence of that application
+ *
+ * @param {String} urlScheme
+ * @returns {Promise<Boolean>}
+ */
+export default async function isAppInstalled(urlScheme) {
+    try {
+        return await Linking.canOpenURL(`${urlScheme}://`);
+    } catch {
+        return false;
+    }
+}

--- a/src/libs/isAppInstalled/index.native.js
+++ b/src/libs/isAppInstalled/index.native.js
@@ -4,12 +4,16 @@ import {Linking} from 'react-native';
  * Gets the URLSchema and check the existence of that application
  *
  * @param {String} urlScheme
- * @returns {Promise<Boolean>}
+ * @returns {Promise}
  */
 export default async function isAppInstalled(urlScheme) {
-    try {
-        return await Linking.canOpenURL(`${urlScheme}://`);
-    } catch {
-        return false;
-    }
+    return new Promise((resolve, reject) => {
+        Linking.canOpenURL(`${urlScheme}://`)
+            .then((isInstalled) => {
+                resolve(isInstalled);
+            })
+            .catch((error) => {
+                reject(error);
+            });
+    });
 }

--- a/src/libs/isAppInstalled/index.native.js
+++ b/src/libs/isAppInstalled/index.native.js
@@ -6,7 +6,7 @@ import {Linking} from 'react-native';
  * @param {String} urlScheme
  * @returns {Promise}
  */
-export default async function isAppInstalled(urlScheme) {
+export default function isAppInstalled(urlScheme) {
     return new Promise((resolve, reject) => {
         Linking.canOpenURL(`${urlScheme}://`)
             .then((isInstalled) => {


### PR DESCRIPTION
### Details
This PR includes a method of detecting installed apps for the Expensify.cash app on Android & iOS.

#### iOS only
As discussed in the issue, currently added `venmo` app `URLscheme` on iOS.
If more apps need to be added, Then I can add them to `LSApplicationQueriesSchemes`  under `info.plist`


#### Android
Does not need additional steps to be done with new apps.

### Fixed Issues
Fixes: https://github.com/Expensify/Expensify.cash/issues/1526

### Tests
#### iOS and Android

- After importing `isAppInstalled` function, it will execute from `index.native.js`
- The function returns a promise with a boolean result (`true` or `false`)
- To call the function use `async` `await`  ( eg: `await isAppInstalled('venmo')`)

#### Desktop and Web

- The function will execute from `index.js`
- It will always return `false`

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

