### PR TITLE
Delay fetching report history so the app can initialize quickly 

### DIFF
--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -688,12 +688,13 @@ function fetchAll(shouldRedirectToReport = true, shouldRecordHomePageTiming = fa
                 }
             }
 
-            Log.info('[Report] Fetching report actions for reports', true, {reportIDs});
+            // Delay fetching report history as it increases sign in to interactive time by ~2X
             setTimeout(() => {
+                Log.info('[Report] Fetching report actions for reports', true, {reportIDs});
                 _.each(reportIDs, (reportID) => {
                     fetchActions(reportID);
                 });
-            }, 5000);
+            }, 8000);
 
             if (shouldRecordHomePageTiming) {
                 Timing.end(CONST.TIMING.HOMEPAGE_REPORTS_LOADED);

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -681,11 +681,13 @@ function fetchAll(shouldRedirectToReport = true, shouldRecordHomePageTiming = fa
             if (shouldRedirectToReport) {
                 // Update currentlyViewedReportID to be our first reportID from our report collection if we don't have
                 // one already.
-                if (!lastViewedReportID) {
-                    const firstReportID = _.first(reportIDs);
-                    const currentReportID = firstReportID ? String(firstReportID) : '';
-                    Onyx.merge(ONYXKEYS.CURRENTLY_VIEWED_REPORTID, currentReportID);
+                if (lastViewedReportID) {
+                    return;
                 }
+
+                const firstReportID = _.first(reportIDs);
+                const currentReportID = firstReportID ? String(firstReportID) : '';
+                Onyx.merge(ONYXKEYS.CURRENTLY_VIEWED_REPORTID, currentReportID);
             }
 
             // Delay fetching report history as it increases sign in to interactive time by ~2X

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -681,19 +681,19 @@ function fetchAll(shouldRedirectToReport = true, shouldRecordHomePageTiming = fa
             if (shouldRedirectToReport) {
                 // Update currentlyViewedReportID to be our first reportID from our report collection if we don't have
                 // one already.
-                if (lastViewedReportID) {
-                    return;
+                if (!lastViewedReportID) {
+                    const firstReportID = _.first(reportIDs);
+                    const currentReportID = firstReportID ? String(firstReportID) : '';
+                    Onyx.merge(ONYXKEYS.CURRENTLY_VIEWED_REPORTID, currentReportID);
                 }
-
-                const firstReportID = _.first(reportIDs);
-                const currentReportID = firstReportID ? String(firstReportID) : '';
-                Onyx.merge(ONYXKEYS.CURRENTLY_VIEWED_REPORTID, currentReportID);
             }
 
             Log.info('[Report] Fetching report actions for reports', true, {reportIDs});
-            _.each(reportIDs, (reportID) => {
-                fetchActions(reportID);
-            });
+            setTimeout(() => {
+                _.each(reportIDs, (reportID) => {
+                    fetchActions(reportID);
+                });
+            }, 5000);
 
             if (shouldRecordHomePageTiming) {
                 Timing.end(CONST.TIMING.HOMEPAGE_REPORTS_LOADED);

--- a/src/pages/home/ReportScreen.js
+++ b/src/pages/home/ReportScreen.js
@@ -31,6 +31,7 @@ class ReportScreen extends React.Component {
 
     componentDidMount() {
         this.prepareTransition();
+        this.storeCurrentlyViewedReport();
     }
 
     componentDidUpdate(prevProps) {

--- a/src/pages/home/sidebar/SidebarLinks.js
+++ b/src/pages/home/sidebar/SidebarLinks.js
@@ -68,6 +68,9 @@ const propTypes = {
 
     // The chat priority mode
     priorityMode: PropTypes.string,
+
+    // Whether we have the necessary report data to load the sidebar
+    initialReportDataLoaded: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -80,6 +83,7 @@ const defaultProps = {
     network: null,
     currentlyViewedReportID: '',
     priorityMode: CONST.PRIORITY_MODE.DEFAULT,
+    initialReportDataLoaded: false,
 };
 
 class SidebarLinks extends React.Component {
@@ -88,6 +92,10 @@ class SidebarLinks extends React.Component {
     }
 
     render() {
+        if (!this.props.initialReportDataLoaded) {
+            return null;
+        }
+
         const activeReportID = parseInt(this.props.currentlyViewedReportID, 10);
 
         const {recentReports} = getSidebarOptions(
@@ -183,6 +191,9 @@ export default compose(
         },
         priorityMode: {
             key: ONYXKEYS.NVP_PRIORITY_MODE,
+        },
+        initialReportDataLoaded: {
+            key: ONYXKEYS.INITIAL_REPORT_DATA_LOADED,
         },
     }),
 )(SidebarLinks);


### PR DESCRIPTION
### Details
When a user first signs in we are fetching all of their report history for all reports right away before the app is even interactive. This is causing massive numbers of network requests and data processing that prevent the app from loading fast.

This approximately cuts the time it takes to reach the fully loaded sidebar on Android in _half_.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/160975

### Tests
The test I performed was to drop a console.log() here and here:

```diff
diff --git a/src/pages/home/sidebar/OptionRow.js b/src/pages/home/sidebar/OptionRow.js
index 88fd1edcf..a973d97a2 100644
--- a/src/pages/home/sidebar/OptionRow.js
+++ b/src/pages/home/sidebar/OptionRow.js
@@ -115,6 +115,7 @@ const OptionRow = ({
         ({displayName, login}) => ({displayName, tooltip: login}),
     );

+    console.log('OptionRow Rendered');
     return (
         <Hoverable>
             {hovered => (
```

```diff
diff --git a/src/pages/signin/PasswordForm.js b/src/pages/signin/PasswordForm.js
index 173d29458..ea05b3f54 100644
--- a/src/pages/signin/PasswordForm.js
+++ b/src/pages/signin/PasswordForm.js
@@ -49,6 +49,7 @@ class PasswordForm extends React.Component {
      * Check that all the form fields are valid, then trigger the submit callback
      */
     validateAndSubmitForm() {
+        console.log('Sign In Pressed');
         if (!this.state.password.trim()
             || (this.props.account.requiresTwoFactorAuth && !this.state.twoFactorAuthCode.trim())
         ) {
```
- Then I measured the time it took to go from pressing the sign in button to seeing the first `OptionRow` render in the `SidebarLinks` which tends to correspond with whether or not it is visible.
- I then repeated this test against `main` and go the following results

## `main`
```
[Wed Apr 21 2021 09:28:32.312]  LOG      Sign In Pressed
[Wed Apr 21 2021 09:28:43.683]  LOG      OptionRow rendered
```
11 seconds

## this branch
```
[Wed Apr 21 2021 09:35:54.446]  LOG      Sign In Pressed
[Wed Apr 21 2021 09:35:59.862]  LOG      OptionRow rendered
```
5.3 seconds

### QA Steps
No QA besides regressions

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
