### PR TITLE
[IS-2601] fixed cursor position after adding emoji

### DIFF
--- a/src/components/TextInputFocusable/index.js
+++ b/src/components/TextInputFocusable/index.js
@@ -46,6 +46,15 @@ const propTypes = {
     Override this in case you need to set focus on one field out of many, or when you want to disable autoFocus */
     autoFocus: PropTypes.bool,
 
+    /** Update selection position on change */
+    onSelectionChange: PropTypes.func,
+
+    /** Selection Object */
+    selection: PropTypes.shape({
+        start: PropTypes.number,
+        end: PropTypes.number,
+    }),
+
     ...withLocalizePropTypes,
 };
 
@@ -63,6 +72,11 @@ const defaultProps = {
     isDisabled: false,
     autoFocus: false,
     forwardedRef: null,
+    onSelectionChange: () => { },
+    selection: {
+        start: 0,
+        end: 0,
+    },
 };
 
 const IMAGE_EXTENSIONS = {
@@ -127,6 +141,11 @@ class TextInputFocusable extends React.Component {
         }
         if (prevProps.defaultValue !== this.props.defaultValue) {
             this.updateNumberOfLines();
+        }
+
+        if (prevProps.selection !== this.props.selection) {
+            // eslint-disable-next-line react/no-did-update-set-state
+            this.setState({selection: this.props.selection});
         }
     }
 
@@ -231,6 +250,7 @@ class TextInputFocusable extends React.Component {
                 /* eslint-disable-next-line react/jsx-props-no-spreading */
                 {...propsWithoutStyles}
                 disabled={this.props.isDisabled}
+                onSelectionChange={this.props.onSelectionChange}
             />
         );
     }

--- a/src/components/TextInputFocusable/index.native.js
+++ b/src/components/TextInputFocusable/index.native.js
@@ -24,6 +24,13 @@ const propTypes = {
 
     /** Prevent edits and interactions like focus for this input. */
     isDisabled: PropTypes.bool,
+
+    /** Selection Object */
+    selection: PropTypes.shape({
+        start: PropTypes.number,
+        end: PropTypes.number,
+    }),
+
 };
 
 const defaultProps = {
@@ -32,6 +39,10 @@ const defaultProps = {
     autoFocus: false,
     isDisabled: false,
     forwardedRef: null,
+    selection: {
+        start: 0,
+        end: 0,
+    },
 };
 
 class TextInputFocusable extends React.Component {
@@ -53,6 +64,8 @@ class TextInputFocusable extends React.Component {
     }
 
     render() {
+        // Selection Property not worked in IOS properly, So removed from props.
+        const {selection, ...newProps} = this.props;
         return (
             <TextInput
                 ref={el => this.textInput = el}
@@ -60,7 +73,7 @@ class TextInputFocusable extends React.Component {
                 rejectResponderTermination={false}
                 editable={!this.props.isDisabled}
                 /* eslint-disable-next-line react/jsx-props-no-spreading */
-                {...this.props}
+                {...newProps}
             />
         );
     }

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -112,6 +112,7 @@ class ReportActionCompose extends React.Component {
         this.shouldFocusInputOnScreenFocus = canFocusInputOnScreenFocus();
         this.focusEmojiSearchInput = this.focusEmojiSearchInput.bind(this);
         this.measureEmojiPopoverAnchorPosition = this.measureEmojiPopoverAnchorPosition.bind(this);
+        this.onSelectionChange = this.onSelectionChange.bind(this);
         this.emojiPopoverAnchor = null;
         this.emojiSearchInput = null;
 
@@ -126,6 +127,10 @@ class ReportActionCompose extends React.Component {
             emojiPopoverAnchorPosition: {
                 horizontal: 0,
                 vertical: 0,
+            },
+            selection: {
+                start: props.comment.length,
+                end: props.comment.length,
             },
         };
     }
@@ -147,6 +152,10 @@ class ReportActionCompose extends React.Component {
 
     componentWillUnmount() {
         Dimensions.removeEventListener('change', this.measureEmojiPopoverAnchorPosition);
+    }
+
+    onSelectionChange(e) {
+        this.setState({selection: e.nativeEvent.selection});
     }
 
     /**
@@ -269,8 +278,16 @@ class ReportActionCompose extends React.Component {
      */
     addEmojiToTextBox(emoji) {
         this.hideEmojiPicker();
-        this.textInput.value = this.comment + emoji;
+        const {selection} = this.state;
+        this.textInput.value = this.comment.slice(0, selection.start)
+            + emoji + this.comment.slice(selection.end, this.comment.length);
+        const updatedSelection = {
+            start: selection.start + emoji.length,
+            end: selection.start + emoji.length,
+        };
+        this.setState({selection: updatedSelection});
         this.setIsFocused(true);
+        this.focus();
         this.updateComment(this.textInput.value);
     }
 
@@ -420,6 +437,8 @@ class ReportActionCompose extends React.Component {
                                     shouldClear={this.state.textInputShouldClear}
                                     onClear={() => this.setTextInputShouldClear(false)}
                                     isDisabled={isComposeDisabled}
+                                    selection={this.state.selection}
+                                    onSelectionChange={this.onSelectionChange}
                                 />
 
                             </>


### PR DESCRIPTION
### Details
Fixed these issues
1.  Update Cursor position after adding emoji in safari
2. Make input focus after adding emoji
3. when the cursor in the middle of the text the emoji added at the end of the text, Also fixed this issue and add emoji to the current cursor position.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/2601

### Tests
1.  Add emoji in the safari browser.
2.  Add emoji in the middle of text

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web
**VIDEO**: https://recordit.co/ziMaD0TipI
#### Mobile Web
**VIDEO**: https://recordit.co/WFYVuK3m9z
#### Desktop
**VIDEO** :https://recordit.co/WvLfDW0iEx
#### iOS
**VIDEO**: https://recordit.co/7ULinokWwp
#### Android
https://user-images.githubusercontent.com/31027036/119298365-bf9aef00-bc11-11eb-8a2e-5b9b5da12c2b.mp4

