### PR TITLE
[NO QA] Fix spelling

### DIFF
--- a/src/libs/Navigation/AppNavigator/ModalStackNavigators.js
+++ b/src/libs/Navigation/AppNavigator/ModalStackNavigators.js
@@ -163,7 +163,7 @@ const SettingsModalStackNavigator = () => (
             component={SettingsProfilePage}
         />
         <SettingsModalStack.Screen
-            name="Settings_Add_Seconday_Login"
+            name="Settings_Add_Secondary_Login"
             component={SettingsAddSecondaryLoginPage}
         />
         <SettingsModalStack.Screen

--- a/src/libs/Navigation/linkingConfig.js
+++ b/src/libs/Navigation/linkingConfig.js
@@ -48,7 +48,7 @@ export default {
                         path: ROUTES.SETTINGS_PROFILE,
                         exact: true,
                     },
-                    Settings_Add_Seconday_Login: {
+                    Settings_Add_Secondary_Login: {
                         path: ROUTES.SETTINGS_ADD_LOGIN,
                     },
                 },


### PR DESCRIPTION
### Details
The route name for secondary login add was spelled wrong. Let's use the correct spelling.

### Tests
N/A

### QA Steps
N/A