### PR TITLE
Add ability to get the current operating system, display subset of emojis if on Windows

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -128,6 +128,14 @@ const CONST = {
         STARTUP: 8000,
         RECONNECT: 1000,
     },
+
+    OS: {
+        WINDOWS: 'Windows',
+        MAC_OS: 'Mac OS',
+        ANDROID: 'Android',
+        IOS: 'iOS',
+        LINUX: 'Linux',
+    },
 };
 
 export default CONST;

--- a/src/CONST.js
+++ b/src/CONST.js
@@ -135,6 +135,7 @@ const CONST = {
         ANDROID: 'Android',
         IOS: 'iOS',
         LINUX: 'Linux',
+        NATIVE: 'Native',
     },
 };
 

--- a/src/libs/getOperatingSystem.js
+++ b/src/libs/getOperatingSystem.js
@@ -1,0 +1,31 @@
+import CONST from '../CONST';
+
+/**
+ * Reads the current operating system.
+ * @return {String | null}
+ */
+function getOperatingSystem() {
+    if (!window || !window.navigator) {
+        return null;
+    }
+    const {userAgent, platform} = window.navigator;
+    const macosPlatforms = ['Macintosh', 'MacIntel', 'MacPPC', 'Mac68K'];
+    const windowsPlatforms = ['Win32', 'Win64', 'Windows', 'WinCE'];
+    const iosPlatforms = ['iPhone', 'iPad', 'iPod'];
+
+    let os = null;
+    if (macosPlatforms.includes(platform)) {
+        os = CONST.OS.MAC_OS;
+    } else if (iosPlatforms.includes(platform)) {
+        os = CONST.OS.IOS;
+    } else if (windowsPlatforms.includes(platform)) {
+        os = CONST.OS.WINDOWS;
+    } else if (/Android/.test(userAgent)) {
+        os = CONST.OS.ANDROID;
+    } else if (/Linux/.test(platform)) {
+        os = CONST.OS.LINUX;
+    }
+    return os;
+}
+
+export default getOperatingSystem;

--- a/src/libs/getOperatingSystem.js
+++ b/src/libs/getOperatingSystem.js
@@ -1,3 +1,4 @@
+import {Platform} from 'react-native';
 import CONST from '../CONST';
 
 /**
@@ -5,9 +6,19 @@ import CONST from '../CONST';
  * @return {String | null}
  */
 function getOperatingSystem() {
-    if (!window || !window.navigator) {
-        return null;
+    // When running on a native device
+    if (!window || !window.navigator || !window.navigator.platform) {
+        switch (Platform.OS) {
+            case 'ios':
+                return CONST.OS.IOS;
+            case 'android':
+                return CONST.OS.ANDROID;
+            default:
+                return CONST.OS.NATIVE;
+        }
     }
+
+    // When running on web, we can check window.navigator
     const {userAgent, platform} = window.navigator;
     const macosPlatforms = ['Macintosh', 'MacIntel', 'MacPPC', 'Mac68K'];
     const windowsPlatforms = ['Win32', 'Win64', 'Windows', 'WinCE'];

--- a/src/libs/getOperatingSystem/index.js
+++ b/src/libs/getOperatingSystem/index.js
@@ -1,24 +1,10 @@
-import {Platform} from 'react-native';
-import CONST from '../CONST';
+import CONST from '../../CONST';
 
 /**
- * Reads the current operating system.
+ * Reads the current operating system when running on Web/Mobile-Web/Desktop
  * @return {String | null}
  */
-function getOperatingSystem() {
-    // When running on a native device
-    if (!window || !window.navigator || !window.navigator.platform) {
-        switch (Platform.OS) {
-            case 'ios':
-                return CONST.OS.IOS;
-            case 'android':
-                return CONST.OS.ANDROID;
-            default:
-                return CONST.OS.NATIVE;
-        }
-    }
-
-    // When running on web, we can check window.navigator
+export default () => {
     const {userAgent, platform} = window.navigator;
     const macosPlatforms = ['Macintosh', 'MacIntel', 'MacPPC', 'Mac68K'];
     const windowsPlatforms = ['Win32', 'Win64', 'Windows', 'WinCE'];
@@ -37,6 +23,4 @@ function getOperatingSystem() {
         os = CONST.OS.LINUX;
     }
     return os;
-}
-
-export default getOperatingSystem;
+};

--- a/src/libs/getOperatingSystem/index.native.js
+++ b/src/libs/getOperatingSystem/index.native.js
@@ -1,0 +1,17 @@
+import {Platform} from 'react-native';
+import CONST from '../../CONST';
+
+/**
+ * Reads the current operating system for native platforms.
+ * @return {String | null}
+ */
+export default () => {
+    switch (Platform.OS) {
+        case 'ios':
+            return CONST.OS.IOS;
+        case 'android':
+            return CONST.OS.ANDROID;
+        default:
+            return CONST.OS.NATIVE;
+    }
+};

--- a/src/pages/home/report/EmojiPickerMenu/index.js
+++ b/src/pages/home/report/EmojiPickerMenu/index.js
@@ -53,7 +53,7 @@ class EmojiPickerMenu extends Component {
         this.unfilteredHeaderIndices = [0, 33, 59, 87, 98, 120, 147];
 
         // If we're on Windows, don't display the flag emojis (the last category),
-        // since Windows doesn't support them (and only displays country codes)
+        // since Windows doesn't support them (and only displays country codes instead)
         this.emojis = getOperatingSystem() === CONST.OS.WINDOWS
             ? emojis.slice(0, this.unfilteredHeaderIndices.pop())
             : emojis;

--- a/src/pages/home/report/EmojiPickerMenu/index.js
+++ b/src/pages/home/report/EmojiPickerMenu/index.js
@@ -55,7 +55,7 @@ class EmojiPickerMenu extends Component {
         // If we're on Windows, don't display the flag emojis (the last category),
         // since Windows doesn't support them (and only displays country codes instead)
         this.emojis = getOperatingSystem() === CONST.OS.WINDOWS
-            ? emojis.slice(0, this.unfilteredHeaderIndices.pop())
+            ? emojis.slice(0, this.unfilteredHeaderIndices.pop() * this.numColumns)
             : emojis;
 
         this.filterEmojis = _.debounce(this.filterEmojis.bind(this), 300);

--- a/src/pages/home/report/EmojiPickerMenu/index.js
+++ b/src/pages/home/report/EmojiPickerMenu/index.js
@@ -57,7 +57,7 @@ class EmojiPickerMenu extends Component {
         this.emojis = getOperatingSystem() === CONST.OS.WINDOWS
             ? emojis.slice(0, this.unfilteredHeaderIndices.pop())
             : emojis;
-        
+
         this.filterEmojis = _.debounce(this.filterEmojis.bind(this), 300);
         this.highlightAdjacentEmoji = this.highlightAdjacentEmoji.bind(this);
         this.scrollToHighlightedIndex = this.scrollToHighlightedIndex.bind(this);

--- a/src/pages/home/report/EmojiPickerMenu/index.js
+++ b/src/pages/home/report/EmojiPickerMenu/index.js
@@ -11,6 +11,7 @@ import TextInputFocusable from '../../../../components/TextInputFocusable';
 import withWindowDimensions, {windowDimensionsPropTypes} from '../../../../components/withWindowDimensions';
 import withLocalize, {withLocalizePropTypes} from '../../../../components/withLocalize';
 import compose from '../../../../libs/compose';
+import getOperatingSystem from '../../../../libs/getOperatingSystem';
 
 const propTypes = {
     // Function to add the selected emoji to the main compose text input
@@ -49,7 +50,13 @@ class EmojiPickerMenu extends Component {
         // The positions are static, and are calculated as index/numColumns (8 in our case)
         // This is because each row of 8 emojis counts as one index
         // If more emojis are ever added to emojis.js this will need to be updated or things will break
+        this.emojis = emojis;
         this.unfilteredHeaderIndices = [0, 33, 59, 87, 98, 120, 147];
+
+        // If we're on windows, don't display the flag emojis (the last category), since Windows doesn't support them
+        if (getOperatingSystem() === CONST.OS.WINDOWS) {
+            this.emojis = emojis.slice(0, this.unfilteredHeaderIndices.pop());
+        }
 
         this.filterEmojis = _.debounce(this.filterEmojis.bind(this), 300);
         this.highlightAdjacentEmoji = this.highlightAdjacentEmoji.bind(this);
@@ -60,7 +67,7 @@ class EmojiPickerMenu extends Component {
         this.renderItem = this.renderItem.bind(this);
 
         this.state = {
-            filteredEmojis: emojis,
+            filteredEmojis: this.emojis,
             headerIndices: this.unfilteredHeaderIndices,
             highlightedIndex: -1,
             currentScrollOffset: 0,
@@ -130,7 +137,7 @@ class EmojiPickerMenu extends Component {
      * @param {String} arrowKey
      */
     highlightAdjacentEmoji(arrowKey) {
-        const firstNonHeaderIndex = this.state.filteredEmojis.length === emojis.length ? this.numColumns : 0;
+        const firstNonHeaderIndex = this.state.filteredEmojis.length === this.emojis.length ? this.numColumns : 0;
 
         // If nothing is highlighted and an arrow key is pressed
         // select the first emoji
@@ -188,7 +195,7 @@ class EmojiPickerMenu extends Component {
     scrollToHighlightedIndex() {
         // If there are headers in the emoji array, so we need to offset by their heights as well
         let numHeaders = 0;
-        if (this.state.filteredEmojis.length === emojis.length) {
+        if (this.state.filteredEmojis.length === this.emojis.length) {
             numHeaders = this.unfilteredHeaderIndices
                 .filter(i => this.state.highlightedIndex > i * this.numColumns).length;
         }
@@ -228,14 +235,14 @@ class EmojiPickerMenu extends Component {
         if (normalizedSearchTerm === '') {
             // There are no headers when searching, so we need to re-make them sticky when there is no search term
             this.setState({
-                filteredEmojis: emojis,
+                filteredEmojis: this.emojis,
                 headerIndices: this.unfilteredHeaderIndices,
                 highlightedIndex: this.numColumns,
             });
             return;
         }
 
-        const newFilteredEmojiList = _.filter(emojis, emoji => (
+        const newFilteredEmojiList = _.filter(this.emojis, emoji => (
             !emoji.header
             && emoji.code !== CONST.EMOJI_SPACER
             && _.find(emoji.keywords, keyword => keyword.includes(normalizedSearchTerm))

--- a/src/pages/home/report/EmojiPickerMenu/index.js
+++ b/src/pages/home/report/EmojiPickerMenu/index.js
@@ -53,7 +53,8 @@ class EmojiPickerMenu extends Component {
         this.emojis = emojis;
         this.unfilteredHeaderIndices = [0, 33, 59, 87, 98, 120, 147];
 
-        // If we're on windows, don't display the flag emojis (the last category), since Windows doesn't support them
+        // If we're on Windows, don't display the flag emojis (the last category),
+        // since Windows doesn't support them (and only displays country codes)
         if (getOperatingSystem() === CONST.OS.WINDOWS) {
             this.emojis = emojis.slice(0, this.unfilteredHeaderIndices.pop());
         }

--- a/src/pages/home/report/EmojiPickerMenu/index.js
+++ b/src/pages/home/report/EmojiPickerMenu/index.js
@@ -50,15 +50,14 @@ class EmojiPickerMenu extends Component {
         // The positions are static, and are calculated as index/numColumns (8 in our case)
         // This is because each row of 8 emojis counts as one index
         // If more emojis are ever added to emojis.js this will need to be updated or things will break
-        this.emojis = emojis;
         this.unfilteredHeaderIndices = [0, 33, 59, 87, 98, 120, 147];
 
         // If we're on Windows, don't display the flag emojis (the last category),
         // since Windows doesn't support them (and only displays country codes)
-        if (getOperatingSystem() === CONST.OS.WINDOWS) {
-            this.emojis = emojis.slice(0, this.unfilteredHeaderIndices.pop());
-        }
-
+        this.emojis = getOperatingSystem() === CONST.OS.WINDOWS
+            ? emojis.slice(0, this.unfilteredHeaderIndices.pop())
+            : emojis;
+        
         this.filterEmojis = _.debounce(this.filterEmojis.bind(this), 300);
         this.highlightAdjacentEmoji = this.highlightAdjacentEmoji.bind(this);
         this.scrollToHighlightedIndex = this.scrollToHighlightedIndex.bind(this);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Windows doesn't support flag emojis (and just displays country codes instead), so let's prevent those emojis from displaying in the emoji picker if we're on Windows.

To do this, I added a function `getOperatingSystem` that reads the current operating system.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/2761

### Tests
For the `getOperatingSystem` function, I logged its results for all operating systems and verified that they were correct. 

I then verified that flag emojis don't appear in the emoji picker on Windows.



### QA Steps
1. On a Windows laptop, sign in, and navigate to any chat.
2. Open the emoji picker. Scroll down to the bottom and verify that there is no "Flags" category.

### Tested On

- [x] Web

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
https://user-images.githubusercontent.com/31285285/117775650-4abcd200-b26d-11eb-859c-194b4fba9265.mp4



