### PR TITLE
Create finishReleaseCycle workflow

### DIFF
--- a/.github/workflows/finishReleaseCycle.yml
+++ b/.github/workflows/finishReleaseCycle.yml
@@ -79,12 +79,11 @@ jobs:
       - name: 🚀 Push tags to trigger staging deploy 🚀
         run: git push --tags
 
-      - name: Create StagingDeployCash
+      - name: Create new StagingDeployCash
         uses: Expensify/Expensify.cash/.github/actions/createOrUpdateStagingDeploy@master
         with:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
           NPM_VERSION: ${{ steps.bumpVersion.outputs.NEW_VERSION }}
-          NEW_PULL_REQUESTS: https://github.com/Expensify/Expensify.cash/pull/${{ needs.chooseDeployActions.outputs.mergedPullRequest }}
 
       # This Slack step is duplicated in all workflows, if you make a change to this step, make sure to update all
       # the other workflows with the same change

--- a/.github/workflows/finishReleaseCycle.yml
+++ b/.github/workflows/finishReleaseCycle.yml
@@ -16,14 +16,12 @@ jobs:
     steps:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
+          ref: staging
           fetch-depth: 0
           token: ${{ secrets.OS_BOTIFY_TOKEN }}
 
       - name: Set up git config
         run: git config user.name OSBotify
-
-      - name: Checkout staging branch
-        run: git checkout staging
 
       - name: Set new version for production branch
         run: echo "PRODUCTION_VERSION=$(npm run print-version --silent)" >> $GITHUB_ENV

--- a/.github/workflows/finishReleaseCycle.yml
+++ b/.github/workflows/finishReleaseCycle.yml
@@ -1,0 +1,108 @@
+name: Prepare production deploy
+
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  # This job is executed when a StagingDeployCash is closed.
+  # It updates the production branch to trigger the production deploy,
+  # and creates a new StagingDeployCash for the next release cycle.
+  updateProduction:
+    runs-on: ubuntu-latest
+
+    # Note: Anyone with Triage access to the Expensify.cash repo can trigger a production deploy
+    if: contains(github.event.issue.labels.*.name, 'StagingDeployCash')
+    steps:
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.OS_BOTIFY_TOKEN }}
+
+      - name: Set up git config
+        run: git config user.name OSBotify
+
+      - name: Checkout staging branch
+        run: git checkout staging
+
+      - name: Set new version for production branch
+        run: echo "PRODUCTION_VERSION=$(npm run print-version --silent)" >> $GITHUB_ENV
+
+      - name: Create Pull Request (production)
+        # Version: 2.4.3
+        uses: repo-sync/pull-request@33777245b1aace1a58c87a29c90321aa7a74bd7d
+        with:
+          source_branch: staging
+          destination_branch: production
+          pr_label: automerge
+          github_token: ${{ secrets.OS_BOTIFY_TOKEN }}
+          pr_title: Update version to ${{ env.PRODUCTION_VERSION }} on staging
+          pr_body: Update version to ${{ env.PRODUCTION_VERSION }}
+
+      - name: Create a new branch off master
+        run: |
+          git checkout master
+          git checkout -b version-bump-${{ github.sha }}
+          git push --set-upstream origin version-bump-${{ github.sha }}
+
+      - name: Generate a new version
+        id: bumpVersion
+        uses: Expensify/Expensify.cash/.github/actions/bumpVersion@master
+        with:
+          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+
+      - name: Commit new version
+        run: |
+          git add \
+            ./package.json \
+            ./package-lock.json \
+            ./android/app/build.gradle \
+            ./ios/ExpensifyCash/Info.plist \
+            ./ios/ExpensifyCashTests/Info.plist
+          git commit -m "Update version to ${{ steps.bumpVersion.outputs.NEW_VERSION }}"
+
+      - name: Create Pull Request (master)
+        uses: peter-evans/create-pull-request@09b9ac155b0d5ad7d8d157ed32158c1b73689109
+        with:
+          token: ${{ secrets.OS_BOTIFY_TOKEN }}
+          author: OSBotify <reactnative@expensify.com>
+          base: master
+          branch: version-bump-${{ github.sha }}
+          title: Update version to ${{ steps.bumpVersion.outputs.NEW_VERSION }} on master
+          body: Update version to ${{ steps.bumpVersion.outputs.NEW_VERSION }}
+          labels: automerge
+
+      #TODO: Once we add cherry picking, we will need run this from elsewhere
+      - name: Tag version
+        run: git tag ${{ steps.bumpVersion.outputs.NEW_VERSION }}
+
+      - name: 🚀 Push tags to trigger staging deploy 🚀
+        run: git push --tags
+
+      - name: Create StagingDeployCash
+        uses: Expensify/Expensify.cash/.github/actions/createOrUpdateStagingDeploy@master
+        with:
+          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+          NPM_VERSION: ${{ steps.bumpVersion.outputs.NEW_VERSION }}
+          NEW_PULL_REQUESTS: https://github.com/Expensify/Expensify.cash/pull/${{ needs.chooseDeployActions.outputs.mergedPullRequest }}
+
+      # This Slack step is duplicated in all workflows, if you make a change to this step, make sure to update all
+      # the other workflows with the same change
+      - uses: 8398a7/action-slack@v3
+        name: Job failed Slack notification
+        if: ${{ failure() }}
+        with:
+          status: custom
+          fields: workflow, repo
+          custom_payload: |
+            {
+              channel: '#announce',
+              attachments: [{
+                color: "#DB4545",
+                pretext: `<!here>`,
+                text: `💥 ${process.env.AS_REPO} failed on ${process.env.AS_WORKFLOW} workflow 💥`,
+              }]
+            }
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -159,7 +159,7 @@ jobs:
       - name: Set Staging Version
         run: echo "STAGING_VERSION=$(npm run print-version --silent)" >> $GITHUB_ENV
 
-      - name: Create Pull Request
+      - name: Create Pull Request (staging)
         # Version: 2.4.3
         uses: repo-sync/pull-request@33777245b1aace1a58c87a29c90321aa7a74bd7d
         with:


### PR DESCRIPTION
### Details
This is _slightly_ different from the design doc in that we're going to be deploying to staging/production only when the corresponding branch has actually been updated. So we have two workflows, `finishReleaseCycle` and `deploy`, rather than just the one `productionDeployCash` outlined in the doc. The high-level process is the same:

1) QA is completed, so the `StagingDeployCash` is closed
2) That triggers the `finishReleaseCycle` workflow, which:
    i) Creates an automerge pull request from staging -> production
    ii) Generates a new BUILD version on master and deploys staging (i.e: deploy all the PRs that were deferred during QA)
    iii) Creates a new `StagingDeployCash`
3) When the automerge PR from (2i) is merged and the production branch is actually updated, then the `deploy` workflow is triggered and we'll create a release to perform the actual production deploy.

### Fixed Issues
Fixes (partial) https://github.com/Expensify/Expensify/issues/155221

### Tests
To test this workflow, we'll need to:

1) Merge this PR
2) Close an E.cash issue labeled `StagingDeployCash`

We'll then expect that:

- [ ] An automerge PR is created from staging -> production
- [ ] A new `BUILD` version is created off master.
- [ ] An automerge PR for that new version is created w/ master as the base. Only the version files should be updated in that PR, and it should be merged.
- [ ] Tags should be pushed, and a staging deploy should happen
- [ ] A new StagingDeployCash should be triggered.

