### PR TITLE
Pass validateLinkPropTypes directly to prevent error

### DIFF
--- a/src/pages/SetPasswordPage.js
+++ b/src/pages/SetPasswordPage.js
@@ -39,7 +39,7 @@ const propTypes = {
     }),
 
     // The accountID and validateCode are passed via the URL
-    route: PropTypes.objectOf(validateLinkPropTypes),
+    route: validateLinkPropTypes,
 };
 
 const defaultProps = {

--- a/src/pages/ValidateLoginPage.js
+++ b/src/pages/ValidateLoginPage.js
@@ -1,5 +1,4 @@
 import {Component} from 'react';
-import PropTypes from 'prop-types';
 import lodashGet from 'lodash/get';
 import validateLinkPropTypes from './validateLinkPropTypes';
 import {validateLogin} from '../libs/actions/User';
@@ -8,7 +7,7 @@ const propTypes = {
     /* Onyx Props */
 
     // The accountID and validateCode are passed via the URL
-    route: PropTypes.objectOf(validateLinkPropTypes),
+    route: validateLinkPropTypes,
 };
 
 const defaultProps = {


### PR DESCRIPTION
cc: @marcaaron since you found this

### Details
Passes validateLinkPropTypes directly instead of using `objectOf` which was causing a JS error.

### Fixed Issues
<Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing>
Fixes N/A

### Tests
1. Log into an account on E.cash 
2. Open your developer console
2. Navigate to the following URL `http://localhost:8080/v/41/EGFEPALHG` 
3. Confirm you **don't** see the following error in your console. 
```JS
Warning: Failed prop type: Invalid prop `route.name` of type `string` supplied to `ValidateLoginPage`, expected `object`.
```

### QA Steps
1. Log into an account on E.cash on staging
2. Open your developer console
2. Navigate to the following URL `http://staging.expensify.cash/v/41/EGFEPALHG` 
3. Confirm you **don't** see the following error in your console. 
```JS
Warning: Failed prop type: Invalid prop `route.name` of type `string` supplied to `ValidateLoginPage`, expected `object`.
```

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
N/A no UI changes. 

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
