### PR TITLE
Fixed reportTiltle in header showing only emails

### DIFF
--- a/src/pages/home/HeaderView.js
+++ b/src/pages/home/HeaderView.js
@@ -15,7 +15,6 @@ import withWindowDimensions, {windowDimensionsPropTypes} from '../../components/
 import MultipleAvatars from '../../components/MultipleAvatars';
 import Navigation from '../../libs/Navigation/Navigation';
 import ROUTES from '../../ROUTES';
-import {getReportParticipantsTitle} from '../../libs/reportUtils';
 import DisplayNames from '../../components/DisplayNames';
 import {getPersonalDetailsForLogins} from '../../libs/OptionsListUtils';
 import {participantPropTypes} from './sidebar/optionPropTypes';
@@ -54,6 +53,7 @@ const defaultProps = {
 
 const HeaderView = (props) => {
     const participants = lodashGet(props.report, 'participants', []);
+    const reportTitle = lodashGet(props.report, 'reportName', '');
     const displayNamesWithTooltips = _.map(
         getPersonalDetailsForLogins(participants, props.personalDetails),
         ({displayName, login}) => ({displayName, tooltip: login}),
@@ -94,7 +94,7 @@ const HeaderView = (props) => {
                             />
                             <View style={[styles.flex1, styles.flexRow]}>
                                 <DisplayNames
-                                    fullTitle={getReportParticipantsTitle(participants)}
+                                    fullTitle={reportTitle}
                                     displayNamesWithTooltips={displayNamesWithTooltips}
                                     tooltipEnabled
                                     numberOfLines={1}


### PR DESCRIPTION
Please review @roryabraham 

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes #2668

### Tests / QA Steps
1. Open Any report on all supported platforms and see the Report Title in the Header. It should show the names of Users.
2. There is one exception, for some users their Phone numbers or emails are used as titles but not for all reports. 

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web / Desktop
<!-- Insert screenshots of your changes on the web platform-->
![image](https://user-images.githubusercontent.com/24370807/116913079-aaf8b600-ac66-11eb-9447-f03a98d97777.png)


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
![image](https://user-images.githubusercontent.com/24370807/116914442-5ce4b200-ac68-11eb-98d7-12a4733a12c1.png)

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
 
##### Image by @roryabraham 
 
![image](https://user-images.githubusercontent.com/24370807/116917601-7daf0680-ac6c-11eb-85f0-b59f79cdc227.png)

 
#### Android
<!-- Insert screenshots of your changes on the Android platform-->
![image](https://user-images.githubusercontent.com/24370807/116915166-4db23400-ac69-11eb-92bf-d4bc8c5a8280.png)