### PR TITLE
Change GSD to focus

### DIFF
--- a/src/pages/settings/PreferencesPage.js
+++ b/src/pages/settings/PreferencesPage.js
@@ -42,8 +42,8 @@ const priorityModes = {
     },
     gsd: {
         value: CONST.PRIORITY_MODE.GSD,
-        label: 'GSD',
-        description: 'This will only display unread and pinned chats, all sorted alphabetically. Get Shit Done.',
+        label: '#focus',
+        description: '#focus – This will only display unread and pinned chats, all sorted alphabetically.',
     },
 };
 


### PR DESCRIPTION
### Details
We need to change "Get Shit Done" to "#focus" to prevent our app from being rejected by the app stores due to illicit language.

### Fixed Issues
Slack discussion [here](https://expensify.slack.com/archives/C03U7DCU4/p1617811032180500)

### Tests / QA Steps
1) Open the preferences page
2) Change the priority mode, make sure you see `#focus` and not `GSD` in the drop-down.
3) The description beneath _should not_ include the word "shit".

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web
![image](https://user-images.githubusercontent.com/47436092/113906458-2448da00-9789-11eb-8dad-a18abd963119.png)

#### Mobile Web
![image](https://user-images.githubusercontent.com/47436092/113906644-4fcbc480-9789-11eb-8b16-07f84af088d1.png)

![image](https://user-images.githubusercontent.com/47436092/113906669-56f2d280-9789-11eb-8839-b1aba70f8074.png)

#### Desktop
![image](https://user-images.githubusercontent.com/47436092/113906928-a0dbb880-9789-11eb-93c9-28f0674c8b20.png)

#### iOS
![image](https://user-images.githubusercontent.com/47436092/113907244-f7e18d80-9789-11eb-9740-bb2cc1cfe227.png)

![image](https://user-images.githubusercontent.com/47436092/113907271-fd3ed800-9789-11eb-93e4-39b4e7a612d7.png)

#### Android

![image](https://user-images.githubusercontent.com/47436092/113907768-9b32a280-978a-11eb-9036-16ce1eae889d.png)
![image](https://user-images.githubusercontent.com/47436092/113907824-aab1eb80-978a-11eb-91a2-3396c8636d00.png)
