### PR TITLE
Profile - GMT time is not displayed #2097

### DIFF
--- a/src/pages/DetailsPage.js
+++ b/src/pages/DetailsPage.js
@@ -101,7 +101,15 @@ const DetailsPage = ({personalDetails, route}) => {
                                     <Text style={[styles.textP]} numberOfLines={1}>
                                         {moment().tz(details.timezone.selected).format('LT')}
                                         {' '}
-                                        {moment().tz(details.timezone.selected).zoneAbbr()}
+                                        {isNaN(moment().tz(details.timezone.selected).zoneAbbr()) ? ( 
+                                            <Text>{moment().tz(details.timezone.selected).zoneAbbr()}</Text>
+                                        ) : (
+                                            <Text>
+                                                {moment.tz(details.timezone.selected).toString().split("-")[0].slice(-3)}
+                                                {' '}
+                                                {moment().tz(details.timezone.selected).zoneAbbr()}
+                                            </Text>
+                                        )}
                                     </Text>
                                 </View>
                             ) : null}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This issue is resolved by just modifying moment syntax because in the moment library, some timezone abbreviation, not support. so if return numeric value I've put modified syntax to show GMT.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes https://github.com/Expensify/Expensify.cash/issues/2097

### Tests

1. Pull code from GitHub and install its dependencies via the below command: npm install
2. Run this project locally via npm run web / npm run android
3. login via existing credentials.
4. Go to the settings page then open the profile tab.
5. Set desired timezone.
6. log out and log in with another account.
7. search for the first account and check his/her profile and check on the local time option. It will show GMT or any other timezone.
 

### QA Steps
I've already QA this issue and it's working properly.

### Tested On

- [x] Web
- [x] Mobile Web
- [ ] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
![2021-05-16](https://user-images.githubusercontent.com/43398804/118920803-b9c4b580-b954-11eb-885c-8cdc8ec34c58.png)


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
![2021-05-17](https://user-images.githubusercontent.com/43398804/118920840-c5b07780-b954-11eb-8dd4-e9f069c2ed11.png)


#### Android
![2021-05-17](https://user-images.githubusercontent.com/43398804/118920855-ca752b80-b954-11eb-859c-198520f68b1d.jpg)

