### PR TITLE
Add SCREENS constants. Navigate without linkTo from drawer component.

### DIFF
--- a/src/CONFIG.js
+++ b/src/CONFIG.js
@@ -2,23 +2,12 @@ import lodashGet from 'lodash/get';
 import {Platform} from 'react-native';
 import Config from 'react-native-config';
 import getPlatform from './libs/getPlatform/index';
-
-/**
- * Let's make everyone's life just a bit easier by adding / to the end of any config URL's if it's not already present
- * @param {String} url
- * @returns {String}
- */
-function wrapWithBackslash(url) {
-    if (!url.endsWith('/')) {
-        return `${url}/`;
-    }
-    return url;
-}
+import {addTrailingForwardSlash} from './libs/Url';
 
 // Set default values to contributor friendly values to make development work out of the box without an .env file
-const expensifyCashURL = wrapWithBackslash(lodashGet(Config, 'EXPENSIFY_URL_CASH', 'https://expensify.cash/'));
-const expensifyURL = wrapWithBackslash(lodashGet(Config, 'EXPENSIFY_URL_COM', 'https://www.expensify.com/'));
-const ngrokURL = wrapWithBackslash(lodashGet(Config, 'NGROK_URL', ''));
+const expensifyCashURL = addTrailingForwardSlash(lodashGet(Config, 'EXPENSIFY_URL_CASH', 'https://expensify.cash/'));
+const expensifyURL = addTrailingForwardSlash(lodashGet(Config, 'EXPENSIFY_URL_COM', 'https://www.expensify.com/'));
+const ngrokURL = addTrailingForwardSlash(lodashGet(Config, 'NGROK_URL', ''));
 const useNgrok = lodashGet(Config, 'USE_NGROK', 'false') === 'true';
 const useWebProxy = lodashGet(Config, 'USE_WEB_PROXY', 'true') === 'true';
 const expensifyComWithProxy = getPlatform() === 'web' && useWebProxy ? '/' : expensifyURL;

--- a/src/ROUTES.js
+++ b/src/ROUTES.js
@@ -43,7 +43,7 @@ export default {
 
         const pathSegments = route.split('/');
         return {
-            reportID: Number(lodashGet(pathSegments, 1, 0)),
+            reportID: lodashGet(pathSegments, 1),
         };
     },
 };

--- a/src/ROUTES.js
+++ b/src/ROUTES.js
@@ -1,3 +1,6 @@
+import lodashGet from 'lodash/get';
+import {addTrailingForwardSlash} from './libs/Url';
+
 /**
  * This is a file containing constants for all of the routes we want to be able to go to
  */
@@ -31,12 +34,16 @@ export default {
 
     /**
      * @param {String} route
-     * @returns {Number}
+     * @returns {Object}
      */
-    getReportIDFromRoute: (route) => {
-        if (!route.startsWith(`${REPORT}/`)) {
-            return '';
+    parseReportRouteParams: (route) => {
+        if (!route.startsWith(addTrailingForwardSlash(REPORT))) {
+            return {};
         }
-        return Number(route.split('/')[1]);
+
+        const pathSegments = route.split('/');
+        return {
+            reportID: lodashGet(pathSegments, 1),
+        };
     },
 };

--- a/src/ROUTES.js
+++ b/src/ROUTES.js
@@ -1,6 +1,9 @@
 /**
  * This is a file containing constants for all of the routes we want to be able to go to
  */
+
+const REPORT = 'r';
+
 export default {
     HOME: '',
     SETTINGS: 'settings',
@@ -12,7 +15,7 @@ export default {
     getSettingsAddLoginRoute: type => `settings/addlogin/${type}`,
     NEW_GROUP: 'new/group',
     NEW_CHAT: 'new/chat',
-    REPORT: 'r',
+    REPORT,
     REPORT_WITH_ID: 'r/:reportID',
     getReportRoute: reportID => `r/${reportID}`,
     IOU_REQUEST: 'iou/request',
@@ -25,4 +28,15 @@ export default {
     getDetailsRoute: login => `details/${login}`,
     VALIDATE_LOGIN: 'v',
     VALIDATE_LOGIN_WITH_VALIDATE_CODE: 'v/:accountID/:validateCode',
+
+    /**
+     * @param {String} route
+     * @returns {Number}
+     */
+    getReportIDFromRoute: (route) => {
+        if (!route.startsWith(`${REPORT}/`)) {
+            return '';
+        }
+        return Number(route.split('/')[1]);
+    },
 };

--- a/src/ROUTES.js
+++ b/src/ROUTES.js
@@ -43,7 +43,7 @@ export default {
 
         const pathSegments = route.split('/');
         return {
-            reportID: lodashGet(pathSegments, 1),
+            reportID: Number(lodashGet(pathSegments, 1, 0)),
         };
     },
 };

--- a/src/SCREENS.js
+++ b/src/SCREENS.js
@@ -1,0 +1,8 @@
+/**
+ * This is a file containing constants for all of the screen names. In most cases, we should use the routes for
+ * navigation. But there are situations where we may need to access screen names directly.
+ */
+export default {
+    REPORT: 'Report',
+    SIGN_IN: 'SignIn',
+};

--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -46,6 +46,7 @@ import {
     NewChatModalStackNavigator,
     SettingsModalStackNavigator,
 } from './ModalStackNavigators';
+import SCREENS from '../../../SCREENS';
 
 Onyx.connect({
     key: ONYXKEYS.MY_PERSONAL_DETAILS,
@@ -194,7 +195,7 @@ class AuthScreens extends React.Component {
                         title: 'Expensify.cash',
                     }}
                     initialParams={{
-                        screen: 'Report',
+                        screen: SCREENS.REPORT,
                         params: {
                             reportID: this.initialReportID,
                         },

--- a/src/libs/Navigation/AppNavigator/MainDrawerNavigator.js
+++ b/src/libs/Navigation/AppNavigator/MainDrawerNavigator.js
@@ -27,9 +27,7 @@ const MainDrawerNavigator = props => (
         )}
         sceneContainerStyle={styles.navigationSceneContainer}
         edgeWidth={500}
-        drawerContent={() => (
-            <SidebarScreen />
-        )}
+        drawerContent={() => <SidebarScreen />}
     >
         <Drawer.Screen
             name="Report"

--- a/src/libs/Navigation/AppNavigator/PublicScreens.js
+++ b/src/libs/Navigation/AppNavigator/PublicScreens.js
@@ -3,6 +3,7 @@ import {createStackNavigator} from '@react-navigation/stack';
 import SignInPage from '../../../pages/signin/SignInPage';
 import SetPasswordPage from '../../../pages/SetPasswordPage';
 import ValidateLoginPage from '../../../pages/ValidateLoginPage';
+import SCREENS from '../../../SCREENS';
 
 const RootStack = createStackNavigator();
 const defaultScreenOptions = {
@@ -16,7 +17,7 @@ const defaultScreenOptions = {
 export default () => (
     <RootStack.Navigator>
         <RootStack.Screen
-            name="SignIn"
+            name={SCREENS.SIGN_IN}
             options={defaultScreenOptions}
             component={SignInPage}
         />

--- a/src/libs/Navigation/Navigation.js
+++ b/src/libs/Navigation/Navigation.js
@@ -5,6 +5,7 @@ import {getIsDrawerOpenFromState} from '@react-navigation/drawer';
 
 import linkTo from './linkTo';
 import ROUTES from '../../ROUTES';
+import SCREENS from '../../SCREENS';
 
 export const navigationRef = React.createRef();
 
@@ -37,12 +38,18 @@ function navigate(route = ROUTES.HOME) {
     // If we're navigating to the signIn page, replace the existing route in the stack with the SignIn route so that we
     // don't mistakenly route back to any older routes after the user signs in
     if (route === ROUTES.SIGNIN) {
-        navigationRef.current.dispatch(StackActions.replace('SignIn'));
+        navigationRef.current.dispatch(StackActions.replace(SCREENS.SIGN_IN));
         return;
     }
 
     if (route === ROUTES.HOME) {
         openDrawer();
+        return;
+    }
+
+    const reportID = ROUTES.getReportIDFromRoute(route);
+    if (reportID) {
+        navigationRef.current.navigate(SCREENS.REPORT, {reportID});
         return;
     }
 

--- a/src/libs/Navigation/Navigation.js
+++ b/src/libs/Navigation/Navigation.js
@@ -47,7 +47,7 @@ function navigate(route = ROUTES.HOME) {
         return;
     }
 
-    const reportID = ROUTES.getReportIDFromRoute(route);
+    const {reportID} = ROUTES.parseReportRouteParams(route);
     if (reportID) {
         navigationRef.current.navigate(SCREENS.REPORT, {reportID});
         return;

--- a/src/libs/Navigation/linkingConfig.js
+++ b/src/libs/Navigation/linkingConfig.js
@@ -1,4 +1,5 @@
 import ROUTES from '../../ROUTES';
+import SCREENS from '../../SCREENS';
 
 export default {
     prefixes: [
@@ -12,10 +13,10 @@ export default {
         screens: {
             Home: {
                 path: ROUTES.HOME,
-                initialRouteName: 'Report',
+                initialRouteName: SCREENS.REPORT,
                 screens: {
                     // Report route
-                    Report: ROUTES.REPORT_WITH_ID,
+                    [SCREENS.REPORT]: ROUTES.REPORT_WITH_ID,
                 },
             },
 

--- a/src/libs/Url.js
+++ b/src/libs/Url.js
@@ -1,0 +1,16 @@
+/**
+ * Add / to the end of any URL if not present
+ * @param {String} url
+ * @returns {String}
+ */
+function addTrailingForwardSlash(url) {
+    if (!url.endsWith('/')) {
+        return `${url}/`;
+    }
+    return url;
+}
+
+export {
+    // eslint-disable-next-line import/prefer-default-export
+    addTrailingForwardSlash,
+};


### PR DESCRIPTION
### Details
Pretty weird issue, but starting to think ~~the navigation ref~~ `linkTo()` is in some cases unreliable (at least when navigating from within the drawer). Switched to ~~passing a `navigation` object to the drawer component~~ using `navigationRef.navigate(screen, params)` and URL handling works as intended on mobile web.

Push state issue still remains.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/2188

### Tests
### QA Steps
1. Login with an account that has multiple conversations 
2. Click on one chat
3. Verify the reportID changes in the URL
4. Go back to the LHN
5. Click on another chat
6. Verify the reportID changes in the URL
7. Verify the reportID does not quickly change back to the wrong id in the URL
8. Re-test on all platforms to make sure navigation works normally.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
