### PR TITLE
[Chat] - Priority Mode dropdown arrow isn't responsive

### DIFF
--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -208,6 +208,7 @@ const styles = {
         iconContainer: {
             top: 12,
             right: 12,
+            pointerEvents: 'none',
         },
     },
 


### PR DESCRIPTION

### Details
- Updated the icon styling to make it not have a pointer event so the dropdown behind can be selected

### Fixed Issues
<Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing>
Fixes https://github.com/Expensify/Expensify.cash/issues/1645

### Tests
- Go to profile page for a user & select the priority mode dropdown by clicking on the icon

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web

https://user-images.githubusercontent.com/12075600/110383881-cdc57000-8011-11eb-9359-e3112e83dcfd.mov

#### Mobile Web

https://user-images.githubusercontent.com/12075600/110384162-1c730a00-8012-11eb-896a-8081e7ab752b.mov

#### Desktop

https://user-images.githubusercontent.com/12075600/110384181-24cb4500-8012-11eb-84a7-96d728d66379.mov

#### iOS

https://user-images.githubusercontent.com/12075600/110384218-2eed4380-8012-11eb-911e-25b7a9196c0e.mov

#### Android

https://user-images.githubusercontent.com/12075600/110384247-37457e80-8012-11eb-992e-b8bf6879f650.mov
