### PR TITLE
Added dynamic repositioning for Context menu on resize

### DIFF
--- a/src/components/Hoverable/index.js
+++ b/src/components/Hoverable/index.js
@@ -69,6 +69,9 @@ class Hoverable extends Component {
      * @param {Object} event - A click event
      */
     resetHoverStateOnOutsideClick(event) {
+        if (!this.state.isHovered) {
+            return;
+        }
         if (this.wrapperView && !this.wrapperView.contains(event.target)) {
             this.setIsHovered(false);
         }

--- a/src/components/PopoverWithMeasuredContent.js
+++ b/src/components/PopoverWithMeasuredContent.js
@@ -66,9 +66,12 @@ class PopoverWithMeasuredContent extends Component {
     shouldComponentUpdate(nextProps, nextState) {
         if (this.props.isVisible
             && (nextProps.windowWidth !== this.props.windowWidth
-                || nextProps.windowHeight !== this.props.windowHeight)) {
+            || nextProps.windowHeight !== this.props.windowHeight)) {
             return true;
         }
+
+        // This component does not require re-render until any prop or state changes as we get the necessary info
+        // at first render. This component is attached to each message on the Chat list thus we prevent its re-renders
         return !_.isEqual(
             _.omit(this.props, ['windowWidth', 'windowHeight']),
             _.omit(nextProps, ['windowWidth', 'windowHeight']),
@@ -129,7 +132,6 @@ class PopoverWithMeasuredContent extends Component {
     }
 
     render() {
-        console.debug('render');
         const adjustedAnchorPosition = this.calculateAdjustedAnchorPosition();
         const horizontalShift = computeHorizontalShift(
             adjustedAnchorPosition.left,

--- a/src/components/PopoverWithMeasuredContent.js
+++ b/src/components/PopoverWithMeasuredContent.js
@@ -64,7 +64,15 @@ class PopoverWithMeasuredContent extends Component {
     }
 
     shouldComponentUpdate(nextProps, nextState) {
-        return !_.isEqual(this.props, nextProps) || !_.isEqual(this.state, nextState);
+        if (this.props.isVisible
+            && (nextProps.windowWidth !== this.props.windowWidth
+                || nextProps.windowHeight !== this.props.windowHeight)) {
+            return true;
+        }
+        return !_.isEqual(
+            _.omit(this.props, ['windowWidth', 'windowHeight']),
+            _.omit(nextProps, ['windowWidth', 'windowHeight']),
+        ) || !_.isEqual(this.state, nextState);
     }
 
     /**
@@ -121,6 +129,7 @@ class PopoverWithMeasuredContent extends Component {
     }
 
     render() {
+        console.debug('render');
         const adjustedAnchorPosition = this.calculateAdjustedAnchorPosition();
         const horizontalShift = computeHorizontalShift(
             adjustedAnchorPosition.left,

--- a/src/components/PopoverWithMeasuredContent.js
+++ b/src/components/PopoverWithMeasuredContent.js
@@ -29,6 +29,8 @@ const propTypes = {
     // A function with content to measure. This component will use this.props.children by default,
     // but in the case the children are not displayed, the measurement will not work.
     measureContent: PropTypes.func.isRequired,
+
+    ...windowDimensionsPropTypes,
 };
 
 const defaultProps = {

--- a/src/components/PopoverWithMeasuredContent.js
+++ b/src/components/PopoverWithMeasuredContent.js
@@ -4,15 +4,15 @@ import PropTypes from 'prop-types';
 import {View} from 'react-native';
 import Popover from './Popover';
 import {propTypes as popoverPropTypes, defaultProps as defaultPopoverProps} from './Popover/PopoverPropTypes';
-import {windowDimensionsPropTypes} from './withWindowDimensions';
+import withWindowDimensions, {windowDimensionsPropTypes} from './withWindowDimensions';
 import CONST from '../CONST';
 import styles from '../styles/styles';
+import {computeHorizontalShift, computeVerticalShift} from '../styles/getPopoverWithMeasuredContentStyles';
 
 const propTypes = {
     // All popover props except:
     // 1) anchorPosition (which is overridden for this component)
-    // 2) windowDimensionsPropTypes, which is unneeded.
-    ...(_.omit(popoverPropTypes, ['anchorPosition', ...(_.keys(windowDimensionsPropTypes))])),
+    ...(_.omit(popoverPropTypes, ['anchorPosition'])),
 
     // The horizontal and vertical anchors points for the popover
     anchorPosition: PropTypes.shape({
@@ -119,12 +119,27 @@ class PopoverWithMeasuredContent extends Component {
     }
 
     render() {
+        const adjustedAnchorPosition = this.calculateAdjustedAnchorPosition();
+        const horizontalShift = computeHorizontalShift(
+            adjustedAnchorPosition.left,
+            this.popoverWidth,
+            this.props.windowWidth,
+        );
+        const verticalShift = computeVerticalShift(
+            adjustedAnchorPosition.top,
+            this.popoverHeight,
+            this.props.windowHeight,
+        );
+        const shifedAnchorPosition = {
+            left: adjustedAnchorPosition.left + horizontalShift,
+            top: adjustedAnchorPosition.top + verticalShift,
+        };
         return this.state.isContentMeasured
             ? (
                 <Popover
                     // eslint-disable-next-line react/jsx-props-no-spreading
                     {...this.props}
-                    anchorPosition={this.calculateAdjustedAnchorPosition()}
+                    anchorPosition={shifedAnchorPosition}
                 >
                     {this.props.measureContent()}
                 </Popover>
@@ -146,4 +161,4 @@ class PopoverWithMeasuredContent extends Component {
 PopoverWithMeasuredContent.propTypes = propTypes;
 PopoverWithMeasuredContent.defaultProps = defaultProps;
 
-export default PopoverWithMeasuredContent;
+export default withWindowDimensions(PopoverWithMeasuredContent);

--- a/src/components/PressableWithSecondaryInteraction/index.js
+++ b/src/components/PressableWithSecondaryInteraction/index.js
@@ -66,5 +66,7 @@ class PressableWithSecondaryInteraction extends Component {
 
 PressableWithSecondaryInteraction.propTypes = propTypes;
 PressableWithSecondaryInteraction.defaultProps = defaultProps;
-// eslint-disable-next-line react/jsx-props-no-spreading
-export default React.forwardRef((props, ref) => <PressableWithSecondaryInteraction {...props} forwardedRef={ref} />);
+export default React.forwardRef((props, ref) => (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <PressableWithSecondaryInteraction {...props} forwardedRef={ref} />
+));

--- a/src/components/PressableWithSecondaryInteraction/index.js
+++ b/src/components/PressableWithSecondaryInteraction/index.js
@@ -9,6 +9,13 @@ const propTypes = {
 
     // The children which should be contained in this wrapper component.
     children: PropTypes.node.isRequired,
+
+    // The ref to the search input (may be null on small screen widths)
+    forwardedRef: PropTypes.func,
+};
+
+const defaultProps = {
+    forwardedRef: () => {},
 };
 
 /**
@@ -22,6 +29,9 @@ class PressableWithSecondaryInteraction extends Component {
     }
 
     componentDidMount() {
+        if (this.props.forwardedRef && _.isFunction(this.props.forwardedRef)) {
+            this.props.forwardedRef(this.pressableRef);
+        }
         this.pressableRef.addEventListener('contextmenu', this.executeSecondaryInteractionOnContextMenu);
     }
 
@@ -55,5 +65,6 @@ class PressableWithSecondaryInteraction extends Component {
 }
 
 PressableWithSecondaryInteraction.propTypes = propTypes;
-
-export default PressableWithSecondaryInteraction;
+PressableWithSecondaryInteraction.defaultProps = defaultProps;
+// eslint-disable-next-line react/jsx-props-no-spreading
+export default React.forwardRef((props, ref) => <PressableWithSecondaryInteraction {...props} forwardedRef={ref} />);

--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -107,6 +107,7 @@ class ReportActionItem extends Component {
 
     /**
      * Get the Context menu anchor position
+     * We calculate the achor coordinates from measureInWindow async method
      *
      * @returns {Promise<Object>}
      * @memberof ReportActionItem

--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -233,7 +233,11 @@ class ReportActionItem extends Component {
                                 <UnreadActionIndicator />
                             )}
                             <View
-                                style={getReportActionItemStyle(hovered || this.props.draftMessage)}
+                                style={getReportActionItemStyle(
+                                    hovered
+                                    || this.state.isPopoverVisible
+                                    || this.props.draftMessage,
+                                )}
                                 onLayout={this.props.onLayout}
                             >
                                 {!this.props.displayAsGroup

--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -80,6 +80,7 @@ class ReportActionItem extends Component {
         this.popoverAnchor = null;
         this.showPopover = this.showPopover.bind(this);
         this.hidePopover = this.hidePopover.bind(this);
+        this.measureContent = this.measureContent.bind(this);
         this.selection = '';
         this.measureContextMenuAnchorPosition = this.measureContextMenuAnchorPosition.bind(this);
     }
@@ -179,6 +180,24 @@ class ReportActionItem extends Component {
         this.setState({isPopoverVisible: false});
     }
 
+    /**
+     * Used to calculate the Context Menu Dimensions
+     *
+     * @returns {JSX}
+     * @memberof ReportActionItem
+     */
+    measureContent() {
+        return (
+            <ReportActionContextMenu
+                isVisible
+                selection={this.selection}
+                reportID={this.props.reportID}
+                reportAction={this.props.action}
+                hidePopover={this.hidePopover}
+            />
+        );
+    }
+
     render() {
         let children;
         if (this.props.action.actionName === 'IOU') {
@@ -242,33 +261,25 @@ class ReportActionItem extends Component {
                                     isMini
                                 />
                             </View>
-                            <PopoverWithMeasuredContent
-                                isVisible={this.state.isPopoverVisible}
-                                onClose={this.hidePopover}
-                                anchorPosition={this.state.popoverAnchorPosition}
-                                animationIn="fadeIn"
-                                animationOutTiming={1}
-                                measureContent={() => (
-                                    <ReportActionContextMenu
-                                        isVisible
-                                        selection={this.selection}
-                                        reportID={this.props.reportID}
-                                        reportAction={this.props.action}
-                                        hidePopover={this.hidePopover}
-                                    />
-                                )}
-                            >
-                                <ReportActionContextMenu
-                                    isVisible
-                                    reportID={this.props.reportID}
-                                    reportAction={this.props.action}
-                                    draftMessage={this.props.draftMessage}
-                                    hidePopover={this.hidePopover}
-                                />
-                            </PopoverWithMeasuredContent>
                         </View>
                     )}
                 </Hoverable>
+                <PopoverWithMeasuredContent
+                    isVisible={this.state.isPopoverVisible}
+                    onClose={this.hidePopover}
+                    anchorPosition={this.state.popoverAnchorPosition}
+                    animationIn="fadeIn"
+                    animationOutTiming={1}
+                    measureContent={this.measureContent}
+                >
+                    <ReportActionContextMenu
+                        isVisible
+                        reportID={this.props.reportID}
+                        reportAction={this.props.action}
+                        draftMessage={this.props.draftMessage}
+                        hidePopover={this.hidePopover}
+                    />
+                </PopoverWithMeasuredContent>
             </PressableWithSecondaryInteraction>
         );
     }

--- a/src/styles/getPopoverWithMeasuredContentStyles.js
+++ b/src/styles/getPopoverWithMeasuredContentStyles.js
@@ -1,0 +1,58 @@
+import {roundToNearestMultipleOfFour} from './util';
+import variables from './variables';
+
+/**
+ * Compute the amount that the Context menu's Anchor needs to be horizontally shifted
+ * in order to keep it from displaying in the gutters.
+ *
+ * @param {Number} anchorLeftEdge - Menu's anchor Left edge.
+ * @param {Number} menuWidth - The width of the menu itself.
+ * @param {Number} windowWidth - The width of the Window.
+ * @returns {Number}
+ */
+function computeHorizontalShift(anchorLeftEdge, menuWidth, windowWidth) {
+    const popoverRightEdge = anchorLeftEdge + menuWidth;
+    if (anchorLeftEdge < variables.gutterWidth) {
+        // Anchor is in left gutter, shift right by a multiple of four.
+        return roundToNearestMultipleOfFour(variables.gutterWidth - anchorLeftEdge);
+    }
+
+    if (popoverRightEdge > (windowWidth - variables.gutterWidth)) {
+        // Anchor is in right gutter, shift left by a multiple of four.
+        return roundToNearestMultipleOfFour(windowWidth - variables.gutterWidth - popoverRightEdge);
+    }
+
+    // Anchor is not in the gutter, so no need to shift it horizontally
+    return 0;
+}
+
+/**
+ * Compute the amount that the Context menu's Anchor needs to be vertically shifted
+ * in order to keep it from displaying in the window.
+ *
+ * @param {Number} anchorTopEdge - Menu's anchor Top edge.
+ * @param {Number} menuHeight - The height of the menu itself.
+ * @param {Number} windowHeight - The height of the Window.
+ * @returns {Number}
+ */
+function computeVerticalShift(anchorTopEdge, menuHeight, windowHeight) {
+    const popoverBottomEdge = anchorTopEdge + menuHeight;
+
+    if (anchorTopEdge < 0) {
+        // Anchor is in top window Edge, shift bottom by a multiple of four.
+        return roundToNearestMultipleOfFour(0 - anchorTopEdge);
+    }
+
+    if (popoverBottomEdge > windowHeight) {
+        // Anchor is in Bottom window Edge, shift top by a multiple of four.
+        return roundToNearestMultipleOfFour(windowHeight - popoverBottomEdge);
+    }
+
+    // Anchor is not in the gutter, so no need to shift it vertically
+    return 0;
+}
+
+export {
+    computeHorizontalShift,
+    computeVerticalShift,
+};

--- a/src/styles/getPopoverWithMeasuredContentStyles.js
+++ b/src/styles/getPopoverWithMeasuredContentStyles.js
@@ -1,4 +1,4 @@
-import {roundToNearestMultipleOfFour} from './util';
+import roundToNearestMultipleOfFour from './roundToNearestMultipleOfFour';
 import variables from './variables';
 
 /**

--- a/src/styles/getTooltipStyles.js
+++ b/src/styles/getTooltipStyles.js
@@ -4,7 +4,7 @@ import colors from './colors';
 import themeColors from './themes/default';
 import fontFamily from './fontFamily';
 import variables from './variables';
-import {roundToNearestMultipleOfFour} from './util';
+import roundToNearestMultipleOfFour from './roundToNearestMultipleOfFour';
 
 // This defines the proximity with the edge of the window in which tooltips should not be displayed.
 // If a tooltip is too close to the edge of the screen, we'll shift it towards the center.

--- a/src/styles/getTooltipStyles.js
+++ b/src/styles/getTooltipStyles.js
@@ -4,36 +4,17 @@ import colors from './colors';
 import themeColors from './themes/default';
 import fontFamily from './fontFamily';
 import variables from './variables';
+import {roundToNearestMultipleOfFour} from './util';
 
 // This defines the proximity with the edge of the window in which tooltips should not be displayed.
 // If a tooltip is too close to the edge of the screen, we'll shift it towards the center.
-const GUTTER_WIDTH = 16;
+const GUTTER_WIDTH = variables.gutterWidth;
 
 // The height of a tooltip pointer
 const POINTER_HEIGHT = 4;
 
 // The width of a tooltip pointer
 const POINTER_WIDTH = 12;
-
-/**
- * The Expensify.cash repo is very consistent about doing spacing in multiples of 4.
- * In an effort to maintain that consistency, we'll make sure that any distance we're shifting the tooltip
- * is a multiple of 4.
- *
- * @param {Number} n
- * @returns {Number}
- */
-function roundToNearestMultipleOfFour(n) {
-    if (n > 0) {
-        return Math.ceil(n / 4.0) * 4;
-    }
-
-    if (n < 0) {
-        return Math.floor(n / 4.0) * 4;
-    }
-
-    return 0;
-}
 
 /**
  * Compute the amount the tooltip needs to be horizontally shifted in order to keep it from displaying in the gutters.

--- a/src/styles/roundToNearestMultipleOfFour.js
+++ b/src/styles/roundToNearestMultipleOfFour.js
@@ -18,5 +18,4 @@ function roundToNearestMultipleOfFour(n) {
     return 0;
 }
 
-// eslint-disable-next-line import/prefer-default-export
-export {roundToNearestMultipleOfFour};
+export default roundToNearestMultipleOfFour;

--- a/src/styles/util.js
+++ b/src/styles/util.js
@@ -1,0 +1,22 @@
+/**
+ * The Expensify.cash repo is very consistent about doing spacing in multiples of 4.
+ * In an effort to maintain that consistency, we'll make sure that any distance we're shifting the components
+ * are a multiple of 4.
+ *
+ * @param {Number} n
+ * @returns {Number}
+ */
+function roundToNearestMultipleOfFour(n) {
+    if (n > 0) {
+        return Math.ceil(n / 4.0) * 4;
+    }
+
+    if (n < 0) {
+        return Math.floor(n / 4.0) * 4;
+    }
+
+    return 0;
+}
+
+// eslint-disable-next-line import/prefer-default-export
+export {roundToNearestMultipleOfFour};

--- a/src/styles/variables.js
+++ b/src/styles/variables.js
@@ -26,4 +26,5 @@ export default {
     sideBarWidth: 375,
     pdfPageMaxWidth: 992,
     tooltipzIndex: 10050,
+    gutterWidth: 16,
 };


### PR DESCRIPTION
Please review

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes #2784

### Tests \ QA Steps
1. Open any chat.
2. Right-click the Chat message.
3. Context menu should open.
#### Test 1
Resize the browser to see if the context menu is moved along.
#### Test 2
Right-click any message near the edge of the window. The menu should be completely visible.

### Tested On

- [x] Web
- [ ] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web / Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

https://user-images.githubusercontent.com/24370807/118009932-2693ea80-b36c-11eb-8fb6-c3c1b2c15f9f.mp4
