### PR TITLE
Prevent Push_Authenticate commands from being skipped

### DIFF
--- a/src/libs/PusherConnectionManager.js
+++ b/src/libs/PusherConnectionManager.js
@@ -32,7 +32,6 @@ function init() {
             API.Push_Authenticate({
                 socket_id: socketID,
                 channel_name: channel.name,
-                doNotRetry: true,
             })
                 .then((data) => {
                     if (data.jsonCode === 407) {

--- a/src/libs/PusherConnectionManager.js
+++ b/src/libs/PusherConnectionManager.js
@@ -32,6 +32,8 @@ function init() {
             API.Push_Authenticate({
                 socket_id: socketID,
                 channel_name: channel.name,
+                doNotRetry: true,
+                forceNetworkRequest: true,
             })
                 .then((data) => {
                     if (data.jsonCode === 407) {


### PR DESCRIPTION
### Details
Since it is possible to make a `Push_Authenticate` request while we are in the process of authenticating we must allow these requests to run no matter what and not be skipped. This resolves an issue on Desktop where an expired `authToken` prevents us from reconnecting to Pusher.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/156049

### Tests
1. Run `npm run desktop`
2. Mess up the `authToken` in `localStorage` by editing it (**key:** `session`)
3. `command + q` to quit the app
4. Run `npm run desktop` again
5. Verify that once the app loads you are subscribed to the `private-user-accountID-*` channel via `window.getPusherInstance().channels` in JS console.
![Screen Shot 2021-03-02 at 10 48 20 AM](https://user-images.githubusercontent.com/32969087/109713080-debf3e80-7b44-11eb-8b6e-b8ba4d522968.png)

### Tested On

- [x] Web
- [ ] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
