### PR TITLE
fixed Sidebar theme

### DIFF
--- a/src/components/ScreenWrapper.js
+++ b/src/components/ScreenWrapper.js
@@ -30,7 +30,7 @@ const defaultProps = {
 };
 
 const ScreenWrapper = props => (
-    <SafeAreaInsetsContext.Consumer style={props.style}>
+    <SafeAreaInsetsContext.Consumer>
         {(insets) => {
             const {paddingTop, paddingBottom} = getSafeAreaPadding(insets);
             const paddingStyle = {};
@@ -44,11 +44,11 @@ const ScreenWrapper = props => (
             }
 
             return (
-                <View
-                    style={[
-                        styles.flex1,
-                        paddingStyle,
-                    ]}
+                <View style={_.union([
+                    props.style,
+                    styles.flex1,
+                    paddingStyle,
+                ])}
                 >
                     <HeaderGap />
                     {// If props.children is a function, call it to provide the insets to the children.


### PR DESCRIPTION
Please review @marcaaron. As these changes are directly linked to your code.

### Details
` <SafeAreaInsetsContext.Consumer>` does not have styling support but in `ScreenWrapper` component was passing parent style prop to it. I have moved it to the child `View` which is working without regression.

### Fixed Issues
Fixes #1967 

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

|Before|After|
|-----|-------|
| ![image](https://user-images.githubusercontent.com/24370807/112022928-bed5d600-8b58-11eb-93b6-43395c9a622d.png)| ![image](https://user-images.githubusercontent.com/24370807/112022840-a9f94280-8b58-11eb-9b8f-aaf4c8ba2377.png) |

CC @shawnborton