### PR TITLE
Use debounce for onDimensionChange in withWindowDimensions HOC

### DIFF
--- a/src/components/withWindowDimensions.js
+++ b/src/components/withWindowDimensions.js
@@ -1,4 +1,5 @@
 import React, {Component} from 'react';
+import _ from 'underscore';
 import PropTypes from 'prop-types';
 import {Dimensions} from 'react-native';
 import getComponentDisplayName from '../libs/getComponentDisplayName';
@@ -28,7 +29,7 @@ export default function (WrappedComponent) {
         constructor(props) {
             super(props);
 
-            this.onDimensionChange = this.onDimensionChange.bind(this);
+            this.onDimensionChange = _.debounce(this.onDimensionChange.bind(this), 100);
 
             const initialDimensions = Dimensions.get('window');
             const isSmallScreenWidth = initialDimensions.width <= variables.mobileResponsiveWidthBreakpoint;

--- a/src/components/withWindowDimensions.js
+++ b/src/components/withWindowDimensions.js
@@ -29,6 +29,13 @@ export default function (WrappedComponent) {
         constructor(props) {
             super(props);
 
+            // Using debounce here as a temporary fix for a bug in react-native
+            // https://github.com/facebook/react-native/issues/29290
+            // When the app is sent to background on iPads, onDimensionChange callback is called with
+            // swapped window dimensions before it was called with correct dimensions within miliseconds, then
+            // drawer is being positioned incorrectly due to animation issues in react-navigation.
+            // Adding debounce here slows down window dimension changes to let
+            // react-navigation to complete the positioning of elements properly.
             this.onDimensionChange = _.debounce(this.onDimensionChange.bind(this), 100);
 
             const initialDimensions = Dimensions.get('window');


### PR DESCRIPTION
cc @deetergp 

### Details
React native has a bug where it calls onDimensionChange callback with swapped dimensions for a very short time before it's called with correct dimensions. https://github.com/facebook/react-native/issues/29290

When this happens, a bug in react-navigation causes left menu to be positioned in the center instead of left side. We're fixing this issue by using debounce to prevent onDimensionChange callback from being called multiple times within 100ms to let react-navigation to complete its animations and positioning elements properly.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/2180

### Tests
Verified that left menu is not shown in the center when the app is loaded from background on iPad devices.

### QA Steps

1. Launch App on iPad with iOS 12
2. Open any chat
3. Switch orientation of iPad from landscape to portrait
4. Switch orientation back to landscape
5. Tap on home button on iPAD to put app into the background
6. Open App from background
7. Observe that left menu is not shown in the center

### Tested On

- [X] Web
- [X] Mobile Web
- [X] Desktop
- [X] iOS
- [X] Android

### Screenshots

#### iOS

https://user-images.githubusercontent.com/3853003/117861354-40103600-b289-11eb-9024-55490b5ccc79.mov

