### PR TITLE
[IS-2151] Fixed Fab hidden by keyboard on IPAD

### DIFF
--- a/src/components/FAB.js
+++ b/src/components/FAB.js
@@ -1,5 +1,7 @@
 import React, {PureComponent} from 'react';
-import {Pressable, Animated, Easing} from 'react-native';
+import {
+    Pressable, Animated, Easing, KeyboardAvoidingView, Platform,
+} from 'react-native';
 import PropTypes from 'prop-types';
 import Icon from './Icon';
 import {Plus} from './Icon/Expensicons';
@@ -64,15 +66,17 @@ class FAB extends PureComponent {
         });
 
         return (
-            <AnimatedPressable
-                onPress={this.props.onPress}
-                style={[
-                    styles.floatingActionButton,
-                    {transform: [{rotate}], backgroundColor},
-                ]}
-            >
-                <AnimatedIcon src={Plus} fill={fill} />
-            </AnimatedPressable>
+            <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : 'height'}>
+                <AnimatedPressable
+                    onPress={this.props.onPress}
+                    style={[
+                        styles.floatingActionButton,
+                        {transform: [{rotate}], backgroundColor},
+                    ]}
+                >
+                    <AnimatedIcon src={Plus} fill={fill} />
+                </AnimatedPressable>
+            </KeyboardAvoidingView>
         );
     }
 }


### PR DESCRIPTION
### Details
### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/2151

### QA Steps

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
![image](https://user-images.githubusercontent.com/31027036/113219291-06571300-9279-11eb-89ce-3a3670d125d8.png)

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
![image](https://user-images.githubusercontent.com/31027036/113219353-21c21e00-9279-11eb-9dd4-ec569d3af398.png)

#### Desktop
![image](https://user-images.githubusercontent.com/31027036/113219516-6fd72180-9279-11eb-9af0-740f3ad50ddd.png)

#### iPad
<img width="665" alt="Screen Shot 2021-03-31 at 6 13 16 PM" src="https://user-images.githubusercontent.com/31027036/113218937-4f5a9780-9278-11eb-826c-d046b6656842.png">

#### tablet Android
<img width="1231" alt="Screen Shot 2021-03-31 at 6 18 14 PM" src="https://user-images.githubusercontent.com/31027036/113218952-55507880-9278-11eb-8268-2d1f5ff3415d.png">
