### PR TITLE
Add native popover component

### DIFF
--- a/src/components/Popover/index.native.js
+++ b/src/components/Popover/index.native.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import {propTypes, defaultProps} from './PopoverPropTypes';
+import CONST from '../../CONST';
+import Modal from '../Modal';
+import withWindowDimensions from '../withWindowDimensions';
+
+/*
+ * This is a convenience wrapper around the Modal component for a responsive Popover.
+ * On small screen widths, it uses BottomDocked modal type, and a Popover type on wide screen widths.
+ */
+const Popover = props => (
+    <Modal
+        type={CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED}
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...props}
+    />
+);
+
+Popover.propTypes = propTypes;
+Popover.defaultProps = defaultProps;
+Popover.displayName = 'Popover';
+
+export default withWindowDimensions(Popover);

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -831,6 +831,7 @@ const styles = {
     emojiText: {
         fontFamily: fontFamily.GTA_BOLD,
         fontSize: variables.iconSizeLarge,
+        textAlign: 'center',
         ...spacing.pv1,
         ...spacing.ph2,
     },


### PR DESCRIPTION
### Details
On tablets we were using popovers like on a desktop due to screen size and that doesn't work very well in that environment. This ensures that we always show popovers as bottom docked regardless of native platform. 

### Fixed Issues
https://github.com/Expensify/Expensify.cash/pull/1991#issuecomment-821735996

### Tests/QA
1. Log in and select a conversation
2. Click the emoji button
3. If you are on a native app or mobile web the picker should be bottom docked. Otherwise it should be a popup

### Tested On

- [x] Web
- [x] Mobile Web
- [ ] Desktop
- [x] iOS
- [ ] Android

### Screenshots
![2021-04-20_09-33-01](https://user-images.githubusercontent.com/42391420/115430129-53b40980-a1c1-11eb-9b26-d054544eb8a9.png)


