### PR TITLE
Try naming VERSION to something else to not conflict

### DIFF
--- a/.github/actions/markPullRequestsAsDeployed/action.yml
+++ b/.github/actions/markPullRequestsAsDeployed/action.yml
@@ -8,7 +8,7 @@ inputs:
         description: "Check if deploying to production"
         required: false
         default: "false"
-    VERSION:
+    DEPLOY_VERSION:
         description: "The app version in which the pull requests were deployed"
         required: true
     GITHUB_TOKEN:

--- a/.github/actions/markPullRequestsAsDeployed/index.js
+++ b/.github/actions/markPullRequestsAsDeployed/index.js
@@ -16,7 +16,7 @@ const prList = JSON.parse(core.getInput('PR_LIST', {required: true}));
 const isProd = JSON.parse(
     core.getInput('IS_PRODUCTION_DEPLOY', {required: true}),
 );
-const version = JSON.parse(core.getInput('VERSION', {required: true}));
+const version = JSON.parse(core.getInput('DEPLOY_VERSION', {required: true}));
 const token = core.getInput('GITHUB_TOKEN', {required: true});
 const octokit = github.getOctokit(token);
 const githubUtils = new GithubUtils(octokit);

--- a/.github/actions/markPullRequestsAsDeployed/markPullRequestsAsDeployed.js
+++ b/.github/actions/markPullRequestsAsDeployed/markPullRequestsAsDeployed.js
@@ -6,7 +6,7 @@ const prList = JSON.parse(core.getInput('PR_LIST', {required: true}));
 const isProd = JSON.parse(
     core.getInput('IS_PRODUCTION_DEPLOY', {required: true}),
 );
-const version = JSON.parse(core.getInput('VERSION', {required: true}));
+const version = JSON.parse(core.getInput('DEPLOY_VERSION', {required: true}));
 const token = core.getInput('GITHUB_TOKEN', {required: true});
 const octokit = github.getOctokit(token);
 const githubUtils = new GithubUtils(octokit);

--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -292,7 +292,7 @@ jobs:
         with:
           PR_LIST: ${{ steps.getReleasePRList.outputs.PR_LIST }}
           IS_PRODUCTION_DEPLOY: ${{ env.SHOULD_DEPLOY_PRODUCTION == 'true' }}
-          VERSION: ${{ env.VERSION }}
+          DEPLOY_VERSION: ${{ env.VERSION }}
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
           ANDROID: ${{ needs.android.result }}
           DESKTOP: ${{ needs.desktop.result }}


### PR DESCRIPTION
### Details
Trying to fix a broken workflow, I think having an `env` variable named `VERSION` and a `with:` variable named `VERSION` might be causing this issue, but this is a guess.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/2557

### Tests
1. Merge this PR
2. Verify that a version is included in the deploy message when it goes out