### PR TITLE
Fixed moving cursor to end problem except IOUAmountPage

### DIFF
--- a/src/components/TextInputFocusable/index.js
+++ b/src/components/TextInputFocusable/index.js
@@ -37,9 +37,6 @@ const propTypes = {
 
     // Whether or not this TextInput is disabled.
     isDisabled: PropTypes.bool,
-
-    // Whether or not force move cursor to end all the time
-    forceMoveCursorToEnd: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -52,7 +49,6 @@ const defaultProps = {
     onDragLeave: () => {},
     onDrop: () => {},
     isDisabled: false,
-    forceMoveCursorToEnd: false,
 };
 
 const IMAGE_EXTENSIONS = {
@@ -114,9 +110,6 @@ class TextInputFocusable extends React.Component {
         }
         if (prevProps.defaultValue !== this.props.defaultValue) {
             this.updateNumberOfLines();
-            if (this.props.forceMoveCursorToEnd) {
-                this.moveCursorToEnd();
-            }
         }
     }
 
@@ -202,19 +195,6 @@ class TextInputFocusable extends React.Component {
             this.setState({
                 numberOfLines: this.getNumberOfLines(lineHeight, paddingTopAndBottom, this.textInput.scrollHeight),
             });
-        });
-    }
-
-    /**
-     * Move cursor to end by setting start and end
-     * to length of the input value.
-     */
-    moveCursorToEnd() {
-        this.setState({
-            selection: {
-                start: this.props.defaultValue.length,
-                end: this.props.defaultValue.length,
-            },
         });
     }
 

--- a/src/components/TextInputFocusable/index.js
+++ b/src/components/TextInputFocusable/index.js
@@ -37,6 +37,9 @@ const propTypes = {
 
     // Whether or not this TextInput is disabled.
     isDisabled: PropTypes.bool,
+
+    // Whether or not force move cursor to end all the time
+    forceMoveCursorToEnd: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -49,6 +52,7 @@ const defaultProps = {
     onDragLeave: () => {},
     onDrop: () => {},
     isDisabled: false,
+    forceMoveCursorToEnd: false,
 };
 
 const IMAGE_EXTENSIONS = {
@@ -110,7 +114,9 @@ class TextInputFocusable extends React.Component {
         }
         if (prevProps.defaultValue !== this.props.defaultValue) {
             this.updateNumberOfLines();
-            this.moveCursorToEnd();
+            if (this.props.forceMoveCursorToEnd) {
+                this.moveCursorToEnd();
+            }
         }
     }
 

--- a/src/pages/iou/steps/IOUAmountPage.js
+++ b/src/pages/iou/steps/IOUAmountPage.js
@@ -94,7 +94,6 @@ class IOUAmountPage extends React.Component {
                                         ref={el => this.textInput = el}
                                         defaultValue={this.props.amount}
                                         textAlign="left"
-                                        forceMoveCursorToEnd
                                 />
                                 <Text
                                     style={[styles.iouAmountText, styles.invisible, {left: 100000}]}

--- a/src/pages/iou/steps/IOUAmountPage.js
+++ b/src/pages/iou/steps/IOUAmountPage.js
@@ -94,6 +94,7 @@ class IOUAmountPage extends React.Component {
                                         ref={el => this.textInput = el}
                                         defaultValue={this.props.amount}
                                         textAlign="left"
+                                        forceMoveCursorToEnd
                                 />
                                 <Text
                                     style={[styles.iouAmountText, styles.invisible, {left: 100000}]}


### PR DESCRIPTION
@johnmlee101 

### Details
- Added `forceMoveCursorToEnd` prop to `TextInputFocusable` component.
- Set this prop in `IOUAmountPage` to keep the cursor at the end all the time.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/1691

### Tests
### Tested On

- [X] Web
- [X] Mobile Web
- [X] Desktop
- [X] iOS
- [X] Android

### Screenshots

#### Web

https://user-images.githubusercontent.com/3853003/112159732-61399c00-8be1-11eb-8793-8584b3d5db87.mov