### PR TITLE
Fix react navigation issues with IOUModal

### DIFF
--- a/src/pages/iou/IOUBillPage.js
+++ b/src/pages/iou/IOUBillPage.js
@@ -3,10 +3,10 @@ import IOUModal from './IOUModal';
 import ScreenWrapper from '../../components/ScreenWrapper';
 
 export default props => (
-    // eslint-disable-next-line react/jsx-props-no-spreading
     <ScreenWrapper>
-        {() => 
+        {() => (
+            // eslint-disable-next-line react/jsx-props-no-spreading
             <IOUModal {...props} hasMultipleParticipants />
-        }
+        )}
     </ScreenWrapper>
 );

--- a/src/pages/iou/IOUBillPage.js
+++ b/src/pages/iou/IOUBillPage.js
@@ -1,7 +1,12 @@
 import React from 'react';
 import IOUModal from './IOUModal';
+import ScreenWrapper from '../../components/ScreenWrapper';
 
 export default props => (
     // eslint-disable-next-line react/jsx-props-no-spreading
-    <IOUModal {...props} hasMultipleParticipants />
+    <ScreenWrapper>
+        {() => 
+            <IOUModal {...props} hasMultipleParticipants />
+        }
+    </ScreenWrapper>
 );

--- a/src/pages/iou/IOUModal.js
+++ b/src/pages/iou/IOUModal.js
@@ -108,7 +108,7 @@ class IOUModal extends Component {
                         <Header title={this.getTitleForStep()} />
                         <View style={[styles.reportOptions, styles.flexRow]}>
                             <TouchableOpacity
-                                onCloseButtonPress={Navigation.dismissModal}
+                                onPress={Navigation.dismissModal}
                                 style={[styles.touchableButtonImage]}
                             >
                                 <Icon src={Close} />

--- a/src/pages/iou/IOURequestPage.js
+++ b/src/pages/iou/IOURequestPage.js
@@ -1,7 +1,12 @@
 import React from 'react';
+import ScreenWrapper from '../../components/ScreenWrapper';
 import IOUModal from './IOUModal';
 
 export default props => (
     // eslint-disable-next-line react/jsx-props-no-spreading
-    <IOUModal {...props} />
+    <ScreenWrapper>
+        {() => (
+            <IOUModal {...props} />
+        )}
+    </ScreenWrapper>
 );

--- a/src/pages/iou/IOURequestPage.js
+++ b/src/pages/iou/IOURequestPage.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import ScreenWrapper from '../../components/ScreenWrapper';
 import IOUModal from './IOUModal';
+import ScreenWrapper from '../../components/ScreenWrapper';
 
 export default props => (
-    // eslint-disable-next-line react/jsx-props-no-spreading
     <ScreenWrapper>
         {() => (
+            // eslint-disable-next-line react/jsx-props-no-spreading
             <IOUModal {...props} />
         )}
     </ScreenWrapper>


### PR DESCRIPTION
### Details

Fixes a couple of issues related to the IOUModal pages and the recent React-native-navigation implementation:
- Reverted to the onPress prop to fix the close button
- Wrapped Modal pages in `<ScreenWrapper>`, fixing the status bar margin on mobile and aligning with other Modals
- DOES NOT FIX the issue where navigating directly to `localhost/iou/request` shows a grey background, as this doesn't occur when users use the navigation routing (should investigate this later)


### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/1769

### Tests

_Save the following diff as `diff.txt` and apply with `git apply diff.txt` (make sure you include the empty new line!)_
```
diff --git a/src/components/CreateMenu.js b/src/components/CreateMenu.js
index 7c7afe3a..e37c842c 100644
--- a/src/components/CreateMenu.js
+++ b/src/components/CreateMenu.js
@@ -52,13 +52,13 @@ class CreateMenu extends PureComponent {
         const menuItemData = [
             {
                 icon: ChatBubble,
-                text: 'New Chat',
-                onPress: () => this.setOnModalHide(() => Navigation.navigate(ROUTES.NEW_CHAT)),
+                text: 'New Request',
+                onPress: () => this.setOnModalHide(() => Navigation.navigate(ROUTES.IOU_REQUEST)),
             },
             {
                 icon: Users,
-                text: 'New Group',
-                onPress: () => this.setOnModalHide(() => Navigation.navigate(ROUTES.NEW_GROUP)),
+                text: 'New Split',
+                onPress: () => this.setOnModalHide(() => Navigation.navigate(ROUTES.IOU_BILL)),
             },
         ].map(item => ({
             ...item,

```

**Confirm close button now works**
- Press the + (FAB) and select Request Money OR Split Bill
- Attempt to close the modal with the X button
- Modal should close
- Reopen, click next to navigate through the steps
- Attempt to close the modal with the X button
- Modal should close

**Confirm header does not overlap the status bar**
- Press the + (FAB) and select Request Money OR Split Bill
- Confirm that the status bar is not overlapped (margin should be similar to the Profile page header)

_Example of existing problem:_
![Screenshot 2021-03-15 at 12 47 10](https://user-images.githubusercontent.com/10736861/111155797-d9261780-858c-11eb-9b97-d1db9b586910.png)


### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
![ioustatusweb](https://user-images.githubusercontent.com/10736861/111157060-569e5780-858e-11eb-8a31-8eafbfcc081b.png)


#### Mobile Web
![ioustatusmweb](https://user-images.githubusercontent.com/10736861/111157572-f0660480-858e-11eb-81a3-1c5a9d74d2e1.png)


#### Desktop
<img width="400" alt="ioustatusdesktop" src="https://user-images.githubusercontent.com/10736861/111156972-3bcbe300-858e-11eb-88e6-d2d41c909a22.png">


#### iOS
![ioustatusios](https://user-images.githubusercontent.com/10736861/111157489-d6c4bd00-858e-11eb-9462-958617354b47.png)


#### Android
![ioustatusandroid](https://user-images.githubusercontent.com/10736861/111157046-51d9a380-858e-11eb-9a14-311dc0b63652.png)

