### PR TITLE
Fix scrolling problem for LHN

### DIFF
--- a/src/components/IOUConfirmationList.js
+++ b/src/components/IOUConfirmationList.js
@@ -198,9 +198,10 @@ class IOUConfirmationList extends Component {
 
     render() {
         return (
-            <View style={[styles.flex1, styles.w100]}>
+            <View style={[styles.flex1, styles.w100, styles.justifyContentBetween]}>
                 <View style={[styles.flex1]}>
                     <OptionsList
+                        listContainerStyles={[styles.flexGrow0]}
                         sections={this.getSections()}
                         disableArrowKeysActions
                         hideAdditionalOptionStates

--- a/src/components/OptionsList.js
+++ b/src/components/OptionsList.js
@@ -200,7 +200,7 @@ class OptionsList extends Component {
 
     render() {
         return (
-            <View style={[this.props.listContainerStyles]}>
+            <View style={this.props.listContainerStyles}>
                 {this.props.headerMessage ? (
                     <View style={[styles.ph5, styles.pb5]}>
                         <Text style={[styles.textLabel, styles.colorMuted]}>

--- a/src/components/OptionsList.js
+++ b/src/components/OptionsList.js
@@ -80,7 +80,7 @@ const defaultProps = {
     optionBackgroundColor: undefined,
     optionHoveredStyle: undefined,
     contentContainerStyles: [],
-    listContainerStyles: undefined,
+    listContainerStyles: [styles.flex1],
     sections: [],
     focusedIndex: 0,
     selectedOptions: [],
@@ -200,7 +200,7 @@ class OptionsList extends Component {
 
     render() {
         return (
-            <View style={[...(this.props.listContainerStyles ? this.props.listContainerStyles : [styles.flex1])]}>
+            <View style={[this.props.listContainerStyles]}>
                 {this.props.headerMessage ? (
                     <View style={[styles.ph5, styles.pb5]}>
                         <Text style={[styles.textLabel, styles.colorMuted]}>

--- a/src/components/OptionsList.js
+++ b/src/components/OptionsList.js
@@ -80,7 +80,7 @@ const defaultProps = {
     optionBackgroundColor: undefined,
     optionHoveredStyle: undefined,
     contentContainerStyles: [],
-    listContainerStyles: [],
+    listContainerStyles: undefined,
     sections: [],
     focusedIndex: 0,
     selectedOptions: [],

--- a/src/components/OptionsList.js
+++ b/src/components/OptionsList.js
@@ -11,6 +11,9 @@ const propTypes = {
     // option Background Color
     optionBackgroundColor: PropTypes.string,
 
+    // option flexStyle for the options list container
+    listContainerStyles: PropTypes.arrayOf(PropTypes.object),
+
     // Style for hovered state
     // eslint-disable-next-line react/forbid-prop-types
     optionHoveredStyle: PropTypes.object,
@@ -77,6 +80,7 @@ const defaultProps = {
     optionBackgroundColor: undefined,
     optionHoveredStyle: undefined,
     contentContainerStyles: [],
+    listContainerStyles: [],
     sections: [],
     focusedIndex: 0,
     selectedOptions: [],
@@ -196,7 +200,7 @@ class OptionsList extends Component {
 
     render() {
         return (
-            <View style={[styles.flexGrow0]}>
+            <View style={[...(this.props.listContainerStyles ? this.props.listContainerStyles : [styles.flex1])]}>
                 {this.props.headerMessage ? (
                     <View style={[styles.ph5, styles.pb5]}>
                         <Text style={[styles.textLabel, styles.colorMuted]}>


### PR DESCRIPTION
<If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit.>

### Details
<Explanation of the change or anything fishy that is going on>

I originally added flexGrow0 to the OptionsList because the view for IOUConfirmationList wasn’t showing the components as per the design. But flexGrow0 caused a regression in LHN because it stopped it from growing beyond its fixed height and width, and therefore, affected scrolling.

This solution solves the issue by using flexGrow0 only when it is passed as a prop. So components that need flex1 as a style in OptionsList have no regression. 

### Fixed Issues
<Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing>

The PR fixes the issue mentioned by the following comment: 

https://github.com/Expensify/Expensify.cash/pull/2120#issuecomment-819943605

### Tests

1. Go to IOUSplit page and continue until you reach IOUConfirm
2. Verify if all the rows and comments are shown.
3. Go to LHN, and verify you can scroll down the list


### QA Steps

Same as Tests. 

### Tested On

- [x] Web
- [x] Mobile Web
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
