### PR TITLE
Fix blank screen on IOU confirm page

### DIFF
--- a/src/pages/home/sidebar/OptionRow.js
+++ b/src/pages/home/sidebar/OptionRow.js
@@ -1,4 +1,5 @@
 import _ from 'underscore';
+import lodashGet from 'lodash/get';
 import React, {memo} from 'react';
 import PropTypes from 'prop-types';
 import {
@@ -17,7 +18,6 @@ import Hoverable from '../../../components/Hoverable';
 import DisplayNames from '../../../components/DisplayNames';
 import IOUBadge from '../../../components/IOUBadge';
 import colors from '../../../styles/colors';
-import lodashGet from "lodash/get";
 
 const propTypes = {
     /** Background Color of the Option Row */

--- a/src/pages/home/sidebar/OptionRow.js
+++ b/src/pages/home/sidebar/OptionRow.js
@@ -17,6 +17,7 @@ import Hoverable from '../../../components/Hoverable';
 import DisplayNames from '../../../components/DisplayNames';
 import IOUBadge from '../../../components/IOUBadge';
 import colors from '../../../styles/colors';
+import lodashGet from "lodash/get";
 
 const propTypes = {
     /** Background Color of the Option Row */
@@ -115,7 +116,7 @@ const OptionRow = ({
         ? hoverStyle.backgroundColor
         : backgroundColor;
     const focusedBackgroundColor = styles.sidebarLinkActive.backgroundColor;
-    const isMultipleParticipant = option.participantsList.length > 1;
+    const isMultipleParticipant = lodashGet(option, 'participantsList.length', 0) > 1;
     const displayNamesWithTooltips = _.map(
         option.participantsList,
         ({displayName, firstName, login}) => (


### PR DESCRIPTION
### Details
The `option.participantsList` may be undefined (per it's prop types [here](https://github.com/Expensify/Expensify.cash/blob/15f9b08595a975a779d84d298b7ae32830aa2e68/src/pages/home/sidebar/optionPropTypes.js#L22)). So this PR ensures that we're safely checking the length of that array.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/2969

### Tests / QA Steps
1. Open a chat on an account in the IOU beta.
1. Press the `+` icon
1. Press "Request Money"
1. Enter an amount in the modal.
1. Hit `Next`
1. Verify that the app doesn't crash or fail with a white screen. 

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web
![image](https://user-images.githubusercontent.com/47436092/118574282-f3b97000-b738-11eb-8664-834cbb4c9216.png)

#### Mobile Web
![image](https://user-images.githubusercontent.com/47436092/118574727-e0f36b00-b739-11eb-9cd5-54c48fc7ed0f.png)

#### Desktop
![image](https://user-images.githubusercontent.com/47436092/118680730-d4135d80-b7b3-11eb-8799-0fd82873cf64.png)

#### iOS
![image](https://user-images.githubusercontent.com/47436092/118575094-89093400-b73a-11eb-8330-7c451b533730.png)

#### Android
![image](https://user-images.githubusercontent.com/47436092/118681787-b5619680-b7b4-11eb-86ea-186c2e533778.png)
