### PR TITLE
fixed splash screen slightly jumps before hiding

### DIFF
--- a/src/Expensify.js
+++ b/src/Expensify.js
@@ -1,7 +1,7 @@
 import lodashGet from 'lodash/get';
 import PropTypes from 'prop-types';
 import React, {PureComponent} from 'react';
-import {View} from 'react-native';
+import {View, StatusBar} from 'react-native';
 import Onyx, {withOnyx} from 'react-native-onyx';
 
 import BootSplash from './libs/BootSplash';
@@ -74,7 +74,7 @@ class Expensify extends PureComponent {
 
         // Initialize this client as being an active client
         ActiveClientManager.init();
-
+        this.hideSplash = this.hideSplash.bind(this);
         this.state = {
             isOnyxMigrated: false,
         };
@@ -87,7 +87,7 @@ class Expensify extends PureComponent {
                 // When we don't have an authToken we'll want to show the sign in screen immediately so we'll hide our
                 // boot screen right away
                 if (!this.getAuthToken()) {
-                    BootSplash.hide({fade: true});
+                    this.hideSplash();
                 }
 
                 this.setState({isOnyxMigrated: true});
@@ -115,13 +115,21 @@ class Expensify extends PureComponent {
                         return;
                     }
 
-                    BootSplash.hide({fade: true});
+                    this.hideSplash();
                 });
         }
     }
 
     getAuthToken() {
         return lodashGet(this.props, 'session.authToken', null);
+    }
+
+    hideSplash() {
+        BootSplash.hide({fade: true}).then(() => {
+            // To prevent the splash from shifting positions we set status bar translucent after splash is hidden.
+            // on IOS it has no effect.
+            StatusBar.setTranslucent(true);
+        });
     }
 
     render() {

--- a/src/components/CustomStatusBar/index.android.js
+++ b/src/components/CustomStatusBar/index.android.js
@@ -9,7 +9,6 @@ export default class CustomStatusBar extends React.Component {
     componentDidMount() {
         StatusBar.setBarStyle('dark-content', true);
         StatusBar.setBackgroundColor('transparent', true);
-        StatusBar.setTranslucent(true);
     }
 
     render() {

--- a/src/components/CustomStatusBar/index.android.js
+++ b/src/components/CustomStatusBar/index.android.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {StatusBar} from 'react-native';
 
 /**
- * Only the Android platform supports "setBackgroundColor" and "setTranslucent"
+ * Only the Android platform supports "setBackgroundColor"
  */
 
 export default class CustomStatusBar extends React.Component {


### PR DESCRIPTION
Please review @Beamanator.

### Details
Previously, We manage to fix this issue by making the status bar translucent from the android theme https://github.com/Expensify/Expensify.cash/pull/2567. but it caused a regression https://github.com/Expensify/Expensify.cash/issues/2577#issuecomment-827244046.

#### New Solution
1. Another way to fix this is by setting the status bar translucent, only after the Splash screen is hidden.

### Fixed Issues
<Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing>
Fixes #2542

### Tests / QA Steps
1. Kill the chat app if open
2. Relaunch the app
3. Notice that the Splash screen should fade away without jumping up or down.

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [x] Android (affected platform)

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->

https://user-images.githubusercontent.com/24370807/116290968-aee18f80-a7b1-11eb-88c7-c6fdcc07d205.mp4

