### PR TITLE
Fix escape key for modal closing

### DIFF
--- a/src/components/AttachmentModal.js
+++ b/src/components/AttachmentModal.js
@@ -79,7 +79,10 @@ class AttachmentModal extends PureComponent {
             return;
         }
 
-        this.props.onConfirm(this.state.file);
+        if (this.props.onConfirm) {
+            this.props.onConfirm(this.state.file);
+        }
+
         this.setState({isModalOpen: false});
     }
 

--- a/src/components/Modal/BaseModal.js
+++ b/src/components/Modal/BaseModal.js
@@ -36,7 +36,6 @@ class BaseModal extends PureComponent {
      * Listens to specific keyboard keys when the modal has been opened
      */
     subscribeToKeyEvents() {
-        KeyboardShortcut.subscribe('Escape', this.props.onClose, [], true);
         KeyboardShortcut.subscribe('Enter', this.props.onSubmit, [], true);
     }
 
@@ -44,7 +43,6 @@ class BaseModal extends PureComponent {
      * Stops listening to keyboard keys when modal has been closed
      */
     unsubscribeFromKeyEvents() {
-        KeyboardShortcut.unsubscribe('Escape');
         KeyboardShortcut.unsubscribe('Enter');
     }
 
@@ -75,6 +73,9 @@ class BaseModal extends PureComponent {
                     }
                     this.props.onClose();
                 }}
+
+                // Note: Escape key on web/desktop will trigger onBackButtonPress callback
+                // eslint-disable-next-line react/jsx-props-no-multi-spaces
                 onBackButtonPress={this.props.onClose}
                 onModalShow={() => {
                     this.subscribeToKeyEvents();

--- a/src/components/ScreenWrapper.js
+++ b/src/components/ScreenWrapper.js
@@ -2,9 +2,11 @@ import _ from 'underscore';
 import React from 'react';
 import PropTypes from 'prop-types';
 import {View} from 'react-native';
+import {withNavigation} from '@react-navigation/compat';
 import {SafeAreaInsetsContext} from 'react-native-safe-area-context';
 import styles, {getSafeAreaPadding} from '../styles/styles';
 import HeaderGap from './HeaderGap';
+import KeyboardShortcut from '../libs/KeyboardShortcut';
 
 const propTypes = {
     // Array of additional styles to add
@@ -21,48 +23,76 @@ const propTypes = {
 
     // Whether to include padding top
     includePaddingTop: PropTypes.bool,
+
+    // react-navigation object that will allow us to goBack()
+    navigation: PropTypes.shape({
+
+        // Returns to the previous navigation state e.g. if this is inside a Modal we will dismiss it
+        goBack: PropTypes.func,
+    }),
 };
 
 const defaultProps = {
     style: [],
     includePaddingBottom: true,
     includePaddingTop: true,
+    navigation: {
+        goBack: () => {},
+    },
 };
 
-const ScreenWrapper = props => (
-    <SafeAreaInsetsContext.Consumer>
-        {(insets) => {
-            const {paddingTop, paddingBottom} = getSafeAreaPadding(insets);
-            const paddingStyle = {};
+class ScreenWrapper extends React.Component {
+    componentDidMount() {
+        this.unsubscribe = KeyboardShortcut.subscribe('Escape', () => {
+            this.props.navigation.goBack();
+        }, [], true);
+    }
 
-            if (props.includePaddingTop) {
-                paddingStyle.paddingTop = paddingTop;
-            }
+    componentWillUnmount() {
+        if (!this.unsubscribe) {
+            return;
+        }
 
-            if (props.includePaddingBottom) {
-                paddingStyle.paddingBottom = paddingBottom;
-            }
+        this.unsubscribe();
+    }
 
-            return (
-                <View style={[
-                    ...props.style,
-                    styles.flex1,
-                    paddingStyle,
-                ]}
-                >
-                    <HeaderGap />
-                    {// If props.children is a function, call it to provide the insets to the children.
-                        _.isFunction(props.children)
-                            ? props.children(insets)
-                            : props.children
+    render() {
+        return (
+            <SafeAreaInsetsContext.Consumer>
+                {(insets) => {
+                    const {paddingTop, paddingBottom} = getSafeAreaPadding(insets);
+                    const paddingStyle = {};
+
+                    if (this.props.includePaddingTop) {
+                        paddingStyle.paddingTop = paddingTop;
                     }
-                </View>
-            );
-        }}
-    </SafeAreaInsetsContext.Consumer>
-);
+
+                    if (this.props.includePaddingBottom) {
+                        paddingStyle.paddingBottom = paddingBottom;
+                    }
+
+                    return (
+                        <View style={[
+                            ...this.props.style,
+                            styles.flex1,
+                            paddingStyle,
+                        ]}
+                        >
+                            <HeaderGap />
+                            {// If props.children is a function, call it to provide the insets to the children.
+                                _.isFunction(this.props.children)
+                                    ? this.props.children(insets)
+                                    : this.props.children
+                            }
+                        </View>
+                    );
+                }}
+            </SafeAreaInsetsContext.Consumer>
+        );
+    }
+}
 
 ScreenWrapper.propTypes = propTypes;
 ScreenWrapper.defaultProps = defaultProps;
 ScreenWrapper.displayName = 'ScreenWrapper';
-export default ScreenWrapper;
+export default withNavigation(ScreenWrapper);

--- a/src/libs/KeyboardShortcut/index.js
+++ b/src/libs/KeyboardShortcut/index.js
@@ -90,6 +90,7 @@ const KeyboardShortcut = {
      * @param {Function} callback The callback to call
      * @param {String|Array} modifiers Can either be shift or control
      * @param {Boolean} captureOnInputs Should we capture the event on inputs too?
+     * @returns {Function} clean up method
      */
     subscribe(key, callback, modifiers = 'shift', captureOnInputs = false) {
         const keyCode = this.getKeyCode(key);
@@ -97,6 +98,7 @@ const KeyboardShortcut = {
             events[keyCode] = [];
         }
         events[keyCode].push({callback, modifiers: _.isArray(modifiers) ? modifiers : [modifiers], captureOnInputs});
+        return () => this.unsubscribe(key);
     },
 
     /**

--- a/src/libs/KeyboardShortcut/index.native.js
+++ b/src/libs/KeyboardShortcut/index.native.js
@@ -3,7 +3,9 @@
  * a website.
  */
 const KeyboardShortcut = {
-    subscribe() {},
+    subscribe() {
+        return () => {};
+    },
     unsubscribe() {},
 };
 


### PR DESCRIPTION
### Details
There are two situations where `Escape` key was not working

1. The `Popover` component because `react-native-modal` is registering the `Escape` key press as a "back button press" and we are trying to close it twice (rather we toggle it so it just reopens again)
2. When we moved the right hand panel modals to `react-navigation` we lost the ability to close via `Escape`. This should add that behavior back in at the `ScreenWrapper` level so that any screen wrapped in that component should be able to trigger a `goBack()` if the `esc` key is pressed

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/1039

### Tests
### QA Steps
1. Tap on the User avatar in the Sidebar
2. Press `Escape` after the right panel opens
3. Verify the right panel closes
4. Repeat test with all similar right panel modals - New Chat, New Group, Search, Chat User Details etc
5. Tap on the FAB
6. Press `Escape`
7. Verify the popover menus closes
8. Click on an attachment in a chat to open the large modal
9. Press `Escape`
10. Verify the image view modal closes

### Tested On

- [x] Web
- [x] Desktop

**These platforms have no hardware keyboard so I did not bother to test them beyond ensuring no broken behaviors were introduced**
- Mobile Web - N/A
- iOS - N/A
- Android - N/A

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
