### PR TITLE
Checkout code and set up npm for deploy code

### DIFF
--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -265,6 +265,13 @@ jobs:
     if: ${{ always() }}
     needs: [android, desktop, iOS, web]
     steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+
       - run: echo "Status android = ${{ needs.android.result }}, desktop = ${{ needs.desktop.result }}, iOS = ${{ needs.iOS.result }}, web = ${{ needs.web.result }}"
 
       - name: Set version


### PR DESCRIPTION
### Details
in https://github.com/Expensify/Expensify.cash/runs/2384940915?check_suite_focus=true the `VERSION` environment variable was not set causing the workflow to fail. I assume this is because we have not checked out the repo and haven't set up `npm`. Leaving `npm run print-version --silent` to just fail and set `VERSION` to an empty string. 

### Fixed Issues
Fixes failing deploys

### Tests
1. Merge this PR
2. Verify there is a comment left saying this PR was deployed to staging.