### PR TITLE
Fix contains usage in GH Actions to unbreak deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Check if merged pull request was an automatic version bump PR
         id: isAutomergePR
-        run: echo "::set-output name=IS_AUTOMERGE_PR::${{ constains(steps.getMergedPullRequest.outputs.labels, automerge) && github.actor == 'OSBotify' }}"
+        run: echo "::set-output name=IS_AUTOMERGE_PR::${{ contains(steps.getMergedPullRequest.outputs.labels.*.name, 'automerge') && github.actor == 'OSBotify' }}"
 
   deployStaging:
     runs-on: ubuntu-latest

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -32,7 +32,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 
       - name: Check if merged pull request was an automatic version bump PR
-        run: echo "::set-output name=IS_VERSION_BUMP_PR::${{ contains(steps.getMergedPullRequest.outputs.labels, automerge) && github.actor == 'OSBotify' }}"
+        run: echo "::set-output name=IS_VERSION_BUMP_PR::${{ contains(steps.getMergedPullRequest.outputs.labels.*.name, 'automerge') && github.actor == 'OSBotify' }}"
 
   skipDeploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Broken workflow run: https://github.com/Expensify/Expensify.cash/actions/runs/658590878
Proper example of "contains" usage:

![image](https://user-images.githubusercontent.com/47436092/111361855-6334b580-864b-11eb-80b1-738779333e9c.png)
