### PR TITLE
stop read reports from filtering if pinned

### DIFF
--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -190,7 +190,7 @@ function getOptions(reports, personalDetails, draftComments, activeReportID, {
         if (shouldFilterReport) {
             return;
         }
-        if (hideReadReports && report.unreadActionCount === 0) {
+        if (hideReadReports && report.unreadActionCount === 0 && !report.isPinned) {
             return;
         }
         const reportPersonalDetails = getPersonalDetailsForLogins(logins, personalDetails);

--- a/tests/unit/OptionsListUtilsTest.js
+++ b/tests/unit/OptionsListUtilsTest.js
@@ -35,7 +35,7 @@ describe('OptionsListUtils', () => {
             reportID: 3,
             participants: ['reedrichards@expensify.com'],
             reportName: 'Mister Fantastic',
-            unreadActionCount: 1,
+            unreadActionCount: 0,
         },
         4: {
             lastVisitedTimestamp: 1610666739298,


### PR DESCRIPTION
### Fixed Issues
https://github.com/Expensify/Expensify.cash/issues/1452
fix for bug from previous issue PR:
https://github.com/Expensify/Expensify.cash/pull/1553

Fix for GSD mode filtering pinned reports when they are read.

Tested on Web and updated automated tests to cover this case.

### Test steps

1. With Priority Mode set to Most Recent, pin some chats
2. Switch Priority Mode to GSD, see pinned chats do not disappear from the list of chats. 

Priority mode can be changed by opening the settings menu by coming in your avatar. 

Please look at the linked pull request for screenshots of how to do this

Additionally run:
`npm run test`
As the changes to the tests cover this case. 