### PR TITLE
fixed tooltip shows up on Mobile Web while navigating the reports

### DIFF
--- a/src/components/Hoverable/index.js
+++ b/src/components/Hoverable/index.js
@@ -25,22 +25,22 @@ class Hoverable extends Component {
 
         // we like to Block the hover on touch devices but we keep it for Hybrid devices so
         // following logic blocks hover on touch devices.
-        this.touchStartListener = () => {
+        this.disableHover = () => {
             this.hoverDisabled = true;
         };
-        this.touchEndListener = () => {
+        this.enableHover = () => {
             this.hoverDisabled = false;
         };
-        document.addEventListener('touchstart', this.touchStartListener);
+        document.addEventListener('touchstart', this.disableHover);
 
         // Remember Touchend fires before `mouse` events so we have to use alternative.
-        document.addEventListener('touchmove', this.touchEndListener);
+        document.addEventListener('touchmove', this.enableHover);
     }
 
     componentWillUnmount() {
         document.removeEventListener('mousedown', this.resetHoverStateOnOutsideClick);
-        document.removeEventListener('touchstart', this.touchStartListener);
-        document.removeEventListener('touchmove', this.touchEndListener);
+        document.removeEventListener('touchstart', this.disableHover);
+        document.removeEventListener('touchmove', this.enableHover);
     }
 
     /**

--- a/src/components/Hoverable/index.js
+++ b/src/components/Hoverable/index.js
@@ -22,10 +22,25 @@ class Hoverable extends Component {
 
     componentDidMount() {
         document.addEventListener('mousedown', this.resetHoverStateOnOutsideClick);
+
+        // we like to Block the hover on touch devices but we keep it for Hybrid devices so
+        // following logic blocks hover on touch devices.
+        this.touchStartListener = () => {
+            this.hoverDisabled = true;
+        };
+        this.touchEndListener = () => {
+            this.hoverDisabled = false;
+        };
+        document.addEventListener('touchstart', this.touchStartListener);
+
+        // Remember Touchend fires before `mouse` events so we have to use alternative.
+        document.addEventListener('touchmove', this.touchEndListener);
     }
 
     componentWillUnmount() {
         document.removeEventListener('mousedown', this.resetHoverStateOnOutsideClick);
+        document.removeEventListener('touchstart', this.touchStartListener);
+        document.removeEventListener('touchmove', this.touchEndListener);
     }
 
     /**
@@ -34,8 +49,13 @@ class Hoverable extends Component {
      * @param {Boolean} isHovered - Whether or not this component is hovered.
      */
     setIsHovered(isHovered) {
-        if (isHovered !== this.state.isHovered) {
+        if (isHovered !== this.state.isHovered && !(isHovered && this.hoverDisabled)) {
             this.setState({isHovered}, isHovered ? this.props.onHoverIn : this.props.onHoverOut);
+        }
+
+        // we reset the Hover block in case touchmove was not first after touctstart
+        if (!isHovered) {
+            this.hoverDisabled = false;
         }
     }
 


### PR DESCRIPTION
Please review @roryabraham 

### Details
Blocked the hover events on the `Hoverable` component on touch events.

### Fixed Issues
Fixes #1490
https://github.com/Expensify/Expensify.cash/pull/1632#issuecomment-805954359

### Tests
Open the App on any Mobile web platform and click on the names on the report title on the Home page. It should open the report and no tooltip should be shown.


### Tested On
- [x] Mobile Web


### Screenshots
N/A 

https://user-images.githubusercontent.com/24370807/112365932-3b55e980-8cfe-11eb-978e-c63f7c334a23.mp4



