### PR TITLE
[No QA] Fix web DisplayNames

### DIFF
--- a/src/components/DisplayNames/index.js
+++ b/src/components/DisplayNames/index.js
@@ -88,7 +88,7 @@ class DisplayNames extends PureComponent {
                 numberOfLines={1}
                 ref={el => this.containerRef = el}
             >
-                {_.map(this.props.displayNamesToTooltips, ({displayName, tooltip}, index) => (
+                {_.map(this.props.displayNamesWithTooltips, ({displayName, tooltip}, index) => (
                     <Fragment key={index}>
                         <Tooltip
                             key={index}
@@ -102,10 +102,10 @@ class DisplayNames extends PureComponent {
                                 {displayName}
                             </Text>
                         </Tooltip>
-                        {index < this.props.displayNamesToTooltips.length - 1 && <Text>,&nbsp;</Text>}
+                        {index < this.props.displayNamesWithTooltips.length - 1 && <Text>,&nbsp;</Text>}
                     </Fragment>
                 ))}
-                {this.props.displayNamesToTooltips.length > 1 && this.state.isEllipsisActive
+                {this.props.displayNamesWithTooltips.length > 1 && this.state.isEllipsisActive
                     && (
                         <View style={styles.displayNameTooltipEllipsis}>
                             <Tooltip text={this.props.fullTitle}>


### PR DESCRIPTION
### Details
I borked web by failing to retest after making changes during a PR review. PR in question was [this one](https://github.com/Expensify/Expensify.cash/pull/2215). I renamed a prop but missed a couple usages of that prop, and thus web was _severely_ borked (i.e: does not work at all).

### Fixed Issues
n/a – web does not work at all on master right now

### Tests
1. Run the app
2. Make sure it works.

### QA Steps
Should be covered by basic regression testing.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web
![image](https://user-images.githubusercontent.com/47436092/114262257-d81db580-9993-11eb-816e-18e420bbc5aa.png)

#### Mobile Web
![image](https://user-images.githubusercontent.com/47436092/114262293-0bf8db00-9994-11eb-8bc3-71fe5219832f.png)

#### Desktop
![image](https://user-images.githubusercontent.com/47436092/114262315-3b0f4c80-9994-11eb-8812-dcfdc3d0d414.png)

#### iOS
![image](https://user-images.githubusercontent.com/47436092/114262273-ef5ca300-9993-11eb-88b2-662da904d45f.png)

#### Android
![image](https://user-images.githubusercontent.com/47436092/114262475-0ea80000-9995-11eb-9c3f-131ae83b578d.png)

