### PR TITLE
Make sure we show the compose box on login

### DIFF
--- a/src/libs/actions/Session.js
+++ b/src/libs/actions/Session.js
@@ -23,7 +23,10 @@ Onyx.connect({
 function setSuccessfulSignInData(data) {
     PushNotification.register(data.accountID);
     Onyx.multiSet({
-        [ONYXKEYS.SESSION]: _.pick(data, 'authToken', 'accountID', 'email'),
+        [ONYXKEYS.SESSION]: {
+            shouldShowComposeInput: true,
+            ..._.pick(data, 'authToken', 'accountID', 'email'),
+        },
     });
 }
 


### PR DESCRIPTION
@Jag96 please review
h/t @parasharrajat for the suggestion [here](https://github.com/Expensify/Expensify.cash/issues/2804#issuecomment-840617799), looks like that was exactly it!

### Details
Make sure we show the compose box on login. We were setting at part of the ONYX session here: https://github.com/Expensify/Expensify.cash/blob/e1185d2e0037ac09538706dec8778e075a7d212b/src/Expensify.js#L26

But not in this other spot.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/2804

### Tests
1. Uninstall the app
2. Reinstall the app
3. Log in and navigate to a conversation 
4. Make sure the compose input shows at the bottom
![Kapture 2021-05-13 at 10 50 33](https://user-images.githubusercontent.com/4741899/118165449-27169a80-b3d9-11eb-9c83-9a0f45a1bfb1.gif)
