### PR TITLE
Fix typo in automerge workflow

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -23,7 +23,7 @@ jobs:
           uses: Expensify/Expensify.cash/.github/actions/isPullRequestMergeable@master
           with:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            PULL_REQUEST_NUMBER: ${{ github.events.pull_request.number }}
+            PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
 
     master:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Failed workflow run: https://github.com/Expensify/Expensify.cash/runs/2135524966?check_suite_focus=true

[This PR](https://github.com/Expensify/Expensify.cash/pull/1847/files) introduced a typo in the `automerge` workflow. This PR should fix that typo. 