### PR TITLE
Add should deploy to production env variable

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -5,11 +5,17 @@ on:
     push:
         tags:
             - '*'
+    release:
+      types: [created]
 
 jobs:
     build:
         if: github.actor == 'OSBotify'
         runs-on: ubuntu-latest
+        env:
+#          TODO: Uncomment when we'd like to deploy to production
+#          SHOULD_DEPLOY_PRODUCTION: ${{ github.event_name == 'release' }}
+          SHOULD_DEPLOY_PRODUCTION: ${{ false }}
         steps:
             - uses: actions/checkout@v2
 

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -5,11 +5,17 @@ on:
     push:
         tags:
             - '*'
+    release:
+      types: [created]
 
 jobs:
     build:
         if: github.actor == 'OSBotify'
         runs-on: macos-latest
+        env:
+#          TODO: Uncomment when we'd like to deploy to staging
+#          SHOULD_DEPLOY_PRODUCTION: ${{ github.event_name == 'release' }}
+          SHOULD_DEPLOY_PRODUCTION: ${{ true }}
         steps:
             - uses: actions/checkout@v2
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -5,6 +5,8 @@ on:
     push:
         tags:
             - '*'
+    release:
+      types: [created]
 
 env:
   DEVELOPER_DIR: /Applications/Xcode_12.3.app/Contents/Developer
@@ -13,6 +15,10 @@ jobs:
     build:
         if: github.actor == 'OSBotify'
         runs-on: macos-latest
+        env:
+#          TODO: Uncomment when we'd like to deploy to production
+#          SHOULD_DEPLOY_PRODUCTION: ${{ github.event_name == 'release' }}
+          SHOULD_DEPLOY_PRODUCTION: ${{ false }}
         steps:
             - uses: actions/checkout@v2
 

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -5,11 +5,17 @@ on:
     push:
         tags:
             - '*'
+    release:
+      types: [created]
 
 jobs:
     build:
         if: github.actor == 'OSBotify'
         runs-on: ubuntu-latest
+        env:
+#          TODO: Uncomment when we'd like to deploy to staging
+#          SHOULD_DEPLOY_PRODUCTION: ${{ github.event_name == 'release' }}
+          SHOULD_DEPLOY_PRODUCTION: ${{ true }}
 
         steps:
             - uses: actions/checkout@v2


### PR DESCRIPTION
### Details
Adds logic to determine where to deploy (staging vs production).

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/155196
Fixes https://github.com/Expensify/Expensify/issues/155195

### Tests
1. Merge this PR
2. Make sure that:
  - On web, always deploy to production
  - On desktop, always deploy to production
  - On iOS, always deploy to staging
  - On Android, always deploy to staging
