### PR TITLE
Set openByDefault prop only for small screen width

### DIFF
--- a/src/libs/Navigation/AppNavigator/MainDrawerNavigator.js
+++ b/src/libs/Navigation/AppNavigator/MainDrawerNavigator.js
@@ -55,7 +55,7 @@ const MainDrawerNavigator = (props) => {
     * This is usually needed after login/create account and re-launches */
     return (
         <Drawer.Navigator
-            openByDefault
+            openByDefault={props.isSmallScreenWidth}
             drawerType={getNavigationDrawerType(props.isSmallScreenWidth)}
             drawerStyle={getNavigationDrawerStyle(
                 props.windowWidth,


### PR DESCRIPTION
cc @Jag96 

### Details
When we set openByDefault on persistent drawer, it stays open when the orientation is changed back to portrait even though the current route is set to a chat. This is causing an issue in react-navigation and drawer is not being closed when another chat is selected. 

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/2447

### Tests
Verified that chats are accessible when the orientation is switched between landscape and portrait. And chat view is not closed when the app is sent to background.

### QA Steps

1. Open app in Landscape orientation
2. Open any chat
3. Rotate device to Portrait
4. Observe that chat window is visible instead of drawer
5. Try to open another chat
6. Observe that drawer is closed and chat view is opened

### Tested On

- [X] Web
- [X] Mobile Web
- [X] Desktop
- [X] iOS
- [X] Android

### Screenshots

#### Mobile Web
https://user-images.githubusercontent.com/3853003/117899787-c6e00580-b2bf-11eb-9ae1-17cfff6336ea.mov

#### Desktop

https://user-images.githubusercontent.com/3853003/117900100-71582880-b2c0-11eb-8a63-0cb8d80256fa.mov


#### iOS (iPhone)

https://user-images.githubusercontent.com/3853003/117898949-09084780-b2be-11eb-8e4c-c860b615fbd0.mov

#### iOS (iPad)

https://user-images.githubusercontent.com/3853003/117899551-45887300-b2bf-11eb-80d0-f156ac70353a.mov

#### Android

https://user-images.githubusercontent.com/3853003/117902756-132e4400-b2c6-11eb-9e19-956a8bf8ab9e.mov

