### PR TITLE
Fix react-navigation drawer history issues on web/mWeb

### DIFF
--- a/src/libs/Navigation/CustomActions.js
+++ b/src/libs/Navigation/CustomActions.js
@@ -1,0 +1,33 @@
+import {CommonActions} from '@react-navigation/native';
+
+/**
+ * In order to create the desired browser navigation behavior on web and mobile web we need to replace any
+ * type: 'drawer' routes with a type: 'route' so that when pushing to a report screen we never show the
+ * drawer. We don't want to remove these since we always want the history length to increase by 1 whenever
+ * we are moving to a new report screen or back to a previous one. This is a workaround since
+ * react-navigation default behavior for a drawer is to skip pushing history states when navigating to the
+ * current route
+ *
+ * @param {String} screenName
+ * @param {Object} params
+ * @returns {Function}
+ */
+function pushDrawerRoute(screenName, params) {
+    return (state) => {
+        const screenRoute = {type: 'route', name: screenName};
+        const history = [...state.history].map(() => screenRoute);
+        history.push(screenRoute);
+        return CommonActions.reset({
+            ...state,
+            routes: [{
+                name: screenName,
+                params,
+            }],
+            history,
+        });
+    };
+}
+
+export default {
+    pushDrawerRoute,
+};

--- a/src/libs/Navigation/Navigation.js
+++ b/src/libs/Navigation/Navigation.js
@@ -6,6 +6,7 @@ import {getIsDrawerOpenFromState} from '@react-navigation/drawer';
 import linkTo from './linkTo';
 import ROUTES from '../../ROUTES';
 import SCREENS from '../../SCREENS';
+import CustomActions from './CustomActions';
 
 export const navigationRef = React.createRef();
 
@@ -49,7 +50,7 @@ function navigate(route = ROUTES.HOME) {
 
     const {reportID} = ROUTES.parseReportRouteParams(route);
     if (reportID) {
-        navigationRef.current.navigate(SCREENS.REPORT, {reportID});
+        navigationRef.current.dispatch(CustomActions.pushDrawerRoute(SCREENS.REPORT, {reportID}));
         return;
     }
 

--- a/src/pages/home/ReportScreen.js
+++ b/src/pages/home/ReportScreen.js
@@ -31,6 +31,7 @@ class ReportScreen extends React.Component {
 
     componentDidMount() {
         this.prepareTransition();
+        this.storeCurrentlyViewedReport();
     }
 
     componentDidUpdate(prevProps) {


### PR DESCRIPTION
### Details
This PR adds a custom action to use with react-navigation when navigating to report routes. This is necessary since the default behavior on web and mobile web is to call `window.history.replaceState()` in most cases since navigating to the `Report` screen with new params does not add an entry to the history stack. 

There might be a way to propose a fix for this in `react-navigation` itself, but I'm unsure whether this is the intended behavior and for now this gives us the desired behavior. `react-navigation` is intended to be extensible so I'm assuming this solution is OK.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/157550
Fixes https://github.com/Expensify/Expensify.cash/issues/2028

### Tests
### QA Steps (web, mobile-web)
1. Open the app and sign in
2. Select a chat
3. Verify you are brought to that chat (if mWeb verify the chat slides into view)
4. Press the browser back button
5. Verify that you return to the previous chat (if mWeb verify that we are brought to the LHN)
6. Test navigating to several chats without pressing the browser back button
7. Press the browser back button and verify that we are brought to all the previous chats (on mWeb we should first see the LHN but be able to slide the LHN to the left to reveal the chat)

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
