### PR TITLE
Add a Github Action check for Podfile lock changes

### DIFF
--- a/.github/scripts/verifyPodfile.sh
+++ b/.github/scripts/verifyPodfile.sh
@@ -7,6 +7,9 @@ declare -r NC='\033[0m'
 podfileSha=$(openssl sha1 ../../ios/Podfile | awk '{print $2}')
 podfileLockSha=$(awk '/PODFILE CHECKSUM: /{print $3}' ../../ios/Podfile.lock)
 
+# not sure where I am...
+echo pwd
+
 if [ $podfileSha == $podfileLockSha ]; then
     echo -e "${GREEN}Podfile verified!${NC}"
     exit 0

--- a/.github/scripts/verifyPodfile.sh
+++ b/.github/scripts/verifyPodfile.sh
@@ -8,7 +8,7 @@ podfileSha=$(openssl sha1 ../../ios/Podfile | awk '{print $2}')
 podfileLockSha=$(awk '/PODFILE CHECKSUM: /{print $3}' ../../ios/Podfile.lock)
 
 # not sure where I am...
-echo pwd
+echo $(pwd)
 
 if [ $podfileSha == $podfileLockSha ]; then
     echo -e "${GREEN}Podfile verified!${NC}"

--- a/.github/scripts/verifyPodfile.sh
+++ b/.github/scripts/verifyPodfile.sh
@@ -4,11 +4,11 @@ declare -r GREEN='\033[0;32m'
 declare -r RED='\033[0;31m'
 declare -r NC='\033[0m'
 
-podfileSha=$(openssl sha1 ../../ios/Podfile | awk '{print $2}')
-podfileLockSha=$(awk '/PODFILE CHECKSUM: /{print $3}' ../../ios/Podfile.lock)
+podfileSha=$(openssl sha1 ios/Podfile | awk '{print $2}')
+podfileLockSha=$(awk '/PODFILE CHECKSUM: /{print $3}' ios/Podfile.lock)
 
-# not sure where I am...
-echo $(pwd)
+echo "Podfile: $podfileSha"
+echo "Podfile.lock: $podfileLockSha"
 
 if [ $podfileSha == $podfileLockSha ]; then
     echo -e "${GREEN}Podfile verified!${NC}"

--- a/.github/scripts/verifyPodfile.sh
+++ b/.github/scripts/verifyPodfile.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+declare -r GREEN='\033[0;32m'
+declare -r RED='\033[0;31m'
+declare -r NC='\033[0m'
+
+podfileSha=$(openssl sha1 ../../ios/Podfile | awk '{print $2}')
+podfileLockSha=$(awk '/PODFILE CHECKSUM: /{print $3}' ../../ios/Podfile.lock)
+
+if [ $podfileSha == $podfileLockSha ]; then
+    echo -e "${GREEN}Podfile verified!${NC}"
+    exit 0
+else
+    echo -e "${RED}Error: Podfile.lock out of date with Podfile. Did you forget to run \`npx pod-install\`?${NC}"
+    exit 1
+fi

--- a/.github/workflows/verifyPodfile.yml
+++ b/.github/workflows/verifyPodfile.yml
@@ -1,0 +1,25 @@
+name: Verify Podfile
+
+on:
+    pull_request:
+        types: [opened, synchronize]
+
+jobs:
+    verify:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+
+            - name: Use Node.js
+              uses: actions/setup-node@v1
+              with:
+                node-version: '14.x'
+
+            - name: Install node packages
+              uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
+              with:
+                  timeout_minutes: 10
+                  max_attempts: 5
+                  command: npm ci
+
+            - run: ./.github/scripts/verifyPodfile.sh

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,7 +1,7 @@
 require_relative '../node_modules/react-native/scripts/react_native_pods'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
-platform :ios, '12.0'
+platform :ios, '11.0'
 
 target 'ExpensifyCash' do
   config = use_native_modules!

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,7 +1,7 @@
 require_relative '../node_modules/react-native/scripts/react_native_pods'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
-platform :ios, '11.0'
+platform :ios, '12.0'
 
 target 'ExpensifyCash' do
   config = use_native_modules!


### PR DESCRIPTION
cc @AndrewGable 

### Details
Prevents merging Podfile change when Podfile.lock does not match

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/156218

### Tests
For these tests I did a fake change to the `Podfile` without merging the `Podfile.lock` and the action showed these results:

![Screen Shot 2021-03-10 at 10 23 13 AM](https://user-images.githubusercontent.com/32969087/110693130-2ff5b080-818b-11eb-9988-3799c77b0663.png)

Removed the `Podfile` change it is passes now
![Screen Shot 2021-03-10 at 10 20 06 AM](https://user-images.githubusercontent.com/32969087/110693139-3126dd80-818b-11eb-94cb-dffc156ba3e9.png)

### Tested On

N/A

### Screenshots

N/A