### PR TITLE
Prevent duplicate attachments from posting if submitted quickly

### DIFF
--- a/src/components/AttachmentModal.js
+++ b/src/components/AttachmentModal.js
@@ -69,6 +69,11 @@ class AttachmentModal extends PureComponent {
      * Execute the onConfirm callback and close the modal.
      */
     submitAndClose() {
+        // If the modal has already been closed, don't allow another submission
+        if (!this.state.isModalOpen) {
+            return;
+        }
+
         this.props.onConfirm(this.state.file);
         this.setState({isModalOpen: false});
     }


### PR DESCRIPTION
<If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit.>

### Details
Ensures we don't upload attachments while the AttachmentModal is closed

### Fixed Issues
<Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing>
Fixes https://github.com/Expensify/Expensify/issues/155057

### Tests
1. Copy an image to your clipboard and paste it into cash
2. Tap `return` on the keyboard multiple times quickly
3. Confirm only one attachment is uploaded

### Tested On
Web, Desktop, and Mobile Web. This issue is not present on iOS and Android.

### Screenshots
N/A