### PR TITLE
Don't skip all actions on version update PRs, because it also skips automerge

### DIFF
--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -94,7 +94,7 @@ jobs:
             ./android/app/build.gradle \
             ./ios/ExpensifyCash/Info.plist \
             ./ios/ExpensifyCashTests/Info.plist
-          git commit -m "[skip actions] Update version to ${{ steps.bumpVersion.outputs.NEW_VERSION }}"
+          git commit -m "Update version to ${{ steps.bumpVersion.outputs.NEW_VERSION }}"
 
       - name: Create Pull Request (master)
         uses: peter-evans/create-pull-request@09b9ac155b0d5ad7d8d157ed32158c1b73689109


### PR DESCRIPTION

### Details
[This PR](https://github.com/Expensify/Expensify.cash/pull/1802/files) added some code to skip all Github Actions on automatically generated version-bump PRs, because we never wait for tests to finish on those anyways. However, this also skips the `automerge` workflow, which prevents the master branch from actually being updated.

Merge to test