### PR TITLE
Fix width of report header on mobile web

### DIFF
--- a/src/pages/home/HeaderView.js
+++ b/src/pages/home/HeaderView.js
@@ -40,7 +40,7 @@ const propTypes = {
     }),
 
     // Personal details of all the users
-    personalDetails: PropTypes.arrayOf(participantPropTypes).isRequired,
+    personalDetails: PropTypes.objectOf(participantPropTypes).isRequired,
 
     ...windowDimensionsPropTypes,
 };
@@ -83,7 +83,7 @@ const HeaderView = (props) => {
                                     Navigation.navigate(ROUTES.getProfileRoute(participants[0]));
                                 }
                             }}
-                            style={[styles.flexRow, styles.alignItemsCenter]}
+                            style={[styles.flexRow, styles.alignItemsCenter, styles.flex1]}
                         >
                             <MultipleAvatars avatarImageURLs={props.report.icons} />
                             <View style={[styles.flex1, styles.flexRow]}>


### PR DESCRIPTION
@NikkiWines I was having a hard time nailing this down, and I ended up doing a git bisect and found this was originally caused  by the change here: https://github.com/Expensify/Expensify.cash/commit/4ce6b365cc576e857d70685dbc1c711bc9e6e080

### Details
I believe that just adding `flex: 1` fixes the width problem so that everything stays within the view.

### Fixed Issues
<Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing>
Fixes https://github.com/Expensify/Expensify/issues/157960

Fixes https://github.com/Expensify/Expensify/issues/157960

### Tests
1. Start a group chat with 4 people
2. Verify that the report page is shown properly and the name of the report is truncated with "..." when the screen has a narrow width

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
![image](https://user-images.githubusercontent.com/1228807/112067985-9c2ec780-8b2e-11eb-8175-5a504371397f.png)

#### Mobile Web
![image](https://user-images.githubusercontent.com/1228807/112068008-a650c600-8b2e-11eb-9331-82d09b05c00e.png)


#### Desktop
![image](https://user-images.githubusercontent.com/1228807/112068138-efa11580-8b2e-11eb-84c2-2f24d9346e84.png)
![image](https://user-images.githubusercontent.com/1228807/112068154-f760ba00-8b2e-11eb-8425-2bdd2dc0c0ab.png)


#### iOS
![image](https://user-images.githubusercontent.com/1228807/112068830-53780e00-8b30-11eb-9623-d6963c1d066c.png)


#### Android
![image](https://user-images.githubusercontent.com/1228807/112069273-27a95800-8b31-11eb-9f80-babf02b1dd6d.png)
