### PR TITLE
Make all conditionals one line in GH Actions

### DIFF
--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -38,9 +38,7 @@ jobs:
   skipDeploy:
     runs-on: ubuntu-latest
     needs: chooseDeployActions
-    if: |
-      ${{ needs.chooseDeployActions.outputs.isStagingDeployLocked == 'true' }} &&
-      ${{ needs.chooseDeployActions.outputs.isVersionBumpPR == 'false' }}
+    if: ${{ needs.chooseDeployActions.outputs.isStagingDeployLocked == 'true' && needs.chooseDeployActions.outputs.isVersionBumpPR == 'false' }}
 
     steps:
       - name: Comment on deferred PR
@@ -140,9 +138,7 @@ jobs:
   updateStaging:
     runs-on: ubuntu-latest
     needs: chooseDeployActions
-    if: |
-      ${{ needs.chooseDeployActions.outputs.isVersionBumpPR == 'true' }} &&
-      ${{ needs.chooseDeployActions.outputs.isStagingDeployLocked == 'false' }}
+    if: ${{ needs.chooseDeployActions.outputs.isVersionBumpPR == 'true' && needs.chooseDeployActions.outputs.isStagingDeployLocked == 'false' }}
 
     steps:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f


### PR DESCRIPTION
Broken workflow run: https://github.com/Expensify/Expensify.cash/runs/2125065170?check_suite_focus=true

`skipDeploy` and `updateStaging` should never be happening at the same time.

### Tests
Tested a bit in public-test-repo by:

1) Replicating the multiline syntax we had here for a number of different jobs
2) Seeing that they were all running no matter what
3) Making them all one line
4) Seeing that they were all run or skipped correctly https://github.com/Andrew-Test-Org/Public-Test-Repo/actions/runs/658903062