### PR TITLE
Fix attachment uploads by moving stringify call

### DIFF
--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -489,7 +489,7 @@ function Push_Authenticate(parameters) {
  * @param {String} parameters.reportComment
  * @param {Number} parameters.reportID
  * @param {String} parameters.clientID
- * @param {File} [parameters.file]
+ * @param {File|Object} [parameters.file]
  * @returns {Promise}
  */
 function Report_AddComment(parameters) {

--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -489,7 +489,7 @@ function Push_Authenticate(parameters) {
  * @param {String} parameters.reportComment
  * @param {Number} parameters.reportID
  * @param {String} parameters.clientID
- * @param {Object} [parameters.file]
+ * @param {File} [parameters.file]
  * @returns {Promise}
  */
 function Report_AddComment(parameters) {

--- a/src/libs/HttpUtils.js
+++ b/src/libs/HttpUtils.js
@@ -43,7 +43,10 @@ function processHTTPRequest(url, method = 'get', body = null) {
  */
 function xhr(command, data, type = 'post') {
     const formData = new FormData();
-    _.each(data, (val, key) => formData.append(key, _.isObject(val) ? JSON.stringify(val) : val));
+    _.each(data, (val, key) => {
+        // Automatically stringify any object parameters unless they are Blob (and subclasses like File)
+        formData.append(key, !_.isObject(val) || val instanceof Blob ? val : JSON.stringify(val));
+    });
     return processHTTPRequest(`${CONFIG.EXPENSIFY.URL_API_ROOT}api?command=${command}`, type, formData);
 }
 

--- a/src/libs/HttpUtils.js
+++ b/src/libs/HttpUtils.js
@@ -43,9 +43,7 @@ function processHTTPRequest(url, method = 'get', body = null) {
  */
 function xhr(command, data, type = 'post') {
     const formData = new FormData();
-    _.each(data, (val, key) => {
-        formData.append(key, val);
-    });
+    _.each(data, (val, key) => formData.append(key, val));
     return processHTTPRequest(`${CONFIG.EXPENSIFY.URL_API_ROOT}api?command=${command}`, type, formData);
 }
 

--- a/src/libs/HttpUtils.js
+++ b/src/libs/HttpUtils.js
@@ -44,8 +44,7 @@ function processHTTPRequest(url, method = 'get', body = null) {
 function xhr(command, data, type = 'post') {
     const formData = new FormData();
     _.each(data, (val, key) => {
-        // Automatically stringify any object parameters unless they are Blob (and subclasses like File)
-        formData.append(key, !_.isObject(val) || val instanceof Blob ? val : JSON.stringify(val));
+        formData.append(key, val);
     });
     return processHTTPRequest(`${CONFIG.EXPENSIFY.URL_API_ROOT}api?command=${command}`, type, formData);
 }

--- a/src/libs/actions/NameValuePair.js
+++ b/src/libs/actions/NameValuePair.js
@@ -1,3 +1,4 @@
+import _ from 'underscore';
 import Onyx from 'react-native-onyx';
 import lodashGet from 'lodash.get';
 import * as API from '../API';
@@ -28,7 +29,7 @@ function get(name, onyxKey, defaultValue) {
  * @param {String} [onyxKeyName]
  */
 function set(name, value, onyxKeyName) {
-    API.SetNameValuePair({name, value});
+    API.SetNameValuePair({name, value: _.isObject(value) ? JSON.stringify(value) : value});
 
     // Update the associated onyx key if we've passed the associated key name
     if (onyxKeyName) {

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -201,7 +201,7 @@ function getFromReportParticipants(reports) {
  * @param {Object} details
  */
 function setPersonalDetails(details) {
-    API.PersonalDetails_Update({details});
+    API.PersonalDetails_Update({details: JSON.stringify(details)});
 
     if (details.timezone) {
         NameValuePair.set(CONST.NVP.TIMEZONE, details.timezone);


### PR DESCRIPTION
### Details
We added the logic to auto stringify object params but `_.isObject()` returns `true` when we have a `Blob` (`File` is a subclass)
 
### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/156388

### Tests
1. Upload an attachment and verify it works.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
