### PR TITLE
Remove wildcard array mapping of label to name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Check if merged pull request was an automatic version bump PR
         id: isAutomergePR
-        run: echo "::set-output name=IS_AUTOMERGE_PR::${{ contains(steps.getMergedPullRequest.outputs.labels.*.name, 'automerge') && github.actor == 'OSBotify' }}"
+        run: echo "::set-output name=IS_AUTOMERGE_PR::${{ contains(steps.getMergedPullRequest.outputs.labels, 'automerge') && github.actor == 'OSBotify' }}"
 
   deployStaging:
     runs-on: ubuntu-latest

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Check if merged pull request was an automatic version bump PR
         id: isVersionBumpPR
-        run: echo "::set-output name=IS_VERSION_BUMP_PR::${{ contains(steps.getMergedPullRequest.outputs.labels.*.name, 'automerge') && github.actor == 'OSBotify' }}"
+        run: echo "::set-output name=IS_VERSION_BUMP_PR::${{ contains(steps.getMergedPullRequest.outputs.labels, 'automerge') && github.actor == 'OSBotify' }}"
 
   skipDeploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION

### Details
https://github.com/Expensify/Expensify.cash/pull/1810 fixed the automerge issues we've been having, so that version bump PRs are successfully auto-merged to master. However, that automerge caused [this workflow run](https://github.com/Expensify/Expensify.cash/runs/2126497700?check_suite_focus=true), which would have led to an infinite loop of bumping version, automerging PR, and bumping version again.

The purpose of this PR is to prevent that infinite loop.

Normally Github labels are objects, where the 'name' property of the object is the text content of the label. In that case, the wildcard syntax would be correct, like in this example from their docs:

![image](https://user-images.githubusercontent.com/47436092/111396186-ccccb800-867b-11eb-90f9-e03929791333.png)

However, https://github.com/actions-ecosystem/action-get-merged-pull-request [internally maps labels to their name](https://github.com/actions-ecosystem/action-get-merged-pull-request/blob/cb1e7423b3ca9886f619a8b93874b2e72abfb87c/src/main.ts#L62) to provide it's label output. So we don't need to do that wildcard mapping stuff.
