### PR TITLE
Stop fetching more report history twice onEndReached

### DIFF
--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -218,6 +218,11 @@ class ReportActionsView extends React.Component {
      * displaying.
      */
     loadMoreChats() {
+        // Only fetch more if we are not already fetching so that we don't initiate duplicate requests.
+        if (this.state.isLoadingMoreChats) {
+            return;
+        }
+
         const minSequenceNumber = _.chain(this.props.reportActions)
             .pluck('sequenceNumber')
             .min()


### PR DESCRIPTION
### Details

Just noticed we were making double API requests to `Report_GetHistory` when reaching the end of a chat

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/2708

### Tests
1. Scroll to the top of a chat that has greater than 50 comments while filtering the Network tab in Chrome Dev Tools for `Report_GetHistory`
2. Verify that when we reach the top of a chat we are only calling `Report_GetHistory` once and cannot call it again while we are fetching new history.

**Tip:** On mobile I just added a log here to prove the API is only called once

```diff
diff --git a/src/libs/API.js b/src/libs/API.js
index be75675ec..840139b70 100644
--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -525,6 +525,7 @@ function Report_AddComment(parameters) {
  * @returns {Promise}
  */
 function Report_GetHistory(parameters) {
+    console.log('Calling Report_GetHistory');
     const commandName = 'Report_GetHistory';
     requireParameters(['reportID'],
         parameters, commandName);
```

### QA Steps
1. Verify loading new messages when reaching the end of chats works OK on various platforms.

### Tested On

- [x] Web
- [x] Mobile Web - Can use Safari to test this in Simulator
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
