### PR TITLE
Re-add app activate showing the window

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -186,6 +186,7 @@ const mainWindow = (() => {
             });
 
             app.on('before-quit', () => quitting = true);
+            app.on('activate', () => browserWindow.show());
 
             // Hide the app if we expected to upgrade to a new version but never did.
             if (expectedUpdateVersion && app.getVersion() !== expectedUpdateVersion) {

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -186,7 +186,11 @@ const mainWindow = (() => {
             });
 
             app.on('before-quit', () => quitting = true);
-            app.on('activate', () => browserWindow.show());
+            app.on('activate', () => {
+                if (!expectedUpdateVersion || app.getVersion() === expectedUpdateVersion) {
+                    browserWindow.show();
+                }
+            });
 
             // Hide the app if we expected to upgrade to a new version but never did.
             if (expectedUpdateVersion && app.getVersion() !== expectedUpdateVersion) {

--- a/ubuntu-xenial-16.04-cloudimg-console.log
+++ b/ubuntu-xenial-16.04-cloudimg-console.log
@@ -1,3 +1,0 @@
-[106438.241934] e1000 0000:00:08.0 enp0s8: Reset adapter
-[106438.245184] e1000 0000:00:03.0 enp0s3: Reset adapter
-[241903.956205] e1000 0000:00:03.0 enp0s3: Reset adapter

--- a/ubuntu-xenial-16.04-cloudimg-console.log
+++ b/ubuntu-xenial-16.04-cloudimg-console.log
@@ -1,0 +1,3 @@
+[106438.241934] e1000 0000:00:08.0 enp0s8: Reset adapter
+[106438.245184] e1000 0000:00:03.0 enp0s3: Reset adapter
+[241903.956205] e1000 0000:00:03.0 enp0s3: Reset adapter


### PR DESCRIPTION
cc: @roryabraham since you reviewed the original PR (linked below) and I want to make sure I'm now accidentally breaking the auto-update functionality somehow

### Details
We removed this line [here](https://github.com/Expensify/Expensify.cash/pull/1318/files#diff-9276f078b750aa322d09bda48c79eb8034941df5b0f0f0c4f8b898cf9c652c41L141) which made it so that when you close the desktop app by clicking the `x` button or `cmd+w` you can no longer re-open the app.

### Fixed Issues
https://github.com/Expensify/Expensify/issues/156206

### Tests
1. Open the desktop app
2. Click the x in the top left
3. Make sure you can re-open the app from the task bar
4. Close the app with `cmd+w` 
5. Make sure you can re-open the app from the task bar

### Tested On
- [x] Desktop
