### PR TITLE
Use create-pull-request action instead of repo-sync/pull-request

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -27,8 +27,10 @@ jobs:
           git checkout master
           git config user.name OSBotify
 
-      - name: Checkout new branch
-        run: git checkout -b version-bump-${{ github.sha }}
+      - name: Create new branch
+        run: |
+          git checkout -b version-bump-${{ github.sha }}
+          git push --set-upstream origin version-bump-${{ github.sha }}
 
       - name: Generate version
         id: bumpVersion
@@ -47,49 +49,19 @@ jobs:
           git commit -m "Update version to ${{ steps.bumpVersion.outputs.NEW_VERSION }}"
           git tag ${{ steps.bumpVersion.outputs.NEW_VERSION }}
 
-      - name: Push new version
-        run: git push --set-upstream origin version-bump-${{ github.sha }}
-
       - name: Push tags
         run: git push --tags
 
-      # This Slack step is duplicated in all workflows, if you make a change to this step, make sure to update all
-      # the other workflows with the same change
-      - uses: 8398a7/action-slack@v3
-        name: Job failed Slack notification
-        if: ${{ failure() }}
-        with:
-          status: custom
-          fields: workflow, repo
-          custom_payload: |
-            {
-              channel: '#announce',
-              attachments: [{
-                color: "#DB4545",
-                pretext: `<!here>`,
-                text: `💥 ${process.env.AS_REPO} failed on ${process.env.AS_WORKFLOW} workflow 💥`,
-              }]
-            }
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
-
-  create_pull_request:
-    runs-on: ubuntu-latest
-    needs: version
-    steps:
-      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.OS_BOTIFY_TOKEN }}
       - name: Create Pull Request
-        # Version: 2.4.3
-        uses: repo-sync/pull-request@33777245b1aace1a58c87a29c90321aa7a74bd7d
+        uses: peter-evans/create-pull-request@09b9ac155b0d5ad7d8d157ed32158c1b73689109
         with:
-          source_branch: version-bump-${{ github.sha }}
-          destination_branch: "master"
-          pr_label: "automerge"
-          github_token: ${{ secrets.OS_BOTIFY_TOKEN }}
+          token: ${{ secrets.OS_BOTIFY_TOKEN }}
+          branch: version-bump-${{ github.sha }}
+          base: master
+          commit-message: format('Update version to {0}', ${{ steps.bumpVersion.outputs.NEW_VERSION }})
+          author: OSBotify
+          committer: 'OSBotify reactnative@expensify.com'
+          labels: automerge
 
       # This Slack step is duplicated in all workflows, if you make a change to this step, make sure to update all
       # the other workflows with the same change

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -56,11 +56,11 @@ jobs:
         uses: peter-evans/create-pull-request@09b9ac155b0d5ad7d8d157ed32158c1b73689109
         with:
           token: ${{ secrets.OS_BOTIFY_TOKEN }}
-          branch: version-bump-${{ github.sha }}
+          author: OSBotify <reactnative@expensify.com>
           base: master
-          commit-message: format('Update version to {0}', ${{ steps.bumpVersion.outputs.NEW_VERSION }})
-          author: OSBotify
-          committer: 'OSBotify reactnative@expensify.com'
+          branch: version-bump-${{ github.sha }}
+          title: Update version to ${{ steps.bumpVersion.outputs.NEW_VERSION }}
+          body: Update version to ${{ steps.bumpVersion.outputs.NEW_VERSION }}
           labels: automerge
 
       # This Slack step is duplicated in all workflows, if you make a change to this step, make sure to update all


### PR DESCRIPTION
### Details
This eliminates the need for a second job in the `version`/`preDeploy` workflow, because unlike `repo-sync/pull-request`, `peter-evans/create-pull-request` works on macOS runners, which we need to use in order for `PlistBuddy` to work.

This is important because we need to run actions at the beginning of the workflow, whose data is used throughout (and again at the end of the workflow). Using separate jobs, there is no clean way to share the output of a specific step between the jobs. So we would end up running two duplicate actions in each job, and it gets very messy and takes longer.

### Fixed Issues
Fixes (partial) https://github.com/Expensify/Expensify/issues/155208

### Tests

I ran a pretty closely simulated test of this workflow update in [Public-Test-Repo](https://github.com/Andrew-Test-Org/Public-Test-Repo). I used the following workflow to simulate these changes:

```yaml
name: Create Pull Request Test

on:
  push:
    branches: [main]

jobs:
  build:
    runs-on: macos-latest
    steps:
      - uses: actions/checkout@v2
        with:
          fetch-depth: 0
      
      - name: Setup git
        run: |
          git fetch
          git checkout main
          git config user.name roryabraham
      
      - name: Create a new branch
        run: |
          git checkout -b version-bump-${{ github.sha }}
          git push --set-upstream origin version-bump-${{ github.sha }}


      - name: Modify some code
        run: echo ${{ github.sha }} >> myFile.txt

      - name: Commit and tag new version
        run: |
          git add myFile.txt
          git commit -m "Create file myFile.txt"
          git tag 1.0.6-3

      - name: Push tags
        run: git push --tags

      - name: Create Pull Request
        uses: peter-evans/create-pull-request@09b9ac155b0d5ad7d8d157ed32158c1b73689109
        with:
          author: OSBotify <reactnative@expensify.com>
          base: main
          body: Update version to ${{ github.sha }}
          branch: version-bump-${{ github.sha }}
          labels: automerge
          title: Update version to ${{ github.sha }}
          token: ${{ secrets.GITHUB_TOKEN }}
```

And [this workflow run](https://github.com/Andrew-Test-Org/Public-Test-Repo/runs/2093004898?check_suite_focus=true) was the result.

As you can see, the [tag created by this workflow](https://github.com/Andrew-Test-Org/Public-Test-Repo/releases/tag/1.0.6-3), contains the [changes](https://github.com/Andrew-Test-Org/Public-Test-Repo/compare/1.0.6-2...1.0.6-3) from the "Modify some code" section of the workflow, here simulating the execution of the `bumpVersion` action.

Lastly, you can see the PR it created [here](https://github.com/Andrew-Test-Org/Public-Test-Repo/pull/32).