### PR TITLE
Wrong argument name give to automerge-action

### DIFF
--- a/.github/workflows/updateProtectedBranch.yml
+++ b/.github/workflows/updateProtectedBranch.yml
@@ -102,7 +102,7 @@ jobs:
         uses: pascalgn/automerge-action@39d831e1bb389bd242626bc25d4060064a97181c
         env:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
-          PULL_REQUEST_NUMBER: ${{ steps.createPullRequest.outputs.pr_number }}
+          PULL_REQUEST: ${{ steps.createPullRequest.outputs.pr_number }}
 
       # This Slack step is duplicated in all workflows, if you make a change to this step, make sure to update all
       # the other workflows with the same change


### PR DESCRIPTION
Fixing https://github.com/Expensify/Expensify/issues/157916
Following-up on https://github.com/Expensify/Expensify.cash/pull/2329
Sneaky silent failed workflow run: https://github.com/Expensify/Expensify.cash/runs/2579087959?check_suite_focus=true

**What happened:** argument name given to automerge-action should have been just `PULL_REQUEST`, not `PULL_REQUEST_NUMBER`

![image](https://user-images.githubusercontent.com/47436092/118190897-a10a4c00-b3f8-11eb-9eed-54538546c6f2.png)