### PR TITLE
Auto-retry cocoapods installation

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,14 +33,12 @@ jobs:
             - name: Install detox
               run: npm install -g detox-cli
 
-            - run: cd ios
-
             - name: Install cocoapods
               uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
               with:
                 timeout_minutes: 15
                 max_attempts: 3
-                command: pod install --repo-update
+                command: cd ios && pod install --repo-update
 
             - name: Install brew depdencies
               run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,8 +33,14 @@ jobs:
             - name: Install detox
               run: npm install -g detox-cli
 
+            - run: cd ios
+
             - name: Install cocoapods
-              run: cd ios && pod install --repo-update
+              uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
+              with:
+                timeout_minutes: 15
+                max_attempts: 3
+                command: pod install --repo-update
 
             - name: Install brew depdencies
               run: |


### PR DESCRIPTION

### Details
I had two iOS e2e test runs fail due to network errors during cocoapods installation.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/157765

### Tests
Wait for E2E tests to pass on this PR.

### Tested On

- Github only :)