### PR TITLE
Update sort order for Search Page `lastVisitedTimestamp`

### DIFF
--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -342,7 +342,7 @@ function getSearchOptions(
         showChatPreviewLine: true,
         showReportsWithNoComments: true,
         includePersonalDetails: true,
-        sortByLastMessageTimestamp: true,
+        sortByLastMessageTimestamp: false,
     });
 }
 

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -338,7 +338,7 @@ function getSearchOptions(
         includeRecentReports: true,
         includeMultipleParticipantReports: true,
         maxRecentReportsToShow: 0, // Unlimited
-        prioritizePinnedReports: true,
+        prioritizePinnedReports: false,
         showChatPreviewLine: true,
         showReportsWithNoComments: true,
         includePersonalDetails: true,

--- a/tests/unit/OptionsListUtilsTest.js
+++ b/tests/unit/OptionsListUtilsTest.js
@@ -177,9 +177,6 @@ describe('OptionsListUtils', () => {
         // Then all of the reports should be shown, including the one that has no message on them.
         expect(results.recentReports.length).toBe(_.size(REPORTS));
 
-        // Then pinned report should be listed first even though it is the oldest
-        expect(results.recentReports[0].login).toBe('reedrichards@expensify.com');
-
         // When we filter again but provide a searchValue
         results = OptionsListUtils.getSearchOptions(REPORTS, PERSONAL_DETAILS, 'spider');
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
A concise explanation can be found here https://github.com/Expensify/Expensify.cash/issues/2960#issuecomment-842417227.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes  #2960

### Tests / QA Steps
1. Open the E.cash app on any platform.
2. Open different chats and remember the order.
3. Open the Search Page by clicking the search icon on the LHN topbar.
4. Observe the order of chats, they should be in reverse order as of your order in Step 2. Recent visited should come up.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [ ] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

https://user-images.githubusercontent.com/24370807/118538482-deaa0480-b76b-11eb-87a1-79afe536627e.mp4


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

https://user-images.githubusercontent.com/24370807/118540242-08fcc180-b76e-11eb-943c-2a86b82370f5.mp4


#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

https://user-images.githubusercontent.com/24370807/118539184-bc64b680-b76c-11eb-8f12-2f21876265f8.mp4



#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->

https://user-images.githubusercontent.com/24370807/118546580-c63ee780-b775-11eb-84bb-2e86047b1fe7.mp4

