### PR TITLE
fixed unread message indicator UI

### DIFF
--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -119,7 +119,7 @@ class ReportActionItem extends Component {
                 <Hoverable>
                     {hovered => (
                         <View>
-                            {!hovered && this.props.shouldDisplayNewIndicator && (
+                            {this.props.shouldDisplayNewIndicator && (
                                 <UnreadActionIndicator />
                             )}
                             <View style={getReportActionItemStyle(hovered)}>

--- a/src/styles/getReportActionItemStyles.js
+++ b/src/styles/getReportActionItemStyles.js
@@ -32,5 +32,6 @@ export function getMiniReportActionContextMenuWrapperStyle(isReportActionItemGro
         ...(isReportActionItemGrouped ? positioning.tn8 : positioning.tn4),
         ...positioning.r4,
         position: 'absolute',
+        zIndex: 1,
     };
 }


### PR DESCRIPTION
Please review.

### Details
Fixed -> Hovering over the message hides the new unread message indicator and the context menu remains in hovered stated.

### Fixed Issues
<Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing>
Fixes #2541

### Tests / QA Steps
1. Log into expensify.cash on the web or desktop app
2. Go to a chat with unread messages
3. Hover over the new message line indicator, the line should be visible behind the context menu.
4. In the same (new) chat, hover over the Copy function on the context menu.
5. Slowly move the cursor to another message, the previous message's context menu should be hidden.

### Tested On

- [x] Web
- [ ] Mobile Web (Unaffected)
- [x] Desktop
- [ ] iOS (Unaffected)
- [ ] Android (Unaffected)

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web / Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

https://user-images.githubusercontent.com/24370807/116512401-983c5500-a8e5-11eb-81c6-1f23962dda4c.mp4



