### PR TITLE
Use turnstyle to avoid race conditions in version workflow

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -15,7 +15,7 @@ jobs:
                   fetch-depth: 0
                   token: ${{ secrets.OS_BOTIFY_TOKEN }}
 
-            - uses: softprops/turnstyle@v1
+            - uses: softprops/turnstyle@8db075d65b19bf94e6e8687b504db69938dc3c65
               with:
                   poll-interval-seconds: 10
               env:

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -15,13 +15,11 @@ jobs:
                   fetch-depth: 0
                   token: ${{ secrets.OS_BOTIFY_TOKEN }}
 
-            - name: Setup Node
-              uses: actions/setup-node@v1
+            - uses: softprops/turnstyle@v1
               with:
-                  node-version: '14.x'
-
-            - name: Install dependenices
-              run: npm ci
+                  poll-interval-seconds: 10
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Set up git
               run: |


### PR DESCRIPTION

### Details
[Turnstyle](https://github.com/softprops/turnstyle) is a cool Github Action which acts as a queuing service, ensuring that for any workflow that it's used on, only one instance of that workflow will execute at a time. This helps us prevent race conditions with our versioning workflow.

From the author:

> This tool focuses on serializing workflows. Typically in CI/CD, CI can happen independently but deployments need to happen serially. Workflows by nature are async, when a commit is pushed a new workflow is triggered. The idea behind turnstyle is that you can add a serialization step inside your workflow so that checks to see if there is a previous workflow run in progress, it awaits its completion or optionally continues after waiting a configurable amount of time before progressing.

Also, we don't need to be installing dependencies or setting up node for this workflow, so I removed those unnecessary steps.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/147462

### Tests
1. I tested this a fair amount in [Andrew-Test-Org/Public-Test-Repo](https://github.com/Andrew-Test-Org/Public-Test-Repo/actions/workflows/testTurnstyle.yml) and confirmed it works in both ubuntu and macos.
2. In order to properly test this, we need to merge this PR, followed immediately by a dummy PR. We should then see the `version` workflow of the second PR waiting on completion of the `version` workflow of this PR.

### Tested On

- Github