### PR TITLE
Fix success icon in ReportActionContextMenu

### DIFF
--- a/src/components/MenuItem.js
+++ b/src/components/MenuItem.js
@@ -24,11 +24,15 @@ const propTypes = {
 
     // Boolean whether to display the ArrowRight icon
     shouldShowRightArrow: PropTypes.bool,
+
+    // A boolean flag that gives the icon a green fill if true
+    success: PropTypes.bool,
 };
 
 const defaultProps = {
     shouldShowRightArrow: false,
     wrapperStyle: {},
+    success: false,
 };
 
 const MenuItem = ({
@@ -37,6 +41,7 @@ const MenuItem = ({
     title,
     shouldShowRightArrow,
     wrapperStyle,
+    success,
 }) => (
     <Pressable
         onPress={onPress}
@@ -50,7 +55,7 @@ const MenuItem = ({
             <>
                 <View style={styles.flexRow}>
                     <View style={styles.createMenuIcon}>
-                        <Icon src={icon} fill={getIconFillColor(getButtonState(hovered, pressed))} />
+                        <Icon src={icon} fill={getIconFillColor(getButtonState(hovered, pressed, success))} />
                     </View>
                     <View style={styles.justifyContentCenter}>
                         <Text style={[styles.createMenuText, styles.ml3]}>

--- a/src/pages/home/report/ReportActionContextMenuItem.js
+++ b/src/pages/home/report/ReportActionContextMenuItem.js
@@ -79,6 +79,7 @@ class ReportActionContextMenuItem extends Component {
                         icon={icon}
                         onPress={this.triggerPressAndUpdateSuccess}
                         wrapperStyle={styles.pr9}
+                        success={this.state.success}
                     />
                 )
         );


### PR DESCRIPTION
### Details
Fixes a regression caused by [this PR](https://github.com/Expensify/Expensify.cash/pull/2232). Shoutout to @parasharrajat for [pointing this out in slack](https://expensify.slack.com/archives/C01GTK53T8Q/p1618275006130700).

### Fixed Issues
n/a – fixes a regression

### Tests / QA Steps
1. Open the `ReportActionContextMenu`
2. Copy a message
3. Make sure that the arrow becomes green after the message is successfully copied.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web
![image](https://user-images.githubusercontent.com/47436092/114481498-85254780-9bb9-11eb-9e7b-1975838e5f89.png)

#### Mobile Web
![image](https://user-images.githubusercontent.com/47436092/114481660-ddf4e000-9bb9-11eb-9afd-7fdd2afa0938.png)

#### Desktop
![image](https://user-images.githubusercontent.com/47436092/114481863-552a7400-9bba-11eb-9abd-c94d11ea3492.png)

#### iOS
![image](https://user-images.githubusercontent.com/47436092/114481788-29a78980-9bba-11eb-88e3-588214296d38.png)

#### Android
![image](https://user-images.githubusercontent.com/47436092/114482123-dd107e00-9bba-11eb-9f26-cbb7c00e751b.png)

