### PR TITLE
Show a user's display name for 'is typing' indicator

### DIFF
--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -67,14 +67,14 @@ function getDisplayName(login, personalDetail) {
         return userLogin;
     }
 
-    if (userDetails.displayName) {
-        return userDetails.displayName;
-    }
-
     const firstName = userDetails.firstName || '';
     const lastName = userDetails.lastName || '';
+    const fullName = (`${firstName} ${lastName}`).trim();
+    if (fullName) {
+        return fullName;
+    }
 
-    return (`${firstName} ${lastName}`).trim() || userLogin;
+    return userDetails.displayName || userLogin;
 }
 
 /**

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -67,6 +67,10 @@ function getDisplayName(login, personalDetail) {
         return userLogin;
     }
 
+    if (userDetails.displayName) {
+        return userDetails.displayName;
+    }
+
     const firstName = userDetails.firstName || '';
     const lastName = userDetails.lastName || '';
 
@@ -86,6 +90,8 @@ function formatPersonalDetails(personalDetailsList) {
         const displayName = getDisplayName(login, personalDetailsResponse);
         const pronouns = lodashGet(personalDetailsResponse, 'pronouns', '');
         const timezone = lodashGet(personalDetailsResponse, 'timeZone', CONST.DEFAULT_TIME_ZONE);
+        const firstName = lodashGet(personalDetailsResponse, 'firstName', '');
+        const lastName = lodashGet(personalDetailsResponse, 'lastName', '');
 
         return {
             ...finalObject,
@@ -93,6 +99,8 @@ function formatPersonalDetails(personalDetailsList) {
                 login,
                 avatar,
                 displayName,
+                firstName,
+                lastName,
                 pronouns,
                 timezone,
             },

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -70,11 +70,8 @@ function getDisplayName(login, personalDetail) {
     const firstName = userDetails.firstName || '';
     const lastName = userDetails.lastName || '';
     const fullName = (`${firstName} ${lastName}`).trim();
-    if (fullName) {
-        return fullName;
-    }
 
-    return userDetails.displayName || userLogin;
+    return fullName || userLogin;
 }
 
 /**


### PR DESCRIPTION
@NikkiWines will you please review this?

### Details
This PR adds a check for the displayName inside `getDisplayName`, since we can set that value inside `formatPersonalDetails` but not set the first/last name. I've also added the first/last name to `formatPersonalDetails` to ensure that when we fetch the personalDetailsList, we're storing those values in Onyx. If there is a reason we don't want to do this, please let me know, but since we're using first/last name in other parts of the app it made sense to add it here.

### Fixed Issues
<Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing>
Fixes Expensify/Expensify/issues/159835

### Tests
1. Login as User A who has personal details set for first and last name (you can set these values by clicking on the profile icon, then clicking on profile)
2. Login as User B and start a chat with User A
3. Type in the textbox as User A, see that User A's first and last name show up instead of their email address
4. For a user who does not have first/last name set, type as that user and confirm that in the opposite chat window the email address still shows

I also confirmed the following works

1. User A types, User B sees personalDetail name
2. User A changes name, User A sees personalDetail name updated everywhere
3. User A types, User B sees old name in "is typing" indicator
4. User B refreshes
5. User A types after refresh, "Is typing" indicator shows User A's new name

### QA Steps
1. Login as User A who has personal details set for first and last name (you can set these values by clicking on the profile icon, then clicking on profile)
2. Login as User B and start a chat with User A
3. Type in the textbox as User A, see that User A's first and last name show up instead of their email address

Note: a regression is being added for this in https://github.com/Expensify/Expensify/issues/159794

### Tested On
- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
![image](https://user-images.githubusercontent.com/3981102/114108156-60fafb00-9887-11eb-9063-48f9d00ce7fe.png)
![image](https://user-images.githubusercontent.com/3981102/114108157-62c4be80-9887-11eb-95f3-5164571640b2.png)

