### PR TITLE
Fix race condition with automerge and lockDeploys workflow

### DIFF
--- a/.github/workflows/lockDeploys.yml
+++ b/.github/workflows/lockDeploys.yml
@@ -18,12 +18,19 @@ jobs:
 
       - name: Wait for any preDeploy version jobs to finish
         uses: tomchv/wait-my-workflow@2da0b8a92211e6d7c9964602b99a7052080a1d61
-        id: waitForPreDeploy
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           checkName: version
           intervalSeconds: 10
           timeoutSeconds: 360
+
+      - name: Wait for any automerge-master jobs to finish
+        uses: tomchv/wait-my-workflow@2da0b8a92211e6d7c9964602b99a7052080a1d61
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: master
+          intervalSeconds: 10
+          timeoutSeconds: 150
 
       - uses: softprops/turnstyle@8db075d65b19bf94e6e8687b504db69938dc3c65
         with:
@@ -34,6 +41,7 @@ jobs:
       - name: Create a new branch
         run: |
           git config user.name OSBotify
+          git pull origin master
           git checkout -b version-patch-${{ github.sha }}
           git push --set-upstream origin version-patch-${{ github.sha }}
 


### PR DESCRIPTION

### Details
Following up on testing https://github.com/Expensify/Expensify.cash/pull/1938

See [this comment](https://github.com/Expensify/Expensify.cash/pull/1938#issuecomment-803112206) for more context.

This hopefully eliminates a race condition between the `lockDeploys`, `preVersion`, and `automerge` workflows.

### Fixed Issues
<Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing>
Fixes https://github.com/Expensify/Expensify/issues/155210
