### PR TITLE
Fix whitescreen when logging into a different account

### DIFF
--- a/src/libs/Navigation/AppNavigator/MainDrawerNavigator.js
+++ b/src/libs/Navigation/AppNavigator/MainDrawerNavigator.js
@@ -32,17 +32,13 @@ const defaultProps = {
 
 const Drawer = createDrawerNavigator();
 
-/**
- * We are decorating findLastAccessedReport so that it caches the first result once the reports load.
- * This will ensure the initialParams are only set once for the ReportScreen.
- */
-const getInitialReportScreenParams = _.once((reports) => {
+const getInitialReportScreenParams = (reports) => {
     const last = findLastAccessedReport(reports);
 
     // Fallback to empty if for some reason reportID cannot be derived - prevents the app from crashing
     const reportID = lodashGet(last, 'reportID', '');
     return {reportID: String(reportID)};
-});
+};
 
 const MainDrawerNavigator = (props) => {
     // When there are no reports there's no point to render the empty navigator


### PR DESCRIPTION
### Details
This `once` call would cache the results of the report to drop into, regardless of what accounts should have access to it. When logging out and then back into a different account, this would cause a blank screen to load instead of your most recent chat.

See this slack thread for more info: https://expensify.slack.com/archives/C01GTK53T8Q/p1622059995292000

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/2659

### Tests
1. Sign into an account
2. Make note of which chat you are brought to
3. Sign out
4. Sign into a different account without refreshing the page. 
5. _Verify_ you are brought to a different chat, and one that you have access to.

### QA Steps
1. Sign into an account
2. Make note of which chat you are brought to
3. Sign out
4. Sign into a different account without refreshing the page. 
5. _Verify_ you are brought to a different chat, and one that you have access to.

### Tested On

Mobile platforms all drop into the LHN, so I tested to verify it did not crash, but did not test this PRs specific functionality

- [x] Web
- [ ] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
![image](https://user-images.githubusercontent.com/22447860/119745877-f22c2e00-be43-11eb-96d1-0f26c71591ad.png)

#### Mobile Web
Mobile platforms all drop into the LHN, so I tested to verify it did not crash, but did not test this PRs specific functionality

#### Desktop
![image](https://user-images.githubusercontent.com/22447860/119745858-e80a2f80-be43-11eb-9154-f15e906051bf.png)

#### iOS
Mobile platforms all drop into the LHN, so I tested to verify it did not crash, but did not test this PRs specific functionality

#### Android
Mobile platforms all drop into the LHN, so I tested to verify it did not crash, but did not test this PRs specific functionality