### PR TITLE
Add API command for Mobile_GetConstants

### DIFF
--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -616,6 +616,23 @@ function SetNameValuePair(parameters) {
     return Network.post(commandName, parameters);
 }
 
+/**
+ *
+ * @param {Object} parameters
+ * @param {String[]} data
+ * @returns {Promise}
+ */
+function Mobile_GetConstants(parameters) {
+    const commandName = 'Mobile_GetConstants';
+    requireParameters(['data'], parameters, commandName);
+
+    // For some reason, the Mobile_GetConstants endpoint requires a JSON string, so we need to stringify the data param
+    const finalParameters = parameters;
+    finalParameters.data = JSON.stringify(parameters.data);
+
+    return Network.post(commandName, finalParameters);
+}
+
 export {
     getAuthToken,
     Authenticate,
@@ -628,6 +645,7 @@ export {
     GetRequestCountryCode,
     Graphite_Timer,
     Log,
+    Mobile_GetConstants,
     PersonalDetails_GetForEmails,
     PersonalDetails_Update,
     Push_Authenticate,


### PR DESCRIPTION
@Julesssss will you please review this?

### Details
This PR adds the `Mobile_GetConstants` endpoint to Expensify.cash to enable us to fetch data via that endpoint.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/157008

### Tests
1. Download and apply [this diff](https://github.com/Expensify/Expensify.cash/files/6119843/mobile_getConstants_diff.txt) via `git apply mobile_getConstants_diff.txt`
2. Run the app on web, sign in, select a chat, and hit enter in the compose box without typing anything
3. Confirm you see the data in the logs. You can also use the console debugger to view the json value.

### Tested On
- [x] Web
