### PR TITLE
Use correct GH action to get PR

### DIFF
--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Get merged pull request
         id: getMergedPullRequest
-        uses: actions-ecosystem/get-merged-pull-request@cb1e7423b3ca9886f619a8b93874b2e72abfb87c
+        uses: actions-ecosystem/action-get-merged-pull-request@59afe90821bb0b555082ce8ff1e36b03f91553d9
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
cc @roryabraham 

### Details
Looks like we had a typo on which action to use and it threw this error when testing https://github.com/Expensify/Expensify.cash/pull/1745

> Unable to resolve action `actions-ecosystem/get-merged-pull-request@cb1e7423b3ca9886f619a8b93874b2e72abfb87c`, repository not found

This will fix that error.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/pull/1745#issuecomment-797741868

### Tests
Continuing tests from https://github.com/Expensify/Expensify.cash/pull/1745
