### PR TITLE
[No QA] Include app version in PR deploy comments

### DIFF
--- a/.github/actions/markPullRequestsAsDeployed/action.yml
+++ b/.github/actions/markPullRequestsAsDeployed/action.yml
@@ -8,6 +8,9 @@ inputs:
         description: "Check if deploying to production"
         required: false
         default: "false"
+    VERSION:
+        description: "The app version in which the pull requests were deployed"
+        required: true
     GITHUB_TOKEN:
         description: "Github token for authentication"
         required: true

--- a/.github/actions/markPullRequestsAsDeployed/index.js
+++ b/.github/actions/markPullRequestsAsDeployed/index.js
@@ -49,7 +49,7 @@ const webResult = getDeployTableMessage(core.getInput('WEB', {required: true}));
 const workflowURL = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}`
     + `/actions/runs/${process.env.GITHUB_RUN_ID}`;
 
-let message = `🚀 [Deployed](${workflowURL}) to ${isProd ? 'production' : 'staging'} in v${version}🚀`;
+let message = `🚀 [Deployed](${workflowURL}) to ${isProd ? 'production' : 'staging'} in version: ${version}🚀`;
 message += `\n\n platform | result \n ---|--- \n🤖 android 🤖|${androidResult} \n🖥 desktop 🖥|${desktopResult}`;
 message += `\n🍎 iOS 🍎|${iOSResult} \n🕸 web 🕸|${webResult}`;
 

--- a/.github/actions/markPullRequestsAsDeployed/index.js
+++ b/.github/actions/markPullRequestsAsDeployed/index.js
@@ -16,6 +16,7 @@ const prList = JSON.parse(core.getInput('PR_LIST', {required: true}));
 const isProd = JSON.parse(
     core.getInput('IS_PRODUCTION_DEPLOY', {required: true}),
 );
+const version = JSON.parse(core.getInput('VERSION', {required: true}));
 const token = core.getInput('GITHUB_TOKEN', {required: true});
 const octokit = github.getOctokit(token);
 const githubUtils = new GithubUtils(octokit);
@@ -48,7 +49,7 @@ const webResult = getDeployTableMessage(core.getInput('WEB', {required: true}));
 const workflowURL = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}`
     + `/actions/runs/${process.env.GITHUB_RUN_ID}`;
 
-let message = `🚀 [Deployed](${workflowURL}) to ${isProd ? 'production' : 'staging'} 🚀`;
+let message = `🚀 [Deployed](${workflowURL}) to ${isProd ? 'production' : 'staging'} in v${version}🚀`;
 message += `\n\n platform | result \n ---|--- \n🤖 android 🤖|${androidResult} \n🖥 desktop 🖥|${desktopResult}`;
 message += `\n🍎 iOS 🍎|${iOSResult} \n🕸 web 🕸|${webResult}`;
 

--- a/.github/actions/markPullRequestsAsDeployed/markPullRequestsAsDeployed.js
+++ b/.github/actions/markPullRequestsAsDeployed/markPullRequestsAsDeployed.js
@@ -6,6 +6,7 @@ const prList = JSON.parse(core.getInput('PR_LIST', {required: true}));
 const isProd = JSON.parse(
     core.getInput('IS_PRODUCTION_DEPLOY', {required: true}),
 );
+const version = JSON.parse(core.getInput('VERSION', {required: true}));
 const token = core.getInput('GITHUB_TOKEN', {required: true});
 const octokit = github.getOctokit(token);
 const githubUtils = new GithubUtils(octokit);
@@ -38,7 +39,7 @@ const webResult = getDeployTableMessage(core.getInput('WEB', {required: true}));
 const workflowURL = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}`
     + `/actions/runs/${process.env.GITHUB_RUN_ID}`;
 
-let message = `🚀 [Deployed](${workflowURL}) to ${isProd ? 'production' : 'staging'} 🚀`;
+let message = `🚀 [Deployed](${workflowURL}) to ${isProd ? 'production' : 'staging'} in v${version}🚀`;
 message += `\n\n platform | result \n ---|--- \n🤖 android 🤖|${androidResult} \n🖥 desktop 🖥|${desktopResult}`;
 message += `\n🍎 iOS 🍎|${iOSResult} \n🕸 web 🕸|${webResult}`;
 

--- a/.github/actions/markPullRequestsAsDeployed/markPullRequestsAsDeployed.js
+++ b/.github/actions/markPullRequestsAsDeployed/markPullRequestsAsDeployed.js
@@ -39,7 +39,7 @@ const webResult = getDeployTableMessage(core.getInput('WEB', {required: true}));
 const workflowURL = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}`
     + `/actions/runs/${process.env.GITHUB_RUN_ID}`;
 
-let message = `🚀 [Deployed](${workflowURL}) to ${isProd ? 'production' : 'staging'} in v${version}🚀`;
+let message = `🚀 [Deployed](${workflowURL}) to ${isProd ? 'production' : 'staging'} in version: ${version}🚀`;
 message += `\n\n platform | result \n ---|--- \n🤖 android 🤖|${androidResult} \n🖥 desktop 🖥|${desktopResult}`;
 message += `\n🍎 iOS 🍎|${iOSResult} \n🕸 web 🕸|${webResult}`;
 

--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -292,6 +292,7 @@ jobs:
         with:
           PR_LIST: ${{ steps.getReleasePRList.outputs.PR_LIST }}
           IS_PRODUCTION_DEPLOY: ${{ env.SHOULD_DEPLOY_PRODUCTION == 'true' }}
+          VERSION: ${{ env.version }}
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
           ANDROID: ${{ needs.android.result }}
           DESKTOP: ${{ needs.desktop.result }}

--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -292,7 +292,7 @@ jobs:
         with:
           PR_LIST: ${{ steps.getReleasePRList.outputs.PR_LIST }}
           IS_PRODUCTION_DEPLOY: ${{ env.SHOULD_DEPLOY_PRODUCTION == 'true' }}
-          VERSION: ${{ env.version }}
+          VERSION: ${{ env.VERSION }}
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
           ANDROID: ${{ needs.android.result }}
           DESKTOP: ${{ needs.desktop.result }}


### PR DESCRIPTION


### Details
Adds the app version to the deploy comments in PRs

### Fixed Issues
No issue, just noticed this when looking at some regressions [here](https://github.com/Expensify/Expensify.cash/pull/2460) that it would be nice to definitively know in which version the PR was deployed.

### Tests
1. Merge _when the `StagingDeployCash` is not locked_ to test
2. Verify that the newly deployed app version is included in the deploy comment.