### PR TITLE
Make OSBotify perform the automerge

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -31,7 +31,7 @@ jobs:
               uses: pascalgn/automerge-action@c9bd1823770819dc8fb8a5db2d11a3a95fbe9b07
               if: github.event.pull_request.mergeable && github.event.pull_request.mergeable_state == 'clean'
               env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 
             # This Slack step is duplicated in all workflows, if you make a change to this step, make sure to update all
             # the other workflows with the same change

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -63,6 +63,15 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.OS_BOTIFY_TOKEN }}
 
+        # TODO: Remove once we know that automerge doesn't infinitely loop with this action
+      - name: Check current version
+        id: checkCurrentVersion
+        run: echo "::set-output name=CURRENT_VERSION::$(npm run print-version --silent)"
+
+        # TODO: Remove once we know that automerge doesn't infinitely loop with this action
+      - name: Quit early
+        run: if [[ ${{ steps.checkCurrentVersion.outputs.CURRENT_VERSION == '1.0.2-60' }} ]]; then exit 1; fi;
+
       - uses: softprops/turnstyle@8db075d65b19bf94e6e8687b504db69938dc3c65
         with:
           poll-interval-seconds: 10


### PR DESCRIPTION

### Details
[This PR](https://github.com/Expensify/Expensify.cash/pull/1806) restored the automerge workflow, but failed to see us through a full deploy, because the automerged PR did not re-trigger the `preDeploy` workflow.

I found [this GH issue](https://github.com/peter-evans/create-pull-request/issues/48), and I believe it alludes to the [root of the problem](https://github.com/peter-evans/create-pull-request/issues/48#issuecomment-536184102). Basically, GH actions can't be triggered by other GH actions. It also presents a solution, which I've implemented in this PR. That is, make OS_BOTIFY merge the version-bump PR and hopefully it will merge another action.

We have [code in place in the `preDeploy` workflow](https://github.com/Expensify/Expensify.cash/blob/693d75fc95e3b36592c7605067470c492931b894/.github/workflows/preDeploy.yml#L13) that should check if the PR that triggered it was an automerge version bump PR, but merging this PR would be the first real test of that code.

_If that code doesn't work_, there is a risk that we could be causing an infinite loop where we bump the version, create an automerge PR, merge the PR, causing us to then bump the version again and restart the process. 😬 Hopefully _THAT_ doesn't happen.

