### PR TITLE
Add SDK token endpoints for Wallet KYC 

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -77,6 +77,11 @@ const CONST = {
     ERROR: {
         API_OFFLINE: 'API is offline',
     },
+    NETWORK: {
+        METHOD: {
+            POST: 'post',
+        },
+    },
     NVP: {
         PAYPAL_ME_ADDRESS: 'expensify_payPalMeAddress',
         PRIORITY_MODE: 'priorityMode',

--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -689,6 +689,15 @@ function CreateIOUSplit(parameters) {
     return Network.post(commandName, parameters);
 }
 
+/**
+ * @returns {Promise}
+ */
+function Wallet_GetOnfidoSDKToken() {
+    return Network.post('Wallet_GetOnfidoSDKToken');
+}
+
+window.Wallet_GetOnfidoSDKToken;
+
 export {
     getAuthToken,
     Authenticate,
@@ -723,4 +732,5 @@ export {
     CreateIOUTransaction,
     CreateIOUSplit,
     ValidateEmail,
+    Wallet_GetOnfidoSDKToken,
 };

--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -388,7 +388,7 @@ function DeleteLogin(parameters) {
 function Get(parameters, shouldUseSecure = false) {
     const commandName = 'Get';
     requireParameters(['returnValueList'], parameters, commandName);
-    return Network.post(commandName, parameters, 'post', shouldUseSecure);
+    return Network.post(commandName, parameters, CONST.NETWORK.METHOD.POST, shouldUseSecure);
 }
 
 /**
@@ -694,10 +694,15 @@ function CreateIOUSplit(parameters) {
  * @returns {Promise}
  */
 function Wallet_GetOnfidoSDKToken() {
-    return Network.post('Wallet_GetOnfidoSDKToken');
+    return Network.post('Wallet_GetOnfidoSDKToken', {}, CONST.NETWORK.METHOD.POST, true);
 }
 
-window.Wallet_GetOnfidoSDKToken;
+/**
+ * @returns {Promise}
+ */
+function Plaid_GetLinkToken() {
+    return Network.post('Plaid_GetLinkToken', {}, CONST.NETWORK.METHOD.POST, true);
+}
 
 export {
     getAuthToken,
@@ -715,6 +720,7 @@ export {
     Mobile_GetConstants,
     PersonalDetails_GetForEmails,
     PersonalDetails_Update,
+    Plaid_GetLinkToken,
     Push_Authenticate,
     Report_AddComment,
     Report_GetHistory,

--- a/src/libs/HttpUtils.js
+++ b/src/libs/HttpUtils.js
@@ -1,5 +1,6 @@
 import _ from 'underscore';
 import CONFIG from '../CONFIG';
+import CONST from '../CONST';
 
 /**
  * Send an HTTP request, and attempt to resolve the json response.
@@ -26,7 +27,7 @@ function processHTTPRequest(url, method = 'get', body = null) {
  * @param {Boolean} shouldUseSecure should we use the secure server
  * @returns {Promise}
  */
-function xhr(command, data, type = 'post', shouldUseSecure = false) {
+function xhr(command, data, type = CONST.NETWORK.METHOD.POST, shouldUseSecure = false) {
     const formData = new FormData();
     _.each(data, (val, key) => formData.append(key, val));
     const apiRoot = shouldUseSecure ? CONFIG.EXPENSIFY.URL_EXPENSIFY_SECURE : CONFIG.EXPENSIFY.URL_API_ROOT;

--- a/src/libs/Network.js
+++ b/src/libs/Network.js
@@ -3,6 +3,7 @@ import lodashGet from 'lodash/get';
 import Onyx from 'react-native-onyx';
 import HttpUtils from './HttpUtils';
 import ONYXKEYS from '../ONYXKEYS';
+import CONST from '../CONST';
 
 let isQueuePaused = false;
 
@@ -177,7 +178,7 @@ setInterval(processNetworkRequestQueue, 1000);
  * @param {Boolean} shouldUseSecure - Whether we should use the secure API
  * @returns {Promise}
  */
-function post(command, data = {}, type = 'post', shouldUseSecure = false) {
+function post(command, data = {}, type = CONST.NETWORK.METHOD.POST, shouldUseSecure = false) {
     return new Promise((resolve, reject) => {
         // Add the write request to a queue of actions to perform
         networkRequestQueue.push({


### PR DESCRIPTION
### Details
Holding on the Web-Secure PR [here](https://github.com/Expensify/Web-Secure/pull/1934) which should be deployed to **production** before we remove the HOLD here.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/161730
Fixes https://github.com/Expensify/Expensify/issues/161730

### Tests
This can be tested by forcing the APIs being added to run and verifying they are able to access Web-Secure. Although, it's not totally necessary as they are not used in the code yet. Here's what I did:

1. made both of these commands globally accessible by sticking them on `window` at the bottom of `API.js` e.g. 

```js
window.Wallet_GetOnfidoSDKToken = Wallet_GetOnfidoSDKToken;
window.Plaid_GetLinkToken = Plaid_GetLinkToken;
```
2. Then called each one from the JS console like this

```js
Wallet_GetOnfidoSDKToken().then(res => console.log(res));
Plaid_GetLinkToken().then(res => console.log(res));
```
3. Verified they returned a response with the tokens

### QA Steps
No QA

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
