### PR TITLE
Make iOS update commands run in sequence instead of all at once

### DIFF
--- a/.github/actions/bumpVersion/bumpVersion.js
+++ b/.github/actions/bumpVersion/bumpVersion.js
@@ -28,21 +28,18 @@ function updateNativeVersions(version) {
         });
 
     // Update iOS
-    updateiOSVersion(version)
-        .then((promiseValues) => {
-            // The first promiseValue will be the CFBundleVersion, so confirm it has 4 parts before setting the env var
-            const cfBundleVersion = promiseValues[0];
-            if (_.isString(cfBundleVersion) && cfBundleVersion.split('.').length === 4) {
-                core.setOutput('NEW_IOS_VERSION', cfBundleVersion);
-                console.log('Successfully updated iOS!');
-            } else {
-                core.setFailed(`Failed to set NEW_IOS_VERSION. CFBundleVersion: ${cfBundleVersion}`);
-            }
-        })
-        .catch((err) => {
-            console.error('Error updating iOS');
-            core.setFailed(err);
-        });
+    try {
+        const cfBundleVersion = updateiOSVersion(version);
+        if (_.isString(cfBundleVersion) && cfBundleVersion.split('.').length === 4) {
+            core.setOutput('NEW_IOS_VERSION', cfBundleVersion);
+            console.log('Successfully updated iOS!');
+        } else {
+            core.setFailed(`Failed to set NEW_IOS_VERSION. CFBundleVersion: ${cfBundleVersion}`);
+        }
+    } catch (err) {
+        console.error('Error updating iOS');
+        core.setFailed(err);
+    }
 }
 
 const octokit = github.getOctokit(core.getInput('GITHUB_TOKEN', {required: true}));

--- a/.github/actions/bumpVersion/index.js
+++ b/.github/actions/bumpVersion/index.js
@@ -188,12 +188,17 @@ exports.updateiOSVersion = function updateiOSVersion(version) {
     console.log('Updating iOS', `CFBundleShortVersionString: ${shortVersion}`, `CFBundleVersion: ${cfVersion}`);
 
     // Pass back the cfVersion in the return array so we can set the NEW_IOS_VERSION in ios.yml
-    return Promise.all([
-        cfVersion,
+    const updatePromise = [
         exec(`/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${shortVersion}" ${PLIST_PATH}`),
         exec(`/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${shortVersion}" ${PLIST_PATH_TEST}`),
         exec(`/usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${cfVersion}" ${PLIST_PATH}`),
         exec(`/usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${cfVersion}" ${PLIST_PATH_TEST}`),
+    ]
+        .reduce((previousPromise, currentPromise) => previousPromise.then(() => currentPromise()), Promise.resolve());
+
+    return Promise.all([
+        cfVersion,
+        updatePromise,
     ]);
 };
 

--- a/.github/actions/bumpVersion/index.js
+++ b/.github/actions/bumpVersion/index.js
@@ -38,21 +38,18 @@ function updateNativeVersions(version) {
         });
 
     // Update iOS
-    updateiOSVersion(version)
-        .then((promiseValues) => {
-            // The first promiseValue will be the CFBundleVersion, so confirm it has 4 parts before setting the env var
-            const cfBundleVersion = promiseValues[0];
-            if (_.isString(cfBundleVersion) && cfBundleVersion.split('.').length === 4) {
-                core.setOutput('NEW_IOS_VERSION', cfBundleVersion);
-                console.log('Successfully updated iOS!');
-            } else {
-                core.setFailed(`Failed to set NEW_IOS_VERSION. CFBundleVersion: ${cfBundleVersion}`);
-            }
-        })
-        .catch((err) => {
-            console.error('Error updating iOS');
-            core.setFailed(err);
-        });
+    try {
+        const cfBundleVersion = updateiOSVersion(version);
+        if (_.isString(cfBundleVersion) && cfBundleVersion.split('.').length === 4) {
+            core.setOutput('NEW_IOS_VERSION', cfBundleVersion);
+            console.log('Successfully updated iOS!');
+        } else {
+            core.setFailed(`Failed to set NEW_IOS_VERSION. CFBundleVersion: ${cfBundleVersion}`);
+        }
+    } catch (err) {
+        console.error('Error updating iOS');
+        core.setFailed(err);
+    }
 }
 
 const octokit = github.getOctokit(core.getInput('GITHUB_TOKEN', {required: true}));
@@ -104,8 +101,7 @@ octokit.repos.listTags({
 /***/ 322:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
-const {promisify} = __nccwpck_require__(1669);
-const exec = promisify(__nccwpck_require__(3129).exec);
+const {execSync} = __nccwpck_require__(3129);
 const fs = __nccwpck_require__(5747).promises;
 const path = __nccwpck_require__(5622);
 const getMajorVersion = __nccwpck_require__(6688);
@@ -180,26 +176,21 @@ exports.updateAndroidVersion = function updateAndroidVersion(versionName, versio
  * Updates the CFBundleShortVersionString and the CFBundleVersion.
  *
  * @param {String} version
- * @returns {Promise}
+ * @returns {String}
  */
 exports.updateiOSVersion = function updateiOSVersion(version) {
     const shortVersion = version.split('-')[0];
     const cfVersion = version.includes('-') ? version.replace('-', '.') : `${version}.0`;
     console.log('Updating iOS', `CFBundleShortVersionString: ${shortVersion}`, `CFBundleVersion: ${cfVersion}`);
 
-    // Pass back the cfVersion in the return array so we can set the NEW_IOS_VERSION in ios.yml
-    const updatePromise = [
-        exec(`/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${shortVersion}" ${PLIST_PATH}`),
-        exec(`/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${shortVersion}" ${PLIST_PATH_TEST}`),
-        exec(`/usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${cfVersion}" ${PLIST_PATH}`),
-        exec(`/usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${cfVersion}" ${PLIST_PATH_TEST}`),
-    ]
-        .reduce((previousPromise, currentPromise) => previousPromise.then(() => currentPromise()), Promise.resolve());
+    // Update Plists
+    execSync(`/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${shortVersion}" ${PLIST_PATH}`);
+    execSync(`/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${shortVersion}" ${PLIST_PATH_TEST}`);
+    execSync(`/usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${cfVersion}" ${PLIST_PATH}`);
+    execSync(`/usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${cfVersion}" ${PLIST_PATH_TEST}`);
 
-    return Promise.all([
-        cfVersion,
-        updatePromise,
-    ]);
+    // Return the cfVersion so we can set the NEW_IOS_VERSION in ios.yml
+    return cfVersion;
 };
 
 

--- a/.github/libs/nativeVersionUpdater.js
+++ b/.github/libs/nativeVersionUpdater.js
@@ -1,5 +1,4 @@
-const {promisify} = require('util');
-const exec = promisify(require('child_process').exec);
+const {execSync} = require('child_process');
 const fs = require('fs').promises;
 const path = require('path');
 const getMajorVersion = require('semver/functions/major');
@@ -74,24 +73,19 @@ exports.updateAndroidVersion = function updateAndroidVersion(versionName, versio
  * Updates the CFBundleShortVersionString and the CFBundleVersion.
  *
  * @param {String} version
- * @returns {Promise}
+ * @returns {String}
  */
 exports.updateiOSVersion = function updateiOSVersion(version) {
     const shortVersion = version.split('-')[0];
     const cfVersion = version.includes('-') ? version.replace('-', '.') : `${version}.0`;
     console.log('Updating iOS', `CFBundleShortVersionString: ${shortVersion}`, `CFBundleVersion: ${cfVersion}`);
 
-    // Pass back the cfVersion in the return array so we can set the NEW_IOS_VERSION in ios.yml
-    const updatePromise = [
-        exec(`/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${shortVersion}" ${PLIST_PATH}`),
-        exec(`/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${shortVersion}" ${PLIST_PATH_TEST}`),
-        exec(`/usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${cfVersion}" ${PLIST_PATH}`),
-        exec(`/usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${cfVersion}" ${PLIST_PATH_TEST}`),
-    ]
-        .reduce((previousPromise, currentPromise) => previousPromise.then(() => currentPromise()), Promise.resolve());
+    // Update Plists
+    execSync(`/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${shortVersion}" ${PLIST_PATH}`);
+    execSync(`/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${shortVersion}" ${PLIST_PATH_TEST}`);
+    execSync(`/usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${cfVersion}" ${PLIST_PATH}`);
+    execSync(`/usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${cfVersion}" ${PLIST_PATH_TEST}`);
 
-    return Promise.all([
-        cfVersion,
-        updatePromise,
-    ]);
+    // Return the cfVersion so we can set the NEW_IOS_VERSION in ios.yml
+    return cfVersion;
 };

--- a/.github/libs/nativeVersionUpdater.js
+++ b/.github/libs/nativeVersionUpdater.js
@@ -82,11 +82,16 @@ exports.updateiOSVersion = function updateiOSVersion(version) {
     console.log('Updating iOS', `CFBundleShortVersionString: ${shortVersion}`, `CFBundleVersion: ${cfVersion}`);
 
     // Pass back the cfVersion in the return array so we can set the NEW_IOS_VERSION in ios.yml
-    return Promise.all([
-        cfVersion,
+    const updatePromise = [
         exec(`/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${shortVersion}" ${PLIST_PATH}`),
         exec(`/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${shortVersion}" ${PLIST_PATH_TEST}`),
         exec(`/usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${cfVersion}" ${PLIST_PATH}`),
         exec(`/usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${cfVersion}" ${PLIST_PATH_TEST}`),
+    ]
+        .reduce((previousPromise, currentPromise) => previousPromise.then(() => currentPromise()), Promise.resolve());
+
+    return Promise.all([
+        cfVersion,
+        updatePromise,
     ]);
 };


### PR DESCRIPTION
cc @tgolen because I reused a trick I saw you used in `migrateOnyx` to get these promises to run one after another instead of all at the same time (although in my case the order doesn't matter).

### Details
My theory is that this workflow failed because we have multiple asynchronous commands attempting to read from and write to the same file at the same time. Ideas for how to verify that theory are welcome.

### Fixed Issues
Fixes [failed deploys](https://expensify.slack.com/archives/C03V9A4TB/p1616532437119200)

### Tests
Not tested locally.