### PR TITLE
Profile - GMT time is not displayed

### DIFF
--- a/src/pages/DetailsPage.js
+++ b/src/pages/DetailsPage.js
@@ -46,7 +46,8 @@ const DetailsPage = ({personalDetails, route, translate}) => {
     // arrived here via the ParticipantsPage and should be allowed to navigate back to it
     const shouldShowBackButton = Boolean(route.params.reportID);
     const timezone = moment().tz(details.timezone.selected);
-
+    const currentTime = isNaN(timezone.zoneAbbr()) ? timezone.zoneAbbr() : `${timezone.toString().split("-")[0].slice(-3)} ${timezone.zoneAbbr()}` 
+    
     return (
         <ScreenWrapper>
             <HeaderWithCloseButton
@@ -107,17 +108,7 @@ const DetailsPage = ({personalDetails, route, translate}) => {
                                         {translate('detailsPage.localTime')}
                                     </Text>
                                     <Text style={[styles.textP]} numberOfLines={1}>
-                                        {moment().tz(details.timezone.selected).format('LT')}
-                                        {' '}
-                                        {isNaN(timezone.zoneAbbr()) ? (
-                                            <Text>{timezone.zoneAbbr()}</Text>
-                                        ) : (
-                                            <Text>
-                                            {timezone.toString().split("-")[0].slice(-3)}
-                                            {' '}
-                                            {timezone.zoneAbbr()}
-                                            </Text>
-                                        )}
+                                        {timezone.format('LT')}{' '}{currentTime}
                                     </Text>
                                 </View>
                             ) : null}

--- a/src/pages/DetailsPage.js
+++ b/src/pages/DetailsPage.js
@@ -46,8 +46,7 @@ const DetailsPage = ({personalDetails, route, translate}) => {
     // arrived here via the ParticipantsPage and should be allowed to navigate back to it
     const shouldShowBackButton = Boolean(route.params.reportID);
     const timezone = moment().tz(details.timezone.selected);
-    const currentTime = isNaN(timezone.zoneAbbr()) ? timezone.zoneAbbr() : `${timezone.toString().split("-")[0].slice(-3)} ${timezone.zoneAbbr()}` 
-    
+    const currentTime = Number.isNaN(Number(timezone.zoneAbbr())) ? timezone.zoneAbbr() : `${timezone.toString().split(/[+-]/)[0].slice(-3)} ${timezone.zoneAbbr()}`;
     return (
         <ScreenWrapper>
             <HeaderWithCloseButton
@@ -108,7 +107,9 @@ const DetailsPage = ({personalDetails, route, translate}) => {
                                         {translate('detailsPage.localTime')}
                                     </Text>
                                     <Text style={[styles.textP]} numberOfLines={1}>
-                                        {timezone.format('LT')}{' '}{currentTime}
+                                        {timezone.format('LT')}
+                                        {' '}
+                                        {currentTime}
                                     </Text>
                                 </View>
                             ) : null}

--- a/src/pages/DetailsPage.js
+++ b/src/pages/DetailsPage.js
@@ -45,7 +45,8 @@ const DetailsPage = ({personalDetails, route, translate}) => {
     // If we have a reportID param this means that we
     // arrived here via the ParticipantsPage and should be allowed to navigate back to it
     const shouldShowBackButton = Boolean(route.params.reportID);
-    
+    const timezone = moment().tz(details.timezone.selected);
+
     return (
         <ScreenWrapper>
             <HeaderWithCloseButton
@@ -108,7 +109,15 @@ const DetailsPage = ({personalDetails, route, translate}) => {
                                     <Text style={[styles.textP]} numberOfLines={1}>
                                         {moment().tz(details.timezone.selected).format('LT')}
                                         {' '}
-                                        {moment().tz(details.timezone.selected).zoneAbbr()}
+                                        {isNaN(timezone.zoneAbbr()) ? (
+                                            <Text>{timezone.zoneAbbr()}</Text>
+                                        ) : (
+                                            <Text>
+                                            {timezone.toString().split("-")[0].slice(-3)}
+                                            {' '}
+                                            {timezone.zoneAbbr()}
+                                            </Text>
+                                        )}
                                     </Text>
                                 </View>
                             ) : null}

--- a/src/pages/DetailsPage.js
+++ b/src/pages/DetailsPage.js
@@ -46,7 +46,8 @@ const DetailsPage = ({personalDetails, route, translate}) => {
     // arrived here via the ParticipantsPage and should be allowed to navigate back to it
     const shouldShowBackButton = Boolean(route.params.reportID);
     const timezone = moment().tz(details.timezone.selected);
-    const currentTime = Number.isNaN(Number(timezone.zoneAbbr())) ? timezone.zoneAbbr() : `${timezone.toString().split(/[+-]/)[0].slice(-3)} ${timezone.zoneAbbr()}`;
+    const GMTTime = `${timezone.toString().split(/[+-]/)[0].slice(-3)} ${timezone.zoneAbbr()}`;
+    const currentTime = Number.isNaN(Number(timezone.zoneAbbr())) ? timezone.zoneAbbr() : GMTTime;
     return (
         <ScreenWrapper>
             <HeaderWithCloseButton

--- a/src/pages/DetailsPage.js
+++ b/src/pages/DetailsPage.js
@@ -45,6 +45,7 @@ const DetailsPage = ({personalDetails, route, translate}) => {
     // If we have a reportID param this means that we
     // arrived here via the ParticipantsPage and should be allowed to navigate back to it
     const shouldShowBackButton = Boolean(route.params.reportID);
+    
     return (
         <ScreenWrapper>
             <HeaderWithCloseButton


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This issue is resolved by just modifying moment syntax because in the moment library, some timezone abbreviations, not support. so if return the numeric value I've put modified syntax to show GMT.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes https://github.com/Expensify/Expensify.cash/issues/2097

### Tests
Pull

1.  code from GitHub and install its dependencies via the below command: npm install
2. Run this project locally via npm run web / npm run android
3. login via existing credentials.
4. Go to the settings page then open the profile tab.
5. Set desired timezone.
6. log out and log in with another account.
7. search for the first account and check his/her profile and check on the local time option. It will show GMT or any other time zone.

### QA Steps
I've already QA this issue and it's working properly.

### Tested On

- [x] Web
- [x] Mobile Web
- [ ] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
![web](https://user-images.githubusercontent.com/43398804/119504880-04e22c80-bd8a-11eb-95bb-be01e10a50f0.png)


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
![web](https://user-images.githubusercontent.com/43398804/119504842-fbf15b00-bd89-11eb-9f6f-c3268fb46e65.png)


#### iOS
![ios](https://user-images.githubusercontent.com/43398804/119504892-09a6e080-bd8a-11eb-8806-b4bf4cab52d0.png)


#### Android
![and](https://user-images.githubusercontent.com/43398804/119504910-0dd2fe00-bd8a-11eb-98cc-7c4d4865e13d.jpeg)


**I have read the CLA Document and I hereby sign the CLA**