### PR TITLE
Display full names for search page option rows

### DIFF
--- a/src/components/OptionsList.js
+++ b/src/components/OptionsList.js
@@ -74,6 +74,10 @@ const propTypes = {
 
     /** Toggle between compact and default view of the option */
     optionMode: PropTypes.oneOf(['compact', 'default']),
+
+    /* Whether we should display full display names for each option.
+     * If this is false, then we only display each participant's first name */
+    shouldShowFullDisplayNames: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -94,6 +98,7 @@ const defaultProps = {
     innerRef: null,
     showTitleTooltip: false,
     optionMode: undefined,
+    shouldShowFullDisplayNames: false,
 };
 
 class OptionsList extends Component {
@@ -170,6 +175,7 @@ class OptionsList extends Component {
                 showSelectedState={this.props.canSelectMultipleOptions}
                 hideAdditionalOptionStates={this.props.hideAdditionalOptionStates}
                 forceTextUnreadStyle={this.props.forceTextUnreadStyle}
+                shouldShowFullDisplayNames={this.props.shouldShowFullDisplayNames}
             />
         );
     }

--- a/src/components/OptionsList.js
+++ b/src/components/OptionsList.js
@@ -75,8 +75,8 @@ const propTypes = {
     /** Toggle between compact and default view of the option */
     optionMode: PropTypes.oneOf(['compact', 'default']),
 
-    /* Whether we should display full display names for each option.
-     * If this is false, then we only display each participant's first name for group chats */
+    /* Whether we should display full display names of participants for group chat options.
+     * If this is false, then we only display each participant's first name. */
     shouldShowFullDisplayNames: PropTypes.bool,
 };
 

--- a/src/components/OptionsList.js
+++ b/src/components/OptionsList.js
@@ -76,7 +76,7 @@ const propTypes = {
     optionMode: PropTypes.oneOf(['compact', 'default']),
 
     /* Whether we should display full display names for each option.
-     * If this is false, then we only display each participant's first name */
+     * If this is false, then we only display each participant's first name for group chats */
     shouldShowFullDisplayNames: PropTypes.bool,
 };
 

--- a/src/components/OptionsSelector.js
+++ b/src/components/OptionsSelector.js
@@ -64,6 +64,10 @@ const propTypes = {
     /** Whether to focus the textinput after an option is selected */
     shouldFocusOnSelectRow: PropTypes.bool,
 
+    /* Whether we should display full display names for each option.
+     * If this is false, then we only display each participant's first name */
+    shouldShowFullDisplayNames: PropTypes.bool,
+
     ...withLocalizePropTypes,
 };
 
@@ -79,6 +83,7 @@ const defaultProps = {
     forceTextUnreadStyle: false,
     showTitleTooltip: false,
     shouldFocusOnSelectRow: false,
+    shouldShowFullDisplayNames: false,
 };
 
 class OptionsSelector extends Component {
@@ -217,6 +222,7 @@ class OptionsSelector extends Component {
                     hideAdditionalOptionStates={this.props.hideAdditionalOptionStates}
                     forceTextUnreadStyle={this.props.forceTextUnreadStyle}
                     showTitleTooltip={this.props.showTitleTooltip}
+                    shouldShowFullDisplayNames={this.props.shouldShowFullDisplayNames}
                 />
             </View>
         );

--- a/src/components/OptionsSelector.js
+++ b/src/components/OptionsSelector.js
@@ -65,7 +65,7 @@ const propTypes = {
     shouldFocusOnSelectRow: PropTypes.bool,
 
     /* Whether we should display full display names for each option.
-     * If this is false, then we only display each participant's first name */
+     * If this is false, then we only display each participant's first name for group chats */
     shouldShowFullDisplayNames: PropTypes.bool,
 
     ...withLocalizePropTypes,

--- a/src/components/OptionsSelector.js
+++ b/src/components/OptionsSelector.js
@@ -64,8 +64,8 @@ const propTypes = {
     /** Whether to focus the textinput after an option is selected */
     shouldFocusOnSelectRow: PropTypes.bool,
 
-    /* Whether we should display full display names for each option.
-     * If this is false, then we only display each participant's first name for group chats */
+    /* Whether we should display full display names of participants for group chat options.
+     * If this is false, then we only display each participant's first name. */
     shouldShowFullDisplayNames: PropTypes.bool,
 
     ...withLocalizePropTypes,

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -56,20 +56,23 @@ function getPersonalDetailsForLogins(logins, personalDetails) {
  * @return {String}
  */
 function getSearchText(report, personalDetailList) {
-    const searchTerms = [];
+    // Use a set because it skips adding duplicates
+    // which could potentially significantly speed up our
+    // regex search if someone has thousands of chats
+    const searchTerms = new Set();
 
     _.each(personalDetailList, (personalDetail) => {
-        searchTerms.push(personalDetail.displayName);
-        searchTerms.push(personalDetail.login);
+        searchTerms.add(personalDetail.displayName);
+        searchTerms.add(personalDetail.login);
     });
 
     if (report) {
-        searchTerms.push(report.reportName);
-        searchTerms.push(...report.reportName.split(',').map(name => name.trim()));
-        searchTerms.push(...report.participants);
+        searchTerms.add(report.reportName);
+        searchTerms.add(...report.reportName.split(',').map(name => name.trim()));
+        searchTerms.add(...report.participants);
     }
 
-    return _.unique(searchTerms).join(' ');
+    return _.unique(Array.from(searchTerms)).join(' ');
 }
 
 /**

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -64,6 +64,7 @@ function getSearchText(report, personalDetailList) {
     });
 
     if (report) {
+        searchTerms.push(report.reportName);
         searchTerms.push(...report.reportName.split(',').map(name => name.trim()));
         searchTerms.push(...report.participants);
     }
@@ -97,7 +98,7 @@ function createOption(personalDetailList, report, draftComments, {showChatPrevie
         : '';
     const tooltipText = getReportParticipantsTitle(lodashGet(report, ['participants'], []));
 
-    return {
+    const res = {
         text: report ? report.reportName : personalDetail.displayName,
         alternateText: (showChatPreviewLine && lastMessageText)
             ? lastMessageText
@@ -118,6 +119,8 @@ function createOption(personalDetailList, report, draftComments, {showChatPrevie
         hasOutstandingIOU,
         iouReportID: lodashGet(report, 'iouReportID'),
     };
+
+    return res;
 }
 
 Onyx.connect({

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -98,7 +98,7 @@ function createOption(personalDetailList, report, draftComments, {showChatPrevie
         : '';
     const tooltipText = getReportParticipantsTitle(lodashGet(report, ['participants'], []));
 
-    const res = {
+    return {
         text: report ? report.reportName : personalDetail.displayName,
         alternateText: (showChatPreviewLine && lastMessageText)
             ? lastMessageText
@@ -119,8 +119,6 @@ function createOption(personalDetailList, report, draftComments, {showChatPrevie
         hasOutstandingIOU,
         iouReportID: lodashGet(report, 'iouReportID'),
     };
-
-    return res;
 }
 
 Onyx.connect({

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -67,7 +67,6 @@ function getSearchText(report, personalDetailList) {
     });
 
     if (report) {
-        searchTerms.add(report.reportName);
         searchTerms.add(...report.reportName.split(',').map(name => name.trim()));
         searchTerms.add(...report.participants);
     }

--- a/src/pages/SearchPage.js
+++ b/src/pages/SearchPage.js
@@ -171,6 +171,7 @@ class SearchPage extends Component {
                         hideSectionHeaders
                         hideAdditionalOptionStates
                         showTitleTooltip
+                        shouldShowFullDisplayNames
                     />
                 </View>
                 <KeyboardSpacer />

--- a/src/pages/home/sidebar/OptionRow.js
+++ b/src/pages/home/sidebar/OptionRow.js
@@ -118,9 +118,10 @@ const OptionRow = ({
     const isMultipleParticipant = option.participantsList.length > 1;
     const displayNamesWithTooltips = _.map(
         option.participantsList,
-        ({displayName, firstName, login}) => (
-            {displayName: (isMultipleParticipant && !shouldShowFullDisplayNames ? firstName : displayName) || login, tooltip: login}
-        ),
+        ({displayName, firstName, login}) => ({
+            displayName: (isMultipleParticipant && !shouldShowFullDisplayNames ? firstName : displayName) || login,
+            tooltip: login,
+        }),
     );
     const fullTitle = displayNamesWithTooltips.map(({displayName}) => displayName).join(', ');
     return (

--- a/src/pages/home/sidebar/OptionRow.js
+++ b/src/pages/home/sidebar/OptionRow.js
@@ -52,6 +52,10 @@ const propTypes = {
 
     /** Toggle between compact and default view */
     mode: PropTypes.oneOf(['compact', 'default']),
+
+    /* Whether we should display full display names for each option.
+     * If this is false, then we only display each participant's first name */
+    shouldShowFullDisplayNames: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -64,6 +68,7 @@ const defaultProps = {
     showTitleTooltip: false,
     mode: 'default',
     onSelectRow: null,
+    shouldShowFullDisplayNames: false,
 };
 
 const OptionRow = ({
@@ -78,6 +83,7 @@ const OptionRow = ({
     forceTextUnreadStyle,
     showTitleTooltip,
     mode,
+    shouldShowFullDisplayNames,
 }) => {
     const textStyle = optionIsFocused
         ? styles.sidebarLinkActiveText
@@ -114,7 +120,7 @@ const OptionRow = ({
     const displayNamesWithTooltips = _.map(
         option.participantsList,
         ({displayName, firstName, login}) => (
-            {displayName: (isMultipleParticipant ? firstName : displayName) || login, tooltip: login}
+            {displayName: (isMultipleParticipant && !shouldShowFullDisplayNames ? firstName : displayName) || login, tooltip: login}
         ),
     );
     const fullTitle = displayNamesWithTooltips.map(({displayName}) => displayName).join(', ');

--- a/src/pages/home/sidebar/OptionRow.js
+++ b/src/pages/home/sidebar/OptionRow.js
@@ -54,7 +54,7 @@ const propTypes = {
     mode: PropTypes.oneOf(['compact', 'default']),
 
     /* Whether we should display full display names for each option.
-     * If this is false, then we only display each participant's first name */
+     * If this is false, then we only display each participant's first name for group chats */
     shouldShowFullDisplayNames: PropTypes.bool,
 };
 

--- a/src/pages/home/sidebar/OptionRow.js
+++ b/src/pages/home/sidebar/OptionRow.js
@@ -55,7 +55,7 @@ const propTypes = {
 
     /* Whether we should display full display names of participants for group chat options.
      * If this is false, then we only display each participant's first name. */
-    shouldShowFullDisplayNames: PropTypes.bool,
+    shouldShowFullDisplayNames: PropTypes.bool.isRequired,
 };
 
 const defaultProps = {
@@ -68,7 +68,6 @@ const defaultProps = {
     showTitleTooltip: false,
     mode: 'default',
     onSelectRow: null,
-    shouldShowFullDisplayNames: false,
 };
 
 const OptionRow = ({

--- a/src/pages/home/sidebar/OptionRow.js
+++ b/src/pages/home/sidebar/OptionRow.js
@@ -53,8 +53,8 @@ const propTypes = {
     /** Toggle between compact and default view */
     mode: PropTypes.oneOf(['compact', 'default']),
 
-    /* Whether we should display full display names for each option.
-     * If this is false, then we only display each participant's first name for group chats */
+    /* Whether we should display full display names of participants for group chat options.
+     * If this is false, then we only display each participant's first name. */
     shouldShowFullDisplayNames: PropTypes.bool,
 };
 


### PR DESCRIPTION
The search page is confusing because we don't display the full names of participants for each group chat option.
- This means that a group chat with 3 participants that had actual report name `Jasper Huang, Ricky Bobby, Lorem Ipsum` would be displayed as `Jasper, Ricky, Lorem`. This makes it confusing when searching since the search term (aka the report name) doesn't match up with the displayed option.

### Fixed Issues
Fixes N/A

### Tests
WIP

### QA Steps
WIP

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
