### PR TITLE
Change IOUBadge color depending on which user owes money

### DIFF
--- a/src/components/IOUBadge.js
+++ b/src/components/IOUBadge.js
@@ -11,18 +11,31 @@ const propTypes = {
     iouReport: PropTypes.shape({
         /** The total amount in cents */
         total: PropTypes.number,
+
+        /** The owner of the IOUReport */
+        ownerEmail: PropTypes.string,
     }),
+
+    /** Session of currently logged in user */
+    session: PropTypes.shape({
+        email: PropTypes.string.isRequired,
+    }).isRequired,
 };
 
 const defaultProps = {
     iouReport: {
         total: 0,
+        ownerEmail: null,
     },
 };
 
 const IOUBadge = props => (
     <View
-        style={[styles.badge, styles.badgeSuccess, styles.ml2]}
+        style={[
+            styles.badge,
+            styles.ml2,
+            props.session.email === props.iouReport.ownerEmail ? styles.badgeSuccess : styles.badgeDanger,
+        ]}
     >
         <Text
             style={styles.badgeText}
@@ -39,5 +52,8 @@ IOUBadge.defaultProps = defaultProps;
 export default withOnyx({
     iouReport: {
         key: ({iouReportID}) => `${ONYXKEYS.COLLECTION.REPORT_IOUS}${iouReportID}`,
+    },
+    session: {
+        key: ONYXKEYS.SESSION,
     },
 })(IOUBadge);


### PR DESCRIPTION
@Julesssss will you please review this?

### Details
This PR updates the IOUBadge color to be red if the user owes money and green if they are owed money.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/154518

### Tests/QA
1. Sign in with 2 different users on 2 different platforms
2. Have User A request money from User B, confirm that an IOU badge shows up 
3. Confirm the badge for User A is green and the badge for User B is red
4. Confirm the badge color is correct in both the header and the option list
5. Have User B request money from User A so that User A owes User B, confirm the badge colors switch

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web
![image](https://user-images.githubusercontent.com/3981102/119426084-74d6b100-bcbd-11eb-98a2-312bddef3055.png)

#### Mobile Web
<img src='https://user-images.githubusercontent.com/3981102/119427078-3e9a3100-bcbf-11eb-85cc-30cd16d2e4cf.png' width='300'/>
<img src='https://user-images.githubusercontent.com/3981102/119427136-583b7880-bcbf-11eb-8467-4b3000727778.png' width='300'/>

#### Desktop
![image](https://user-images.githubusercontent.com/3981102/119426433-1231e500-bcbe-11eb-9871-7ef44b0cabfb.png)

#### iOS
<img src='https://user-images.githubusercontent.com/3981102/119426094-7b652880-bcbd-11eb-96f4-6d2027fd9dc2.png' width='300'/>
<img src='https://user-images.githubusercontent.com/3981102/119426108-815b0980-bcbd-11eb-8f7d-8c4978864921.png' width='300'/>

#### Android
<img src='https://user-images.githubusercontent.com/3981102/119426470-283fa580-bcbe-11eb-96c6-7e8c4c590f99.png' width='300'/>
