### PR TITLE
Fix auto-adding AutoAssignerTriage label to new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,6 @@
 ---
+name: ""
+about: ""
 labels: AutoAssignerTriage
 ---
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
 ---
-name: ""
-about: ""
+name: Standard issue template
+about: A standard template to follow when creating an issue in this repository
 labels: AutoAssignerTriage
 ---
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
 
### Details
<!-- Explanation of the change or anything fishy that is going on -->

`name:` and `about:` front-matter need to be added (and not empty) in `ISSUE_TEMPLATE.md` to make label-adding work.

I found this text in [Github Documentation](https://docs.github.com/en/github-ae@latest/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates):

> To be included in the community profile checklist, issue templates must be located in the `.github/ISSUE_TEMPLATE` folder and contain valid `name:` and `about:` YAML front matter.

I tried setting empty `name:` and `about:` values in my personal repo [here](https://github.com/Beamanator/Just-To-Learn/blob/master/.github/ISSUE_TEMPLATE/add_label_invalid.md), but you can clearly the error stating these values cannot be empty:

<img width="650" alt="Screen Shot 2021-05-13 at 11 01 59 AM" src="https://user-images.githubusercontent.com/3885503/118104922-08fe6980-b3dc-11eb-8d26-307a8b7557da.png">

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes https://github.com/Expensify/Expensify/issues/163447

### Tests
Once merged, try creating a new issue in this repo & notice if `AutoAssignerTriage` was automatically added to the issue. You shouldn't have to create the issue to see the label, you just have to click "New Issue" and the label should be added.

### QA Steps
See above

### Tested On

- [x] Github (my personal repo)

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

N/A
