### PR TITLE
Give isVersionBumpPR step an ID

### DIFF
--- a/.github/actions/isStagingDeployLocked/index.js
+++ b/.github/actions/isStagingDeployLocked/index.js
@@ -18,7 +18,10 @@ const run = function () {
     const githubUtils = new GithubUtils(octokit);
 
     return githubUtils.getStagingDeployCash()
-        .then(({labels}) => core.setOutput('IS_LOCKED', _.contains(_.pluck(labels, 'name'), '🔐 LockCashDeploys 🔐')))
+        .then(({labels}) => {
+            console.log(`Found StagingDeployCash with labels: ${_.pluck(labels, 'name')}`);
+            core.setOutput('IS_LOCKED', _.contains(_.pluck(labels, 'name'), '🔐 LockCashDeploys 🔐'));
+        })
         .catch((err) => {
             console.warn('No open StagingDeployCash found, continuing...', err);
             core.setOutput('IS_LOCKED', false);

--- a/.github/actions/isStagingDeployLocked/isStagingDeployLocked.js
+++ b/.github/actions/isStagingDeployLocked/isStagingDeployLocked.js
@@ -8,7 +8,10 @@ const run = function () {
     const githubUtils = new GithubUtils(octokit);
 
     return githubUtils.getStagingDeployCash()
-        .then(({labels}) => core.setOutput('IS_LOCKED', _.contains(_.pluck(labels, 'name'), '🔐 LockCashDeploys 🔐')))
+        .then(({labels}) => {
+            console.log(`Found StagingDeployCash with labels: ${_.pluck(labels, 'name')}`);
+            core.setOutput('IS_LOCKED', _.contains(_.pluck(labels, 'name'), '🔐 LockCashDeploys 🔐'));
+        })
         .catch((err) => {
             console.warn('No open StagingDeployCash found, continuing...', err);
             core.setOutput('IS_LOCKED', false);

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
   deployStaging:
     runs-on: ubuntu-latest
     needs: validate
-    if: ${{ needs.validate.outputs.isAutomergePR == 'true' && github.ref == 'refs/heads/staging' }}
+    if: ${{ needs.validate.outputs.isAutomergePR && github.ref == 'refs/heads/staging' }}
 
     steps:
       - name: Checkout staging
@@ -42,7 +42,7 @@ jobs:
   deployProduction:
     runs-on: ubuntu-latest
     needs: validate
-    if: ${{ needs.validate.outputs.isAutomergePR == 'true' && github.ref == 'refs/heads/production' }}
+    if: ${{ needs.validate.outputs.isAutomergePR && github.ref == 'refs/heads/production' }}
 
     steps:
       - name: Checkout production

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
   deployStaging:
     runs-on: ubuntu-latest
     needs: validate
-    if: ${{ needs.validate.outputs.isAutomergePR && github.ref == 'refs/heads/staging' }}
+    if: ${{ needs.validate.outputs.isAutomergePR == 'true' && github.ref == 'refs/heads/staging' }}
 
     steps:
       - name: Checkout staging
@@ -42,7 +42,7 @@ jobs:
   deployProduction:
     runs-on: ubuntu-latest
     needs: validate
-    if: ${{ needs.validate.outputs.isAutomergePR && github.ref == 'refs/heads/production' }}
+    if: ${{ needs.validate.outputs.isAutomergePR == 'true' && github.ref == 'refs/heads/production' }}
 
     steps:
       - name: Checkout production

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -39,7 +39,7 @@ jobs:
     needs: chooseDeployActions
     if: |
       ${{ needs.chooseDeployActions.outputs.isStagingDeployLocked == 'true' }} &&
-      ${{ needs.chooseDeployActions.isVersionBumpPR == 'false' }}
+      ${{ !needs.chooseDeployActions.isVersionBumpPR }}
 
     steps:
       - name: Comment on deferred PR
@@ -53,7 +53,7 @@ jobs:
   version:
     runs-on: macos-latest
     needs: chooseDeployActions
-    if: ${{ needs.chooseDeployActions.outputs.isVersionBumpPR == 'false' }}
+    if: ${{ !needs.chooseDeployActions.outputs.isVersionBumpPR }}
     outputs:
       newVersion: ${{ steps.bumpVersion.outputs.NEW_VERSION }}
 
@@ -133,8 +133,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: chooseDeployActions
     if: |
-      ${{ needs.chooseDeployActions.outputs.isVersionBumpPR == 'true' }}
-      && ${{ needs.chooseDeployActions.outputs.isStagingDeployLocked == 'false' }}
+      ${{ needs.chooseDeployActions.outputs.isVersionBumpPR }} &&
+      ${{ needs.chooseDeployActions.outputs.isStagingDeployLocked == 'false' }}
 
     steps:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -109,6 +109,13 @@ jobs:
           body: Update version to ${{ steps.bumpVersion.outputs.NEW_VERSION }}
           labels: automerge
 
+      - name: Update StagingDeployCash
+        uses: Expensify/Expensify.cash/.github/actions/createOrUpdateStagingDeploy@master
+        with:
+          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+          NPM_VERSION: ${{ steps.bumpVersion.outputs.NEW_VERSION }}
+          NEW_PULL_REQUESTS: https://github.com/Expensify/Expensify.cash/pull/${{ needs.chooseDeployActions.outputs.mergedPullRequest }}
+
       # This Slack step is duplicated in all workflows, if you make a change to this step, make sure to update all
       # the other workflows with the same change
       - uses: 8398a7/action-slack@v3
@@ -143,6 +150,9 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.OS_BOTIFY_TOKEN }}
 
+      - name: Checkout master branch
+        run: git checkout master
+
       - name: Create Pull Request
         # Version: 2.4.3
         uses: repo-sync/pull-request@33777245b1aace1a58c87a29c90321aa7a74bd7d
@@ -151,12 +161,5 @@ jobs:
           destination_branch: staging
           pr_label: automerge
           github_token: ${{ secrets.OS_BOTIFY_TOKEN }}
-          pr_title: Update version to ${{ steps.bumpVersion.outputs.NEW_VERSION }} on staging
-          pr_body: Update version to ${{ steps.bumpVersion.outputs.NEW_VERSION }}
-
-      - name: Update StagingDeployCash
-        uses: Expensify/Expensify.cash/.github/actions/createOrUpdateStagingDeploy@master
-        with:
-          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
-          NPM_VERSION: ${{ steps.bumpVersion.outputs.NEW_VERSION }}
-          NEW_PULL_REQUESTS: https://github.com/Expensify/Expensify.cash/pull/${{ needs.chooseDeployActions.outputs.mergedPullRequest }}
+          pr_title: Update version to $(npm run print-version --silent) on staging
+          pr_body: Update version to $(npm run print-version --silent)

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -40,7 +40,7 @@ jobs:
     needs: chooseDeployActions
     if: |
       ${{ needs.chooseDeployActions.outputs.isStagingDeployLocked == 'true' }} &&
-      ${{ needs.chooseDeployActions.isVersionBumpPR == 'false' }}
+      ${{ needs.chooseDeployActions.outputs.isVersionBumpPR == 'false' }}
 
     steps:
       - name: Comment on deferred PR

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -32,6 +32,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 
       - name: Check if merged pull request was an automatic version bump PR
+        id: isVersionBumpPR
         run: echo "::set-output name=IS_VERSION_BUMP_PR::${{ contains(steps.getMergedPullRequest.outputs.labels.*.name, 'automerge') && github.actor == 'OSBotify' }}"
 
   skipDeploy:

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -40,7 +40,7 @@ jobs:
     needs: chooseDeployActions
     if: |
       ${{ needs.chooseDeployActions.outputs.isStagingDeployLocked == 'true' }} &&
-      ${{ !needs.chooseDeployActions.isVersionBumpPR }}
+      ${{ needs.chooseDeployActions.isVersionBumpPR == 'false' }}
 
     steps:
       - name: Comment on deferred PR
@@ -54,7 +54,7 @@ jobs:
   version:
     runs-on: macos-latest
     needs: chooseDeployActions
-    if: ${{ !needs.chooseDeployActions.outputs.isVersionBumpPR }}
+    if: ${{ needs.chooseDeployActions.outputs.isVersionBumpPR == 'false' }}
     outputs:
       newVersion: ${{ steps.bumpVersion.outputs.NEW_VERSION }}
 
@@ -134,7 +134,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: chooseDeployActions
     if: |
-      ${{ needs.chooseDeployActions.outputs.isVersionBumpPR }} &&
+      ${{ needs.chooseDeployActions.outputs.isVersionBumpPR == 'true' }} &&
       ${{ needs.chooseDeployActions.outputs.isStagingDeployLocked == 'false' }}
 
     steps:


### PR DESCRIPTION
Trying to debug problems with [this workflow run](https://github.com/Expensify/Expensify.cash/runs/2124477061?check_suite_focus=true), and I found several bugs:

1) The `chooseDeployActions` job was not outputting anything for it's `isVersionBumpPR` output. The reason for that was because it references `steps.isVersionBumpPR.outputs`, but there was no step with the `isVersionBumpPR` id. That's fixed now.
2) One of the `if` conditions for the `skipDeploy` job referenced `needs.chooseDeployActions.isVersionBumpPR`, but the `chooseDeployActions` job has no field `isVersionBumpPR`. Instead, we needed to reference `needs.chooseDeployActions.outputs.isVersionBumpPR` to reference the outputs of the required job.
3) The `updateStaging` job was trying to reference a step output of a different job (which should never be executed in the same workflow run as `updateStaging`. Instead, just use the version on master (because after all, we're updating the version on staging using the version on master).
4) We were referencing the merged pull request in the `updateStaging` job and adding it to the `StagingDeployCash`. However, if the `updateStaging` should only ever run if an automated version-bump PR is merged. Instead, we want a manually merged PR with code written by humans to be included in the `StagingDeployCash`, so we update that in the `version` job instead.