### PR TITLE
Delay report history fetch to give app a chance to initialize

### DIFF
--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -119,7 +119,7 @@ class AuthScreens extends React.Component {
         PersonalDetails.fetch();
         User.getUserDetails();
         User.getBetas();
-        fetchAllReports(true, true, 8000);
+        fetchAllReports(true, true, true);
         fetchCountryCodeByRequestIP();
         UnreadIndicatorUpdater.listenForReportChanges();
 

--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -10,7 +10,7 @@ import CONST from '../../../CONST';
 import compose from '../../compose';
 import {
     subscribeToReportCommentEvents,
-    fetchAll as fetchAllReports,
+    fetchAllReports,
 } from '../../actions/Report';
 import * as PersonalDetails from '../../actions/PersonalDetails';
 import * as Pusher from '../../Pusher/pusher';
@@ -119,7 +119,7 @@ class AuthScreens extends React.Component {
         PersonalDetails.fetch();
         User.getUserDetails();
         User.getBetas();
-        fetchAllReports(true, true);
+        fetchAllReports(true, true, 8000);
         fetchCountryCodeByRequestIP();
         UnreadIndicatorUpdater.listenForReportChanges();
 

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -647,9 +647,13 @@ function fetchActions(reportID, offset) {
  *
  * @param {Boolean} shouldRedirectToReport this is set to false when the network reconnect code runs
  * @param {Boolean} shouldRecordHomePageTiming whether or not performance timing should be measured
- * @param {Number} fetchActionsDelay
+ * @param {Boolean} shouldDelayActionsFetch when the app loads we want to delay the fetching of additional actions
  */
-function fetchAllReports(shouldRedirectToReport = true, shouldRecordHomePageTiming = false, fetchActionsDelay = 0) {
+function fetchAllReports(
+    shouldRedirectToReport = true,
+    shouldRecordHomePageTiming = false,
+    shouldDelayActionsFetch = false,
+) {
     let reportIDs = [];
 
     API.Get({
@@ -683,7 +687,10 @@ function fetchAllReports(shouldRedirectToReport = true, shouldRecordHomePageTimi
                 _.each(reportIDs, (reportID) => {
                     fetchActions(reportID);
                 });
-            }, fetchActionsDelay);
+
+            // We are waiting 8 seconds since this provides a good time window to allow the UI to finish loading before
+            // bogging it down with more requests and operations.
+            }, shouldDelayActionsFetch ? 8000 : 0);
 
             // Update currentlyViewedReportID to be our first reportID from our report collection if we don't have
             // one already.

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -315,7 +315,6 @@ function fetchChatReportsByIDs(chatList) {
             // than updating props for each report and re-rendering had merge been used.
             Onyx.mergeCollection(ONYXKEYS.COLLECTION.REPORT_IOUS, reportIOUData);
             Onyx.mergeCollection(ONYXKEYS.COLLECTION.REPORT, simplifiedReports);
-            Onyx.set(ONYXKEYS.INITIAL_REPORT_DATA_LOADED, true);
 
             // Fetch the personal details if there are any
             PersonalDetails.getFromReportParticipants(Object.values(simplifiedReports));
@@ -580,13 +579,14 @@ function unsubscribeFromReportChannel(reportID) {
  * set of participants and redirect to it.
  *
  * @param {String[]} participants
+ * @returns {Promise}
  */
 function fetchOrCreateChatReport(participants) {
     if (participants.length < 2) {
         throw new Error('fetchOrCreateChatReport() must have at least two participants');
     }
 
-    API.CreateChatReport({
+    return API.CreateChatReport({
         emailList: participants.join(','),
     })
         .then((data) => {
@@ -600,33 +600,6 @@ function fetchOrCreateChatReport(participants) {
 
             // Redirect the logged in person to the new report
             Navigation.navigate(ROUTES.getReportRoute(reportID));
-        });
-}
-
-/**
- * Get all chat reports and provide the proper report name
- * by fetching sharedReportList and personalDetails
- *
- * @returns {Promise} only used internally when fetchAll() is called
- */
-function fetchChatReports() {
-    return API.Get({
-        returnValueList: 'chatList',
-    })
-        .then((response) => {
-            if (response.jsonCode !== 200) {
-                return;
-            }
-
-            // Get all the chat reports if they have any, otherwise create one with concierge
-            if (lodashGet(response, 'chatList', []).length) {
-                // The string cast here is necessary as Get rvl='chatList' may return an int
-                fetchChatReportsByIDs(String(response.chatList).split(','));
-            } else {
-                fetchOrCreateChatReport([currentUserEmail, 'concierge@expensify.com']);
-            }
-
-            return response.chatList;
         });
 }
 
@@ -676,28 +649,50 @@ function fetchActions(reportID, offset) {
  * @param {Boolean} shouldRecordHomePageTiming whether or not performance timing should be measured
  */
 function fetchAll(shouldRedirectToReport = true, shouldRecordHomePageTiming = false) {
-    fetchChatReports()
-        .then((reportIDs) => {
-            if (shouldRedirectToReport) {
-                // Update currentlyViewedReportID to be our first reportID from our report collection if we don't have
-                // one already.
-                if (lastViewedReportID) {
-                    return;
-                }
+    let reportIDs = [];
 
-                const firstReportID = _.first(reportIDs);
-                const currentReportID = firstReportID ? String(firstReportID) : '';
-                Onyx.merge(ONYXKEYS.CURRENTLY_VIEWED_REPORTID, currentReportID);
+    API.Get({
+        returnValueList: 'chatList',
+    })
+        .then((response) => {
+            if (response.jsonCode !== 200) {
+                return;
             }
 
-            Log.info('[Report] Fetching report actions for reports', true, {reportIDs});
-            _.each(reportIDs, (reportID) => {
-                fetchActions(reportID);
-            });
+            // The string cast here is necessary as Get rvl='chatList' may return an int
+            reportIDs = String(response.chatList).split(',');
+
+            // Get all the chat reports if they have any, otherwise create one with concierge
+            if (reportIDs.length) {
+                return fetchChatReportsByIDs(reportIDs);
+            }
+
+            return fetchOrCreateChatReport([currentUserEmail, 'concierge@expensify.com']);
+        })
+        .then(() => {
+            Onyx.set(ONYXKEYS.INITIAL_REPORT_DATA_LOADED, true);
 
             if (shouldRecordHomePageTiming) {
                 Timing.end(CONST.TIMING.HOMEPAGE_REPORTS_LOADED);
             }
+
+            // Delay fetching report history as it significantly increases sign in to interactive time
+            setTimeout(() => {
+                Log.info('[Report] Fetching report actions for reports', true, {reportIDs});
+                _.each(reportIDs, (reportID) => {
+                    fetchActions(reportID);
+                });
+            }, 8000);
+
+            // Update currentlyViewedReportID to be our first reportID from our report collection if we don't have
+            // one already.
+            if (!shouldRedirectToReport || lastViewedReportID) {
+                return;
+            }
+
+            const firstReportID = _.first(reportIDs);
+            const currentReportID = firstReportID ? String(firstReportID) : '';
+            Onyx.merge(ONYXKEYS.CURRENTLY_VIEWED_REPORTID, currentReportID);
         });
 }
 

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -270,7 +270,7 @@ function updateIOUReportData(chatReport) {
  * chat report IDs
  *
  * @param {Array} chatList
- * @return {Promise} only used internally when fetchAll() is called
+ * @return {Promise} only used internally when fetchAllReports() is called
  */
 function fetchChatReportsByIDs(chatList) {
     let fetchedReports;
@@ -647,8 +647,9 @@ function fetchActions(reportID, offset) {
  *
  * @param {Boolean} shouldRedirectToReport this is set to false when the network reconnect code runs
  * @param {Boolean} shouldRecordHomePageTiming whether or not performance timing should be measured
+ * @param {Number} fetchActionsDelay
  */
-function fetchAll(shouldRedirectToReport = true, shouldRecordHomePageTiming = false) {
+function fetchAllReports(shouldRedirectToReport = true, shouldRecordHomePageTiming = false, fetchActionsDelay = 0) {
     let reportIDs = [];
 
     API.Get({
@@ -676,13 +677,13 @@ function fetchAll(shouldRedirectToReport = true, shouldRecordHomePageTiming = fa
                 Timing.end(CONST.TIMING.HOMEPAGE_REPORTS_LOADED);
             }
 
-            // Delay fetching report history as it significantly increases sign in to interactive time
-            setTimeout(() => {
+            // Optionally delay fetching report history as it significantly increases sign in to interactive time
+            _.delay(() => {
                 Log.info('[Report] Fetching report actions for reports', true, {reportIDs});
                 _.each(reportIDs, (reportID) => {
                     fetchActions(reportID);
                 });
-            }, 8000);
+            }, fetchActionsDelay);
 
             // Update currentlyViewedReportID to be our first reportID from our report collection if we don't have
             // one already.
@@ -889,11 +890,11 @@ Onyx.connect({
 
 // When the app reconnects from being offline, fetch all of the reports and their actions
 NetworkConnection.onReconnect(() => {
-    fetchAll(false);
+    fetchAllReports(false);
 });
 
 export {
-    fetchAll,
+    fetchAllReports,
     fetchActions,
     fetchOrCreateChatReport,
     addAction,

--- a/src/pages/home/report/ReportActionItemSingle.js
+++ b/src/pages/home/report/ReportActionItemSingle.js
@@ -18,7 +18,11 @@ const propTypes = {
     action: PropTypes.shape(ReportActionPropTypes).isRequired,
 
     // All of the personalDetails
-    personalDetails: PropTypes.objectOf(personalDetailsPropType).isRequired,
+    personalDetails: PropTypes.objectOf(personalDetailsPropType),
+};
+
+const defaultProps = {
+    personalDetails: {},
 };
 
 const ReportActionItemSingle = ({action, personalDetails}) => {
@@ -59,6 +63,7 @@ const ReportActionItemSingle = ({action, personalDetails}) => {
 };
 
 ReportActionItemSingle.propTypes = propTypes;
+ReportActionItemSingle.defaultProps = defaultProps;
 export default withOnyx({
     personalDetails: {
         key: ONYXKEYS.PERSONAL_DETAILS,

--- a/src/pages/home/sidebar/SidebarLinks.js
+++ b/src/pages/home/sidebar/SidebarLinks.js
@@ -68,6 +68,9 @@ const propTypes = {
 
     // The chat priority mode
     priorityMode: PropTypes.string,
+
+    // Whether we have the necessary report data to load the sidebar
+    initialReportDataLoaded: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -80,6 +83,7 @@ const defaultProps = {
     network: null,
     currentlyViewedReportID: '',
     priorityMode: CONST.PRIORITY_MODE.DEFAULT,
+    initialReportDataLoaded: false,
 };
 
 class SidebarLinks extends React.Component {
@@ -88,6 +92,11 @@ class SidebarLinks extends React.Component {
     }
 
     render() {
+        // Wait until the reports are actually loaded before displaying the LHN
+        if (!this.props.initialReportDataLoaded) {
+            return null;
+        }
+
         const activeReportID = parseInt(this.props.currentlyViewedReportID, 10);
 
         const {recentReports} = getSidebarOptions(
@@ -183,6 +192,9 @@ export default compose(
         },
         priorityMode: {
             key: ONYXKEYS.NVP_PRIORITY_MODE,
+        },
+        initialReportDataLoaded: {
+            key: ONYXKEYS.INITIAL_REPORT_DATA_LOADED,
         },
     }),
 )(SidebarLinks);


### PR DESCRIPTION
### Details
When a user first signs in we are fetching all of their report history for all reports right away before the app is even interactive. This is causing massive numbers of network requests and data processing that prevent the app from loading fast.

This approximately cuts the time it takes to reach the fully loaded sidebar on Android in _half_.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/160975
Fixes https://github.com/Expensify/Expensify.cash/issues/2278

### Tests
The test I performed was to drop a console.log() here and here:

```diff
diff --git a/src/pages/home/sidebar/OptionRow.js b/src/pages/home/sidebar/OptionRow.js
index 88fd1edcf..a973d97a2 100644
--- a/src/pages/home/sidebar/OptionRow.js
+++ b/src/pages/home/sidebar/OptionRow.js
@@ -115,6 +115,7 @@ const OptionRow = ({
         ({displayName, login}) => ({displayName, tooltip: login}),
     );

+    console.log('OptionRow Rendered');
     return (
         <Hoverable>
             {hovered => (
```

```diff
diff --git a/src/pages/signin/PasswordForm.js b/src/pages/signin/PasswordForm.js
index 173d29458..ea05b3f54 100644
--- a/src/pages/signin/PasswordForm.js
+++ b/src/pages/signin/PasswordForm.js
@@ -49,6 +49,7 @@ class PasswordForm extends React.Component {
      * Check that all the form fields are valid, then trigger the submit callback
      */
     validateAndSubmitForm() {
+        console.log('Sign In Pressed');
         if (!this.state.password.trim()
             || (this.props.account.requiresTwoFactorAuth && !this.state.twoFactorAuthCode.trim())
         ) {
```
- Then I measured the time it took to go from pressing the sign in button to seeing the first `OptionRow` render in the `SidebarLinks` which tends to correspond with whether or not it is visible.
- I then repeated this test against `main` and go the following results

## `main`
```
[Wed Apr 21 2021 09:28:32.312]  LOG      Sign In Pressed
[Wed Apr 21 2021 09:28:43.683]  LOG      OptionRow rendered
```
11 seconds

## this branch
```
[Wed Apr 21 2021 09:35:54.446]  LOG      Sign In Pressed
[Wed Apr 21 2021 09:35:59.862]  LOG      OptionRow rendered
```
5.3 seconds

### QA Steps
No QA besides regressions

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
