### PR TITLE
Add autofocus to emoji picker text input

### DIFF
--- a/src/pages/home/report/EmojiPickerMenu/index.js
+++ b/src/pages/home/report/EmojiPickerMenu/index.js
@@ -322,6 +322,7 @@ class EmojiPickerMenu extends Component {
                             style={styles.textInput}
                             defaultValue=""
                             ref={el => this.searchInput = el}
+                            autoFocus
                         />
                     </View>
                 )}


### PR DESCRIPTION
### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/2950

### Tests
1. Open a chat in Expenisfy.cash. 
2. Open the emoji picker. Verify that the text input focuses.

### QA Steps
Same as the above tests

### Tested On

- [x] Web
- [ ] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
https://user-images.githubusercontent.com/31285285/118468225-22364b80-b737-11eb-8944-12beb79b7c2e.mp4


#### Desktop
https://user-images.githubusercontent.com/31285285/118468165-13e82f80-b737-11eb-9c20-2d63d7e0bc4e.mp4
