### PR TITLE
Change mail icon

### DIFF
--- a/assets/images/mail.svg
+++ b/assets/images/mail.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 24.3.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 20 20" style="enable-background:new 0 0 20 20;" xml:space="preserve">
-<path d="M18.2,4c-0.1-0.1-0.5-0.2-0.8-0.2h-15C2.2,3.8,1.9,3.9,1.8,4L10,9.6L18.2,4z"/>
-<path d="M10.8,10.6c-0.2,0.1-0.5,0.2-0.8,0.2s-0.5-0.1-0.8-0.2l-8-5.4V15c0,0.8,0.5,1.2,1.2,1.2h15c0.8,0,1.2-0.5,1.2-1.2V5.2
-	L10.8,10.6z"/>
+<path d="M18.6,4.5C18.4,4,18,3.8,17.5,3.8h-15C2,3.8,1.6,4,1.4,4.5l8.6,5.8L18.6,4.5z"/>
+<path d="M10.8,11.2c-0.2,0.1-0.5,0.2-0.8,0.2s-0.5-0.1-0.8-0.2l-8-5.4V15c0,0.8,0.5,1.2,1.2,1.2h15c0.8,0,1.2-0.5,1.2-1.2V5.9
+	L10.8,11.2z"/>
 </svg>

--- a/assets/images/mail.svg
+++ b/assets/images/mail.svg
@@ -1,1 +1,8 @@
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><title>mail</title><path d="M15,6a1,1,0,0,0-.45-.83l-6-4a1,1,0,0,0-1.1,0l-6,4A1,1,0,0,0,1,6v7a1,1,0,0,0,1,1H14a1,1,0,0,0,1-1ZM8,2l5.41,3.61L8,9,2.59,5.61Z"/></svg>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 24.3.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 20 20" style="enable-background:new 0 0 20 20;" xml:space="preserve">
+<path d="M18.2,4c-0.1-0.1-0.5-0.2-0.8-0.2h-15C2.2,3.8,1.9,3.9,1.8,4L10,9.6L18.2,4z"/>
+<path d="M10.8,10.6c-0.2,0.1-0.5,0.2-0.8,0.2s-0.5-0.1-0.8-0.2l-8-5.4V15c0,0.8,0.5,1.2,1.2,1.2h15c0.8,0,1.2-0.5,1.2-1.2V5.2
+	L10.8,10.6z"/>
+</svg>


### PR DESCRIPTION
### Details
Updates the mail icon.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/164436

### Tests / QA Steps (web/desktop)
1. Hover over a chat.
1. Verify that the `ReportActionContextMenu` that appears displays a closed envelope icon instead of an open one.
1. Hover over the closed envelope icon, and verify that the Tooltip says 'Mark as Unread'
1. Right-click on a chat.
1. Verify that the `Mark as Unread` menu item displays a closed envelope icon.

### Tests / QA Steps (iOS/Android/mWeb)
1. Long-press a chat.
1. Verify that the `Mark as Unread` menu item displays a closed envelope icon.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
![image](https://user-images.githubusercontent.com/47436092/118739944-87557400-b7ff-11eb-943c-09deb3a887bb.png)

![image](https://user-images.githubusercontent.com/47436092/118739956-8f151880-b7ff-11eb-9603-2aa8d4ca1076.png)

#### Mobile Web
(ignore the highlight bugs that are present on `main`)

![image](https://user-images.githubusercontent.com/47436092/118740273-49a51b00-b800-11eb-99f0-dc1490ea4ccc.png)

#### Desktop
![image](https://user-images.githubusercontent.com/47436092/118739750-0f874980-b7ff-11eb-8645-4a87c519987d.png)

![image](https://user-images.githubusercontent.com/47436092/118739760-157d2a80-b7ff-11eb-9ddc-7414240fd466.png)

#### iOS
![image](https://user-images.githubusercontent.com/47436092/118740676-4fe7c700-b801-11eb-8fa3-9b48801e3b85.png)

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
