### PR TITLE
Don't require clean mergeable state

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -68,10 +68,11 @@ jobs:
         - name: Check PR mergable states
           run: echo "Mergeable - ${{ github.event.pull_request.mergeable }} Clean - ${{ github.event.pull_request.mergeable_state }}"
 
+        # TODO: make sure PR is in "clean" mergeable_state
         - name: Check for an auto merge
           # Version: 0.12.0
           uses: pascalgn/automerge-action@c9bd1823770819dc8fb8a5db2d11a3a95fbe9b07
-          if: github.event.pull_request.mergeable && github.event.pull_request.mergeable_state == 'clean'
+          if: github.event.pull_request.mergeable
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION

### Details
[This PR comment](https://github.com/Expensify/Expensify.cash/pull/1821#issuecomment-800758569) lays out the current state of our deploys. We're very close, but we're not successfully updating the `staging` branch because of failing CLA checks on the automerge PR.

Ideally we would skip CLA on automerge PRs so that they would be able to be in a clean mergeable_state (no failing checks), but unfortunately that code is not working. The purpose of this PR is to get deploys in a functional state before I leave for the night.
