### PR TITLE
Run iOS E2E tests only when relevant files have changed

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
     test:
-        if: git diff --exit-code ./* ./.* src/**/* config/**/* assets/**/* tests/**/*
+        if: git diff --exit-code ./* ./.* src/**/* config/**/* assets/**/* tests/e2e/* tests/utils/*
         runs-on: macos-10.15
         steps:
             - uses: actions/checkout@v2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,7 +17,7 @@ jobs:
                 git fetch
                 git checkout ${{ github.head_ref }}
             - name: Check diff
-              run: if [[ git diff $(find . -regextype posix-extended -regex "\.\/(src|ios|assets|(tests\/(e2e|utils))|__mocks__|\.env.*|[^\/]*.js(on)?)") ]]; then echo "diff found"; else echo "no diff"; fi;
+              run: if [[ git diff --exit-code $(find . -regextype posix-extended -regex "\.\/(src|ios|assets|(tests\/(e2e|utils))|__mocks__|\.env.*|[^\/]*.js(on)?)") ]]; then echo "diff found"; else echo "no diff"; fi;
     test:
         needs: check_diff
         runs-on: macos-10.15

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,6 +16,8 @@ jobs:
               run: |
                   git fetch
                   git checkout
+            - name: Echo anything?
+              run: echo "Hello world"
             - name: Check diff
               run: echo $(git diff $(find -E . -regex "\.\/(src|ios|assets|(tests\/(e2e|utils))|__mocks__|\.env.*|[^\/]*.js(on)?)"))
     test:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,12 +12,9 @@ jobs:
         runs-on: macos-latest
         steps:
             - uses: actions/checkout@v2
-            - name: Setup git
-              run: |
-                  git fetch
-                  git checkout ${{ github.head_ref }}
-            - name: Echo anything?
-              run: echo "Hello world"
+              with:
+                ref: ${{ github.event.pull_request.head.sha }}
+
             - name: Check diff
               run: echo $(git diff $(find -E . -regex "\.\/(src|ios|assets|(tests\/(e2e|utils))|__mocks__|\.env.*|[^\/]*.js(on)?)"))
     test:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,11 +8,18 @@ env:
     DEVELOPER_DIR: /Applications/Xcode_12.3.app/Contents/Developer
 
 jobs:
+    check_diff:
+        runs-on: macos-latest
+        steps:
+            - uses: actions/checkout@v2
+            - name: Setup git
+              run: |
+                  git fetch
+                  git checkout
+            - name: Check diff
+              run: echo $(git diff $(find . -regextype posix-extended -regex "\.\/(src|ios|assets|(tests\/(e2e|utils))|__mocks__|\.env.*|[^\/]*.js(on)?)"))
     test:
-        if: |
-            git fetch \
-            && git checkout ${{ github.head_ref }} \
-            && $(git diff --exit-code $(find . -regextype posix-extended -regex "\.\/(src|ios|assets|(tests\/(e2e|utils))|__mocks__|\.env.*|[^\/]*.js(on)?)")))
+        needs: check_diff
         runs-on: macos-10.15
         steps:
             - uses: actions/checkout@v2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,6 +13,7 @@ jobs:
         steps:
             - uses: actions/checkout@v2
               with:
+                fetch-depth: 0
                 ref: ${{ github.event.pull_request.head.sha }}
 
             - name: Echo full diff

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,7 +17,7 @@ jobs:
                   git fetch
                   git checkout
             - name: Check diff
-              run: echo $(git diff $(find . -regextype posix-extended -regex "\.\/(src|ios|assets|(tests\/(e2e|utils))|__mocks__|\.env.*|[^\/]*.js(on)?)"))
+              run: echo $(git diff $(find -E . -regex "\.\/(src|ios|assets|(tests\/(e2e|utils))|__mocks__|\.env.*|[^\/]*.js(on)?)"))
     test:
         needs: check_diff
         runs-on: macos-10.15

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,7 +15,7 @@ jobs:
             - name: Setup git
               run: |
                   git fetch
-                  git checkout
+                  git checkout ${{ github.head_ref }}
             - name: Echo anything?
               run: echo "Hello world"
             - name: Check diff

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,8 +8,18 @@ env:
     DEVELOPER_DIR: /Applications/Xcode_12.3.app/Contents/Developer
 
 jobs:
+    check_diff:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - name: Set up git
+              run: |
+                git fetch
+                git checkout ${{ github.head_ref }}
+            - name: Check diff
+              run: git diff --exit-code ./* ./.* src/**/* config/**/* assets/**/* tests/e2e/* tests/utils/*
     test:
-        if: git diff --exit-code ./* ./.* src/**/* config/**/* assets/**/* tests/e2e/* tests/utils/*
+        needs: check_diff
         runs-on: macos-10.15
         steps:
             - uses: actions/checkout@v2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,7 +17,9 @@ jobs:
                 git fetch
                 git checkout ${{ github.head_ref }}
             - name: Check diff
-              run: git diff --exit-code ./* ./.* src/**/* config/**/* assets/**/* tests/e2e/* tests/utils/*
+              run: |
+                cd Expensify/Expensify.cash
+                git diff --exit-code ./* ./.* src/**/* config/**/* assets/**/* tests/e2e/* tests/utils/*
     test:
         needs: check_diff
         runs-on: macos-10.15

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,6 +20,7 @@ jobs:
 
             - name: Check diff
               run: echo $(git diff $(find -E . -regex "\.\/(src|ios|assets|(tests\/(e2e|utils))|__mocks__|\.env.*|[^\/]*.js(on)?)"))
+
     test:
         needs: check_diff
         runs-on: macos-10.15

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,18 +8,10 @@ env:
     DEVELOPER_DIR: /Applications/Xcode_12.3.app/Contents/Developer
 
 jobs:
-    check_diff:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v2
-            - name: Set up git
-              run: |
-                git fetch
-                git checkout ${{ github.head_ref }}
-            - name: Check diff
-              run: echo $(git diff $(find . -regextype posix-extended -regex "\.\/(src|ios|assets|(tests\/(e2e|utils))|__mocks__|\.env.*|[^\/]*.js(on)?)"))
     test:
-        needs: check_diff
+        if: git fetch \
+            && git checkout ${{ github.head_ref }} \
+            && git diff --exit-code $(find . -regextype posix-extended -regex "\.\/(src|ios|assets|(tests\/(e2e|utils))|__mocks__|\.env.*|[^\/]*.js(on)?)"))
         runs-on: macos-10.15
         steps:
             - uses: actions/checkout@v2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,7 +11,7 @@ jobs:
     test:
         if: git fetch \
             && git checkout ${{ github.head_ref }} \
-            && git diff --exit-code $(find . -regextype posix-extended -regex "\.\/(src|ios|assets|(tests\/(e2e|utils))|__mocks__|\.env.*|[^\/]*.js(on)?)"))
+            && $(git diff --exit-code $(find . -regextype posix-extended -regex "\.\/(src|ios|assets|(tests\/(e2e|utils))|__mocks__|\.env.*|[^\/]*.js(on)?)")))
         runs-on: macos-10.15
         steps:
             - uses: actions/checkout@v2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,6 +9,7 @@ env:
 
 jobs:
     test:
+        if: git diff --exit-code ./* ./.* src/**/* config/**/* assets/**/* tests/**/*
         runs-on: macos-10.15
         steps:
             - uses: actions/checkout@v2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,7 +17,7 @@ jobs:
                 git fetch
                 git checkout ${{ github.head_ref }}
             - name: Check diff
-              run: git diff --exit-code $(find . -regextype posix-extended -regex "\.\/(src|ios|assets|(tests\/(e2e|utils))|__mocks__|\.env.*|[^\/]*.js(on)?)")
+              run: if [[ git diff $(find . -regextype posix-extended -regex "\.\/(src|ios|assets|(tests\/(e2e|utils))|__mocks__|\.env.*|[^\/]*.js(on)?)") ]]; then echo "diff found"; else echo "no diff";
     test:
         needs: check_diff
         runs-on: macos-10.15

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,7 +9,8 @@ env:
 
 jobs:
     test:
-        if: git fetch \
+        if: |
+            git fetch \
             && git checkout ${{ github.head_ref }} \
             && $(git diff --exit-code $(find . -regextype posix-extended -regex "\.\/(src|ios|assets|(tests\/(e2e|utils))|__mocks__|\.env.*|[^\/]*.js(on)?)")))
         runs-on: macos-10.15

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,6 +15,9 @@ jobs:
               with:
                 ref: ${{ github.event.pull_request.head.sha }}
 
+            - name: Echo full diff
+              run: echo $(git diff)
+
             - name: Check diff
               run: echo $(git diff $(find -E . -regex "\.\/(src|ios|assets|(tests\/(e2e|utils))|__mocks__|\.env.*|[^\/]*.js(on)?)"))
     test:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,7 +17,7 @@ jobs:
                 git fetch
                 git checkout ${{ github.head_ref }}
             - name: Check diff
-              run: git diff --exit-code $(find -E . -regex "\.\/(src|ios|assets|(tests\/(e2e|utils))|__mocks__|\.env.*|[^\/]*.js(on)?)")
+              run: git diff --exit-code $(find . -regextype posix-extended -regex "\.\/(src|ios|assets|(tests\/(e2e|utils))|__mocks__|\.env.*|[^\/]*.js(on)?)")
     test:
         needs: check_diff
         runs-on: macos-10.15

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,9 +17,7 @@ jobs:
                 git fetch
                 git checkout ${{ github.head_ref }}
             - name: Check diff
-              run: |
-                cd Expensify/Expensify.cash
-                git diff --exit-code ./* ./.* src/**/* config/**/* assets/**/* tests/e2e/* tests/utils/*
+              run: git diff --exit-code $(find -E . -regex "\.\/(src|ios|assets|(tests\/(e2e|utils))|__mocks__|\.env.*|[^\/]*.js(on)?)")
     test:
         needs: check_diff
         runs-on: macos-10.15

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,10 +17,10 @@ jobs:
                 ref: ${{ github.event.pull_request.head.sha }}
 
             - name: Echo full diff
-              run: echo $(git diff)
+              run: echo $(git diff master...${{ github.event.pull_request.head.sha }})
 
             - name: Check diff
-              run: echo $(git diff $(find -E . -regex "\.\/(src|ios|assets|(tests\/(e2e|utils))|__mocks__|\.env.*|[^\/]*.js(on)?)"))
+              run: echo $(git diff master...${{ github.event.pull_request.head.sha }} $(find -E . -regex "\.\/(src|ios|assets|(tests\/(e2e|utils))|__mocks__|\.env.*|[^\/]*.js(on)?)"))
 
     test:
         needs: check_diff

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,7 +17,7 @@ jobs:
                 git fetch
                 git checkout ${{ github.head_ref }}
             - name: Check diff
-              run: if [[ git diff --exit-code $(find . -regextype posix-extended -regex "\.\/(src|ios|assets|(tests\/(e2e|utils))|__mocks__|\.env.*|[^\/]*.js(on)?)") ]]; then echo "diff found"; else echo "no diff"; fi;
+              run: echo $(git diff $(find . -regextype posix-extended -regex "\.\/(src|ios|assets|(tests\/(e2e|utils))|__mocks__|\.env.*|[^\/]*.js(on)?)"))
     test:
         needs: check_diff
         runs-on: macos-10.15

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,7 +17,7 @@ jobs:
                 git fetch
                 git checkout ${{ github.head_ref }}
             - name: Check diff
-              run: if [[ git diff $(find . -regextype posix-extended -regex "\.\/(src|ios|assets|(tests\/(e2e|utils))|__mocks__|\.env.*|[^\/]*.js(on)?)") ]]; then echo "diff found"; else echo "no diff";
+              run: if [[ git diff $(find . -regextype posix-extended -regex "\.\/(src|ios|assets|(tests\/(e2e|utils))|__mocks__|\.env.*|[^\/]*.js(on)?)") ]]; then echo "diff found"; else echo "no diff"; fi;
     test:
         needs: check_diff
         runs-on: macos-10.15

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -4,6 +4,8 @@ on:
     push:
         branches: [master]
 
+# HEllo froom GH workflow
+
 jobs:
     version:
         runs-on: ubuntu-16.04

--- a/src/CONFIG.js
+++ b/src/CONFIG.js
@@ -3,6 +3,8 @@ import {Platform} from 'react-native';
 import Config from 'react-native-config';
 import getPlatform from './libs/getPlatform/index';
 
+// Hello from src
+
 /**
  * Let's make everyone's life just a bit easier by adding / to the end of any config URL's if it's not already present
  * @param {String} url

--- a/src/CONFIG.js
+++ b/src/CONFIG.js
@@ -3,8 +3,6 @@ import {Platform} from 'react-native';
 import Config from 'react-native-config';
 import getPlatform from './libs/getPlatform/index';
 
-// Hello from src
-
 /**
  * Let's make everyone's life just a bit easier by adding / to the end of any config URL's if it's not already present
  * @param {String} url


### PR DESCRIPTION

### Details
Only run iOS E2E tests when any of the following files have changed:

- Any files at the project root
- Any files in the src directory
- Any config files
- Any assets
- Any tests

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/155395

### Tests

I did a fair amount of local testing to verify that this command works as expected. Try changing files all over the place and see if they are caught by this `git diff` command.

TBD

### Tested On

- Github