### PR TITLE
Undo revert of clean staging PR check

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -68,11 +68,10 @@ jobs:
         - name: Check PR mergable states
           run: echo "Mergeable - ${{ github.event.pull_request.mergeable }} Clean - ${{ github.event.pull_request.mergeable_state }}"
 
-        # TODO: make sure PR is in "clean" mergeable_state
         - name: Check for an auto merge
           # Version: 0.12.0
           uses: pascalgn/automerge-action@c9bd1823770819dc8fb8a5db2d11a3a95fbe9b07
-          if: github.event.pull_request.mergeable
+          if: github.event.pull_request.mergeable && github.event.pull_request.mergeable_state == 'clean'
           env:
             GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -11,11 +11,8 @@ jobs:
         runs-on: ubuntu-latest
         # This job only runs for pull request comments or pull request target events (not issue comments)
         # It does not run for pull requests created by OSBotify
-        # TODO: Fix this if so that it doesn't run CLA for pull requests created by OSBotify
         if: ${{ github.event.issue.pull_request || (github.event_name == 'pull_request_target' && github.event.pull_request.user.login != 'OSBotify') }}
         steps:
-            # TODO: remove this first run step
-            - run: echo ${{ github.event.pull_request.user.login }}
             - uses: actions-ecosystem/action-regex-match@9c35fe9ac1840239939c59e5db8839422eed8a73
               id: sign
               with:


### PR DESCRIPTION
### Details
This reverts some checks for the "clean" status of a staging PR. I believe with our current code we are correctly skipping the CLA checks, meaning the staging PR will be clean and able to be merged.

### Fixed Issues
Fixes N/A

### Tests
1. Merge this PR
2. Verify that the staging PR created and merged automatically
