### PR TITLE
Announce in Slack if automerge fails because PR is not mergeable

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -26,11 +26,15 @@ jobs:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
 
+        - name: Fail workflow if PR is not mergeable
+          if: ${{ steps.isPullRequestMergeable.outputs.IS_MERGEABLE }}
+          run: exit 1
+
         # This Slack step is duplicated in all workflows, if you make a change to this step, make sure to update all
         # the other workflows with the same change
         - uses: 8398a7/action-slack@v3
           name: Job failed Slack notification
-          if: ${{ steps.isPullRequestMergeable.outputs.IS_MERGEABLE == 'false' }}
+          if: ${{ failure() }}
           with:
             status: custom
             fields: workflow, repo
@@ -46,7 +50,6 @@ jobs:
           env:
             GITHUB_TOKEN: ${{ github.token }}
             SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
-
 
     master:
         runs-on: ubuntu-latest

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -26,6 +26,28 @@ jobs:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
 
+        # This Slack step is duplicated in all workflows, if you make a change to this step, make sure to update all
+        # the other workflows with the same change
+        - uses: 8398a7/action-slack@v3
+          name: Job failed Slack notification
+          if: ${{ steps.isPullRequestMergeable.outputs.IS_MERGEABLE == 'false' }}
+          with:
+            status: custom
+            fields: workflow, repo
+            custom_payload: |
+              {
+                channel: '#announce',
+                attachments: [{
+                  color: "#DB4545",
+                  pretext: `<!here>`,
+                  text: `💥 ${process.env.AS_REPO} failed on ${process.env.AS_WORKFLOW} workflow 💥`,
+                }]
+              }
+          env:
+            GITHUB_TOKEN: ${{ github.token }}
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+
+
     master:
         runs-on: ubuntu-latest
         needs: getPullRequestMergeability

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -27,7 +27,7 @@ jobs:
             PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
 
         - name: Fail workflow if PR is not mergeable
-          if: ${{ steps.isPullRequestMergeable.outputs.IS_MERGEABLE }}
+          if: ${{ steps.isPullRequestMergeable.outputs.IS_MERGEABLE == 'false' }}
           run: exit 1
 
         # This Slack step is duplicated in all workflows, if you make a change to this step, make sure to update all

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -68,12 +68,11 @@ jobs:
               uses: hmarr/auto-approve-action@7782c7e2bdf62b4d79bdcded8332808fd2f179cd
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
-              if: needs.getPullRequestMergeability.outputs.isMergeable == 'true' && steps.changed.outputs.files_updated == 'android/app/build.gradle ios/ExpensifyCash/Info.plist ios/ExpensifyCashTests/Info.plist package-lock.json package.json' && steps.changed.outputs.files_created == '' && steps.changed.outputs.files_deleted == ''
+              if: steps.changed.outputs.files_updated == 'android/app/build.gradle ios/ExpensifyCash/Info.plist ios/ExpensifyCashTests/Info.plist package-lock.json package.json' && steps.changed.outputs.files_created == '' && steps.changed.outputs.files_deleted == ''
 
             - name: Check for an auto merge
               # Version: 0.12.0
               uses: pascalgn/automerge-action@c9bd1823770819dc8fb8a5db2d11a3a95fbe9b07
-              if: needs.getPullRequestMergeability.outputs.isMergeable == 'true'
               env:
                   GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 
@@ -108,12 +107,11 @@ jobs:
           uses: hmarr/auto-approve-action@7782c7e2bdf62b4d79bdcded8332808fd2f179cd
           with:
             github-token: ${{ secrets.GITHUB_TOKEN }}
-          if: needs.getPullRequestMergeability.outputs.isMergeable == 'true' && github.event.pull_request.head.ref == 'master'
+          if: github.event.pull_request.head.ref == 'master'
 
         - name: Check for an auto merge
           # Version: 0.12.0
           uses: pascalgn/automerge-action@c9bd1823770819dc8fb8a5db2d11a3a95fbe9b07
-          if: needs.getPullRequestMergeability.outputs.isMergeable == 'true'
           env:
             GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 
@@ -148,12 +146,11 @@ jobs:
           uses: hmarr/auto-approve-action@7782c7e2bdf62b4d79bdcded8332808fd2f179cd
           with:
             github-token: ${{ secrets.GITHUB_TOKEN }}
-          if: needs.getPullRequestMergeability.outputs.isMergeable == 'true' && github.event.pull_request.head.ref == 'staging'
+          if: github.event.pull_request.head.ref == 'staging'
 
         - name: Check for an auto merge
           # Version: 0.12.0
           uses: pascalgn/automerge-action@c9bd1823770819dc8fb8a5db2d11a3a95fbe9b07
-          if: needs.getPullRequestMergeability.outputs.isMergeable == 'true'
           env:
             GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -70,7 +70,7 @@ jobs:
             - name: Check for an auto merge
               # Version: 0.12.0
               uses: pascalgn/automerge-action@c9bd1823770819dc8fb8a5db2d11a3a95fbe9b07
-              if: needs.getPullRequestMergeability.outputs.isMergeable == 'true' && github.event.pull_request.mergeable_state == 'clean'
+              if: needs.getPullRequestMergeability.outputs.isMergeable == 'true'
               env:
                   GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 
@@ -110,7 +110,7 @@ jobs:
         - name: Check for an auto merge
           # Version: 0.12.0
           uses: pascalgn/automerge-action@c9bd1823770819dc8fb8a5db2d11a3a95fbe9b07
-          if: needs.getPullRequestMergeability.outputs.isMergeable == 'true' && github.event.pull_request.mergeable_state == 'clean'
+          if: needs.getPullRequestMergeability.outputs.isMergeable == 'true'
           env:
             GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 
@@ -150,7 +150,7 @@ jobs:
         - name: Check for an auto merge
           # Version: 0.12.0
           uses: pascalgn/automerge-action@c9bd1823770819dc8fb8a5db2d11a3a95fbe9b07
-          if: needs.getPullRequestMergeability.outputs.isMergeable == 'true' && github.event.pull_request.mergeable_state == 'clean'
+          if: needs.getPullRequestMergeability.outputs.isMergeable == 'true'
           env:
             GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 


### PR DESCRIPTION
Fixing failed workflow run: https://github.com/Expensify/Expensify.cash/runs/2143920797?check_suite_focus=true

The `mergeable_state` of a PR is mix of whether it is `mergeable` _and_ has all its PR checks completed and passed. While checks are still running, the `mergeable_state` is `unstable`. Both `mergeable` and `mergeable_state` are determined asynchronously in Github using background jobs.

So we have a custom Javascript action to poll continually until the mergeability of a PR is settled. This PR adds a slack announcement in the case that an `automerge` PR is created that's _not_ mergeable (should not happen, hence the slack announcement). We also could poll and wait for the `mergeable_state` to be settled, but frankly we don't care about that field, since we skip all the checks on the `automerge` PRs anyways. So this PR also removes the checks we had in place for `mergeable_state`, which caused the automerge workflow to silently fail unnecessarily.