### PR TITLE
Fix "Add Attachment" Menu Item

### DIFF
--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -232,7 +232,7 @@ class ReportActionCompose extends React.Component {
                                                 menuItems={[
                                                     {
                                                         icon: Paperclip,
-                                                        text: 'Upload Photo',
+                                                        text: 'Add Attachment',
                                                         onSelected: () => {
                                                             openPicker({
                                                                 onPicked: (file) => {


### PR DESCRIPTION
### Details
- Fixes menu item text change caused by https://github.com/Expensify/Expensify.cash/pull/2131
- 
### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/2053

### Tests
- Go into any chat and click the + icon

### QA Steps
- same as above

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
![Screen Shot 2021-04-06 at 6 05 23 PM](https://user-images.githubusercontent.com/12075600/113796744-d12d4380-9704-11eb-8871-9c07a4f4a07d.png)

#### Mobile Web
<img width="482" alt="Screen Shot 2021-04-06 at 6 24 22 PM" src="https://user-images.githubusercontent.com/12075600/113797056-5fa1c500-9705-11eb-827b-7e9dd3f7a340.png">

#### Desktop
<img width="1312" alt="Screen Shot 2021-04-06 at 6 15 13 PM" src="https://user-images.githubusercontent.com/12075600/113796778-e30ee680-9704-11eb-8817-9d78d32705ee.png">

#### iOS
<img width="482" alt="Screen Shot 2021-04-06 at 6 22 07 PM" src="https://user-images.githubusercontent.com/12075600/113796873-076ac300-9705-11eb-819b-6a5066edd16f.png">

#### Android
<img width="464" alt="Screen Shot 2021-04-06 at 6 17 01 PM" src="https://user-images.githubusercontent.com/12075600/113796819-f4f08980-9704-11eb-87d2-190caed10a78.png">
