### PR TITLE
Limit initial fetch of history API calls to subset of recently accessed reports

### DIFF
--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -17,7 +17,7 @@ import Timing from './Timing';
 import * as API from '../API';
 import CONST from '../../CONST';
 import Log from '../Log';
-import {isReportMessageAttachment} from '../reportUtils';
+import {isReportMessageAttachment, sortReportsByLastVisited} from '../reportUtils';
 import Timers from '../Timers';
 import {dangerouslyGetReportActionsMaxSequenceNumber, isReportMissingActions} from './ReportActions';
 
@@ -811,9 +811,19 @@ function fetchAllReports(
                 // content and improve chat switching experience by only downloading content we don't have yet.
                 // This improves performance significantly when reconnecting by limiting API requests and unnecessary
                 // data processing by Onyx.
-                const reportIDsToFetchActions = _.filter(returnedReportIDs, id => (
+                const reportIDsWithMissingActions = _.filter(returnedReportIDs, id => (
                     isReportMissingActions(id, reportMaxSequenceNumbers[id])
                 ));
+
+                // Once we have the reports that are missing actions we will find the intersection between the most
+                // recently accessed reports and reports missing actions. Then we'll fetch the history for a small
+                // set to avoid making too many network requests at once.
+                const reportIDsToFetchActions = _.chain(sortReportsByLastVisited(allReports))
+                    .map(report => report.reportID)
+                    .reverse()
+                    .intersection(reportIDsWithMissingActions)
+                    .slice(0, 10)
+                    .value();
 
                 if (_.isEmpty(reportIDsToFetchActions)) {
                     console.debug('[Report] Local reportActions up to date. Not fetching additional actions.');

--- a/src/libs/reportUtils.js
+++ b/src/libs/reportUtils.js
@@ -22,22 +22,32 @@ function isReportMessageAttachment(reportMessageText) {
 }
 
 /**
+ * Given a collection of reports returns them sorted by last visited
+ *
+ * @param {Object} reports
+ * @returns {Array}
+ */
+function sortReportsByLastVisited(reports) {
+    return _.chain(reports)
+        .toArray()
+        .filter(report => report && report.reportID)
+        .sortBy('lastVisitedTimestamp')
+        .value();
+}
+
+/**
  * Given a collection of reports returns the most recently accessed one
  *
  * @param {Record<String, {lastVisitedTimestamp, reportID}>|Array<{lastVisitedTimestamp, reportID}>} reports
  * @returns {Object}
  */
 function findLastAccessedReport(reports) {
-    return _.chain(reports)
-        .toArray()
-        .filter(report => report && report.reportID)
-        .sortBy('lastVisitedTimestamp')
-        .last()
-        .value();
+    return _.last(sortReportsByLastVisited(reports));
 }
 
 export {
     getReportParticipantsTitle,
     isReportMessageAttachment,
     findLastAccessedReport,
+    sortReportsByLastVisited,
 };


### PR DESCRIPTION
### Details

We took some steps to improve the first sign in experience by delaying the report history API calls. But on a first sign in they can still flood the user with network requests. So if you have 80 chats then you will make 80 network requests if you have no report actions in storage. That's probably unnecessary in a lot of cases and we can get away with just the first 10 recently accessed reports.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/2937

### Tests
1. Sign out of E.cash and sign back in on an account that has over 20 chats
2. Verify in the Chrome Dev Tools that a max of 10 calls (excluding current report) to `Report_GetHistory` are made when the app initializes (**Note:** These call will also take ~8 seconds to fire once logged in)

<img width="808" alt="Screen Shot 2021-05-25 at 7 39 22 AM" src="https://user-images.githubusercontent.com/32969087/119543692-a8045900-bd2c-11eb-96df-7df5c0cd2233.png">


### QA Steps
1. Test log in and log out flow on various platforms

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
**Note:** No UI changes were made in this PR

#### Web
<img width="911" alt="2021-05-25_07-44-09" src="https://user-images.githubusercontent.com/32969087/119544017-06313c00-bd2d-11eb-9899-3c5eb4ae3768.png">

#### Mobile Web
<img width="408" alt="2021-05-25_07-47-22" src="https://user-images.githubusercontent.com/32969087/119544488-763fc200-bd2d-11eb-91be-2cd2e999e444.png">

#### Desktop
<img width="1310" alt="2021-05-25_07-51-33" src="https://user-images.githubusercontent.com/32969087/119545052-0b42bb00-bd2e-11eb-81e0-2b623b22de99.png">

#### iOS
<img width="408" alt="2021-05-25_07-58-47" src="https://user-images.githubusercontent.com/32969087/119545933-0cc0b300-bd2f-11eb-8ddf-891f5bb3ddb2.png">

#### Android
<img width="339" alt="2021-05-25_08-10-32" src="https://user-images.githubusercontent.com/32969087/119547344-b5234700-bd30-11eb-9aef-18e11b91dd6b.png">
