### PR TITLE
fix:synchronization between state in report switch

### DIFF
--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -64,7 +64,7 @@ class ReportActionCompose extends React.Component {
         this.comment = props.comment;
 
         this.state = {
-            isFocused: false,
+            isFocused: true,
             textInputShouldClear: false,
             isCommentEmpty: props.comment.length === 0,
             isMenuVisible: false,
@@ -72,17 +72,8 @@ class ReportActionCompose extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
-        // The first time the component loads the props is empty and the next time it may contain value.
-        // If it does let's update this.comment so that it matches the defaultValue that we show in textInput.
-        if (this.props.comment && prevProps.comment === '' && prevProps.comment !== this.props.comment) {
-            this.comment = this.props.comment;
-        }
-
-        // When any modal goes from visible to hidden or when the report ID changes, bring focus to the compose field
-        if (
-            (prevProps.modal.isVisible && !this.props.modal.isVisible)
-            || (prevProps.reportID !== this.props.reportID)
-        ) {
+        // When any modal goes from visible to hidden, bring focus to the compose field
+        if (prevProps.modal.isVisible && !this.props.modal.isVisible) {
             this.setIsFocused(true);
         }
     }
@@ -255,6 +246,7 @@ class ReportActionCompose extends React.Component {
                                     )}
                                 </AttachmentPicker>
                                 <TextInputFocusable
+                                    autoFocus
                                     multiline
                                     ref={el => this.textInput = el}
                                     textAlignVertical="top"

--- a/src/pages/home/report/ReportView.js
+++ b/src/pages/home/report/ReportView.js
@@ -30,6 +30,7 @@ class ReportView extends React.Component {
                     <ReportActionCompose
                         onSubmit={text => addAction(this.props.reportID, text)}
                         reportID={this.props.reportID}
+                        key={this.props.reportID}
                     />
                 </SwipeableView>
                 <KeyboardSpacer />


### PR DESCRIPTION
### Details

Drafted message text should constrained to the user selected when the text was entered into the compose box, draft icon should show only when text exists in the compose box.

### Fixed Issues

https://github.com/Expensify/Expensify.cash/issues/2100

### Tests

1. Start a chat with user A
2. Start a chat with user B
3. Start writing  a message to user A and don't send
4. Switch to user B and TextInput must be empty and a draft icon must appers in user A

### QA Steps

<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

**After drafting message text in the compose box for (but prior to sending), text continues to show after clicking into another chat (2 users)**

1.Open a chat with User A
2.Enter text into the compose box (but do not send)
3.Switch to chat with User B
4.Notice: Message drafted in compose box to User A continues to show in compose box in chat with User B

**After drafting message text in the compose box for (but prior to sending), text continues to show after clicking into another chat (3 users)**

1.Open a chat with User A
2.Enter text into the compose box (but do not send)
3.Switch to chat with User B
4.Switch to a chat with User C
5.Notice: Message drafted in compose box to User A continues to show in compose box in chat with User C

**Draft icon continues to show when text does not exist in the compose box**

1.Open a chat with User A
2.Enter text into the compose box (but do not send), wait 3-5 seconds
3.Switch to chat with User B
4.Go back to chat with User A, delete the text drafted in compose box
5.Switch to chat with User C
6.Notice: Draft icon continues to show next to User A even though you deleted the text in the compose box

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

https://user-images.githubusercontent.com/14885967/113079947-6338c780-91ac-11eb-9cc1-e4698c80c54f.mp4

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

https://user-images.githubusercontent.com/14885967/113239599-6d78c580-9281-11eb-9f6b-b33db3d5a20d.mp4

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

https://user-images.githubusercontent.com/14885967/113233357-6ba90500-9275-11eb-9496-0c97a9c921c3.mp4

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

I don't have a mac to test and record the screen

#### Android
<!-- Insert screenshots of your changes on the Android platform-->

https://user-images.githubusercontent.com/14885967/113286317-6920cc80-92c2-11eb-9f3c-4f933e5feba9.mp4

