### PR TITLE
Update expensify-common hash for link fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11074,15 +11074,14 @@
       }
     },
     "expensify-common": {
-      "version": "git+https://github.com/Expensify/expensify-common.git#58ed3e9e813a9bc1cf0dd4626ce90ef35110369c",
-      "from": "git+https://github.com/Expensify/expensify-common.git#58ed3e9e813a9bc1cf0dd4626ce90ef35110369c",
+      "version": "git+https://github.com/Expensify/expensify-common.git#c7becaa79e10c10da521261ebb83dd3871847e84",
+      "from": "git+https://github.com/Expensify/expensify-common.git#c7becaa79e10c10da521261ebb83dd3871847e84",
       "requires": {
         "classnames": "2.2.5",
         "clipboard": "2.0.4",
         "html-entities": "^1.3.1",
         "jquery": "3.3.1",
-        "lodash.get": "4.4.2",
-        "lodash.has": "4.5.2",
+        "lodash": "4.17.21",
         "prop-types": "15.7.2",
         "react": "16.12.0",
         "react-dom": "16.12.0",
@@ -11091,6 +11090,11 @@
         "underscore": "1.9.1"
       },
       "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
         "react": {
           "version": "16.12.0",
           "resolved": "https://registry.npmjs.org/react/-/react-16.12.0.tgz",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "electron-log": "^4.2.4",
     "electron-serve": "^1.0.0",
     "electron-updater": "^4.3.4",
-    "expensify-common": "git+https://github.com/Expensify/expensify-common.git#58ed3e9e813a9bc1cf0dd4626ce90ef35110369c",
+    "expensify-common": "git+https://github.com/Expensify/expensify-common.git#c7becaa79e10c10da521261ebb83dd3871847e84",
     "file-loader": "^6.0.0",
     "html-entities": "^1.3.1",
     "lodash.get": "^4.4.2",


### PR DESCRIPTION
Just hash changes to apply https://github.com/Expensify/expensify-common/pull/353

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/153365

### Tests
1.sent the following message
```
[test `[test](google.com)`](google.com)
https://www.upwork.com/jobs/~016781e062ce860b84
```
1. Verified it linked properly
![image](https://user-images.githubusercontent.com/22447860/111223052-e09fed80-8599-11eb-96fb-e83d1a6b1ee3.png)

### Tested On

- [ ] Web
- [ ] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android