### PR TITLE
Update roryabraham/auto-approve-action ref

### DIFF
--- a/.github/workflows/updateProtectedBranch.yml
+++ b/.github/workflows/updateProtectedBranch.yml
@@ -92,7 +92,7 @@ jobs:
       # TODO: Once https://github.com/hmarr/auto-approve-action/pull/186 is merged, point back at the non-forked repo
       - name: Check for an auto approve
         # Version: 2.0.0
-        uses: roryabraham/auto-approve-action@1d9eaca19e005b39bc4495c51fc7439734b2753d
+        uses: roryabraham/auto-approve-action@6bb4a3dcf07664d0131e1c74a4bc6d0d8c849978
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pull-request-number: ${{ steps.createPullRequest.outputs.pr_number }}


### PR DESCRIPTION
Fixing https://github.com/Expensify/Expensify/issues/157916
Follow-up for https://github.com/Expensify/Expensify.cash/pull/2329
Failed workflow: https://github.com/Expensify/Expensify.cash/runs/2578898948?check_suite_focus=true

**What happened?** There was a code error in my [forked version of the auto-approve-action repo](https://github.com/roryabraham/auto-approve-action/commits/Rory-AutoApproveAnyPullRequest).

**Testing:** There was a stupid JS error which wasn't caught by my unit testing, but I [tested the fix in another repo](https://github.com/Andrew-Test-Org/Public-Test-Repo/pull/49/checks?check_run_id=2579019387) and it [worked](https://github.com/Andrew-Test-Org/Public-Test-Repo/pull/35).