### PR TITLE
Add IOU routes to Universal Links (AASA)

### DIFF
--- a/apple-app-site-association
+++ b/apple-app-site-association
@@ -11,6 +11,7 @@
                     "/details/*",
                     "/v/*",
                     "/add-bank-account/*",
+                    "/iou/*",
                 ]
             }
         ]


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Updated the AASA (apple-app-site-association) file with configuration for the IOU routes

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes #2401

### Tests
1. Have the E.cash app installed
2. Open an IOU link like https://staging.expensify.cash/iou/split/reportID
3. The link should be handled in-app - it should launch the E.cash app or prompt you to use E.cash to open the link

### QA Steps
Same as above

### Tested On
I've tested primarily on iOS. 
Since I can't test this change locally, I've just verified the other platforms are still working

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
<!-- ![image](https://user-images.githubusercontent.com/12156624/118790375-5ed08700-b89e-11eb-8c22-445009b0e9da.png)  -->


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
<!-- ![image](https://user-images.githubusercontent.com/12156624/118790438-6f80fd00-b89e-11eb-8bdf-6587b82cb43f.png) -->

#### Desktop

<!-- ![image](https://user-images.githubusercontent.com/12156624/118789874-e36ed580-b89d-11eb-8f74-9888962992f3.png) -->

#### iOS

_The changes that I used to test this locally were reverted._

https://user-images.githubusercontent.com/12156624/118555332-3d22b300-b76b-11eb-8705-eb25417fda76.mp4

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
<!-- ![image](https://user-images.githubusercontent.com/12156624/118791007-f6ce7080-b89e-11eb-866f-20f81f97dba1.png) -->

