### PR TITLE
Don't run CLA workflow twice

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -65,6 +65,9 @@ jobs:
             github-token: ${{ secrets.GITHUB_TOKEN }}
           if: github.event.pull_request.mergeable && github.event.pull_request.head.ref == 'master'
 
+        - name: Check PR mergable states
+          - run: echo "Mergeable - ${{ github.event.pull_request.mergeable }} Clean - ${{ github.event.pull_request.mergeable_state }}"
+
         - name: Check for an auto merge
           # Version: 0.12.0
           uses: pascalgn/automerge-action@c9bd1823770819dc8fb8a5db2d11a3a95fbe9b07

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -66,7 +66,7 @@ jobs:
           if: github.event.pull_request.mergeable && github.event.pull_request.head.ref == 'master'
 
         - name: Check PR mergable states
-          - run: echo "Mergeable - ${{ github.event.pull_request.mergeable }} Clean - ${{ github.event.pull_request.mergeable_state }}"
+          run: echo "Mergeable - ${{ github.event.pull_request.mergeable }} Clean - ${{ github.event.pull_request.mergeable_state }}"
 
         - name: Check for an auto merge
           # Version: 0.12.0

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -6,7 +6,7 @@ on:
     pull_request_target:
         types: [opened, closed, synchronize]
     pull_request:
-      branches-ignore: [staging, production]
+      branches-ignore: [master, staging, production]
 
 jobs:
     CLA:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -5,8 +5,7 @@ on:
         types: [created]
     pull_request_target:
         types: [opened, closed, synchronize]
-    pull_request:
-      branches-ignore: [master, staging, production]
+        branches-ignore: [staging, production]
 
 jobs:
     CLA:

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -63,16 +63,6 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.OS_BOTIFY_TOKEN }}
 
-        # TODO: Remove once we know that automerge doesn't infinitely loop with this action
-      - name: Check current version
-        id: checkCurrentVersion
-        run: echo "::set-output name=CURRENT_VERSION::$(npm run print-version --silent)"
-
-        # TODO: Remove once we know that automerge doesn't infinitely loop with this action
-      - name: Quit early
-        if: ${{ steps.checkCurrentVersion.outputs.CURRENT_VERSION == '1.0.2-60' }}
-        run: exit 1
-
       - uses: softprops/turnstyle@8db075d65b19bf94e6e8687b504db69938dc3c65
         with:
           poll-interval-seconds: 10


### PR DESCRIPTION
### Details
This PR fixes a side effect of https://github.com/Expensify/Expensify.cash/pull/1802#issuecomment-800657505 where the CLA workflow runs on master twice. Since we already have this workflow running on `pull_request_target`, we should be able to exclude it from running on master for `pull_request` actions

### Tests
Created this PR, confirmed the CLA workflow only ran once on `pull_request_target`
![image](https://user-images.githubusercontent.com/3981102/111391816-98a0c980-8672-11eb-8330-0f7290207dbd.png)
