### PR TITLE
Add iOS exception handling for beta review

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -129,6 +129,8 @@ platform :ios do
         }
     )
 
+    # TODO: Remove this Exception handling when https://github.com/fastlane/fastlane/issues/18408 is resolved
+    # See: https://github.com/Expensify/Expensify.cash/pull/3166 for more information
     rescue Exception => e
       if e.message.include? "Another build is in review"
         UI.important("Another build is already in external beta review. Skipping external beta review submission")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -113,15 +113,8 @@ platform :ios do
 
     upload_to_testflight(
         api_key_path: "./ios/ios-fastlane-json-key.json",
-        # TODO: Remove skip_waiting_for_build_processing when https://github.com/fastlane/fastlane/issues/18408 is resolved
-        # See: https://github.com/Expensify/Expensify.cash/pull/1984 for more information
-        skip_waiting_for_build_processing: true,
-        # TODO: Set distribute_external back to true when https://github.com/fastlane/fastlane/issues/18408 is resolved
-        # See: https://github.com/Expensify/Expensify.cash/pull/1984 for more information
-        distribute_external: false,
-        # TODO: Set reject_build_waiting_for_review back to true when https://github.com/fastlane/fastlane/issues/18408 is resolved
-        # See: https://github.com/Expensify/Expensify.cash/pull/1984 for more information
-        reject_build_waiting_for_review: false,
+        distribute_external: true,
+        reject_build_waiting_for_review: true,
         changelog: "Thank you for beta testing Expensify.cash, this version includes bug fixes and improvements.",
         groups: ["Beta"],
         demo_account_required: true,
@@ -135,6 +128,13 @@ platform :ios do
             notes: "Use the account provided. Thank you for the review."
         }
     )
+
+    rescue Exception => e
+      if e.message.include? "Another build is in review"
+        UI.important("Another build is already in external beta review. Skipping external beta review submission")
+      else
+        raise
+      end
 
     upload_symbols_to_crashlytics(
       dsym_path: lane_context[SharedValues::DSYM_OUTPUT_PATH],


### PR DESCRIPTION
### Details
Adds the exception handling code as mentioned in this GitHub comment: https://github.com/fastlane/fastlane/issues/18408#issuecomment-843423247

I am not 100% that this exception handling will work on first run, it was hard to confirm that this check `e.message.include? "Another build is in review"` will work, but I am feeling confident it's a good first try.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/2748

### Tests
1. Merge this PR
2. It will create a TestFlight release and will test this code 🚀