### PR TITLE
Manually handle keyboard to prevent Android crash

### DIFF
--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -173,7 +173,7 @@ class AuthScreens extends React.Component {
                 mode="modal"
 
                 // We are disabling the default keyboard handling here since the automatic behavior is to close a
-                // keyboard that's open when swiping left on a modal. In those cases, pressing the back button on
+                // keyboard that's open when swiping to dismiss a modal. In those cases, pressing the back button on
                 // a header will briefly open and close the keyboard and crash Android.
                 // eslint-disable-next-line react/jsx-props-no-multi-spaces
                 keyboardHandlingEnabled={false}

--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -171,6 +171,12 @@ class AuthScreens extends React.Component {
         return (
             <RootStack.Navigator
                 mode="modal"
+
+                // We are disabling the default keyboard handling here since the automatic behavior is to close a
+                // keyboard that's open when swiping left on a modal. In those cases, pressing the back button on
+                // a header will briefly open and close the keyboard and crash Android.
+                // eslint-disable-next-line react/jsx-props-no-multi-spaces
+                keyboardHandlingEnabled={false}
             >
                 {/* The MainDrawerNavigator contains the SidebarScreen and ReportScreen */}
                 <RootStack.Screen


### PR DESCRIPTION
### Details
Fix Android crash due to automatic handling of software keyboard

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/2694

### Tests
### QA Steps
Repeat steps in linked issue...

1. Launch the app
2. Log in with expensifail account
3. Select any user
4. Click on Plus button and select Request Money
5. Put any amount and Click Next
6. In Field What's it for? - put some text (make sure the software keyboard is displayed)
7. Tap on back arrow
8. Verify the Android app does not crash. 

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
