### PR TITLE
Only show environment badge next to chats header

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -9,19 +9,25 @@ const propTypes = {
     /** Title of the Header */
     title: PropTypes.string.isRequired,
 
+    // Should we show the environment badge (dev/stg)?
+    shouldShowEnvironmentBadge: PropTypes.bool,
+
     // Fontsize
     textSize: PropTypes.oneOf(['default', 'large']),
 };
 
 const defaultProps = {
     textSize: 'default',
+    shouldShowEnvironmentBadge: false,
 };
 const Header = props => (
     <View style={[styles.flex1, styles.flexRow]}>
         <Text numberOfLines={2} style={[styles.headerText, props.textSize === 'large' && styles.textLarge]}>
             {props.title}
         </Text>
-        <EnvironmentBadge />
+        {props.shouldShowEnvironmentBadge && (
+            <EnvironmentBadge />
+        )}
     </View>
 );
 

--- a/src/pages/home/sidebar/SidebarLinks.js
+++ b/src/pages/home/sidebar/SidebarLinks.js
@@ -126,7 +126,11 @@ class SidebarLinks extends React.Component {
                     ]}
                     nativeID="drag-area"
                 >
-                    <Header textSize="large" title="Chats" />
+                    <Header
+                        textSize="large"
+                        title="Chats"
+                        shouldShowEnvironmentBadge
+                    />
                     <TouchableOpacity
                         style={[styles.flexRow, styles.ph5]}
                         onPress={this.showSearchPage}


### PR DESCRIPTION
@Julesssss will you please review this?

### Details
This PR removes the environment badges from modals in e.cash which were added in [this PR](https://github.com/Expensify/Expensify.cash/pull/2506)

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/161818

1. Run the app on dev on all platforms and sign in, confirm you see a `dev` badge next to the `Chats` header.
2. Open the settings modal, confirm you don't see a `dev` badge

### QA Steps
1. When running the app on staging, confirm the STG badge shows next to the Chats header when signed in.
2. Open the settings modal, confirm you don't see a badge next to `Settings`

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
![image](https://user-images.githubusercontent.com/3981102/116286889-98e9b580-a744-11eb-9026-a6d04caf5fba.png)
![image](https://user-images.githubusercontent.com/3981102/116286895-9ab37900-a744-11eb-951a-0645ec836f73.png)
![image](https://user-images.githubusercontent.com/3981102/116286907-9dae6980-a744-11eb-88ca-907fc399e4f8.png)
