### PR TITLE
Filter out empty strings in createOrUpdateStagingDeployCash

### DIFF
--- a/.github/actions/createOrUpdateStagingDeploy/createOrUpdateStagingDeploy.js
+++ b/.github/actions/createOrUpdateStagingDeploy/createOrUpdateStagingDeploy.js
@@ -12,8 +12,14 @@ const githubUtils = new GithubUtils(octokit);
 githubUtils.getStagingDeployCash()
     .then(() => githubUtils.updateStagingDeployCash(
         newVersion,
-        _.map(core.getInput('NEW_PULL_REQUESTS').split(','), PR => PR.trim()) || [],
-        _.map(core.getInput('NEW_DEPLOY_BLOCKERS').split(','), deployBlocker => deployBlocker.trim()) || [],
+        _.filter(
+            _.map(core.getInput('NEW_PULL_REQUESTS').split(','), PR => PR.trim()),
+            PR => !_.isEmpty(PR),
+        ),
+        _.filter(
+            _.map(core.getInput('NEW_DEPLOY_BLOCKERS').split(','), deployBlocker => deployBlocker.trim()),
+            PR => !_.isEmpty(PR),
+        ),
     ))
     .then(({data}) => {
         console.log('Successfully updated StagingDeployCash!', data.html_url);

--- a/.github/actions/createOrUpdateStagingDeploy/index.js
+++ b/.github/actions/createOrUpdateStagingDeploy/index.js
@@ -22,8 +22,14 @@ const githubUtils = new GithubUtils(octokit);
 githubUtils.getStagingDeployCash()
     .then(() => githubUtils.updateStagingDeployCash(
         newVersion,
-        _.map(core.getInput('NEW_PULL_REQUESTS').split(','), PR => PR.trim()) || [],
-        _.map(core.getInput('NEW_DEPLOY_BLOCKERS').split(','), deployBlocker => deployBlocker.trim()) || [],
+        _.filter(
+            _.map(core.getInput('NEW_PULL_REQUESTS').split(','), PR => PR.trim()),
+            PR => !_.isEmpty(PR),
+        ),
+        _.filter(
+            _.map(core.getInput('NEW_DEPLOY_BLOCKERS').split(','), deployBlocker => deployBlocker.trim()),
+            PR => !_.isEmpty(PR),
+        ),
     ))
     .then(({data}) => {
         console.log('Successfully updated StagingDeployCash!', data.html_url);
@@ -417,8 +423,10 @@ class GithubUtils {
         return this.generateVersionComparisonURL(`${GITHUB_OWNER}/${EXPENSIFY_CASH_REPO}`, tag, 'PATCH')
             .then((comparisonURL) => {
                 const sortedPRList = _.sortBy(_.unique(PRList), URL => GithubUtils.getPullRequestNumberFromURL(URL));
-                // eslint-disable-next-line max-len
-                const sortedDeployBlockers = _.sortBy(_.unique(deployBlockers), URL => GithubUtils.getIssueOrPullRequestNumberFromURL(URL));
+                const sortedDeployBlockers = _.sortBy(
+                    _.unique(deployBlockers),
+                    URL => GithubUtils.getIssueOrPullRequestNumberFromURL(URL),
+                );
 
                 // Tag version and comparison URL
                 let issueBody = `**Release Version:** \`${tag}\`\r\n`;

--- a/.github/actions/isStagingDeployLocked/index.js
+++ b/.github/actions/isStagingDeployLocked/index.js
@@ -338,8 +338,10 @@ class GithubUtils {
         return this.generateVersionComparisonURL(`${GITHUB_OWNER}/${EXPENSIFY_CASH_REPO}`, tag, 'PATCH')
             .then((comparisonURL) => {
                 const sortedPRList = _.sortBy(_.unique(PRList), URL => GithubUtils.getPullRequestNumberFromURL(URL));
-                // eslint-disable-next-line max-len
-                const sortedDeployBlockers = _.sortBy(_.unique(deployBlockers), URL => GithubUtils.getIssueOrPullRequestNumberFromURL(URL));
+                const sortedDeployBlockers = _.sortBy(
+                    _.unique(deployBlockers),
+                    URL => GithubUtils.getIssueOrPullRequestNumberFromURL(URL),
+                );
 
                 // Tag version and comparison URL
                 let issueBody = `**Release Version:** \`${tag}\`\r\n`;

--- a/.github/actions/markPullRequestsAsDeployed/index.js
+++ b/.github/actions/markPullRequestsAsDeployed/index.js
@@ -354,8 +354,10 @@ class GithubUtils {
         return this.generateVersionComparisonURL(`${GITHUB_OWNER}/${EXPENSIFY_CASH_REPO}`, tag, 'PATCH')
             .then((comparisonURL) => {
                 const sortedPRList = _.sortBy(_.unique(PRList), URL => GithubUtils.getPullRequestNumberFromURL(URL));
-                // eslint-disable-next-line max-len
-                const sortedDeployBlockers = _.sortBy(_.unique(deployBlockers), URL => GithubUtils.getIssueOrPullRequestNumberFromURL(URL));
+                const sortedDeployBlockers = _.sortBy(
+                    _.unique(deployBlockers),
+                    URL => GithubUtils.getIssueOrPullRequestNumberFromURL(URL),
+                );
 
                 // Tag version and comparison URL
                 let issueBody = `**Release Version:** \`${tag}\`\r\n`;

--- a/.github/libs/GithubUtils.js
+++ b/.github/libs/GithubUtils.js
@@ -307,8 +307,10 @@ class GithubUtils {
         return this.generateVersionComparisonURL(`${GITHUB_OWNER}/${EXPENSIFY_CASH_REPO}`, tag, 'PATCH')
             .then((comparisonURL) => {
                 const sortedPRList = _.sortBy(_.unique(PRList), URL => GithubUtils.getPullRequestNumberFromURL(URL));
-                // eslint-disable-next-line max-len
-                const sortedDeployBlockers = _.sortBy(_.unique(deployBlockers), URL => GithubUtils.getIssueOrPullRequestNumberFromURL(URL));
+                const sortedDeployBlockers = _.sortBy(
+                    _.unique(deployBlockers),
+                    URL => GithubUtils.getIssueOrPullRequestNumberFromURL(URL),
+                );
 
                 // Tag version and comparison URL
                 let issueBody = `**Release Version:** \`${tag}\`\r\n`;


### PR DESCRIPTION
### Details
Hotfix for https://github.com/Expensify/Expensify.cash/runs/2098738279?check_suite_focus=true

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/pull/1745#issuecomment-797761976

### Tests
Merge to test.

Also I verified that `_.filter()` where none of the items matches returns an empty array, which is what we want:

![image](https://user-images.githubusercontent.com/47436092/111003997-07adb380-833d-11eb-9d9e-96e444c2a29c.png)