### PR TITLE
Give github token to getReleasePullRequestList

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,6 +43,7 @@ jobs:
         uses: Expensify/Expensify.cash/.github/actions/getReleasePullRequestList@master
         with:
           TAG: ${{ env.PRODUCTION_VERSION }}
+          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 
       - name: Generate Release Body
         id: getReleaseBody


### PR DESCRIPTION
More testing of https://github.com/Expensify/Expensify.cash/pull/1859

Failed workflow run: https://github.com/Expensify/Expensify.cash/runs/2144520848?check_suite_focus=true

We forgot to pass a required `GITHUB_TOKEN` input to the `getReleasePullRequestList` action.