### PR TITLE
Allow inviting users via Search page

### DIFF
--- a/src/components/OptionsList.js
+++ b/src/components/OptionsList.js
@@ -53,9 +53,6 @@ const propTypes = {
     // Callback to fire when a row is selected
     onSelectRow: PropTypes.func,
 
-    // Optional header title
-    headerTitle: PropTypes.string,
-
     // Optional header message
     headerMessage: PropTypes.string,
 
@@ -79,7 +76,6 @@ const defaultProps = {
     forceTextUnreadStyle: false,
     onSelectRow: () => {},
     headerMessage: '',
-    headerTitle: '',
     innerRef: null,
 };
 
@@ -99,10 +95,6 @@ class OptionsList extends Component {
         }
 
         if (nextProps.selectedOptions.length !== this.props.selectedOptions.length) {
-            return true;
-        }
-
-        if (nextProps.headerTitle !== this.props.headerTitle) {
             return true;
         }
 
@@ -191,12 +183,6 @@ class OptionsList extends Component {
             <View style={[styles.flex1]}>
                 {this.props.headerMessage ? (
                     <View style={[styles.ph5, styles.pb5]}>
-                        {this.props.headerTitle ? (
-                            <Text style={[styles.h4, styles.mb1]}>
-                                {this.props.headerTitle}
-                            </Text>
-                        ) : null}
-
                         <Text style={[styles.textLabel, styles.colorMuted]}>
                             {this.props.headerMessage}
                         </Text>

--- a/src/components/OptionsSelector.js
+++ b/src/components/OptionsSelector.js
@@ -189,7 +189,6 @@ class OptionsSelector extends Component {
                     sections={this.props.sections}
                     focusedIndex={this.state.focusedIndex}
                     selectedOptions={this.props.selectedOptions}
-                    headerTitle={this.props.headerTitle}
                     canSelectMultipleOptions={this.props.canSelectMultipleOptions}
                     hideSectionHeaders={this.props.hideSectionHeaders}
                     headerMessage={this.props.headerMessage}

--- a/src/components/OptionsSelector.js
+++ b/src/components/OptionsSelector.js
@@ -39,9 +39,6 @@ const propTypes = {
     // Options that have already been selected
     selectedOptions: PropTypes.arrayOf(optionPropTypes),
 
-    // Optional header title
-    headerTitle: PropTypes.string,
-
     // Optional header message
     headerMessage: PropTypes.string,
 
@@ -65,7 +62,6 @@ const defaultProps = {
     onSelectRow: () => {},
     placeholderText: 'Name, email, or phone number',
     selectedOptions: [],
-    headerTitle: '',
     headerMessage: '',
     canSelectMultipleOptions: false,
     hideSectionHeaders: false,

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -402,9 +402,39 @@ function getSidebarOptions(reports, personalDetails, draftComments, activeReport
     });
 }
 
+/**
+ * Helper method that returns the text to be used for the header's message and title (if any)
+ *
+ * @param {Boolean} hasSelectableOptions
+ * @param {Boolean} hasUserToInvite
+ * @param {Boolean} [maxParticipantsReached]
+ * @return {String}
+ */
+function getHeaderTitleAndMessage(hasSelectableOptions, hasUserToInvite, maxParticipantsReached = false) {
+    if (maxParticipantsReached) {
+        return {
+            headerTitle: '',
+            headerMessage: CONST.MESSAGES.MAXIMUM_PARTICIPANTS_REACHED,
+        };
+    }
+
+    if (!hasSelectableOptions && !hasUserToInvite) {
+        return {
+            headerTitle: '',
+            headerMessage: CONST.MESSAGES.NO_CONTACTS_FOUND,
+        };
+    }
+
+    return {
+        headerTitle: '',
+        headerMessage: '',
+    };
+}
+
 export {
     getSearchOptions,
     getNewChatOptions,
     getNewGroupOptions,
     getSidebarOptions,
+    getHeaderTitleAndMessage,
 };

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -410,25 +410,16 @@ function getSidebarOptions(reports, personalDetails, draftComments, activeReport
  * @param {Boolean} [maxParticipantsReached]
  * @return {String}
  */
-function getHeaderTitleAndMessage(hasSelectableOptions, hasUserToInvite, maxParticipantsReached = false) {
+function getHeaderMessage(hasSelectableOptions, hasUserToInvite, maxParticipantsReached = false) {
     if (maxParticipantsReached) {
-        return {
-            headerTitle: '',
-            headerMessage: CONST.MESSAGES.MAXIMUM_PARTICIPANTS_REACHED,
-        };
+        return CONST.MESSAGES.MAXIMUM_PARTICIPANTS_REACHED;
     }
 
     if (!hasSelectableOptions && !hasUserToInvite) {
-        return {
-            headerTitle: '',
-            headerMessage: CONST.MESSAGES.NO_CONTACTS_FOUND,
-        };
+        return CONST.MESSAGES.NO_CONTACTS_FOUND;
     }
 
-    return {
-        headerTitle: '',
-        headerMessage: '',
-    };
+    return '';
 }
 
 export {
@@ -436,5 +427,5 @@ export {
     getNewChatOptions,
     getNewGroupOptions,
     getSidebarOptions,
-    getHeaderTitleAndMessage,
+    getHeaderMessage,
 };

--- a/src/pages/NewChatPage.js
+++ b/src/pages/NewChatPage.js
@@ -3,7 +3,7 @@ import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import {withOnyx} from 'react-native-onyx';
 import OptionsSelector from '../components/OptionsSelector';
-import {getNewChatOptions, getHeaderTitleAndMessage} from '../libs/OptionsListUtils';
+import {getNewChatOptions, getHeaderMessage} from '../libs/OptionsListUtils';
 import ONYXKEYS from '../ONYXKEYS';
 import styles from '../styles/styles';
 import {fetchOrCreateChatReport} from '../libs/actions/Report';
@@ -110,7 +110,7 @@ class NewChatPage extends Component {
 
     render() {
         const sections = this.getSections();
-        const {headerTitle, headerMessage} = getHeaderTitleAndMessage(
+        const headerMessage = getHeaderMessage(
             this.state.personalDetails.length !== 0,
             Boolean(this.state.userToInvite),
         );
@@ -142,7 +142,6 @@ class NewChatPage extends Component {
                                 personalDetails,
                             });
                         }}
-                        headerTitle={headerTitle}
                         headerMessage={headerMessage}
                         hideSectionHeaders
                         disableArrowKeysActions

--- a/src/pages/NewChatPage.js
+++ b/src/pages/NewChatPage.js
@@ -3,14 +3,13 @@ import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import {withOnyx} from 'react-native-onyx';
 import OptionsSelector from '../components/OptionsSelector';
-import {getNewChatOptions} from '../libs/OptionsListUtils';
+import {getNewChatOptions, getHeaderTitleAndMessage} from '../libs/OptionsListUtils';
 import ONYXKEYS from '../ONYXKEYS';
 import styles from '../styles/styles';
 import {fetchOrCreateChatReport} from '../libs/actions/Report';
 import KeyboardSpacer from '../components/KeyboardSpacer';
 import withWindowDimensions, {windowDimensionsPropTypes} from '../components/withWindowDimensions';
 import {hide as hideSidebar} from '../libs/actions/Sidebar';
-import CONST from '../CONST';
 import HeaderWithCloseButton from '../components/HeaderWithCloseButton';
 import {redirectToLastReport} from '../libs/actions/App';
 import HeaderGap from '../components/HeaderGap';
@@ -68,26 +67,6 @@ class NewChatPage extends Component {
     }
 
     /**
-     * Helper method that returns the text to be used for the header's message and title (if any)
-     *
-     * @return {String}
-     */
-    getHeaderTitleAndMessage() {
-        const hasSelectableOptions = this.state.personalDetails.length !== 0;
-        if (!hasSelectableOptions && !this.state.userToInvite) {
-            return {
-                headerTitle: '',
-                headerMessage: CONST.MESSAGES.NO_CONTACTS_FOUND,
-            };
-        }
-
-        return {
-            headerTitle: '',
-            headerMessage: '',
-        };
-    }
-
-    /**
      * Returns the sections needed for the OptionsSelector
      *
      * @returns {Array}
@@ -131,7 +110,10 @@ class NewChatPage extends Component {
 
     render() {
         const sections = this.getSections();
-        const {headerTitle, headerMessage} = this.getHeaderTitleAndMessage();
+        const {headerTitle, headerMessage} = getHeaderTitleAndMessage(
+            this.state.personalDetails.length !== 0,
+            Boolean(this.state.userToInvite),
+        );
 
         return (
             <>

--- a/src/pages/NewGroupPage.js
+++ b/src/pages/NewGroupPage.js
@@ -4,7 +4,7 @@ import {View, Text, Pressable} from 'react-native';
 import PropTypes from 'prop-types';
 import {withOnyx} from 'react-native-onyx';
 import OptionsSelector from '../components/OptionsSelector';
-import {getNewGroupOptions} from '../libs/OptionsListUtils';
+import {getNewGroupOptions, getHeaderTitleAndMessage} from '../libs/OptionsListUtils';
 import ONYXKEYS from '../ONYXKEYS';
 import styles from '../styles/styles';
 import {fetchOrCreateChatReport} from '../libs/actions/Report';
@@ -70,34 +70,6 @@ class NewGroupPage extends Component {
             personalDetails,
             selectedOptions: [],
             userToInvite,
-        };
-    }
-
-    /**
-     * Helper method that returns the text to be used for the header's message and title (if any)
-     *
-     * @param {Boolean} maxParticipantsReached
-     * @return {String}
-     */
-    getHeaderTitleAndMessage(maxParticipantsReached) {
-        if (maxParticipantsReached) {
-            return {
-                headerTitle: '',
-                headerMessage: CONST.MESSAGES.MAXIMUM_PARTICIPANTS_REACHED,
-            };
-        }
-
-        const hasSelectableOptions = this.state.personalDetails.length + this.state.recentReports.length !== 0;
-        if (!hasSelectableOptions && !this.state.userToInvite) {
-            return {
-                headerTitle: '',
-                headerMessage: CONST.MESSAGES.NO_CONTACTS_FOUND,
-            };
-        }
-
-        return {
-            headerTitle: '',
-            headerMessage: '',
         };
     }
 
@@ -205,7 +177,11 @@ class NewGroupPage extends Component {
     render() {
         const maxParticipantsReached = this.state.selectedOptions.length === CONST.REPORT.MAXIMUM_PARTICIPANTS;
         const sections = this.getSections(maxParticipantsReached);
-        const {headerTitle, headerMessage} = this.getHeaderTitleAndMessage(maxParticipantsReached);
+        const {headerTitle, headerMessage} = getHeaderTitleAndMessage(
+            this.state.personalDetails.length + this.state.recentReports.length !== 0,
+            Boolean(this.state.userToInvite),
+            maxParticipantsReached,
+        );
         return (
             <>
                 <HeaderGap />

--- a/src/pages/NewGroupPage.js
+++ b/src/pages/NewGroupPage.js
@@ -177,7 +177,7 @@ class NewGroupPage extends Component {
     render() {
         const maxParticipantsReached = this.state.selectedOptions.length === CONST.REPORT.MAXIMUM_PARTICIPANTS;
         const sections = this.getSections(maxParticipantsReached);
-        const {headerTitle, headerMessage} = getHeaderTitleAndMessage(
+        const headerMessage = getHeaderMessage(
             this.state.personalDetails.length + this.state.recentReports.length !== 0,
             Boolean(this.state.userToInvite),
             maxParticipantsReached,
@@ -214,7 +214,6 @@ class NewGroupPage extends Component {
                                 personalDetails,
                             });
                         }}
-                        headerTitle={headerTitle}
                         headerMessage={headerMessage}
                         disableArrowKeysActions
                         hideAdditionalOptionStates

--- a/src/pages/NewGroupPage.js
+++ b/src/pages/NewGroupPage.js
@@ -4,7 +4,7 @@ import {View, Text, Pressable} from 'react-native';
 import PropTypes from 'prop-types';
 import {withOnyx} from 'react-native-onyx';
 import OptionsSelector from '../components/OptionsSelector';
-import {getNewGroupOptions, getHeaderTitleAndMessage} from '../libs/OptionsListUtils';
+import {getNewGroupOptions, getHeaderMessage} from '../libs/OptionsListUtils';
 import ONYXKEYS from '../ONYXKEYS';
 import styles from '../styles/styles';
 import {fetchOrCreateChatReport} from '../libs/actions/Report';

--- a/src/pages/SearchPage.js
+++ b/src/pages/SearchPage.js
@@ -3,7 +3,7 @@ import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import {withOnyx} from 'react-native-onyx';
 import OptionsSelector from '../components/OptionsSelector';
-import {getSearchOptions, getHeaderTitleAndMessage} from '../libs/OptionsListUtils';
+import {getSearchOptions, getHeaderMessage} from '../libs/OptionsListUtils';
 import ONYXKEYS from '../ONYXKEYS';
 import styles from '../styles/styles';
 import KeyboardSpacer from '../components/KeyboardSpacer';
@@ -130,7 +130,7 @@ class SearchPage extends Component {
 
     render() {
         const sections = this.getSections();
-        const {headerTitle, headerMessage} = getHeaderTitleAndMessage(
+        const headerMessage = getHeaderMessage(
             (this.state.recentReports.length + this.state.personalDetails.length) !== 0,
             Boolean(this.state.userToInvite),
         );
@@ -164,7 +164,6 @@ class SearchPage extends Component {
                                 personalDetails,
                             });
                         }}
-                        headerTitle={headerTitle}
                         headerMessage={headerMessage}
                         hideSectionHeaders
                         hideAdditionalOptionStates

--- a/src/pages/SearchPage.js
+++ b/src/pages/SearchPage.js
@@ -14,6 +14,7 @@ import withWindowDimensions, {windowDimensionsPropTypes} from '../components/wit
 import {fetchOrCreateChatReport} from '../libs/actions/Report';
 import HeaderWithCloseButton from '../components/HeaderWithCloseButton';
 import HeaderGap from '../components/HeaderGap';
+import CONST from '../CONST';
 
 const personalDetailsPropTypes = PropTypes.shape({
     // The login of the person (either email or phone number)
@@ -57,6 +58,7 @@ class SearchPage extends Component {
         const {
             recentReports,
             personalDetails,
+            userToInvite,
         } = getSearchOptions(
             props.reports,
             props.personalDetails,
@@ -67,6 +69,27 @@ class SearchPage extends Component {
             searchValue: '',
             recentReports,
             personalDetails,
+            userToInvite,
+        };
+    }
+
+    /**
+     * Helper method that returns the text to be used for the header's message and title (if any)
+     *
+     * @return {String}
+     */
+    getHeaderTitleAndMessage() {
+        const hasSelectableOptions = (this.state.recentReports.length + this.state.personalDetails.length) !== 0;
+        if (!hasSelectableOptions && !this.state.userToInvite) {
+            return {
+                headerTitle: '',
+                headerMessage: CONST.MESSAGES.NO_CONTACTS_FOUND,
+            };
+        }
+
+        return {
+            headerTitle: '',
+            headerMessage: '',
         };
     }
 
@@ -76,12 +99,23 @@ class SearchPage extends Component {
      * @returns {Array}
      */
     getSections() {
-        return [{
+        const sections = [{
             title: 'RECENT',
             data: this.state.recentReports.concat(this.state.personalDetails),
             shouldShow: true,
             indexOffset: 0,
         }];
+
+        if (this.state.userToInvite) {
+            sections.push(({
+                undefined,
+                data: [this.state.userToInvite],
+                shouldShow: true,
+                indexOffset: 0,
+            }));
+        }
+
+        return sections;
     }
 
     /**
@@ -117,6 +151,7 @@ class SearchPage extends Component {
 
     render() {
         const sections = this.getSections();
+        const {headerTitle, headerMessage} = this.getHeaderTitleAndMessage();
 
         return (
             <>
@@ -134,6 +169,7 @@ class SearchPage extends Component {
                             const {
                                 recentReports,
                                 personalDetails,
+                                userToInvite,
                             } = getSearchOptions(
                                 this.props.reports,
                                 this.props.personalDetails,
@@ -141,10 +177,13 @@ class SearchPage extends Component {
                             );
                             this.setState({
                                 searchValue,
+                                userToInvite,
                                 recentReports,
                                 personalDetails,
                             });
                         }}
+                        headerTitle={headerTitle}
+                        headerMessage={headerMessage}
                         hideSectionHeaders
                         hideAdditionalOptionStates
                     />

--- a/src/pages/SearchPage.js
+++ b/src/pages/SearchPage.js
@@ -3,7 +3,7 @@ import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import {withOnyx} from 'react-native-onyx';
 import OptionsSelector from '../components/OptionsSelector';
-import {getSearchOptions} from '../libs/OptionsListUtils';
+import {getSearchOptions, getHeaderTitleAndMessage} from '../libs/OptionsListUtils';
 import ONYXKEYS from '../ONYXKEYS';
 import styles from '../styles/styles';
 import KeyboardSpacer from '../components/KeyboardSpacer';
@@ -14,7 +14,6 @@ import withWindowDimensions, {windowDimensionsPropTypes} from '../components/wit
 import {fetchOrCreateChatReport} from '../libs/actions/Report';
 import HeaderWithCloseButton from '../components/HeaderWithCloseButton';
 import HeaderGap from '../components/HeaderGap';
-import CONST from '../CONST';
 
 const personalDetailsPropTypes = PropTypes.shape({
     // The login of the person (either email or phone number)
@@ -70,26 +69,6 @@ class SearchPage extends Component {
             recentReports,
             personalDetails,
             userToInvite,
-        };
-    }
-
-    /**
-     * Helper method that returns the text to be used for the header's message and title (if any)
-     *
-     * @return {String}
-     */
-    getHeaderTitleAndMessage() {
-        const hasSelectableOptions = (this.state.recentReports.length + this.state.personalDetails.length) !== 0;
-        if (!hasSelectableOptions && !this.state.userToInvite) {
-            return {
-                headerTitle: '',
-                headerMessage: CONST.MESSAGES.NO_CONTACTS_FOUND,
-            };
-        }
-
-        return {
-            headerTitle: '',
-            headerMessage: '',
         };
     }
 
@@ -151,7 +130,10 @@ class SearchPage extends Component {
 
     render() {
         const sections = this.getSections();
-        const {headerTitle, headerMessage} = this.getHeaderTitleAndMessage();
+        const {headerTitle, headerMessage} = getHeaderTitleAndMessage(
+            (this.state.recentReports.length + this.state.personalDetails.length) !== 0,
+            Boolean(this.state.userToInvite),
+        );
 
         return (
             <>


### PR DESCRIPTION
### Details
Users can be invited via New Group and New Chat screens only. This adds the ability to invite them via Search as well.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/155394

### Tests
1. Tap magnifying glass
2. Enter email for a user who is not in the search list
3. Tap user
4. Verify you are brought to a chat with this user

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
![Screen Shot 2021-03-10 at 11 30 33 AM](https://user-images.githubusercontent.com/32969087/110700508-1f960380-8194-11eb-9f84-b9e067b7374c.png)
![Screen Shot 2021-03-10 at 11 30 39 AM](https://user-images.githubusercontent.com/32969087/110700506-1e64d680-8194-11eb-8ae2-f692adba9769.png)

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
