### PR TITLE
If we edit the most recent message, update the lastMessageText in the report object as well

### DIFF
--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -488,6 +488,13 @@ function updateReportActionMessage(reportID, sequenceNumber, message) {
     const actionToMerge = {};
     actionToMerge[sequenceNumber] = {message: [message]};
     Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`, actionToMerge);
+
+    // If this is the most recent message, update the lastMessageText in the report object as well
+    if (sequenceNumber === reportMaxSequenceNumbers[reportID]) {
+        Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, {
+            lastMessageText: message.html,
+        });
+    }
 }
 
 /**


### PR DESCRIPTION
@ctkochan22 please review

### Details
When editing a comment, update the `lastMessageText` of a report if the comment we're editing is the last comment in the report.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/2805

### Tests/QA
1. Edit a comment of yours that is the last comment on a report
2. Make sure the preview of the comment is also update in the LHN:
![Kapture 2021-05-24 at 21 38 29](https://user-images.githubusercontent.com/4741899/119440684-a3fb1b80-bcd9-11eb-99c0-0cf4f8c36611.gif)

3. As the other participant on the report, make sure your preview also updates as well:
![Kapture 2021-05-24 at 21 40 23](https://user-images.githubusercontent.com/4741899/119440701-ae1d1a00-bcd9-11eb-9f40-73bdc3777acd.gif)