### PR TITLE
[NO QA] Fix location of issue template so label AutoAssignerTriage should auto-add

### DIFF
--- a/.github/ISSUE_TEMPLATE/Standard.md
+++ b/.github/ISSUE_TEMPLATE/Standard.md
@@ -1,6 +1,6 @@
 ---
 name: Standard issue template
-about: A standard template to follow when creating an issue in this repository
+about: A standard template to follow when creating a new issue in this repository
 labels: AutoAssignerTriage
 ---
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

As mentioned [here](https://github.com/Expensify/Expensify/issues/163447#issuecomment-840760462), we have to use the "new issue templates" for labels to be auto-added to new issues... I tested this in a personal repository ([code here](https://github.com/Beamanator/RIPS-Validation-CExt/edit/master/.github/ISSUE_TEMPLATE/Bug.md)). If you create an issue ([here](https://github.com/Beamanator/RIPS-Validation-CExt/issues/new/choose)) you can see the label(s) are added automatically.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes https://github.com/Expensify/Expensify/issues/163447

### Tests
After merging, open new issue via the "New Issue" -> "Get Started" (next to "Standard issue template"), see `AutoAssignerTriage` on the new issue.

### QA Steps

See above

### Tested On

- [x] Github (my personal repo)

### Screenshots

N/A
