### PR TITLE
Focus compose box when LHN report clicked

### DIFF
--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -78,8 +78,11 @@ class ReportActionCompose extends React.Component {
             this.comment = this.props.comment;
         }
 
-        // When any modal goes from visible to hidden, bring focus to the compose field
-        if (prevProps.modal.isVisible && !this.props.modal.isVisible) {
+        // When any modal goes from visible to hidden or when the report ID changes, bring focus to the compose field
+        if (
+            (prevProps.modal.isVisible && !this.props.modal.isVisible)
+            || (prevProps.reportID !== this.props.reportID)
+        ) {
             this.setIsFocused(true);
         }
     }


### PR DESCRIPTION
<If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit.>

### Details
<Explanation of the change or anything fishy that is going on>

When a user clicks on a chat from the LHN, the `ReportView` component updates, showing the latest conversation. At this point, we want the compose box at the bottom to be focused so that users can quickly and efficiently start typing a new message.

This change will make the compose box (`ReportActionCompose`) automatically get focused whenever the `reportID` prop changes, which happens whenever a user clicks on a different chat / report - not just via the LHN.

### Fixed Issues
<Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing>
Fixes https://github.com/Expensify/Expensify/issues/158106

### Tests
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

1. View any chat
2. Open a new chat by clicking it on the LHN
3. See the compose box automatically get focused

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

https://user-images.githubusercontent.com/3885503/112335496-f5c8fa80-8cc4-11eb-8664-41baf4e265ac.mov

#### Web
<!-- Insert screenshots of your changes on the web platform-->
See above

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
Not needed

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
See above

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
Not needed

#### Android
<!-- Insert screenshots of your changes on the Android platform-->

Not needed
