### PR TITLE
Exclude Concierge from IOU flows (2nd attempt)

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -113,6 +113,7 @@ const CONST = {
 
     EMAIL: {
         CHRONOS: 'chronos@expensify.com',
+        CONCIERGE: 'concierge@expensify.com',
     },
 
     ENVIRONMENT: {

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -167,6 +167,7 @@ function isSearchStringMatch(searchValue, searchText) {
 function getOptions(reports, personalDetails, draftComments, activeReportID, {
     selectedOptions = [],
     maxRecentReportsToShow = 0,
+    excludeConcierge = false,
     includeMultipleParticipantReports = false,
     includePersonalDetails = false,
     includeRecentReports = false,
@@ -227,6 +228,11 @@ function getOptions(reports, personalDetails, draftComments, activeReportID, {
 
     // Always exclude already selected options and the currently logged in user
     const loginOptionsToExclude = [...selectedOptions, {login: currentUserLogin}];
+
+    if (excludeConcierge) {
+        loginOptionsToExclude.push({login: CONST.EMAIL.CONCIERGE});
+    }
+
     if (includeRecentReports) {
         for (let i = 0; i < allReportOptions.length; i++) {
             // Stop adding options to the recentReports array when we reach the maxRecentReportsToShow value
@@ -348,16 +354,19 @@ function getSearchOptions(
  * @param {Object} reports
  * @param {Object} personalDetails
  * @param {String} searchValue
+ * @param {Boolean} excludeConcierge
  * @returns {Object}
  */
 function getNewChatOptions(
     reports,
     personalDetails,
     searchValue = '',
+    excludeConcierge,
 ) {
     return getOptions(reports, personalDetails, {}, 0, {
         searchValue,
         includePersonalDetails: true,
+        excludeConcierge,
     });
 }
 
@@ -399,6 +408,7 @@ function getIOUConfirmationOptionsFromParticipants(
  * @param {Object} personalDetails
  * @param {String} searchValue
  * @param {Array} selectedOptions
+ * @param {Boolean} excludeConcierge
  * @returns {Object}
  */
 function getNewGroupOptions(
@@ -406,6 +416,7 @@ function getNewGroupOptions(
     personalDetails,
     searchValue = '',
     selectedOptions = [],
+    excludeConcierge,
 ) {
     return getOptions(reports, personalDetails, {}, 0, {
         searchValue,
@@ -414,6 +425,7 @@ function getNewGroupOptions(
         includePersonalDetails: true,
         includeMultipleParticipantReports: false,
         maxRecentReportsToShow: 5,
+        excludeConcierge,
     });
 }
 

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -537,7 +537,7 @@ function updateReportWithNewAction(reportID, reportAction) {
     }
 
     // If the comment came from Concierge let's not show a notification since we already show one for expensify.com
-    if (lodashGet(reportAction, 'actorEmail') === 'concierge@expensify.com') {
+    if (lodashGet(reportAction, 'actorEmail') === CONST.EMAIL.CONCIERGE) {
         return;
     }
 
@@ -846,7 +846,7 @@ function fetchAllReports(
                 return fetchChatReportsByIDs(reportIDs);
             }
 
-            return fetchOrCreateChatReport([currentUserEmail, 'concierge@expensify.com'], false);
+            return fetchOrCreateChatReport([currentUserEmail, CONST.EMAIL.CONCIERGE], false);
         })
         .then((returnedReportIDs) => {
             Onyx.set(ONYXKEYS.INITIAL_REPORT_DATA_LOADED, true);

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -308,10 +308,10 @@ class ReportActionCompose extends React.Component {
     render() {
         // eslint-disable-next-line no-unused-vars
         const hasMultipleParticipants = lodashGet(this.props.report, 'participants.length') > 1;
+        const hasConciergeParticipant = _.contains(this.props.report.participants, CONST.EMAIL.CONCIERGE);
 
         // Prevents focusing and showing the keyboard while the drawer is covering the chat.
         const isComposeDisabled = this.props.isDrawerOpen && this.props.isSmallScreenWidth;
-
         return (
             <View style={[styles.chatItemCompose]}>
                 <View style={[
@@ -352,7 +352,7 @@ class ReportActionCompose extends React.Component {
                                                 animationIn="fadeInUp"
                                                 animationOut="fadeOutDown"
                                                 menuItems={[
-                                                    ...(Permissions.canUseIOU() ? [
+                                                    ...(!hasConciergeParticipant && Permissions.canUseIOU() ? [
                                                         hasMultipleParticipants
                                                             ? {
                                                                 icon: Receipt,

--- a/src/pages/iou/steps/IOUParticipantsPage/IOUParticipantsRequest.js
+++ b/src/pages/iou/steps/IOUParticipantsPage/IOUParticipantsRequest.js
@@ -48,6 +48,7 @@ class IOUParticipantsRequest extends Component {
             props.reports,
             props.personalDetails,
             '',
+            true,
         );
 
         this.state = {
@@ -105,6 +106,7 @@ class IOUParticipantsRequest extends Component {
                         this.props.reports,
                         this.props.personalDetails,
                         searchValue,
+                        true,
                     );
                     this.setState({
                         searchValue,

--- a/src/pages/iou/steps/IOUParticipantsPage/IOUParticipantsSplit.js
+++ b/src/pages/iou/steps/IOUParticipantsPage/IOUParticipantsSplit.js
@@ -80,6 +80,7 @@ class IOUParticipantsSplit extends Component {
             props.personalDetails,
             '',
             props.participants,
+            true,
         );
 
         this.state = {
@@ -179,6 +180,7 @@ class IOUParticipantsSplit extends Component {
                 this.props.personalDetails,
                 isOptionInList ? prevState.searchValue : '',
                 newSelectedOptions,
+                true,
             );
             return {
                 recentReports,
@@ -213,6 +215,7 @@ class IOUParticipantsSplit extends Component {
                             this.props.personalDetails,
                             searchValue,
                             [],
+                            true,
                         );
                         this.setState({
                             searchValue,

--- a/tests/unit/OptionsListUtilsTest.js
+++ b/tests/unit/OptionsListUtilsTest.js
@@ -131,6 +131,29 @@ describe('OptionsListUtils', () => {
         },
     };
 
+    const REPORTS_WITH_CONCIERGE = {
+        ...REPORTS,
+
+        9: {
+            lastVisitedTimestamp: 1610666739302,
+            lastMessageTimestamp: 1,
+            isPinned: false,
+            reportID: 9,
+            participants: ['concierge@expensify.com'],
+            reportName: 'Concierge',
+            unreadActionCount: 1,
+        },
+    };
+
+    const PERSONAL_DETAILS_WITH_CONCIERGE = {
+        ...PERSONAL_DETAILS,
+
+        'concierge@expensify.com': {
+            displayName: 'Concierge',
+            login: 'concierge@expensify.com',
+        },
+    };
+
     // Set the currently logged in user, report data, and personal details
     beforeAll(() => {
         Onyx.init({
@@ -210,6 +233,29 @@ describe('OptionsListUtils', () => {
         expect(results.personalDetails[0].text).toBe('Spider-Man');
         expect(results.personalDetails[1].text).toBe('Invisible Woman');
         expect(results.personalDetails[2].login).toBe('natasharomanoff@expensify.com');
+
+        // Test for Concierge's existence in chat options
+        results = OptionsListUtils.getNewChatOptions(REPORTS_WITH_CONCIERGE, PERSONAL_DETAILS_WITH_CONCIERGE);
+
+        // Concierge is included in the results by default and all the personalDetails should be returned
+        // minus the currently logged in user
+        expect(results.personalDetails.length).toBe(_.size(PERSONAL_DETAILS_WITH_CONCIERGE) - 1);
+        expect(results.personalDetails).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({login: 'concierge@expensify.com'}),
+            ]),
+        );
+
+        // Test by excluding Concierge from the results
+        results = OptionsListUtils.getNewChatOptions(REPORTS_WITH_CONCIERGE, PERSONAL_DETAILS_WITH_CONCIERGE, '', true);
+
+        // All the personalDetails should be returned minus the currently logged in user and Concierge
+        expect(results.personalDetails.length).toBe(_.size(PERSONAL_DETAILS_WITH_CONCIERGE) - 2);
+        expect(results.personalDetails).not.toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({login: 'concierge@expensify.com'}),
+            ]),
+        );
     });
 
     it('getNewGroupOptions()', () => {
@@ -311,6 +357,41 @@ describe('OptionsListUtils', () => {
         expect(results.personalDetails.length).toBe(0);
         expect(results.userToInvite).not.toBe(null);
         expect(results.userToInvite.login).toBe('+15005550006');
+
+        // Test Concierge's existence in new group options
+        results = OptionsListUtils.getNewGroupOptions(REPORTS_WITH_CONCIERGE, PERSONAL_DETAILS_WITH_CONCIERGE);
+
+        // Concierge is included in the results by default. We should expect all the personalDetails to show
+        // (minus the 5 that are already showing and the currently logged in user)
+        expect(results.personalDetails.length).toBe(_.size(PERSONAL_DETAILS_WITH_CONCIERGE) - 6);
+        expect(results.recentReports).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({login: 'concierge@expensify.com'}),
+            ]),
+        );
+
+        // Test by excluding Concierge from the results
+        results = OptionsListUtils.getNewGroupOptions(
+            REPORTS_WITH_CONCIERGE,
+            PERSONAL_DETAILS_WITH_CONCIERGE,
+            '',
+            [],
+            true,
+        );
+
+        // We should expect all the personalDetails to show (minus the 5 that are already showing,
+        // the currently logged in user and Concierge)
+        expect(results.personalDetails.length).toBe(_.size(PERSONAL_DETAILS_WITH_CONCIERGE) - 7);
+        expect(results.personalDetails).not.toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({login: 'concierge@expensify.com'}),
+            ]),
+        );
+        expect(results.recentReports).not.toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({login: 'concierge@expensify.com'}),
+            ]),
+        );
     });
 
     it('getSidebarOptions() with default priority mode', () => {


### PR DESCRIPTION
cc @Luke9389 @roryabraham 

### Details
This is a duplicate of https://github.com/Expensify/Expensify.cash/pull/2740 and I'm using `_.contains()` to avoid crashing the app if `this.props.report.participant` is `undefined`.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/2698

### Tests
* Tested manually and made sure that users cannot initiate IOU request with Concierge.
* Tested group creation and verified it's not crashing as described in https://github.com/Expensify/Expensify.cash/issues/2809


### QA Steps
```
- Open 1:1 and group chat with Concierge
- Press `+` icon next to chat composer
- Observe that there is no `Request Money` or `Split Bill` option on menu
```

```
- Open 1:1 and group chat without Concierge
- Press `+` icon next to chat composer
- Observe that there is a `Request Money` or `Split Bill` option on menu
```

```
- Press big green `+` icon on the sidebar
- Select `Request Money` or `Split Bill`
- Enter a random amount and press `Next`
- Search Concierge
- Observe that Concierge doesn't appear among results
```

Q&A steps for group creation issue https://github.com/Expensify/Expensify.cash/issues/2809
```
* Launch the app and login
* Create a group with 2 or more users
* Focus on the input field to type
```

### Tested On

- [X] Web
- [X] Mobile Web
- [X] Desktop
- [X] iOS
- [X] Android

### Screenshots


#### Web
<img width="1440" alt="Screenshot 2021-05-13 at 00 47 33" src="https://user-images.githubusercontent.com/3853003/118057909-dd03c980-b384-11eb-95bc-e4f4a5729864.png">
<img width="1440" alt="Screenshot 2021-05-13 at 00 47 18" src="https://user-images.githubusercontent.com/3853003/118057915-df662380-b384-11eb-8c8c-489326c1319f.png">
<img width="1440" alt="Screenshot 2021-05-13 at 00 46 59" src="https://user-images.githubusercontent.com/3853003/118057920-dffeba00-b384-11eb-977c-c9fdc042f7a6.png">
<img width="1440" alt="Screenshot 2021-05-13 at 00 46 48" src="https://user-images.githubusercontent.com/3853003/118057921-e0975080-b384-11eb-8240-4361e1049fb2.png">
<img width="1439" alt="Screenshot 2021-05-13 at 00 46 37" src="https://user-images.githubusercontent.com/3853003/118057922-e12fe700-b384-11eb-974f-c9bd0cfb1b9a.png">
<img width="1440" alt="Screenshot 2021-05-13 at 00 46 24" src="https://user-images.githubusercontent.com/3853003/118057923-e1c87d80-b384-11eb-88bd-34fc3260680d.png">

