### PR TITLE
Make context menu items accessible and readable by screen readers

### DIFF
--- a/src/pages/home/report/ReportActionContextMenuItem.js
+++ b/src/pages/home/report/ReportActionContextMenuItem.js
@@ -68,6 +68,8 @@ class ReportActionContextMenuItem extends Component {
                 ? (
                     <Tooltip text={text}>
                         <Pressable
+                            accessible
+                            accessibilityLabel={text}
                             onPress={this.triggerPressAndUpdateSuccess}
                             style={
                                 ({hovered, pressed}) => [


### PR DESCRIPTION
### Details
This allows mini context menu items for report actions to be readable by screen readers and highlightable.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/3103

### Tests
1. Download [the screen reader extension for Chrome](https://chrome.google.com/webstore/detail/screen-reader/kgejglhpjiefppelpmljglcjbhoiplfn)
2. Navigate to any chat.
3. Hover over a sent message and click on the context menu items. Verify that the screen reader reads them back to you.
4. For desktop (Mac) turn on Voiceover in the accessibility settings.
5. Repeat steps 3 and 4.

### QA Steps
Same as tests

### Tested On

- [x] Web
- [x] Desktop

### Screenshots (sound on)

#### Web
https://user-images.githubusercontent.com/31285285/119442778-06e0c700-bd5b-11eb-8d01-678f0e80cd92.mp4

#### Desktop
https://user-images.githubusercontent.com/31285285/119442795-0f390200-bd5b-11eb-81bc-de7e95a978af.mp4