### PR TITLE
[No QA] Fix scroll issue

### DIFF
--- a/src/components/IOUConfirmationList.js
+++ b/src/components/IOUConfirmationList.js
@@ -212,6 +212,8 @@ class IOUConfirmationList extends Component {
                 <View style={[styles.flex1]}>
                     <OptionsList
                         listContainerStyles={[{
+                            // Give max height to the list container so that it does not extend
+                            // beyond the comment view as well as button
                             maxHeight: Dimensions.get('window').height - this.minimumBottomOffset
                                 - this.props.insets.top - this.props.insets.bottom,
                         }]}

--- a/src/components/IOUConfirmationList.js
+++ b/src/components/IOUConfirmationList.js
@@ -1,8 +1,9 @@
 import React, {Component} from 'react';
-import {View} from 'react-native';
+import {Dimensions, View} from 'react-native';
 import PropTypes from 'prop-types';
 import {TextInput} from 'react-native-gesture-handler';
 import {withOnyx} from 'react-native-onyx';
+import {withSafeAreaInsets} from 'react-native-safe-area-context';
 import styles from '../styles/styles';
 import Text from './Text';
 import themeColors from '../styles/themes/default';
@@ -13,6 +14,7 @@ import {
 import OptionsList from './OptionsList';
 import ButtonWithLoader from './ButtonWithLoader';
 import ONYXKEYS from '../ONYXKEYS';
+import SafeAreaInsetPropTypes from '../pages/SafeAreaInsetPropTypes';
 
 const propTypes = {
     // Callback to inform parent modal of success
@@ -26,6 +28,9 @@ const propTypes = {
 
     // Should we request a single or multiple participant selection from user
     hasMultipleParticipants: PropTypes.bool.isRequired,
+
+    // Safe area insets required for mobile devices margins
+    insets: SafeAreaInsetPropTypes.isRequired,
 
     // IOU amount
     iouAmount: PropTypes.string.isRequired,
@@ -80,6 +85,11 @@ const defaultProps = {
 };
 
 class IOUConfirmationList extends Component {
+    constructor(props) {
+        super(props);
+        this.minimumBottomOffset = 240;
+    }
+
     /**
      * Returns the sections needed for the OptionsSelector
      *
@@ -201,7 +211,10 @@ class IOUConfirmationList extends Component {
             <View style={[styles.flex1, styles.w100, styles.justifyContentBetween]}>
                 <View style={[styles.flex1]}>
                     <OptionsList
-                        listContainerStyles={[styles.flexGrow0]}
+                        listContainerStyles={[{
+                            maxHeight: Dimensions.get('window').height - this.minimumBottomOffset
+                                - this.props.insets.top - this.props.insets.bottom,
+                        }]}
                         sections={this.getSections()}
                         disableArrowKeysActions
                         hideAdditionalOptionStates
@@ -252,4 +265,4 @@ export default withOnyx({
     myPersonalDetails: {
         key: ONYXKEYS.MY_PERSONAL_DETAILS,
     },
-})(IOUConfirmationList);
+})(withSafeAreaInsets(IOUConfirmationList));

--- a/src/components/IOUConfirmationList.js
+++ b/src/components/IOUConfirmationList.js
@@ -84,6 +84,9 @@ const defaultProps = {
     comment: '',
 };
 
+// Gives height to offset the button and comment box
+// so that the OptionsList is fixed above the offset
+// and becomes scrollable beyond it
 const MINIMUM_BOTTOM_OFFSET = 240;
 
 class IOUConfirmationList extends Component {

--- a/src/components/IOUConfirmationList.js
+++ b/src/components/IOUConfirmationList.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import {Dimensions, View} from 'react-native';
+import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import {TextInput} from 'react-native-gesture-handler';
 import {withOnyx} from 'react-native-onyx';
@@ -15,6 +15,8 @@ import OptionsList from './OptionsList';
 import ButtonWithLoader from './ButtonWithLoader';
 import ONYXKEYS from '../ONYXKEYS';
 import SafeAreaInsetPropTypes from '../pages/SafeAreaInsetPropTypes';
+import withWindowDimensions, {windowDimensionsPropTypes} from './withWindowDimensions';
+import compose from '../libs/compose';
 
 const propTypes = {
     // Callback to inform parent modal of success
@@ -54,6 +56,8 @@ const propTypes = {
         reportID: PropTypes.number,
         participantsList: PropTypes.arrayOf(PropTypes.object),
     })).isRequired,
+
+    ...windowDimensionsPropTypes,
 
     /* Onyx Props */
 
@@ -213,7 +217,7 @@ class IOUConfirmationList extends Component {
                         listContainerStyles={[{
                             // Give max height to the list container so that it does not extend
                             // beyond the comment view as well as button
-                            maxHeight: Dimensions.get('window').height - MINIMUM_BOTTOM_OFFSET
+                            maxHeight: this.props.windowHeight - MINIMUM_BOTTOM_OFFSET
                                 - this.props.insets.top - this.props.insets.bottom,
                         }]}
                         sections={this.getSections()}
@@ -261,9 +265,9 @@ IOUConfirmationList.displayName = 'IOUConfirmPage';
 IOUConfirmationList.propTypes = propTypes;
 IOUConfirmationList.defaultProps = defaultProps;
 
-export default withOnyx({
+export default compose(withOnyx({
     iou: {key: ONYXKEYS.IOU},
     myPersonalDetails: {
         key: ONYXKEYS.MY_PERSONAL_DETAILS,
     },
-})(withSafeAreaInsets(IOUConfirmationList));
+}), withSafeAreaInsets, withWindowDimensions)(IOUConfirmationList);

--- a/src/components/IOUConfirmationList.js
+++ b/src/components/IOUConfirmationList.js
@@ -84,12 +84,9 @@ const defaultProps = {
     comment: '',
 };
 
-class IOUConfirmationList extends Component {
-    constructor(props) {
-        super(props);
-        this.minimumBottomOffset = 240;
-    }
+const MINIMUM_BOTTOM_OFFSET = 240;
 
+class IOUConfirmationList extends Component {
     /**
      * Returns the sections needed for the OptionsSelector
      *
@@ -214,7 +211,7 @@ class IOUConfirmationList extends Component {
                         listContainerStyles={[{
                             // Give max height to the list container so that it does not extend
                             // beyond the comment view as well as button
-                            maxHeight: Dimensions.get('window').height - this.minimumBottomOffset
+                            maxHeight: Dimensions.get('window').height - MINIMUM_BOTTOM_OFFSET
                                 - this.props.insets.top - this.props.insets.bottom,
                         }]}
                         sections={this.getSections()}

--- a/src/components/IOUConfirmationList.js
+++ b/src/components/IOUConfirmationList.js
@@ -84,9 +84,8 @@ const defaultProps = {
     comment: '',
 };
 
-// Gives height to offset the button and comment box
-// so that the OptionsList is fixed above the offset
-// and becomes scrollable beyond it
+// Gives minimum height to offset the height of
+// button and comment box
 const MINIMUM_BOTTOM_OFFSET = 240;
 
 class IOUConfirmationList extends Component {

--- a/src/pages/home/sidebar/SidebarScreen.js
+++ b/src/pages/home/sidebar/SidebarScreen.js
@@ -101,7 +101,7 @@ class SidebarScreen extends Component {
                                 {
                                     icon: Users,
                                     text: 'New Group',
-                                    onSelected: () => Navigation.navigate(ROUTES.NEW_GROUP),
+                                    onSelected: () => Navigation.navigate(ROUTES.IOU_BILL),
                                 },
                             ]}
 

--- a/src/pages/home/sidebar/SidebarScreen.js
+++ b/src/pages/home/sidebar/SidebarScreen.js
@@ -101,7 +101,7 @@ class SidebarScreen extends Component {
                                 {
                                     icon: Users,
                                     text: 'New Group',
-                                    onSelected: () => Navigation.navigate(ROUTES.IOU_BILL),
+                                    onSelected: () => Navigation.navigate(ROUTES.NEW_GROUP),
                                 },
                             ]}
 


### PR DESCRIPTION
<If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit.>

### Details
Initially, I solved the problem of the input boxes not lining up using flexGrow0 but that prompted the list to not grow. 

So, I worked on a solution to instead give the OptionsList a maxHeight, so that anything beyond that would be scrollable. 

### Fixed Issues
<Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing>
Fixes #1988


### Tests
1. Make these changes locally: https://github.com/Expensify/Expensify.cash/compare/jules-showIOUMenuOptions?expand=1
2. Go to IOUSplit page and continue until you reach IOUConfirm
3. Verify if all the rows and comments are shown.
4. Add multiple participants (till the screen is filled)
5. Verify you can scroll through the list


### QA Steps
Please ping @Julesssss to run the QA steps, as this is not yet possible for external QA

### Tested On

- [x] Web
- [x] Mobile Web
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

<img width="1425" alt="Screenshot 2021-04-28 at 11 28 55" src="https://user-images.githubusercontent.com/19339044/116352607-21d02200-a815-11eb-907d-f6959bb80841.png">

<img width="1415" alt="Screenshot 2021-04-28 at 11 29 12" src="https://user-images.githubusercontent.com/19339044/116352615-24327c00-a815-11eb-857e-d0ec9391c77f.png">


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

<img width="399" alt="Screenshot 2021-04-28 at 11 30 18" src="https://user-images.githubusercontent.com/19339044/116352624-2694d600-a815-11eb-8f89-f1efd5a727f5.png">


#### iOS
![viber_image_2021-04-28_11-02-13](https://user-images.githubusercontent.com/19339044/116352676-40361d80-a815-11eb-9a5c-757756ad82b6.png)

![viber_image_2021-04-28_11-02-11](https://user-images.githubusercontent.com/19339044/116352681-41ffe100-a815-11eb-80cd-3688b823f65d.png)

<img width="399" alt="Screenshot 2021-04-28 at 11 30 18" src="https://user-images.githubusercontent.com/19339044/116352685-43310e00-a815-11eb-81b4-9659a706e09a.png">

