### PR TITLE
Implement library to format time/dates for international users.

### DIFF
--- a/src/libs/DateUtils.js
+++ b/src/libs/DateUtils.js
@@ -1,7 +1,6 @@
 import moment from 'moment';
 import 'moment-timezone';
 import Onyx from 'react-native-onyx';
-import Str from 'expensify-common/lib/str';
 import ONYXKEYS from '../ONYXKEYS';
 import CONST from '../CONST';
 
@@ -15,13 +14,15 @@ Onyx.connect({
  * Gets the user's stored time-zone NVP and returns a localized
  * Moment object for the given timestamp
  *
+ * @param {String} locale
  * @param {Number} timestamp
  *
  * @returns  {Moment}
  *
  * @private
  */
-function getLocalMomentFromTimestamp(timestamp) {
+function getLocalMomentFromTimestamp(locale, timestamp) {
+    moment.locale(locale);
     return moment.unix(timestamp).tz(timezone);
 }
 
@@ -33,32 +34,48 @@ function getLocalMomentFromTimestamp(timestamp) {
  * Jan 20 at 5:30 PM          within the past year
  * Jan 20, 2019 at 5:30 PM    anything over 1 year ago
  *
+ * @param {String} locale
  * @param {Number} timestamp
  * @param {Boolean} includeTimeZone
  *
  * @returns {String}
  */
-function timestampToDateTime(timestamp, includeTimeZone = false) {
-    const date = getLocalMomentFromTimestamp(timestamp);
-    const isThisYear = moment().format('YYYY') === date.format('YYYY');
-    const isToday = moment().format('D MMM YYYY') === date.format('D MMM YYYY');
-    const yesterday = moment().add(-1, 'day').format('D MMM YYYY');
-    const isYesterday = yesterday === date.format('D MMM YYYY');
+function timestampToDateTime(locale, timestamp, includeTimeZone = false) {
+    const date = getLocalMomentFromTimestamp(locale, timestamp);
 
-    let format = 'LT';
-    if (isYesterday) {
-        format = `[Yesterday at] ${format}`;
-    } else if (!isToday) {
-        format = `MMM D [at] ${format}`;
-    } else if (!isThisYear) {
-        format = `MMM D, YYYY [at] ${format}`;
-    }
+    moment.calendarFormat = function (myMoment, now) {
+        const diff = myMoment.diff(now, 'days', true);
 
-    if (includeTimeZone) {
-        format = `${format} [UTC]Z`;
-    }
+        let retVal = 'sameElse';
 
-    return date.format(format);
+        if (diff < -1) {
+            retVal = 'lastWeek';
+        } else if (diff < 0) {
+            retVal = 'lastDay';
+        } else if (diff < 1) {
+            retVal = 'sameDay';
+        } else if (diff < 2) {
+            retVal = 'nextDay';
+        } else if (diff < 7) {
+            retVal = 'nextWeek';
+        }
+
+        if (includeTimeZone) {
+            retVal = 'timeZone';
+        }
+
+        return retVal;
+    };
+
+    return moment().calendar(date, {
+        sameDay: '[Today at] LT',
+        nextDay: '[Tomorrow at] LT',
+        nextWeek: 'MMM D [at] LT',
+        lastDay: '[Yesterday at] LT',
+        lastWeek: 'MMM D [at] LT',
+        sameElse: 'MMM D, YYYY [at] LT',
+        timeZone: 'LT [UTC]Z',
+    });
 }
 
 /**
@@ -74,41 +91,15 @@ function timestampToDateTime(timestamp, includeTimeZone = false) {
  * Jan 20               within the past year
  * Jan 20, 2019         anything over 1 year
  *
+ * @param {String} locale
  * @param {Number} timestamp
  *
  * @returns {String}
  */
-function timestampToRelative(timestamp) {
-    const date = getLocalMomentFromTimestamp(timestamp);
-    const durationFromLocalNow = moment.duration(
-        date.diff(getLocalMomentFromTimestamp(moment().unix())),
-    );
-    const round = num => Math.floor(Math.abs(num));
+function timestampToRelative(locale, timestamp) {
+    const date = getLocalMomentFromTimestamp(locale, timestamp);
 
-    if (date.isAfter(moment().subtract(60, 'seconds'))) {
-        return '< 1 minute ago';
-    }
-
-    if (date.isAfter(moment().subtract(60, 'minutes'))) {
-        const minutes = round(durationFromLocalNow.asMinutes());
-        return `${minutes} ${Str.pluralize('minute', 'minutes', minutes)} ago`;
-    }
-
-    if (date.isAfter(moment().subtract(24, 'hours'))) {
-        const hours = round(durationFromLocalNow.asHours());
-        return `${hours} ${Str.pluralize('hour', 'hours', hours)} ago`;
-    }
-
-    if (date.isAfter(moment().subtract(30, 'days'))) {
-        const days = round(durationFromLocalNow.asDays());
-        return `${days} ${Str.pluralize('day', 'days', days)} ago`;
-    }
-
-    if (date.isAfter(moment().subtract(1, 'year'))) {
-        return date.format('MMM D');
-    }
-
-    return date.format('MMM D, YYYY');
+    return moment(date).fromNow();
 }
 
 /**

--- a/src/libs/DateUtils.js
+++ b/src/libs/DateUtils.js
@@ -42,26 +42,15 @@ function getLocalMomentFromTimestamp(locale, timestamp) {
  */
 function timestampToDateTime(locale, timestamp, includeTimeZone = false) {
     const date = getLocalMomentFromTimestamp(locale, timestamp);
-    const TZ = '[UTC]Z';
-
-    if (includeTimeZone) {
-        return moment(date).calendar({
-            sameDay: `[Today at] LT ${TZ}`,
-            nextDay: `[Tomorrow at] LT ${TZ}`,
-            nextWeek: `MMM D [at] LT ${TZ}`,
-            lastDay: `[Yesterday at] LT ${TZ}`,
-            lastWeek: `MMM D [at] LT ${TZ}`,
-            sameElse: `MMM D, YYYY [at] LT ${TZ}`,
-        });
-    }
+    const tz = includeTimeZone ? ' [UTC]Z' : '';
 
     return moment(date).calendar({
-        sameDay: '[Today at] LT',
-        nextDay: '[Tomorrow at] LT',
-        nextWeek: 'MMM D [at] LT',
-        lastDay: '[Yesterday at] LT',
-        lastWeek: 'MMM D [at] LT',
-        sameElse: 'MMM D, YYYY [at] LT',
+        sameDay: `[Today at] LT${tz}`,
+        nextDay: `[Tomorrow at] LT${tz}`,
+        nextWeek: `MMM D [at] LT${tz}`,
+        lastDay: `[Yesterday at] LT${tz}`,
+        lastWeek: `MMM D [at] LT${tz}`,
+        sameElse: `MMM D, YYYY [at] LT${tz}`,
     });
 }
 

--- a/src/libs/DateUtils.js
+++ b/src/libs/DateUtils.js
@@ -42,6 +42,7 @@ function getLocalMomentFromTimestamp(locale, timestamp) {
  */
 function timestampToDateTime(locale, timestamp, includeTimeZone = false) {
     const date = getLocalMomentFromTimestamp(locale, timestamp);
+    const TZ = '[UTC]Z';
 
     moment.calendarFormat = function (myMoment, now) {
         const diff = myMoment.diff(now, 'days', true);
@@ -60,21 +61,27 @@ function timestampToDateTime(locale, timestamp, includeTimeZone = false) {
             retVal = 'nextWeek';
         }
 
-        if (includeTimeZone) {
-            retVal = 'timeZone';
-        }
-
         return retVal;
     };
 
-    return moment().calendar(date, {
+    if (includeTimeZone) {
+        return moment(date).calendar({
+            sameDay: `[Today at] LT ${TZ}`,
+            nextDay: `[Tomorrow at] LT ${TZ}`,
+            nextWeek: `MMM D [at] LT ${TZ}`,
+            lastDay: `[Yesterday at] LT ${TZ}`,
+            lastWeek: `MMM D [at] LT ${TZ}`,
+            sameElse: `MMM D, YYYY [at] LT ${TZ}`,
+        });
+    }
+
+    return moment(date).calendar({
         sameDay: '[Today at] LT',
         nextDay: '[Tomorrow at] LT',
         nextWeek: 'MMM D [at] LT',
         lastDay: '[Yesterday at] LT',
         lastWeek: 'MMM D [at] LT',
         sameElse: 'MMM D, YYYY [at] LT',
-        timeZone: 'LT [UTC]Z',
     });
 }
 

--- a/src/libs/DateUtils.js
+++ b/src/libs/DateUtils.js
@@ -44,26 +44,6 @@ function timestampToDateTime(locale, timestamp, includeTimeZone = false) {
     const date = getLocalMomentFromTimestamp(locale, timestamp);
     const TZ = '[UTC]Z';
 
-    moment.calendarFormat = function (myMoment, now) {
-        const diff = myMoment.diff(now, 'days', true);
-
-        let retVal = 'sameElse';
-
-        if (diff < -1) {
-            retVal = 'lastWeek';
-        } else if (diff < 0) {
-            retVal = 'lastDay';
-        } else if (diff < 1) {
-            retVal = 'sameDay';
-        } else if (diff < 2) {
-            retVal = 'nextDay';
-        } else if (diff < 7) {
-            retVal = 'nextWeek';
-        }
-
-        return retVal;
-    };
-
     if (includeTimeZone) {
         return moment(date).calendar({
             sameDay: `[Today at] LT ${TZ}`,

--- a/src/pages/home/report/ReportActionItemDate.js
+++ b/src/pages/home/report/ReportActionItemDate.js
@@ -11,7 +11,7 @@ const propTypes = {
 
 const ReportActionItemDate = props => (
     <Text style={[styles.chatItemMessageHeaderTimestamp]}>
-        {DateUtils.timestampToDateTime(props.timestamp)}
+        {DateUtils.timestampToDateTime('en', props.timestamp)}
     </Text>
 );
 


### PR DESCRIPTION
### Details
- Added a first parameter to the two exposed functions in the DateUtils library, `timestampToDateTime` and `timestampToRelative`. 
- Replaced the `timestampToRelative` function implementation with `moment().fromNow()` method.
- Implemented the `timestampToDateTime` function with the moment `calendar()` method with the exact configuration as that of the current implementation in Expensify.
- Both the methods are locale-aware.

### Fixed Issues
https://github.com/Expensify/Expensify.cash/issues/1856

### Tests
1. Go to the main chat page of the application and select any conversation.
2. Have a conversation and check the date-time implementation passing multiple locales.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web
![image](https://user-images.githubusercontent.com/25154948/112422435-fd39e380-8d58-11eb-8b2c-d61d786153d3.png)


#### Mobile Web
![image](https://user-images.githubusercontent.com/25154948/112422819-9668fa00-8d59-11eb-8bbb-73c0ebb2ddc2.png)


#### Desktop
![image](https://user-images.githubusercontent.com/25154948/112423002-eb0c7500-8d59-11eb-8e46-e5d1b8f91f15.png)


#### iOS
![Simulator Screen Shot - iPhone 11 - 2021-03-25 at 12 20 26](https://user-images.githubusercontent.com/25154948/112429259-8571b600-8d64-11eb-9390-9e176c854286.png)


#### Android
![image](https://user-images.githubusercontent.com/25154948/112426730-8a346b00-8d60-11eb-9415-127e6b6e01f0.png)

