### PR TITLE
[No QA] Update expensify-common hash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11074,8 +11074,8 @@
       }
     },
     "expensify-common": {
-      "version": "git+https://github.com/Expensify/expensify-common.git#c7becaa79e10c10da521261ebb83dd3871847e84",
-      "from": "git+https://github.com/Expensify/expensify-common.git#c7becaa79e10c10da521261ebb83dd3871847e84",
+      "version": "git+https://github.com/Expensify/expensify-common.git#b89c2c591a2f76ae1a3d8a4a2e2d5e5159d65edc",
+      "from": "git+https://github.com/Expensify/expensify-common.git#b89c2c591a2f76ae1a3d8a4a2e2d5e5159d65edc",
       "requires": {
         "classnames": "2.2.5",
         "clipboard": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "electron-log": "^4.2.4",
     "electron-serve": "^1.0.0",
     "electron-updater": "^4.3.4",
-    "expensify-common": "git+https://github.com/Expensify/expensify-common.git#c7becaa79e10c10da521261ebb83dd3871847e84",
+    "expensify-common": "git+https://github.com/Expensify/expensify-common.git#b89c2c591a2f76ae1a3d8a4a2e2d5e5159d65edc",
     "file-loader": "^6.0.0",
     "html-entities": "^1.3.1",
     "lodash.get": "^4.4.2",


### PR DESCRIPTION
Update hash for https://github.com/Expensify/expensify-common/pull/354

The change to expensify-common is only used in Web-Secure and has been tested in the associated PR: https://github.com/Expensify/Web-Secure/pull/1895

<!--- 
### Details
<Explanation of the change or anything fishy that is going on>

### Fixed Issues
<Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing>
Fixes GH_LINK

### Tests

Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 


### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android
- [ ]
 --->
