### PR TITLE
[No QA] Update caniuse browserlist to improve babel transpilation and resolve build warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6908,9 +6908,9 @@
       "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
     },
     "caniuse-lite": {
-      "version": "1.0.30001148",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001148.tgz",
-      "integrity": "sha512-E66qcd0KMKZHNJQt9hiLZGE3J4zuTqE1OnU53miEVtylFbwOEmeA5OsRu90noZful+XGSQOni1aT2tiqu/9yYw==",
+      "version": "1.0.30001211",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001211.tgz",
+      "integrity": "sha512-v3GXWKofIkN3PkSidLI5d1oqeKNsam9nQkqieoMhP87nxOY0RPDC8X2+jcv8pjV4dRozPLSoMqNii9sDViOlIg==",
       "dev": true
     },
     "capture-exit": {


### PR DESCRIPTION

### Details
When running webpack builds, we have had this warning:

```
[Renderer] Browserslist: caniuse-lite is outdated. Please run:
[Renderer] npx browserslist@latest --update-db
[Renderer] 
[Renderer] Why you should do it regularly:
[Renderer] https://github.com/browserslist/browserslist#browsers-data-updating
```

So I ran that command, verified that the warning is gone, and committed the diff. I also did some basic regression testing on web and desktop.

### Fixed Issues
n/a, just cleanup.

### Tests
Tests and QA should be covered by regular regression testing, I believe this is just updating the browser compatibility data used by the babel transpiler.
