### PR TITLE
[No QA]Update readme to include link for updating encrypted secrets

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -38,8 +38,6 @@ The GitHub workflows require a large list of secrets to deploy, notify and test 
 14. `APPLE_DEMO_EMAIL` - Demo account email used for https://appstoreconnect.apple.com/
 15. `APPLE_DEMO_PASSWORD` - Demo account password used for https://appstoreconnect.apple.com/
 
-## Updating 
-
 ## Actions
 
 All these _workflows_ are comprised of atomic _actions_. Most of the time, we can use pre-made and independently maintained actions to create powerful workflows that meet our needs. However, when we want to do something very specific or have a more complex or robust action in mind, we can create our own _actions_.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -18,7 +18,7 @@
 
 ## Secrets
 The GitHub workflows require a large list of secrets to deploy, notify and test the code:
-1. `LARGE_SECRET_PASSPHRASE` - decrypts secrets stored in various encrypted files stored in GitHub repository:
+1. `LARGE_SECRET_PASSPHRASE` - decrypts secrets stored in various encrypted files stored in GitHub repository. To create updated versions of these encrypted files, refer to steps 1-4 of [this encrypted secrets help page](https://docs.github.com/en/actions/reference/encrypted-secrets#limits-for-secrets) using the `LARGE_SECRET_PASSPHRASE`.
    1. `android/app/my-upload-key.keystore.gpg`
    2. `android/app/android-fastlane-json-key.json.gpg`
    3. `ios/chat_expensify_appstore.mobileprovision`
@@ -37,6 +37,8 @@ The GitHub workflows require a large list of secrets to deploy, notify and test 
 13. `APPLE_CONTACT_PHONE` - Phone number used for contact between Expensify and Apple for https://appstoreconnect.apple.com/
 14. `APPLE_DEMO_EMAIL` - Demo account email used for https://appstoreconnect.apple.com/
 15. `APPLE_DEMO_PASSWORD` - Demo account password used for https://appstoreconnect.apple.com/
+
+## Updating 
 
 ## Actions
 


### PR DESCRIPTION
@AndrewGable will you please review this? Lmk if there's any other info we want to add here

### Details
This PR updates the workflow.md to include the help link for updating encrypted secrets used in the repo.

### Tests
See the changes in https://github.com/Expensify/Expensify.cash/blob/joe-encrypted-secrets-readme/.github/workflows/README.md#secrets