### PR TITLE
[IS-2122] Fixed dropdown issue on android

### DIFF
--- a/src/components/Picker/index.js
+++ b/src/components/Picker/index.js
@@ -23,6 +23,7 @@ const Picker = ({
         value={value}
         Icon={icon}
         disabled={disabled}
+        fixAndroidTouchableBug
     />
 );
 


### PR DESCRIPTION
### Details

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/2122

### Tests

### QA Steps
1. Launch the app and login
2. Tap on the profile icon to open settings
3. Tap on the profile
4. Unselect checkbox for Set my time zone
5. Tap dropdown arrow for Timezone , Preferred pronouns and Priority mode in preferences
6. Dropdown arrow now working on all platforms

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
