### PR TITLE
Fix automerge race condition again

### DIFF
--- a/.github/workflows/lockDeploys.yml
+++ b/.github/workflows/lockDeploys.yml
@@ -24,6 +24,9 @@ jobs:
           intervalSeconds: 10
           timeoutSeconds: 360
 
+      - name: Wait for any automerge jobs to start
+        run: sleep 30
+
       - name: Wait for any automerge-master jobs to finish
         uses: tomchv/wait-my-workflow@2da0b8a92211e6d7c9964602b99a7052080a1d61
         with:

--- a/.github/workflows/lockDeploys.yml
+++ b/.github/workflows/lockDeploys.yml
@@ -25,7 +25,7 @@ jobs:
           timeoutSeconds: 360
 
       - name: Wait for any automerge jobs to start
-        run: sleep 30
+        run: sleep 60
 
       - name: Wait for any automerge-master jobs to finish
         uses: tomchv/wait-my-workflow@2da0b8a92211e6d7c9964602b99a7052080a1d61


### PR DESCRIPTION

### Details
Following up on https://github.com/Expensify/Expensify.cash/pull/1945 

That didn't quite work because by the time we went to check for an ongoing automerge PR, the automerge workflow run had not yet started. To solve that, just wait for a minute before checking for ongoing automerge PRs.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/155210

### Tests
Retest https://github.com/Expensify/Expensify.cash/pull/1938