### PR TITLE
Updating some IOU styles

### DIFF
--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1341,12 +1341,13 @@ const styles = {
     }, 0),
 
     iouPreviewBox: {
+        backgroundColor: themeColors.componentBG,
         borderColor: themeColors.border,
         borderWidth: 1,
         borderRadius: variables.componentBorderRadiusCard,
         padding: 20,
         marginTop: 16,
-        maxWidth: 300,
+        maxWidth: variables.sideBarWidth,
         width: '100%',
     },
 


### PR DESCRIPTION
### Details
This adds a white background to the IOU preview component and gives it a larger maxWidth so it looks nicer in the sideDocked modal. 

### Fixed Issues
N/A

### Tests / QA Steps
1. Request money from someone in order to create the IOU preview component
2. Hover over the preview component, and make sure the preview component has a white background
3. Click on the "View Details" link above the component. When the IOU detailed view launches, makes sure the preview box stretches to the full width of the detailed view. 

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web
![image](https://user-images.githubusercontent.com/2319350/118897872-0a3e0380-b8c0-11eb-85f6-e4287695766b.png)


#### Mobile Web
![Screenshot 2021-05-27 at 11 34 10](https://user-images.githubusercontent.com/10736861/119811969-8bf4e900-bedf-11eb-8eca-0f239cd53f29.png)


#### Desktop
![image](https://user-images.githubusercontent.com/2319350/118897934-39547500-b8c0-11eb-94c2-84a7f61573b4.png)


#### iOS
![Simulator Screen Shot - iPhone 11 - 2021-05-27 at 10 59 55](https://user-images.githubusercontent.com/10736861/119812038-9dd68c00-bedf-11eb-9df3-654338a89d97.png)


#### Android
![image](https://user-images.githubusercontent.com/521248/119056556-2c707800-b9cb-11eb-83c6-a81392cfd9e0.png)
![image](https://user-images.githubusercontent.com/521248/119056543-24183d00-b9cb-11eb-9531-f3a809c360ac.png)

