### PR TITLE
Add link to all Upwork jobs to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -26,3 +26,5 @@ Where is this issue occurring?
 **Logs:** https://stackoverflow.com/c/expensify/questions/4856
 **Notes/Photos/Videos:** Any additional supporting documentation
 **Expensify/Expensify Issue URL:**
+
+[View all open jobs on Upwork](https://www.upwork.com/ab/jobs/search/?q=Expensify%20React%20Native&sort=recency&user_location_match=2)


### PR DESCRIPTION
### Details
This PR updates the issue template to include a link to all Upwork jobs

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/160617

### Tests
You can see the updated template [here](https://github.com/Expensify/Expensify.cash/blob/joe-add-open-jobs-link/.github/ISSUE_TEMPLATE.md)

### QA Steps
N/A

### Tested On
N/A