### PR TITLE
Don't allow users to create chats with domain accounts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11562,8 +11562,8 @@
       }
     },
     "expensify-common": {
-      "version": "git+https://github.com/Expensify/expensify-common.git#d5edd0a956ef5c12fb6e9493d1f4608289f82a0e",
-      "from": "git+https://github.com/Expensify/expensify-common.git#d5edd0a956ef5c12fb6e9493d1f4608289f82a0e",
+      "version": "git+https://github.com/Expensify/expensify-common.git#05b8a007e9faa8e3b7a1ddd7348503acca6f4e95",
+      "from": "git+https://github.com/Expensify/expensify-common.git#05b8a007e9faa8e3b7a1ddd7348503acca6f4e95",
       "requires": {
         "classnames": "2.2.5",
         "clipboard": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "electron-log": "^4.2.4",
     "electron-serve": "^1.0.0",
     "electron-updater": "^4.3.4",
-    "expensify-common": "git+https://github.com/Expensify/expensify-common.git#d5edd0a956ef5c12fb6e9493d1f4608289f82a0e",
+    "expensify-common": "git+https://github.com/Expensify/expensify-common.git#05b8a007e9faa8e3b7a1ddd7348503acca6f4e95",
     "file-loader": "^6.0.0",
     "html-entities": "^1.3.1",
     "lodash": "4.17.21",

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -287,7 +287,7 @@ function getOptions(reports, personalDetails, draftComments, activeReportID, {
             && recentReportOptions.length === 0
             && personalDetailsOptions.length === 0
             && _.every(selectedOptions, option => option.login !== searchValue)
-            && ((Str.isValidEmail(searchValue) && !Str.startsWith(searchValue, '+@')) || Str.isValidPhone(searchValue))
+            && ((Str.isValidEmail(searchValue) && !Str.isDomainEmail(searchValue)) || Str.isValidPhone(searchValue))
             && (searchValue !== CONST.EMAIL.CHRONOS || Permissions.canUseChronos())
     ) {
         // If the phone number doesn't have an international code then let's prefix it with the

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -287,7 +287,7 @@ function getOptions(reports, personalDetails, draftComments, activeReportID, {
             && recentReportOptions.length === 0
             && personalDetailsOptions.length === 0
             && _.every(selectedOptions, option => option.login !== searchValue)
-            && (Str.isValidEmail(searchValue) || Str.isValidPhone(searchValue))
+            && ((Str.isValidEmail(searchValue) && !Str.startsWith(searchValue, '+@')) || Str.isValidPhone(searchValue))
             && (searchValue !== CONST.EMAIL.CHRONOS || Permissions.canUseChronos())
     ) {
         // If the phone number doesn't have an international code then let's prefix it with the


### PR DESCRIPTION
cc @Beamanator @roryabraham 

### Details
This PR prevents a user from creating a chat with a domain account email (email that starts with `+@`).

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/2441

### Tests/QA Steps
1. Login to e.cash, click the green + to create a new chat
2. Type out a valid email that starts with `+@`, confirm you can't click the row to create a new chat

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/3981102/117061544-30b44a00-acd7-11eb-98a2-4557cc1940ee.png) | ![image](https://user-images.githubusercontent.com/3981102/117061504-25f9b500-acd7-11eb-9375-050d85598cd8.png) |

