### PR TITLE
Fix visible scroll bars on web and non scrollable content on mWeb

### DIFF
--- a/src/components/OptionsList.js
+++ b/src/components/OptionsList.js
@@ -191,10 +191,7 @@ class OptionsList extends Component {
 
     render() {
         return (
-
-            // need to set a height (0 works in this case) so that the view will scroll on mobile
-            // NOTE: the view will still fill its container since it has flex: 1 on it
-            <View style={[styles.flex1, {height: 0}]}>
+            <View style={[styles.flex1]}>
                 {this.props.headerMessage ? (
                     <View style={[styles.ph5, styles.pb5]}>
                         <Text style={[styles.textLabel, styles.colorMuted]}>

--- a/src/libs/Navigation/AppNavigator/ModalStackNavigators.js
+++ b/src/libs/Navigation/AppNavigator/ModalStackNavigators.js
@@ -31,12 +31,14 @@ const defaultSubRouteOptions = {
 const IOUBillStackNavigator = () => (
     <IOUBillModalStack.Navigator
         path={ROUTES.IOU_BILL}
+        screenOptions={{
+            ...defaultSubRouteOptions,
+        }}
     >
         <IOUBillModalStack.Screen
             name="IOU_Bill_Root"
             component={IOUBillPage}
             options={{
-                ...defaultSubRouteOptions,
                 title: 'Split',
             }}
         />
@@ -46,12 +48,14 @@ const IOUBillStackNavigator = () => (
 const IOURequestModalStackNavigator = () => (
     <IOURequestModalStack.Navigator
         path={ROUTES.IOU_REQUEST}
+        screenOptions={{
+            ...defaultSubRouteOptions,
+        }}
     >
         <IOURequestModalStack.Screen
             name="IOU_Request_Root"
             component={IOURequestPage}
             options={{
-                ...defaultSubRouteOptions,
                 title: 'Request',
             }}
         />
@@ -61,12 +65,14 @@ const IOURequestModalStackNavigator = () => (
 const DetailsModalStackNavigator = () => (
     <DetailsModalStack.Navigator
         path={ROUTES.DETAILS}
+        screenOptions={{
+            ...defaultSubRouteOptions,
+        }}
     >
         <DetailsModalStack.Screen
             name="Details_Root"
             component={DetailsPage}
             options={{
-                ...defaultSubRouteOptions,
                 title: 'Details',
             }}
         />
@@ -76,12 +82,14 @@ const DetailsModalStackNavigator = () => (
 const SearchModalStackNavigator = () => (
     <SearchModalStack.Navigator
         path={ROUTES.SEARCH}
+        screenOptions={{
+            ...defaultSubRouteOptions,
+        }}
     >
         <SearchModalStack.Screen
             name="Search_Root"
             component={SearchPage}
             options={{
-                ...defaultSubRouteOptions,
                 title: 'Search',
             }}
         />
@@ -91,12 +99,14 @@ const SearchModalStackNavigator = () => (
 const NewGroupModalStackNavigator = () => (
     <NewGroupModalStack.Navigator
         path={ROUTES.NEW_GROUP}
+        screenOptions={{
+            ...defaultSubRouteOptions,
+        }}
     >
         <NewGroupModalStack.Screen
             name="NewGroup_Root"
             component={NewGroupPage}
             options={{
-                ...defaultSubRouteOptions,
                 title: 'New Group',
             }}
         />
@@ -106,12 +116,14 @@ const NewGroupModalStackNavigator = () => (
 const NewChatModalStackNavigator = () => (
     <NewChatModalStack.Navigator
         path={ROUTES.NEW_CHAT}
+        screenOptions={{
+            ...defaultSubRouteOptions,
+        }}
     >
         <NewChatModalStack.Screen
             name="NewChat_Root"
             component={NewChatPage}
             options={{
-                ...defaultSubRouteOptions,
                 title: 'New Chat',
             }}
         />
@@ -121,46 +133,30 @@ const NewChatModalStackNavigator = () => (
 const SettingsModalStackNavigator = () => (
     <SettingsModalStack.Navigator
         path={ROUTES.SETTINGS}
+        screenOptions={{
+            ...defaultSubRouteOptions,
+            title: 'Settings',
+        }}
     >
         <SettingsModalStack.Screen
             name="Settings_Root"
             component={SettingsInitialPage}
-            options={{
-                ...defaultSubRouteOptions,
-                title: 'Settings',
-            }}
         />
         <SettingsModalStack.Screen
             name="Settings_Profile"
             component={SettingsProfilePage}
-            options={{
-                ...defaultSubRouteOptions,
-                title: 'Settings',
-            }}
         />
         <SettingsModalStack.Screen
             name="Settings_Preferences"
             component={SettingsPreferencesPage}
-            options={{
-                ...defaultSubRouteOptions,
-                title: 'Settings',
-            }}
         />
         <SettingsModalStack.Screen
             name="Settings_Password"
             component={SettingsPasswordPage}
-            options={{
-                ...defaultSubRouteOptions,
-                title: 'Settings',
-            }}
         />
         <SettingsModalStack.Screen
             name="Settings_Payments"
             component={SettingsPaymentsPage}
-            options={{
-                ...defaultSubRouteOptions,
-                title: 'Settings',
-            }}
         />
     </SettingsModalStack.Navigator>
 );

--- a/src/pages/settings/PasswordPage.js
+++ b/src/pages/settings/PasswordPage.js
@@ -66,7 +66,7 @@ class PasswordPage extends Component {
                     onBackButtonPress={() => Navigation.navigate(ROUTES.SETTINGS)}
                     onCloseButtonPress={Navigation.dismissModal}
                 />
-                <View style={[styles.p5, styles.flex1, styles.overflowScroll]}>
+                <View style={[styles.p5, styles.flex1, styles.overflowAuto]}>
                     <View style={styles.flexGrow1}>
                         <Text style={[styles.mb6, styles.textP]}>
                             Changing your password will update your password for both your Expensify.com

--- a/src/pages/settings/ProfilePage.js
+++ b/src/pages/settings/ProfilePage.js
@@ -149,7 +149,7 @@ class ProfilePage extends Component {
                     onBackButtonPress={() => Navigation.navigate(ROUTES.SETTINGS)}
                     onCloseButtonPress={Navigation.dismissModal}
                 />
-                <View style={[styles.p5, styles.flex1, styles.overflowScroll]}>
+                <View style={[styles.p5, styles.flex1, styles.overflowAuto]}>
                     <Avatar
                         style={[styles.avatarLarge, styles.alignSelfCenter]}
                         source={this.props.myPersonalDetails.avatar}

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1164,6 +1164,7 @@ const styles = {
 
     navigationScreenCardStyle: {
         backgroundColor: themeColors.appBG,
+        height: '100%',
     },
 
     invisible: {

--- a/src/styles/utilities/overflow.js
+++ b/src/styles/utilities/overflow.js
@@ -1,3 +1,5 @@
+import overflowAuto from './overflowAuto';
+
 /**
  * Overflow utility styles with Bootstrap inspired naming.
  *
@@ -15,4 +17,6 @@ export default {
     overflowScroll: {
         overflow: 'scroll',
     },
+
+    overflowAuto,
 };

--- a/src/styles/utilities/overflowAuto/index.js
+++ b/src/styles/utilities/overflowAuto/index.js
@@ -1,0 +1,3 @@
+export default {
+    overflow: 'auto',
+};

--- a/src/styles/utilities/overflowAuto/index.native.js
+++ b/src/styles/utilities/overflowAuto/index.native.js
@@ -1,0 +1,4 @@
+// Overflow auto doesn't exist in react-native so we'll default to overflow: visible
+export default {
+    overflow: 'visible',
+};


### PR DESCRIPTION
### Details
Overflow scroll creates weird ugly scrollbars on web and modals are not scrolling properly cc @NikkiWines 

Also, undoes the `height: 0` trick we used here https://github.com/Expensify/Expensify.cash/pull/2101 since it's no longer needed after the other changes.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/158769
Fixes https://github.com/Expensify/Expensify.cash/issues/2147

### Tests
1. Navigate to `/settings/profile` & `/settings/password`
2. Verify there are no visible scrollbars on web views with content that does not overflow
3. Verify the screen can be scroll on smaller screen mobile views if the content overflows

**Test New Group Button appears**
1. Navigate to New Group screen
2. Verify options can be scrolled
3. Select 4 options
4. Verify the Create Group button appears

![Screen Shot 2021-03-30 at 8 48 04 AM](https://user-images.githubusercontent.com/32969087/113040583-a9eadb00-9134-11eb-961a-aaee9e16dfae.png)

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web
![2021-03-29_14-39-33](https://user-images.githubusercontent.com/32969087/112916652-af94e200-909c-11eb-854b-80963d59740d.png)
![2021-03-29_14-39-27](https://user-images.githubusercontent.com/32969087/112916655-b28fd280-909c-11eb-9c78-bcf26f0846a6.png)

#### Mobile Web
https://user-images.githubusercontent.com/32969087/112923268-afe7aa00-90a9-11eb-996f-886c02fc3fb2.mp4

#### Desktop
https://user-images.githubusercontent.com/32969087/112926957-e9bbaf00-90af-11eb-8c06-8a8e70ca84ca.mp4

#### iOS
![2021-03-29_16-44-11](https://user-images.githubusercontent.com/32969087/112926589-5bdfc400-90af-11eb-91c3-e243f3eb916f.png)

#### Android
![2021-03-29_16-56-14](https://user-images.githubusercontent.com/32969087/112926798-b11bd580-90af-11eb-9309-885fe7f05a48.png)
