### PR TITLE
Don't deploy staging when StagingDeployCash is locked

### DIFF
--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -112,7 +112,6 @@ jobs:
 
       #TODO: Once we add cherry picking, we will need run this from elsewhere
       - name: 🚀 Push tags to trigger staging deploy 🚀
-        if: ${{ needs.chooseDeployActions.outputs.isStagingDeployLocked == 'false' }}
         run: git push --tags
 
       - name: Update StagingDeployCash

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -52,7 +52,7 @@ jobs:
   version:
     runs-on: macos-latest
     needs: chooseDeployActions
-    if: ${{ needs.chooseDeployActions.outputs.isVersionBumpPR == 'false' }}
+    if: ${{ needs.chooseDeployActions.outputs.isStagingDeployLocked == 'false' && needs.chooseDeployActions.outputs.isVersionBumpPR == 'false' }}
     outputs:
       newVersion: ${{ steps.bumpVersion.outputs.NEW_VERSION }}
 


### PR DESCRIPTION

### Details
Failed workflow run: https://github.com/Expensify/Expensify.cash/runs/2195663283?check_suite_focus=true

We were planning on doing staging deploys only when the `staging` branch is updated, so that meant we would create a new version on master when a new PR is merged, regardless of whether the `StagingDeployCash` is locked. However, we've since made deploys happen in the `version` workflow, but we forgot to skip the workflow when the `StagingDeployCash` is locked. 

### Fixed Issues
n/a

### Tests
1) Make sure the `StagingDeployCash` is locked
2) Merge this PR
3) Make sure the staging deploy is skipped