### PR TITLE
Echo cla actor

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -13,6 +13,7 @@ jobs:
         # It does not run for pull requests created by OSBotify
         if: ${{ github.event.issue.pull_request || (github.event_name == 'pull_request_target' && github.event.pull_request.user.login != 'OSBotify') }}
         steps:
+            # TODO: remove this first run step
             - run: echo ${{ github.event.pull_request.user.login }}
             - uses: actions-ecosystem/action-regex-match@9c35fe9ac1840239939c59e5db8839422eed8a73
               id: sign

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -13,6 +13,7 @@ jobs:
         # It does not run for pull requests created by OSBotify
         if: github.event.issue.pull_request || (github.event_name == 'pull_request_target' && github.event.pull_request.user.login != 'OSBotify')
         steps:
+            - run: echo ${{ github.event.pull_request.user.login }}
             - uses: actions-ecosystem/action-regex-match@9c35fe9ac1840239939c59e5db8839422eed8a73
               id: sign
               with:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ubuntu-latest
         # This job only runs for pull request comments or pull request target events (not issue comments)
         # It does not run for pull requests created by OSBotify
-        if: github.event.issue.pull_request || (github.event_name == 'pull_request_target' && github.event.pull_request.user.login != 'OSBotify')
+        if: ${{ github.event.issue.pull_request || (github.event_name == 'pull_request_target' && github.event.pull_request.user.login != 'OSBotify') }}
         steps:
             - run: echo ${{ github.event.pull_request.user.login }}
             - uses: actions-ecosystem/action-regex-match@9c35fe9ac1840239939c59e5db8839422eed8a73


### PR DESCRIPTION
Tested in Public-Test-Repo https://github.com/Andrew-Test-Org/Public-Test-Repo/pull/44/checks?check_run_id=2127201191 and `github.event.pull_request.user.login` does give the creator of the PR. So it must be some other syntax error. This is a bit of a shot-in-the-dark, but given the following passage from the GH Actions docs, I think it's worth a shot:

![image](https://user-images.githubusercontent.com/47436092/111406154-fba05980-868e-11eb-8cd0-604e19e7ee4f.png)
