### PR TITLE
Allow OSBotify to skip CLA checks

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -35,4 +35,4 @@ jobs:
                   branch: 'master'
                   remote-organization-name: 'Expensify'
                   remote-repository-name: 'CLA'
-                  allowlist: botify
+                  allowlist: OSBotify


### PR DESCRIPTION
<If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit.>

### Details
We moved from using @botify to @OSBotify - But forgot to update this check for @OSBotify to allow to skip the CLA. This will allow auto merge PRs to continue without failing the GH checks. For example: https://github.com/Expensify/Expensify.cash/actions/runs/615425110

### Tests
1. Merge this PR
2. I will verify that the PR it puts up is auto approved and merged correctly without  the CLA step failing