### PR TITLE
ask notification previlages after re-login

### DIFF
--- a/src/libs/actions/SignInRedirect.js
+++ b/src/libs/actions/SignInRedirect.js
@@ -18,6 +18,14 @@ Onyx.connect({
     callback: val => currentlyViewedReportID = val,
 });
 
+let currentActiveClients;
+Onyx.connect({
+    key: ONYXKEYS.ACTIVE_CLIENTS,
+    callback: (val) => {
+        currentActiveClients = !val ? [] : val;
+    },
+});
+
 /**
  * Clears the Onyx store and redirects to the sign in page.
  * Normally this method would live in Session.js, but that would cause a circular dependency with Network.js.
@@ -39,9 +47,10 @@ function redirectToSignIn(errorMessage) {
         return;
     }
 
-    // Save the reportID before calling redirect or otherwise when clear
+    // Save the reportID and activeClients before calling redirect or otherwise when clear
     // is finished the value saved here will already be null
     const reportID = currentlyViewedReportID;
+    const activeClients = currentActiveClients;
     redirect(ROUTES.SIGNIN);
     Onyx.clear().then(() => {
         if (errorMessage) {
@@ -49,6 +58,9 @@ function redirectToSignIn(errorMessage) {
         }
         if (reportID) {
             Onyx.set(ONYXKEYS.CURRENTLY_VIEWED_REPORTID, reportID);
+        }
+        if (activeClients && activeClients.length > 0) {
+            Onyx.set(ONYXKEYS.ACTIVE_CLIENTS, activeClients);
         }
     });
 }


### PR DESCRIPTION
### Details
This issue happens when the user logs out from the system, Onyx store clears the data. It does not keep the `activeClients` in the `localstorage`.

In `SignInRedirect.js` I am getting `currentActiveClients` value when the user logs out from the system.
After that, In redirectToSignIn() method, I have set `currentActiveClients` again after clearing the onyx storage.
Then active clients won't get removed when the user signs out and a notification alert will display.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/1609

### Tests

- Navigate to [http://localhost:8080/#/signin](http://localhost:8080/#/signin) on web on Chrome browser
- Click into the padlock in the URL bar and set notifications to default
- Sign in
- Sign out via /settings
- Sign in again
- Leave a comment on a report that is not currently in the view from another session as a shared user (this should trigger the prompt to appear)

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web
![Screenshot 2021-03-10 at 20 00 01](https://user-images.githubusercontent.com/18027269/110644546-36ac1400-81db-11eb-805f-15a88a7c7af9.png)
