### PR TITLE
[No QA] Don't always deploy desktop to production

### DIFF
--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -94,7 +94,6 @@ jobs:
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          SHOULD_DEPLOY_PRODUCTION: true
 
       - name: Build staging desktop app
         if: ${{ env.SHOULD_DEPLOY_PRODUCTION == 'false' }}
@@ -106,7 +105,6 @@ jobs:
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          SHOULD_DEPLOY_PRODUCTION: false
 
   iOS:
     name: Build and deploy iOS


### PR DESCRIPTION

### Details
We we're hard-coding a `SHOULD_DEPLOY_PRODUCTION` environment variable in these steps because we wanted to make that value available to the runner. However, this was affecting the `if` statement that was dependent upon that environment variable, causing us to always deploy to production. The workflow-level environment variable should be available to the runner via "the operating system's normal method for reading environment variables.", so let's just try to remove the step-level environment variable altogether and see if it works.

### Fixed Issues
n/a, but slack convo [here](https://expensify.slack.com/archives/C01GTK53T8Q/p1618431963227000)

### Tests
1. Merge with the StagingDeployCash unlocked.
2. Desktop should deploy to staging but not production.

### Tested On
- Test in Github only