### PR TITLE
Set lineHeight for the report action compose box to 20px

### DIFF
--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -790,6 +790,7 @@ const styles = {
         borderWidth: 0,
         borderRadius: 0,
         height: 'auto',
+        lineHeight: '25px',
 
         // On Android, multiline TextInput with height: 'auto' will show extra padding unless they are configured with
         // paddingVertical: 0, alignSelf: 'center', and textAlignVertical: 'center'

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -790,7 +790,7 @@ const styles = {
         borderWidth: 0,
         borderRadius: 0,
         height: 'auto',
-        lineHeight: 25,
+        lineHeight: 20,
 
         // On Android, multiline TextInput with height: 'auto' will show extra padding unless they are configured with
         // paddingVertical: 0, alignSelf: 'center', and textAlignVertical: 'center'

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -790,7 +790,7 @@ const styles = {
         borderWidth: 0,
         borderRadius: 0,
         height: 'auto',
-        lineHeight: '25px',
+        lineHeight: 25,
 
         // On Android, multiline TextInput with height: 'auto' will show extra padding unless they are configured with
         // paddingVertical: 0, alignSelf: 'center', and textAlignVertical: 'center'


### PR DESCRIPTION
### Details
For whatever reason, emojis have a line height of 25px, in contrast to the line-height of 20px that plain text has. This means that the check happening [here](https://github.com/Expensify/Expensify.cash/blob/9efcc63e4eb9dd27fac35d7bfc92b3400554be0c/src/components/TextInputFocusable/index.js#L150-L152) thinks that we need two rows to display the emoji when we only actually need 1.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/2490

### Tests
Typed emojis into the report action compose box and verified that they displayed in the correct number of rows.

### QA Steps
1. Navigate to any chat
2. Type emojis in the report action compose box. Verify that they display in the correct number of rows, aren't cutoff, and don't have any extra vertical space.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web
<img width="1792" alt="Screen Shot 2021-04-21 at 4 52 55 PM" src="https://user-images.githubusercontent.com/31285285/115526191-5ea29300-a2c2-11eb-9c5f-70eacd30b569.png">

#### Mobile Web
![simulator_screenshot_8D6C4E11-CB1D-401B-999C-B43F21E8B817](https://user-images.githubusercontent.com/31285285/115526097-4468b500-a2c2-11eb-9caa-ffbaa586dde7.png)

#### Desktop
<img width="1200" alt="Screen Shot 2021-04-21 at 4 56 26 PM" src="https://user-images.githubusercontent.com/31285285/115526368-872a8d00-a2c2-11eb-9f1c-15372634ef6d.png">

#### iOS
![simulator_screenshot_D18875E9-981E-475D-8F2C-A53C99F5F223](https://user-images.githubusercontent.com/31285285/115526509-b0e3b400-a2c2-11eb-81e1-129a249e3f92.png)

#### Android
![Screenshot_1618995607](https://user-images.githubusercontent.com/31285285/115526913-1afc5900-a2c3-11eb-963a-635c8f6c8b3e.png)

