### PR TITLE
Remove duplicate branch bug for staging

### DIFF
--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -104,17 +104,6 @@ jobs:
           body: Update version to ${{ steps.bumpVersion.outputs.NEW_VERSION }}
           labels: automerge
 
-      - name: Create Pull Request (staging)
-        uses: peter-evans/create-pull-request@09b9ac155b0d5ad7d8d157ed32158c1b73689109
-        with:
-          token: ${{ secrets.OS_BOTIFY_TOKEN }}
-          author: OSBotify <reactnative@expensify.com>
-          base: staging
-          branch: version-bump-${{ github.sha }}
-          title: Update version to ${{ steps.bumpVersion.outputs.NEW_VERSION }} on staging
-          body: Update version to ${{ steps.bumpVersion.outputs.NEW_VERSION }}
-          labels: automerge
-
       - name: Update StagingDeployCash
         uses: Expensify/Expensify.cash/.github/actions/createOrUpdateStagingDeploy@master
         with:


### PR DESCRIPTION
### Details
We were trying to quickly spin up the ability for master to mirror staging. However, this doesn't seem to be working as intended, so we will try again on Monday.

### Fixed Issues
Fixes broken version PRs

### Tests
1. Merge this and make sure it generates a correct version
2. Also make sure it merges the version PR