### PR TITLE
Give automerge label to automerge PRs

### DIFF
--- a/.github/workflows/updateProtectedBranch.yml
+++ b/.github/workflows/updateProtectedBranch.yml
@@ -64,6 +64,7 @@ jobs:
           github_token: ${{ secrets.OS_BOTIFY_TOKEN }}
           pr_title: Update version to ${{ env.NEW_VERSION }} on ${{ github.event.inputs.TARGET_BRANCH }}
           pr_body: Update version to ${{ env.NEW_VERSION }}
+          pr_label: automerge
 
       - name: Check if pull request is mergeable
         id: isPullRequestMergeable


### PR DESCRIPTION
Fixing https://github.com/Expensify/Expensify/issues/157916
Following up on https://github.com/Expensify/Expensify.cash/pull/2329
Sneaky silently failed workflow https://github.com/Expensify/Expensify.cash/runs/2579250985?check_suite_focus=true

**What happened?**

pascalgn/automerge has a default value for labels it expects a PR to have for them to be merged:

![image](https://user-images.githubusercontent.com/47436092/118192708-66ee7980-b3fb-11eb-8f8f-f9eedbab6571.png)
