### PR TITLE
Profile - GMT time is not displayed #2097

### DIFF
--- a/src/pages/DetailsPage.js
+++ b/src/pages/DetailsPage.js
@@ -101,7 +101,15 @@ const DetailsPage = ({personalDetails, route}) => {
                                     <Text style={[styles.textP]} numberOfLines={1}>
                                         {moment().tz(details.timezone.selected).format('LT')}
                                         {' '}
-                                        {moment().tz(details.timezone.selected).zoneAbbr()}
+                                        {isNaN(moment().tz(details.timezone.selected).zoneAbbr()) ? ( 
+                                            <Text>{moment().tz(details.timezone.selected).zoneAbbr()}</Text>
+                                        ) : (
+                                            <Text>
+                                                {moment.tz(details.timezone.selected).toString().split("-")[0].slice(-3)}
+                                                {' '}
+                                                {moment().tz(details.timezone.selected).zoneAbbr()}
+                                            </Text>
+                                        )}
                                     </Text>
                                 </View>
                             ) : null}

--- a/src/pages/DetailsPage.js
+++ b/src/pages/DetailsPage.js
@@ -40,7 +40,7 @@ const DetailsPage = ({personalDetails, route}) => {
     // If we have a reportID param this means that we
     // arrived here via the ParticipantsPage and should be allowed to navigate back to it
     const shouldShowBackButton = Boolean(route.params.reportID);
-    const timezone = moment().tz(details.timezone.selected);
+    const timezone = moment().tz(details.timezone.selected); 
     
     return (
         <ScreenWrapper>

--- a/src/pages/DetailsPage.js
+++ b/src/pages/DetailsPage.js
@@ -41,6 +41,7 @@ const DetailsPage = ({personalDetails, route}) => {
     // arrived here via the ParticipantsPage and should be allowed to navigate back to it
     const shouldShowBackButton = Boolean(route.params.reportID);
     const timezone = moment().tz(details.timezone.selected);
+    
     return (
         <ScreenWrapper>
             <HeaderWithCloseButton

--- a/src/pages/DetailsPage.js
+++ b/src/pages/DetailsPage.js
@@ -101,15 +101,7 @@ const DetailsPage = ({personalDetails, route}) => {
                                     <Text style={[styles.textP]} numberOfLines={1}>
                                         {moment().tz(details.timezone.selected).format('LT')}
                                         {' '}
-                                        {isNaN(moment().tz(details.timezone.selected).zoneAbbr()) ? ( 
-                                            <Text>{moment().tz(details.timezone.selected).zoneAbbr()}</Text>
-                                        ) : (
-                                            <Text>
-                                                {moment.tz(details.timezone.selected).toString().split("-")[0].slice(-3)}
-                                                {' '}
-                                                {moment().tz(details.timezone.selected).zoneAbbr()}
-                                            </Text>
-                                        )}
+                                        {moment().tz(details.timezone.selected).zoneAbbr()}
                                     </Text>
                                 </View>
                             ) : null}

--- a/src/pages/DetailsPage.js
+++ b/src/pages/DetailsPage.js
@@ -40,7 +40,7 @@ const DetailsPage = ({personalDetails, route}) => {
     // If we have a reportID param this means that we
     // arrived here via the ParticipantsPage and should be allowed to navigate back to it
     const shouldShowBackButton = Boolean(route.params.reportID);
-
+    const timezone = moment().tz(details.timezone.selected);
     return (
         <ScreenWrapper>
             <HeaderWithCloseButton
@@ -99,17 +99,17 @@ const DetailsPage = ({personalDetails, route}) => {
                                         Local Time
                                     </Text>
                                     <Text style={[styles.textP]} numberOfLines={1}>
-                                        {moment().tz(details.timezone.selected).format('LT')}
+                                        {timezone.format('LT')}
                                         {' '}
-                                        {isNaN(moment().tz(details.timezone.selected).zoneAbbr()) ? ( 
-                                            <Text>{moment().tz(details.timezone.selected).zoneAbbr()}</Text>
+                                        {isNaN(timezone.zoneAbbr()) ? (
+                                            <Text>{timezone.zoneAbbr()}</Text>
                                         ) : (
                                             <Text>
-                                                {moment.tz(details.timezone.selected).toString().split("-")[0].slice(-3)}
-                                                {' '}
-                                                {moment().tz(details.timezone.selected).zoneAbbr()}
+                                            {timezone.toString().split("-")[0].slice(-3)}
+                                            {' '}
+                                            {timezone.zoneAbbr()}
                                             </Text>
-                                        )}
+                                        )}                                    
                                     </Text>
                                 </View>
                             ) : null}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This issue is resolved by just modifying moment syntax because in the moment library, some timezone abbreviation, not support. so if return numeric value I've put modified syntax to show GMT.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes https://github.com/Expensify/Expensify.cash/issues/2097

### Tests
1. Pull code from GitHub and install its dependencies via the below command: npm install
2. Run this project locally via npm run web / npm run android
3. login via existing credentials.
4. Go to the settings page then open the profile tab.
5. Set desired timezone.
6. log out and log in with another account.
7. search for the first account and check his/her profile and check on the local time option. It will show GMT or any other timezone.

### QA Steps
I've already QA this issue and it's working properly.

### Tested On

- [x] Web
- [x] Mobile Web
- [ ] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
![2021-05-16](https://user-images.githubusercontent.com/43398804/118449114-6a8e4300-b710-11eb-83f1-5dee9364b43b.png)


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
![2021-05-17](https://user-images.githubusercontent.com/43398804/118449146-737f1480-b710-11eb-9e44-198cb16265d1.png)


#### Android
![2021-05-17](https://user-images.githubusercontent.com/43398804/118449165-78dc5f00-b710-11eb-903f-74998bdb99cc.jpg)


**I have read the CLA Document and I hereby sign the CLA**