### PR TITLE
#3019 move pointerEvents style from Image to View for Avatar

### DIFF
--- a/src/components/Avatar.js
+++ b/src/components/Avatar.js
@@ -1,5 +1,5 @@
 import React, {PureComponent} from 'react';
-import {Image} from 'react-native';
+import {Image, View} from 'react-native';
 import PropTypes from 'prop-types';
 import styles from '../styles/styles';
 
@@ -10,6 +10,9 @@ const propTypes = {
     /** Extra styles to pass */
     style: PropTypes.arrayOf(PropTypes.any),
 
+    /** Extra styles to pass to View wrapper */
+    containerStyle: PropTypes.arrayOf(PropTypes.any),
+
     /** Set the size of Avatar */
     size: PropTypes.oneOf(['default', 'small']),
 };
@@ -17,6 +20,7 @@ const propTypes = {
 const defaultProps = {
     source: '',
     style: [],
+    containerStyle: [],
     size: 'default',
 };
 
@@ -27,13 +31,15 @@ class Avatar extends PureComponent {
         }
 
         return (
-            <Image
-                source={{uri: this.props.source}}
-                style={[
-                    this.props.size === 'small' ? styles.avatarSmall : styles.avatarNormal,
-                    ...this.props.style,
-                ]}
-            />
+            <View style={[...this.props.containerStyle, styles.avatarWrapper]}>
+                <Image
+                    source={{uri: this.props.source}}
+                    style={[
+                        this.props.size === 'small' ? styles.avatarSmall : styles.avatarNormal,
+                        ...this.props.style,
+                    ]}
+                />
+            </View>
         );
     }
 }

--- a/src/components/Avatar.js
+++ b/src/components/Avatar.js
@@ -39,7 +39,7 @@ class Avatar extends PureComponent {
             : [this.props.style];
 
         return (
-            <View style={[...this.props.containerStyles, styles.avatarWrapper]}>
+            <View pointerEvents="none" style={this.props.containerStyles}>
                 <Image
                     source={{uri: this.props.source}}
                     style={[

--- a/src/components/Avatar.js
+++ b/src/components/Avatar.js
@@ -8,10 +8,10 @@ const propTypes = {
     source: PropTypes.string,
 
     /** Extra styles to pass */
-    style: PropTypes.arrayOf(PropTypes.any),
+    styles: PropTypes.arrayOf(PropTypes.object),
 
     /** Extra styles to pass to View wrapper */
-    containerStyle: PropTypes.arrayOf(PropTypes.any),
+    containerStyles: PropTypes.arrayOf(PropTypes.object),
 
     /** Set the size of Avatar */
     size: PropTypes.oneOf(['default', 'small']),
@@ -19,8 +19,8 @@ const propTypes = {
 
 const defaultProps = {
     source: '',
-    style: [],
-    containerStyle: [],
+    styles: [],
+    containerStyles: [],
     size: 'default',
 };
 
@@ -31,12 +31,12 @@ class Avatar extends PureComponent {
         }
 
         return (
-            <View style={[...this.props.containerStyle, styles.avatarWrapper]}>
+            <View style={[...this.props.containerStyles, styles.avatarWrapper]}>
                 <Image
                     source={{uri: this.props.source}}
                     style={[
                         this.props.size === 'small' ? styles.avatarSmall : styles.avatarNormal,
-                        ...this.props.style,
+                        ...this.props.styles,
                     ]}
                 />
             </View>

--- a/src/components/Avatar.js
+++ b/src/components/Avatar.js
@@ -1,3 +1,4 @@
+import _ from 'underscore';
 import React, {PureComponent} from 'react';
 import {Image, View} from 'react-native';
 import PropTypes from 'prop-types';
@@ -8,7 +9,10 @@ const propTypes = {
     source: PropTypes.string,
 
     /** Extra styles to pass */
-    styles: PropTypes.arrayOf(PropTypes.object),
+    style: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.object),
+        PropTypes.object,
+    ]),
 
     /** Extra styles to pass to View wrapper */
     containerStyles: PropTypes.arrayOf(PropTypes.object),
@@ -19,7 +23,7 @@ const propTypes = {
 
 const defaultProps = {
     source: '',
-    styles: [],
+    style: [],
     containerStyles: [],
     size: 'default',
 };
@@ -30,13 +34,17 @@ class Avatar extends PureComponent {
             return null;
         }
 
+        const propsStyle = _.isArray(this.props.style)
+            ? this.props.style
+            : [this.props.style];
+
         return (
             <View style={[...this.props.containerStyles, styles.avatarWrapper]}>
                 <Image
                     source={{uri: this.props.source}}
                     style={[
                         this.props.size === 'small' ? styles.avatarSmall : styles.avatarNormal,
-                        ...this.props.styles,
+                        ...propsStyle,
                     ]}
                 />
             </View>

--- a/src/components/Avatar.js
+++ b/src/components/Avatar.js
@@ -1,4 +1,3 @@
-import _ from 'underscore';
 import React, {PureComponent} from 'react';
 import {Image, View} from 'react-native';
 import PropTypes from 'prop-types';
@@ -8,11 +7,8 @@ const propTypes = {
     /** Url source for the avatar */
     source: PropTypes.string,
 
-    /** Extra styles to pass */
-    style: PropTypes.oneOfType([
-        PropTypes.arrayOf(PropTypes.object),
-        PropTypes.object,
-    ]),
+    /** Extra styles to pass to Image */
+    imageStyles: PropTypes.arrayOf(PropTypes.object),
 
     /** Extra styles to pass to View wrapper */
     containerStyles: PropTypes.arrayOf(PropTypes.object),
@@ -23,7 +19,7 @@ const propTypes = {
 
 const defaultProps = {
     source: '',
-    style: [],
+    imageStyles: [],
     containerStyles: [],
     size: 'default',
 };
@@ -34,17 +30,13 @@ class Avatar extends PureComponent {
             return null;
         }
 
-        const propsStyle = _.isArray(this.props.style)
-            ? this.props.style
-            : [this.props.style];
-
         return (
             <View pointerEvents="none" style={this.props.containerStyles}>
                 <Image
                     source={{uri: this.props.source}}
                     style={[
                         this.props.size === 'small' ? styles.avatarSmall : styles.avatarNormal,
-                        ...propsStyle,
+                        ...this.props.imageStyles,
                     ]}
                 />
             </View>

--- a/src/components/AvatarWithIndicator.js
+++ b/src/components/AvatarWithIndicator.js
@@ -123,7 +123,7 @@ class AvatarWithIndicator extends PureComponent {
 
         return (
             <View
-                style={[this.props.size === 'large' ? styles.avatarLarge : styles.sidebarAvatar]}
+                style={[this.props.size === 'large' ? styles.avatarLarge : styles.sidebarAvatar, styles.avatarWrapper]}
             >
                 <Avatar
                     style={[this.props.size === 'large' ? styles.avatarLarge : null]}

--- a/src/components/AvatarWithIndicator.js
+++ b/src/components/AvatarWithIndicator.js
@@ -126,7 +126,7 @@ class AvatarWithIndicator extends PureComponent {
                 style={[this.props.size === 'large' ? styles.avatarLarge : styles.sidebarAvatar]}
             >
                 <Avatar
-                    style={[this.props.size === 'large' ? styles.avatarLarge : null]}
+                    styles={[this.props.size === 'large' ? styles.avatarLarge : null]}
                     source={this.props.source}
                 />
                 <Animated.View style={StyleSheet.flatten(indicatorStyles)}>

--- a/src/components/AvatarWithIndicator.js
+++ b/src/components/AvatarWithIndicator.js
@@ -126,7 +126,7 @@ class AvatarWithIndicator extends PureComponent {
                 style={[this.props.size === 'large' ? styles.avatarLarge : styles.sidebarAvatar]}
             >
                 <Avatar
-                    style={[this.props.size === 'large' ? styles.avatarLarge : null]}
+                    imageStyles={[this.props.size === 'large' ? styles.avatarLarge : null]}
                     source={this.props.source}
                 />
                 <Animated.View style={StyleSheet.flatten(indicatorStyles)}>

--- a/src/components/AvatarWithIndicator.js
+++ b/src/components/AvatarWithIndicator.js
@@ -126,7 +126,7 @@ class AvatarWithIndicator extends PureComponent {
                 style={[this.props.size === 'large' ? styles.avatarLarge : styles.sidebarAvatar]}
             >
                 <Avatar
-                    styles={[this.props.size === 'large' ? styles.avatarLarge : null]}
+                    style={[this.props.size === 'large' ? styles.avatarLarge : null]}
                     source={this.props.source}
                 />
                 <Animated.View style={StyleSheet.flatten(indicatorStyles)}>

--- a/src/components/AvatarWithIndicator.js
+++ b/src/components/AvatarWithIndicator.js
@@ -123,7 +123,7 @@ class AvatarWithIndicator extends PureComponent {
 
         return (
             <View
-                style={[this.props.size === 'large' ? styles.avatarLarge : styles.sidebarAvatar, styles.avatarWrapper]}
+                style={[this.props.size === 'large' ? styles.avatarLarge : styles.sidebarAvatar]}
             >
                 <Avatar
                     style={[this.props.size === 'large' ? styles.avatarLarge : null]}

--- a/src/components/MultipleAvatars.js
+++ b/src/components/MultipleAvatars.js
@@ -25,10 +25,7 @@ const defaultProps = {
 const MultipleAvatars = ({
     avatarImageURLs, size, secondAvatarStyle,
 }) => {
-    const avatarContainerStyles = [
-        size === 'small' ? styles.emptyAvatarSmall : styles.emptyAvatar,
-        styles.avatarWrapper,
-    ];
+    const avatarContainerStyles = [size === 'small' ? styles.emptyAvatarSmall : styles.emptyAvatar];
     const singleAvatarStyles = size === 'small' ? styles.singleAvatarSmall : styles.singleAvatar;
     const secondAvatarStyles = [
         size === 'small' ? styles.secondAvatarSmall : styles.secondAvatar,
@@ -48,7 +45,7 @@ const MultipleAvatars = ({
     }
 
     return (
-        <View style={avatarContainerStyles}>
+        <View style={[...avatarContainerStyles, styles.avatarWrapper]}>
             <View
                 style={singleAvatarStyles}
             >

--- a/src/components/MultipleAvatars.js
+++ b/src/components/MultipleAvatars.js
@@ -25,7 +25,7 @@ const defaultProps = {
 const MultipleAvatars = ({
     avatarImageURLs, size, secondAvatarStyle,
 }) => {
-    const avatarContainerStyles = [size === 'small' ? styles.emptyAvatarSmall : styles.emptyAvatar];
+    const avatarContainerStyles = size === 'small' ? styles.emptyAvatarSmall : styles.emptyAvatar;
     const singleAvatarStyles = size === 'small' ? styles.singleAvatarSmall : styles.singleAvatar;
     const secondAvatarStyles = [
         size === 'small' ? styles.secondAvatarSmall : styles.secondAvatar,
@@ -45,7 +45,7 @@ const MultipleAvatars = ({
     }
 
     return (
-        <View style={[...avatarContainerStyles, styles.avatarWrapper]}>
+        <View style={[avatarContainerStyles, styles.avatarWrapper]}>
             <View
                 style={singleAvatarStyles}
             >

--- a/src/components/MultipleAvatars.js
+++ b/src/components/MultipleAvatars.js
@@ -25,7 +25,10 @@ const defaultProps = {
 const MultipleAvatars = ({
     avatarImageURLs, size, secondAvatarStyle,
 }) => {
-    const avatarContainerStyles = size === 'small' ? styles.emptyAvatarSmall : styles.emptyAvatar;
+    const avatarContainerStyles = [
+        size === 'small' ? styles.emptyAvatarSmall : styles.emptyAvatar,
+        styles.avatarWrapper,
+    ];
     const singleAvatarStyles = size === 'small' ? styles.singleAvatarSmall : styles.singleAvatar;
     const secondAvatarStyles = [
         size === 'small' ? styles.secondAvatarSmall : styles.secondAvatar,

--- a/src/components/MultipleAvatars.js
+++ b/src/components/MultipleAvatars.js
@@ -45,7 +45,7 @@ const MultipleAvatars = ({
     }
 
     return (
-        <View style={[avatarContainerStyles, styles.avatarWrapper]}>
+        <View pointerEvents="none" style={avatarContainerStyles}>
             <View
                 style={singleAvatarStyles}
             >

--- a/src/pages/DetailsPage.js
+++ b/src/pages/DetailsPage.js
@@ -64,7 +64,7 @@ const DetailsPage = ({personalDetails, route, translate}) => {
                         <View style={styles.pageWrapper}>
                             <Avatar
                                 containerStyles={[styles.avatarLarge, styles.mb3]}
-                                style={[styles.avatarLarge]}
+                                imageStyles={[styles.avatarLarge]}
                                 source={details.avatar}
                             />
                             <Text style={[styles.displayName, styles.mt1, styles.mb6]} numberOfLines={1}>

--- a/src/pages/DetailsPage.js
+++ b/src/pages/DetailsPage.js
@@ -64,7 +64,7 @@ const DetailsPage = ({personalDetails, route, translate}) => {
                         <View style={styles.pageWrapper}>
                             <Avatar
                                 containerStyles={[styles.avatarLarge, styles.mb3]}
-                                styles={[styles.avatarLarge]}
+                                style={[styles.avatarLarge]}
                                 source={details.avatar}
                             />
                             <Text style={[styles.displayName, styles.mt1, styles.mb6]} numberOfLines={1}>

--- a/src/pages/DetailsPage.js
+++ b/src/pages/DetailsPage.js
@@ -63,7 +63,7 @@ const DetailsPage = ({personalDetails, route, translate}) => {
                     <View>
                         <View style={styles.pageWrapper}>
                             <View
-                                style={[styles.avatarLarge, styles.mb3]}
+                                style={[styles.avatarLarge, styles.mb3, styles.avatarWrapper]}
                             >
                                 <Avatar
                                     style={[styles.avatarLarge]}

--- a/src/pages/DetailsPage.js
+++ b/src/pages/DetailsPage.js
@@ -63,7 +63,7 @@ const DetailsPage = ({personalDetails, route, translate}) => {
                     <View>
                         <View style={styles.pageWrapper}>
                             <Avatar
-                                containerStyle={[styles.avatarLarge, styles.mb3, styles.avatarWrapper]}
+                                containerStyle={[styles.avatarLarge, styles.mb3]}
                                 style={[styles.avatarLarge]}
                                 source={details.avatar}
                             />

--- a/src/pages/DetailsPage.js
+++ b/src/pages/DetailsPage.js
@@ -62,14 +62,11 @@ const DetailsPage = ({personalDetails, route, translate}) => {
                 {details ? (
                     <View>
                         <View style={styles.pageWrapper}>
-                            <View
-                                style={[styles.avatarLarge, styles.mb3, styles.avatarWrapper]}
-                            >
-                                <Avatar
-                                    style={[styles.avatarLarge]}
-                                    source={details.avatar}
-                                />
-                            </View>
+                            <Avatar
+                                containerStyle={[styles.avatarLarge, styles.mb3, styles.avatarWrapper]}
+                                style={[styles.avatarLarge]}
+                                source={details.avatar}
+                            />
                             <Text style={[styles.displayName, styles.mt1, styles.mb6]} numberOfLines={1}>
                                 {details.displayName
                                     ? details.displayName

--- a/src/pages/DetailsPage.js
+++ b/src/pages/DetailsPage.js
@@ -63,8 +63,8 @@ const DetailsPage = ({personalDetails, route, translate}) => {
                     <View>
                         <View style={styles.pageWrapper}>
                             <Avatar
-                                containerStyle={[styles.avatarLarge, styles.mb3]}
-                                style={[styles.avatarLarge]}
+                                containerStyles={[styles.avatarLarge, styles.mb3]}
+                                styles={[styles.avatarLarge]}
                                 source={details.avatar}
                             />
                             <Text style={[styles.displayName, styles.mt1, styles.mb6]} numberOfLines={1}>

--- a/src/pages/home/report/ReportActionItemSingle.js
+++ b/src/pages/home/report/ReportActionItemSingle.js
@@ -51,7 +51,7 @@ const ReportActionItemSingle = ({
     return (
         <View style={wrapperStyles}>
             <Avatar
-                style={[styles.actionAvatar]}
+                imageStyles={[styles.actionAvatar]}
                 source={avatarUrl}
             />
             <View style={[styles.chatItemRight]}>

--- a/src/pages/home/report/ReportActionItemSingle.js
+++ b/src/pages/home/report/ReportActionItemSingle.js
@@ -51,7 +51,7 @@ const ReportActionItemSingle = ({
     return (
         <View style={wrapperStyles}>
             <Avatar
-                styles={[styles.actionAvatar]}
+                style={[styles.actionAvatar]}
                 source={avatarUrl}
             />
             <View style={[styles.chatItemRight]}>

--- a/src/pages/home/report/ReportActionItemSingle.js
+++ b/src/pages/home/report/ReportActionItemSingle.js
@@ -51,7 +51,7 @@ const ReportActionItemSingle = ({
     return (
         <View style={wrapperStyles}>
             <Avatar
-                style={[styles.actionAvatar]}
+                styles={[styles.actionAvatar]}
                 source={avatarUrl}
             />
             <View style={[styles.chatItemRight]}>

--- a/src/pages/home/report/ReportActionItemSingle.js
+++ b/src/pages/home/report/ReportActionItemSingle.js
@@ -50,10 +50,12 @@ const ReportActionItemSingle = ({
     const personArray = displayName ? [{type: 'TEXT', text: displayName}] : action.person;
     return (
         <View style={wrapperStyles}>
-            <Avatar
-                style={[styles.actionAvatar]}
-                source={avatarUrl}
-            />
+            <View style={styles.avatarWrapper}>
+                <Avatar
+                    style={[styles.actionAvatar]}
+                    source={avatarUrl}
+                />
+            </View>
             <View style={[styles.chatItemRight]}>
                 <View style={[styles.chatItemMessageHeader]}>
                     {_.map(personArray, (fragment, index) => (

--- a/src/pages/home/report/ReportActionItemSingle.js
+++ b/src/pages/home/report/ReportActionItemSingle.js
@@ -50,12 +50,10 @@ const ReportActionItemSingle = ({
     const personArray = displayName ? [{type: 'TEXT', text: displayName}] : action.person;
     return (
         <View style={wrapperStyles}>
-            <View style={styles.avatarWrapper}>
-                <Avatar
-                    style={[styles.actionAvatar]}
-                    source={avatarUrl}
-                />
-            </View>
+            <Avatar
+                style={[styles.actionAvatar]}
+                source={avatarUrl}
+            />
             <View style={[styles.chatItemRight]}>
                 <View style={[styles.chatItemMessageHeader]}>
                     {_.map(personArray, (fragment, index) => (

--- a/src/pages/settings/Profile/ProfilePage.js
+++ b/src/pages/settings/Profile/ProfilePage.js
@@ -269,12 +269,10 @@ class ProfilePage extends Component {
                     onCloseButtonPress={() => Navigation.dismissModal(true)}
                 />
                 <ScrollView style={styles.flex1} contentContainerStyle={styles.p5}>
-                    <View style={styles.avatarWrapper}>
-                        <Avatar
-                            style={[styles.avatarLarge, styles.alignSelfCenter]}
-                            source={this.props.myPersonalDetails.avatar}
-                        />
-                    </View>
+                    <Avatar
+                        style={[styles.avatarLarge, styles.alignSelfCenter]}
+                        source={this.props.myPersonalDetails.avatar}
+                    />
                     <AttachmentPicker>
                         {({openPicker}) => (
                             <>

--- a/src/pages/settings/Profile/ProfilePage.js
+++ b/src/pages/settings/Profile/ProfilePage.js
@@ -270,7 +270,7 @@ class ProfilePage extends Component {
                 />
                 <ScrollView style={styles.flex1} contentContainerStyle={styles.p5}>
                     <Avatar
-                        style={[styles.avatarLarge, styles.alignSelfCenter]}
+                        styles={[styles.avatarLarge, styles.alignSelfCenter]}
                         source={this.props.myPersonalDetails.avatar}
                     />
                     <AttachmentPicker>

--- a/src/pages/settings/Profile/ProfilePage.js
+++ b/src/pages/settings/Profile/ProfilePage.js
@@ -270,7 +270,7 @@ class ProfilePage extends Component {
                 />
                 <ScrollView style={styles.flex1} contentContainerStyle={styles.p5}>
                     <Avatar
-                        style={[styles.avatarLarge, styles.alignSelfCenter]}
+                        imageStyles={[styles.avatarLarge, styles.alignSelfCenter]}
                         source={this.props.myPersonalDetails.avatar}
                     />
                     <AttachmentPicker>

--- a/src/pages/settings/Profile/ProfilePage.js
+++ b/src/pages/settings/Profile/ProfilePage.js
@@ -270,7 +270,7 @@ class ProfilePage extends Component {
                 />
                 <ScrollView style={styles.flex1} contentContainerStyle={styles.p5}>
                     <Avatar
-                        styles={[styles.avatarLarge, styles.alignSelfCenter]}
+                        style={[styles.avatarLarge, styles.alignSelfCenter]}
                         source={this.props.myPersonalDetails.avatar}
                     />
                     <AttachmentPicker>

--- a/src/pages/settings/Profile/ProfilePage.js
+++ b/src/pages/settings/Profile/ProfilePage.js
@@ -269,10 +269,12 @@ class ProfilePage extends Component {
                     onCloseButtonPress={() => Navigation.dismissModal(true)}
                 />
                 <ScrollView style={styles.flex1} contentContainerStyle={styles.p5}>
-                    <Avatar
-                        style={[styles.avatarLarge, styles.alignSelfCenter]}
-                        source={this.props.myPersonalDetails.avatar}
-                    />
+                    <View style={styles.avatarWrapper}>
+                        <Avatar
+                            style={[styles.avatarLarge, styles.alignSelfCenter]}
+                            source={this.props.myPersonalDetails.avatar}
+                        />
+                    </View>
                     <AttachmentPicker>
                         {({openPicker}) => (
                             <>

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -993,7 +993,6 @@ const styles = {
         width: variables.componentSizeNormal,
         backgroundColor: themeColors.icon,
         borderRadius: variables.componentSizeNormal,
-        pointerEvents: 'none',
     },
 
     avatarSmall: {
@@ -1001,7 +1000,6 @@ const styles = {
         width: variables.avatarSizeSmall,
         backgroundColor: themeColors.icon,
         borderRadius: variables.avatarSizeSmall,
-        pointerEvents: 'none',
     },
 
     avatarInnerText: {
@@ -1028,6 +1026,10 @@ const styles = {
     avatar: {
         backgroundColor: themeColors.sidebar,
         borderColor: themeColors.sidebar,
+    },
+
+    avatarWrapper: {
+        pointerEvents: 'none',
     },
 
     focusedAvatar: {

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1028,10 +1028,6 @@ const styles = {
         borderColor: themeColors.sidebar,
     },
 
-    avatarWrapper: {
-        pointerEvents: 'none',
-    },
-
     focusedAvatar: {
         backgroundColor: themeColors.border,
         borderColor: themeColors.border,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
@marcaaron Please check out the fix for https://github.com/Expensify/Expensify.cash/pull/3092/files#r639059422

### Details
<!-- Explanation of the change or anything fishy that is going on -->

Since there is no `pointerEvents` style on [react native Image](https://reactnative.dev/docs/image-style-props#props), and we need to apply that style to a [View](https://reactnative.dev/docs/view#pointerevents) instead, a new `avatarWrapper` style was created and **all Avatars** across the app now have a wrapping View with that style. 

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes #3019

### Tests
### QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

Mobile web Safari iOS:
1. On chat page tap on user icon to go to user details
2. Use 3D touch (long press on simulator) on the Profile icon
3. Make sure there is no image preview pop-up as in this video:

https://user-images.githubusercontent.com/43996225/118888031-2003f680-b8c9-11eb-8e12-2d0c5f8f3988.mp4

Other platforms:
1. On chat page tap on user icon to go to user details
2. Make sure the profile icon doesn't do anything unexpected when you long press it or try to interact with it in any other way.

**Try doing the same for any avatar on the app. All the avatars should be covered by this PR, not just the one mentioned on the original issue #3019**

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
<img width="379" alt="Screen Shot 2021-05-24 at 20 56 24" src="https://user-images.githubusercontent.com/64093836/119388148-91c9af00-bcd2-11eb-8921-b564e4f4d238.png">

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
<img width="379" alt="Simulator Screen Shot - iPhone 11 - 2021-05-24 at 20 54 23" src="https://user-images.githubusercontent.com/64093836/119387887-41525180-bcd2-11eb-9f9b-7cd5a5aedce5.png">

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
<img width="462" alt="Screen Shot 2021-05-24 at 21 00 04" src="https://user-images.githubusercontent.com/64093836/119388520-10265100-bcd3-11eb-9176-f5502b06a452.png">

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
<img width="379" alt="Screen Shot 2021-05-24 at 21 00 04" src="https://user-images.githubusercontent.com/64093836/119390424-b410fc00-bcd5-11eb-9042-57244d8172eb.png">

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
<img width="379" alt="Screen Shot 2021-05-24 at 21 00 04" src="https://user-images.githubusercontent.com/64093836/119390693-1669fc80-bcd6-11eb-9091-4176ccac84c1.png">