### PR TITLE
Remove bottom border from modals

### DIFF
--- a/src/components/AttachmentModal.js
+++ b/src/components/AttachmentModal.js
@@ -105,6 +105,7 @@ class AttachmentModal extends PureComponent {
                 >
                     <HeaderWithCloseButton
                         title={this.props.title}
+                        shouldShowBorderBottom
                         onDownloadButtonPress={() => fileDownload(sourceURL)}
                         onCloseButtonPress={() => this.setState({isModalOpen: false})}
                     />

--- a/src/components/HeaderWithCloseButton.js
+++ b/src/components/HeaderWithCloseButton.js
@@ -37,8 +37,8 @@ const defaultProps = {
     onCloseButtonPress: () => {},
     onBackButtonPress: () => {},
     shouldShowBackButton: false,
-    textSize: 'default',
-    shouldShowBorderBottom: true,
+    textSize: 'large',
+    shouldShowBorderBottom: false,
 };
 
 const HeaderWithCloseButton = props => (


### PR DESCRIPTION
@marcaaron could you please review? 

### Details
This removes the bottom border from most modals (except Attachment modal) and makes the text size larger by default as well. 

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/157102

### Tests
1. Click on your profile picture in the top right to launch the Settings modal.
2. Make sure the modal header does not have a bottom border
3. Make sure the modal header text is in a larger size (17px)
4. Open an attachment, and make sure the modal header has a bottom border

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web
![image](https://user-images.githubusercontent.com/2319350/111381718-5beec580-86a6-11eb-9078-26b9df1256bd.png)
![image](https://user-images.githubusercontent.com/2319350/111381758-67da8780-86a6-11eb-9b87-3d72cee7ebec.png)



#### Mobile Web
![image](https://user-images.githubusercontent.com/2319350/111381947-ac662300-86a6-11eb-8576-4ca601cf8fae.png)

![image](https://user-images.githubusercontent.com/2319350/111381973-b1c36d80-86a6-11eb-8eba-f7cf57cbeaaf.png)


#### Desktop
![image](https://user-images.githubusercontent.com/2319350/111382003-b851e500-86a6-11eb-8364-405680031b2e.png)

![image](https://user-images.githubusercontent.com/2319350/111382019-bd169900-86a6-11eb-853a-8d8552642b4d.png)


#### iOS
![image](https://user-images.githubusercontent.com/2319350/111381802-788afd80-86a6-11eb-93ae-ad610d8fb527.png)

![image](https://user-images.githubusercontent.com/2319350/111381793-745ee000-86a6-11eb-8080-1c998a9335a5.png)



#### Android
I can't get images to show up, but my changes are at least present:
![image](https://user-images.githubusercontent.com/2319350/111382369-2eeee280-86a7-11eb-9772-c5548b9348b9.png)

![image](https://user-images.githubusercontent.com/2319350/111382395-3adaa480-86a7-11eb-9a66-e6e3ed93ada2.png)

