### PR TITLE
Automatically add label AutoAssignerTriage to issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,7 @@
+---
+labels: AutoAssignerTriage
+---
+
 If you haven’t already, check out our [contributing guidelines](https://github.com/Expensify/ReactNativeChat/blob/main/CONTRIBUTING.md) for onboarding and email contributors@expensify.com to request to join our Slack channel!
 ___
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

Adding label `AutoAssignerTriage` to be automatically added to new issues created with the template. Users _can_ remove the label if they want (which is perfect, in case employees want to create issues that don't need to be triaged immediately).

cc @roryabraham @AndrewGable @arielgreen 

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes https://github.com/Expensify/Expensify/issues/163447

### Tests

N/A (can only test in production after clicking "new issue"

### QA Steps

N/A

### Tested On

N/A

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

N/A

