### PR TITLE
Fix crash on new chat creation due to undefined sequenceNumber

### DIFF
--- a/src/libs/Navigation/AppNavigator/MainDrawerNavigator.js
+++ b/src/libs/Navigation/AppNavigator/MainDrawerNavigator.js
@@ -41,7 +41,7 @@ const getInitialReportScreenParams = _.once((reports) => {
 
     // Fallback to empty if for some reason reportID cannot be derived - prevents the app from crashing
     const reportID = lodashGet(last, 'reportID', '');
-    return {reportID};
+    return {reportID: String(reportID)};
 });
 
 const MainDrawerNavigator = (props) => {

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -940,16 +940,16 @@ function addAction(reportID, text, file) {
  *  is last read (meaning that the entire report history has been read)
  */
 function updateLastReadActionID(reportID, sequenceNumber) {
-    // If we don't have a maxSequenceNumber for this report then we will assume that the report has just been created
-    // and use 0 for the maxSequenceNumber. Otherwise, we'll have an undefined sequenceNumber in cases where no
-    // sequenceNumber is explicitly passed.
-    const maxSequenceNumber = !_.isUndefined(reportMaxSequenceNumbers[reportID])
-        ? reportMaxSequenceNumbers[reportID]
-        : 0;
+    // If we aren't specifying a sequenceNumber and have no maxSequenceNumber for this report then we should not update
+    // the last read. Most likely, we have just created the report and it has no comments. But we should err on the side
+    // of caution and do nothing in this case.
+    if (_.isUndefined(sequenceNumber) && _.isUndefined(reportMaxSequenceNumbers[reportID])) {
+        return;
+    }
 
     // Need to subtract 1 from sequenceNumber so that the "New" marker appears in the right spot (the last read
     // action). If 1 isn't subtracted then the "New" marker appears one row below the action (the first unread action)
-    const lastReadSequenceNumber = (sequenceNumber - 1) || maxSequenceNumber;
+    const lastReadSequenceNumber = (sequenceNumber - 1) || reportMaxSequenceNumbers[reportID];
 
     setLocalLastRead(reportID, lastReadSequenceNumber);
 

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -940,9 +940,16 @@ function addAction(reportID, text, file) {
  *  is last read (meaning that the entire report history has been read)
  */
 function updateLastReadActionID(reportID, sequenceNumber) {
+    // If we don't have a maxSequenceNumber for this report then we will assume that the report has just been created
+    // and use 0 for the maxSequenceNumber. Otherwise, we'll have an undefined sequenceNumber in cases where no
+    // sequenceNumber is explicitly passed.
+    const maxSequenceNumber = !_.isUndefined(reportMaxSequenceNumbers[reportID])
+        ? reportMaxSequenceNumbers[reportID]
+        : 0;
+
     // Need to subtract 1 from sequenceNumber so that the "New" marker appears in the right spot (the last read
     // action). If 1 isn't subtracted then the "New" marker appears one row below the action (the first unread action)
-    const lastReadSequenceNumber = (sequenceNumber - 1) || reportMaxSequenceNumbers[reportID];
+    const lastReadSequenceNumber = (sequenceNumber - 1) || maxSequenceNumber;
 
     setLocalLastRead(reportID, lastReadSequenceNumber);
 

--- a/src/pages/home/sidebar/OptionRow.js
+++ b/src/pages/home/sidebar/OptionRow.js
@@ -194,7 +194,7 @@ const OptionRow = ({
                         <View style={[styles.flexRow, styles.alignItemsCenter]}>
                             {option.hasDraftComment && (
                                 <View style={styles.ml2}>
-                                    <Icon src={Pencil} height="16" width="16" />
+                                    <Icon src={Pencil} height={16} width={16} />
                                 </View>
                             )}
                             {option.hasOutstandingIOU && (
@@ -202,7 +202,7 @@ const OptionRow = ({
                             )}
                             {option.isPinned && (
                                 <View style={styles.ml2}>
-                                    <Icon src={Pin} height="16" width="16" />
+                                    <Icon src={Pin} height={16} width={16} />
                                 </View>
                             )}
                         </View>


### PR DESCRIPTION
cc @tgolen @Gonals I think this change is safe but need a second opinion. another option could be to not mark the report as "read" until the `reportMaxSequenceNumber[reportID]` exists, but that's difficult since there's no way to know this has happened because of the async Onyx callbacks etc.

### Details
- When a chat is first created it does not yet have a `reportMaxSequenceNumbers[reportID]`
- We are still trying to mark it as "read" but since it has no history yet it crashes and leads to a white screen of death.

**Bonus:** The rest of the code changes are related to `propTypes` and thought I'd sneak them in here.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/2704

### Tests
### QA Steps
1. Create a new chat with a user that you have no existing chat with via New Group, New Chat, or Search flows
2. Verify you do not experience a white screen and are brought to the chat.
3. Test "new marker" and unread behavior for regressions

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
