### PR TITLE
Update User_UploadAvatar to take in a file instead of a base64 image

### DIFF
--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -583,12 +583,12 @@ function User_SecondaryLogin_Send(parameters) {
 
 /**
  * @param {Object} parameters
- * @param {String} parameters.base64image
+ * @param {File|Object} parameters.file
  * @returns {Promise}
  */
 function User_UploadAvatar(parameters) {
     const commandName = 'User_UploadAvatar';
-    requireParameters(['base64image'], parameters, commandName);
+    requireParameters(['file'], parameters, commandName);
     return Network.post(commandName, parameters);
 }
 

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -211,10 +211,10 @@ function setPersonalDetails(details) {
 /**
  * Sets the user's avatar image
  *
- * @param {String} base64image
+ * @param {File|Object} file
  */
-function setAvatar(base64image) {
-    API.User_UploadAvatar({base64image}).then((response) => {
+function setAvatar(file) {
+    API.User_UploadAvatar({file}).then((response) => {
         // Once we get the s3url back, update the personal details for the user with the new avatar URL
         if (response.jsonCode === 200) {
             setPersonalDetails({avatar: response.s3url});


### PR DESCRIPTION
Held upon https://github.com/Expensify/Web-Expensify/pull/30517

### Details
Updates User_Upload avatar so that it doesn't have to take in a base64 image string to work. 

### Fixed Issues
<Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing>
Fixes https://github.com/Expensify/Expensify/issues/156268

### Tests
1. Add a debug point [here](https://github.com/Expensify/Expensify.cash/blob/664a1361d52dcd66a56bcc1a88e09d4bfccbcf58/src/libs/actions/Report.js#L515) and open your JS Console
2. In a chat, add an attachment and press `Upload`
3. When the debug point is triggered run the following: 
```
personalDetails = _PersonalDetails__WEBPACK_IMPORTED_MODULE_11__;
personalDetails.setAvatar(file)
```
and then continue execution 
4. Wait a few seconds and confirm your profile picture is updated.
5. Refresh the page and confirm your user avatar is updated. 

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
N/A

cc: @marcaaron since we discussed this