### PR TITLE
[NO QA] Remove up unused Timing key

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -63,7 +63,6 @@ const CONST = {
         HOMEPAGE_INITIAL_RENDER: 'homepage_initial_render',
         HOMEPAGE_REPORTS_LOADED: 'homepage_reports_loaded',
         SWITCH_REPORT: 'switch_report',
-        HOT: 'hot',
         COLD: 'cold',
     },
     MESSAGES: {


### PR DESCRIPTION
### Details
Simply removes a deprecated timing key that was not previously cleaned up. The [related dashboard](https://graphs.expensify.com/grafana/d/yj2EobAGz/expensify-cash-timing?orgId=1&from=now-90d&to=now) is also being removed.

### Fixed Issues
N/A, this is simply deleting a key.

### Tests
- Run the app
- Switch report
- Ensure no errors show in the console

### QA Steps
N/A -- see above

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android