### PR TITLE
Remove step ID as it's not needed and causing errors

### DIFF
--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -278,7 +278,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 
       - name: Comment on issues
-        id: getReleasePRList
         uses: Expensify/Expensify.cash/.github/actions/markPullRequestsAsDeployed@main
         with:
           PR_LIST: ${{ steps.getReleasePRList.outputs.PR_LIST }}


### PR DESCRIPTION
### Details
There was a startup error with our new deployment commenting code as seen here https://github.com/Expensify/Expensify.cash/actions/runs/764799755

`The workflow is not valid. .github/workflows/platformDeploy.yml (Line: 281, Col: 13): The identifier 'getReleasePRList' may not be used more than once within the same scope.`

I removed the duplicate ID as it's not required for this step, just a copy paste mistake.


### Fixed Issues
Fixes startup error here: https://github.com/Expensify/Expensify.cash/actions/runs/764799755

### Tests
1. Merge this PR
2. Verify the deploy works successfully with no errors.