### PR TITLE
Remove flag that is causing iOS to fail to upload

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -114,6 +114,9 @@ platform :ios do
     upload_to_testflight(
         api_key_path: "./ios/ios-fastlane-json-key.json",
         distribute_external: true,
+        # TODO: Set reject_build_waiting_for_review back to true when https://github.com/fastlane/fastlane/issues/18408 is resolved
+        # See: https://github.com/Expensify/Expensify.cash/pull/1984 for more information
+        reject_build_waiting_for_review: false,
         changelog: "Thank you for beta testing Expensify.cash, this version includes bug fixes and improvements.",
         groups: ["Beta"],
         demo_account_required: true,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -114,7 +114,6 @@ platform :ios do
     upload_to_testflight(
         api_key_path: "./ios/ios-fastlane-json-key.json",
         distribute_external: true,
-        reject_build_waiting_for_review: true,
         changelog: "Thank you for beta testing Expensify.cash, this version includes bug fixes and improvements.",
         groups: ["Beta"],
         demo_account_required: true,


### PR DESCRIPTION
### Details
The `reject_build_waiting_for_review` flag is throwing errors on all iOS builds. We've created an issue with Fastlane here: https://github.com/fastlane/fastlane/issues/18408 but we are unsure when they will be able to look into the issue, so let's remove that flag for now.

### Fixed Issues
Fixes broken iOS workflows

### Tests
1. Merge this PR
2. Verify iOS builds and deploys correctly