### PR TITLE
Skip mobile staging deploys for production releases

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -48,8 +48,10 @@ jobs:
               if: ${{ env.SHOULD_DEPLOY_PRODUCTION == 'false' }}
               run: bundle exec fastlane android beta
 
+            # TODO: uncomment when we want to release iOS to production
             - name: Run Fastlane production
-              if: ${{ env.SHOULD_DEPLOY_PRODUCTION == 'true' }}
+#              if: ${{ env.SHOULD_DEPLOY_PRODUCTION == 'true' }}
+              if: ${{ env.SHOULD_DEPLOY_PRODUCTION == 'true' && 'false' == 'true' }}
               run: bundle exec fastlane android production
               env:
                 VERSION: ${{ env.VERSION }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,9 +13,7 @@ jobs:
         if: github.actor == 'OSBotify'
         runs-on: ubuntu-latest
         env:
-#          TODO: Uncomment when we'd like to deploy to production
-#          SHOULD_DEPLOY_PRODUCTION: ${{ github.event_name == 'release' }}
-          SHOULD_DEPLOY_PRODUCTION: ${{ false }}
+          SHOULD_DEPLOY_PRODUCTION: ${{ github.event_name == 'release' }}
         steps:
             - uses: actions/checkout@v2
 

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -47,6 +47,7 @@ jobs:
                   LARGE_SECRET_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
 
             - name: Run Fastlane beta
+              if: ${{ env.SHOULD_DEPLOY_PRODUCTION == 'false' }}
               run: bundle exec fastlane android beta
 
             - name: Run Fastlane production

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -16,9 +16,7 @@ jobs:
         if: github.actor == 'OSBotify'
         runs-on: macos-latest
         env:
-#          TODO: Uncomment when we'd like to deploy to production7
-#          SHOULD_DEPLOY_PRODUCTION: ${{ github.event_name == 'release' }}
-          SHOULD_DEPLOY_PRODUCTION: ${{ false }}
+          SHOULD_DEPLOY_PRODUCTION: ${{ github.event_name == 'release' }}
         steps:
             - uses: actions/checkout@v2
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -69,8 +69,10 @@ jobs:
                   APPLE_DEMO_EMAIL: ${{ secrets.APPLE_DEMO_EMAIL }}
                   APPLE_DEMO_PASSWORD: ${{ secrets.APPLE_DEMO_PASSWORD }}
 
+            # TODO: uncomment when we want to release iOS to production
             - name: Run Fastlane for App Store release
-              if: ${{ env.SHOULD_DEPLOY_PRODUCTION == 'true' }}
+#              if: ${{ env.SHOULD_DEPLOY_PRODUCTION == 'true' }}
+              if: ${{ env.SHOULD_DEPLOY_PRODUCTION == 'true' && 'false' == 'true' }}
               run: bundle exec fastlane ios production
               env:
                 VERSION: ${{ env.NEW_IOS_VERSION }}

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -63,6 +63,7 @@ jobs:
                 LARGE_SECRET_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
 
             - name: Run Fastlane
+              if: ${{ env.SHOULD_DEPLOY_PRODUCTION == 'false' }}
               run: bundle exec fastlane ios beta
               env:
                   APPLE_CONTACT_EMAIL: ${{ secrets.APPLE_CONTACT_EMAIL }}


### PR DESCRIPTION

### Details
Android and iOS staging deploys will invariably fail if the version has already been deployed. Therefore, when creating a production release, we want to make sure we're skipping staging deploys.

### Fixed Issues
Failed workflow runs:

- https://github.com/Expensify/Expensify.cash/commit/e2de490140f5f16058b9d80f485c1fe987f3b958/checks
- https://github.com/Expensify/Expensify.cash/commit/e2de490140f5f16058b9d80f485c1fe987f3b958/checks

### Tests
1) Merge this PR
2) Close a StagingDeployCash
3) The iOS and Android deploy workflows should be triggered, but it should not attempt to deploy staging. We should not be pinged in #announce 
