### PR TITLE
Make automerge workflows trigger deploys

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -74,7 +74,7 @@ jobs:
           uses: pascalgn/automerge-action@c9bd1823770819dc8fb8a5db2d11a3a95fbe9b07
           if: github.event.pull_request.mergeable
           env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 
         # This Slack step is duplicated in all workflows, if you make a change to this step, make sure to update all
         # the other workflows with the same change
@@ -113,7 +113,7 @@ jobs:
           uses: pascalgn/automerge-action@c9bd1823770819dc8fb8a5db2d11a3a95fbe9b07
           if: github.event.pull_request.mergeable && github.event.pull_request.mergeable_state == 'clean'
           env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 
         # This Slack step is duplicated in all workflows, if you make a change to this step, make sure to update all
         # the other workflows with the same change


### PR DESCRIPTION
Last deploy runs succeeded in updating the `staging` branch with new code. However, the automerged PR failed to trigger a staging deploy. The reason for this is almost definitely because we used the `GITHUB_TOKEN` to trigger the merge, and Github Actions prevents the Github Actions bot from triggering another workflow. To fix, just use the `OS_BOTIFY_TOKEN`