### PR TITLE
Fix unresponsive TextInputFocusable

### DIFF
--- a/src/components/TextInputFocusable/index.js
+++ b/src/components/TextInputFocusable/index.js
@@ -220,9 +220,13 @@ class TextInputFocusable extends React.Component {
         const propStyles = StyleSheet.flatten(this.props.style);
         propStyles.outline = 'none';
         const propsWithoutStyles = _.omit(this.props, 'style');
-        const propsWithoutValueOrDefaultValue = this.props.defaultValue
-            ? _.omit(propsWithoutStyles, 'value')
-            : _.omit(propsWithoutStyles, 'defaultValue');
+        let propsWithoutValueOrDefaultValue = propsWithoutStyles;
+        if (this.props.defaultValue || !this.props.value) {
+            propsWithoutValueOrDefaultValue = _.omit(propsWithoutValueOrDefaultValue, 'value');
+        }
+        if (!this.props.defaultValue) {
+            propsWithoutValueOrDefaultValue = _.omit(propsWithoutValueOrDefaultValue, 'defaultValue');
+        }
         return (
             <TextInput
                 ref={el => this.textInput = el}


### PR DESCRIPTION
cc @marcaaron 

### Details
TextInputFocusable is unresponsive in some cases as we pass empty values to TextInput all the time.

### Fixed Issues
Fixes GH_LINK
Regression introduced by https://github.com/Expensify/Expensify.cash/pull/2203

### Tests
Verified that report comment composer is responsive.

### QA Steps
1. Login to Expensify.cash website
2. Select a report from sidebar
3. Start typing messages
4. Verify that text input is responsive 

 
### Tested On

- [X] Web
- [X] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

https://user-images.githubusercontent.com/3853003/114761527-804aca00-9d58-11eb-8897-4439b94d002f.mov


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
