### PR TITLE
Active report should be visible in sidebar if mode is GSD

### DIFF
--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -185,13 +185,10 @@ function getOptions(reports, personalDetails, draftComments, activeReportID, {
 
         // Skip this entry if it has no comments and is not the active report. We will only show reports from
         // people we have sent or received at least one message with.
-        const hasNoComments = report.lastMessageTimestamp === 0;
-        const shouldFilterReport = !showReportsWithNoComments && hasNoComments
-            && report.reportID !== activeReportID && !report.isPinned;
-        if (shouldFilterReport) {
-            return;
-        }
-        if (hideReadReports && report.unreadActionCount === 0 && !report.isPinned) {
+        const shouldFilterReportIfEmpty = !showReportsWithNoComments && report.lastMessageTimestamp === 0;
+        const shouldFilterReportIfRead = hideReadReports && report.unreadActionCount === 0;
+        const shouldFilterReport = shouldFilterReportIfEmpty || shouldFilterReportIfRead;
+        if (report.reportID !== activeReportID && !report.isPinned && shouldFilterReport) {
             return;
         }
         const reportPersonalDetails = getPersonalDetailsForLogins(logins, personalDetails);

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -183,9 +183,13 @@ function getOptions(reports, personalDetails, draftComments, activeReportID, {
             return;
         }
 
-        // Skip this entry if it has no comments and is not the active report. We will only show reports from
-        // people we have sent or received at least one message with.
+        // Skip this entry only if the report is not an active report & is not Pinned
+        // as well as
+        // it reports with no comments needs to be skipped, (only show reports from people we have sent or
+        //  received at least one message with.)
         const shouldFilterReportIfEmpty = !showReportsWithNoComments && report.lastMessageTimestamp === 0;
+
+        // If Read reports needs to be skipped
         const shouldFilterReportIfRead = hideReadReports && report.unreadActionCount === 0;
         const shouldFilterReport = shouldFilterReportIfEmpty || shouldFilterReportIfRead;
         if (report.reportID !== activeReportID && !report.isPinned && shouldFilterReport) {

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -183,13 +183,7 @@ function getOptions(reports, personalDetails, draftComments, activeReportID, {
             return;
         }
 
-        // Skip this entry only if the report is not an active report & is not Pinned
-        // as well as
-        // it reports with no comments needs to be skipped, (only show reports from people we have sent or
-        //  received at least one message with.)
         const shouldFilterReportIfEmpty = !showReportsWithNoComments && report.lastMessageTimestamp === 0;
-
-        // If Read reports needs to be skipped
         const shouldFilterReportIfRead = hideReadReports && report.unreadActionCount === 0;
         const shouldFilterReport = shouldFilterReportIfEmpty || shouldFilterReportIfRead;
         if (report.reportID !== activeReportID && !report.isPinned && shouldFilterReport) {


### PR DESCRIPTION
Please Review.

### Details
We forget to set the Check for Pinned and Active report while adjusting the SiebarOptions for the GSD mode. I have fixed it and Make the if statement more readable.

### Fixed Issues
<Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing>
Fixes #1682 

### Tests
 1. open any chat.
 2. Now Set the Settings Preioty Mode to _GSD_.
 3. Active report should be visible in the sidebar.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->


https://user-images.githubusercontent.com/24370807/110586774-b2d13800-8198-11eb-9d9e-fbbefe1991e5.mp4


