### PR TITLE
[IS-1500] Fixed compose field alignment issue

### DIFF
--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -12,6 +12,7 @@ import display from './utilities/display';
 import overflow from './utilities/overflow';
 import whiteSpace from './utilities/whiteSpace';
 import wordBreak from './utilities/wordBreak';
+import textInputAlignSelf from './utilities/textInputAlignSelf';
 
 const styles = {
     // Add all of our utility and helper styles
@@ -663,7 +664,7 @@ const styles = {
         paddingHorizontal: 8,
         marginVertical: 5,
         paddingVertical: 0,
-        alignSelf: 'center',
+        ...textInputAlignSelf,
         textAlignVertical: 'center',
     }, 0),
 

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -664,7 +664,7 @@ const styles = {
         paddingHorizontal: 8,
         marginVertical: 5,
         paddingVertical: 0,
-        ...textInputAlignSelf,
+        ...textInputAlignSelf.center,
         textAlignVertical: 'center',
     }, 0),
 

--- a/src/styles/utilities/textInputAlignSelf/index.js
+++ b/src/styles/utilities/textInputAlignSelf/index.js
@@ -1,3 +1,5 @@
 export default {
-    alignSelf: 'center',
+    center: {
+        alignSelf: 'center',
+    },
 };

--- a/src/styles/utilities/textInputAlignSelf/index.js
+++ b/src/styles/utilities/textInputAlignSelf/index.js
@@ -1,0 +1,3 @@
+export default {
+    alignSelf: 'center',
+};

--- a/src/styles/utilities/textInputAlignSelf/index.native.js
+++ b/src/styles/utilities/textInputAlignSelf/index.native.js
@@ -1,0 +1,1 @@
+export default {};

--- a/src/styles/utilities/textInputAlignSelf/index.native.js
+++ b/src/styles/utilities/textInputAlignSelf/index.native.js
@@ -1,1 +1,3 @@
-export default {};
+export default {
+    center: {},
+};


### PR DESCRIPTION
### Details
Added `textInputAlignSelf` utility for `textInputCompose` style object.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/1500

### Tests
Please look at `message compose box` now text inside of the compose box is aligned.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
#### Web
![image](https://user-images.githubusercontent.com/31027036/109044323-30da0d00-76ca-11eb-9926-bdc336cb99b6.png)

#### Mobile Web
![image](https://user-images.githubusercontent.com/31027036/109044432-4e0edb80-76ca-11eb-990d-3332ceecd3e6.png)

#### Desktop
![image](https://user-images.githubusercontent.com/31027036/109044634-86aeb500-76ca-11eb-9fa2-da2262a8caa0.png)

#### iOS
![image](https://user-images.githubusercontent.com/31027036/109044982-f6bd3b00-76ca-11eb-8f31-a27db3fd5ba6.png)

#### Android
![image](https://user-images.githubusercontent.com/31027036/109045221-384de600-76cb-11eb-8c7e-cf7f5f7f61c9.png)
