### PR TITLE
Temporarily hide incomplete IOU modal

### DIFF
--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -186,6 +186,7 @@ class ReportActionCompose extends React.Component {
         // focus this from the chat switcher.
         // https://github.com/Expensify/Expensify.cash/issues/1228
         const inputDisable = this.props.isSmallScreenWidth && Navigation.isDrawerOpen();
+        // eslint-disable-next-line no-unused-vars
         const hasMultipleParticipants = lodashGet(this.props.report, 'participants.length') > 1;
 
         return (
@@ -233,6 +234,11 @@ class ReportActionCompose extends React.Component {
                                                     }, 10);
                                                 }}
                                                 onItemSelected={() => this.setMenuVisibility(false)}
+                                                menuOptions={CONST.MENU_ITEM_KEYS.ATTACHMENT_PICKER}
+
+                                                /**
+                                                 * Temporarily hiding IOU Modal options while Modal is incomplete. Will
+                                                 * be replaced by a beta flag once IOUConfirm is completed.
                                                 menuOptions={hasMultipleParticipants
                                                     ? [
                                                         CONST.MENU_ITEM_KEYS.SPLIT_BILL,
@@ -240,6 +246,7 @@ class ReportActionCompose extends React.Component {
                                                     : [
                                                         CONST.MENU_ITEM_KEYS.REQUEST_MONEY,
                                                         CONST.MENU_ITEM_KEYS.ATTACHMENT_PICKER]}
+                                                */
                                             />
                                         </>
                                     )}

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -234,7 +234,7 @@ class ReportActionCompose extends React.Component {
                                                     }, 10);
                                                 }}
                                                 onItemSelected={() => this.setMenuVisibility(false)}
-                                                menuOptions={CONST.MENU_ITEM_KEYS.ATTACHMENT_PICKER}
+                                                menuOptions={[CONST.MENU_ITEM_KEYS.ATTACHMENT_PICKER]}
 
                                                 /**
                                                  * Temporarily hiding IOU Modal options while Modal is incomplete. Will

--- a/src/pages/home/sidebar/SidebarScreen.js
+++ b/src/pages/home/sidebar/SidebarScreen.js
@@ -90,10 +90,19 @@ class SidebarScreen extends Component {
                             onItemSelected={this.onCreateMenuItemSelected}
                             menuOptions={[
                                 CONST.MENU_ITEM_KEYS.NEW_CHAT,
+                                CONST.MENU_ITEM_KEYS.NEW_GROUP,
+                            ]}
+
+                            /**
+                             * Temporarily hiding IOU Modal options while Modal is incomplete. Will
+                             * be replaced by a beta flag once IOUConfirm is completed.
+                            menuOptions={[
+                                CONST.MENU_ITEM_KEYS.NEW_CHAT,
                                 CONST.MENU_ITEM_KEYS.REQUEST_MONEY,
                                 CONST.MENU_ITEM_KEYS.NEW_GROUP,
                                 CONST.MENU_ITEM_KEYS.SPLIT_BILL,
                             ]}
+                            */
                         />
                     </>
                 )}


### PR DESCRIPTION
### Details
The IOU Modal is being completed in stages -- see [parent tracking issue](https://github.com/Expensify/Expensify/issues/148974). We have just merged an issue which implements the updated create menu, but are not quite ready to expose the Modal to everyone. 

Once we complete the modal we will implement a beta flag, but for now we simply want to disable the menu option from being shown. This also avoids confusion, as the new options currently route to the same old modal.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/154620

### Tests

_Note that Expensify.cash currently shows new menu options for IOU, you **should NOT** see these while testing_

**Verify IOU menu options are not displayed**
- Tap the global FAB button
- The only visible items should be: 'New Chat' and 'New Group'
- Open a chat
- Tap the + button next to chat input
- The only visible item should be: 'Add Attachment'

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

**Web**
![Screenshot 2021-03-22 at 16 36 11](https://user-images.githubusercontent.com/10736861/112025121-c3849500-8b2c-11eb-940b-d17106404744.png)
![Screenshot 2021-03-22 at 16 36 02](https://user-images.githubusercontent.com/10736861/112025126-c5e6ef00-8b2c-11eb-8769-c7e6ff2d5ec0.png)

**Android**
![device-2021-03-22-163933](https://user-images.githubusercontent.com/10736861/112025678-532a4380-8b2d-11eb-96cb-312dfb581ea7.png)
![device-2021-03-22-163837](https://user-images.githubusercontent.com/10736861/112025685-545b7080-8b2d-11eb-90e1-065bf5d89906.png)

**iOS**
![Simulator Screen Shot - iPhone 11 - 2021-03-22 at 16 46 14](https://user-images.githubusercontent.com/10736861/112026458-275b8d80-8b2e-11eb-98b8-cae9f6b8f259.png)
![Simulator Screen Shot - iPhone 11 - 2021-03-22 at 16 45 57](https://user-images.githubusercontent.com/10736861/112026470-2a567e00-8b2e-11eb-940a-a8fd22200f25.png)

**Desktop**
<img width="740" alt="Screenshot 2021-03-22 at 16 45 29" src="https://user-images.githubusercontent.com/10736861/112026383-0dba4600-8b2e-11eb-83aa-e26d79856863.png">
<img width="709" alt="Screenshot 2021-03-22 at 16 45 23" src="https://user-images.githubusercontent.com/10736861/112026397-11e66380-8b2e-11eb-82e5-b20cbad5ae6c.png">

**Mobile Web**
![Simulator Screen Shot - iPhone 11 - 2021-03-22 at 16 47 10](https://user-images.githubusercontent.com/10736861/112026593-43f7c580-8b2e-11eb-94cf-0aba6e4a37e3.png)
