### PR TITLE
Profile - GMT time is not displayed #2097

### DIFF
--- a/src/pages/DetailsPage.js
+++ b/src/pages/DetailsPage.js
@@ -45,6 +45,8 @@ const DetailsPage = ({personalDetails, route, translate}) => {
     // If we have a reportID param this means that we
     // arrived here via the ParticipantsPage and should be allowed to navigate back to it
     const shouldShowBackButton = Boolean(route.params.reportID);
+    const timezone = moment().tz(details.timezone.selected);
+
     return (
         <ScreenWrapper>
             <HeaderWithCloseButton
@@ -107,7 +109,15 @@ const DetailsPage = ({personalDetails, route, translate}) => {
                                     <Text style={[styles.textP]} numberOfLines={1}>
                                         {moment().tz(details.timezone.selected).format('LT')}
                                         {' '}
-                                        {moment().tz(details.timezone.selected).zoneAbbr()}
+                                        {isNaN(timezone.zoneAbbr()) ? (
+                                            <Text>{timezone.zoneAbbr()}</Text>
+                                        ) : (
+                                            <Text>
+                                            {timezone.toString().split("-")[0].slice(-3)}
+                                            {' '}
+                                            {timezone.zoneAbbr()}
+                                            </Text>
+                                        )}
                                     </Text>
                                 </View>
                             ) : null}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This issue is resolved by just modifying moment syntax because in the moment library, some timezone abbreviations, not support. so if return the numeric value I've put modified syntax to show GMT.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes https://github.com/Expensify/Expensify.cash/issues/2097

### Tests

1. Pull code from GitHub and install its dependencies via the below command: npm install
2. Run this project locally via npm run web / npm run android
3. login via existing credentials.
4. Go to the settings page then open the profile tab.
5. Set desired timezone.
6. log out and log in with another account.
7. search for the first account and check his/her profile and check on the local time option. It will show GMT or any other time zone.

### QA Steps
I've already QA this issue and it's working properly.

### Tested On

- [x] Web
- [x] Mobile Web
- [ ] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
![web](https://user-images.githubusercontent.com/43398804/119501086-26d9b000-bd86-11eb-8ff4-4e883af5854b.png)


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
![web](https://user-images.githubusercontent.com/43398804/119501117-30631800-bd86-11eb-86e3-1c92ce16e18f.png)


#### iOS
![ios](https://user-images.githubusercontent.com/43398804/119501128-33f69f00-bd86-11eb-99ae-9d22c548f314.png)


#### Android
![Uploading and.jpeg…]()


**I have read the CLA Document and I hereby sign the CLA**