### PR TITLE
fixed user's own message is `unread` on different plaforms 

### DIFF
--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -336,7 +336,7 @@ function removeOptimisticActions(reportID) {
 function updateReportWithNewAction(reportID, reportAction) {
     const newMaxSequenceNumber = reportAction.sequenceNumber;
     const isFromCurrentUser = reportAction.actorAccountID === currentUserAccountID;
-    const lastReadSequenceNumber = lastReadSequenceNumbers[reportID] || 0;
+    const initialLastReadSequenceNumber = lastReadSequenceNumbers[reportID] || 0;
 
     // When handling an action from the current users we can assume that their
     // last read actionID has been updated in the server but not necessarily reflected
@@ -352,13 +352,15 @@ function updateReportWithNewAction(reportID, reportAction) {
     // by handleReportChanged
     const updatedReportObject = {
         reportID,
-        unreadActionCount: newMaxSequenceNumber - lastReadSequenceNumber,
+
+        // Use updated lastReadSequenceNumber, value may have been modified by setLocalLastRead
+        unreadActionCount: newMaxSequenceNumber - (lastReadSequenceNumbers[reportID] || 0),
         maxSequenceNumber: reportAction.sequenceNumber,
     };
 
     // If the report action from pusher is a higher sequence number than we know about (meaning it has come from
     // a chat participant in another application), then the last message text and author needs to be updated as well
-    if (newMaxSequenceNumber > lastReadSequenceNumber) {
+    if (newMaxSequenceNumber > initialLastReadSequenceNumber) {
         updatedReportObject.lastMessageTimestamp = reportAction.timestamp;
         updatedReportObject.lastMessageText = messageText;
         updatedReportObject.lastActorEmail = reportAction.actorEmail;


### PR DESCRIPTION
Please review @marcaaron 

### Details
 we were using the stale reference to `lastReadSequenceNumber` which caused the linked issue. I have refactored the code and fixed it.

### Fixed Issues
<Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing>
Fixes #1985 

### Tests
Tried sending messages as explained in the issue.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [ ] iOS
- [x] Android

### Screenshots
> ### To the same User

https://user-images.githubusercontent.com/24370807/112392837-183c3180-8d20-11eb-8099-781008fe3169.mp4

---
> ### To another User

  https://user-images.githubusercontent.com/24370807/112392850-1ecaa900-8d20-11eb-9ca3-8050ee8d3013.mp4 



