### PR TITLE
fix: ReportScreen is blank, indefinitely loading on web/desktop

### DIFF
--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1251,7 +1251,7 @@ const styles = {
     },
 
     fullScreenLoading: {
-        backgroundColor: themeColors.modalBackdrop,
+        backgroundColor: themeColors.componentBG,
         opacity: 0.8,
         justifyContent: 'center',
         alignItems: 'center',


### PR DESCRIPTION
<If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit.>
@marcaaron 

### Details
Addresses the regresion found for #2221 
The details and the steps are the same as in that PR

### Fixed Issues
Fixes #2327

### Tests
On web/desktop

1. Be logged out 
2. Log in
3. Soon after loading should stop and you should see the chat view
4. There should not be a loader, loading indefinitely

Also please cover the steps in #2221 

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android
