### PR TITLE
[WIP] [No QA] Only deploy to staging after staging branch has been updated

### DIFF
--- a/.github/actions/checkForAutomergePullRequests/action.yml
+++ b/.github/actions/checkForAutomergePullRequests/action.yml
@@ -1,0 +1,12 @@
+name: 'Check for Automerge PRs'
+description: 'Check for any open PRs with the `automerge` label'
+inputs:
+  GITHUB_TOKEN:
+    description: Auth token for Expensify.cash Github
+    required: true
+outputs:
+  OPEN_PR_FOUND:
+    description: Whether or not any open automerge PRs were found.
+runs:
+  using: 'node12'
+  main: './index.js'

--- a/.github/actions/checkForAutomergePullRequests/checkForAutomergePullRequests.js
+++ b/.github/actions/checkForAutomergePullRequests/checkForAutomergePullRequests.js
@@ -1,0 +1,35 @@
+const _ = require('underscore');
+const core = require('@actions/core');
+const github = require('@actions/github');
+const GithubUtils = require('../../libs/GithubUtils');
+
+const run = function () {
+    const octokit = github.getOctokit(core.getInput('GITHUB_TOKEN', {required: true}));
+
+    console.log('Checking for any open automerge PRs...');
+    return octokit.issues.listForRepo({
+        owner: GithubUtils.GITHUB_OWNER,
+        repo: GithubUtils.EXPENSIFY_CASH_REPO,
+        labels: GithubUtils.AUTOMERGE_LABEL,
+        state: 'open',
+    })
+        .then(({data}) => {
+            if (data.length > 0) {
+                console.log('Found these open automerge pull requests:', _.pluck(data, 'html_url'));
+                core.setOutput('OPEN_PR_FOUND', true);
+            } else {
+                console.log('Found no open automerge pull requests!');
+                core.setOutput('OPEN_PR_FOUND', false);
+            }
+        })
+        .catch((err) => {
+            console.error('An error occurred trying to find PRs with the `automerge` label:', err);
+            core.setFailed(err);
+        });
+};
+
+if (require.main === module) {
+    run();
+}
+
+module.exports = run;

--- a/.github/actions/checkForAutomergePullRequests/index.js
+++ b/.github/actions/checkForAutomergePullRequests/index.js
@@ -5,7 +5,7 @@ module.exports =
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 608:
+/***/ 7988:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 const _ = __nccwpck_require__(4987);
@@ -15,16 +15,26 @@ const GithubUtils = __nccwpck_require__(7999);
 
 const run = function () {
     const octokit = github.getOctokit(core.getInput('GITHUB_TOKEN', {required: true}));
-    const githubUtils = new GithubUtils(octokit);
 
-    return githubUtils.getStagingDeployCash()
-        .then(({labels}) => {
-            console.log(`Found StagingDeployCash with labels: ${_.pluck(labels, 'name')}`);
-            core.setOutput('IS_LOCKED', _.contains(_.pluck(labels, 'name'), '🔐 LockCashDeploys 🔐'));
+    console.log('Checking for any open automerge PRs...');
+    return octokit.issues.listForRepo({
+        owner: GithubUtils.GITHUB_OWNER,
+        repo: GithubUtils.EXPENSIFY_CASH_REPO,
+        labels: GithubUtils.AUTOMERGE_LABEL,
+        state: 'open',
+    })
+        .then(({data}) => {
+            if (data.length > 0) {
+                console.log('Found these open automerge pull requests:', _.pluck(data, 'html_url'));
+                core.setOutput('OPEN_PR_FOUND', true);
+            } else {
+                console.log('Found no open automerge pull requests!');
+                core.setOutput('OPEN_PR_FOUND', false);
+            }
         })
         .catch((err) => {
-            console.warn('No open StagingDeployCash found, continuing...', err);
-            core.setOutput('IS_LOCKED', false);
+            console.error('An error occurred trying to find PRs with the `automerge` label:', err);
+            core.setFailed(err);
         });
 };
 
@@ -15469,6 +15479,6 @@ module.exports = require("zlib");;
 /******/ 	// module exports must be returned from runtime so entry inlining is disabled
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
-/******/ 	return __nccwpck_require__(608);
+/******/ 	return __nccwpck_require__(7988);
 /******/ })()
 ;

--- a/.github/actions/createOrUpdateStagingDeploy/index.js
+++ b/.github/actions/createOrUpdateStagingDeploy/index.js
@@ -130,6 +130,7 @@ const ISSUE_OR_PULL_REQUEST_REGEX = new RegExp(`${GITHUB_BASE_URL_REGEX.source}/
 
 const APPLAUSE_BOT = 'applausebot';
 const STAGING_DEPLOY_CASH_LABEL = 'StagingDeployCash';
+const AUTOMERGE_LABEL = 'automerge';
 
 class GithubUtils {
     /**
@@ -583,6 +584,7 @@ module.exports = GithubUtils;
 module.exports.GITHUB_OWNER = GITHUB_OWNER;
 module.exports.EXPENSIFY_CASH_REPO = EXPENSIFY_CASH_REPO;
 module.exports.STAGING_DEPLOY_CASH_LABEL = STAGING_DEPLOY_CASH_LABEL;
+module.exports.AUTOMERGE_LABEL = AUTOMERGE_LABEL;
 
 
 /***/ }),

--- a/.github/actions/getReleaseBody/index.js
+++ b/.github/actions/getReleaseBody/index.js
@@ -43,6 +43,7 @@ const ISSUE_OR_PULL_REQUEST_REGEX = new RegExp(`${GITHUB_BASE_URL_REGEX.source}/
 
 const APPLAUSE_BOT = 'applausebot';
 const STAGING_DEPLOY_CASH_LABEL = 'StagingDeployCash';
+const AUTOMERGE_LABEL = 'automerge';
 
 class GithubUtils {
     /**
@@ -496,6 +497,7 @@ module.exports = GithubUtils;
 module.exports.GITHUB_OWNER = GITHUB_OWNER;
 module.exports.EXPENSIFY_CASH_REPO = EXPENSIFY_CASH_REPO;
 module.exports.STAGING_DEPLOY_CASH_LABEL = STAGING_DEPLOY_CASH_LABEL;
+module.exports.AUTOMERGE_LABEL = AUTOMERGE_LABEL;
 
 
 /***/ }),

--- a/.github/actions/isPullRequestMergeable/index.js
+++ b/.github/actions/isPullRequestMergeable/index.js
@@ -78,6 +78,7 @@ const ISSUE_OR_PULL_REQUEST_REGEX = new RegExp(`${GITHUB_BASE_URL_REGEX.source}/
 
 const APPLAUSE_BOT = 'applausebot';
 const STAGING_DEPLOY_CASH_LABEL = 'StagingDeployCash';
+const AUTOMERGE_LABEL = 'automerge';
 
 class GithubUtils {
     /**
@@ -531,6 +532,7 @@ module.exports = GithubUtils;
 module.exports.GITHUB_OWNER = GITHUB_OWNER;
 module.exports.EXPENSIFY_CASH_REPO = EXPENSIFY_CASH_REPO;
 module.exports.STAGING_DEPLOY_CASH_LABEL = STAGING_DEPLOY_CASH_LABEL;
+module.exports.AUTOMERGE_LABEL = AUTOMERGE_LABEL;
 
 
 /***/ }),

--- a/.github/actions/markPullRequestsAsDeployed/index.js
+++ b/.github/actions/markPullRequestsAsDeployed/index.js
@@ -61,6 +61,7 @@ const ISSUE_OR_PULL_REQUEST_REGEX = new RegExp(`${GITHUB_BASE_URL_REGEX.source}/
 
 const APPLAUSE_BOT = 'applausebot';
 const STAGING_DEPLOY_CASH_LABEL = 'StagingDeployCash';
+const AUTOMERGE_LABEL = 'automerge';
 
 class GithubUtils {
     /**
@@ -514,6 +515,7 @@ module.exports = GithubUtils;
 module.exports.GITHUB_OWNER = GITHUB_OWNER;
 module.exports.EXPENSIFY_CASH_REPO = EXPENSIFY_CASH_REPO;
 module.exports.STAGING_DEPLOY_CASH_LABEL = STAGING_DEPLOY_CASH_LABEL;
+module.exports.AUTOMERGE_LABEL = AUTOMERGE_LABEL;
 
 
 /***/ }),

--- a/.github/libs/GithubUtils.js
+++ b/.github/libs/GithubUtils.js
@@ -14,6 +14,7 @@ const ISSUE_OR_PULL_REQUEST_REGEX = new RegExp(`${GITHUB_BASE_URL_REGEX.source}/
 
 const APPLAUSE_BOT = 'applausebot';
 const STAGING_DEPLOY_CASH_LABEL = 'StagingDeployCash';
+const AUTOMERGE_LABEL = 'automerge';
 
 class GithubUtils {
     /**
@@ -467,3 +468,4 @@ module.exports = GithubUtils;
 module.exports.GITHUB_OWNER = GITHUB_OWNER;
 module.exports.EXPENSIFY_CASH_REPO = EXPENSIFY_CASH_REPO;
 module.exports.STAGING_DEPLOY_CASH_LABEL = STAGING_DEPLOY_CASH_LABEL;
+module.exports.AUTOMERGE_LABEL = AUTOMERGE_LABEL;

--- a/.github/scripts/buildActions.sh
+++ b/.github/scripts/buildActions.sh
@@ -10,6 +10,7 @@ ACTIONS_DIR="$(dirname "$(dirname "$0")")/actions"
 # List of paths to all JS files that implement our GH Actions
 declare -r GITHUB_ACTIONS=(
     "$ACTIONS_DIR/bumpVersion/bumpVersion.js"
+    "$ACTIONS_DIR/checkForAutomergePullRequests/checkForAutomergePullRequests.js"
     "$ACTIONS_DIR/createOrUpdateStagingDeploy/createOrUpdateStagingDeploy.js"
     "$ACTIONS_DIR/getReleaseBody/getReleaseBody.js"
     "$ACTIONS_DIR/getReleasePullRequestList/getReleasePullRequestList.js"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy code to staging or production
 
 on:
   push:
-    branches: [production]
+    branches: [staging, production]
 
 jobs:
   validate:
@@ -20,6 +20,24 @@ jobs:
       - name: Check if merged pull request was an automatic version bump PR
         id: isAutomergePR
         run: echo "::set-output name=IS_AUTOMERGE_PR::${{ contains(steps.getMergedPullRequest.outputs.labels, 'automerge') && github.actor == 'OSBotify' }}"
+
+  deployStaging:
+    runs-on: ubuntu-latest
+    needs: validate
+    if: ${{ needs.validate.outputs.isAutomergePR == 'true' && github.ref == 'refs/heads/staging' }}
+
+    steps:
+      - name: Checkout staging branch
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        with:
+          ref: staging
+          token: ${{ secrets.OS_BOTIFY_TOKEN }}
+
+      - name: Tag version
+        run: git tag $(npm run print-version --silent)
+
+      - name: 🚀 Push tags to trigger staging deploy 🚀
+        run: git push --tags
 
   deployProduction:
     runs-on: ubuntu-latest

--- a/.github/workflows/lockDeploys.yml
+++ b/.github/workflows/lockDeploys.yml
@@ -79,10 +79,6 @@ jobs:
       - name: Tag version
         run: git tag ${{ steps.bumpVersion.outputs.NEW_VERSION }}
 
-      # TODO: Once we add cherry picking, we will need run this from the deploy workflow
-      - name: 🚀 Push tags to trigger staging deploy 🚀
-        run: git push --tags
-
       - name: Update StagingDeployCash
         uses: Expensify/Expensify.cash/.github/actions/createOrUpdateStagingDeploy@master
         with:

--- a/.github/workflows/lockDeploys.yml
+++ b/.github/workflows/lockDeploys.yml
@@ -16,6 +16,12 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.OS_BOTIFY_TOKEN }}
 
+      - uses: softprops/turnstyle@8db075d65b19bf94e6e8687b504db69938dc3c65
+        with:
+          poll-interval-seconds: 10
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Wait for any preDeploy version jobs to finish
         uses: tomchv/wait-my-workflow@2da0b8a92211e6d7c9964602b99a7052080a1d61
         with:
@@ -34,12 +40,6 @@ jobs:
           checkName: master
           intervalSeconds: 10
           timeoutSeconds: 150
-
-      - uses: softprops/turnstyle@8db075d65b19bf94e6e8687b504db69938dc3c65
-        with:
-          poll-interval-seconds: 10
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create a new branch
         run: |

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -69,6 +69,25 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Check for any open automerge PRs
+        id: checkForAutomergePRs
+        uses: Expensify/Expensify.cash/.github/actions/checkForAutomergePullRequests@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Wait for any automerge jobs to start
+        if: ${{ steps.checkForAutomergePRs.outputs.OPEN_PR_FOUND == 'true' }}
+        run: sleep 30
+
+      - name: Wait for any automerge-master jobs to finish
+        if: ${{ steps.checkForAutomergePRs.outputs.OPEN_PR_FOUND == 'true' }}
+        uses: tomchv/wait-my-workflow@2da0b8a92211e6d7c9964602b99a7052080a1d61
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: master
+          intervalSeconds: 10
+          timeoutSeconds: 150
+
       - name: Set up git
         run: |
           git fetch
@@ -110,10 +129,6 @@ jobs:
       - name: Tag version
         run: git tag ${{ steps.bumpVersion.outputs.NEW_VERSION }}
 
-      #TODO: Once we add cherry picking, we will need run this from elsewhere
-      - name: 🚀 Push tags to trigger staging deploy 🚀
-        run: git push --tags
-
       - name: Update StagingDeployCash
         uses: Expensify/Expensify.cash/.github/actions/createOrUpdateStagingDeploy@master
         with:
@@ -145,7 +160,7 @@ jobs:
   updateStaging:
     runs-on: ubuntu-latest
     needs: chooseDeployActions
-    if: ${{ needs.chooseDeployActions.outputs.isVersionBumpPR == 'true' && needs.chooseDeployActions.outputs.isStagingDeployLocked == 'false' }}
+    if: ${{ needs.chooseDeployActions.outputs.isVersionBumpPR == 'true' }}
 
     steps:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f

--- a/tests/unit/checkForAutomergePullRequestsTest.js
+++ b/tests/unit/checkForAutomergePullRequestsTest.js
@@ -1,0 +1,72 @@
+const core = require('@actions/core');
+const github = require('@actions/github');
+const run = require('../../.github/actions/checkForAutomergePullRequests/checkForAutomergePullRequests');
+
+// Static mock function for core.getInput
+const mockGetInput = jest.fn().mockImplementation((arg) => {
+    if (arg === 'GITHUB_TOKEN') {
+        return 'fake_token';
+    }
+});
+
+// Mock functions that we can adjust between each test
+const mockSetOutput = jest.fn();
+const mockSetFailed = jest.fn();
+const mockListForRepo = jest.fn();
+
+beforeAll(() => {
+    // Mock core module
+    core.getInput = mockGetInput;
+    core.setFailed = mockSetFailed;
+    core.setOutput = mockSetOutput;
+
+    const mocktokit = {
+        issues: {
+            listForRepo: mockListForRepo,
+        },
+    };
+    github.getOctokit = jest.fn().mockImplementation(() => mocktokit);
+});
+
+beforeEach(() => {
+    // Reset mocks before each test
+    jest.resetModules();
+});
+
+afterEach(() => {
+    mockSetOutput.mockClear();
+    mockSetFailed.mockClear();
+    mockListForRepo.mockClear();
+});
+
+afterAll(() => {
+    jest.clearAllMocks();
+});
+
+describe('checkForAutomergePullRequestsTest', () => {
+    test('outputs true when there are open automerge pull requests', () => {
+        mockListForRepo.mockResolvedValue({
+            data: [
+                {html_url: 'https://github.com/Expensify/Expensify.cash/pull/1'},
+                {html_url: 'https://github.com/Expensify/Expensify.cash/pull/2'},
+            ],
+        });
+        return run().then(() => {
+            expect(mockSetOutput).toHaveBeenCalledWith('OPEN_PR_FOUND', true);
+        });
+    });
+
+    test('outputs false when there are no open automerge pull requests', () => {
+        mockListForRepo.mockResolvedValue({data: []});
+        return run().then(() => {
+            expect(mockSetOutput).toHaveBeenCalledWith('OPEN_PR_FOUND', false);
+        });
+    });
+
+    test('catches API error', () => {
+        mockListForRepo.mockRejectedValue({err: 'You done goofed, kid.'});
+        return run().then(() => {
+            expect(mockSetFailed).toHaveBeenCalledWith({err: 'You done goofed, kid.'});
+        });
+    });
+});


### PR DESCRIPTION
cc @deetergp Since you're digging into some GH Actions stuff right now too.


### Details
For a while now, we've been deploying the master branch to staging. This was always meant to be temporary just to get deploys working, for a number of reasons. This PR changes the deploy process such that we deploy to staging from the staging branch, and only after the staging branch has been successfully updated. _Why,_ you ask?

1. This will pave the way to allow us to build a CP process. We have been trying to get by without one for a couple weeks now, and so far have not had a single day in which all PRs pass QA and there are no open deploy blockers. Therefore we haven't run a single production deploy since we started using the new QA process. I think this alone is proof that we need some way to CP or revert changes.
1. This will simplify the process of comparing changes between releases and has the potential to lead to a number of simplifications in the deploy-related JS code. (not included in this PR because I don't want it to get too big to review)
1. Also, it conceptually makes sense that the code on staging should be from the staging branch, and the code on production should be from the production branch.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/157916

### Tests
Added unit tests for new Javascript action. To live-test these changes:

1) Make sure that the `StagingDeployCash` is _not_ locked.
2) Merge two PRs in quick succession and verify that:

- [ ] `preDeploy::version` runs for both pull requests, but due to turnstyle only one of them begins. Let's call the one that starts "run A", and the one that waits "run B"
- [ ] (run A) In `preDeploy::version`, a new `BUILD` version is created for the first PR
- [ ] (run A) An automerge PR for that version is created against the `master` branch.
- [ ] (run A) Tags are not pushed, so a staging deploy does not happen yet.
- [ ] (run B) At this point, it's expected that `runB::preDeploy` will begin, since "run A" will have finished.
- [ ] (run B) `preDeploy` should check for open automerge _PRs_, and should find that one is open! It should then _wait_ for any automerge _workflow runs_ to _begin_ (using sleep).
- [ ] (run A) `automerge` workflow should begin for the PR created in `runA::preDeploy::version`
- [ ] (run B) `runB::preDeploy` Should start waiting for any automerge workflow runs to _finish_ (wait-my-workflow).
- [ ] (run A) Meanwhile, the automerge PR created by run A should be merged.
- [ ] (run B) Run B should wait for any `deploy::stagingDeploy` jobs to start (using sleep)
- [ ] (run A) `runA::preDeploy::updateStaging` should start, and a PR should be created to merge master into staging
- [ ] (run A) The PR from the previous step should be auto-merged.
- [ ] (run A) `runA::deploy::deployStaging` should start, tag the version, and push tags. A staging deploy should begin on all platforms
- [ ] (run B) `runB::preDeploy::version` should now be free to create another new `BUILD` version. There should be no version conflict
- [ ] (run B) finishes with a staging deploy via the normal process: `preDeploy::version` -> `automerge::master` -> `preDeploy::updateStaging` -> `automerge::staging` -> `deploy::deployStaging`

WOW that's complicated. Maybe we need to step back and rethink this a bit... 😅
