### PR TITLE
Add app menu item for updating

### DIFF
--- a/src/Expensify.js
+++ b/src/Expensify.js
@@ -46,8 +46,8 @@ const propTypes = {
         accountID: PropTypes.number,
     }),
 
-    // Version of newly downloaded update.
-    version: PropTypes.string,
+    // Whether a new update is available and ready to install.
+    updateAvailable: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -55,7 +55,7 @@ const defaultProps = {
         authToken: null,
         accountID: null,
     },
-    version: '',
+    updateAvailable: false,
 };
 
 class Expensify extends PureComponent {
@@ -98,7 +98,7 @@ class Expensify extends PureComponent {
         return (
             <>
                 {/* We include the modal for showing a new update at the top level so the option is always present. */}
-                {this.props.version ? <UpdateAppModal updateVersion={this.props.version} /> : null}
+                {this.props.updateAvailable ? <UpdateAppModal /> : null}
                 <NavigationRoot authenticated={Boolean(authToken)} />
             </>
         );
@@ -111,8 +111,8 @@ export default withOnyx({
     session: {
         key: ONYXKEYS.SESSION,
     },
-    version: {
-        key: ONYXKEYS.UPDATE_VERSION,
+    updateAvailable: {
+        key: ONYXKEYS.UPDATE_AVAILABLE,
         initWithStoredValues: false,
     },
 })(Expensify);

--- a/src/ONYXKEYS.js
+++ b/src/ONYXKEYS.js
@@ -38,8 +38,8 @@ export default {
     // Contains the user preference for the LHN priority mode
     PRIORITY_MODE: 'priorityMode',
 
-    // Contains the version of the update that has newly been downloaded.
-    UPDATE_VERSION: 'updateVersion',
+    // Indicates whether an update is available and ready to beinstalled.
+    UPDATE_AVAILABLE: 'updateAvailable',
 
     // Saves the current country code which is displayed when the user types a phone number without
     // an international code

--- a/src/components/UpdateAppModal/UpdateAppModalPropTypes.js
+++ b/src/components/UpdateAppModal/UpdateAppModalPropTypes.js
@@ -3,15 +3,10 @@ import PropTypes from 'prop-types';
 const propTypes = {
     // Callback to fire when we want to trigger the update.
     onSubmit: PropTypes.func,
-
-    // Version string for the app to update to.
-    // eslint-disable-next-line react/no-unused-prop-types
-    version: PropTypes.string,
 };
 
 const defaultProps = {
     onSubmit: null,
-    version: '',
 };
 
 export {propTypes, defaultProps};

--- a/src/components/UpdateAppModal/index.desktop.js
+++ b/src/components/UpdateAppModal/index.desktop.js
@@ -8,7 +8,7 @@ const UpdateAppModal = (props) => {
         if (props.onSubmit) {
             props.onSubmit();
         }
-        ipcRenderer.sendSync('start-update', props.version);
+        ipcRenderer.sendSync('start-update');
     };
     return <BaseUpdateAppModal onSubmit={updateApp} />;
 };

--- a/src/libs/Notification/LocalNotification/BrowserNotifications.js
+++ b/src/libs/Notification/LocalNotification/BrowserNotifications.js
@@ -122,17 +122,14 @@ export default {
 
     /**
      * Create a notification to indicate that an update is available.
-     *
-     * @param {Object} params
-     * @param {String} params.version
      */
-    pushUpdateAvailableNotification({version}) {
+    pushUpdateAvailableNotification() {
         push({
             title: 'Update available',
             body: 'A new version of Expensify.cash is available!',
             delay: 0,
             onClick: () => {
-                Onyx.merge(ONYXKEYS.UPDATE_VERSION, version);
+                Onyx.merge(ONYXKEYS.UPDATE_AVAILABLE, true);
             },
         });
     },

--- a/src/libs/Notification/LocalNotification/index.js
+++ b/src/libs/Notification/LocalNotification/index.js
@@ -4,8 +4,8 @@ function showCommentNotification({reportAction, onClick}) {
     BrowserNotifications.pushReportCommentNotification({reportAction, onClick});
 }
 
-function showUpdateAvailableNotification({version}) {
-    BrowserNotifications.pushUpdateAvailableNotification({version});
+function showUpdateAvailableNotification() {
+    BrowserNotifications.pushUpdateAvailableNotification();
 }
 
 export default {

--- a/src/setup/index.desktop.js
+++ b/src/setup/index.desktop.js
@@ -9,7 +9,7 @@ export default function () {
         rootTag: document.getElementById('root'),
     });
 
-    ipcRenderer.on('update-downloaded', (_, version) => {
-        LocalNotification.showUpdateAvailableNotification({version});
+    ipcRenderer.on('update-downloaded', () => {
+        LocalNotification.showUpdateAvailableNotification();
     });
 }


### PR DESCRIPTION
### Details
Implements an app menu item for updating the app when an update has been fully downloaded.


### Fixed Issues
Fixes #1664.

### Tests
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

1. Open app, see that Update option is grayed out.
2. Download app and without hitting the notification, notice that Update option is now available.
3. Even after continuing to interact with the app, the Update option stays available in the menu.
4. When hitting the update app, it correctly goes through the auto-update flow.

### Tested On

- [ ] Web
- [ ] Mobile Web
- [X] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
N/A

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
N/A

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
Here's a video of the new experience: https://www.dropbox.com/s/iuyhnwjck4ofejo/Screen%20Recording%202021-03-13%20at%2010.46.05%20AM.mov?dl=0

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
N/A

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
N/A
