### PR TITLE
Fixed Pressing `Enter` immediately after pasting a image in the Compose Box closes the modal. 

### DIFF
--- a/src/components/Modal/BaseModal.js
+++ b/src/components/Modal/BaseModal.js
@@ -69,7 +69,12 @@ class BaseModal extends PureComponent {
         );
         return (
             <ReactNativeModal
-                onBackdropPress={this.props.onClose}
+                onBackdropPress={(e) => {
+                    if (e && e.type === 'keydown' && e.key === 'Enter') {
+                        return;
+                    }
+                    this.props.onClose();
+                }}
                 onBackButtonPress={this.props.onClose}
                 onModalShow={() => {
                     this.subscribeToKeyEvents();


### PR DESCRIPTION
Please review.

### Details
A detailed explanation of issue #2063 is here https://github.com/Expensify/Expensify.cash/issues/2063#issuecomment-806634078

### Fixed Issues
<Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing>
Fixes #2063

### Tests
1. Copy an image to the clipboard
2. Click on compose box in a chat with a user or test account
3. Paste the image into composing by typing `command+v`
4. Immediately tap enter twice or more.
5. Modal should not close.
6. After the modal is visible, pressing `enter` submits the image. (Image will not be submitted until the modal is fully visible we can do this but we come to consent https://github.com/Expensify/Expensify.cash/issues/2063#issuecomment-807680158).

### QA Steps
1. Perform the above steps to test it.


### Tested On

- [x] Web
- [ ] Mobile Web (Not affected by issue)
- [x] Desktop
- [ ] iOS (Not affected by issue)
- [ ] Android (Not affected by issue)

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web

https://user-images.githubusercontent.com/24370807/112681769-2cee0600-8e95-11eb-9c0a-6143ebbc4320.mp4


#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

https://user-images.githubusercontent.com/24370807/112682830-ab977300-8e96-11eb-9846-27dfc7e7d560.mp4


