### PR TITLE
Fix Mobile Web Scrolling in OptionsList

### DIFF
--- a/src/components/OptionsList.js
+++ b/src/components/OptionsList.js
@@ -190,7 +190,9 @@ class OptionsList extends Component {
 
     render() {
         return (
-            <View style={[styles.flex1]}>
+
+            // need to set a height (0 works in this case) so that the view will scroll on mobile
+            <View style={[styles.flex1, {height: 0}]}>
                 {this.props.headerMessage ? (
                     <View style={[styles.ph5, styles.pb5]}>
                         <Text style={[styles.textLabel, styles.colorMuted]}>

--- a/src/components/OptionsList.js
+++ b/src/components/OptionsList.js
@@ -191,7 +191,8 @@ class OptionsList extends Component {
     render() {
         return (
 
-            <View style={[styles.flex1]}>
+            // need to set a height (0 works in this case) so that the view will scroll on mobile
+            <View style={[styles.flex1, {height: 0}]}>
                 {this.props.headerMessage ? (
                     <View style={[styles.ph5, styles.pb5]}>
                         <Text style={[styles.textLabel, styles.colorMuted]}>
@@ -213,7 +214,6 @@ class OptionsList extends Component {
                     renderItem={this.renderItem}
                     renderSectionHeader={this.renderSectionHeader}
                     extraData={this.props.focusedIndex}
-                    style={[styles.flex1]}
                 />
             </View>
         );

--- a/src/components/OptionsList.js
+++ b/src/components/OptionsList.js
@@ -192,6 +192,7 @@ class OptionsList extends Component {
         return (
 
             // need to set a height (0 works in this case) so that the view will scroll on mobile
+            // NOTE: the view will still fill its container since it has flex: 1 on it
             <View style={[styles.flex1, {height: 0}]}>
                 {this.props.headerMessage ? (
                     <View style={[styles.ph5, styles.pb5]}>

--- a/src/components/OptionsList.js
+++ b/src/components/OptionsList.js
@@ -191,8 +191,7 @@ class OptionsList extends Component {
     render() {
         return (
 
-            // need to set a height (0 works in this case) so that the view will scroll on mobile
-            <View style={[styles.flex1, {height: 0}]}>
+            <View style={[styles.flex1]}>
                 {this.props.headerMessage ? (
                     <View style={[styles.ph5, styles.pb5]}>
                         <Text style={[styles.textLabel, styles.colorMuted]}>
@@ -214,6 +213,7 @@ class OptionsList extends Component {
                     renderItem={this.renderItem}
                     renderSectionHeader={this.renderSectionHeader}
                     extraData={this.props.focusedIndex}
+                    style={[styles.flex1]}
                 />
             </View>
         );


### PR DESCRIPTION
### Details

For some reason, the outer View in the OptionsList grows to fill the entire length of it's children on mobile (and therefore overflows the page), and therefore prevents scrolling.

I added `height: 0` to this View (it still grows to fill its container since it has `flex: 1`) so that it doesn't overflow the document body. Ideally we can find a better solution that isn't as confusing/janky, I'll dig deeper when I have more time.

I've been unable to test it on iOS/Android (my dev env is broken), but I can verify that this doesn't break anything on Web, Mobile-Web, and Desktop.


### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/158391
Fixes https://github.com/Expensify/Expensify/issues/158390

### Tests
1. Log into an account with a large amount of contacts (enough to cause overflow when selecting a new chat).
2. Verify that you are able to scroll.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Mobile Web

https://user-images.githubusercontent.com/31285285/112598688-eaeba280-8e49-11eb-9249-9e223301f12f.mp4

#### Web

https://user-images.githubusercontent.com/31285285/112598698-f048ed00-8e49-11eb-8026-352a075cef98.mp4

#### Desktop

https://user-images.githubusercontent.com/31285285/112598716-f63ece00-8e49-11eb-8490-5322329039fe.mp4



