### PR TITLE
fixed count alignment on the LHN avatars

### DIFF
--- a/src/components/MultipleAvatars.js
+++ b/src/components/MultipleAvatars.js
@@ -63,7 +63,7 @@ const MultipleAvatars = ({
                         />
                     ) : (
                         <View
-                            style={singleAvatarStyles}
+                            style={[singleAvatarStyles, styles.alignItemsCenter, styles.justifyContentCenter]}
                         >
                             <Text style={size === 'small'
                                 ? styles.avatarInnerTextSmall

--- a/src/components/MultipleAvatars.js
+++ b/src/components/MultipleAvatars.js
@@ -1,8 +1,9 @@
 import React, {memo} from 'react';
 import PropTypes from 'prop-types';
-import {Image, Text, View} from 'react-native';
+import {Image, View} from 'react-native';
 import styles from '../styles/styles';
 import Avatar from './Avatar';
+import Text from './Text';
 
 const propTypes = {
     /** Array of avatar URL */

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -988,7 +988,6 @@ const styles = {
     avatarInnerText: {
         color: themeColors.textReversed,
         fontSize: variables.fontSizeSmall,
-        lineHeight: 24,
         marginLeft: -3,
         textAlign: 'center',
     },
@@ -996,7 +995,6 @@ const styles = {
     avatarInnerTextSmall: {
         color: themeColors.textReversed,
         fontSize: variables.fontSizeExtraSmall,
-        lineHeight: 18,
         marginLeft: -2,
         textAlign: 'center',
     },

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -988,7 +988,7 @@ const styles = {
     avatarInnerText: {
         color: themeColors.textReversed,
         fontSize: variables.fontSizeSmall,
-        lineHeight: 24,
+        lineHeight: undefined,
         marginLeft: -3,
         textAlign: 'center',
     },
@@ -996,7 +996,7 @@ const styles = {
     avatarInnerTextSmall: {
         color: themeColors.textReversed,
         fontSize: variables.fontSizeExtraSmall,
-        lineHeight: 18,
+        lineHeight: undefined,
         marginLeft: -2,
         textAlign: 'center',
     },

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -988,6 +988,7 @@ const styles = {
     avatarInnerText: {
         color: themeColors.textReversed,
         fontSize: variables.fontSizeSmall,
+        lineHeight: 24,
         marginLeft: -3,
         textAlign: 'center',
     },
@@ -995,6 +996,7 @@ const styles = {
     avatarInnerTextSmall: {
         color: themeColors.textReversed,
         fontSize: variables.fontSizeExtraSmall,
+        lineHeight: 18,
         marginLeft: -2,
         textAlign: 'center',
     },


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
Please review @roryabraham. 

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes #2795

### Tests
 Performed some visual Tests
 1. edited the count manually to see if it is centered.

### QA Steps
1. Open E.cash
2. On LHN, observe the group chats that has 2 & more participants.
3. Count of participants should be centered.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web  
<!-- Insert screenshots of your changes on the desktop platform-->
![count-w](https://user-images.githubusercontent.com/24370807/119417473-821e8a80-bd13-11eb-8354-e4424a243ec3.png)

#### Mobile Web 
![IMG_20210525_051438](https://user-images.githubusercontent.com/24370807/119419594-3c17f580-bd18-11eb-8c39-78b8d8f01480.jpg)

![IMG_20210525_051000](https://user-images.githubusercontent.com/24370807/119419417-d9bef500-bd17-11eb-9a5b-5660c1f6794c.jpg)


#### Desktop
![Screenshot 2021-05-25 08:50:17](https://user-images.githubusercontent.com/24370807/119434671-4a750a00-bd36-11eb-96b3-71c5c3c4b722.png)



#### iOS
![Simulator Screen Shot - iPhone 11 - 2021-05-25 at 15 27 31](https://user-images.githubusercontent.com/24370807/119558895-9e780100-bdbf-11eb-931b-c75397c3c18a.png)



#### Android
<!-- Insert screenshots of your changes on the Android platform-->
![IMG_20210525_090017](https://user-images.githubusercontent.com/24370807/119435645-2e726800-bd38-11eb-9d15-8527ad4e3828.jpg)
