### PR TITLE
Only fetch report history we need on reconnect + fix sign out issue

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -125,7 +125,11 @@ const CONST = {
         STAGING: 'STG',
         PRODUCTION: 'PROD',
     },
-    DELAY: {
+
+    // Used to delay the initial fetching of reportActions when the app first inits or reconnects (e.g. returning
+    // from backgound). The times are based on how long it generally seems to take for the app to become interactive
+    // in each scenario.
+    FETCH_ACTIONS_DELAY: {
         STARTUP: 8000,
         RECONNECT: 1000,
     },

--- a/src/CONST.js
+++ b/src/CONST.js
@@ -125,6 +125,10 @@ const CONST = {
         STAGING: 'STG',
         PRODUCTION: 'PROD',
     },
+    DELAY: {
+        STARTUP: 8000,
+        RECONNECT: 1000,
+    },
 };
 
 export default CONST;

--- a/src/libs/CollectionUtils.js
+++ b/src/libs/CollectionUtils.js
@@ -6,7 +6,7 @@ import _ from 'underscore';
  * e.g. {1: '1', 2: '2', 3: '3'} -> '3'
  *
  * @param {Object} object
- * @return {*}
+ * @returns {*}
  */
 function lastItem(object = {}) {
     const lastKey = _.last(_.keys(object)) || 0;

--- a/src/libs/CollectionUtils.js
+++ b/src/libs/CollectionUtils.js
@@ -8,11 +8,23 @@ import _ from 'underscore';
  * @param {Object} object
  * @return {*}
  */
-export function lastItem(object = {}) {
+function lastItem(object = {}) {
     const lastKey = _.last(_.keys(object)) || 0;
     return object[lastKey];
 }
 
-export default {
+/**
+ * Used to grab the id for a particular collection item's key.
+ * e.g. reportActions_1 -> 1
+ *
+ * @param {String} key
+ * @returns {String}
+ */
+function extractCollectionItemID(key) {
+    return key.split('_')[1];
+}
+
+export {
     lastItem,
+    extractCollectionItemID,
 };

--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -48,6 +48,7 @@ import {
     SettingsModalStackNavigator,
 } from './ModalStackNavigators';
 import SCREENS from '../../../SCREENS';
+import Timers from '../../Timers';
 
 Onyx.connect({
     key: ONYXKEYS.MY_PERSONAL_DETAILS,
@@ -120,14 +121,14 @@ class AuthScreens extends React.Component {
         // Refresh the personal details, timezone and betas every 30 minutes
         // There is no pusher event that sends updated personal details data yet
         // See https://github.com/Expensify/ReactNativeChat/issues/468
-        this.interval = setInterval(() => {
+        this.interval = Timers.register(setInterval(() => {
             if (this.props.network.isOffline) {
                 return;
             }
             PersonalDetails.fetch();
             User.getUserDetails();
             User.getBetas();
-        }, 1000 * 60 * 30);
+        }, 1000 * 60 * 30));
 
         Timing.end(CONST.TIMING.HOMEPAGE_INITIAL_RENDER);
 

--- a/src/libs/Timers.js
+++ b/src/libs/Timers.js
@@ -1,0 +1,31 @@
+import _ from 'underscore';
+
+const timers = [];
+
+/**
+ * Register a timer so it can be cleaned up later.
+ *
+ * @param {Number} timerID
+ * @return {Number}
+ */
+function register(timerID) {
+    timers.push(timerID);
+    return timerID;
+}
+
+/**
+ * Clears all timers that we have registered. Use for long running tasks that may begin once logged out.
+ */
+function clearAll() {
+    _.each(timers, (timer) => {
+        // We don't know whether it's a setTimeout or a setInterval, but it doesn't really matter. If the id doesn't
+        // exist nothing bad happens.
+        clearTimeout(timer);
+        clearInterval(timer);
+    });
+}
+
+export default {
+    register,
+    clearAll,
+};

--- a/src/libs/Timers.js
+++ b/src/libs/Timers.js
@@ -6,7 +6,7 @@ const timers = [];
  * Register a timer so it can be cleaned up later.
  *
  * @param {Number} timerID
- * @return {Number}
+ * @returns {Number}
  */
 function register(timerID) {
     timers.push(timerID);

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -61,7 +61,7 @@ function getDisplayName(login, personalDetail) {
     // If we have a number like +15857527441@expensify.sms then let's remove @expensify.sms
     // so that the option looks cleaner in our UI.
     const userLogin = Str.removeSMSDomain(login);
-    const userDetails = personalDetail || personalDetails[login];
+    const userDetails = personalDetail || lodashGet(personalDetails, login);
 
     if (!userDetails) {
         return userLogin;

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -812,7 +812,7 @@ function fetchAllReports(
             }
 
             // Optionally delay fetching report history as it significantly increases sign in to interactive time
-            Timers.register(setTimeout(() => {
+            const timerID = setTimeout(() => {
                 // Filter reports to see which ones have actions we need to fetch so we can preload Onyx with new
                 // content and improve chat switching experience
                 const reportIDsToFetchActions = _.filter(returnedReportIDs, id => (
@@ -832,7 +832,10 @@ function fetchAllReports(
 
                 // We are waiting 8 seconds since this provides a good time window to allow the UI to finish loading
                 // before bogging it down with more requests and operations.
-            }, shouldDelayActionsFetch ? 8000 : 1000));
+            }, shouldDelayActionsFetch ? 8000 : 1000);
+
+            // Register the timer so we can clean it up on sign out if it has not yet fired.
+            Timers.register(timerID);
         });
 }
 

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -68,8 +68,8 @@ const typingWatchTimers = {};
  *     - Optimistically creating a report action
  *     - Handling a report action via Pusher
  *
- * Those values are stored in reportMaxSequenceNumbers and treated as the main source of truth about what a report's max
- * sequenceNumber is.
+ * Those values are stored in reportMaxSequenceNumbers and treated as the main source of truth for each report's max
+ * sequenceNumber.
  */
 const reportMaxSequenceNumbers = {};
 
@@ -797,8 +797,10 @@ function fetchAllReports(
                 Timing.end(CONST.TIMING.HOMEPAGE_REPORTS_LOADED);
             }
 
-            // Optionally delay fetching report history as it significantly increases sign in to interactive time.
-            const timerID = setTimeout(() => {
+            // Delay fetching report history as it significantly increases sign in to interactive time.
+            // Register the timer so we can clean it up if the user quickly logs out after logging in. If we don't
+            // cancel the timer we'll make unnecessary API requests from the sign in page.
+            Timers.register(setTimeout(() => {
                 // Filter reports to see which ones have actions we need to fetch so we can preload Onyx with new
                 // content and improve chat switching experience by only downloading content we don't have yet.
                 // This improves performance significantly when reconnecting by limiting API requests and unnecessary
@@ -823,11 +825,7 @@ function fetchAllReports(
                 // We are waiting a set amount of time to allow the UI to finish loading before bogging it down with
                 // more requests and operations. Startup delay is longer since there is a lot more work done to build
                 // up the UI when the app first initializes.
-            }, shouldDelayActionsFetch ? CONST.FETCH_ACTIONS_DELAY.STARTUP : CONST.FETCH_ACTIONS_DELAY.RECONNECT);
-
-            // Register the timer so we can clean it up if the user logs out after logging in. If we don't cancel the
-            // timer we'll make unnecessary API requests from the sign in page.
-            Timers.register(timerID);
+            }, shouldDelayActionsFetch ? CONST.FETCH_ACTIONS_DELAY.STARTUP : CONST.FETCH_ACTIONS_DELAY.RECONNECT));
         });
 }
 

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -812,10 +812,10 @@ function fetchAllReports(
                     return;
                 }
 
+                console.debug('[Report] Fetching reportActions for reportIDs: ', {
+                    reportIDs: reportIDsToFetchActions,
+                });
                 _.each(reportIDsToFetchActions, (reportID) => {
-                    console.debug('[Report] Fetching reportActions for reportIDs: ', {
-                        reportIDs: reportIDsToFetchActions,
-                    });
                     const offset = dangerouslyGetReportActionsMaxSequenceNumber(reportID, false);
                     fetchActions(reportID, offset);
                 });

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -65,18 +65,15 @@ Onyx.connect({
 const maxReportActionsSequenceNumbers = {};
 Onyx.connect({
     key: ONYXKEYS.COLLECTION.REPORT_ACTIONS,
-    callback: (val, key) => {
-        if (!key || !val) {
+    callback: (actions, key) => {
+        if (!key || !actions) {
             return;
         }
 
         const reportID = CollectionUtils.extractCollectionItemID(key);
-        const mostRecentAction = _.chain(val)
-            .filter(action => !action.loading)
-            .sortBy('sequenceNumber')
-            .last()
-            .value();
-
+        const actionsArray = _.toArray(actions);
+        const mostRecentNonLoadingActionIndex = _.findLastIndex(actionsArray, action => !action.loading);
+        const mostRecentAction = actionsArray[mostRecentNonLoadingActionIndex];
         if (!mostRecentAction || _.isUndefined(mostRecentAction.sequenceNumber)) {
             return;
         }
@@ -731,6 +728,9 @@ function fetchOrCreateChatReport(participants, shouldNavigate = true) {
                 // Redirect the logged in person to the new report
                 Navigation.navigate(ROUTES.getReportRoute(data.reportID));
             }
+
+            // We are returning an array with the reportID here since fetchAllReports calls this method or
+            // fetchChatReportsByIDs which returns an array of reportIDs.
             return [data.reportID];
         });
 }

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -808,10 +808,14 @@ function fetchAllReports(
                 ));
 
                 if (_.isEmpty(reportIDsToFetchActions)) {
+                    console.debug('[Report] Local reportActions up to date. Not fetching additional actions.');
                     return;
                 }
 
                 _.each(reportIDsToFetchActions, (reportID) => {
+                    console.debug('[Report] Fetching reportActions for reportIDs: ', {
+                        reportIDs: reportIDsToFetchActions,
+                    });
                     const offset = dangerouslyGetReportActionsMaxSequenceNumber(reportID, false);
                     fetchActions(reportID, offset);
                 });

--- a/src/libs/actions/ReportActions.js
+++ b/src/libs/actions/ReportActions.js
@@ -9,7 +9,7 @@ import * as CollectionUtils from '../CollectionUtils';
  * What's the difference between reportMaxSequenceNumbers and reportActionsMaxSequenceNumbers?
  *
  * Knowing the maxSequenceNumber for a report does not necessarily mean we have stored the report actions for that
- * report. To optimize and understand which reportActions we need to fetch we also keep track of the max sequenceNumber
+ * report. To understand and optimize which reportActions we need to fetch we also keep track of the max sequenceNumber
  * for the stored reportActions in reportActionsMaxSequenceNumbers. This allows us to initially download all
  * reportActions when the app starts up and then only download the actions that we need when the app reconnects.
  *
@@ -64,7 +64,7 @@ function dangerouslyGetReportActionsMaxSequenceNumber(reportID, shouldWarn = tru
  */
 function isReportMissingActions(reportID, maxKnownSequenceNumber) {
     return _.isUndefined(reportActionsMaxSequenceNumbers[reportID])
-    || reportActionsMaxSequenceNumbers[reportID] < maxKnownSequenceNumber;
+        || reportActionsMaxSequenceNumbers[reportID] < maxKnownSequenceNumber;
 }
 
 export {

--- a/src/libs/actions/ReportActions.js
+++ b/src/libs/actions/ReportActions.js
@@ -47,7 +47,7 @@ Onyx.connect({
 function dangerouslyGetReportActionsMaxSequenceNumber(reportID, shouldWarn = true) {
     if (shouldWarn) {
         // eslint-disable-next-line max-len
-        console.error('dangerouslyGetReportActionsMaxSequenceNumber is unreliable and should not be used to access the maxSequenceNumber for a report. Use reportMaxSequenceNumbers[reportID] instead.');
+        console.error('WARNING: dangerouslyGetReportActionsMaxSequenceNumber is unreliable as it ONLY references reportActions in storage. It should not be used to access the maxSequenceNumber for a report. Use reportMaxSequenceNumbers[reportID] instead.');
     }
 
     return reportActionsMaxSequenceNumbers[reportID];

--- a/src/libs/actions/ReportActions.js
+++ b/src/libs/actions/ReportActions.js
@@ -1,0 +1,72 @@
+import _ from 'underscore';
+import Onyx from 'react-native-onyx';
+import ONYXKEYS from '../../ONYXKEYS';
+import * as CollectionUtils from '../CollectionUtils';
+
+/**
+ * Map of the most recent non-loading sequenceNumber for a reportActions_* key in Onyx by reportID.
+ *
+ * What's the difference between reportMaxSequenceNumbers and reportActionsMaxSequenceNumbers?
+ *
+ * Knowing the maxSequenceNumber for a report does not necessarily mean we have stored the report actions for that
+ * report. To optimize and understand which reportActions we need to fetch we also keep track of the max sequenceNumber
+ * for the stored reportActions in reportActionsMaxSequenceNumbers. This allows us to initially download all
+ * reportActions when the app starts up and then only download the actions that we need when the app reconnects.
+ *
+ * This information should only be used in the correct contexts. In most cases, reportMaxSequenceNumbers should be
+ * referenced and not the locally stored reportAction's max sequenceNumber.
+ */
+const reportActionsMaxSequenceNumbers = {};
+Onyx.connect({
+    key: ONYXKEYS.COLLECTION.REPORT_ACTIONS,
+    callback: (actions, key) => {
+        if (!key || !actions) {
+            return;
+        }
+
+        const reportID = CollectionUtils.extractCollectionItemID(key);
+        const actionsArray = _.toArray(actions);
+        const mostRecentNonLoadingActionIndex = _.findLastIndex(actionsArray, action => !action.loading);
+        const mostRecentAction = actionsArray[mostRecentNonLoadingActionIndex];
+        if (!mostRecentAction || _.isUndefined(mostRecentAction.sequenceNumber)) {
+            return;
+        }
+
+        reportActionsMaxSequenceNumbers[reportID] = mostRecentAction.sequenceNumber;
+    },
+});
+
+/**
+ * WARNING: Do not use this method to access the maxSequenceNumber for a report. This ONLY returns the maxSequenceNumber
+ * for reportActions that are stored in Onyx under a reportActions_* key.
+ *
+ * @param {Number} reportID
+ * @param {Boolean} shouldWarn
+ * @returns {Number}
+ */
+function dangerouslyGetReportActionsMaxSequenceNumber(reportID, shouldWarn = true) {
+    if (shouldWarn) {
+        // eslint-disable-next-line max-len
+        console.error('dangerouslyGetReportActionsMaxSequenceNumber is unreliable and should not be used to access the maxSequenceNumber for a report. Use reportMaxSequenceNumbers[reportID] instead.');
+    }
+
+    return reportActionsMaxSequenceNumbers[reportID];
+}
+
+/**
+ * Compares the maximum sequenceNumber that we know about with the most recent report action we have saved.
+ * If we have no report actions at all for the report we will assume that it is missing actions.
+ *
+ * @param {Number} reportID
+ * @param {Number} maxKnownSequenceNumber
+ * @returns {Boolean}
+ */
+function isReportMissingActions(reportID, maxKnownSequenceNumber) {
+    return _.isUndefined(reportActionsMaxSequenceNumbers[reportID])
+    || reportActionsMaxSequenceNumbers[reportID] < maxKnownSequenceNumber;
+}
+
+export {
+    isReportMissingActions,
+    dangerouslyGetReportActionsMaxSequenceNumber,
+};

--- a/src/libs/actions/ReportActions.js
+++ b/src/libs/actions/ReportActions.js
@@ -46,8 +46,9 @@ Onyx.connect({
  */
 function dangerouslyGetReportActionsMaxSequenceNumber(reportID, shouldWarn = true) {
     if (shouldWarn) {
-        // eslint-disable-next-line max-len
-        console.error('WARNING: dangerouslyGetReportActionsMaxSequenceNumber is unreliable as it ONLY references reportActions in storage. It should not be used to access the maxSequenceNumber for a report. Use reportMaxSequenceNumbers[reportID] instead.');
+        console.error('WARNING: dangerouslyGetReportActionsMaxSequenceNumber is unreliable as it ONLY references '
+            + 'reportActions in storage. It should not be used to access the maxSequenceNumber for a report. Use '
+            + 'reportMaxSequenceNumbers[reportID] instead.');
     }
 
     return reportActionsMaxSequenceNumbers[reportID];

--- a/src/libs/actions/Session.js
+++ b/src/libs/actions/Session.js
@@ -8,6 +8,7 @@ import CONFIG from '../../CONFIG';
 import PushNotification from '../Notification/PushNotification';
 import Timing from './Timing';
 import CONST from '../../CONST';
+import Timers from '../Timers';
 
 let credentials = {};
 Onyx.connect({
@@ -55,6 +56,7 @@ function createAccount(login) {
  */
 function signOut() {
     Timing.clearData();
+    Timers.clearAll();
     redirectToSignIn();
 
     console.debug('Redirecting to Sign In because signOut() was called');

--- a/src/libs/actions/Session.js
+++ b/src/libs/actions/Session.js
@@ -8,7 +8,6 @@ import CONFIG from '../../CONFIG';
 import PushNotification from '../Notification/PushNotification';
 import Timing from './Timing';
 import CONST from '../../CONST';
-import Timers from '../Timers';
 
 let credentials = {};
 Onyx.connect({
@@ -56,7 +55,6 @@ function createAccount(login) {
  */
 function signOut() {
     Timing.clearData();
-    Timers.clearAll();
     redirectToSignIn();
 
     console.debug('Redirecting to Sign In because signOut() was called');

--- a/src/libs/actions/SignInRedirect.js
+++ b/src/libs/actions/SignInRedirect.js
@@ -3,6 +3,7 @@ import ONYXKEYS from '../../ONYXKEYS';
 import * as Pusher from '../Pusher/pusher';
 import UnreadIndicatorUpdater from '../UnreadIndicatorUpdater';
 import PushNotification from '../Notification/PushNotification';
+import Timers from '../Timers';
 
 let currentURL;
 Onyx.connect({
@@ -28,6 +29,7 @@ function redirectToSignIn(errorMessage) {
     UnreadIndicatorUpdater.stopListeningForReportChanges();
     PushNotification.deregister();
     Pusher.disconnect();
+    Timers.clearAll();
 
     if (!currentURL) {
         return;

--- a/src/libs/actions/SignInRedirect.js
+++ b/src/libs/actions/SignInRedirect.js
@@ -1,7 +1,6 @@
 import Onyx from 'react-native-onyx';
 import ONYXKEYS from '../../ONYXKEYS';
 import * as Pusher from '../Pusher/pusher';
-import NetworkConnection from '../NetworkConnection';
 import UnreadIndicatorUpdater from '../UnreadIndicatorUpdater';
 import PushNotification from '../Notification/PushNotification';
 
@@ -26,17 +25,11 @@ Onyx.connect({
  * @param {String} [errorMessage] error message to be displayed on the sign in page
  */
 function redirectToSignIn(errorMessage) {
-    NetworkConnection.stopListeningForReconnect();
     UnreadIndicatorUpdater.stopListeningForReportChanges();
     PushNotification.deregister();
     Pusher.disconnect();
 
     if (!currentURL) {
-        return;
-    }
-
-    // If we are already on the signin page, don't redirect
-    if (currentURL.indexOf('signin') !== -1) {
         return;
     }
 


### PR DESCRIPTION
### Details

This PR is a little all over the place since I cleaned a few things up as I went, but mostly addresses two major issues:

1. When reconnection callbacks fire we are re-downloading report history even if we have that history stored to disk. This is inefficient and also causes a network request to fire for each chat you have - which can be quite a lot of requests and really bog things down, trigger storage eviction, etc.
2. I also noticed we were delaying a few network requests with timers and not cleaning them up on sign out which means that we would call them needlessly. Rather than allow this to happen I created a way to prevent that from happening in the `Timers` namespace. We register a timer id and then just clear them all on sign out.

**Other minor issues also being cleaned up here:**
- `NetworkConnection.stopListeningForReconnect()` was being called twice for no clear reason on sign out
- We were also still checking to see if we are on the `signin` route when signing out but that route was recently removed

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/2615

### Tests
1. Log in as USER A (easy to inspect storage and networking on web or desktop so use one of those)
2. Close the tab
3. Add several comments to a report shared with USER A as USER B (use separate session e.g. incognito tab)
4. In USER A browser session create a new empty tab and open Chrome Dev Tools to reveal the Network tab
5. Paste the sites's url and hit enter
6. Watch the Network tab and verify that you don't see tons of requests to `Report_GetHistory` and only see the one for the report with new content
7. Inspect the response and verify that the `history` array only has as many comments as were added on the previous report.
8. Refresh the page and wait watching the JS console for the log
```
[info] [Report] Local reportActions up to date. Not fetching additional actions. - {}
```
9. Log out and log back in several times and verify there are no issues doing so

### QA Steps
1. Log in and log out repeatedly on the various platforms and verify there are no issues doing so

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
