### PR TITLE
Fix re-authentication by catching errors correctly

### DIFF
--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -168,7 +168,7 @@ Network.registerErrorHandler((queuedRequest, error) => {
     Onyx.merge(ONYXKEYS.SESSION, {loading: false, error: 'Cannot connect to server'});
 
     // Reject the queued request with an API offline error so that the original caller can handle it.
-    queuedRequest.reject(CONST.ERROR.API_OFFLINE);
+    queuedRequest.reject(new Error(CONST.ERROR.API_OFFLINE));
 });
 
 /**


### PR DESCRIPTION
cc @nickmurray47 

### Details
We recently modified the code so that a generic error handler will reject a queued request with an error message. Prior to that change we were actually throwing an error. Which is a bit different and caused this code here to break since there is no `error.message` just an error string in the Promise rejection response.

https://github.com/Expensify/Expensify.cash/blob/287b7132862bddeb9ff42518d1e3982d32c6a470/src/libs/API.js#L164-L172

https://github.com/Expensify/Expensify.cash/blob/287b7132862bddeb9ff42518d1e3982d32c6a470/src/libs/API.js#L290-L295

### Fixed Issues
https://expensify.slack.com/archives/C011W8BJ9L6/p1615313362004800

### Tests
This is pretty hard to test actually since you need the following scenario to line up perfectly in order to reproduce this...

1. Trigger a "re-authentication"
2. Lose connectivity _while_ attempting to re-authenticate
3. Get logged out

**To simulate this I did the following:**

1. Invalidate the `authToken` in `session` by messing with `localStorage` in Chrome DevTools
2. Added this diff to force any calls to Authenticate to fail with a typical of a fetch() failed error (which happens when we have lost connectivity)
```diff
diff --git a/src/libs/HttpUtils.js b/src/libs/HttpUtils.js
index 32f5e48d..3c7aada2 100644
--- a/src/libs/HttpUtils.js
+++ b/src/libs/HttpUtils.js
@@ -26,6 +26,10 @@ function processHTTPRequest(url, method = 'get', body = null) {
  * @returns {Promise}
  */
 function xhr(command, data, type = 'post') {
+    if (command === 'Authenticate') {
+        return new Promise((res, rej) => rej(new TypeError('Failed to fetch')));
+    }
+
     const formData = new FormData();
     _.each(data, (val, key) => formData.append(key, val));
     return processHTTPRequest(`${CONFIG.EXPENSIFY.URL_API_ROOT}api?command=${command}`, type, formData);
```
3. Selected a new chat to make a new call to `Push_Authenticate` that would trigger a reauthentication and then a failed request.

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
