### PR TITLE
Focus compose field when modal dismissed

### DIFF
--- a/src/components/Modal/BaseModal.js
+++ b/src/components/Modal/BaseModal.js
@@ -20,6 +20,7 @@ class BaseModal extends PureComponent {
 
     componentWillUnmount() {
         this.unsubscribeFromKeyEvents();
+        setModalVisibility(false);
     }
 
     /**

--- a/src/components/Modal/BaseModal.js
+++ b/src/components/Modal/BaseModal.js
@@ -14,13 +14,22 @@ class BaseModal extends PureComponent {
     constructor(props) {
         super(props);
 
+        this.hideModalAndRemoveEventListeners = this.hideModalAndRemoveEventListeners.bind(this);
         this.subscribeToKeyEvents = this.subscribeToKeyEvents.bind(this);
         this.unsubscribeFromKeyEvents = this.unsubscribeFromKeyEvents.bind(this);
     }
 
     componentWillUnmount() {
+        this.hideModalAndRemoveEventListeners();
+    }
+
+    /**
+     * Hides modal and unsubscribes from key event listeners
+     */
+    hideModalAndRemoveEventListeners() {
         this.unsubscribeFromKeyEvents();
         setModalVisibility(false);
+        this.props.onModalHide();
     }
 
     /**
@@ -66,11 +75,7 @@ class BaseModal extends PureComponent {
                     this.subscribeToKeyEvents();
                     setModalVisibility(true);
                 }}
-                onModalHide={() => {
-                    this.unsubscribeFromKeyEvents();
-                    setModalVisibility(false);
-                    this.props.onModalHide();
-                }}
+                onModalHide={this.hideModalAndRemoveEventListeners}
                 onSwipeComplete={this.props.onClose}
                 swipeDirection={swipeDirection}
                 isVisible={this.props.isVisible}

--- a/src/libs/Navigation/Navigation.js
+++ b/src/libs/Navigation/Navigation.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import {StackActions, DrawerActions} from '@react-navigation/native';
 import {getIsDrawerOpenFromState} from '@react-navigation/drawer';
-import {setModalVisibility} from '../actions/Modal'
 
 import linkTo from './linkTo';
 import ROUTES from '../../ROUTES';
@@ -52,9 +51,6 @@ function navigate(route) {
 function dismissModal() {
     // This should take us to the first view of the modal's stack navigator
     navigationRef.current.dispatch(StackActions.popToTop());
-
-    // Update modal visilibity in Onyx
-    setModalVisibility(false);
 
     // From there we can just navigate back and open the drawer
     goBack();

--- a/src/libs/Navigation/Navigation.js
+++ b/src/libs/Navigation/Navigation.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {StackActions, DrawerActions} from '@react-navigation/native';
 import {getIsDrawerOpenFromState} from '@react-navigation/drawer';
+import {setModalVisibility} from '../actions/Modal'
 
 import linkTo from './linkTo';
 import ROUTES from '../../ROUTES';
@@ -51,6 +52,9 @@ function navigate(route) {
 function dismissModal() {
     // This should take us to the first view of the modal's stack navigator
     navigationRef.current.dispatch(StackActions.popToTop());
+
+    // Update modal visilibity in Onyx
+    setModalVisibility(false);
 
     // From there we can just navigate back and open the drawer
     goBack();


### PR DESCRIPTION
### Details
<Explanation of the change or anything fishy that is going on>

Re-implemented compose field being focused when a page-level modal gets dismissed (this broke due to a small regression that was introduced by the recent React-navigation overhaul).

Before the React-Navigation upgrade, closing a page-modal (like /search) would trigger `BaseModal`'s `onModalHide` callback, which is where we handled a few important things (mainly unsubscribing from keyboard events and setting modal visibility).

After the React-navigation overhaul, when a user navigates away from a page with a modal, `BaseModal` gets taken out of the DOM before it has time to trigger its `onModalHide` callback.

To fix, I've added a new function `hideModalAndRemoveEventListeners` which contains the functions to hide the modal and unregister key event listeners. This function is now called in `componentWillUnmount` (for page-modals that unmount immediately upon navigation) and in `onModalHide` (for FAB, which isn't unmounted after its modal hides).

Other notes can be found here: https://github.com/Expensify/Expensify/issues/154180#issuecomment-799676117

Note: Original PR which focused the compose field when closing modals (cc @tgolen): https://github.com/Expensify/Expensify.cash/pull/1699

### Fixed Issues
<Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing>
Fixes https://github.com/Expensify/Expensify/issues/154180

### Tests
1. Go to a chat and start typing a comment
2. Open up the LHN search
3. Close the search modal (or select any chat)
4. Verify that the compose field gets focus

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [ ] ~iOS~ (n/a because the field does not get focus by design)
- [ ] ~Android~ (n/a because the field does not get focus by design)

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
Not really any screenshots necessary

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
Not really any screenshots necessary

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
Not really any screenshots necessary

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
Not really any screenshots necessary

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
Not really any screenshots necessary
