### PR TITLE
fix: remove unnecessary manual focus

### DIFF
--- a/src/components/TextInputFocusable/index.js
+++ b/src/components/TextInputFocusable/index.js
@@ -92,7 +92,6 @@ class TextInputFocusable extends React.Component {
     }
 
     componentDidMount() {
-        this.focusInput();
         this.updateNumberOfLines();
 
         // This callback prop is used by the parent component using the constructor to
@@ -210,10 +209,6 @@ class TextInputFocusable extends React.Component {
                 numberOfLines: this.getNumberOfLines(lineHeight, paddingTopAndBottom, this.textInput.scrollHeight),
             });
         });
-    }
-
-    focusInput() {
-        this.textInput.focus();
     }
 
     render() {


### PR DESCRIPTION
Please review.

### Details
Fix the regression https://expensify.slack.com/archives/C01GTK53T8Q/p1619030226468300 


### Tests / QA Steps
1. open a chat on Mobile Web and then navigate back to another screen.
2. Now going back to the chat should not open the keyboard automatically

### Tested On

- [ ] Web
- [x] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
 NA