### PR TITLE
[No QA] Point CLA repo at master branch not main

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -33,7 +33,7 @@ jobs:
               with:
                   path-to-signatures: '${{ github.repository }}/cla.json'
                   path-to-document: 'https://github.com/${{ github.repository }}/blob/main/CLA.md'
-                  branch: 'main'
+                  branch: 'master'
                   remote-organization-name: 'Expensify'
                   remote-repository-name: 'CLA'
                   lock-pullrequest-aftermerge: false


### PR DESCRIPTION
### Details
CLA is failing everywhere in E.cash right now because I pointed it at `main` instead of `master`. But the [CLA repo](https://github.com/Expensify/CLA) still has master as the default branch.

### Fixed Issues
n/a

### Tests
We should find out if this works depending on if CLA passes on this PR
