### PR TITLE
[No QA] Use env and do not set SHOULD_DEPLOY_PRODUCTION

### DIFF
--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -94,7 +94,6 @@ jobs:
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          SHOULD_DEPLOY_PRODUCTION: true
 
       - name: Build staging desktop app
         if: ${{ env.SHOULD_DEPLOY_PRODUCTION == 'false' }}
@@ -106,7 +105,6 @@ jobs:
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          SHOULD_DEPLOY_PRODUCTION: false
 
   iOS:
     name: Build and deploy iOS


### PR DESCRIPTION
### Details
We were always deploying production and staging (when we only want to deploy one at a time) because of a little bug. This PR will fix that and only deploy one environment at a time.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/2409

### Tests
1. Merge this PR
2. Verify that only staging is deployed
3. Verify in the logs that it is deployed to the right s3 bucket `staging-expensify-cash`