### PR TITLE
Update repo-sync/pull-request ref to version that outputs pr_number

### DIFF
--- a/.github/workflows/updateProtectedBranch.yml
+++ b/.github/workflows/updateProtectedBranch.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Create Pull Request
         id: createPullRequest
         # Version: 2.4.3
-        uses: repo-sync/pull-request@33777245b1aace1a58c87a29c90321aa7a74bd7d
+        uses: repo-sync/pull-request@65194d8015be7624d231796ddee1cd52a5023cb3
         with:
           source_branch: ${{ env.HEAD_BRANCH }}
           destination_branch: ${{ github.event.inputs.TARGET_BRANCH }}


### PR DESCRIPTION
Fixing https://github.com/Expensify/Expensify/issues/157916
Follow-up to https://github.com/Expensify/Expensify.cash/pull/2329
Failed workflow run: https://github.com/Expensify/Expensify.cash/commit/e16252f47640d5ba5328d979a3f3c4bea746545d/checks

What happened? I was relying on an output from the repo-sync/pull-request action that [didn't exist in the commit hash we were pointing to](https://github.com/repo-sync/pull-request/commits/master). So this PR just updates our action to point at the latest commit hash: https://github.com/repo-sync/pull-request/commits/master