### PR TITLE
feature: Include polyfill.io for web builds

### DIFF
--- a/config/webpack/webpack.common.js
+++ b/config/webpack/webpack.common.js
@@ -35,6 +35,7 @@ const webpackConfig = {
         new HtmlWebpackPlugin({
             template: 'web/index.html',
             filename: 'index.html',
+            usePolyfillIO: platform === 'web',
         }),
 
         // Copies favicons into the dist/ folder to use for unread status

--- a/web/index.html
+++ b/web/index.html
@@ -28,6 +28,10 @@
     </style>
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1">
     <link rel="shortcut icon" id="favicon" href="/favicon.png">
+    <% if (htmlWebpackPlugin.options.usePolyfillIO) { %>
+        <!-- polyfill.io is only needed on Web to support older browsers. It should not be loaded for desktop -->
+        <script src="https://polyfill.io/v3/polyfill.min.js?features=default%2CResizeObserver&flags=gated"></script>
+    <% } %>
 </head>
 <body>
     <div style="position: absolute; top: 0; left: 0; right: 0; height: 30px;" id="drag-area"></div>


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
@Julesssss 

### Details
Provide a custom `HtmlWebpackPlugin` option to prevent bundling the script tag that adds polyfill.io on desktop
It's not needed there - desktop already works with latest tech
The script tag that loads polyfill.io is only included on web (and mWeb)

The `ResizeObserver` is added as it's not included in the `default` features
It's needed for the app to work on iOS 12 mWeb Safari

The `gated` flag is added to skip polyfilling a feature that is already supported
natively by the browser

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes #2520

### Tests
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->
1. Have an iOS 12 simulator
2. Launch Safari
3. Open Expensify
4. Login
5. The app should be able to load past login and be usable (Previously it would break after login)

Since I've made changes to the webpack config and the index file that's used for desktop as well please run the same steps on desktop too

No changes to the native platforms

### QA Steps
Same as above

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
![image](https://user-images.githubusercontent.com/12156624/117355323-1aff7a00-aebb-11eb-9153-478523fe7148.png)

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

https://user-images.githubusercontent.com/12156624/117355410-38344880-aebb-11eb-87e5-cec3628ef17c.mov

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
![image](https://user-images.githubusercontent.com/12156624/117355501-539f5380-aebb-11eb-9d3f-e56a13bc01cb.png)
