### PR TITLE
Expand swipe area for MainDrawerNavigator

### DIFF
--- a/src/libs/Navigation/AppNavigator/MainDrawerNavigator.js
+++ b/src/libs/Navigation/AppNavigator/MainDrawerNavigator.js
@@ -26,6 +26,7 @@ const MainDrawerNavigator = props => (
             props.isSmallScreenWidth,
         )}
         sceneContainerStyle={styles.navigationSceneContainer}
+        edgeWidth={500}
         drawerContent={() => (
             <SidebarScreen />
         )}


### PR DESCRIPTION
@trjExpensify 

### Details
Expanded swipe area for most of the screen(500) to navigate backwards/forwards from the LHN to the chat.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/2025

### Tests

- Open the application
- Enter a chat
- Swipe screen to left on anywhere on the screen
- Make sure chat list displayed correctly

### Tested On

- [X] Web (Gesture is not supported on Web. No regression.)
- [X] Mobile Web (Gesture is not supported on Web. No regression.)
- [X] Desktop (Gesture is not supported on Desktop. No regression.)
- [X] iOS
- [X] Android

### Screenshots

#### iOS

https://user-images.githubusercontent.com/3853003/112501951-941a9600-8d81-11eb-9009-2f1e9a877abf.mov

#### Android

https://user-images.githubusercontent.com/3853003/112502020-9ed52b00-8d81-11eb-9b77-a1a9b7dbd292.mov


