### PR TITLE
Use the normal pin icon for the LHN

### DIFF
--- a/src/pages/home/sidebar/OptionRow.js
+++ b/src/pages/home/sidebar/OptionRow.js
@@ -10,7 +10,7 @@ import {
 import styles, {getBackgroundAndBorderStyle, getBackgroundColorStyle} from '../../../styles/styles';
 import {optionPropTypes} from './optionPropTypes';
 import Icon from '../../../components/Icon';
-import {Pencil, PinCircle, Checkmark} from '../../../components/Icon/Expensicons';
+import {Pencil, Pin, Checkmark} from '../../../components/Icon/Expensicons';
 import MultipleAvatars from '../../../components/MultipleAvatars';
 import themeColors from '../../../styles/themes/default';
 import Hoverable from '../../../components/Hoverable';
@@ -194,7 +194,7 @@ const OptionRow = ({
                         <View style={[styles.flexRow, styles.alignItemsCenter]}>
                             {option.hasDraftComment && (
                                 <View style={styles.ml2}>
-                                    <Icon src={Pencil} />
+                                    <Icon src={Pencil} height="16" width="16" />
                                 </View>
                             )}
                             {option.hasOutstandingIOU && (
@@ -202,7 +202,7 @@ const OptionRow = ({
                             )}
                             {option.isPinned && (
                                 <View style={styles.ml2}>
-                                    <Icon src={PinCircle} />
+                                    <Icon src={Pin} height="16" width="16" />
                                 </View>
                             )}
                         </View>


### PR DESCRIPTION
cc @shawnborton 

### Details
Just swapping out the icon and decreasing their size a little bit.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes https://github.com/Expensify/Expensify.cash/issues/2666

### Tests / QA
1. Have a draft message on one report, have another report pinned, and another report pinned with a draft
2. Verify the pin icon in the LHN does not have the circle behind it anymore and the icons are slightly smaller

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
![image](https://user-images.githubusercontent.com/1228807/117069385-a32e2580-ace9-11eb-994a-09bc0ccdc63c.png)

#### Mobile Web
![image](https://user-images.githubusercontent.com/1228807/117069415-ade8ba80-ace9-11eb-8411-15daebc9526e.png)

#### Desktop
![image](https://user-images.githubusercontent.com/1228807/117069633-f86a3700-ace9-11eb-99f6-2d96007d02ef.png)

#### iOS
![image](https://user-images.githubusercontent.com/1228807/117076754-2fdde100-acf4-11eb-8baf-96a8469eaff8.png)

#### Android
![image](https://user-images.githubusercontent.com/1228807/117074215-4d10b080-acf0-11eb-8f4b-4ba5ee5c19b1.png)
