### PR TITLE
[IS-1513] populate cursor to compose box after chat has been selected

### DIFF
--- a/src/ONYXKEYS.js
+++ b/src/ONYXKEYS.js
@@ -63,7 +63,7 @@ export default {
 
     // For Modal
     MODAL: {
-        IS_MODAL_SHOWN: false,
-        MODAL_TYPE: '',
+        IS_SHOWN: 'modalIsShown',
+        TYPE: 'modalType',
     },
 };

--- a/src/ONYXKEYS.js
+++ b/src/ONYXKEYS.js
@@ -60,4 +60,10 @@ export default {
         REPORT_DRAFT_COMMENT: 'reportDraftComment_',
         REPORT_USER_IS_TYPING: 'reportUserIsTyping_',
     },
+
+    // For Modal
+    MODAL: {
+        IS_MODAL_SHOWN: false,
+        MODAL_TYPE: '',
+    },
 };

--- a/src/components/RightDockedModal.js
+++ b/src/components/RightDockedModal.js
@@ -101,9 +101,9 @@ export default withOnyx({
         key: ONYXKEYS.CURRENT_URL,
     },
     modalType: {
-        key: ONYXKEYS.MODAL.MODAL_TYPE,
+        key: ONYXKEYS.MODAL.TYPE,
     },
     isModalShown: {
-        key: ONYXKEYS.MODAL.IS_MODAL_SHOWN,
+        key: ONYXKEYS.MODAL.IS_SHOWN,
     },
 })(RightDockedModal);

--- a/src/components/RightDockedModal.js
+++ b/src/components/RightDockedModal.js
@@ -22,16 +22,14 @@ const propTypes = {
     // Url currently in view
     currentURL: PropTypes.string,
 
-    isModalShown: PropTypes.bool,
+    isModalShown: PropTypes.bool.isRequired,
 
-    modalType: PropTypes.string,
+    modalType: PropTypes.string.isRequired,
 };
 
 const defaultProps = {
     route: '',
     currentURL: '',
-    isModalShown: false,
-    modalType: '',
 };
 
 class RightDockedModal extends PureComponent {

--- a/src/components/RightDockedModal.js
+++ b/src/components/RightDockedModal.js
@@ -1,4 +1,4 @@
-import React, {memo} from 'react';
+import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {withOnyx} from 'react-native-onyx';
 import CONST from '../CONST';
@@ -6,6 +6,7 @@ import themeColors from '../styles/themes/default';
 import ONYXKEYS from '../ONYXKEYS';
 import Modal from './Modal';
 import {redirectToLastReport} from '../libs/actions/App';
+import {modalHide} from '../libs/actions/Modal';
 
 /**
  * Right-docked modal view showing a user's settings.
@@ -20,25 +21,75 @@ const propTypes = {
     /* Onyx Props */
     // Url currently in view
     currentURL: PropTypes.string,
+
+    isModalShown: PropTypes.bool,
+
+    modalType: PropTypes.string,
 };
 
 const defaultProps = {
     route: '',
     currentURL: '',
+    isModalShown: false,
+    modalType: '',
 };
 
-const RightDockedModal = memo(({
-    route, children, currentURL,
-}) => (
-    <Modal
-        type={CONST.MODAL.MODAL_TYPE.RIGHT_DOCKED}
-        onClose={redirectToLastReport}
-        isVisible={currentURL === route}
-        backgroundColor={themeColors.componentBG}
-    >
-        {children}
-    </Modal>
-));
+class RightDockedModal extends PureComponent {
+    constructor(props) {
+        super(props);
+
+        this.onClose = this.onClose.bind(this);
+        this.modalHandler = this.modalHandler.bind(this);
+
+        this.state = {
+            isVisible: false,
+        };
+    }
+
+    componentDidMount() {
+        this.modalHandler();
+    }
+
+    componentDidUpdate(prevProps) {
+        if (prevProps.isModalShown !== this.props.isModalShown || prevProps.currentURL !== this.props.currentURL) {
+            this.modalHandler();
+        }
+    }
+
+    onClose() {
+        const {isModalShown} = this.props;
+        if (isModalShown) {
+            modalHide();
+        }
+        redirectToLastReport();
+    }
+
+    modalHandler() {
+        const {
+            isModalShown, modalType, route, currentURL,
+        } = this.props;
+        if (route === modalType) {
+            this.setState({isVisible: isModalShown});
+        } else {
+            this.setState({isVisible: route === currentURL});
+        }
+    }
+
+
+    render() {
+        const {isVisible} = this.state;
+        return (
+            <Modal
+                type={CONST.MODAL.MODAL_TYPE.RIGHT_DOCKED}
+                onClose={this.onClose}
+                isVisible={isVisible}
+                backgroundColor={themeColors.componentBG}
+            >
+                {this.props.children}
+            </Modal>
+        );
+    }
+}
 
 RightDockedModal.propTypes = propTypes;
 RightDockedModal.defaultProps = defaultProps;
@@ -50,5 +101,11 @@ export default withOnyx({
     },
     currentURL: {
         key: ONYXKEYS.CURRENT_URL,
+    },
+    modalType: {
+        key: ONYXKEYS.MODAL.MODAL_TYPE,
+    },
+    isModalShown: {
+        key: ONYXKEYS.MODAL.IS_MODAL_SHOWN,
     },
 })(RightDockedModal);

--- a/src/libs/actions/Modal.js
+++ b/src/libs/actions/Modal.js
@@ -1,0 +1,26 @@
+import Onyx from 'react-native-onyx';
+import {Keyboard} from 'react-native';
+import ONYXKEYS from '../../ONYXKEYS';
+
+/**
+ * Hide the modal, if it is shown.
+ */
+function modalHide() {
+    Keyboard.dismiss();
+    Onyx.set(ONYXKEYS.MODAL.IS_MODAL_SHOWN, false);
+}
+
+/**
+ * Show the modal, if it is hidden and also set modal type.
+ */
+
+function modalShow(modalType) {
+    Keyboard.dismiss();
+    Onyx.set(ONYXKEYS.MODAL.IS_MODAL_SHOWN, true);
+    Onyx.set(ONYXKEYS.MODAL.MODAL_TYPE, modalType);
+}
+
+export {
+    modalHide,
+    modalShow,
+};

--- a/src/libs/actions/Modal.js
+++ b/src/libs/actions/Modal.js
@@ -7,7 +7,7 @@ import ONYXKEYS from '../../ONYXKEYS';
  */
 function modalHide() {
     Keyboard.dismiss();
-    Onyx.set(ONYXKEYS.MODAL.IS_MODAL_SHOWN, false);
+    Onyx.set(ONYXKEYS.MODAL.IS_SHOWN, false);
 }
 
 /**
@@ -16,8 +16,8 @@ function modalHide() {
 
 function modalShow(modalType) {
     Keyboard.dismiss();
-    Onyx.set(ONYXKEYS.MODAL.IS_MODAL_SHOWN, true);
-    Onyx.set(ONYXKEYS.MODAL.MODAL_TYPE, modalType);
+    Onyx.set(ONYXKEYS.MODAL.IS_SHOWN, true);
+    Onyx.set(ONYXKEYS.MODAL.TYPE, modalType);
 }
 
 export {

--- a/src/pages/SearchPage.js
+++ b/src/pages/SearchPage.js
@@ -15,6 +15,7 @@ import {fetchOrCreateChatReport} from '../libs/actions/Report';
 import HeaderWithCloseButton from '../components/HeaderWithCloseButton';
 import HeaderGap from '../components/HeaderGap';
 import {modalHide} from '../libs/actions/Modal';
+import getPlatform from '../libs/getPlatform';
 
 const personalDetailsPropTypes = PropTypes.shape({
     // The login of the person (either email or phone number)
@@ -73,7 +74,9 @@ class SearchPage extends Component {
     }
 
     onClose() {
-        modalHide();
+        if (['web', 'desktop'].includes(getPlatform())) {
+            modalHide();
+        }
         redirectToLastReport();
     }
 
@@ -108,10 +111,12 @@ class SearchPage extends Component {
                 if (this.props.isSmallScreenWidth) {
                     hideSidebar();
                 }
-                modalHide();
+                if (['web', 'desktop'].includes(getPlatform())) {
+                    modalHide();
 
-                // Wait for modal animate out
-                await new Promise(r => setTimeout(r, 330));
+                    // Wait for modal animate out
+                    await new Promise(r => setTimeout(r, 330));
+                }
                 redirect(ROUTES.getReportRoute(option.reportID));
             });
         } else {

--- a/src/pages/SearchPage.js
+++ b/src/pages/SearchPage.js
@@ -14,6 +14,7 @@ import withWindowDimensions, {windowDimensionsPropTypes} from '../components/wit
 import {fetchOrCreateChatReport} from '../libs/actions/Report';
 import HeaderWithCloseButton from '../components/HeaderWithCloseButton';
 import HeaderGap from '../components/HeaderGap';
+import {modalHide} from '../libs/actions/Modal';
 
 const personalDetailsPropTypes = PropTypes.shape({
     // The login of the person (either email or phone number)
@@ -53,6 +54,7 @@ class SearchPage extends Component {
         super(props);
 
         this.selectReport = this.selectReport.bind(this);
+        this.onClose = this.onClose.bind(this);
 
         const {
             recentReports,
@@ -68,6 +70,11 @@ class SearchPage extends Component {
             recentReports,
             personalDetails,
         };
+    }
+
+    onClose() {
+        modalHide();
+        redirectToLastReport();
     }
 
     /**
@@ -97,10 +104,14 @@ class SearchPage extends Component {
         if (option.reportID) {
             this.setState({
                 searchValue: '',
-            }, () => {
+            }, async () => {
                 if (this.props.isSmallScreenWidth) {
                     hideSidebar();
                 }
+                modalHide();
+
+                // Wait for modal animate out
+                await new Promise(r => setTimeout(r, 330));
                 redirect(ROUTES.getReportRoute(option.reportID));
             });
         } else {
@@ -123,7 +134,7 @@ class SearchPage extends Component {
                 <HeaderGap />
                 <HeaderWithCloseButton
                     title="Search"
-                    onCloseButtonPress={redirectToLastReport}
+                    onCloseButtonPress={this.onClose}
                 />
                 <View style={[styles.flex1, styles.w100]}>
                     <OptionsSelector

--- a/src/pages/home/HomePage.js
+++ b/src/pages/home/HomePage.js
@@ -31,6 +31,7 @@ import {redirect} from '../../libs/actions/App';
 import RightDockedModal from '../../components/RightDockedModal';
 import {getBetas} from '../../libs/actions/User';
 import Account from '../../libs/actions/Account';
+import {modalShow} from '../../libs/actions/Modal';
 
 const propTypes = {
     network: PropTypes.shape({isOffline: PropTypes.bool}),
@@ -82,6 +83,7 @@ class HomePage extends PureComponent {
 
         // Listen for the Command+K key being pressed so the focus can be given to the chat switcher
         KeyboardShortcut.subscribe('K', () => {
+            modalShow(ROUTES.SEARCH);
             redirect(ROUTES.SEARCH);
         }, ['meta'], true);
     }

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -265,7 +265,7 @@ export default compose(
             key: ONYXKEYS.CURRENT_URL,
         },
         isModalShown: {
-            key: ONYXKEYS.MODAL.IS_MODAL_SHOWN,
+            key: ONYXKEYS.MODAL.IS_SHOWN,
         },
     }),
     withWindowDimensions,

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -29,11 +29,17 @@ const propTypes = {
 
     isSidebarShown: PropTypes.bool.isRequired,
 
+    currentURL: PropTypes.string,
+
+    isModalShown: PropTypes.bool,
+
     ...windowDimensionsPropTypes,
 };
 
 const defaultProps = {
     comment: '',
+    isModalShown: false,
+    currentURL: '',
 };
 
 class ReportActionCompose extends React.Component {
@@ -62,6 +68,9 @@ class ReportActionCompose extends React.Component {
         if (this.props.comment && prevProps.comment === '' && prevProps.comment !== this.props.comment) {
             this.comment = this.props.comment;
         }
+        if (this.props.currentURL !== prevProps.currentURL) {
+            this.setIsFocused(!this.props.isModalShown);
+        }
     }
 
     /**
@@ -71,6 +80,9 @@ class ReportActionCompose extends React.Component {
      */
     setIsFocused(shouldHighlight) {
         this.setState({isFocused: shouldHighlight});
+        if (shouldHighlight) {
+            this.textInput?.focus();
+        }
     }
 
     /**
@@ -250,6 +262,12 @@ export default compose(
         },
         isSidebarShown: {
             key: ONYXKEYS.IS_SIDEBAR_SHOWN,
+        },
+        currentURL: {
+            key: ONYXKEYS.CURRENT_URL,
+        },
+        isModalShown: {
+            key: ONYXKEYS.MODAL.IS_MODAL_SHOWN,
         },
     }),
     withWindowDimensions,

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -29,17 +29,15 @@ const propTypes = {
 
     isSidebarShown: PropTypes.bool.isRequired,
 
-    currentURL: PropTypes.string,
+    currentURL: PropTypes.string.isRequired,
 
-    isModalShown: PropTypes.bool,
+    isModalShown: PropTypes.bool.isRequired,
 
     ...windowDimensionsPropTypes,
 };
 
 const defaultProps = {
     comment: '',
-    isModalShown: false,
-    currentURL: '',
 };
 
 class ReportActionCompose extends React.Component {

--- a/src/pages/home/sidebar/SidebarLinks.js
+++ b/src/pages/home/sidebar/SidebarLinks.js
@@ -19,6 +19,8 @@ import {getDefaultAvatar} from '../../../libs/actions/PersonalDetails';
 import KeyboardSpacer from '../../../components/KeyboardSpacer';
 import HeaderGap from '../../../components/HeaderGap';
 import CONST from '../../../CONST';
+import {modalShow} from '../../../libs/actions/Modal';
+import getPlatform from '../../../libs/getPlatform';
 
 const propTypes = {
     // Toggles the navigation menu open and closed
@@ -84,6 +86,9 @@ const defaultProps = {
 
 class SidebarLinks extends React.Component {
     showSearchPage() {
+        if (['web', 'desktop'].includes(getPlatform())) {
+            modalShow(ROUTES.SEARCH);
+        }
         redirect(ROUTES.SEARCH);
     }
 


### PR DESCRIPTION
Hi @tgolen

### Details
I added a generic modal state into Onyx and that can handle all types of Modal in the app but for this task, I handled the only `search modal` and for other models retain the previous logic, can update on demand.

as well as I used the class component for `RightDockedModal` because I need to use `componentDidMount` lifecycle
and in some previous PR reviews, reviewers didn't allow me to use useEffect because that not used in-app yet 

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/1513

### Tests

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
#### Web
https://user-images.githubusercontent.com/31027036/109870053-8c277480-7c61-11eb-990b-de8ffc307a28.mov

#### Mobile Web
https://user-images.githubusercontent.com/31027036/109870469-09eb8000-7c62-11eb-91a4-ed542f63e2ac.mov

#### Desktop
https://user-images.githubusercontent.com/31027036/109870696-5767ed00-7c62-11eb-86d5-2a906cd2dae5.mov

#### iOS
https://user-images.githubusercontent.com/31027036/109871199-dc530680-7c62-11eb-9638-6dc07d4b8f07.mov

#### Android
https://user-images.githubusercontent.com/31027036/109873570-d3afff80-7c65-11eb-85d4-3e8bd46c00d0.mp4

