### PR TITLE
fix: Incomplete reports would cause the app to crash on startup

### DIFF
--- a/src/libs/Navigation/AppNavigator/MainDrawerNavigator.js
+++ b/src/libs/Navigation/AppNavigator/MainDrawerNavigator.js
@@ -1,16 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
+import lodashGet from 'lodash/get';
 import {createDrawerNavigator} from '@react-navigation/drawer';
 import {withOnyx} from 'react-native-onyx';
 
 import withWindowDimensions, {windowDimensionsPropTypes} from '../../../components/withWindowDimensions';
 import FullScreenLoadingIndicator from '../../../components/FullscreenLoadingIndicator';
-import {getInitialReportScreenParams} from '../../reportUtils';
-import styles, {
-    getNavigationDrawerType,
-    getNavigationDrawerStyle,
-} from '../../../styles/styles';
+import styles, {getNavigationDrawerStyle, getNavigationDrawerType} from '../../../styles/styles';
 import ONYXKEYS from '../../../ONYXKEYS';
 import compose from '../../compose';
 import SCREENS from '../../../SCREENS';
@@ -18,6 +15,7 @@ import SCREENS from '../../../SCREENS';
 // Screens
 import SidebarScreen from '../../../pages/home/sidebar/SidebarScreen';
 import ReportScreen from '../../../pages/home/ReportScreen';
+import {findLastAccessedReport} from '../../reportUtils';
 
 const propTypes = {
     // Available reports that would be displayed in this navigator
@@ -33,6 +31,18 @@ const defaultProps = {
 };
 
 const Drawer = createDrawerNavigator();
+
+/**
+ * We are decorating findLastAccessedReport so that it caches the first result once the reports load.
+ * This will ensure the initialParams are only set once for the ReportScreen.
+ */
+const getInitialReportScreenParams = _.once((reports) => {
+    const last = findLastAccessedReport(reports);
+
+    // Fallback to empty if for some reason reportID cannot be derived - prevents the app from crashing
+    const reportID = lodashGet(last, 'reportID', '');
+    return {reportID};
+});
 
 const MainDrawerNavigator = (props) => {
     // When there are no reports there's no point to render the empty navigator
@@ -80,3 +90,4 @@ export default compose(
         },
     }),
 )(MainDrawerNavigator);
+export {getInitialReportScreenParams};

--- a/src/libs/Navigation/AppNavigator/MainDrawerNavigator.js
+++ b/src/libs/Navigation/AppNavigator/MainDrawerNavigator.js
@@ -6,7 +6,7 @@ import {withOnyx} from 'react-native-onyx';
 
 import withWindowDimensions, {windowDimensionsPropTypes} from '../../../components/withWindowDimensions';
 import FullScreenLoadingIndicator from '../../../components/FullscreenLoadingIndicator';
-import {getLastAccessedReport} from '../../reportUtils';
+import {getInitialReportScreenParams} from '../../reportUtils';
 import styles, {
     getNavigationDrawerType,
     getNavigationDrawerStyle,
@@ -34,16 +34,11 @@ const defaultProps = {
 
 const Drawer = createDrawerNavigator();
 
-// Decorated to always returning the result of the first call - keeps Screen initialParams from changing
-const getInitialReport = _.once(getLastAccessedReport);
-
 const MainDrawerNavigator = (props) => {
     // When there are no reports there's no point to render the empty navigator
     if (_.size(props.reports) === 0) {
         return <FullScreenLoadingIndicator visible />;
     }
-
-    const initialReportID = getInitialReport(props.reports).reportID;
 
     /* After the app initializes and reports are available the home navigation is mounted
     * This way routing information is updated (if needed) based on the initial report ID resolved.
@@ -67,7 +62,7 @@ const MainDrawerNavigator = (props) => {
             <Drawer.Screen
                 name={SCREENS.REPORT}
                 component={ReportScreen}
-                initialParams={{reportID: initialReportID.toString()}}
+                initialParams={getInitialReportScreenParams(props.reports)}
             />
         </Drawer.Navigator>
     );

--- a/src/libs/reportUtils.js
+++ b/src/libs/reportUtils.js
@@ -1,6 +1,5 @@
 import _ from 'underscore';
 import Str from 'expensify-common/lib/str';
-import lodashGet from 'lodash/get';
 
 /**
  * Returns the concatenated title for the PrimaryLogins of a report
@@ -37,21 +36,8 @@ function findLastAccessedReport(reports) {
         .value();
 }
 
-/**
- * We are decorating findLastAccessedReport so that it caches the first result once the reports load.
- * This will ensure the initialParams are only set once for the ReportScreen.
- */
-const getInitialReportScreenParams = _.once((reports) => {
-    const last = findLastAccessedReport(reports);
-
-    // Fallback to empty if for some reason reportID cannot be derived - prevents the app from crashing
-    const reportID = lodashGet(last, 'reportID', '');
-    return {reportID};
-});
-
 export {
     getReportParticipantsTitle,
     isReportMessageAttachment,
     findLastAccessedReport,
-    getInitialReportScreenParams,
 };


### PR DESCRIPTION
<If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit.>
@marcaaron

Added filtering so that only valid reports are processed by findLastAccessedReport
Updated getInitialReport to getInitialReportScreenParams and moved to utils

This is a follow up to address the issue found in #2575

Fixes #2497