### PR TITLE
Fix navigating to reports via Search page on staging

### DIFF
--- a/src/ROUTES.js
+++ b/src/ROUTES.js
@@ -1,5 +1,5 @@
 import lodashGet from 'lodash/get';
-import {wrapWithForwardSlash} from './libs/Url';
+import {addTrailingForwardSlash} from './libs/Url';
 
 /**
  * This is a file containing constants for all of the routes we want to be able to go to
@@ -43,13 +43,14 @@ export default {
      * @returns {Object}
      */
     parseReportRouteParams: (route) => {
-        if (!route.startsWith(wrapWithForwardSlash(REPORT))) {
+        if (!route.startsWith(addTrailingForwardSlash(REPORT))) {
             return {};
         }
 
         const pathSegments = route.split('/');
         return {
             reportID: lodashGet(pathSegments, 1),
+            isParticipantsRoute: Boolean(lodashGet(pathSegments, 2)),
         };
     },
 };

--- a/src/libs/Navigation/CustomActions.js
+++ b/src/libs/Navigation/CustomActions.js
@@ -14,8 +14,12 @@ import {CommonActions} from '@react-navigation/native';
  */
 function pushDrawerRoute(screenName, params) {
     return (state) => {
+        if (state.type !== 'drawer') {
+            return CommonActions.navigate(screenName, params);
+        }
+
         const screenRoute = {type: 'route', name: screenName};
-        const history = [...state.history].map(() => screenRoute);
+        const history = [...(state.history || [])].map(() => screenRoute);
         history.push(screenRoute);
         return CommonActions.reset({
             ...state,

--- a/src/libs/Navigation/CustomActions.js
+++ b/src/libs/Navigation/CustomActions.js
@@ -14,6 +14,9 @@ import {CommonActions} from '@react-navigation/native';
  */
 function pushDrawerRoute(screenName, params) {
     return (state) => {
+        // Non Drawer navigators have routes and not history so we'll fallback to navigate() in the case where we are
+        // unable to push a new screen onto the history stack e.g. navigating to a ReportScreen via a modal screen.
+        // Note: One downside of this is that the history will be reset.
         if (state.type !== 'drawer') {
             return CommonActions.navigate(screenName, params);
         }

--- a/src/libs/Navigation/Navigation.js
+++ b/src/libs/Navigation/Navigation.js
@@ -48,6 +48,8 @@ function navigate(route = ROUTES.HOME) {
         return;
     }
 
+    // Navigate to the ReportScreen with a custom action so that we can preserve the history. We're looking to see if we
+    // have a participants route since those should go through linkTo() as they open a different screen.
     const {reportID, isParticipantsRoute} = ROUTES.parseReportRouteParams(route);
     if (reportID && !isParticipantsRoute) {
         navigationRef.current.dispatch(CustomActions.pushDrawerRoute(SCREENS.REPORT, {reportID}));

--- a/src/libs/Navigation/Navigation.js
+++ b/src/libs/Navigation/Navigation.js
@@ -48,8 +48,8 @@ function navigate(route = ROUTES.HOME) {
         return;
     }
 
-    const {reportID} = ROUTES.parseReportRouteParams(route);
-    if (reportID) {
+    const {reportID, isParticipantsRoute} = ROUTES.parseReportRouteParams(route);
+    if (reportID && !isParticipantsRoute) {
         navigationRef.current.dispatch(CustomActions.pushDrawerRoute(SCREENS.REPORT, {reportID}));
         return;
     }

--- a/src/libs/Url.js
+++ b/src/libs/Url.js
@@ -10,23 +10,7 @@ function addTrailingForwardSlash(url) {
     return url;
 }
 
-/**
- * Add / to the beginning and end of any URL if not present
- * @param {String} url
- * @returns {String}
- */
-function wrapWithForwardSlash(url) {
-    const newUrl = addTrailingForwardSlash(url);
-    if (newUrl.startsWith('/')) {
-        return newUrl;
-    }
-
-    return `/${newUrl}`;
-}
-
-
 export {
     // eslint-disable-next-line import/prefer-default-export
     addTrailingForwardSlash,
-    wrapWithForwardSlash,
 };


### PR DESCRIPTION
### Details
Fixes the broken Search page on staging.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/2538

### Tests
### QA Steps
1. Tap on a chat (mobile web)
2. Go back to the LHN
3. Tap on another chat
4. Test the browser back button behavior and verify that we do not get navigated to an empty screen
5. Open the `/search` screen and select a new chat
6. Verify you are able to navigate to that chat by tapping it
7. Find and locate a group DM chat in the LHN and tap it
8. Verify that you can also bring up a `/r/<reportID>/participants` route by tapping on a group chat header avatar

**Note:** The browser button works unexpectedly if we navigate to a new chat via the "Search" page. Considering that to be not a blocker for now, but will keep looking into it in the future.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
