### PR TITLE
Add link to issue template to enforce linking back to Expensify/Expensify if relevant 

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -25,4 +25,4 @@ Where is this issue occurring?
 **Version Number:**
 **Logs:** https://stackoverflow.com/c/expensify/questions/4856
 **Notes/Photos/Videos:** Any additional supporting documentation
-**Expensify/Expensify Issue Link:**
+**Expensify/Expensify Issue URL:**

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -21,8 +21,8 @@ Where is this issue occurring?
  Android
  Desktop App
  Mobile Web
- 
-**Version Number:** 
+
+**Version Number:**
 **Logs:** https://stackoverflow.com/c/expensify/questions/4856
 **Notes/Photos/Videos:** Any additional supporting documentation
-
+**Expensify/Expensify Issue Link:**


### PR DESCRIPTION
### Details
Small change to enforce the habit of linking back to private E/E issues. They are only visible internally but no reason we can't link back.

### Fixed Issues
Fixes no issue just a small improvement