### PR TITLE
Manually bump version to 1.0.2-0 for Apple

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -148,8 +148,8 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         multiDexEnabled rootProject.ext.multiDexEnabled
-        versionCode 1000001486
-        versionName "1.0.1-498"
+        versionCode 1000001487
+        versionName "1.0.2-0"
     }
     splits {
         abi {

--- a/ios/ExpensifyCash/Info.plist
+++ b/ios/ExpensifyCash/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.1</string>
+	<string>1.0.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.0.1.498</string>
+	<string>1.0.2.0</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "expensify.cash",
-  "version": "1.0.1-498",
+  "version": "1.0.2-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expensify.cash",
-  "version": "1.0.1-498",
+  "version": "1.0.2-0",
   "author": "Expensify, Inc.",
   "homepage": "https://expensify.cash",
   "description": "Expensify.cash is the next generation of Expensify: a reimagination of payments based atop a foundation of chat.",


### PR DESCRIPTION
### Details
Since we changed our version schema Apple is not showing our latest updates on TestFlight, so let's manually update the `PATCH` version to get it to show as the latest version

### Fixed Issues
Fixes TF not showing our latest updates

### Tests
1. Merge this
2. Put iOS into review
3. Wait until Apple approves
4. Verify 1.0.2-1 is latest version