### PR TITLE
Fix typo in deployProduction job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
       - name: 🚀 Create release to trigger production deploy 🚀
         uses: softprops/action-gh-release@b7e450da2a4b4cb4bfbae528f788167786cfcedf
         with:
-          tag_name: ${{ env.PRODUCTION_VERSION }]
+          tag_name: ${{ env.PRODUCTION_VERSION }}
           body: ${{ steps.getReleaseBody.outputs.RELEASE_BODY }}
 
         env:


### PR DESCRIPTION
Following up on: https://github.com/Expensify/Expensify.cash/pull/1859

Failed workflow run: https://github.com/Expensify/Expensify.cash/actions/runs/666271840

### Details
Fixes a dumb typo