### PR TITLE
Initialize current user's personal details when personalDetailsList is non empty and they can't be found

### DIFF
--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -110,10 +110,13 @@ function fetch() {
         .then((data) => {
             let myPersonalDetails = {};
 
-            // If personalDetailsList is empty, ensure we set the personal details for the current user
-            const personalDetailsList = _.isEmpty(data.personalDetailsList)
-                ? {[currentUserEmail]: myPersonalDetails}
-                : data.personalDetailsList;
+            // If personalDetailsList does not have the current user ensure we initialize their details with an empty
+            // object at least
+            const personalDetailsList = _.isEmpty(data.personalDetailsList) ? {} : data.personalDetailsList;
+            if (!personalDetailsList[currentUserEmail]) {
+                personalDetailsList[currentUserEmail] = {};
+            }
+
             const allPersonalDetails = formatPersonalDetails(personalDetailsList);
             Onyx.merge(ONYXKEYS.PERSONAL_DETAILS, allPersonalDetails);
 


### PR DESCRIPTION
cc @Julesssss 

### Details
Since it's possible for a user to not have personal details set we need to provide an empty object as a fallback. In the cases where a user has a `personalDetailsList` but no own `expensify_personalDetails` bad things happen like what is linked in the issues.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/158699
Fixes https://github.com/Expensify/Expensify.cash/issues/2247
Fixes https://github.com/Expensify/Expensify.cash/issues/2253

### Tests
1. Create a new account and domain for that account and update the domain admin's personal details
2. Invite a member to the domain and validate their account
3. Without making any changes to personal details (e.g. first name, avatar, etc) sign into Expensify.cash as the invited user
4. Verify they are able to access the settings page and update personal details
5. Verify they are able to leave comments without errors appearing in the JS console.

**Logging in on `main`:**
![Screen Shot 2021-04-06 at 2 00 50 PM](https://user-images.githubusercontent.com/32969087/113791973-8a2d5700-96e0-11eb-8017-daa3cf996438.png)

**Logging in on this branch:**
![Screen Shot 2021-04-06 at 1 56 10 PM](https://user-images.githubusercontent.com/32969087/113791713-f3609a80-96df-11eb-88b6-951b2e8af7c7.png)

### QA Steps
1. Create a new account and login verify settings and leaving comments works as expected.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
![Screen Shot 2021-04-06 at 1 56 10 PM](https://user-images.githubusercontent.com/32969087/113803243-d637c600-96f7-11eb-99aa-30ccd0414a11.png)

#### Mobile Web
![2021-04-06_16-45-45](https://user-images.githubusercontent.com/32969087/113803256-dfc12e00-96f7-11eb-9e70-35480ca7e8a9.png)

#### Desktop
![2021-04-06_16-47-09](https://user-images.githubusercontent.com/32969087/113803260-e2bc1e80-96f7-11eb-995a-b23db93cb575.png)

#### iOS
![2021-04-06_16-48-35](https://user-images.githubusercontent.com/32969087/113803293-ef407700-96f7-11eb-9e45-9d531e4b7ba9.png)

#### Android
![2021-04-06_16-54-53](https://user-images.githubusercontent.com/32969087/113803739-d389a080-96f8-11eb-863c-799aeab74159.png)
