### PR TITLE
Set the leader on Page Focus

### DIFF
--- a/src/Expensify.js
+++ b/src/Expensify.js
@@ -1,7 +1,7 @@
 import lodashGet from 'lodash/get';
 import PropTypes from 'prop-types';
 import React, {PureComponent} from 'react';
-import {View, StatusBar} from 'react-native';
+import {View, StatusBar, AppState} from 'react-native';
 import Onyx, {withOnyx} from 'react-native-onyx';
 
 import BootSplash from './libs/BootSplash';
@@ -15,6 +15,7 @@ import migrateOnyx from './libs/migrateOnyx';
 import styles from './styles/styles';
 import PushNotification from './libs/Notification/PushNotification';
 import UpdateAppModal from './components/UpdateAppModal';
+import Visibility from './libs/Visibility';
 
 // Initialize the store when the app loads for the first time
 Onyx.init({
@@ -75,6 +76,7 @@ class Expensify extends PureComponent {
         // Initialize this client as being an active client
         ActiveClientManager.init();
         this.hideSplash = this.hideSplash.bind(this);
+        this.initializeClient = this.initializeClient.bind(true);
         this.state = {
             isOnyxMigrated: false,
         };
@@ -92,6 +94,8 @@ class Expensify extends PureComponent {
 
                 this.setState({isOnyxMigrated: true});
             });
+
+        AppState.addEventListener('change', this.initializeClient);
     }
 
     componentDidUpdate(prevProps) {
@@ -120,8 +124,18 @@ class Expensify extends PureComponent {
         }
     }
 
+    componentWillUnmount() {
+        AppState.removeEventListener('change', this.initializeClient);
+    }
+
     getAuthToken() {
         return lodashGet(this.props, 'session.authToken', null);
+    }
+
+    initializeClient() {
+        if (Visibility.isVisible()) {
+            ActiveClientManager.init();
+        }
     }
 
     hideSplash() {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
When page focus changes, we set the focused client as Client leader.
1. Listen for `AppState#change` on Expensify.js.
2. When `change` emit , we call `client.init` on `Visibility.isVisible()`. This makes sure that we always have an active leader.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes #2711

### Tests / QA Steps
1. Open the Expensify.cash app on the browser.
2. Now open another tab with Expensify.cash app.
3. focus over the new tab, then focus back on the old tab.
4. Now without going to the new tab just close it from the top bar.
 
![Screenshot 2021-05-06 11:42:26](https://user-images.githubusercontent.com/24370807/117250135-63d61500-ae60-11eb-8cc5-994f45d92db3.png)

5. Now send messages to one of the not active chats from another users' device. 
6. We should receive the notifications.

### Tested On

- [x] Web (affected Platform)
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

<details>
<summary>Before</summary>


https://user-images.githubusercontent.com/24370807/118410821-0f783400-b6af-11eb-8c49-1c51e2f78423.mp4



</details>

<details open>
<summary>After</summary>


https://user-images.githubusercontent.com/24370807/118410975-e3a97e00-b6af-11eb-8137-16f888ed7ce1.mp4



</details>