### PR TITLE
Move ReportActionContextMenu up for grouped ReportActionItems

### DIFF
--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -6,8 +6,10 @@ import {withOnyx} from 'react-native-onyx';
 import CONST from '../../../CONST';
 import ONYXKEYS from '../../../ONYXKEYS';
 import ReportActionPropTypes from './ReportActionPropTypes';
-import styles from '../../../styles/styles';
-import getReportActionItemStyles from '../../../styles/getReportActionItemStyles';
+import {
+    getReportActionItemStyle,
+    getMiniReportActionContextMenuWrapperStyle,
+} from '../../../styles/getReportActionItemStyles';
 import PressableWithSecondaryInteraction from '../../../components/PressableWithSecondaryInteraction';
 import Hoverable from '../../../components/Hoverable';
 import PopoverWithMeasuredContent from '../../../components/PopoverWithMeasuredContent';
@@ -107,12 +109,12 @@ class ReportActionItem extends Component {
                 <Hoverable>
                     {hovered => (
                         <View>
-                            <View style={getReportActionItemStyles(hovered)}>
+                            <View style={getReportActionItemStyle(hovered)}>
                                 {!this.props.displayAsGroup
                                     ? <ReportActionItemSingle action={this.props.action} />
                                     : <ReportActionItemGrouped action={this.props.action} />}
                             </View>
-                            <View style={styles.miniReportActionContextMenuWrapperStyle}>
+                            <View style={getMiniReportActionContextMenuWrapperStyle(this.props.displayAsGroup)}>
                                 <ReportActionContextMenu
                                     reportID={this.props.reportID}
                                     reportActionID={this.props.action.sequenceNumber}

--- a/src/styles/getReportActionItemStyles.js
+++ b/src/styles/getReportActionItemStyles.js
@@ -1,4 +1,5 @@
 import themeColors from './themes/default';
+import positioning from './utilities/positioning';
 
 /**
  * Generate the styles for the ReportActionItem wrapper view.
@@ -6,11 +7,25 @@ import themeColors from './themes/default';
  * @param {Boolean} [isHovered]
  * @returns {Object}
  */
-export default function (isHovered = false) {
+export function getReportActionItemStyle(isHovered = false) {
     return {
         display: 'flex',
         justifyContent: 'space-between',
         backgroundColor: isHovered ? themeColors.hoverComponentBG : themeColors.componentBG,
         cursor: 'default',
+    };
+}
+
+/**
+ * Generate the wrapper styles for the mini ReportActionContextMenu.
+ *
+ * @param {Boolean} isReportActionItemGrouped
+ * @returns {Object}
+ */
+export function getMiniReportActionContextMenuWrapperStyle(isReportActionItemGrouped) {
+    return {
+        ...(isReportActionItemGrouped ? positioning.tn8 : positioning.tn4),
+        ...positioning.r4,
+        position: 'absolute',
     };
 }

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -10,7 +10,6 @@ import sizing from './utilities/sizing';
 import flex from './utilities/flex';
 import display from './utilities/display';
 import overflow from './utilities/overflow';
-import positioning from './utilities/positioning';
 import whiteSpace from './utilities/whiteSpace';
 import wordBreak from './utilities/wordBreak';
 import textInputAlignSelf from './utilities/textInputAlignSelf';
@@ -951,12 +950,6 @@ const styles = {
     defaultModalContainer: {
         backgroundColor: themeColors.componentBG,
         borderColor: colors.transparent,
-    },
-
-    miniReportActionContextMenuWrapperStyle: {
-        ...positioning.tn4,
-        ...positioning.r4,
-        position: 'absolute',
     },
 
     reportActionContextMenuText: {

--- a/src/styles/utilities/positioning.js
+++ b/src/styles/utilities/positioning.js
@@ -6,6 +6,9 @@ export default {
     tn4: {
         top: -16,
     },
+    tn8: {
+        top: -32,
+    },
     r4: {
         right: 16,
     },


### PR DESCRIPTION
### Details
For grouped `ReportActionItem`, shift the context menu up and out of the way of any text.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/157893

### Tests
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### QA Steps
1. Either add a user to the reportActionContextMenu beta in Betatify, or open the Chrome Dev Console, go to the Application tab, then go to LocalStorage, search the "beta" key, and add "reportActionContextMenu" to the JSON array.
2. Write out a long message and copy it to your clipboard. It should be at least long enough to take up multiple lines on your screen without any line breaks.
3. Send the long message twice in a row. The first one should appear adjacent to your avatar, and the second will appear "grouped" below, not adjacent to an Avatar.
4. Hover over both messages, and make sure the menu that appears does not cover any text.

### Tested On

- [x] Web
- [ ] ~~Mobile Web~~
- [x] Desktop
- [ ] ~~iOS~~
- [ ] ~~Android~~

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
![image](https://user-images.githubusercontent.com/47436092/111841984-0d1a7900-88bc-11eb-8994-9f4940385851.png)

![image](https://user-images.githubusercontent.com/47436092/111842005-160b4a80-88bc-11eb-8137-fef330d0c114.png)

#### Mobile Web
This component does not display on mobile web.

#### Desktop
![image](https://user-images.githubusercontent.com/47436092/111842301-73070080-88bc-11eb-80be-6674f6d32012.png)

![image](https://user-images.githubusercontent.com/47436092/111842315-7a2e0e80-88bc-11eb-8c22-6ffb1325700c.png)

#### iOS
This component does not display on iOS

#### Android
This component does not display on Android
