### PR TITLE
Update staging after creating new BUILD version in finishReleaseCycle

### DIFF
--- a/.github/workflows/finishReleaseCycle.yml
+++ b/.github/workflows/finishReleaseCycle.yml
@@ -77,9 +77,17 @@ jobs:
           WORKFLOW: createNewVersion.yml
           INPUTS: '{ "SEMVER_LEVEL": "BUILD" }'
 
-      - name: Pull main to get the new version
+      - name: Update staging branch to trigger staging deploy
+        uses: Expensify/Expensify.cash/.github/actions/triggerWorkflowAndWait@main
+        with:
+          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+          WORKFLOW: updateProtectedBranch.yml
+          INPUTS: '{ "TARGET_BRANCH": "staging" }'
+
+      - name: Pull staging to get the new version
         run: |
-          git pull origin main
+          git checkout staging
+          git pull origin staging
           echo "NEW_VERSION=$(npm run print-version --silent)" >> $GITHUB_ENV
           echo "New version is ${{ env.NEW_VERSION }}"
 


### PR DESCRIPTION
Fixing https://github.com/Expensify/Expensify/issues/157916
Following up on https://github.com/Expensify/Expensify.cash/pull/2329

**What happened?**: After creating the new BUILD version in `finishReleaseCycle`, we did not update the staging branch. Therefore, a staging deploy did not occur. That means that a new `StagingDeployCash` was created, including all the deferred PRs, but that those PRs were not actually deployed. That's no bueno, so this PR fixes it.