### PR TITLE
Android - Main chat screen appears briefly when opening settings option

### DIFF
--- a/src/libs/Navigation/AppNavigator/ModalStackNavigators.js
+++ b/src/libs/Navigation/AppNavigator/ModalStackNavigators.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {createStackNavigator} from '@react-navigation/stack';
+import {createStackNavigator, CardStyleInterpolators} from '@react-navigation/stack';
 import styles from '../../../styles/styles';
 import ROUTES from '../../../ROUTES';
 import NewChatPage from '../../../pages/NewChatPage';
@@ -29,6 +29,7 @@ const IOUBillModalStack = createStackNavigator();
 const defaultSubRouteOptions = {
     cardStyle: styles.navigationScreenCardStyle,
     headerShown: false,
+    cardStyleInterpolator: CardStyleInterpolators.forHorizontalIOS,
 };
 
 const IOUBillStackNavigator = () => (


### PR DESCRIPTION
### Details
- Explicitly set cardStyleInterpolator on child stacks for better transition animation

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/2107

### Tests
- Click your avatar to go to profile, go back and forth between the setting menu items

### QA Steps
- same as above

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web

https://user-images.githubusercontent.com/12075600/115800469-8ad81580-a38f-11eb-9551-58c2ee162be8.mov

#### Mobile Web

https://user-images.githubusercontent.com/12075600/115800492-96c3d780-a38f-11eb-81a5-d55792b63b6e.mov

#### Desktop

https://user-images.githubusercontent.com/12075600/115800508-a04d3f80-a38f-11eb-956e-2e787f6e6396.mov

#### iOS

https://user-images.githubusercontent.com/12075600/115800530-ac390180-a38f-11eb-9ef6-c629cea39c9d.mov

#### Android

https://user-images.githubusercontent.com/12075600/115800553-b5c26980-a38f-11eb-9b8a-7638d06e9265.mov
