### PR TITLE
Make the 2FA keyboard numeric on mobile.

### DIFF
--- a/src/pages/signin/PasswordForm.js
+++ b/src/pages/signin/PasswordForm.js
@@ -88,6 +88,7 @@ class PasswordForm extends React.Component {
                             placeholderTextColor={themeColors.textSupporting}
                             onChangeText={text => this.setState({twoFactorAuthCode: text})}
                             onSubmitEditing={this.validateAndSubmitForm}
+                            keyboardType="numeric"
                         />
                     </View>
                 )}


### PR DESCRIPTION
2FA codes can only be numeric, but the 2FA TextInput pulls up the alphanumeric keyboard on mobile, which makes the UX more complicated than it needs to be. Let's make it so that it pulls up the numeric keypad.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/157494

### Tests
Attempted to log in with an email that requires 2FA (e.g. Expensify email), verified that the 2FA TextInput pulls up the numeric keypad.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Mobile Web
<img width="410" alt="Screen Shot 2021-03-16 at 2 03 10 PM" src="https://user-images.githubusercontent.com/31285285/111263195-6ab28980-8660-11eb-88a7-f9a01982de56.png">

#### iOS
<img width="439" alt="Screen Shot 2021-03-16 at 1 50 23 PM" src="https://user-images.githubusercontent.com/31285285/111263200-6d14e380-8660-11eb-9ebc-c5c89f92e703.png">

#### Android
<img width="390" alt="Screen Shot 2021-03-17 at 2 31 51 PM" src="https://user-images.githubusercontent.com/31285285/111425100-9a7b9300-872d-11eb-91d2-a720699b47ba.png">

cc @robertjchen @marcaaron 