### PR TITLE
Add fetch depth 0 to fetch all tags

### DIFF
--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -266,6 +266,8 @@ jobs:
     needs: [android, desktop, iOS, web]
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@v1


### PR DESCRIPTION
### Details
Got farther in the new deploy process comments 🎉 However, we found another bug. We didn't have all the tags checked out so this `git` command was failing: `git log --format="%s" 1.0.19-6...1.0.26-3` - This fix will resolve that error.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/runs/2385240576?check_suite_focus=true

### Tests
1. Merge this PR
2. Verify there is a comment left on this PR (and a bunch of others) saying it was deployed to staging