### PR TITLE
[IS-2209] fixed bullet points text fitting

### DIFF
--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1294,6 +1294,10 @@ const webViewStyles = {
 
         a: styles.link,
 
+        li: {
+            flexShrink: 1,
+        },
+
         blockquote: {
             borderLeftColor: themeColors.border,
             borderLeftWidth: 4,


### PR DESCRIPTION
### Fixed Issues
<Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing>
Fixes https://github.com/Expensify/Expensify.cash/issues/2209

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<img width="1265" alt="Screen Shot 2021-04-04 at 11 27 14 PM" src="https://user-images.githubusercontent.com/31027036/113577552-6ccc9000-95ef-11eb-8f38-95d9de2c732c.png">

#### Mobile Web
![image](https://user-images.githubusercontent.com/31027036/113577569-7524cb00-95ef-11eb-9232-cc715cbdbe7c.png)

#### Desktop
<img width="1225" alt="Screen Shot 2021-04-05 at 9 02 15 AM" src="https://user-images.githubusercontent.com/31027036/113577586-7f46c980-95ef-11eb-84f3-fed178da86bc.png">

#### iOS
<img width="399" alt="Screen Shot 2021-04-04 at 11 32 06 PM" src="https://user-images.githubusercontent.com/31027036/113577620-8a015e80-95ef-11eb-9b4b-2e8c7fc01648.png">

#### Android
<img width="321" alt="Screen Shot 2021-04-05 at 9 09 46 AM" src="https://user-images.githubusercontent.com/31027036/113577635-8ec61280-95ef-11eb-8851-0e216540c8b8.png">
