### PR TITLE
Add ability to zoom images on web/desktop

### DIFF
--- a/src/components/ImageView/index.js
+++ b/src/components/ImageView/index.js
@@ -1,35 +1,61 @@
-import React, {memo} from 'react';
+import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {View, Image} from 'react-native';
-import styles from '../../styles/styles';
+import {View, Image, Pressable} from 'react-native';
+import styles, {getZoomCursorStyle, getZoomSizingStyle} from '../../styles/styles';
 
 const propTypes = {
     // URL to full-sized image
     url: PropTypes.string.isRequired,
 };
 
-const ImageView = props => (
-    <View
-        style={[
-            styles.w100,
-            styles.h100,
-            styles.alignItemsCenter,
-            styles.justifyContentCenter,
-            styles.overflowHidden,
-        ]}
-    >
-        <Image
-            source={{uri: props.url}}
-            style={[
-                styles.w100,
-                styles.h100,
-            ]}
-            resizeMode="center"
-        />
-    </View>
-);
+class ImageView extends PureComponent {
+    constructor(props) {
+        super(props);
+        this.scrollableRef = null;
+        this.state = {
+            isZoomed: false,
+        };
+    }
+
+    render() {
+        return (
+            <View
+                ref={el => this.scrollableRef = el}
+                style={[
+                    styles.w100,
+                    styles.h100,
+                    styles.alignItemsCenter,
+                    styles.justifyContentCenter,
+                    styles.overflowScroll,
+                    styles.noScrollbars,
+                ]}
+            >
+                <Pressable
+                    style={[
+                        styles.w100,
+                        styles.h100,
+                        styles.flex1,
+                        getZoomCursorStyle(this.state.isZoomed),
+                    ]}
+                    onPress={(e) => {
+                        const {offsetX, offsetY} = e.nativeEvent;
+                        this.setState(prevState => ({
+                            isZoomed: !prevState.isZoomed,
+                        }), () => {
+                            this.scrollableRef.scrollTo(offsetX, offsetY);
+                        });
+                    }}
+                >
+                    <Image
+                        source={{uri: this.props.url}}
+                        style={getZoomSizingStyle(this.state.isZoomed)}
+                        resizeMode="center"
+                    />
+                </Pressable>
+            </View>
+        );
+    }
+}
 
 ImageView.propTypes = propTypes;
-ImageView.displayName = 'ImageView';
-
-export default memo(ImageView);
+export default ImageView;

--- a/src/components/ImageView/index.js
+++ b/src/components/ImageView/index.js
@@ -14,7 +14,27 @@ class ImageView extends PureComponent {
         this.scrollableRef = null;
         this.state = {
             isZoomed: false,
+            isDragging: false,
+            isMouseDown: false,
+            x: 0,
+            y: 0,
         };
+    }
+
+    componentDidMount() {
+        document.addEventListener('mousemove', this.trackMouseMove.bind(this));
+    }
+
+    componentWillUnmount() {
+        document.removeEventListener('mousemove', this.trackMouseMove.bind(this));
+    }
+
+    trackMouseMove() {
+        if (!this.state.isMouseDown) {
+            return;
+        }
+
+        this.setState({isDragging: true});
     }
 
     render() {
@@ -35,15 +55,38 @@ class ImageView extends PureComponent {
                         styles.w100,
                         styles.h100,
                         styles.flex1,
-                        getZoomCursorStyle(this.state.isZoomed),
+                        getZoomCursorStyle(this.state.isZoomed, this.state.isDragging),
                     ]}
+                    onPressIn={() => {
+                        console.log('on press in');
+                        this.setState({
+                            isDragging: false,
+                            isMouseDown: true,
+                        });
+                    }}
                     onPress={(e) => {
+                        if (!this.state.isMouseDown) {
+                            return;
+                        }
+
                         const {offsetX, offsetY} = e.nativeEvent;
+                        this.setState({
+                            x: offsetX * 1.5,
+                            y: offsetY * 1.5,
+                        }, () => {
+                            this.scrollableRef.scrollTo(this.state.x, this.state.y);
+                        });
+                    }}
+                    onPressOut={() => {
+                        console.log('on press out');
+                        if (this.state.isDragging) {
+                            this.setState({isDragging: false, isMouseDown: false});
+                            return;
+                        }
+
                         this.setState(prevState => ({
                             isZoomed: !prevState.isZoomed,
-                        }), () => {
-                            this.scrollableRef.scrollTo(offsetX, offsetY);
-                        });
+                        }));
                     }}
                 >
                     <Image

--- a/src/components/ImageView/index.js
+++ b/src/components/ImageView/index.js
@@ -24,16 +24,16 @@ class ImageView extends PureComponent {
     }
 
     componentDidMount() {
-        document.addEventListener('mousemove', this.trackMouseMove.bind(this));
-        document.addEventListener('touchmove', this.trackMouseMove.bind(this));
+        document.addEventListener('mousemove', this.trackMovement.bind(this));
+        document.addEventListener('touchmove', this.trackMovement.bind(this));
     }
 
     componentWillUnmount() {
-        document.removeEventListener('mousemove', this.trackMouseMove.bind(this));
-        document.removeEventListener('touchmove', this.trackMouseMove.bind(this));
+        document.removeEventListener('mousemove', this.trackMovement.bind(this));
+        document.removeEventListener('touchmove', this.trackMovement.bind(this));
     }
 
-    trackMouseMove(e) {
+    trackMovement(e) {
         if (!this.state.isZoomed) {
             return;
         }

--- a/src/libs/canUseTouchscreen.js
+++ b/src/libs/canUseTouchscreen.js
@@ -1,0 +1,32 @@
+/**
+ * Allows us to identify whether the platform has a touchscreen.
+ *
+ * https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent
+ *
+ * @returns {Boolean}
+ */
+function canUseTouchScreen() {
+    let hasTouchScreen = false;
+    if ('maxTouchPoints' in navigator) {
+        hasTouchScreen = navigator.maxTouchPoints > 0;
+    } else if ('msMaxTouchPoints' in navigator) {
+        hasTouchScreen = navigator.msMaxTouchPoints > 0;
+    } else {
+        const mQ = window.matchMedia && matchMedia('(pointer:coarse)');
+        if (mQ && mQ.media === '(pointer:coarse)') {
+            hasTouchScreen = !!mQ.matches;
+        } else if ('orientation' in window) {
+            hasTouchScreen = true; // deprecated, but good fallback
+        } else {
+            // Only as a last resort, fall back to user agent sniffing
+            const UA = navigator.userAgent;
+            hasTouchScreen = (
+                /\b(BlackBerry|webOS|iPhone|IEMobile)\b/i.test(UA)
+                || /\b(Android|Windows Phone|iPad|iPod)\b/i.test(UA)
+            );
+        }
+    }
+    return hasTouchScreen;
+}
+
+export default canUseTouchScreen;

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1328,11 +1328,16 @@ function getNavigationModalCardStyle(isSmallScreenWidth) {
 
 /**
  * @param {Boolean} isZoomed
+ * @param {Boolean} isDragging
  * @return {Object}
  */
-function getZoomCursorStyle(isZoomed) {
+function getZoomCursorStyle(isZoomed, isDragging) {
+    if (!isZoomed) {
+        return {cursor: 'zoom-in'};
+    }
+
     return {
-        cursor: isZoomed ? 'zoom-out' : 'zoom-in',
+        cursor: isDragging ? 'grabbing' : 'zoom-out',
     };
 }
 
@@ -1342,8 +1347,8 @@ function getZoomCursorStyle(isZoomed) {
  */
 function getZoomSizingStyle(isZoomed) {
     return {
-        height: isZoomed ? '200%' : '100%',
-        width: isZoomed ? '200%' : '100%',
+        height: isZoomed ? '250%' : '100%',
+        width: isZoomed ? '250%' : '100%',
     };
 }
 

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1185,6 +1185,10 @@ const styles = {
         fontWeight: fontWeightBold,
         fontSize: variables.iouAmountTextSize,
     }, 0),
+
+    noScrollbars: {
+        scrollbarWidth: 'none',
+    },
 };
 
 const baseCodeTagStyles = {
@@ -1322,6 +1326,27 @@ function getNavigationModalCardStyle(isSmallScreenWidth) {
     };
 }
 
+/**
+ * @param {Boolean} isZoomed
+ * @return {Object}
+ */
+function getZoomCursorStyle(isZoomed) {
+    return {
+        cursor: isZoomed ? 'zoom-out' : 'zoom-in',
+    };
+}
+
+/**
+ * @param {Boolean} isZoomed
+ * @return {Object}
+ */
+function getZoomSizingStyle(isZoomed) {
+    return {
+        height: isZoomed ? '200%' : '100%',
+        width: isZoomed ? '200%' : '100%',
+    };
+}
+
 export default styles;
 export {
     getSafeAreaPadding,
@@ -1330,4 +1355,6 @@ export {
     getNavigationDrawerStyle,
     getNavigationDrawerType,
     getNavigationModalCardStyle,
+    getZoomCursorStyle,
+    getZoomSizingStyle,
 };


### PR DESCRIPTION
### Details
Adds ability to zoom to 200% by clicking on image attachment on web/mWeb

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/146569

### Tests
**web/desktop**
1. Click on an attachment
2. Verify there is a zoom cursor
3. Click and verify the image zooms
4. Hold and drag and verify the image pans
5. Click again and verify the image zooms back out

**mWeb**
1. Click on an attachment in mobile web browser
1. Verify that pinch to zoom works normally

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
https://user-images.githubusercontent.com/32969087/112687216-43577b80-8e1b-11eb-9963-e342373c804e.mp4

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
https://user-images.githubusercontent.com/32969087/112689955-10af8200-8e1f-11eb-9033-a1c8c61f26ed.mp4

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
