### PR TITLE
Ensure DateUtils timezone isn't undefined

### DIFF
--- a/src/libs/DateUtils.js
+++ b/src/libs/DateUtils.js
@@ -11,7 +11,7 @@ Onyx.connect({
     key: ONYXKEYS.MY_PERSONAL_DETAILS,
     callback: (val) => {
         if (val) {
-            timezone = _.isObject(val) ? val.timezone.selected : val.timezone;
+            timezone = _.isObject(val.timezone) ? val.timezone.selected : val.timezone;
         } else {
             timezone = CONST.DEFAULT_TIME_ZONE.selected;
         }

--- a/src/libs/DateUtils.js
+++ b/src/libs/DateUtils.js
@@ -10,7 +10,7 @@ let timezone;
 Onyx.connect({
     key: ONYXKEYS.MY_PERSONAL_DETAILS,
     callback: (val) => {
-        timezone = val.timezone || CONST.DEFAULT_TIME_ZONE.selected;
+        timezone = val ? val.timezone : CONST.DEFAULT_TIME_ZONE.selected;
         if (_.isObject(timezone)) {
             timezone = val.timezone.selected;
         }

--- a/src/libs/DateUtils.js
+++ b/src/libs/DateUtils.js
@@ -10,10 +10,9 @@ let timezone;
 Onyx.connect({
     key: ONYXKEYS.MY_PERSONAL_DETAILS,
     callback: (val) => {
-        if (val) {
-            timezone = _.isObject(val.timezone) ? val.timezone.selected : val.timezone;
-        } else {
-            timezone = CONST.DEFAULT_TIME_ZONE.selected;
+        timezone = val.timezone || CONST.DEFAULT_TIME_ZONE.selected;
+        if (_.isObject(timezone)) {
+            timezone = val.timezone.selected;
         }
     },
 });


### PR DESCRIPTION
### Details
Slightly incorrect check in https://github.com/Expensify/Expensify.cash/pull/1573 is leading to whitescreens when you load up E.cash unless you refresh. 

### Fixed Issues
<Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing>
Fixes Expensify/Expensify/issues/156383

### Tests
1. Sign into a new account on E.cash 
2. Ensure you don't get a blank white screen and that the app loads as anticipated.

### Tested On
- [x] Web
- [ ] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
N/A