### PR TITLE
Properly pass Android version code to fastlane

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -44,6 +44,9 @@ jobs:
               env:
                   LARGE_SECRET_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
 
+            - name: Set version in ENV
+              run: echo "VERSION_CODE=$(grep -o 'versionCode\s\+\d\+' android/app/build.gradle | awk '{ print $2 }')" >> $GITHUB_ENV
+
             - name: Run Fastlane beta
               if: ${{ env.SHOULD_DEPLOY_PRODUCTION == 'false' }}
               run: bundle exec fastlane android beta
@@ -52,7 +55,7 @@ jobs:
               if: ${{ env.SHOULD_DEPLOY_PRODUCTION == 'true' }}
               run: bundle exec fastlane android production
               env:
-                VERSION: ${{ env.VERSION }}
+                VERSION: ${{ env.VERSION_CODE }}
 
             # These Slack steps are duplicated in all workflows, if you make a change to this step, make sure to update all
             # the other workflows with the same changes
@@ -74,7 +77,3 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ github.token }}
                   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
-
-            - name: Set version in ENV
-              if: ${{ success() }}
-              run: echo "VERSION=$(npm run print-version --silent)" >> $GITHUB_ENV

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -55,7 +55,7 @@ platform :android do
     upload_to_play_store(
       package_name: "com.expensify.chat",
       json_key: './android/app/android-fastlane-json-key.json',
-      version_code: ENV["VERSION"],
+      version_code: ENV["VERSION_CODE"],
       track: 'internal',
       track_promote_to: 'production',
       rollout: '1.0',


### PR DESCRIPTION

### Details
We weren't properly passing the version code to fastlane for the Android production deploy. It's pretty unclear how the Android production deploys were ever working, but we updated Fastlane so our best guess is that we were always passing `''` as the version code, and Fastlane was just defaulting to the latest version. But now in their newer update they are type-checking the version code, so it's failing.

### Fixed Issues
Failed workflow run: https://github.com/Expensify/Expensify.cash/commit/2b3d906b8309142aa8a0d6edea876cc693171c4d/checks

### Tests
Can only test by running a production deploy.