### PR TITLE
Skip automerge on random PRs

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
     getPullRequestMergeability:
+      if: github.actor == 'OSBotify' && github.event.label.name == 'automerge'
       runs-on: ubuntu-latest
       outputs:
         isMergeable: ${{ steps.isPullRequestMergeable.outputs.IS_MERGEABLE }}


### PR DESCRIPTION

### Details
The first job of the automerge workflow is currently running on all PRs. example: https://github.com/Expensify/Expensify.cash/actions/runs/665933320

This PR should fix that.