### PR TITLE
Fix validation of changed files in PR to update main

### DIFF
--- a/.github/workflows/updateProtectedBranch.yml
+++ b/.github/workflows/updateProtectedBranch.yml
@@ -86,7 +86,7 @@ jobs:
           pr-number: ${{ steps.createPullRequest.outputs.pr_number }}
 
       - name: Validate changed files
-        if: ${{ github.event.inputs.TARGET_BRANCH == 'main' && steps.changedFiles.outputs.files_updated == 'android/app/build.gradle ios/ExpensifyCash/Info.plist ios/ExpensifyCashTests/Info.plist package-lock.json package.json' && steps.changedFiles.outputs.files_created == '' && steps.changedFiles.outputs.files_deleted == '' }}
+        if: ${{ github.event.inputs.TARGET_BRANCH == 'main' && (steps.changedFiles.outputs.files_updated != 'android/app/build.gradle ios/ExpensifyCash/Info.plist ios/ExpensifyCashTests/Info.plist package-lock.json package.json' || steps.changedFiles.outputs.files_created != '' || steps.changedFiles.outputs.files_deleted != '') }}
         run: exit 1
 
       # TODO: Once https://github.com/hmarr/auto-approve-action/pull/186 is merged, point back at the non-forked repo


### PR DESCRIPTION
Fixing https://github.com/Expensify/Expensify/issues/157916
Following-up on https://github.com/Expensify/Expensify.cash/pull/2329
Failed workflow: https://github.com/Expensify/Expensify.cash/commit/9580f964768ede17fbbb29e5581b7078b019c8e2/checks

What happened? The validations conditional logic was just wrong – we were failing the workflow when we really wanted to continue. 