### PR TITLE
[HOLD] Reduce iOS slowness by removing draftComment subscription

### DIFF
--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -2,8 +2,6 @@ import _ from 'underscore';
 import React, {Component} from 'react';
 import {Dimensions, View} from 'react-native';
 import PropTypes from 'prop-types';
-import {withOnyx} from 'react-native-onyx';
-import ONYXKEYS from '../../../ONYXKEYS';
 import ReportActionPropTypes from './ReportActionPropTypes';
 import {
     getReportActionItemStyle,
@@ -287,9 +285,4 @@ class ReportActionItem extends Component {
 
 ReportActionItem.propTypes = propTypes;
 ReportActionItem.defaultProps = defaultProps;
-
-export default withOnyx({
-    draftMessage: {
-        key: ({reportID, action}) => `${ONYXKEYS.COLLECTION.REPORT_ACTIONS_DRAFTS}${reportID}_${action.reportActionID}`,
-    },
-})(ReportActionItem);
+export default ReportActionItem;

--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -40,8 +40,6 @@ const propTypes = {
     /** Position index of the report action in the overall report FlatList view */
     index: PropTypes.number.isRequired,
 
-    /* Onyx Props */
-
     /** Draft message - if this is set the comment is in 'edit' mode */
     draftMessage: PropTypes.string,
 

--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -357,6 +357,7 @@ class ReportActionsView extends React.Component {
     }) {
         const shouldDisplayNewIndicator = this.props.report.newMarkerSequenceNumber > 0
                 && item.action.sequenceNumber === this.props.report.newMarkerSequenceNumber;
+        // eslint-disable-next-line max-len
         const draftMessage = this.props.draftMessages[`${ONYXKEYS.COLLECTION.REPORT_ACTIONS_DRAFTS}${this.props.reportID}_${item.action.reportActionID}`];
 
         return (

--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -63,6 +63,9 @@ const propTypes = {
         email: PropTypes.string,
     }),
 
+    /** All draft messages */
+    draftMessages: PropTypes.objectOf(PropTypes.string),
+
     ...windowDimensionsPropTypes,
     ...withDrawerPropTypes,
     ...withLocalizePropTypes,
@@ -76,6 +79,7 @@ const defaultProps = {
     },
     reportActions: {},
     session: {},
+    draftMessages: {},
 };
 
 class ReportActionsView extends React.Component {
@@ -353,6 +357,8 @@ class ReportActionsView extends React.Component {
     }) {
         const shouldDisplayNewIndicator = this.props.report.newMarkerSequenceNumber > 0
                 && item.action.sequenceNumber === this.props.report.newMarkerSequenceNumber;
+        const draftMessage = this.props.draftMessages[`${ONYXKEYS.COLLECTION.REPORT_ACTIONS_DRAFTS}${this.props.reportID}_${item.action.reportActionID}`];
+
         return (
             <ReportActionItem
                 reportID={this.props.reportID}
@@ -363,6 +369,7 @@ class ReportActionsView extends React.Component {
                 hasOutstandingIOU={this.props.report.hasOutstandingIOU}
                 index={index}
                 onLayout={this.recordTimeToMeasureItemLayout}
+                draftMessage={draftMessage}
             />
         );
     }
@@ -425,6 +432,9 @@ export default compose(
         },
         session: {
             key: ONYXKEYS.SESSION,
+        },
+        draftMessages: {
+            key: ONYXKEYS.COLLECTION.REPORT_ACTIONS_DRAFTS,
         },
     }),
 )(ReportActionsView);


### PR DESCRIPTION
@marcaaron @yuwenmemon will you please review?

### Details
This PR removes a subscription that was making it slower to load chats on iOS. **Note: This breaks the draftComment feature, so a fix will have to be implemented to re-introduce that**. More context in this issue: https://github.com/Expensify/Expensify.cash/issues/3167#issuecomment-849127577

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes https://github.com/Expensify/Expensify.cash/issues/3167

### Tests
Note this is much more noticeable on a physical device than it is on simulator

1. Open cash app in IOS
2. Navigate to a conversation
3. Navigate back to LHN
4. Navigate back to the same conversation, confirm the spinner doesn't block the UI for 5-10 seconds

### QA Steps
1. Open cash app in IOS
2. Navigate to a conversation
3. Navigate back to LHN
4. Navigate back to the same conversation, confirm the spinner doesn't block the UI for 5-10 seconds

### Tested On
- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [x] iOS
- [ ] Android
