### PR TITLE
Move Sign Out button into Settings menu

### DIFF
--- a/assets/images/sign-out.svg
+++ b/assets/images/sign-out.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 24.3.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 20 20" style="enable-background:new 0 0 20 20;" xml:space="preserve">
+<g>
+	<path d="M19.5,8.6L16.9,6c-0.5-0.5-1.2-0.5-1.8,0s-0.5,1.2,0,1.8l0.9,1H9.2C8.6,8.8,8,9.3,8,10c0,0.7,0.6,1.2,1.2,1.2H16l-1,1
+		c-0.5,0.5-0.5,1.2,0,1.8c0.2,0.2,0.6,0.4,0.9,0.4s0.6-0.1,0.9-0.4l2.6-2.6C20.1,10.6,20.1,9.4,19.5,8.6z"/>
+	<path d="M10.2,15c0,0.8-0.5,1.2-1.2,1.2H5.2C4.5,16.2,4,15.8,4,15V5c0-0.8,0.5-1.2,1.2-1.2H9c0.8,0,1.2,0.5,1.2,1.2v2.2h2.5V5
+		c0-2.1-1.6-3.8-3.8-3.8H5.2C3.1,1.2,1.5,2.9,1.5,5v10c0,2.1,1.6,3.8,3.8,3.8H9c2.1,0,3.8-1.6,3.8-3.8v-2.2h-2.5V15z"/>
+</g>
+</svg>

--- a/src/components/Icon/Expensicons.js
+++ b/src/components/Icon/Expensicons.js
@@ -29,6 +29,7 @@ import Upload from '../../../assets/images/upload.svg';
 import Camera from '../../../assets/images/camera.svg';
 import Gallery from '../../../assets/images/gallery.svg';
 import Offline from '../../../assets/images/offline.svg';
+import SignOut from '../../../assets/images/sign-out.svg';
 
 export {
     ArrowRight,
@@ -62,4 +63,5 @@ export {
     Upload,
     Users,
     Wallet,
+    SignOut,
 };

--- a/src/pages/settings/InitialPage.js
+++ b/src/pages/settings/InitialPage.js
@@ -1,8 +1,5 @@
 import React from 'react';
-import {
-    TouchableOpacity,
-    View,
-} from 'react-native';
+import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
 import {withOnyx} from 'react-native-onyx';
@@ -16,7 +13,7 @@ import AvatarWithIndicator from '../../components/AvatarWithIndicator';
 import HeaderWithCloseButton from '../../components/HeaderWithCloseButton';
 import Navigation from '../../libs/Navigation/Navigation';
 import {
-    Gear, Lock, Profile, Wallet,
+    Gear, Lock, Profile, Wallet, SignOut,
 } from '../../components/Icon/Expensicons';
 import ScreenWrapper from '../../components/ScreenWrapper';
 import MenuItem from '../../components/MenuItem';
@@ -58,22 +55,28 @@ const menuItems = [
     {
         title: 'Profile',
         icon: Profile,
-        route: ROUTES.SETTINGS_PROFILE,
+        action: () => { Navigation.navigate(ROUTES.SETTINGS_PROFILE); },
     },
     {
         title: 'Preferences',
         icon: Gear,
-        route: ROUTES.SETTINGS_PREFERENCES,
+        action: () => { Navigation.navigate(ROUTES.SETTINGS_PREFERENCES); },
     },
     {
         title: 'Change Password',
         icon: Lock,
-        route: ROUTES.SETTINGS_PASSWORD,
+        action: () => { Navigation.navigate(ROUTES.SETTINGS_PASSWORD); },
     },
     {
         title: 'Payments',
         icon: Wallet,
-        route: ROUTES.SETTINGS_PAYMENTS,
+        action: () => { Navigation.navigate(ROUTES.SETTINGS_PAYMENTS); },
+
+    },
+    {
+        title: 'Sign Out',
+        icon: SignOut,
+        action: signOut,
     },
 ];
 
@@ -126,20 +129,10 @@ const InitialSettingsPage = ({
                             key={item.title}
                             title={item.title}
                             icon={item.icon}
-                            onPress={() => Navigation.navigate(item.route)}
+                            onPress={() => item.action()}
                             shouldShowRightArrow
                         />
                     ))}
-                    <View style={[styles.ph5]}>
-                        <TouchableOpacity
-                            onPress={signOut}
-                            style={[styles.button, styles.w100, styles.mt5]}
-                        >
-                            <Text style={[styles.buttonText]}>
-                                Sign Out
-                            </Text>
-                        </TouchableOpacity>
-                    </View>
                 </View>
                 <View style={[styles.sidebarFooter]}>
                     <Text style={[styles.chatItemMessageHeaderTimestamp]} numberOfLines={1}>


### PR DESCRIPTION
cc: @shawnborton 

### Details
Removes the dedicated `Sign Out` button and instead includes `Sign Out` as an option in the Settings menu. 

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes https://github.com/Expensify/Expensify.cash/issues/2149#issuecomment-814472586

### Tests
1. Log into an account on E.cash 
2. Navigate to `Settings` by clicking on your user avatar
3. Click through the menu items in the Settings page. 
4. Confirm the first four (`Profile`, `Preferences`, `Change Password`, and `Payments`) take you to their respective settings subpages. 
5. Confirm the fifth button `Sign Out` signs you out. 

### QA Steps
1. Repeat `Tests` steps. 


### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots


#### Web

https://user-images.githubusercontent.com/16747822/116935466-3f3d2b80-ac1b-11eb-9dbe-71d24a195aeb.mov

#### Mobile Web

https://user-images.githubusercontent.com/16747822/116935551-58de7300-ac1b-11eb-9bd1-6fbb639d5983.mov

#### Desktop

https://user-images.githubusercontent.com/16747822/116935579-6267db00-ac1b-11eb-8705-d27b7cdddf3c.mov

#### iOS

https://user-images.githubusercontent.com/16747822/116936109-30a34400-ac1c-11eb-8c1f-a52af770d2cf.mov


#### Android

https://user-images.githubusercontent.com/16747822/116936192-53cdf380-ac1c-11eb-9a9d-a2bd1e9dab9c.mov

<details closed>
<summary>React State Error on Android on current main</summary>
<br>
Just a note that I'm also experiencing that same react error on main currently for both Android and iOS but here's a video on Android

https://user-images.githubusercontent.com/16747822/116936186-503a6c80-ac1c-11eb-95a3-b22babbbebd5.mov

</details>