### PR TITLE
Create lockDeploys workflow

### DIFF
--- a/.github/workflows/lockDeploys.yml
+++ b/.github/workflows/lockDeploys.yml
@@ -54,14 +54,14 @@ jobs:
             ./ios/ExpensifyCashTests/Info.plist
           git commit -m "Update version to ${{ steps.bumpVersion.outputs.NEW_VERSION }}"
 
-      - name: Create Pull Request (staging)
+      - name: Create Pull Request (master)
         uses: peter-evans/create-pull-request@09b9ac155b0d5ad7d8d157ed32158c1b73689109
         with:
           token: ${{ secrets.OS_BOTIFY_TOKEN }}
           author: OSBotify <reactnative@expensify.com>
-          base: staging
+          base: master
           branch: version-patch-${{ github.sha }}
-          title: Update version to ${{ steps.bumpVersion.outputs.NEW_VERSION }} on staging
+          title: Update version to ${{ steps.bumpVersion.outputs.NEW_VERSION }} on master
           body: Update version to ${{ steps.bumpVersion.outputs.NEW_VERSION }}
           labels: automerge
 

--- a/.github/workflows/lockDeploys.yml
+++ b/.github/workflows/lockDeploys.yml
@@ -1,0 +1,100 @@
+name: Lock staging deploys during QA
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  lockStagingDeploys:
+    if: ${{ github.event.label.name == '🔐 LockCashDeploys 🔐' && contains(github.event.issue.labels.*.name, 'StagingDeployCash') && github.actor != 'OSBotify' }}
+    runs-on: macos-latest
+    steps:
+      # Version: 2.3.4
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        with:
+          ref: master
+          fetch-depth: 0
+          token: ${{ secrets.OS_BOTIFY_TOKEN }}
+
+      - name: Wait for any preDeploy version jobs to finish
+        uses: tomchv/wait-my-workflow@2da0b8a92211e6d7c9964602b99a7052080a1d61
+        id: waitForPreDeploy
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: version
+          intervalSeconds: 10
+          timeoutSeconds: 360
+
+      - uses: softprops/turnstyle@8db075d65b19bf94e6e8687b504db69938dc3c65
+        with:
+          poll-interval-seconds: 10
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create a new branch
+        run: |
+          git config user.name OSBotify
+          git checkout -b version-patch-${{ github.sha }}
+          git push --set-upstream origin version-patch-${{ github.sha }}
+
+      - name: Generate version
+        id: bumpVersion
+        uses: Expensify/Expensify.cash/.github/actions/bumpVersion@master
+        with:
+          SEMVER_LEVEL: PATCH
+          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+
+      - name: Commit new version
+        run: |
+          git add \
+            ./package.json \
+            ./package-lock.json \
+            ./android/app/build.gradle \
+            ./ios/ExpensifyCash/Info.plist \
+            ./ios/ExpensifyCashTests/Info.plist
+          git commit -m "Update version to ${{ steps.bumpVersion.outputs.NEW_VERSION }}"
+
+      - name: Create Pull Request (staging)
+        uses: peter-evans/create-pull-request@09b9ac155b0d5ad7d8d157ed32158c1b73689109
+        with:
+          token: ${{ secrets.OS_BOTIFY_TOKEN }}
+          author: OSBotify <reactnative@expensify.com>
+          base: staging
+          branch: version-patch-${{ github.sha }}
+          title: Update version to ${{ steps.bumpVersion.outputs.NEW_VERSION }} on staging
+          body: Update version to ${{ steps.bumpVersion.outputs.NEW_VERSION }}
+          labels: automerge
+
+      - name: Tag version
+        run: git tag ${{ steps.bumpVersion.outputs.NEW_VERSION }}
+
+      # TODO: Once we add cherry picking, we will need run this from the deploy workflow
+      - name: 🚀 Push tags to trigger staging deploy 🚀
+        run: git push --tags
+
+      - name: Update StagingDeployCash
+        uses: Expensify/Expensify.cash/.github/actions/createOrUpdateStagingDeploy@master
+        with:
+          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+          NPM_VERSION: ${{ steps.bumpVersion.outputs.NEW_VERSION }}
+
+      # This Slack step is duplicated in all workflows, if you make a change to this step, make sure to update all
+      # the other workflows with the same change
+      - uses: 8398a7/action-slack@v3
+        name: Job failed Slack notification
+        if: ${{ failure() }}
+        with:
+          status: custom
+          fields: workflow, repo
+          custom_payload: |
+            {
+              channel: '#announce',
+              attachments: [{
+                color: "#DB4545",
+                pretext: `<!here>`,
+                text: `💥 ${process.env.AS_REPO} failed on ${process.env.AS_WORKFLOW} workflow 💥`,
+              }]
+            }
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
### Details
To avoid a race condition between this job and `preDeploy:version`, added a new action called https://github.com/TomChv/wait-my-workflow/ . Tested in Public-Test-Repo and seems to work well.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/155210

### Tests
1) Merge this PR, then quickly add the `🔐 LockCashDeploys 🔐` label to the `StagingDeployCash`. We should then expect that:

- [x] The `lockDeploys` workflow should wait for the `preDeploy::version` job to finish before proceeding past `wait-my-workflow`. But then once it does...
- [x] The `bumpVersion` action should be executed w/ `SEMVER_LEVEL = PATCH`
- [x] An automerge PR should be merged to master to bump the `PATCH` version
- [ ] After the `preDeploy` workflow runs again, an automerge PR should be merged to staging from master.
- [x] The `StagingDeployCash` should be updated with the new `PATCH` version

2) Then merge another PR to master, and we should expect:

- [ ] OS Botify comments on the PR to say it will be deployed later
- [ ] The staging deploy should be skipped for this PR. No version-bump PR should be created.
- [ ] The `StagingDeployCash` should not be modified

3) Then close the `StagingDeployCash`, and:

- [ ] A release should be created w/ the `PATCH` version created in step 1
- [ ] A "production deploy" should happen
- [ ] The `BUILD` version should be bumped on master
- [ ] A staging deploy should happen with the new `BUILD` version on master.
- [ ] A new `StagingDeployCash` should be created, and should include the PR merged in step 2.

4) Add the `🔐 LockCashDeploys 🔐` to some random issue, and this workflow should be skipped.
