### PR TITLE
Provide a default build version

### DIFF
--- a/.github/actions/bumpVersion/bumpVersion.js
+++ b/.github/actions/bumpVersion/bumpVersion.js
@@ -62,6 +62,9 @@ return octokit.repos.listTags({
                 .filter(tag => (tag.startsWith(currentPatchVersion)))
                 .map(tag => tag.split('-')[1])
             ),
+
+            // Provide a default of 0 for minimum build version
+            0,
         );
         console.log('Highest build number from current patch version:', highestBuildNumber);
 

--- a/.github/actions/bumpVersion/index.js
+++ b/.github/actions/bumpVersion/index.js
@@ -72,6 +72,9 @@ return octokit.repos.listTags({
                 .filter(tag => (tag.startsWith(currentPatchVersion)))
                 .map(tag => tag.split('-')[1])
             ),
+
+            // Provide a default of 0 for minimum build version
+            0,
         );
         console.log('Highest build number from current patch version:', highestBuildNumber);
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -149,7 +149,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         multiDexEnabled rootProject.ext.multiDexEnabled
         versionCode 1000001488
-        versionName "1.0.2--Infinity"
+        versionName "1.0.2-0"
     }
     splits {
         abi {

--- a/ios/ExpensifyCash/Info.plist
+++ b/ios/ExpensifyCash/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.0.2.-Infinity</string>
+	<string>1.0.2.0</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>

--- a/ios/ExpensifyCashTests/Info.plist
+++ b/ios/ExpensifyCashTests/Info.plist
@@ -19,6 +19,6 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.0.2.-Infinity</string>
+	<string>1.0.2.0</string>
 </dict>
 </plist>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "expensify.cash",
-  "version": "1.0.2--Infinity",
+  "version": "1.0.2-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expensify.cash",
-  "version": "1.0.2--Infinity",
+  "version": "1.0.2-0",
   "author": "Expensify, Inc.",
   "homepage": "https://expensify.cash",
   "description": "Expensify.cash is the next generation of Expensify: a reimagination of payments based atop a foundation of chat.",


### PR DESCRIPTION
### Details
In my PR here: https://github.com/Expensify/Expensify.cash/pull/1634 I set the version to `1.0.2-0`, but I did not push a tag correctly, leaving the code to generate an invalid version `1.0.2--Infinity` (https://github.com/Expensify/Expensify.cash/pull/1635). This PR will fix this in two ways:
1. I pushed the tag correctly this time: https://github.com/Expensify/Expensify.cash/releases/tag/1.0.2-0
2. I also added logic to set the default build to `0` so we should never get a non finite number again

### Tests
1. Merge this PR
2. Verify we get `1.0.2-1` built and uploaded to stores