### PR TITLE
Fix merging personalDetails. Use personalDetails for chat message avatars + names.

### DIFF
--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -1,5 +1,6 @@
 import _ from 'underscore';
 import lodashGet from 'lodash/get';
+import lodashMerge from 'lodash/merge';
 import Onyx from 'react-native-onyx';
 import Str from 'expensify-common/lib/str';
 import ONYXKEYS from '../../ONYXKEYS';
@@ -64,10 +65,6 @@ function getDisplayName(login, personalDetail) {
 
     if (!userDetails) {
         return userLogin;
-    }
-
-    if (userDetails.displayName) {
-        return userDetails.displayName;
     }
 
     const firstName = userDetails.firstName || '';
@@ -208,9 +205,12 @@ function setPersonalDetails(details) {
         NameValuePair.set(CONST.NVP.TIMEZONE, details.timezone);
     }
 
+    const mergedDetails = lodashMerge(personalDetails[currentUserEmail], details);
+    const formattedDetails = formatPersonalDetails({[currentUserEmail]: mergedDetails});
+
     // Update the associated onyx keys
-    Onyx.merge(ONYXKEYS.MY_PERSONAL_DETAILS, details);
-    Onyx.merge(ONYXKEYS.PERSONAL_DETAILS, formatPersonalDetails({[currentUserEmail]: details}));
+    Onyx.merge(ONYXKEYS.MY_PERSONAL_DETAILS, formattedDetails[currentUserEmail]);
+    Onyx.merge(ONYXKEYS.PERSONAL_DETAILS, formattedDetails);
 }
 
 /**

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -197,6 +197,7 @@ function getFromReportParticipants(reports) {
  * Merges partial details object into the local store.
  *
  * @param {Object} details
+ * @private
  */
 function mergeLocalPersonalDetails(details) {
     // We are merging the partial details provided to this method with the existing details we have for the user so

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -206,12 +206,17 @@ function setPersonalDetails(details) {
         NameValuePair.set(CONST.NVP.TIMEZONE, details.timezone);
     }
 
-    const mergedDetails = lodashMerge(personalDetails[currentUserEmail], details);
-    const formattedDetails = formatPersonalDetails({[currentUserEmail]: mergedDetails});
+    // We are merging the partial details provided to this method with the existing details we have for the user so
+    // that we don't overwrite any values that may exist in storage. displayName is a generated field so we'll use the
+    // firstName and lastName + login to update it.
+    const mergedDetails = lodashMerge(personalDetails[currentUserEmail], {
+        ...details,
+        displayName: getDisplayName(currentUserEmail, details),
+    });
 
     // Update the associated onyx keys
-    Onyx.merge(ONYXKEYS.MY_PERSONAL_DETAILS, formattedDetails[currentUserEmail]);
-    Onyx.merge(ONYXKEYS.PERSONAL_DETAILS, formattedDetails);
+    Onyx.merge(ONYXKEYS.MY_PERSONAL_DETAILS, mergedDetails);
+    Onyx.merge(ONYXKEYS.PERSONAL_DETAILS, {[currentUserEmail]: mergedDetails});
 }
 
 /**

--- a/src/pages/DetailsPage.js
+++ b/src/pages/DetailsPage.js
@@ -13,25 +13,7 @@ import Avatar from '../components/Avatar';
 import HeaderWithCloseButton from '../components/HeaderWithCloseButton';
 import Navigation from '../libs/Navigation/Navigation';
 import ScreenWrapper from '../components/ScreenWrapper';
-
-const personalDetailsType = PropTypes.shape({
-    // Display name of the current user from their personal details
-    displayName: PropTypes.string,
-
-    // Avatar URL of the current user from their personal details
-    avatar: PropTypes.string,
-
-    // login of the current user from their personal details
-    login: PropTypes.string,
-
-    // pronouns of the current user from their personal details
-    pronouns: PropTypes.string,
-
-    // timezone of the current user from their personal details
-    timezone: PropTypes.shape({
-        selected: PropTypes.string,
-    }),
-});
+import personalDetailsPropType from './personalDetailsPropType';
 
 const matchType = PropTypes.shape({
     params: PropTypes.shape({
@@ -43,7 +25,7 @@ const matchType = PropTypes.shape({
 const propTypes = {
     /* Onyx Props */
     // The personal details of the person who is logged in
-    personalDetails: personalDetailsType.isRequired,
+    personalDetails: personalDetailsPropType.isRequired,
 
     // Route params
     route: matchType.isRequired,

--- a/src/pages/home/report/ReportActionItemSingle.js
+++ b/src/pages/home/report/ReportActionItemSingle.js
@@ -22,7 +22,7 @@ const propTypes = {
 };
 
 const ReportActionItemSingle = ({action, personalDetails}) => {
-    const {avatar, displayName} = personalDetails[action.actorEmail];
+    const {avatar, displayName} = personalDetails[action.actorEmail] || {};
     const avatarUrl = action.automatic
         ? `${CONST.CLOUDFRONT_URL}/images/icons/concierge_2019.svg`
 

--- a/src/pages/home/report/ReportActionItemSingle.js
+++ b/src/pages/home/report/ReportActionItemSingle.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import {View} from 'react-native';
+import {withOnyx} from 'react-native-onyx';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
 import ReportActionPropTypes from './ReportActionPropTypes';
@@ -9,16 +10,29 @@ import styles from '../../../styles/styles';
 import CONST from '../../../CONST';
 import ReportActionItemDate from './ReportActionItemDate';
 import Avatar from '../../../components/Avatar';
+import ONYXKEYS from '../../../ONYXKEYS';
+import personalDetailsPropType from '../../personalDetailsPropType';
 
 const propTypes = {
     // All the data of the action
     action: PropTypes.shape(ReportActionPropTypes).isRequired,
+
+    // All of the personalDetails
+    personalDetails: PropTypes.objectOf(personalDetailsPropType).isRequired,
 };
 
-const ReportActionItemSingle = ({action}) => {
+const ReportActionItemSingle = ({action, personalDetails}) => {
+    const {avatar, displayName} = personalDetails[action.actorEmail];
     const avatarUrl = action.automatic
         ? `${CONST.CLOUDFRONT_URL}/images/icons/concierge_2019.svg`
-        : action.avatar;
+
+        // Use avatar in personalDetails if we have one then fallback to avatar provided by the action
+        : (avatar || action.avatar);
+
+    // Since the display name for a report action message is delivered with the report history as an array of fragments
+    // we'll need to take the displayName from personal details and have it be in the same format for now. Eventually,
+    // we should stop referring to the report history items entirely for this information.
+    const personArray = displayName ? [{type: 'TEXT', text: displayName}] : action.person;
     return (
         <View style={[styles.chatItem]}>
             <Avatar
@@ -27,7 +41,7 @@ const ReportActionItemSingle = ({action}) => {
             />
             <View style={[styles.chatItemRight]}>
                 <View style={[styles.chatItemMessageHeader]}>
-                    {_.map(action.person, (fragment, index) => (
+                    {_.map(personArray, (fragment, index) => (
                         <ReportActionItemFragment
                             key={`person-${action.sequenceNumber}-${index}`}
                             fragment={fragment}
@@ -45,4 +59,8 @@ const ReportActionItemSingle = ({action}) => {
 };
 
 ReportActionItemSingle.propTypes = propTypes;
-export default ReportActionItemSingle;
+export default withOnyx({
+    personalDetails: {
+        key: ONYXKEYS.PERSONAL_DETAILS,
+    },
+})(ReportActionItemSingle);

--- a/src/pages/personalDetailsPropType.js
+++ b/src/pages/personalDetailsPropType.js
@@ -1,0 +1,20 @@
+import PropTypes from 'prop-types';
+
+export default PropTypes.shape({
+    // Display name of the current user from their personal details
+    displayName: PropTypes.string,
+
+    // Avatar URL of the current user from their personal details
+    avatar: PropTypes.string,
+
+    // login of the current user from their personal details
+    login: PropTypes.string,
+
+    // pronouns of the current user from their personal details
+    pronouns: PropTypes.string,
+
+    // timezone of the current user from their personal details
+    timezone: PropTypes.shape({
+        selected: PropTypes.string,
+    }),
+});


### PR DESCRIPTION
cc @NikkiWines 

### Details
At the moment, there is inconsistency between avatars and display names in report comments and those in personal details. This is because report comments come with their own set of avatars/details. This PR does a couple of things:

- Makes it so report comment UI is always referring to the `personalDetails` first instead of report comment data
- Allows merging incomplete sets of personal details into the `formatPersonalDetails` method so that updating a display name won't overwrite the local avatar + vice versa.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/156316

### Tests
### QA Steps
1. Open a chat
2. Navigate to `/settings/profile` 
3. Update your name
4. Verify it updates in the chat

**Note:** It should not yet update in realtime for any other users. Just the current user.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
![2021-04-05_12-25-01](https://user-images.githubusercontent.com/32969087/113634209-1587e900-960a-11eb-8338-6afac4427018.png)

#### Mobile Web
![2021-04-05_12-25-52](https://user-images.githubusercontent.com/32969087/113634217-191b7000-960a-11eb-8bbd-cf834d1d1541.png)

#### Desktop
![2021-04-05_12-26-48](https://user-images.githubusercontent.com/32969087/113634291-38b29880-960a-11eb-8868-97d5e7784a73.png)

#### iOS
![2021-04-05_12-29-09](https://user-images.githubusercontent.com/32969087/113634494-8d561380-960a-11eb-91fe-853ef22fd2f5.png)

#### Android
![2021-04-05_12-48-09](https://user-images.githubusercontent.com/32969087/113635895-2ede6480-960d-11eb-8a73-051c7d863613.png)
