### PR TITLE
[IS-1520] Return cursor to the compose box after image uploads

### DIFF
--- a/src/components/AttachmentModal.js
+++ b/src/components/AttachmentModal.js
@@ -32,6 +32,7 @@ const propTypes = {
     // Optional callback to fire when we want to preview an image and approve it for use.
     onConfirm: PropTypes.func,
 
+    // Optional callback to fire when we want to do something after modal hide.
     onModalHide: PropTypes.func,
 
     // A function as a child to pass modal launching methods to

--- a/src/components/AttachmentModal.js
+++ b/src/components/AttachmentModal.js
@@ -32,6 +32,8 @@ const propTypes = {
     // Optional callback to fire when we want to preview an image and approve it for use.
     onConfirm: PropTypes.func,
 
+    onModalHide: PropTypes.func,
+
     // A function as a child to pass modal launching methods to
     children: PropTypes.func.isRequired,
 
@@ -51,6 +53,7 @@ const defaultProps = {
     sourceURL: null,
     onConfirm: null,
     isAuthTokenRequired: false,
+    onModalHide: null,
 };
 
 class AttachmentModal extends PureComponent {
@@ -97,6 +100,7 @@ class AttachmentModal extends PureComponent {
                     onClose={() => this.setState({isModalOpen: false})}
                     isVisible={this.state.isModalOpen}
                     backgroundColor={themeColors.componentBG}
+                    onModalHide={this.props.onModalHide}
                 >
                     <HeaderWithCloseButton
                         title={this.props.title}

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -71,6 +71,9 @@ class ReportActionCompose extends React.Component {
      */
     setIsFocused(shouldHighlight) {
         this.setState({isFocused: shouldHighlight});
+        if (shouldHighlight && this.textInput) {
+            this.textInput.focus();
+        }
     }
 
     /**
@@ -162,6 +165,9 @@ class ReportActionCompose extends React.Component {
                         onConfirm={(file) => {
                             addAction(this.props.reportID, '', file);
                             this.setTextInputShouldClear(false);
+                        }}
+                        onModalHide={() => {
+                            this.setIsFocused(true);
                         }}
                     >
                         {({displayFileInModal}) => (


### PR DESCRIPTION
@NicMendonca 
Please have a look.

### Details
<Explanation of the change or anything fishy that is going on>

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/1520

### Tests

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web
https://user-images.githubusercontent.com/31027036/110026407-7fba1f00-7d28-11eb-80bc-e754bc5e160f.mov

#### Mobile Web
https://user-images.githubusercontent.com/31027036/110026532-ab3d0980-7d28-11eb-9369-7ba1d714b918.mov

#### Desktop
https://user-images.githubusercontent.com/31027036/110026230-4da8bd00-7d28-11eb-84de-33ce77fb4d32.mov

#### iOS
https://user-images.githubusercontent.com/31027036/110026923-3cac7b80-7d29-11eb-8a03-b8f387e3d3e5.mov

#### Android
https://user-images.githubusercontent.com/31027036/110030193-53ed6800-7d2d-11eb-93a3-15fe75056eb1.mov
