### PR TITLE
Fix usages of request()

### DIFF
--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -460,7 +460,7 @@ function PersonalDetails_Update(parameters) {
     const commandName = 'PersonalDetails_Update';
     requireParameters(['details'],
         parameters, commandName);
-    return request(commandName, parameters);
+    return Network.post(commandName, parameters);
 }
 
 /**
@@ -601,7 +601,7 @@ function User_SecondaryLogin_Send(parameters) {
 function User_UploadAvatar(parameters) {
     const commandName = 'User_UploadAvatar';
     requireParameters(['base64image'], parameters, commandName);
-    return request(commandName, parameters);
+    return Network.post(commandName, parameters);
 }
 
 /**

--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -339,10 +339,13 @@ class ReportActionsView extends React.Component {
     }
 
     render() {
-        // If there are no comments or the only action is a CREATED action return the placeholder text
-        const isOnlyCreatedAction = _.size(this.props.reportActions) === 1
-            && lastItem(this.props.reportActions).actionName === 'CREATED';
-        if (!_.size(this.props.reportActions) || isOnlyCreatedAction) {
+        // Comments have not loaded at all yet do nothing
+        if (!_.size(this.props.reportActions)) {
+            return null;
+        }
+
+        // If we only have the created action then no one has left a comment
+        if (_.size(this.props.reportActions) === 1) {
             return (
                 <View style={[styles.chatContent, styles.chatContentEmpty]}>
                     <Text style={[styles.textP]}>Be the first person to comment!</Text>

--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -339,13 +339,10 @@ class ReportActionsView extends React.Component {
     }
 
     render() {
-        // Comments have not loaded at all yet do nothing
-        if (!_.size(this.props.reportActions)) {
-            return null;
-        }
-
-        // If we only have the created action then no one has left a comment
-        if (_.size(this.props.reportActions) === 1) {
+        // If there are no comments or the only action is a CREATED action return the placeholder text
+        const isOnlyCreatedAction = _.size(this.props.reportActions) === 1
+            && lastItem(this.props.reportActions).actionName === 'CREATED';
+        if (!_.size(this.props.reportActions) || isOnlyCreatedAction) {
             return (
                 <View style={[styles.chatContent, styles.chatContentEmpty]}>
                     <Text style={[styles.textP]}>Be the first person to comment!</Text>


### PR DESCRIPTION
### Details
A couple of usages of request() snuck in when we merged [this PR](https://github.com/Expensify/Expensify.cash/pull/1525)

### Fixed Issues
No issue

### Tests
None

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
