### PR TITLE
Update issue template to include slack invite email

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-If you haven’t already, check out our [contributing guidelines](https://github.com/Expensify/ReactNativeChat/blob/master/CONTRIBUTING.md) for onboarding!
+If you haven’t already, check out our [contributing guidelines](https://github.com/Expensify/ReactNativeChat/blob/master/CONTRIBUTING.md) for onboarding and email contributors@expensify.com to request to join our Slack channel!
 ___
 
 ## Expected Result:


### PR DESCRIPTION
### Details
This PR adds the slack invite email to the GH issue description. More context in slack: https://expensify.slack.com/archives/C03U7DCU4/p1616600232069200?thread_ts=1616598938.068000&cid=C03U7DCU4.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/158309

### Tests
![image](https://user-images.githubusercontent.com/3981102/112341992-1ec69c80-8c7f-11eb-8b2f-78e10880d81e.png)

### Tested On
N/A

### Screenshots
N/A
