### PR TITLE
Persist IOU data in Onyx

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -20,9 +20,11 @@ const CONST = {
     },
     REPORT: {
         MAXIMUM_PARTICIPANTS: 8,
-        REPORT_ACTIONS_LIMIT: 50,
-        REPORT_ACTION_TYPE: {
-            IOU: 'IOU',
+        ACTIONS: {
+            LIMIT: 50,
+            TYPE: {
+                IOU: 'IOU',
+            },
         },
     },
     MODAL: {

--- a/src/CONST.js
+++ b/src/CONST.js
@@ -21,6 +21,9 @@ const CONST = {
     REPORT: {
         MAXIMUM_PARTICIPANTS: 8,
         REPORT_ACTIONS_LIMIT: 50,
+        REPORT_ACTION_TYPE: {
+            IOU: 'IOU',
+        },
     },
     MODAL: {
         MODAL_TYPE: {

--- a/src/ONYXKEYS.js
+++ b/src/ONYXKEYS.js
@@ -61,5 +61,6 @@ export default {
         REPORT_ACTIONS: 'reportActions_',
         REPORT_DRAFT_COMMENT: 'reportDraftComment_',
         REPORT_USER_IS_TYPING: 'reportUserIsTyping_',
+        REPORT_IOUS: 'reportIOUs_',
     },
 };

--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -605,7 +605,6 @@ function SetNameValuePair(parameters) {
 }
 
 /**
- *
  * @param {Object} parameters
  * @param {String[]} data
  * @returns {Promise}
@@ -621,6 +620,17 @@ function Mobile_GetConstants(parameters) {
     return Network.post(commandName, finalParameters);
 }
 
+/**
+ * @param {Object} parameters
+ * @param {String} parameters.debtorEmail
+ * @returns {Promise}
+ */
+function GetIOUReport(parameters) {
+    const commandName = 'GetIOUReport';
+    requireParameters(['debtorEmail'], parameters, commandName);
+    return Network.post(commandName, parameters);
+}
+
 export {
     getAuthToken,
     Authenticate,
@@ -630,6 +640,7 @@ export {
     DeleteLogin,
     Get,
     GetAccountStatus,
+    GetIOUReport,
     GetRequestCountryCode,
     Graphite_Timer,
     Log,

--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -622,12 +622,12 @@ function Mobile_GetConstants(parameters) {
 
 /**
  * @param {Object} parameters
- * @param {String} parameters.debtorEmail
+ * @param {Number} parameters.reportID
  * @returns {Promise}
  */
 function GetIOUReport(parameters) {
     const commandName = 'GetIOUReport';
-    requireParameters(['debtorEmail'], parameters, commandName);
+    requireParameters(['reportID'], parameters, commandName);
     return Network.post(commandName, parameters);
 }
 

--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -622,12 +622,12 @@ function Mobile_GetConstants(parameters) {
 
 /**
  * @param {Object} parameters
- * @param {Number} parameters.reportID
+ * @param {String} parameters.debtorEmail
  * @returns {Promise}
  */
 function GetIOUReport(parameters) {
     const commandName = 'GetIOUReport';
-    requireParameters(['reportID'], parameters, commandName);
+    requireParameters(['debtorEmail'], parameters, commandName);
     return Network.post(commandName, parameters);
 }
 

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -529,12 +529,11 @@ function getSimplifiedIOUReport(reportID, reportData) {
 }
 
 /**
- * Fetches the updated data for an IOU Report and updates the IOU collection in ONYX
+ * Fetches the updated data for an IOU Report and updates the IOU collection in Onyx
  *
- * @param {Number} reportID
  * @param {Object[]} reportHistory
  */
-function updateIOUReportData(reportID, reportHistory) {
+function updateIOUReportData(reportHistory) {
     const containsIOUAction = _.any(reportHistory, action => action.actionName === 'IOU');
 
     // If there aren't any IOU actions, we don't need to fetch any additional data
@@ -553,14 +552,14 @@ function updateIOUReportData(reportID, reportHistory) {
         return;
     }
 
-    // If we have an IOU action, get the IOU reportID
+    // Since the Chat and the IOU are different reports with different reportIDs, and GetIOUReport only returns the
+    // IOU's reportID, keep track of the IOU's reportID so we can use it to get the IOUReport data via `GetReportStuff`
     let iouReportID = 0;
     API.GetIOUReport({
         debtorEmail: otherParticipants[0],
     }).then((response) => {
         iouReportID = response.reportID;
 
-        Log.info('[Report] Fetching IOU report data', true, iouReportID);
         return API.Get({
             returnValueList: 'reportStuff',
             reportIDList: iouReportID,
@@ -608,7 +607,7 @@ function fetchActions(reportID, offset) {
                 .max()
                 .value();
 
-            updateIOUReportData(reportID, indexedData);
+            updateIOUReportData(indexedData);
 
             Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`, indexedData);
             Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, {maxSequenceNumber});

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -201,7 +201,7 @@ function getSimplifiedIOUReport(reportData) {
 function updateIOUReportData(report) {
     const reportActionList = report.reportActionList || [];
     const containsIOUAction = _.any(reportActionList,
-        reportAction => reportAction.action === CONST.REPORT.REPORT_ACTION_TYPE.IOU);
+        reportAction => reportAction.action === CONST.REPORT.ACTIONS.TYPE.IOU);
 
     // If there aren't any IOU actions, we don't need to fetch any additional data
     if (!containsIOUAction) {
@@ -213,6 +213,7 @@ function updateIOUReportData(report) {
     if (participants.length !== 1) {
         Log.alert('[Report] Report with IOU action has more than 2 participants', true, {
             reportID: report.reportID,
+            participants,
         });
         return;
     }
@@ -613,7 +614,7 @@ function fetchActions(reportID, offset) {
     return API.Report_GetHistory({
         reportID,
         reportActionsOffset,
-        reportActionsLimit: CONST.REPORT.REPORT_ACTIONS_LIMIT,
+        reportActionsLimit: CONST.REPORT.ACTIONS.LIMIT,
     })
         .then((data) => {
             // We must remove all optimistic actions so there will not be any stuck comments. At this point, we should

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -498,7 +498,6 @@ function fetchChatReports() {
 /**
  * Get a simplified version of an IOU report
  *
- * @param {Number} reportID
  * @param {Object} reportData
  * @param {Number} reportData.transactionID
  * @param {Number} reportData.amount
@@ -508,9 +507,10 @@ function fetchChatReports() {
  * @param {Object[]} reportData.transactionList
  * @param {String} reportData.ownerEmail
  * @param {String} reportData.managerEmail
+ * @param {Number} reportData.reportID
  * @returns {Object}
  */
-function getSimplifiedIOUReport(reportID, reportData) {
+function getSimplifiedIOUReport(reportData) {
     const transactions = _.map(reportData.transactionList, transaction => ({
         transactionID: transaction.transactionID,
         amount: transaction.amount,
@@ -520,7 +520,7 @@ function getSimplifiedIOUReport(reportID, reportData) {
     }));
 
     return {
-        reportID,
+        reportID: reportData.reportID,
         ownerEmail: reportData.ownerEmail,
         managerEmail: reportData.managerEmail,
         currency: reportData.currency,
@@ -569,7 +569,7 @@ function updateIOUReportData(reportHistory) {
     }).then((response) => {
         const iouReportData = response.reports[iouReportID];
         Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_IOUS}${iouReportID}`,
-            getSimplifiedIOUReport(iouReportID, iouReportData));
+            getSimplifiedIOUReport(iouReportData));
     });
 }
 

--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -209,9 +209,9 @@ class ReportActionsView extends React.Component {
         }
 
         this.setState({isLoadingMoreChats: true}, () => {
-            // Retrieve the next REPORT_ACTIONS_LIMIT sized page of comments, unless we're near the beginning, in which
+            // Retrieve the next REPORT.ACTIONS.LIMIT sized page of comments, unless we're near the beginning, in which
             // case just get everything starting from 0.
-            const offset = Math.max(minSequenceNumber - CONST.REPORT.REPORT_ACTIONS_LIMIT, 0);
+            const offset = Math.max(minSequenceNumber - CONST.REPORT.ACTIONS.LIMIT, 0);
             fetchActions(this.props.reportID, offset)
                 .then(() => this.setState({isLoadingMoreChats: false}));
         });


### PR DESCRIPTION
### Details
This PR adds a new API command for `GetIOUReport` and starts persisting the IOUReport collection in Onyx.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/157104

### Tests
1. On web, log out of e.cash and open the console (cmd + option + j)
2. Open the `Application` tab and select `localhost:8080` under `Local Storage`
![image](https://user-images.githubusercontent.com/3981102/111380061-1cea5100-8661-11eb-8aed-40d403d1b945.png)
3. Log into an account without an IOU and check the LocalStorage keys, confirm there is nothing shown if you filter by `reportIOU`
![image](https://user-images.githubusercontent.com/3981102/111380304-65097380-8661-11eb-8f1d-9b95f562cf9b.png)
4. Use the `CreateIOUTransaction` Curl request from https://github.com/Expensify/Expensify/issues/157104#issue-829068854 to create an IOU transaction. Ensure the debtorEmail is different from the email/accountID/authToken you set in the cookie field
5. Log into cash as the account of the person who created the IOU. Confirm that you see a value in localStorage for `reportIOU_` that contains the IOU reportID. For an example of the full data, see https://github.com/Expensify/Expensify/issues/157104#issuecomment-799886417
<img src='https://user-images.githubusercontent.com/3981102/111383988-3641cc00-8666-11eb-976f-daa3ac923cb3.png' width='500'/>

6. Log out, and log into cash using the debtorEmail value you used in step 4, confirm you see a value in localStorage for `reportIOU_` that contains the IOU reportID
7. Create an IOUTransaction from an account A that has been the only one to comment on a chat report and User B is the debtor.
8. Confirm that when logging in with UserA, the reportIOU collection contains that report.

Additionally, confirm that there are no regressions with sending messages to other accounts

### Tested On

- [x] Web
- [ ] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
N/A
