### PR TITLE
Remove emojis that are not implemented on mobile safari, and update header indices

### DIFF
--- a/assets/emojis.js
+++ b/assets/emojis.js
@@ -1565,56 +1565,12 @@ const emojis = [
         ],
     },
     {
-        code: '👩‍❤️‍💋‍👨',
-        keywords: [
-            'kiss',
-            'man',
-            'woman',
-        ],
-    },
-    {
-        code: '👨‍❤️‍💋‍👨',
-        keywords: [
-            'kiss',
-            'man',
-        ],
-    },
-    {
-        code: '👩‍❤️‍💋‍👩',
-        keywords: [
-            'kiss',
-            'woman',
-        ],
-    },
-    {
         code: '💑',
         keywords: [
             'couple',
             'heart',
             'love',
             'romance',
-        ],
-    },
-    {
-        code: '👩‍❤️‍👨',
-        keywords: [
-            'couple',
-            'man',
-            'woman',
-        ],
-    },
-    {
-        code: '👨‍❤️‍👨',
-        keywords: [
-            'couple',
-            'man',
-        ],
-    },
-    {
-        code: '👩‍❤️‍👩',
-        keywords: [
-            'couple',
-            'woman',
         ],
     },
     {
@@ -2823,12 +2779,6 @@ const emojis = [
             'jewel',
             'romance',
         ],
-    },
-    {
-        code: CONST.EMOJI_SPACER,
-    },
-    {
-        code: CONST.EMOJI_SPACER,
     },
     {
         code: 'Animals & Nature',

--- a/src/pages/home/report/EmojiPickerMenu/index.js
+++ b/src/pages/home/report/EmojiPickerMenu/index.js
@@ -32,7 +32,7 @@ class EmojiPickerMenu extends Component {
         // The positions are static, and are calculated as index/numColumns (8 in our case)
         // This is because each row of 8 emojis counts as one index
         // If more emojis are ever added to emojis.js this will need to be updated or things will break
-        this.unfilteredHeaderIndices = [0, 34, 60, 88, 99, 121, 148];
+        this.unfilteredHeaderIndices = [0, 33, 59, 87, 98, 120, 147];
 
         this.filterEmojis = _.debounce(this.filterEmojis.bind(this), 300);
         this.renderItem = this.renderItem.bind(this);

--- a/src/pages/home/report/EmojiPickerMenu/index.native.js
+++ b/src/pages/home/report/EmojiPickerMenu/index.native.js
@@ -26,7 +26,7 @@ class EmojiPickerMenu extends Component {
         // The positions are static, and are calculated as index/numColumns (8 in our case)
         // This is because each row of 8 emojis counts as one index
         // If this emojis are ever added to emojis.js this will need to be updated or things will break
-        this.unfilteredHeaderIndices = [0, 34, 60, 88, 99, 121, 148];
+        this.unfilteredHeaderIndices = [0, 33, 59, 87, 98, 120, 147];
 
         this.renderItem = this.renderItem.bind(this);
     }


### PR DESCRIPTION

### Details
Some emojis are actually created by stringing multiple different emojis together and the browser figuring out that they make a different emoji. The emojis removed in this PR are not supported on all platforms so it's best to just get rid of them. 

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/pull/1991#issuecomment-821732999

### Tests/QA
1. Log in on iOS mobile web
2. Choose a conversation
1. Open the emoji picker
2. Scroll down and make sure you don't see any weird spaces in the chat
3. Make sure that the headers are sticking properly (as opposed to emojis sticking where the header should be)


### Tested On
- [x] Mobile Web

#### Mobile Web
![2021-04-19_14-55-13](https://user-images.githubusercontent.com/42391420/115302090-41818f00-a11f-11eb-9817-ea8c3d53e447.png)

