### PR TITLE
Update definition of BootSplash hide on Non-Native platforms

### DIFF
--- a/src/libs/BootSplash/index.js
+++ b/src/libs/BootSplash/index.js
@@ -1,5 +1,5 @@
 export default {
-    hide: () => {},
+    hide: () => new Promise(resolve => resolve()),
     show: () => {},
     getVisibilityStatus: () => new Promise(resolve => resolve()),
 };


### PR DESCRIPTION
### Details
Before, we had a definition of `hide` that didn't support it returning a promise. Let's update it to include this so that people can use it without it breaking on non-native platforms. See issue for more on how this breaks stuff.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/2618

### Tests
Navigate to the sign-in page while logged out. Verify that it renders correctly.

### QA Steps
Same as above tests.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
This only modifies an `index.js` file (and not its corresponding `index.native.js` file, so no native screenshots are needed.

#### Web
<img width="1792" alt="Screen Shot 2021-04-29 at 9 23 27 AM" src="https://user-images.githubusercontent.com/31285285/116491541-b21d6e00-a8cc-11eb-97e9-1ced979a4ca5.png">

#### Mobile Web
<img width="374" alt="Screen Shot 2021-04-29 at 9 23 22 AM" src="https://user-images.githubusercontent.com/31285285/116491559-bb0e3f80-a8cc-11eb-8b0a-a6fd25487934.png">

#### Desktop
<img width="1199" alt="Screen Shot 2021-04-29 at 9 24 16 AM" src="https://user-images.githubusercontent.com/31285285/116491564-bf3a5d00-a8cc-11eb-8cfc-5afd51df3667.png">
