### PR TITLE
Move deploy to staging back to preDeploy for race condition

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy code to staging or production
 
 on:
   push:
-    branches: [staging, production]
+    branches: [production]
 
 jobs:
   validate:
@@ -20,24 +20,6 @@ jobs:
       - name: Check if merged pull request was an automatic version bump PR
         id: isAutomergePR
         run: echo "::set-output name=IS_AUTOMERGE_PR::${{ contains(steps.getMergedPullRequest.outputs.labels, 'automerge') && github.actor == 'OSBotify' }}"
-
-  deployStaging:
-    runs-on: ubuntu-latest
-    needs: validate
-    if: ${{ needs.validate.outputs.isAutomergePR == 'true' && github.ref == 'refs/heads/staging' }}
-
-    steps:
-      - name: Checkout staging
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
-        with:
-          ref: staging
-          token: ${{ secrets.OS_BOTIFY_TOKEN }}
-
-      - name: Tag version
-        run: git tag $(npm run print-version --silent)
-
-      - name: 🚀 Push tags to trigger staging deploy 🚀
-        run: git push --tags
 
   deployProduction:
     runs-on: ubuntu-latest

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -114,6 +114,7 @@ jobs:
           NPM_VERSION: ${{ steps.bumpVersion.outputs.NEW_VERSION }}
           NEW_PULL_REQUESTS: https://github.com/Expensify/Expensify.cash/pull/${{ needs.chooseDeployActions.outputs.mergedPullRequest }}
 
+      #TODO: Once we add cherry picking, we will need run this from elsewhere
       - name: Tag version
         run: git tag ${{ steps.bumpVersion.outputs.NEW_VERSION }}
 

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -114,6 +114,12 @@ jobs:
           NPM_VERSION: ${{ steps.bumpVersion.outputs.NEW_VERSION }}
           NEW_PULL_REQUESTS: https://github.com/Expensify/Expensify.cash/pull/${{ needs.chooseDeployActions.outputs.mergedPullRequest }}
 
+      - name: Tag version
+        run: git tag ${{ steps.bumpVersion.outputs.NEW_VERSION }}
+
+      - name: 🚀 Push tags to trigger staging deploy 🚀
+        run: git push --tags
+
       # This Slack step is duplicated in all workflows, if you make a change to this step, make sure to update all
       # the other workflows with the same change
       - uses: 8398a7/action-slack@v3


### PR DESCRIPTION
### Details
Fixes race condition we added with `deploy.yml` by moving this back into preDeploy which runs under turnstyle which will only allow one staging deploy version to get determined at a time.

### Fixed Issues
Fixes race condition we added with `deploy.yml`

### Tests
1. Merge this PR
2. Verify it pushes tags and runs a staging deploy on the preDeploy step
