### PR TITLE
Add Localization to Attachment Modal

### DIFF
--- a/src/components/AttachmentModal.js
+++ b/src/components/AttachmentModal.js
@@ -23,8 +23,8 @@ import withLocalize, {withLocalizePropTypes} from './withLocalize';
  */
 
 const propTypes = {
-    /** Title of the modal header */
-    title: PropTypes.string,
+    /** Determines title of the modal header depending on if we are uploading an attachment or not */
+    isUploadingAttachment: PropTypes.bool,
 
     /** Optional source URL for the image shown. If not passed in via props must be specified when modal is opened. */
     sourceURL: PropTypes.string,
@@ -52,7 +52,7 @@ const propTypes = {
 };
 
 const defaultProps = {
-    title: '',
+    isUploadingAttachment: false,
     sourceURL: null,
     onConfirm: null,
     isAuthTokenRequired: false,
@@ -110,7 +110,9 @@ class AttachmentModal extends PureComponent {
                     propagateSwipe
                 >
                     <HeaderWithCloseButton
-                        title={this.props.title}
+                        title={this.props.isUploadingAttachment
+                            ? this.props.translate('reportActionCompose.uploadAttachment')
+                            : this.props.translate('common.attachment')}
                         shouldShowBorderBottom
                         onDownloadButtonPress={() => fileDownload(sourceURL)}
                         onCloseButtonPress={() => this.setState({isModalOpen: false})}

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -323,7 +323,7 @@ class ReportActionCompose extends React.Component {
                 ]}
                 >
                     <AttachmentModal
-                        title={this.props.translate('reportActionCompose.uploadAttachment')}
+                        isUploadingAttachment
                         onConfirm={(file) => {
                             addAction(this.props.reportID, '', file);
                             this.setTextInputShouldClear(false);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes https://github.com/Expensify/Expensify.cash/issues/2844

### Tests / QA

1. Add Attachment, make sure the modal says `Upload Attachment`
![Screen Shot 2021-05-14 at 12 48 31 PM](https://user-images.githubusercontent.com/30609178/118321622-b2b02a00-b4b2-11eb-9d1a-0821f982db34.png)

2. Click on the image and make sure a modal opens with the title `Attachment`

![Screen Shot 2021-05-14 at 12 49 58 PM](https://user-images.githubusercontent.com/30609178/118321757-e68b4f80-b4b2-11eb-8be6-8b8c94a364db.png)


For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
