### PR TITLE
Update commit hash of softprops/action-gh-release action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ jobs:
           PR_LIST: ${{ steps.getReleasePRList.outputs.PR_LIST }}
 
       - name: 🚀 Create release to trigger production deploy 🚀
-        uses: softprops/action-gh-release@b7e450da2a4b4cb4bfbae528f788167786cfcedf
+        uses: softprops/action-gh-release@affa18ef97bc9db20076945705aba8c516139abd
         with:
           tag_name: ${{ env.PRODUCTION_VERSION }}
           body: ${{ steps.getReleaseBody.outputs.RELEASE_BODY }}


### PR DESCRIPTION
### Details
Following up on testing [this PR](https://github.com/Expensify/Expensify.cash/pull/1859)

We were using options of the softprops/action-gh-release action which were not available in the commit hash we were pointing to. So this PR just updates our workflow to point to the latest commit hash in the action-gh-release repo.