### PR TITLE
Focus the compose field after closing modals

### DIFF
--- a/src/ONYXKEYS.js
+++ b/src/ONYXKEYS.js
@@ -26,6 +26,11 @@ export default {
     // Contains loading data for the IOU feature (IOUModal, IOUDetail, & IOUPreview Components)
     IOU: 'iou',
 
+    // Keeps track if there is modal currently visible or not
+    MODAL: {
+        IS_VISIBLE: 'modalIsVisible',
+    },
+
     // Contains the personalDetails of the user as well as their timezone
     MY_PERSONAL_DETAILS: 'myPersonalDetails',
 

--- a/src/ONYXKEYS.js
+++ b/src/ONYXKEYS.js
@@ -27,9 +27,7 @@ export default {
     IOU: 'iou',
 
     // Keeps track if there is modal currently visible or not
-    MODAL: {
-        IS_VISIBLE: 'modalIsVisible',
-    },
+    MODAL: 'modal',
 
     // Contains the personalDetails of the user as well as their timezone
     MY_PERSONAL_DETAILS: 'myPersonalDetails',

--- a/src/components/Modal/BaseModal.js
+++ b/src/components/Modal/BaseModal.js
@@ -2,11 +2,13 @@ import React, {PureComponent} from 'react';
 import {View} from 'react-native';
 import ReactNativeModal from 'react-native-modal';
 import {SafeAreaInsetsContext} from 'react-native-safe-area-context';
+
 import KeyboardShortcut from '../../libs/KeyboardShortcut';
 import styles, {getSafeAreaPadding} from '../../styles/styles';
 import themeColors from '../../styles/themes/default';
 import {propTypes, defaultProps} from './ModalPropTypes';
 import getModalStyles from '../../styles/getModalStyles';
+import {setModalVisibility} from '../../libs/actions/Modal';
 
 class BaseModal extends PureComponent {
     constructor(props) {
@@ -20,11 +22,17 @@ class BaseModal extends PureComponent {
         this.unsubscribeFromKeyEvents();
     }
 
+    /**
+     * Listens to specific keyboard keys when the modal has been opened
+     */
     subscribeToKeyEvents() {
         KeyboardShortcut.subscribe('Escape', this.props.onClose, [], true);
         KeyboardShortcut.subscribe('Enter', this.props.onSubmit, [], true);
     }
 
+    /**
+     * Stops listening to keyboard keys when modal has been closed
+     */
     unsubscribeFromKeyEvents() {
         KeyboardShortcut.unsubscribe('Escape');
         KeyboardShortcut.unsubscribe('Enter');
@@ -53,9 +61,13 @@ class BaseModal extends PureComponent {
             <ReactNativeModal
                 onBackdropPress={this.props.onClose}
                 onBackButtonPress={this.props.onClose}
-                onModalShow={this.subscribeToKeyEvents}
+                onModalShow={() => {
+                    this.subscribeToKeyEvents();
+                    setModalVisibility(true);
+                }}
                 onModalHide={() => {
                     this.unsubscribeFromKeyEvents();
+                    setModalVisibility(false);
                     this.props.onModalHide();
                 }}
                 onSwipeComplete={this.props.onClose}

--- a/src/libs/actions/Modal.js
+++ b/src/libs/actions/Modal.js
@@ -1,0 +1,16 @@
+import Onyx from 'react-native-onyx';
+import ONYXKEYS from '../../ONYXKEYS';
+
+/**
+ * Allows other parts of the app to know when a modal has been opened or closed
+ *
+ * @param {bool} isVisible
+ */
+function setModalVisibility(isVisible) {
+    Onyx.merge(ONYXKEYS.MODAL.IS_VISIBLE, {isVisible});
+}
+
+export {
+    // eslint-disable-next-line import/prefer-default-export
+    setModalVisibility,
+};

--- a/src/libs/actions/Modal.js
+++ b/src/libs/actions/Modal.js
@@ -7,7 +7,7 @@ import ONYXKEYS from '../../ONYXKEYS';
  * @param {bool} isVisible
  */
 function setModalVisibility(isVisible) {
-    Onyx.merge(ONYXKEYS.MODAL.IS_VISIBLE, {isVisible});
+    Onyx.merge(ONYXKEYS.MODAL, {isVisible});
 }
 
 export {

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -27,13 +27,21 @@ const propTypes = {
     // The ID of the report actions will be created for
     reportID: PropTypes.number.isRequired,
 
+    // Indicates when the sidebar is shown
     isSidebarShown: PropTypes.bool.isRequired,
+
+    // Details about any modals being used
+    modal: PropTypes.shape({
+        // Indicates if there is a modal currently visible or not
+        isVisible: PropTypes.bool,
+    }),
 
     ...windowDimensionsPropTypes,
 };
 
 const defaultProps = {
     comment: '',
+    modal: {},
 };
 
 class ReportActionCompose extends React.Component {
@@ -61,6 +69,11 @@ class ReportActionCompose extends React.Component {
         // If it does let's update this.comment so that it matches the defaultValue that we show in textInput.
         if (this.props.comment && prevProps.comment === '' && prevProps.comment !== this.props.comment) {
             this.comment = this.props.comment;
+        }
+
+        // When any modal goes from visible to hidden, bring focus to the compose field
+        if (prevProps.modal.isVisible === true && this.props.modal.isVisible === false) {
+            this.setIsFocused(true);
         }
     }
 
@@ -166,9 +179,6 @@ class ReportActionCompose extends React.Component {
                             addAction(this.props.reportID, '', file);
                             this.setTextInputShouldClear(false);
                         }}
-                        onModalHide={() => {
-                            this.setIsFocused(true);
-                        }}
                     >
                         {({displayFileInModal}) => (
                             <>
@@ -256,6 +266,9 @@ export default compose(
         },
         isSidebarShown: {
             key: ONYXKEYS.IS_SIDEBAR_SHOWN,
+        },
+        modal: {
+            key: ONYXKEYS.MODAL,
         },
     }),
     withWindowDimensions,

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -72,7 +72,7 @@ class ReportActionCompose extends React.Component {
         }
 
         // When any modal goes from visible to hidden, bring focus to the compose field
-        if (prevProps.modal.isVisible === true && this.props.modal.isVisible === false) {
+        if (prevProps.modal.isVisible && !this.props.modal.isVisible) {
             this.setIsFocused(true);
         }
     }


### PR DESCRIPTION
### Details
I added a global state for tracking if modals are open or closed, then connected that state to the compose field so it gets focus when modals are closed.

### Fixed Issues
<Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing>
Fixes https://github.com/Expensify/Expensify.cash/issues/1513
Fixes https://github.com/Expensify/Expensify/issues/154180

### Tests
1. Go to a chat and start typing a comment
2. Open up the LHN search 
3. Close the search modal (or select any chat)
4. Verify that the compose field gets focus

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [ ] ~iOS~ (n/a because the field does not get focus by design)
- [ ] ~Android~ (n/a because the field does not get focus by design)

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
Not really any screenshots necessary

#### Mobile Web
Not really any screenshots necessary

#### Desktop
Not really any screenshots necessary

#### iOS
Not really any screenshots necessary

#### Android
Not really any screenshots necessary
