### PR TITLE
Removed Expensify domain from the Sign In page

### DIFF
--- a/src/pages/signin/ChangeExpensifyLoginLink.js
+++ b/src/pages/signin/ChangeExpensifyLoginLink.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {Text, TouchableOpacity, View} from 'react-native';
 import {withOnyx} from 'react-native-onyx';
 import PropTypes from 'prop-types';
+import Str from 'expensify-common/lib/str';
 import styles from '../../styles/styles';
 import {restartSignin} from '../../libs/actions/Session';
 import themeColors from '../../styles/themes/default';
@@ -24,7 +25,7 @@ const ChangeExpensifyLoginLink = ({credentials}) => (
         >
             <Text style={[styles.link]}>
                 Not&nbsp;
-                {credentials.login}
+                {Str.removeSMSDomain(credentials.login)}
             </Text>
         </TouchableOpacity>
     </View>


### PR DESCRIPTION
Please review.

### Details
<Explanation of the change or anything fishy that is going on>


### Fixed Issues
<Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing>
Fixes #2323 

### Tests / QA Steps
1.  Open the Expensify.cash app or head to https://expensify.cash/signin
2. Enter a mobile number where it says Enter your phone or email.
3. On the next screen, observe that the link **does not** displays @expensify.sms after the mobile number


### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->
![Screenshot_20210412_005815](https://user-images.githubusercontent.com/24370807/114397916-d125bb80-9bbc-11eb-9ef3-9e9ed25fa829.png)

