### PR TITLE
[No QA] Remove dupe step from deployBlocker.yml

### DIFF
--- a/.github/workflows/deployBlocker.yml
+++ b/.github/workflows/deployBlocker.yml
@@ -21,13 +21,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
           NEW_DEPLOY_BLOCKERS: ${{ github.event.issue.html_url }}
 
-      - name: Update StagingDeployCash with issue
-        uses: Expensify/Expensify.cash/.github/actions/createOrUpdateStagingDeploy@main
-        if: ${{ github.event_name == 'pull_request' }}
-        with:
-          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
-          NEW_DEPLOY_BLOCKERS: ${{ github.event.pull_request.html_url }}
-
       # This Slack step is duplicated in all workflows, if you make a change to this step, make sure to update all
       # the other workflows with the same change
       - uses: 8398a7/action-slack@v3


### PR DESCRIPTION

### Details
DeployBlocker has been [failing](https://github.com/Expensify/Expensify.cash/runs/2404380867?check_suite_focus=true), including the step to ping the failure in slack. When looking into this, I found a duplicate step, which should be removed.

### Fixed Issues
n/a

### Tests
None.
