### PR TITLE
Retry running npm ci when it fails

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -24,7 +24,11 @@ jobs:
               run: bundle install
 
             - name: Install node packages
-              run: npm ci
+              uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
+              with:
+                timeout_minutes: 10
+                max_attempts: 10
+                command: npm ci
 
             - name: Decrypt keystore
               run: cd android/app && gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output my-upload-key.keystore my-upload-key.keystore.gpg

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -27,7 +27,7 @@ jobs:
               uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
               with:
                 timeout_minutes: 10
-                max_attempts: 10
+                max_attempts: 5
                 command: npm ci
 
             - name: Decrypt keystore

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -22,7 +22,7 @@ jobs:
               uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
               with:
                 timeout_minutes: 10
-                max_attempts: 10
+                max_attempts: 5
                 command: npm ci
 
             - name: Decrypt Developer ID Certificate

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -19,7 +19,11 @@ jobs:
                 node-version: '14.x'
 
             - name: Install node packages
-              run: npm ci -ddd
+              uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
+              with:
+                timeout_minutes: 10
+                max_attempts: 10
+                command: npm ci
 
             - name: Decrypt Developer ID Certificate
               run: cd desktop && gpg --quiet --batch --yes --decrypt --passphrase="$DEVELOPER_ID_SECRET_PASSPHRASE" --output developer_id.p12 developer_id.p12.gpg

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
     test:
-        runs-on: macos-10.15
+        runs-on: macos-latest
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-ruby@v1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,7 +23,11 @@ jobs:
               run: bundle install
 
             - name: Install node packages
-              run: npm install
+              uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
+              with:
+                timeout_minutes: 10
+                max_attempts: 10
+                command: npm ci
 
             - name: Install detox
               run: npm install -g detox-cli

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,7 +26,7 @@ jobs:
               uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
               with:
                 timeout_minutes: 10
-                max_attempts: 10
+                max_attempts: 5
                 command: npm ci
 
             - name: Install detox

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -35,7 +35,7 @@ jobs:
               uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
               with:
                 timeout_minutes: 10
-                max_attempts: 10
+                max_attempts: 5
                 command: npm ci
 
             - name: Install cocoapods

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -32,7 +32,11 @@ jobs:
               run: bundle install
 
             - name: Install node packages
-              run: npm ci -ddd
+              uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
+              with:
+                timeout_minutes: 10
+                max_attempts: 10
+                command: npm ci
 
             - name: Install cocoapods
               run: cd ios && pod install

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,12 @@ jobs:
               with:
                   node-version: '14.x'
 
-            - run: npm ci
+            - name: Install node packages
+              uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
+              with:
+                timeout_minutes: 10
+                max_attempts: 10
+                command: npm ci
 
             - run: npm run lint
               env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
               uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
               with:
                 timeout_minutes: 10
-                max_attempts: 10
+                max_attempts: 5
                 command: npm ci
 
             - run: npm run lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
               uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
               with:
                   timeout_minutes: 10
-                  max_attempts: 10
+                  max_attempts: 5
                   command: npm ci
 
             - run: npm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,15 @@ jobs:
 
             - name: Use Node.js
               uses: actions/setup-node@v1
+              with:
+                node-version: '14.x'
 
-            - run: npm install
+            - name: Install node packages
+              uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
+              with:
+                  timeout_minutes: 10
+                  max_attempts: 10
+                  command: npm ci
 
             - run: npm run test
               env:

--- a/.github/workflows/verifyGithubActionBuilds.yml
+++ b/.github/workflows/verifyGithubActionBuilds.yml
@@ -12,8 +12,15 @@ jobs:
 
             - name: Use Node.js
               uses: actions/setup-node@v1
+              with:
+                node-version: '14.x'
 
-            - run: npm install
+            - name: Install node packages
+              uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
+              with:
+                  timeout_minutes: 10
+                  max_attempts: 10
+                  command: npm ci
 
             # Rebuild all the actions on this branch and check for a diff. Fail if there is one,
             # because that would be a sign that the PR author did not rebuild the Github Actions

--- a/.github/workflows/verifyGithubActionBuilds.yml
+++ b/.github/workflows/verifyGithubActionBuilds.yml
@@ -19,7 +19,7 @@ jobs:
               uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
               with:
                   timeout_minutes: 10
-                  max_attempts: 10
+                  max_attempts: 5
                   command: npm ci
 
             # Rebuild all the actions on this branch and check for a diff. Fail if there is one,

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -44,7 +44,7 @@ jobs:
               uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
               with:
                 timeout_minutes: 10
-                max_attempts: 10
+                max_attempts: 5
                 command: npm ci
 
             - name: Build web

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -40,8 +40,12 @@ jobs:
                 aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                 aws-region: us-east-1
 
-            - name: Install dependenices
-              run: npm ci
+            - name: Install node packages
+              uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
+              with:
+                timeout_minutes: 10
+                max_attempts: 10
+                command: npm ci
 
             - name: Build web
               run: npm run build

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -9,7 +9,7 @@ on:
 jobs:
     build:
         if: github.actor == 'OSBotify'
-        runs-on: ubuntu-16.04
+        runs-on: ubuntu-latest
 
         steps:
             - uses: actions/checkout@v2


### PR DESCRIPTION
### Details
Adds an auto retry mechanism to `npm ci` because it is still happening at a somewhat consistent rate (enough to break deploys). This should allow the `npm ci` command to run for 10 minutes, and if it takes longer than 10 minutes or throws an error, it will retry up to 10 times.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/152345

### Tests
1. Verify all checks pass on this PR (including e2e)
2. Verify once merged, we deploy correctly