### PR TITLE
Skip CLA for pull requests where OSBotify is the author

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -10,6 +10,7 @@ jobs:
     CLA:
         runs-on: ubuntu-latest
         # This job only runs for pull request comments or pull request target events (not issue comments)
+        # It does not run for pull requests created by OSBotify
         if: github.event.issue.pull_request || (github.event_name == 'pull_request_target' && github.event.pull_request.user.login != 'OSBotify')
         steps:
             - uses: actions-ecosystem/action-regex-match@9c35fe9ac1840239939c59e5db8839422eed8a73

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -5,13 +5,12 @@ on:
         types: [created]
     pull_request_target:
         types: [opened, closed, synchronize]
-        branches-ignore: [staging, production]
 
 jobs:
     CLA:
         runs-on: ubuntu-latest
         # This job only runs for pull request comments or pull request target events (not issue comments)
-        if: github.event.issue.pull_request || github.event_name == 'pull_request_target'
+        if: github.event.issue.pull_request || (github.event_name == 'pull_request_target' && github.event.pull_request.head.ref != 'staging' && github.event.pull_request.head.ref != 'production')
         steps:
             - uses: actions-ecosystem/action-regex-match@9c35fe9ac1840239939c59e5db8839422eed8a73
               id: sign

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -10,7 +10,7 @@ jobs:
     CLA:
         runs-on: ubuntu-latest
         # This job only runs for pull request comments or pull request target events (not issue comments)
-        if: github.event.issue.pull_request || (github.event_name == 'pull_request_target' && github.event.pull_request.head.ref != 'staging' && github.event.pull_request.head.ref != 'production')
+        if: github.event.issue.pull_request || (github.event_name == 'pull_request_target' && github.event.pull_request.user.login != 'OSBotify')
         steps:
             - uses: actions-ecosystem/action-regex-match@9c35fe9ac1840239939c59e5db8839422eed8a73
               id: sign


### PR DESCRIPTION

### Details
CLA is failing on automerge PRs, which we think causes them to not be automatically merged.

To fix this, skip CLA for PRs created by `OSBotify`