### PR TITLE
Darken FAB color when active so it looks better on white backgrounds

### DIFF
--- a/src/components/FAB.js
+++ b/src/components/FAB.js
@@ -55,12 +55,12 @@ class FAB extends PureComponent {
 
         const backgroundColor = this.animatedValue.interpolate({
             inputRange: [0, 1],
-            outputRange: [themeColors.buttonSuccessBG, themeColors.sidebar],
+            outputRange: [themeColors.buttonSuccessBG, themeColors.buttonDefaultBG],
         });
 
         const fill = this.animatedValue.interpolate({
             inputRange: [0, 1],
-            outputRange: [themeColors.componentBG, themeColors.icon],
+            outputRange: [themeColors.componentBG, themeColors.heading],
         });
 
         return (


### PR DESCRIPTION
### Details
<Explanation of the change or anything fishy that is going on>

Darkened the FAB when in its "Active" state so it looks better and can be seen easier with a white background.

Colors recommended are mentioned in the linked issue.

### Fixed Issues
<Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing>
Fixes https://github.com/Expensify/Expensify/issues/154000

### Tests
1. Click the green FAB so the "new chat" / "new group" menu pops open.
2. Notice the slightly darker FAB - it should be more easily visible on a white background.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [ ] ~iOS~
- [ ] ~Android~

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

Before:
<img width="359" alt="Screen Shot 2021-03-15 at 3 30 33 PM" src="https://user-images.githubusercontent.com/3885503/111224109-9facd680-85a3-11eb-83f5-fb9891b15299.png">

After:
<img width="359" alt="Screen Shot 2021-03-15 at 3 31 35 PM" src="https://user-images.githubusercontent.com/3885503/111224139-a6d3e480-85a3-11eb-83dd-7254a5f581bc.png">

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
See "Web"

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
See "Web"

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
Not necessary, just a color change

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
Not necessary, just a color change