### PR TITLE
[No QA] Add QA steps to the pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,19 @@ Fixes GH_LINK
 <!--- 
 Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
 Add any additional test steps if test steps are unique to a particular platform.
-Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes.
+Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.
+
+For example:
+1. Click on the text input to bring it into focus
+2. Upload an image via copy paste
+3. Verify a modal appears displaying a preview of that image 
+--->
+
+### QA Steps
+<!--- 
+Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
+Add any additional QA steps if test steps are unique to a particular platform.
+Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.
 
 For example:
 1. Click on the text input to bring it into focus


### PR DESCRIPTION
### Details
Updates the Expensify.cash pull request template to include a section with QA steps for staging QA.

### Fixed Issues
n/a – Talked with @isagoico 1:1 about how many PRs do not have clear QA steps that work on staging. Providing QA steps is a standard practice in all our other repos, so it should be a standard practice in this one too.

### Tests
1. Merge this pull request.
2. Create a new pull request.
3. Ensure that the new pull request is pre-populated with a section titled "QA Steps"

### Tested On
n/a - can only be tested on Github by merging.