### PR TITLE
Fix issue where IOUAction causes crash in empty chat

### DIFF
--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -223,7 +223,7 @@ class ReportActionsView extends React.Component {
     updateSortedReportActions() {
         this.sortedReportActions = _.chain(this.props.reportActions)
             .sortBy('sequenceNumber')
-            .filter(action => action.actionName === 'ADDCOMMENT')
+            .filter(action => action.actionName === 'ADDCOMMENT' || action.actionName === 'IOU')
             .map((item, index) => ({action: item, index}))
             .value()
             .reverse();
@@ -284,7 +284,7 @@ class ReportActionsView extends React.Component {
      * scroll the list to the end. As a report can contain non-message actions, we should confirm that list data exists.
      */
     scrollToListBottom() {
-        if (this.actionListElement && this.actionListElement.data) {
+        if (this.actionListElement) {
             this.actionListElement.scrollToIndex({animated: false, index: 0});
         }
         this.recordMaxAction();

--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -281,10 +281,10 @@ class ReportActionsView extends React.Component {
     /**
      * This function is triggered from the ref callback for the scrollview. That way it can be scrolled once all the
      * items have been rendered. If the number of actions has changed since it was last rendered, then
-     * scroll the list to the end.
+     * scroll the list to the end. As a report can contain non-message actions, we should confirm that list data exists.
      */
     scrollToListBottom() {
-        if (this.actionListElement) {
+        if (this.actionListElement && this.actionListElement.data) {
             this.actionListElement.scrollToIndex({animated: false, index: 0});
         }
         this.recordMaxAction();


### PR DESCRIPTION
### Details
Mobile apps are crashing when the user opens a ChatReport that has an associated `IOUACTION`, but no messages. When we try to scrollToBottom, the index count is inaccurate -- because we are not rendering a list item for an `IOUACTION`.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/158501

### Tests

- Find two users who have not yet sent any messages to one other
- Using the API listed below, create an IOU between these two users (either user can create it)
- Navigate to the chat on mobile, make sure the keyboard gains focus
- Tap outside of the input field and then back into the field a couple of times
- The app should NOT crash!


**Create an IOU transaction**
```
curl --request POST \
  --url 'https://expensify-jules.ngrok.io/api?command=CreateIOUTransaction' \
  --header 'Content-Type: multipart/form-data; boundary=---011000010111000001101001' \
  --cookie 'email=jules%252B4%2540expensify.com; accountID=308; authToken=113FE...428E' \
  --form 'debtorEmail=jules+6@expensify.com' \
  --form currency=USD \
  --form comment=Cake \
  --form amount=110
```

https://user-images.githubusercontent.com/10736861/112659949-d2c95280-8e4c-11eb-822a-9832324fa257.mp4

### QA Steps

Run above test ^ 


### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
N/A