### PR TITLE
Make minimum lint warnings zero

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,6 @@ jobs:
 
             - run: npm ci
 
-            - run: npm run lint
+            - run: npm run lint -- --max-warnings=0
               env:
                   CI: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,6 @@ jobs:
 
             - run: npm ci
 
-            - run: npm run lint -- --max-warnings=0
+            - run: npm run lint
               env:
                   CI: true

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "ios-build": "fastlane ios build",
     "android-build": "fastlane android build",
     "test": "jest",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings=0",
     "print-version": "echo $npm_package_version",
     "detox-build": "detox build --configuration ios.sim.debug",
     "detox-test": "detox test --configuration ios.sim.debug",

--- a/src/components/UpdateAppModal/BaseUpdateAppModal.js
+++ b/src/components/UpdateAppModal/BaseUpdateAppModal.js
@@ -1,4 +1,3 @@
-import _ from 'underscore';
 import React, {PureComponent} from 'react';
 import {
     TouchableOpacity, Text,

--- a/src/components/UpdateAppModal/BaseUpdateAppModal.js
+++ b/src/components/UpdateAppModal/BaseUpdateAppModal.js
@@ -65,7 +65,6 @@ class BaseUpdateAppModal extends PureComponent {
     }
 }
 
-BaseUpdateAppModal.propTypes = _.omit(propTypes, 'version');
-BaseUpdateAppModal.defaultProps = _.omit(defaultProps, 'version');
 BaseUpdateAppModal.propTypes = propTypes;
+BaseUpdateAppModal.defaultProps = defaultProps;
 export default BaseUpdateAppModal;

--- a/src/components/UpdateAppModal/BaseUpdateAppModal.js
+++ b/src/components/UpdateAppModal/BaseUpdateAppModal.js
@@ -67,4 +67,5 @@ class BaseUpdateAppModal extends PureComponent {
 
 BaseUpdateAppModal.propTypes = _.omit(propTypes, 'version');
 BaseUpdateAppModal.defaultProps = _.omit(defaultProps, 'version');
+BaseUpdateAppModal.propTypes = propTypes;
 export default BaseUpdateAppModal;

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -186,7 +186,8 @@ function getOptions(reports, personalDetails, draftComments, activeReportID, {
         // Skip this entry if it has no comments and is not the active report. We will only show reports from
         // people we have sent or received at least one message with.
         const hasNoComments = report.lastMessageTimestamp === 0;
-        const shouldFilterReport = !showReportsWithNoComments && hasNoComments && report.reportID !== activeReportID && !report.isPinned;
+        const shouldFilterReport = !showReportsWithNoComments && hasNoComments
+            && report.reportID !== activeReportID && !report.isPinned;
         if (shouldFilterReport) {
             return;
         }


### PR DESCRIPTION
### Details
Make minimum lint warnings zero, therefore making all lint warnings block PRs so we don't get future warnings in future PRs.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/149529

### Tests
1. Checkout a0b84ec
2. Run `npm run lint`
3. Verify it fails
4. Verify the lint job on this PR passes (meaning I fixed all the lint warnings)