### PR TITLE
Fix web proxy when accessing staging API

### DIFF
--- a/web/proxy.js
+++ b/web/proxy.js
@@ -14,6 +14,9 @@ if (/staging/.test(process.env.EXPENSIFY_URL_COM)) {
     host = 'staging.expensify.com';
 }
 
+// eslint-disable-next-line no-console
+console.log(`Creating proxy with host: ${host}`);
+
 /**
  * Local proxy server that hits the production endpoint
  * to get around CORS issues. We use this so that it's

--- a/web/proxy.js
+++ b/web/proxy.js
@@ -7,6 +7,13 @@ if (process.env.USE_WEB_PROXY === 'false') {
     process.exit();
 }
 
+let host = 'www.expensify.com';
+
+// If we are testing against the staging API then we must use the correct host here or nothing with work.
+if (/staging/.test(process.env.EXPENSIFY_URL_COM)) {
+    host = 'staging.expensify.com';
+}
+
 /**
  * Local proxy server that hits the production endpoint
  * to get around CORS issues. We use this so that it's
@@ -15,12 +22,12 @@ if (process.env.USE_WEB_PROXY === 'false') {
  */
 const server = http.createServer((request, response) => {
     const proxyRequest = https.request({
-        hostname: 'www.expensify.com',
+        hostname: host,
         method: 'POST',
         path: request.url,
         headers: {
             ...request.headers,
-            host: 'www.expensify.com',
+            host,
         },
         port: 443,
     });


### PR DESCRIPTION
### Details

Testing against the staging API doesn't seem to work with the web proxy.

### Fixed Issues
No Issue just something random I noticed while trying to Internal QA something

### Tests
1. Set `USE_WEB_PROXY=true` in `.env`
1. Verify that when running `npm run web` you see that the host is `www.expensify.com` in npm log output e.g.
```
Creating proxy with host: www.expensify.com
Proxy server listening at http://localhost:9000
```
3. Change the `EXPENSIFY_URL_COM` url in `.env` to `https://staging.expensify.com/`
4. Verify that when running `npm run web` you see that the host is `staging.expensify.com` in npm log output e.g.
```
Creating proxy with host: staging.expensify.com
Proxy server listening at http://localhost:9000
```
5. Verify you are accessing the staging server by inspecting network requests

### QA Steps
No QA

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
