### PR TITLE
Let parent component handle defaultValue and value in TextInputFocusable

### DIFF
--- a/src/components/TextInputFocusable/index.js
+++ b/src/components/TextInputFocusable/index.js
@@ -47,8 +47,8 @@ const propTypes = {
 };
 
 const defaultProps = {
-    defaultValue: '',
-    value: '',
+    defaultValue: undefined,
+    value: undefined,
     maxLines: -1,
     onPasteFile: () => {},
     shouldClear: false,
@@ -78,15 +78,15 @@ class TextInputFocusable extends React.Component {
     constructor(props) {
         super(props);
 
+        const initialValue = props.defaultValue
+            ? `${props.defaultValue}`
+            : `${props.value || ''}`;
+
         this.state = {
             numberOfLines: 1,
             selection: {
-                start: this.props.defaultValue
-                    ? `${this.props.defaultValue}`.length
-                    : `${this.props.value}`.length,
-                end: this.props.defaultValue
-                    ? `${this.props.defaultValue}`.length
-                    : `${this.props.value}`.length,
+                start: initialValue.length,
+                end: initialValue.length,
             },
         };
     }
@@ -220,9 +220,6 @@ class TextInputFocusable extends React.Component {
         const propStyles = StyleSheet.flatten(this.props.style);
         propStyles.outline = 'none';
         const propsWithoutStyles = _.omit(this.props, 'style');
-        const propsWithoutValueOrDefaultValue = this.props.defaultValue
-            ? _.omit(propsWithoutStyles, 'value')
-            : _.omit(propsWithoutStyles, 'defaultValue');
         return (
             <TextInput
                 ref={el => this.textInput = el}
@@ -233,7 +230,7 @@ class TextInputFocusable extends React.Component {
                 numberOfLines={this.state.numberOfLines}
                 style={propStyles}
                 /* eslint-disable-next-line react/jsx-props-no-spreading */
-                {...propsWithoutValueOrDefaultValue}
+                {...propsWithoutStyles}
                 disabled={this.props.isDisabled}
             />
         );


### PR DESCRIPTION
cc @stitesExpensify 

### Details
Fixing a regression with the `TextInputFocusable`

### Fixed Issues (Comment)
https://github.com/Expensify/Expensify.cash/pull/2203#issuecomment-819724794

### Tests
### QA Steps
1. Verify that report compose input works normally

### Tested On

- [x] Web
- [x] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
