### PR TITLE
Return early if no valid sequenceNumber can be found

### DIFF
--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -940,10 +940,11 @@ function addAction(reportID, text, file) {
  *  is last read (meaning that the entire report history has been read)
  */
 function updateLastReadActionID(reportID, sequenceNumber) {
-    // If we aren't specifying a sequenceNumber and have no maxSequenceNumber for this report then we should not update
-    // the last read. Most likely, we have just created the report and it has no comments. But we should err on the side
-    // of caution and do nothing in this case.
-    if (_.isUndefined(sequenceNumber) && _.isUndefined(reportMaxSequenceNumbers[reportID])) {
+    // If we aren't specifying a sequenceNumber and have no valid maxSequenceNumber for this report then we should not
+    // update the last read. Most likely, we have just created the report and it has no comments. But we should err on
+    // the side of caution and do nothing in this case.
+    if (_.isUndefined(sequenceNumber)
+        && (!reportMaxSequenceNumbers[reportID] && reportMaxSequenceNumbers[reportID] !== 0)) {
         return;
     }
 


### PR DESCRIPTION
cc @roryabraham 

### Details
Updates a check that only checks for an "undefined" sequenceNumber when it should be ignoring any invalid values for a `sequenceNumber`. Seems like [this PR actually did not make it to production](https://github.com/Expensify/Expensify.cash/pull/2721/files). But I also happened to spot a `null` value in `reportMaxSequenceNumbers` on dev so I think this is a good change regardless.

### Fixed Issues
No issue, but related to https://github.com/Expensify/Expensify.cash/issues/2704

### Tests
### QA Steps
Same as https://github.com/Expensify/Expensify.cash/issues/2704

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
