### PR TITLE
Disable documentTitle in NavigationRoot component

### DIFF
--- a/src/libs/Navigation/NavigationRoot.js
+++ b/src/libs/Navigation/NavigationRoot.js
@@ -40,7 +40,7 @@ class NavigationRoot extends Component {
                 ref={navigationRef}
                 linking={linkingConfig}
                 documentTitle={{
-                    formatter: () => 'Expensify.cash',
+                    formatter: () => `${document.title ?? 'Expensify.cash'}`,
                 }}
             >
                 <AppNavigator authenticated={this.props.authenticated} />

--- a/src/libs/Navigation/NavigationRoot.js
+++ b/src/libs/Navigation/NavigationRoot.js
@@ -40,7 +40,7 @@ class NavigationRoot extends Component {
                 ref={navigationRef}
                 linking={linkingConfig}
                 documentTitle={{
-                    formatter: () => `${document.title ?? 'Expensify.cash'}`,
+                    enabled: false,
                 }}
             >
                 <AppNavigator authenticated={this.props.authenticated} />


### PR DESCRIPTION
[Mu](https://github.com/Expensify/Expensify.cash/issues/2636#issuecomment-843636746)

### Details
The listener that sets the page title when there are new chat items, that gets attached in `AuthScreens` was getting overridden by the `NavigationContainer` in NavigationRoot.js, which apparently mounts a few more times after the listener updates the title. This changes it so that the `NavigationContainer` only sets the title to `Expnesify.cash` when the `document.title` is not already set.

cc @marcaaron 

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes https://github.com/Expensify/Expensify.cash/issues/2636

### Tests/QA
1. Launch the app as Account B and log in
2. As account B, send some messages to account A
3. Go to localhost:8080 as Account A in Web/Chrome
4. Observe the favicons and NEW! Expensify.cash
5. Verify that once `(NEW!) Expensify.cash` is set, it stays set.

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
https://user-images.githubusercontent.com/766197/118739217-bbc83080-b7fd-11eb-9fdf-fe1e3c9565eb.mp4
