### PR TITLE
Convert android version_code from string to int

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -55,7 +55,7 @@ platform :android do
     upload_to_play_store(
       package_name: "com.expensify.chat",
       json_key: './android/app/android-fastlane-json-key.json',
-      version_code: ENV["VERSION_CODE"],
+      version_code: ENV["VERSION_CODE"].to_i,
       track: 'internal',
       track_promote_to: 'production',
       rollout: '1.0',


### PR DESCRIPTION

### Details
Converts Android version_code from string to int. I forgot to make that change in [this other PR](https://github.com/Expensify/Expensify.cash/pull/2292)

### Fixed Issues
Fixes failed workflow runs, example [here](https://github.com/Expensify/Expensify.cash/runs/2310222375).

### Tests
AFAIK this can only be tested by running an Android production deploy.