### PR TITLE
Deploy Android, Web and Desktop to staging and production

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -48,10 +48,8 @@ jobs:
               if: ${{ env.SHOULD_DEPLOY_PRODUCTION == 'false' }}
               run: bundle exec fastlane android beta
 
-            # TODO: uncomment when we want to release iOS to production
             - name: Run Fastlane production
-#              if: ${{ env.SHOULD_DEPLOY_PRODUCTION == 'true' }}
-              if: ${{ env.SHOULD_DEPLOY_PRODUCTION == 'true' && 'false' == 'true' }}
+              if: ${{ env.SHOULD_DEPLOY_PRODUCTION == 'true' }}
               run: bundle exec fastlane android production
               env:
                 VERSION: ${{ env.VERSION }}

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -13,9 +13,7 @@ jobs:
         if: github.actor == 'OSBotify'
         runs-on: macos-latest
         env:
-#          TODO: Uncomment when we'd like to deploy to staging
-#          SHOULD_DEPLOY_PRODUCTION: ${{ github.event_name == 'release' }}
-          SHOULD_DEPLOY_PRODUCTION: ${{ true }}
+          SHOULD_DEPLOY_PRODUCTION: ${{ github.event_name == 'release' }}
         steps:
             - uses: actions/checkout@v2
 

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -13,9 +13,7 @@ jobs:
         if: github.actor == 'OSBotify'
         runs-on: ubuntu-latest
         env:
-#          TODO: Uncomment when we'd like to deploy to staging
-#          SHOULD_DEPLOY_PRODUCTION: ${{ github.event_name == 'release' }}
-          SHOULD_DEPLOY_PRODUCTION: ${{ true }}
+          SHOULD_DEPLOY_PRODUCTION: ${{ github.event_name == 'release' }}
 
         steps:
             - uses: actions/checkout@v2


### PR DESCRIPTION
### Details
Flip the switch and deploy to staging OR production, but not both.

### Fixed Issues
Fixes (partial) https://github.com/Expensify/Expensify/issues/155232

### Tests
1) Merge this PR
2) See that a staging deploy happens, and production deploy does not.

### Tested On
Merge to test!
