### PR TITLE
Add font: fontFamily.GTA to link styles

### DIFF
--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -27,6 +27,7 @@ const styles = {
     link: {
         color: themeColors.link,
         textDecorationColor: themeColors.link,
+        font: fontFamily.GTA,
     },
 
     h1: {

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -27,7 +27,7 @@ const styles = {
     link: {
         color: themeColors.link,
         textDecorationColor: themeColors.link,
-        font: fontFamily.GTA,
+        fontFamily: fontFamily.GTA,
     },
 
     h1: {


### PR DESCRIPTION
The link styles were missing our branding font, so I added it to the styles.

### Fixed Issues
https://github.com/Expensify/Expensify.cash/pull/1910

### Tests
1. Navigate to the sign in page
2. Enter an email, verify that the "Not [email address]" link renders with the correct font.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web
<img width="1792" alt="Screen Shot 2021-04-07 at 2 57 22 PM" src="https://user-images.githubusercontent.com/31285285/113824709-ae596880-97b2-11eb-8434-8a955ffae2c8.png">

#### Mobile Web
<img width="498" alt="Screen Shot 2021-04-07 at 3 05 14 PM" src="https://user-images.githubusercontent.com/31285285/113824723-b1545900-97b2-11eb-99c5-552fa62f0665.png">

#### Desktop
<img width="1203" alt="Screen Shot 2021-04-07 at 3 00 49 PM" src="https://user-images.githubusercontent.com/31285285/113824743-b5807680-97b2-11eb-8cf6-a31c37a21c2f.png">

#### iOS
<img width="495" alt="Screen Shot 2021-04-07 at 3 04 37 PM" src="https://user-images.githubusercontent.com/31285285/113824755-baddc100-97b2-11eb-999a-dedb2488b8c5.png">

#### Android
<img width="399" alt="Screen Shot 2021-04-07 at 3 04 20 PM" src="https://user-images.githubusercontent.com/31285285/113824769-bfa27500-97b2-11eb-95c4-d077338d34b1.png">


cc @shawnborton 
