### PR TITLE
Move UpdateStagingDeployCash to after when tags are pushed

### DIFF
--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -107,10 +107,10 @@ jobs:
           body: Update version to ${{ steps.bumpVersion.outputs.NEW_VERSION }}
           labels: automerge
 
-      #TODO: Once we add cherry picking, we will need run this from elsewhere
       - name: Tag version
         run: git tag ${{ steps.bumpVersion.outputs.NEW_VERSION }}
 
+      #TODO: Once we add cherry picking, we will need run this from elsewhere
       - name: 🚀 Push tags to trigger staging deploy 🚀
         run: git push --tags
 

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -107,19 +107,19 @@ jobs:
           body: Update version to ${{ steps.bumpVersion.outputs.NEW_VERSION }}
           labels: automerge
 
-      - name: Update StagingDeployCash
-        uses: Expensify/Expensify.cash/.github/actions/createOrUpdateStagingDeploy@master
-        with:
-          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
-          NPM_VERSION: ${{ steps.bumpVersion.outputs.NEW_VERSION }}
-          NEW_PULL_REQUESTS: https://github.com/Expensify/Expensify.cash/pull/${{ needs.chooseDeployActions.outputs.mergedPullRequest }}
-
       #TODO: Once we add cherry picking, we will need run this from elsewhere
       - name: Tag version
         run: git tag ${{ steps.bumpVersion.outputs.NEW_VERSION }}
 
       - name: 🚀 Push tags to trigger staging deploy 🚀
         run: git push --tags
+
+      - name: Update StagingDeployCash
+        uses: Expensify/Expensify.cash/.github/actions/createOrUpdateStagingDeploy@master
+        with:
+          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+          NPM_VERSION: ${{ steps.bumpVersion.outputs.NEW_VERSION }}
+          NEW_PULL_REQUESTS: https://github.com/Expensify/Expensify.cash/pull/${{ needs.chooseDeployActions.outputs.mergedPullRequest }}
 
       # This Slack step is duplicated in all workflows, if you make a change to this step, make sure to update all
       # the other workflows with the same change


### PR DESCRIPTION
Broken workflow: https://github.com/Expensify/Expensify.cash/runs/2143576420?check_suite_focus=true

What happened: we tried to use a `git log` command with a tag that was not yet created.

This PR should introduce a temporary fix (because eventually we'll want to only push tags in the `deploy` workflow, not the `preDeploy` workflow. Long-term, the fix would probably be to just create the tag locally in the `preDeploy` workflow but never push it and let it die with the runner. 