### PR TITLE
Update CLA to not lock pull requests after merge

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -25,8 +25,8 @@ jobs:
                 regex: '\s*recheck\s*'
             - name: CLA Assistant
               if: ${{ steps.recheck.outputs.match != '' || steps.sign.outputs.match != '' }} || github.event_name == 'pull_request_target'
-              # Version: 2.0.3-alpha
-              uses: cla-assistant/github-action@50267bf6156835b55d5f7b74d0da0cf0bf26cfe5
+              # Version: 2.1.2-beta
+              uses: cla-assistant/github-action@948230deb0d44dd38957592f08c6bd934d96d0cf
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   PERSONAL_ACCESS_TOKEN : ${{ secrets.CLA_BOTIFY_TOKEN }}
@@ -36,4 +36,5 @@ jobs:
                   branch: 'master'
                   remote-organization-name: 'Expensify'
                   remote-repository-name: 'CLA'
+                  lock-pullrequest-aftermerge: false
                   allowlist: OSBotify


### PR DESCRIPTION
### Details
Updates our CLA bot to not lock pull requests are merged, I asked them to implement this feature for us and they did! 🥳 

https://github.com/cla-assistant/github-action/issues/77
https://github.com/cla-assistant/github-action/pull/78

### Fixed Issues
Fixes https://github.com/cla-assistant/github-action/issues/77

### Tests
1. Merge this PR
2. It will lock this PR as the last PR to be locked (`pull_request_target` is triggered on `master`, not on the code on the head branch)
3. I will create a new "test" PR
4. I will verify it is not locked