### PR TITLE
Fix max participants text in New Group screen

### DIFF
--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -98,7 +98,9 @@ function createOption(personalDetailList, report, draftComments, activeReportID,
 
     return {
         text: report ? report.reportName : personalDetail.displayName,
-        alternateText: (showChatPreviewLine && lastMessageText) ? lastMessageText : personalDetail.login,
+        alternateText: (showChatPreviewLine && lastMessageText)
+            ? lastMessageText
+            : Str.removeSMSDomain(personalDetail.login),
         icons: report ? report.icons : [personalDetail.avatar],
         tooltipText,
         participantsList: personalDetailList,

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -410,11 +410,11 @@ function getSidebarOptions(reports, personalDetails, draftComments, activeReport
  *
  * @param {Boolean} hasSelectableOptions
  * @param {Boolean} hasUserToInvite
- * @param {String} searchValue
+ * @param {String} [searchValue]
  * @param {Boolean} [maxParticipantsReached]
  * @return {String}
  */
-function getHeaderMessage(hasSelectableOptions, hasUserToInvite, searchValue, maxParticipantsReached = false) {
+function getHeaderMessage(hasSelectableOptions, hasUserToInvite, searchValue = '', maxParticipantsReached = false) {
     if (maxParticipantsReached) {
         return CONST.MESSAGES.MAXIMUM_PARTICIPANTS_REACHED;
     }

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -412,11 +412,11 @@ function getSidebarOptions(reports, personalDetails, draftComments, activeReport
  *
  * @param {Boolean} hasSelectableOptions
  * @param {Boolean} hasUserToInvite
- * @param {String} [searchValue]
+ * @param {String} searchValue
  * @param {Boolean} [maxParticipantsReached]
  * @return {String}
  */
-function getHeaderMessage(hasSelectableOptions, hasUserToInvite, searchValue = '', maxParticipantsReached = false) {
+function getHeaderMessage(hasSelectableOptions, hasUserToInvite, searchValue, maxParticipantsReached = false) {
     if (maxParticipantsReached) {
         return CONST.MESSAGES.MAXIMUM_PARTICIPANTS_REACHED;
     }

--- a/src/pages/NewGroupPage.js
+++ b/src/pages/NewGroupPage.js
@@ -176,7 +176,7 @@ class NewGroupPage extends Component {
         const headerMessage = getHeaderMessage(
             this.state.personalDetails.length + this.state.recentReports.length !== 0,
             Boolean(this.state.userToInvite),
-            '',
+            this.state.searchValue,
             maxParticipantsReached,
         );
         return (

--- a/src/pages/NewGroupPage.js
+++ b/src/pages/NewGroupPage.js
@@ -176,6 +176,7 @@ class NewGroupPage extends Component {
         const headerMessage = getHeaderMessage(
             this.state.personalDetails.length + this.state.recentReports.length !== 0,
             Boolean(this.state.userToInvite),
+            '',
             maxParticipantsReached,
         );
         return (

--- a/src/pages/SearchPage.js
+++ b/src/pages/SearchPage.js
@@ -133,6 +133,7 @@ class SearchPage extends Component {
         const headerMessage = getHeaderMessage(
             (this.state.recentReports.length + this.state.personalDetails.length) !== 0,
             Boolean(this.state.userToInvite),
+            this.state.searchValue,
         );
         return (
             <ScreenWrapper>


### PR DESCRIPTION
### Details
https://github.com/Expensify/Expensify.cash/pull/2103

### Fixed Issues (Regression caused by linked PR)
Fixes https://github.com/Expensify/Expensify.cash/issues/2175
### Tests
### QA Steps
1. Navigate to Create Group
2. Select 8 people to add to the group
3. Verify the max participants text appears at the top of the view

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
![Screen Shot 2021-03-31 at 2 49 38 PM](https://user-images.githubusercontent.com/32969087/113230134-1dbfdd00-9234-11eb-9710-ec3376c4e877.png)

#### iOS
![2021-03-31_15-16-20](https://user-images.githubusercontent.com/32969087/113230137-20bacd80-9234-11eb-9ce0-c9a147f36656.png)

#### Android
![2021-03-31_15-19-44](https://user-images.githubusercontent.com/32969087/113230351-8a3adc00-9234-11eb-980e-95af8bc85ea8.png)
