### PR TITLE
[IS-2151] fixed FAB issue

### DIFF
--- a/src/components/FAB/FAB.js
+++ b/src/components/FAB/FAB.js
@@ -1,24 +1,18 @@
 import React, {PureComponent} from 'react';
-import {Pressable, Animated, Easing} from 'react-native';
-import PropTypes from 'prop-types';
-import Icon from './Icon';
-import {Plus} from './Icon/Expensicons';
-import styles, {getAnimatedFABStyle} from '../styles/styles';
-import themeColors from '../styles/themes/default';
+import {
+    Pressable, Animated, Easing,
+} from 'react-native';
+import Icon from '../Icon';
+import {Plus} from '../Icon/Expensicons';
+import styles, {getAnimatedFABStyle} from '../../styles/styles';
+import themeColors from '../../styles/themes/default';
+import fabPropTypes from './fabPropTypes';
 
 const AnimatedIcon = Animated.createAnimatedComponent(Icon);
 AnimatedIcon.displayName = 'AnimatedIcon';
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 AnimatedPressable.displayName = 'AnimatedPressable';
-
-const propTypes = {
-    // Callback to fire on request to toggle the FAB
-    onPress: PropTypes.func.isRequired,
-
-    // Current state (active or not active) of the component
-    isActive: PropTypes.bool.isRequired,
-};
 
 class FAB extends PureComponent {
     constructor(props) {
@@ -77,5 +71,5 @@ class FAB extends PureComponent {
     }
 }
 
-FAB.propTypes = propTypes;
+FAB.propTypes = fabPropTypes;
 export default FAB;

--- a/src/components/FAB/fabPropTypes.js
+++ b/src/components/FAB/fabPropTypes.js
@@ -1,0 +1,11 @@
+import PropTypes from 'prop-types';
+
+const FabPropTypes = {
+    // Callback to fire on request to toggle the FAB
+    onPress: PropTypes.func.isRequired,
+
+    // Current state (active or not active) of the component
+    isActive: PropTypes.bool.isRequired,
+};
+
+export default FabPropTypes;

--- a/src/components/FAB/fabPropTypes.js
+++ b/src/components/FAB/fabPropTypes.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 
-const FabPropTypes = {
+const fabPropTypes = {
     // Callback to fire on request to toggle the FAB
     onPress: PropTypes.func.isRequired,
 
@@ -8,4 +8,4 @@ const FabPropTypes = {
     isActive: PropTypes.bool.isRequired,
 };
 
-export default FabPropTypes;
+export default fabPropTypes;

--- a/src/components/FAB/index.ios.js
+++ b/src/components/FAB/index.ios.js
@@ -6,6 +6,7 @@ import {
 import FAB from './FAB';
 import fabPropTypes from './fabPropTypes';
 
+// KeyboardAvoidingView only need in IOS so that's the reason make platform specific FAB component.
 function Fab({onPress, isActive}) {
     return (
         <KeyboardAvoidingView behavior="position">

--- a/src/components/FAB/index.ios.js
+++ b/src/components/FAB/index.ios.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import {
+    KeyboardAvoidingView,
+} from 'react-native';
+
+import FAB from './FAB';
+import fabPropTypes from './fabPropTypes';
+
+function Fab({onPress, isActive}) {
+    return (
+        <KeyboardAvoidingView behavior="position">
+            <FAB onPress={onPress} isActive={isActive} />
+        </KeyboardAvoidingView>
+    );
+}
+
+Fab.propTypes = fabPropTypes;
+export default Fab;

--- a/src/components/FAB/index.js
+++ b/src/components/FAB/index.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import FAB from './FAB';
+import fabPropTypes from './fabPropTypes';
+
+function Fab({onPress, isActive}) {
+    return <FAB onPress={onPress} isActive={isActive} />;
+}
+
+Fab.propTypes = fabPropTypes;
+export default Fab;

--- a/src/components/FAB/index.js
+++ b/src/components/FAB/index.js
@@ -1,11 +1,3 @@
-import React from 'react';
-
 import FAB from './FAB';
-import fabPropTypes from './fabPropTypes';
 
-function Fab({onPress, isActive}) {
-    return <FAB onPress={onPress} isActive={isActive} />;
-}
-
-Fab.propTypes = fabPropTypes;
-export default Fab;
+export default FAB;


### PR DESCRIPTION
### Details
To fix FAB position on iPad I used `keyboardavoidingview` for IOS Platform.

### Fixed Issues
<Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing>
Fixes https://github.com/Expensify/Expensify.cash/issues/2151

### Tests
Test on all platform and FAB Icon is shown on the appropriate position and tested with click on FAB ICON and it's working on all platform

### QA Steps

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
![image](https://user-images.githubusercontent.com/31027036/114237607-53aa4300-9951-11eb-96bf-89f8c9637734.png)

#### Mobile Web
![image](https://user-images.githubusercontent.com/31027036/114237650-615fc880-9951-11eb-8f16-905319eb0f3f.png)

#### Desktop
![image](https://user-images.githubusercontent.com/31027036/114087236-a0bee400-9881-11eb-84d2-e0a5705a83f3.png)

#### iPad
![image](https://user-images.githubusercontent.com/31027036/114083439-f6dd5880-987c-11eb-81b8-a2c46bde4091.png)


#### Android
![image](https://user-images.githubusercontent.com/31027036/114084646-6a339a00-987e-11eb-9c96-5be7ef198905.png)
