### PR TITLE
[No QA] Remove the ReportActionContextMenu beta

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -3,7 +3,6 @@ const CLOUDFRONT_URL = 'https://d2k5nsl2zxldvw.cloudfront.net';
 const CONST = {
     BETAS: {
         ALL: 'all',
-        REPORT_ACTION_CONTEXT_MENU: 'reportActionContextMenu',
     },
     BUTTON_STATES: {
         DEFAULT: 'default',

--- a/src/pages/home/report/ReportActionContextMenu.js
+++ b/src/pages/home/report/ReportActionContextMenu.js
@@ -22,6 +22,7 @@ const CONTEXT_ACTIONS = [
         icon: ClipboardIcon,
         successText: 'Copied!',
         successIcon: Checkmark,
+        shouldShow: true,
 
         // If return value is true, we switch the `text` and `icon` on
         // `ReportActionContextMenuItem` with `successText` and `successIcon` which will fallback to
@@ -45,6 +46,7 @@ const CONTEXT_ACTIONS = [
     {
         text: 'Copy Link',
         icon: LinkCopy,
+        shouldShow: false,
         onPress: () => {},
     },
 
@@ -52,6 +54,7 @@ const CONTEXT_ACTIONS = [
     {
         text: 'Mark as Unread',
         icon: Mail,
+        shouldShow: false,
         onPress: () => {},
     },
 
@@ -59,6 +62,7 @@ const CONTEXT_ACTIONS = [
     {
         text: 'Edit Comment',
         icon: Pencil,
+        shouldShow: false,
         onPress: () => {},
     },
 
@@ -66,6 +70,7 @@ const CONTEXT_ACTIONS = [
     {
         text: 'Delete Comment',
         icon: Trashcan,
+        shouldShow: false,
         onPress: () => {},
     },
 ];
@@ -95,7 +100,7 @@ const ReportActionContextMenu = (props) => {
     const wrapperStyle = getReportActionContextMenuStyles(props.isMini);
     return props.isVisible && (
         <View style={wrapperStyle}>
-            {CONTEXT_ACTIONS.map(contextAction => (
+            {CONTEXT_ACTIONS.map(contextAction => contextAction.shouldShow && (
                 <ReportActionContextMenuItem
                     icon={contextAction.icon}
                     text={contextAction.text}

--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -69,9 +69,7 @@ class ReportActionItem extends Component {
     showPopover(event) {
         const nativeEvent = event.nativeEvent || {};
         this.capturePressLocation(nativeEvent);
-        if (this.isInReportActionContextMenuBeta()) {
-            this.setState({isPopoverVisible: true});
-        }
+        this.setState({isPopoverVisible: true});
     }
 
     /**
@@ -98,7 +96,6 @@ class ReportActionItem extends Component {
                                     reportAction={this.props.action}
                                     isVisible={
                                         hovered
-                                        && this.isInReportActionContextMenuBeta()
                                         && !this.state.isPopoverVisible
                                     }
                                     isMini

--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -2,9 +2,6 @@ import _ from 'underscore';
 import React, {Component} from 'react';
 import {View} from 'react-native';
 import PropTypes from 'prop-types';
-import {withOnyx} from 'react-native-onyx';
-import CONST from '../../../CONST';
-import ONYXKEYS from '../../../ONYXKEYS';
 import ReportActionPropTypes from './ReportActionPropTypes';
 import {
     getReportActionItemStyle,
@@ -26,14 +23,6 @@ const propTypes = {
 
     // Should the comment have the appearance of being grouped with the previous comment?
     displayAsGroup: PropTypes.bool.isRequired,
-
-    /* --- Onyx Props --- */
-    // List of betas for the current user.
-    betas: PropTypes.arrayOf(PropTypes.string),
-};
-
-const defaultProps = {
-    betas: {},
 };
 
 class ReportActionItem extends Component {
@@ -50,7 +39,6 @@ class ReportActionItem extends Component {
             vertical: 0,
         };
 
-        this.isInReportActionContextMenuBeta = this.isInReportActionContextMenuBeta.bind(this);
         this.showPopover = this.showPopover.bind(this);
         this.hidePopover = this.hidePopover.bind(this);
     }
@@ -59,16 +47,6 @@ class ReportActionItem extends Component {
         return this.state.isPopoverVisible !== nextState.isPopoverVisible
             || this.props.displayAsGroup !== nextProps.displayAsGroup
             || !_.isEqual(this.props.action, nextProps.action);
-    }
-
-    /**
-     * Is the current user in the ReportActionContextMenu beta?
-     *
-     * @returns {Boolean}
-     */
-    isInReportActionContextMenuBeta() {
-        return _.contains(this.props.betas, CONST.BETAS.REPORT_ACTION_CONTEXT_MENU)
-            || _.contains(this.props.betas, CONST.BETAS.ALL);
     }
 
     /**
@@ -154,10 +132,5 @@ class ReportActionItem extends Component {
 }
 
 ReportActionItem.propTypes = propTypes;
-ReportActionItem.defaultProps = defaultProps;
 
-export default withOnyx({
-    betas: {
-        key: ONYXKEYS.BETAS,
-    },
-})(ReportActionItem);
+export default ReportActionItem;


### PR DESCRIPTION


### Details
<Explanation of the change or anything fishy that is going on>

### Fixed Issues
Coming from [this Slack thread](https://expensify.slack.com/archives/C03U7DCU4/p1617641264155600)

### Tests (Web/Desktop)
1. Run the app
2. Hover a message, make sure that the `reportActionContextMenu` appears (it's just one lonely clipboard icon) now 😭

![image](https://user-images.githubusercontent.com/47436092/113637472-84286f00-9629-11eb-9e4f-8302e3759d4c.png)

3. Right-click a message, make sure that the menu appears:

![image](https://user-images.githubusercontent.com/47436092/113637520-a28e6a80-9629-11eb-8fa7-7ee07b79e7af.png)

### Tests (iOS/Android/mWeb)
1. Run the app
2. Long-press a message, make sure that the menu appears:

![image](https://user-images.githubusercontent.com/47436092/113637616-e5e8d900-9629-11eb-8173-62fb03ecea69.png)

### QA Steps
The "Copy Comment" functionality is covered by regression testing, so we shouldn't need any extra QA here.

### Tested On

- [x] Web
- [x] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots

#### Web
![image](https://user-images.githubusercontent.com/47436092/113637472-84286f00-9629-11eb-9e4f-8302e3759d4c.png)
![image](https://user-images.githubusercontent.com/47436092/113637520-a28e6a80-9629-11eb-8fa7-7ee07b79e7af.png)

#### Mobile Web
![image](https://user-images.githubusercontent.com/47436092/113637616-e5e8d900-9629-11eb-8173-62fb03ecea69.png)

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
