### PR TITLE
Fix sign in page styles

### DIFF
--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -341,6 +341,7 @@ const styles = {
         backgroundColor: themeColors.sidebar,
         padding: 20,
         minHeight: '100%',
+        flex: 1,
     },
 
     signInPageLogo: {


### PR DESCRIPTION
### Details
There was an issue with rendering on Desktop Safari/iOS Web for any pages that used the sign in page styles where they wouldn't flex to cover the entire document body. This is due to how Apple's Webkit renders flex styles slightly differently from how Chrome/other browsers do.

I added `flex: 1` to the sign-in page styles to fix this.

### Fixed Issues
Expensify/Expensify#157816

### Tests
1. Navigate to the sign in page, verify it renders correctly (see screenshot).
2. Navigate to the set password page, verify it renders correctly (see screenshot).


### Tested On
- [x] Mobile Web
- [x] Desktop

### Screenshots

#### Web
<img width="1790" alt="Screen Shot 2021-03-19 at 12 23 38 PM" src="https://user-images.githubusercontent.com/31285285/111731245-0553d800-88ae-11eb-9552-f4c7daacf902.png">
<img width="1787" alt="Screen Shot 2021-03-23 at 8 02 28 PM" src="https://user-images.githubusercontent.com/31285285/112143354-b93cc680-8c12-11eb-97b0-916962e1d48a.png">

#### Mobile Web
<img width="376" alt="Screen Shot 2021-04-05 at 8 43 16 AM" src="https://user-images.githubusercontent.com/31285285/113526062-06de0980-95eb-11eb-85ee-61ef94b89520.png">
<img width="376" alt="Screen Shot 2021-04-05 at 8 43 24 AM" src="https://user-images.githubusercontent.com/31285285/113526065-080f3680-95eb-11eb-924c-b47e2f2d4f3d.png">


