### PR TITLE
Fix clientEvents that are causing reconnection attempts

### DIFF
--- a/src/libs/Pusher/pusher.js
+++ b/src/libs/Pusher/pusher.js
@@ -322,6 +322,13 @@ function isSubscribed(channelName) {
  * @param {Object} payload
  */
 function sendEvent(channelName, eventName, payload) {
+    // Check to see if we are subscribed to this channel before sending the event. Sending client events over channels
+    // we are not subscribed too will throw errors and cause reconnection attempts. Subscriptions are not instant and
+    // can happen later than we expect.
+    if (!isSubscribed(channelName)) {
+        return;
+    }
+
     socket.send_event(eventName, payload, channelName);
 }
 

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -48,7 +48,7 @@ class ReportActionCompose extends React.Component {
 
         this.updateComment = this.updateComment.bind(this);
         this.debouncedSaveReportComment = _.debounce(this.debouncedSaveReportComment.bind(this), 1000, false);
-        this.debouncedBroadcastUserIsTyping = _.debounce(() => broadcastUserIsTyping(props.reportID), 100, true);
+        this.debouncedBroadcastUserIsTyping = _.debounce(this.debouncedBroadcastUserIsTyping.bind(this), 100, true);
         this.submitForm = this.submitForm.bind(this);
         this.triggerSubmitShortcut = this.triggerSubmitShortcut.bind(this);
         this.submitForm = this.submitForm.bind(this);
@@ -104,6 +104,14 @@ class ReportActionCompose extends React.Component {
      */
     debouncedSaveReportComment(comment) {
         saveReportComment(this.props.reportID, comment || '');
+    }
+
+    /**
+     * Broadcast that the user is typing. We debounce this method in the constructor to limit how often we publish
+     * client events.
+     */
+    debouncedBroadcastUserIsTyping() {
+        broadcastUserIsTyping(this.props.reportID);
     }
 
     /**


### PR DESCRIPTION
### Details
When reorganizing the `ReportsScreen` client events remained bound to whatever report was passed into the constructor and would throw errors since we are publishing events to a channel we are no longer subscribed to. There's no reason why we should throw an error in this case (which also causes a reconnection attempt). So the solution is to:

1. Make sure we are referencing the correct reportID in the debounced method
2. Stop reconnecting for attempts to send events to channels we are not subscribed to - this is not typically an event that we should respond to with reauthentication and is totally expected as subscriptions take time to resolve.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/157459
Fixes https://github.com/Expensify/Expensify/issues/157266

### Tests
1. Open Expensify.cash to a report and start typing
2. As another user load up that report and see that the user is typing feature works as expected
3. Verify no abnormal reconnection attempts are made
4. Verify that when an attachment is present in the chat it does not flash while you are typing

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
