### PR TITLE
Extract ReportActionContextMenuItem component from the ReportActionContextMenu

### DIFF
--- a/src/pages/home/report/ReportActionContextMenu.js
+++ b/src/pages/home/report/ReportActionContextMenu.js
@@ -1,33 +1,11 @@
 import React from 'react';
-import {Pressable, View} from 'react-native';
+import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import {
     Clipboard, LinkCopy, Mail, Pencil, Trashcan,
 } from '../../../components/Icon/Expensicons';
-import styles from '../../../styles/styles';
 import getReportActionContextMenuStyles from '../../../styles/getReportActionContextMenuStyles';
-import Icon from '../../../components/Icon';
-import Tooltip from '../../../components/Tooltip';
-import CONST from '../../../CONST';
-
-/**
- * Get the string representation of a button's state.
- *
- * @param {Boolean} [isHovered]
- * @param {Boolean} [isPressed]
- * @returns {String}
- */
-function getButtonState(isHovered = false, isPressed = false) {
-    if (isPressed) {
-        return CONST.BUTTON_STATES.PRESSED;
-    }
-
-    if (isHovered) {
-        return CONST.BUTTON_STATES.HOVERED;
-    }
-
-    return CONST.BUTTON_STATES.DEFAULT;
-}
+import ReportActionContextMenuItem from './ReportActionContextMenuItem';
 
 /**
  * A list of all the context actions in this menu.
@@ -87,27 +65,16 @@ const defaultProps = {
 };
 
 const ReportActionContextMenu = (props) => {
-    const {wrapperStyle, getButtonStyle, getIconFillColor} = getReportActionContextMenuStyles(props.isMini);
+    const wrapperStyle = getReportActionContextMenuStyles(props.isMini);
     return props.isVisible && (
-        <View style={[
-            ...wrapperStyle,
-            styles.flex1,
-        ]}
-        >
+        <View style={wrapperStyle}>
             {CONTEXT_ACTIONS.map(contextAction => (
-                <Tooltip
+                <ReportActionContextMenuItem
+                    icon={contextAction.icon}
                     text={contextAction.text}
+                    isMini={props.isMini}
                     key={contextAction.text}
-                >
-                    <Pressable style={({hovered, pressed}) => getButtonStyle(getButtonState(hovered, pressed))}>
-                        {({hovered, pressed}) => (
-                            <Icon
-                                src={contextAction.icon}
-                                fill={getIconFillColor(getButtonState(hovered, pressed))}
-                            />
-                        )}
-                    </Pressable>
-                </Tooltip>
+                />
             ))}
         </View>
     );

--- a/src/pages/home/report/ReportActionContextMenuItem.js
+++ b/src/pages/home/report/ReportActionContextMenuItem.js
@@ -1,0 +1,59 @@
+import React, {memo} from 'react';
+import PropTypes from 'prop-types';
+import {Pressable} from 'react-native';
+import Tooltip from '../../../components/Tooltip';
+import Icon from '../../../components/Icon';
+import getReportActionContextMenuItemStyles from '../../../styles/getReportActionContextMenuItemStyles';
+import CONST from '../../../CONST';
+
+/**
+ * Get the string representation of a button's state.
+ *
+ * @param {Boolean} [isHovered]
+ * @param {Boolean} [isPressed]
+ * @returns {String}
+ */
+function getButtonState(isHovered = false, isPressed = false) {
+    if (isPressed) {
+        return CONST.BUTTON_STATES.PRESSED;
+    }
+
+    if (isHovered) {
+        return CONST.BUTTON_STATES.HOVERED;
+    }
+
+    return CONST.BUTTON_STATES.DEFAULT;
+}
+
+const propTypes = {
+    icon: PropTypes.elementType.isRequired,
+    text: PropTypes.string.isRequired,
+    isMini: PropTypes.bool,
+};
+
+const defaultProps = {
+    isMini: false,
+};
+
+const ReportActionContextMenuItem = (props) => {
+    const {getButtonStyle, getIconFillColor} = getReportActionContextMenuItemStyles(props.isMini);
+    return (
+        <Tooltip text={props.text}>
+            <Pressable style={({hovered, pressed}) => getButtonStyle(getButtonState(hovered, pressed))}>
+                {({hovered, pressed}) => (
+                    <Icon
+                        src={props.icon}
+                        fill={getIconFillColor(getButtonState(hovered, pressed))}
+                    />
+                )}
+            </Pressable>
+        </Tooltip>
+    );
+};
+
+
+ReportActionContextMenuItem.propTypes = propTypes;
+ReportActionContextMenuItem.defaultProps = defaultProps;
+ReportActionContextMenuItem.displayName = 'ReportActionContextMenuItem';
+
+export default memo(ReportActionContextMenuItem);

--- a/src/styles/getReportActionContextMenuItemStyles.js
+++ b/src/styles/getReportActionContextMenuItemStyles.js
@@ -1,0 +1,71 @@
+import CONST from '../CONST';
+import themeColors from './themes/default';
+import styles from './styles';
+import variables from './variables';
+
+/**
+ * Generate a style for the background color of the button, based on its current state.
+ *
+ * @param {String} [buttonState] - One of {'default', 'hovered', 'pressed'}
+ * @returns {Object}
+ */
+function getButtonBackgroundColorStyle(buttonState = CONST.BUTTON_STATES.DEFAULT) {
+    switch (buttonState) {
+        case CONST.BUTTON_STATES.HOVERED:
+            return {backgroundColor: themeColors.hoverComponentBG};
+        case CONST.BUTTON_STATES.PRESSED:
+            return {backgroundColor: themeColors.activeComponentBG};
+        case CONST.BUTTON_STATES.DEFAULT:
+        default:
+            return {};
+    }
+}
+
+/**
+ * Get the fill color for the icons in the menu depending on the state of the button they're in.
+ *
+ * @param {String} [buttonState] - One of {'default', 'hovered', 'pressed'}
+ * @returns {String}
+ */
+function getIconFillColor(buttonState = CONST.BUTTON_STATES.DEFAULT) {
+    switch (buttonState) {
+        case CONST.BUTTON_STATES.HOVERED:
+            return themeColors.text;
+        case CONST.BUTTON_STATES.PRESSED:
+            return themeColors.heading;
+        case CONST.BUTTON_STATES.DEFAULT:
+        default:
+            return themeColors.icon;
+    }
+}
+
+/**
+ * Generate styles for the buttons in the mini ReportActionContextMenu.
+ *
+ * @param {String} [buttonState] - One of {'default', 'hovered', 'pressed'}
+ * @returns {Array}
+ */
+function getMiniButtonStyle(buttonState = CONST.BUTTON_STATES.DEFAULT) {
+    return [
+        getButtonBackgroundColorStyle(buttonState),
+        styles.p1,
+        styles.mv1,
+        styles.mh1,
+        {borderRadius: variables.componentBorderRadiusSmall},
+    ];
+}
+
+/**
+ * Generate dynamic styles for the ReportActionContextMenuItem component.
+ *
+ * @param {Boolean} isMini
+ * @returns {Object}
+ */
+function getReportActionContextMenuItemStyles(isMini) {
+    return {
+        getButtonStyle: isMini ? getMiniButtonStyle : () => {},
+        getIconFillColor,
+    };
+}
+
+export default getReportActionContextMenuItemStyles;

--- a/src/styles/getReportActionContextMenuStyles.js
+++ b/src/styles/getReportActionContextMenuStyles.js
@@ -1,58 +1,11 @@
-import CONST from '../CONST';
 import styles from './styles';
 import variables from './variables';
 import themeColors from './themes/default';
 
-/**
- * Generate styles for the buttons in the mini comment actions menu.
- *
- * @param {String} [buttonState] - One of {'default', 'hovered', 'pressed'}
- * @returns {Array}
- */
-function getMiniButtonStyle(buttonState = CONST.BUTTON_STATES.DEFAULT) {
-    const defaultStyles = [styles.p1, styles.mv1, styles.mh1, {borderRadius: variables.componentBorderRadiusSmall}];
-    switch (buttonState) {
-        case CONST.BUTTON_STATES.HOVERED:
-            return [
-                ...defaultStyles,
-                {
-                    backgroundColor: themeColors.hoverComponentBG,
-                },
-            ];
-        case CONST.BUTTON_STATES.PRESSED:
-            return [
-                ...defaultStyles,
-                {
-                    backgroundColor: themeColors.activeComponentBG,
-                },
-            ];
-        case CONST.BUTTON_STATES.DEFAULT:
-        default:
-            return defaultStyles;
-    }
-}
-
-/**
- * Get the fill color for the icons in the menu depending on the state of the button they're in.
- *
- * @param {String} [buttonState] - One of {'default', 'hovered', 'pressed'}
- * @returns {String}
- */
-function getIconFillColor(buttonState = CONST.BUTTON_STATES.DEFAULT) {
-    switch (buttonState) {
-        case CONST.BUTTON_STATES.HOVERED:
-            return themeColors.text;
-        case CONST.BUTTON_STATES.PRESSED:
-            return themeColors.heading;
-        case CONST.BUTTON_STATES.DEFAULT:
-        default:
-            return themeColors.icon;
-    }
-}
-
 const miniWrapperStyle = [
     styles.flexRow,
     {
+        flex: 1,
         borderRadius: variables.componentBorderRadiusNormal,
         borderWidth: 1,
         backgroundColor: themeColors.componentBG,
@@ -61,17 +14,13 @@ const miniWrapperStyle = [
 ];
 
 /**
- * Get the wrapper and button styles for the comment actions menu.
+ * Generate the wrapper styles for the ReportActionContextMenu.
  *
- * @param {boolean} isMini
- * @returns {Object}
+ * @param {Boolean} isMini
+ * @returns {Array}
  */
 function getReportActionContextMenuStyles(isMini) {
-    return {
-        getIconFillColor,
-        getButtonStyle: isMini ? getMiniButtonStyle : () => {},
-        wrapperStyle: isMini ? miniWrapperStyle : [],
-    };
+    return isMini ? miniWrapperStyle : [];
 }
 
 export default getReportActionContextMenuStyles;


### PR DESCRIPTION
**Note:** The target branch of this PR is a feature branch, not master.

### Details
Really, the purpose of this PR is to simplify the diff of [this other PR](https://github.com/Expensify/Expensify.cash/pull/1469/files). As such, we'll really just testing for regressions.

### Fixed Issues
Partial fix for https://github.com/Expensify/Expensify/issues/147472

### Tests

#### Web/Desktop
1) Run the app
2) Open a report
3) Hover over messages, and verify that you can see the `ReportActionContextMenu`
4) Hover over items of the `ReportActionContextMenu`, make sure their style changes and a tooltip appears.
5) Click on the items. Nothing is expected to happen, but make sure their style changes again.

#### mWeb/iOS/Android
1) Run the app
2) Make sure it runs. You should notice no differences at all. Just check for regressions.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web
![image](https://user-images.githubusercontent.com/47436092/109232756-a8b53f80-777d-11eb-8abe-ff9760932ea1.png)

#### Mobile Web
<img src="https://user-images.githubusercontent.com/47436092/109233587-fe3e1c00-777e-11eb-82e6-3e1a4b4a97a8.png" alt="" width="350px" />

#### Desktop
![image](https://user-images.githubusercontent.com/47436092/109232944-e619cd00-777d-11eb-905c-9e22a07816df.png)

#### iOS
<img src="https://user-images.githubusercontent.com/47436092/109233473-cdf67d80-777e-11eb-9257-681892e3662e.png" alt="" width="350px" />

#### Android
<img src="https://user-images.githubusercontent.com/47436092/109234399-7e18b600-7780-11eb-937c-38c93c0eab04.png" alt="" width="350px" />

