### PR TITLE
fix: splash screen slightly jumps

### DIFF
--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -4,6 +4,7 @@
     <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="android:textColor">#000000</item>
+        <item name="android:windowTranslucentStatus">true</item>
     </style>
 
     <style name="BootTheme" parent="AppTheme">


### PR DESCRIPTION
Please review @Beamanator 

### Details
A detailed proposal can be found here https://github.com/Expensify/Expensify.cash/issues/2542#issuecomment-826450366.

### Fixed Issues
<Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing>
Fixes #2542 

### Tests / QA Steps
1. Kill the chat app if open
2. Relaunch the app
3. Notice that the Splash screen should fade away without jumping up or down.


### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [x] Android (affected platform)

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->

 

<details open>
<summary><h3>Issue</h3></summary>

https://user-images.githubusercontent.com/24370807/116077997-bae72780-a6b3-11eb-87d0-2f40c41d3e5b.mp4




</details>
<details open>
<summary><h3> After Fix </h3></summary>

https://user-images.githubusercontent.com/24370807/116078209-f2ee6a80-a6b3-11eb-9e15-09687bb76780.mp4




</details>