### PR TITLE
Fix popovers after regression

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -38,9 +38,6 @@ const CONST = {
             CENTERED: 'centered',
             BOTTOM_DOCKED: 'bottom_docked',
             POPOVER: 'popover',
-            POPOVER_LEFT_DOCKED: 'popover_left_docked',
-            POPOVER_RIGHT_DOCKED: 'popover_right_docked',
-            POPOVER_CENTER_BOTTOM: 'popover_center_bottom',
             RIGHT_DOCKED: 'right_docked',
         },
         ANCHOR_ORIGIN_VERTICAL: {

--- a/src/components/CreateMenu.js
+++ b/src/components/CreateMenu.js
@@ -5,8 +5,6 @@ import Popover from './Popover';
 import styles from '../styles/styles';
 import withWindowDimensions, {windowDimensionsPropTypes} from './withWindowDimensions';
 import MenuItem from './MenuItem';
-import CONST from '../CONST';
-import {propTypes as ModalPropTypes} from './Modal/ModalPropTypes';
 
 const propTypes = {
     // Callback to fire on request to modal close
@@ -18,9 +16,6 @@ const propTypes = {
     // Callback to fire when a CreateMenu item is selected
     onItemSelected: PropTypes.func.isRequired,
 
-    // Gives the type of the modal
-    popOverType: ModalPropTypes.type,
-
     // Menu items to be rendered on the list
     menuItems: PropTypes.arrayOf(
         PropTypes.shape({
@@ -30,11 +25,32 @@ const propTypes = {
         }),
     ).isRequired,
 
+    // The anchor position of the CreateMenu popover
+    anchorPosition: PropTypes.shape({
+        top: PropTypes.number,
+        right: PropTypes.number,
+        bottom: PropTypes.number,
+        left: PropTypes.number,
+    }).isRequired,
+
+    // A react-native-animatable animation definition for the modal display animation.
+    animationIn: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.object,
+    ]),
+
+    // A react-native-animatable animation definition for the modal hide animation.
+    animationOut: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.object,
+    ]),
+
     ...windowDimensionsPropTypes,
 };
 
 const defaultProps = {
-    popOverType: CONST.MODAL.MODAL_TYPE.POPOVER_LEFT_DOCKED,
+    animationIn: 'fadeIn',
+    animationOut: 'fadeOut',
 };
 
 class CreateMenu extends PureComponent {
@@ -63,13 +79,15 @@ class CreateMenu extends PureComponent {
     render() {
         return (
             <Popover
+                anchorPosition={this.props.anchorPosition}
                 onClose={this.props.onClose}
                 isVisible={this.props.isVisible}
                 onModalHide={() => {
                     this.onModalHide();
                     this.resetOnModalHide();
                 }}
-                popOverType={this.props.popOverType}
+                animationIn={this.props.animationIn}
+                animationOut={this.props.animationOut}
             >
                 <View style={this.props.isSmallScreenWidth ? {} : styles.createMenuContainer}>
                     {this.props.menuItems.map(({
@@ -95,5 +113,5 @@ class CreateMenu extends PureComponent {
 
 CreateMenu.propTypes = propTypes;
 CreateMenu.defaultProps = defaultProps;
-CreateMenu.displayName = 'CreateMenu';
+
 export default withWindowDimensions(CreateMenu);

--- a/src/components/Modal/ModalPropTypes.js
+++ b/src/components/Modal/ModalPropTypes.js
@@ -28,6 +28,12 @@ const propTypes = {
         PropTypes.object,
     ]),
 
+    // A react-native-animatable animation definition for the modal hide animation.
+    animationOut: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.object,
+    ]),
+
     // The anchor position of a popover modal. Has no effect on other modal types.
     popoverAnchorPosition: PropTypes.shape({
         top: PropTypes.number,
@@ -44,6 +50,7 @@ const defaultProps = {
     type: '',
     onModalHide: () => {},
     animationIn: null,
+    animationOut: null,
     popoverAnchorPosition: {},
 };
 

--- a/src/components/Popover/PopoverPropTypes.js
+++ b/src/components/Popover/PopoverPropTypes.js
@@ -12,9 +12,6 @@ const propTypes = {
         bottom: PropTypes.number,
         left: PropTypes.number,
     }).isRequired,
-
-    // Describes what type of pop over is it - based on the position
-    popOverType: modalPropTypes.type,
 };
 
 const defaultProps = {

--- a/src/components/Popover/index.js
+++ b/src/components/Popover/index.js
@@ -3,42 +3,21 @@ import {propTypes, defaultProps} from './PopoverPropTypes';
 import CONST from '../../CONST';
 import Modal from '../Modal';
 import withWindowDimensions from '../withWindowDimensions';
-import styles from '../../styles/styles';
 
 /*
  * This is a convenience wrapper around the Modal component for a responsive Popover.
  * On small screen widths, it uses BottomDocked modal type, and a Popover type on wide screen widths.
  */
-const Popover = (props) => {
-    /**
-     * Get the anchor position using the type of the modal into account
-     * @param {String} type
-     * @returns {Object}
-     */
-    function getAnchorPosition(type) {
-        switch (type) {
-            case CONST.MODAL.MODAL_TYPE.POPOVER_LEFT_DOCKED:
-                return styles.createMenuPositionSidebar;
-            case CONST.MODAL.MODAL_TYPE.POPOVER_CENTER_BOTTOM:
-                return styles.createMenuPositionReportCompose;
-            case CONST.MODAL.MODAL_TYPE.POPOVER_RIGHT_DOCKED:
-                return styles.createMenuPositionProfile;
-            default:
-                return styles.createMenuPositionSidebar;
-        }
-    }
-
-    return (
-        <Modal
-            type={props.isSmallScreenWidth ? CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED : props.popOverType}
-            popoverAnchorPosition={getAnchorPosition(props.popOverType)}
-        // eslint-disable-next-line react/jsx-props-no-spreading
-            {...props}
-            animationIn={props.isSmallScreenWidth ? undefined : props.animationIn}
-            animationOut={props.isSmallScreenWidth ? undefined : props.animationOut}
-        />
-    );
-};
+const Popover = props => (
+    <Modal
+        type={props.isSmallScreenWidth ? CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED : CONST.MODAL.MODAL_TYPE.POPOVER}
+        popoverAnchorPosition={props.anchorPosition}
+    // eslint-disable-next-line react/jsx-props-no-spreading
+        {...props}
+        animationIn={props.isSmallScreenWidth ? undefined : props.animationIn}
+        animationOut={props.isSmallScreenWidth ? undefined : props.animationOut}
+    />
+);
 
 Popover.propTypes = propTypes;
 Popover.defaultProps = defaultProps;

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -17,7 +17,6 @@ import ReportTypingIndicator from './ReportTypingIndicator';
 import AttachmentModal from '../../../components/AttachmentModal';
 import compose from '../../../libs/compose';
 import CreateMenu from '../../../components/CreateMenu';
-import CONST from '../../../CONST';
 import withWindowDimensions from '../../../components/withWindowDimensions';
 import withDrawerState from '../../../components/withDrawerState';
 import canFocusInputOnScreenFocus from '../../../libs/canFocusInputOnScreenFocus';
@@ -248,7 +247,9 @@ class ReportActionCompose extends React.Component {
                                                 isVisible={this.state.isMenuVisible}
                                                 onClose={() => this.setMenuVisibility(false)}
                                                 onItemSelected={() => this.setMenuVisibility(false)}
-                                                popOverType={CONST.MODAL.MODAL_TYPE.POPOVER_CENTER_BOTTOM}
+                                                anchorPosition={styles.createMenuPositionReportActionCompose}
+                                                animationIn="fadeInUp"
+                                                animationOut="fadeOutDown"
                                                 menuItems={[
                                                     {
                                                         icon: Paperclip,

--- a/src/pages/home/sidebar/SidebarScreen.js
+++ b/src/pages/home/sidebar/SidebarScreen.js
@@ -88,7 +88,9 @@ class SidebarScreen extends Component {
                         <CreateMenu
                             onClose={this.toggleCreateMenu}
                             isVisible={this.state.isCreateMenuActive}
-                            popOverType={CONST.MODAL.MODAL_TYPE.POPOVER_LEFT_DOCKED}
+                            anchorPosition={styles.createMenuPositionSidebar}
+                            animationIn="fadeInLeft"
+                            animationOut="fadeOutLeft"
                             onItemSelected={this.onCreateMenuItemSelected}
                             menuItems={[
                                 {

--- a/src/pages/settings/Profile/ProfilePage.js
+++ b/src/pages/settings/Profile/ProfilePage.js
@@ -281,7 +281,9 @@ class ProfilePage extends Component {
                                     onClose={() => this.setState({isEditPhotoMenuVisible: false})}
                                     onItemSelected={() => this.setState({isEditPhotoMenuVisible: false})}
                                     menuItems={this.createMenuItems(openPicker)}
-                                    popOverType={CONST.MODAL.MODAL_TYPE.POPOVER_RIGHT_DOCKED}
+                                    anchorPosition={styles.createMenuPositionProfile}
+                                    animationIn="fadeInRight"
+                                    animationOut="fadeOutRight"
                                 />
                             </>
                         )}

--- a/src/styles/getModalStyles.js
+++ b/src/styles/getModalStyles.js
@@ -110,7 +110,7 @@ export default (type, windowDimensions, popoverAnchorPosition = {}) => {
             animationIn = 'slideInUp';
             animationOut = 'slideOutDown';
             break;
-        case CONST.MODAL.MODAL_TYPE.POPOVER_LEFT_DOCKED:
+        case CONST.MODAL.MODAL_TYPE.POPOVER:
             modalStyle = {
                 ...modalStyle,
                 ...popoverAnchorPosition,
@@ -131,56 +131,8 @@ export default (type, windowDimensions, popoverAnchorPosition = {}) => {
 
             hideBackdrop = true;
             swipeDirection = undefined;
-            animationIn = 'fadeInLeft';
-            animationOut = 'fadeOutLeft';
-            break;
-        case CONST.MODAL.MODAL_TYPE.POPOVER_RIGHT_DOCKED:
-            modalStyle = {
-                ...modalStyle,
-                ...popoverAnchorPosition,
-                ...{
-                    position: 'absolute',
-                    alignItems: 'center',
-                    justifyContent: 'flex-end',
-                },
-            };
-            modalContainerStyle = {
-                borderRadius: 12,
-                borderWidth: 1,
-                borderColor: themeColors.border,
-                justifyContent: 'center',
-                overflow: 'hidden',
-                boxShadow: '0px 0px 10px 0px rgba(0, 0, 0, 0.025)',
-            };
-
-            hideBackdrop = true;
-            swipeDirection = undefined;
-            animationIn = 'fadeInRight';
-            animationOut = 'fadeOutRight';
-            break;
-        case CONST.MODAL.MODAL_TYPE.POPOVER_CENTER_BOTTOM:
-            modalStyle = {
-                ...modalStyle,
-                ...popoverAnchorPosition,
-                ...{
-                    position: 'absolute',
-                    alignItems: 'center',
-                    justifyContent: 'flex-end',
-                },
-            };
-            modalContainerStyle = {
-                borderRadius: 12,
-                borderWidth: 1,
-                borderColor: themeColors.border,
-                justifyContent: 'center',
-                overflow: 'hidden',
-                boxShadow: '0px 0px 10px 0px rgba(0, 0, 0, 0.025)',
-            };
-
-            hideBackdrop = true;
-            swipeDirection = undefined;
-            animationIn = 'fadeInUp';
-            animationOut = 'fadeOutDown';
+            animationIn = 'fadeIn';
+            animationOut = 'fadeOut';
             break;
         case CONST.MODAL.MODAL_TYPE.RIGHT_DOCKED:
             modalStyle = {

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -504,7 +504,7 @@ const styles = {
         top: 100,
     },
 
-    createMenuPositionReportCompose: {
+    createMenuPositionReportActionCompose: {
         left: 18 + variables.sideBarWidth,
         bottom: 75,
     },


### PR DESCRIPTION
cc @npsedhain @tgolen 

### Details
Fixing a regression caused by [this PR](https://github.com/Expensify/Expensify.cash/pull/2222)

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/2420

### Tests / QA Steps (Web/Desktop)
1. Hit the global create FAB, and verify that the `CreateMenu` appears in the correct position in the sidebar. It should fade in from the left and fade out to the left.
2. Hit the `+` icon in the `ReportActionCompose`. Verify that the `CreateMenu` appears in the correct position above the compose input. It should fade in from the bottom and fade out to the bottom.
3. Go to `Settings` -> `Profile` -> `Edit Photo`. Verify that the `CreateMenu` appears in the correct position above the "Edit Photo" button. It should fade in from the right and fade out to the right.
4. Right click on a message, and verify that the `ReportActionContextMenu` appears as it should in the location where the user clicks.
5. Open the emoji picker, make sure it looks normal (it shouldn't have any noticeable animation when it opens and closes).

### Tests / QA Steps (mWeb/iOS/Android)
1. Hit the following buttons, and verify that the `CreateMenu` appears as a bottom-docked modal:
    1. Global create FAB
    1. `+` in the `ReportActionCompose`
    1. `Settings` -> `Profile` -> `Edit Photo`
    1. Long-press a message.
    1. The emoji picker

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

|_Menu_|Web|Mobile Web|Desktop|iOS|Android|
|---|---|---|---|---|---|
|Global Create|![image](https://user-images.githubusercontent.com/47436092/114932048-e9c7e880-9deb-11eb-8f81-45dfcc5be877.png)|![image](https://user-images.githubusercontent.com/47436092/114932625-90ac8480-9dec-11eb-9f0b-a313dab6b8ed.png)|![image](https://user-images.githubusercontent.com/47436092/114933113-2ea04f00-9ded-11eb-9e78-1ffcd51bc750.png)|![image](https://user-images.githubusercontent.com/47436092/114933567-a8d0d380-9ded-11eb-9a86-c940f114269d.png)|![image](https://user-images.githubusercontent.com/47436092/114934136-60fe7c00-9dee-11eb-94db-e05a841e89f1.png)|
|ReportActionCompose|![image](https://user-images.githubusercontent.com/47436092/114932207-15e36980-9dec-11eb-970d-cace8ca56c80.png)|![image](https://user-images.githubusercontent.com/47436092/114932675-9efaa080-9dec-11eb-8333-daf87ee6b87a.png)|![image](https://user-images.githubusercontent.com/47436092/114933154-395ae400-9ded-11eb-8eeb-9bd91af05310.png)|![image](https://user-images.githubusercontent.com/47436092/114933624-b6865900-9ded-11eb-8963-70c924c2e35f.png)|![image](https://user-images.githubusercontent.com/47436092/114934188-72e01f00-9dee-11eb-81ce-2bab34b40fac.png)|
|Edit Photo|![image](https://user-images.githubusercontent.com/47436092/114931957-ca30c000-9deb-11eb-8f17-77a1da099b2f.png)|![image](https://user-images.githubusercontent.com/47436092/114932941-fa2c9300-9dec-11eb-9aa9-25d63a395417.png)|![image](https://user-images.githubusercontent.com/47436092/114933191-44157900-9ded-11eb-8561-44f9cdac027c.png)|![image](https://user-images.githubusercontent.com/47436092/114933654-c1d98480-9ded-11eb-9a6e-2c0ad9f60784.png)|![image](https://user-images.githubusercontent.com/47436092/114934228-7f647780-9dee-11eb-9b60-94c2aa9eb910.png)|
|ReportActionContextMenu|![image](https://user-images.githubusercontent.com/47436092/114931992-d6b51880-9deb-11eb-95f9-bcaae1506e6b.png)|![image](https://user-images.githubusercontent.com/47436092/114932879-e2550f00-9dec-11eb-9926-7885003b2052.png)|![image](https://user-images.githubusercontent.com/47436092/114933245-4f68a480-9ded-11eb-9345-9869d1589190.png)|![image](https://user-images.githubusercontent.com/47436092/114933688-ce5ddd00-9ded-11eb-8841-d18b893b1d96.png)|![image](https://user-images.githubusercontent.com/47436092/114934299-960ace80-9dee-11eb-9f76-9e9f14530ffe.png)|
|Emoji Picker|![image](https://user-images.githubusercontent.com/47436092/114957473-f95c2700-9e15-11eb-97e1-558e29a0d1b8.png)|![image](https://user-images.githubusercontent.com/47436092/114957578-28729880-9e16-11eb-818b-67ea87e2139e.png)|![image](https://user-images.githubusercontent.com/47436092/114957708-74254200-9e16-11eb-9e8e-5329a476b2c2.png)|||

