### PR TITLE
[No QA] Make BootSplash have better parity on web/desktop

### DIFF
--- a/src/libs/BootSplash/index.js
+++ b/src/libs/BootSplash/index.js
@@ -1,5 +1,5 @@
 export default {
-    hide: () => new Promise(resolve => resolve()),
-    show: () => {},
-    getVisibilityStatus: () => new Promise(resolve => resolve()),
+    hide: () => Promise.resolve(),
+    show: () => Promise.resolve(),
+    getVisibilityStatus: () => Promise.resolve('hidden'),
 };


### PR DESCRIPTION


### Details
[react-native-bootsplash](https://github.com/zoontek/react-native-bootsplash) returns a void promise for `hide`, `show`, and a promise that resolves to one of `"visible"`, `"hidden"`, `"transitioning"` for `getVisibilityStatus`. This PR just improves the parity in our web shim so that we don't have another problem like the one solved by [this PR](https://github.com/Expensify/Expensify.cash/pull/2619/files)

### Fixed Issues
n/a

### Tests
Just do some basic regression testing to make sure the app still runs okay and doesn't have any console warnings.

### Tested On

- [x] Web
- [ ] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android
