### PR TITLE
Add Unread Action Indicator

### DIFF
--- a/src/components/UnreadActionIndicator.js
+++ b/src/components/UnreadActionIndicator.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import {Animated, View} from 'react-native';
+import PropTypes from 'prop-types';
+import styles from '../styles/styles';
+import Text from './Text';
+
+const propTypes = {
+    // Animated opacity
+    // eslint-disable-next-line react/forbid-prop-types
+    animatedOpacity: PropTypes.object.isRequired,
+};
+
+const UnreadActionIndicator = props => (
+    <Animated.View style={[
+        styles.unreadIndicatorContainer,
+        {opacity: props.animatedOpacity},
+    ]}
+    >
+        <View style={styles.unreadIndicatorLine} />
+        <Text style={styles.unreadIndicatorText}>
+            NEW
+        </Text>
+    </Animated.View>
+);
+
+UnreadActionIndicator.propTypes = propTypes;
+UnreadActionIndicator.displayName = 'UnreadActionIndicator';
+
+export default UnreadActionIndicator;

--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -4,7 +4,6 @@ import {
     View,
     Keyboard,
     AppState,
-    Easing,
 } from 'react-native';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
@@ -65,9 +64,14 @@ class ReportActionsView extends React.Component {
 
         this.sortedReportActions = [];
         this.timers = [];
-        this.unreadActionCount = 0;
-        this.shouldShowNewActionIndicator = true;
         this.unreadIndicatorOpacity = new Animated.Value(1);
+
+        // Helper variable that keeps track of the unread action count before it updates to zero
+        this.unreadActionCount = 0;
+
+        // Helper variable that prevents the unread indicator to show up for new messages
+        // received while the report is still active
+        this.shouldShowUnreadActionIndicator = true;
 
         this.state = {
             refetchNeeded: true,
@@ -171,7 +175,7 @@ class ReportActionsView extends React.Component {
      * a flag to not show it again if the report is still open
      */
     setUpUnreadActionIndicator() {
-        if (!this.props.isActiveReport || !this.shouldShowNewActionIndicator) {
+        if (!this.props.isActiveReport || !this.shouldShowUnreadActionIndicator) {
             return;
         }
 
@@ -182,14 +186,12 @@ class ReportActionsView extends React.Component {
             this.timers.push(setTimeout(() => {
                 Animated.timing(this.unreadIndicatorOpacity, {
                     toValue: 0,
-                    duration: 500,
-                    easing: Easing.ease,
                     useNativeDriver: false,
                 }).start();
             }, 3000));
         }
 
-        this.shouldShowNewActionIndicator = false;
+        this.shouldShowUnreadActionIndicator = false;
     }
 
     /**

--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -62,15 +62,12 @@ class ReportActionsView extends React.Component {
         this.scrollToListBottom = this.scrollToListBottom.bind(this);
         this.recordMaxAction = this.recordMaxAction.bind(this);
         this.onVisibilityChange = this.onVisibilityChange.bind(this);
-        this.setUpUnreadActionIndicator = this.setUpUnreadActionIndicator.bind(this);
-        this.updateSortedReportActions = this.updateSortedReportActions.bind(this);
 
         this.sortedReportActions = [];
         this.timers = [];
         this.unreadActionCount = 0;
         this.shouldShowNewActionIndicator = true;
         this.unreadIndicatorOpacity = new Animated.Value(1);
-        this.unreadIndicatorTimer = null;
 
         this.state = {
             refetchNeeded: true,
@@ -144,7 +141,6 @@ class ReportActionsView extends React.Component {
             this.keyboardEvent.remove();
         }
 
-        clearTimeout(this.unreadIndicatorTimer);
         AppState.removeEventListener('change', this.onVisibilityChange);
 
         _.each(this.timers, timer => clearTimeout(timer));
@@ -183,14 +179,14 @@ class ReportActionsView extends React.Component {
 
         if (this.unreadActionCount > 0) {
             this.unreadIndicatorOpacity = new Animated.Value(1);
-            this.unreadIndicatorTimer = setTimeout(() => {
+            this.timers.push(setTimeout(() => {
                 Animated.timing(this.unreadIndicatorOpacity, {
                     toValue: 0,
                     duration: 500,
                     easing: Easing.ease,
                     useNativeDriver: false,
                 }).start();
-            }, 3000);
+            }, 3000));
         }
 
         this.shouldShowNewActionIndicator = false;
@@ -291,9 +287,9 @@ class ReportActionsView extends React.Component {
     }) {
         return (
 
-        // <View /> must not be changed to a Fragment
-        // Explanation: https://github.com/Expensify/Expensify.cash/pull/1570#discussion_r583826182
-
+        // Using <View /> instead of a Fragment because there is a difference between how
+        // <InvertedFlatList /> are implemented on native and web/desktop which leads to
+        // the unread indicator on native to render below the message instead of above it.
             <View>
                 {this.unreadActionCount > 0 && index === this.unreadActionCount - 1 && (
                     <UnreadActionIndicator animatedOpacity={this.unreadIndicatorOpacity} />

--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -1,6 +1,10 @@
 import React from 'react';
 import {
-    Animated, View, Keyboard, AppState, Easing,
+    Animated,
+    View,
+    Keyboard,
+    AppState,
+    Easing,
 } from 'react-native';
 import PropTypes from 'prop-types';
 import _ from 'underscore';

--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -16,7 +16,6 @@ import ReportActionPropTypes from './ReportActionPropTypes';
 import InvertedFlatList from '../../../components/InvertedFlatList';
 import {lastItem} from '../../../libs/CollectionUtils';
 import Visibility from '../../../libs/Visibility';
-import compose from '../../../libs/compose';
 
 const propTypes = {
     // The ID of the report actions will be created for
@@ -75,12 +74,6 @@ class ReportActionsView extends React.Component {
     }
 
     componentDidMount() {
-        console.log('mounted', this.props.reportID);
-
-        if (this.props.isActiveReport) {
-            console.log('isActive', this.props.reportID, 'didMount', this.props.report);
-        }
-
         AppState.addEventListener('change', this.onVisibilityChange);
 
         if (this.props.isActiveReport) {
@@ -104,10 +97,6 @@ class ReportActionsView extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
-        if (this.props.isActiveReport) {
-            console.log('isActive', this.props.reportID, 'didUpdate', this.props.report);
-        }
-
         // If we previously had a value for reportActions but no longer have one
         // this can only mean that the reportActions have been deleted. So we must
         // refetch these actions the next time we switch to this chat.
@@ -147,8 +136,6 @@ class ReportActionsView extends React.Component {
     }
 
     componentWillUnmount() {
-        console.log('unmounted', this.props.reportID);
-
         if (this.keyboardEvent) {
             this.keyboardEvent.remove();
         }
@@ -346,22 +333,15 @@ class ReportActionsView extends React.Component {
 ReportActionsView.propTypes = propTypes;
 ReportActionsView.defaultProps = defaultProps;
 
-export default compose(
-    withOnyx({
-        currentlyViewedReportID: {
-            key: ONYXKEYS.CURRENTLY_VIEWED_REPORTID,
-        },
-    }),
-    withOnyx({
-        report: {
-            key: ({currentlyViewedReportID}) => `${ONYXKEYS.COLLECTION.REPORT}${currentlyViewedReportID}`,
-        },
-        reportActions: {
-            key: ({reportID}) => `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`,
-            canEvict: props => !props.isActiveReport,
-        },
-        session: {
-            key: ONYXKEYS.SESSION,
-        },
-    }),
-)(ReportActionsView);
+export default withOnyx({
+    report: {
+        key: ({reportID}) => `${ONYXKEYS.COLLECTION.REPORT}${reportID}`,
+    },
+    reportActions: {
+        key: ({reportID}) => `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`,
+        canEvict: props => !props.isActiveReport,
+    },
+    session: {
+        key: ONYXKEYS.SESSION,
+    },
+})(ReportActionsView);

--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -286,6 +286,10 @@ class ReportActionsView extends React.Component {
         needsLayoutCalculation,
     }) {
         return (
+
+        // <View /> must not be changed to a Fragment
+        // Explanation: https://github.com/Expensify/Expensify.cash/pull/1570#discussion_r583826182
+
             <View>
                 {this.unreadActionCount > 0 && index === this.unreadActionCount - 1 && (
                     <UnreadActionIndicator animatedOpacity={this.unreadIndicatorOpacity} />

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -948,6 +948,32 @@ const styles = {
         marginLeft: 8,
     },
 
+    unreadIndicatorContainer: {
+        position: 'absolute',
+        top: -10,
+        left: 0,
+        width: '100%',
+        height: 20,
+        paddingHorizontal: 20,
+        flexDirection: 'row',
+        alignItems: 'center',
+    },
+
+    unreadIndicatorLine: {
+        height: 1,
+        backgroundColor: themeColors.unreadIndicator,
+        flexGrow: 1,
+        marginRight: 8,
+        opacity: 0.5,
+    },
+
+    unreadIndicatorText: {
+        color: themeColors.unreadIndicator,
+        fontFamily: fontFamily.GTA_BOLD,
+        fontSize: variables.fontSizeSmall,
+        fontWeight: fontWeightBold,
+    },
+
     flipUpsideDown: {
         transform: [{rotate: '180deg'}],
     },

--- a/src/styles/themes/default.js
+++ b/src/styles/themes/default.js
@@ -30,4 +30,5 @@ export default {
     pillBG: colors.gray2,
     buttonDisabledBG: colors.gray2,
     buttonHoveredBG: colors.gray1,
+    unreadIndicator: colors.green,
 };


### PR DESCRIPTION
@marcaaron @roryabraham 

### Details
Created a "last unread" indicator on the Reports View. It appears on the top of the last unread action and fades out after a set time.
It doesn't show up when the report is active and receives a new message.

**About scrollToIndex:**
As mentioned on the issue page, I couldn't find a trivial solution to this, since `scrollToIndex` isn't precise at all with items with dynamic height. I still want to try to calculate the height and use it with `scrollToOffset()`, but I thought it would be better to create a PR with the rest of the code first.

@shawnborton 
**Animation info:**
- Timeout time: 3000 ms;
- Duration: 500 ms;
- Easing: Easing.ease;

Just for reference if you want me to try some other values out.

**Notes:**
1. I actually did not want to use `position: absolute`, and it was working fine everywhere just using `height: 0`. But it seems like ios `<Text />` doesn't like it very much, since it was not showing up (the line was showing, the text wasn't). It was working everywhere else;
2. There is a behavior that I really dislike right now. On small screens, when the `Sidebar` is open, and a new message is received on the active report, it is set as read, and the indicator doesn't show up (if the user re-enters the report). I actually wrote some code around it with `withWindowDimensions`, and adding the `IS_SIDEBAR_SHOWN` onyx prop, but decided to remove it. I believe the best solution would be to start changing the code deeper down, to make sure an action is not set as read if `isSmallScreen` and `IS_SIDEBAR_SHOWN === true`. It would still need some refactoring on the `ReportActionsView` code, but I believe it is the best approach;
3. Maybe anticipating a question here: The `renderItem()` component is wrapped inside a `<View />` instead of a `<React.Fragment />` for compatibility between the native and web/desktop `<InvertedFlatList />`. If we don't do it, the indicator actually shows up on the bottom of the message instead of on the top when on native.

### Fixed Issues
Fixes #1498 

### Tests
1. Make sure the user/group that is sending a new message is not active;
2. Receive a new message;
3. Open the report, it should show the indicator on the top of the last unread message;
4. Verify the indicator fades out after a few seconds;
5. If another message is sent while the report is active, verify the indicator doesn't show up again.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

**Observation:** After I got all the images, I realized the `NEW` text was not bold as on the reference, as well as the spacing was maybe too high. 
Because it takes a while to take new images, and it is very simple, I just changed the Mobile-Web image after making the changes. I hope it is ok.
So, please, the text IS BOLD. Sorry about that.

#### Web
![web](https://i.ibb.co/FWjfVtd/web-gif.gif)

#### Mobile Web
![mobile web](https://i.ibb.co/7XNGFd6/mobile-web.png)

#### Desktop
![deskotp](https://i.ibb.co/VQCd61F/desktop.png)

#### iOS
![ios](https://i.ibb.co/bKhDThf/ios.png)

#### Android
![android](https://i.ibb.co/23SRMLN/android.jpg)
