### PR TITLE
Allow button presses while keyboard is up on Android

### DIFF
--- a/src/pages/signin/SignInPageLayout/SignInPageLayoutNarrow.js
+++ b/src/pages/signin/SignInPageLayout/SignInPageLayoutNarrow.js
@@ -29,7 +29,7 @@ const defaultProps = {
 };
 
 const SignInPageLayoutNarrow = props => (
-    <ScrollView>
+    <ScrollView keyboardShouldPersistTaps="handled">
         <View>
             <View style={[styles.signInPageInnerNative]}>
                 <View style={[styles.signInPageLogoNative]}>


### PR DESCRIPTION
### Details
Previously for pages in the sign in flow, users weren't able to tap the buttons on the screen while the keyboard was up. I added `keyboardShouldPersistTaps`, which should now allow this and reduce the number of taps required to login.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/2546

### Tests
1. Navigated to the sign in page on Android.
2. Typed in my login information.
3. Tapped the button, verified I was able to tap it once to advance to the next screen.
4. Verify above for all subsequent screens in the sign-in flow.

### QA Steps
1. Navigated to the sign in page on Android.
2. Typed in my login information.
3. Tapped the button, verified I was able to tap it once to advance to the next screen.

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
This only shows it for the first screen in the flow, but I tested it for all of the other screens in the flow as well (Set Password Page, Password Form). I didn't include them because I didn't want my password in the screen recording.
https://user-images.githubusercontent.com/31285285/116174702-86ba4800-a741-11eb-8c94-2f4304f9fe23.mp4

