### PR TITLE
Update expensify-common to latest commit hash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10891,8 +10891,8 @@
       }
     },
     "expensify-common": {
-      "version": "git+https://github.com/Expensify/expensify-common.git#485113217cd319cd3b2185e14a5fd03d36b8d3e7",
-      "from": "git+https://github.com/Expensify/expensify-common.git#485113217cd319cd3b2185e14a5fd03d36b8d3e7",
+      "version": "git+https://github.com/Expensify/expensify-common.git#89f4fb8bcfd5c421d6aedb4fda871aed8daa1251",
+      "from": "git+https://github.com/Expensify/expensify-common.git#89f4fb8bcfd5c421d6aedb4fda871aed8daa1251",
       "requires": {
         "classnames": "2.2.5",
         "clipboard": "2.0.4",
@@ -20955,6 +20955,53 @@
         "lodash.merge": "^4.6.2",
         "react": "^16.13.1",
         "underscore": "^1.11.0"
+      },
+      "dependencies": {
+        "expensify-common": {
+          "version": "git+https://github.com/Expensify/expensify-common.git#485113217cd319cd3b2185e14a5fd03d36b8d3e7",
+          "from": "git+https://github.com/Expensify/expensify-common.git#485113217cd319cd3b2185e14a5fd03d36b8d3e7",
+          "requires": {
+            "classnames": "2.2.5",
+            "clipboard": "2.0.4",
+            "html-entities": "^1.3.1",
+            "jquery": "3.3.1",
+            "lodash.get": "4.4.2",
+            "lodash.has": "4.5.2",
+            "prop-types": "15.7.2",
+            "react": "16.12.0",
+            "react-dom": "16.12.0",
+            "simply-deferred": "git+https://github.com/Expensify/simply-deferred.git#77a08a95754660c7bd6e0b6979fdf84e8e831bf5",
+            "underscore": "1.9.1"
+          },
+          "dependencies": {
+            "react": {
+              "version": "16.12.0",
+              "resolved": "https://registry.npmjs.org/react/-/react-16.12.0.tgz",
+              "integrity": "sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==",
+              "requires": {
+                "loose-envify": "^1.1.0",
+                "object-assign": "^4.1.1",
+                "prop-types": "^15.6.2"
+              }
+            },
+            "underscore": {
+              "version": "1.9.1",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+              "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+            }
+          }
+        },
+        "react-dom": {
+          "version": "16.12.0",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.12.0.tgz",
+          "integrity": "sha512-LMxFfAGrcS3kETtQaCkTKjMiifahaMySFDn71fZUNpPHZQEzmk/GiAeIT8JSOrHB23fnuCOMruL2a8NYlw+8Gw==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "scheduler": "^0.18.0"
+          }
+        }
       }
     },
     "react-native-pdf": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "electron-log": "^4.2.4",
     "electron-serve": "^1.0.0",
     "electron-updater": "^4.3.4",
-    "expensify-common": "git+https://github.com/Expensify/expensify-common.git#485113217cd319cd3b2185e14a5fd03d36b8d3e7",
+    "expensify-common": "git+https://github.com/Expensify/expensify-common.git#89f4fb8bcfd5c421d6aedb4fda871aed8daa1251",
     "file-loader": "^6.0.0",
     "html-entities": "^1.3.1",
     "lodash.get": "^4.4.2",


### PR DESCRIPTION
### Details
Update expensify-common to the [latest commit hash](https://github.com/Expensify/expensify-common/commits/master):

![image](https://user-images.githubusercontent.com/47436092/110036135-63e75680-7cf1-11eb-9a41-fd2b3775ef89.png)

### Fixed Issues
Really we're just trying to re-trigger an iOS deploy....

### Tests
None