### PR TITLE
Fix translation typo on AddSecondaryLoginPage

### DIFF
--- a/src/pages/settings/AddSecondaryLoginPage.js
+++ b/src/pages/settings/AddSecondaryLoginPage.js
@@ -135,7 +135,7 @@ class AddSecondaryLoginPage extends Component {
                             </View>
                             <View style={styles.mb6}>
                                 <Text style={[styles.mb1, styles.formLabel]}>
-                                    {this.props.translate('addSecondaryLoginPage.password')}
+                                    {this.props.translate('common.password')}
                                 </Text>
                                 <TextInput
                                     style={styles.textInput}


### PR DESCRIPTION
### Details
Fixes typo on AddSecondaryLogin page, where `addSecondaryLoginPage.password` translation key was used instead of `common.password`

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/2408

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android
