### PR TITLE
[No QA] Fix cherry pick workflow

### DIFF
--- a/.github/actions/getMergeCommitForPullRequest/action.yml
+++ b/.github/actions/getMergeCommitForPullRequest/action.yml
@@ -2,11 +2,17 @@ name: 'Get merge commit for a pull request'
 description: 'Get the merge_commit_sha for a pull request'
 inputs:
   GITHUB_TOKEN:
-    description: 'Github token for authentication'
+    description: Auth token for Expensify.cash Github
     required: true
   PULL_REQUEST_NUMBER:
-    description: 'The number of the pull request'
-    required: true
+    description: The number of the pull request
+    required: false
+  TITLE_REGEX:
+    description: Regex to match PR titles for
+    required: false
+  USER:
+    description: The creator of the pull request
+    required: false
 outputs:
   MERGE_COMMIT_SHA:
     description: 'The merge_commit_sha of the given pull request'

--- a/.github/actions/getMergeCommitForPullRequest/getMergeCommitForPullRequest.js
+++ b/.github/actions/getMergeCommitForPullRequest/getMergeCommitForPullRequest.js
@@ -1,26 +1,66 @@
+const _ = require('underscore');
 const core = require('@actions/core');
 const ActionUtils = require('../../libs/ActionUtils');
 const GithubUtils = require('../../libs/GithubUtils');
 
-const pullRequestNumber = ActionUtils.getJSONInput('PULL_REQUEST_NUMBER', {required: true});
-console.log(`Getting merge_commit_sha for PR #${pullRequestNumber}`);
-GithubUtils.octokit.pulls.get({
+const DEFAULT_PAYLOAD = {
     owner: GithubUtils.GITHUB_OWNER,
     repo: GithubUtils.EXPENSIFY_CASH_REPO,
-    pull_number: pullRequestNumber,
-})
-    .then(({data}) => {
-        const mergeCommitHash = data.merge_commit_sha;
-        if (mergeCommitHash) {
-            console.log(`PR #${pullRequestNumber} has merge_commit_sha ${mergeCommitHash}`);
-            core.setOutput('MERGE_COMMIT_SHA', mergeCommitHash);
-        } else {
-            const err = new Error(`Could not find merge_commit_sha for pull request ${pullRequestNumber}`);
-            console.error(err);
-            core.setFailed(err);
-        }
-    })
-    .catch((err) => {
-        console.log(`An unknown error occurred with the GitHub API: ${err}`);
+};
+
+const pullRequestNumber = ActionUtils.getJSONInput('PULL_REQUEST_NUMBER', {required: false}, null);
+const user = ActionUtils.getJSONInput('USER', {required: false}, null);
+const titleRegex = ActionUtils.getJSONInput('TITLE_REGEX', {required: false}, null);
+
+if (pullRequestNumber) {
+    console.log(`Looking for pull request w/ number: ${pullRequestNumber}`);
+}
+
+if (user) {
+    console.log(`Looking for pull request w/ user: ${user}`);
+}
+
+if (titleRegex) {
+    console.log(`Looking for pull request w/ title matching: ${titleRegex.toString()}`);
+}
+
+/**
+ * Process a pull request and outputs it's merge commit hash.
+ *
+ * @param {Object} PR
+ */
+function outputMergeCommitHash(PR) {
+    if (!_.isEmpty(PR)) {
+        console.log(`Found matching pull request: ${PR.html_url}`);
+        core.setOutput('MERGE_COMMIT_SHA', PR.merge_commit_sha);
+    } else {
+        const err = new Error('Could not find matching pull request');
+        console.error(err);
         core.setFailed(err);
-    });
+    }
+}
+
+/**
+ * Handle an unknown API error.
+ *
+ * @param {Error} err
+ */
+function handleUnknownError(err) {
+    console.log(`An unknown error occurred with the GitHub API: ${err}`);
+    core.setFailed(err);
+}
+
+if (pullRequestNumber) {
+    GithubUtils.octokit.pulls.get({
+        ...DEFAULT_PAYLOAD,
+        pull_number: pullRequestNumber,
+    })
+        .then(({data}) => outputMergeCommitHash(data))
+        .catch(handleUnknownError);
+} else {
+    GithubUtils.octokit.pulls.list(DEFAULT_PAYLOAD)
+        .then(({data}) => {
+            const matchingPR = _.find(data, PR => PR.user.login === user && titleRegex.test(PR.title));
+            outputMergeCommitHash(matchingPR);
+        });
+}

--- a/.github/actions/getMergeCommitForPullRequest/index.js
+++ b/.github/actions/getMergeCommitForPullRequest/index.js
@@ -8,32 +8,72 @@ module.exports =
 /***/ 265:
 /***/ ((__unused_webpack_module, __unused_webpack_exports, __nccwpck_require__) => {
 
+const _ = __nccwpck_require__(4987);
 const core = __nccwpck_require__(2186);
 const ActionUtils = __nccwpck_require__(970);
 const GithubUtils = __nccwpck_require__(7999);
 
-const pullRequestNumber = ActionUtils.getJSONInput('PULL_REQUEST_NUMBER', {required: true});
-console.log(`Getting merge_commit_sha for PR #${pullRequestNumber}`);
-GithubUtils.octokit.pulls.get({
+const DEFAULT_PAYLOAD = {
     owner: GithubUtils.GITHUB_OWNER,
     repo: GithubUtils.EXPENSIFY_CASH_REPO,
-    pull_number: pullRequestNumber,
-})
-    .then(({data}) => {
-        const mergeCommitHash = data.merge_commit_sha;
-        if (mergeCommitHash) {
-            console.log(`PR #${pullRequestNumber} has merge_commit_sha ${mergeCommitHash}`);
-            core.setOutput('MERGE_COMMIT_SHA', mergeCommitHash);
-        } else {
-            const err = new Error(`Could not find merge_commit_sha for pull request ${pullRequestNumber}`);
-            console.error(err);
-            core.setFailed(err);
-        }
-    })
-    .catch((err) => {
-        console.log(`An unknown error occurred with the GitHub API: ${err}`);
+};
+
+const pullRequestNumber = ActionUtils.getJSONInput('PULL_REQUEST_NUMBER', {required: false}, null);
+const user = ActionUtils.getJSONInput('USER', {required: false}, null);
+const titleRegex = ActionUtils.getJSONInput('TITLE_REGEX', {required: false}, null);
+
+if (pullRequestNumber) {
+    console.log(`Looking for pull request w/ number: ${pullRequestNumber}`);
+}
+
+if (user) {
+    console.log(`Looking for pull request w/ user: ${user}`);
+}
+
+if (titleRegex) {
+    console.log(`Looking for pull request w/ title matching: ${titleRegex.toString()}`);
+}
+
+/**
+ * Process a pull request and outputs it's merge commit hash.
+ *
+ * @param {Object} PR
+ */
+function outputMergeCommitHash(PR) {
+    if (!_.isEmpty(PR)) {
+        console.log(`Found matching pull request: ${PR.html_url}`);
+        core.setOutput('MERGE_COMMIT_SHA', PR.merge_commit_sha);
+    } else {
+        const err = new Error('Could not find matching pull request');
+        console.error(err);
         core.setFailed(err);
-    });
+    }
+}
+
+/**
+ * Handle an unknown API error.
+ *
+ * @param {Error} err
+ */
+function handleUnknownError(err) {
+    console.log(`An unknown error occurred with the GitHub API: ${err}`);
+    core.setFailed(err);
+}
+
+if (pullRequestNumber) {
+    GithubUtils.octokit.pulls.get({
+        ...DEFAULT_PAYLOAD,
+        pull_number: pullRequestNumber,
+    })
+        .then(({data}) => outputMergeCommitHash(data))
+        .catch(handleUnknownError);
+} else {
+    GithubUtils.octokit.pulls.list(DEFAULT_PAYLOAD)
+        .then(({data}) => {
+            const matchingPR = _.find(data, PR => PR.user.login === user && titleRegex.test(PR.title));
+            outputMergeCommitHash(matchingPR);
+        });
+}
 
 
 /***/ }),

--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -8,7 +8,8 @@ on:
         required: true
       NEW_VERSION:
         description: The new app version
-        required: true
+        required: false
+        default: ''
 
 jobs:
   validateActor:
@@ -23,9 +24,42 @@ jobs:
           username: ${{ github.actor }}
           team: expensify-cash-deployers
 
+  createNewVersion:
+    needs: validate
+    runs-on: ubuntu-latest
+    if: ${{ needs.validateActor.outputs.IS_DEPLOYER && github.event.inputs.NEW_VERSION == '' }}
+    outputs:
+      NEW_VERSION: ${{ steps.getNewVersion.outputs.NEW_VERSION }}
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: softprops/turnstyle@8db075d65b19bf94e6e8687b504db69938dc3c65
+        with:
+          poll-interval-seconds: 10
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create new BUILD version
+        uses: Expensify/Expensify.cash/.github/actions/triggerWorkflowAndWait@main
+        with:
+          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+          WORKFLOW: createNewVersion.yml
+          INPUTS: '{ "SEMVER_LEVEL": "BUILD" }'
+
+      - name: Pull main to get the new version
+        id: getNewVersion
+        run: |
+          git pull origin main
+          echo "New version is $(npm run print-version --silent)"
+          echo "::set-output name=NEW_VERSION::$(npm run print-version --silent)"
+
   cherryPick:
-    needs: validateActor
-    if: ${{ needs.validateActor.outputs.IS_DEPLOYER }}
+    needs: [validateActor, createNewVersion]
+    if: ${{ always() && needs.validateActor.outputs.IS_DEPLOYER }}
     runs-on: ubuntu-latest
     steps:
       # Version: 2.3.4
@@ -47,13 +81,23 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PULL_REQUEST_NUMBER: ${{ github.event.inputs.PULL_REQUEST_NUMBER }}
 
+      - name: Save correct NEW_VERSION to env
+        run: |
+          if [[ -z ${{ github.event.inputs.NEW_VERSION }} ]]; then
+            echo "NEW_VERSION=${{ needs.createNewVersion.outputs.NEW_VERSION }}
+            echo "New version is ${{ env.NEW_VERSION }}"
+          else
+            echo "NEW_VERSION=${{ github.event.inputs.NEW_VERSION }}" >> $GITHUB_ENV
+            echo "New version is ${{ env.NEW_VERSION }}"
+          fi;
+
       - name: Get merge commit for version-bump pull request
         id: getVersionBumpMergeCommit
         uses: Expensify/Expensify.cash/.github/actions/getMergeCommitForPullRequest@main
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           USER: OSBotify
-          TITLE_REGEX: Update version to ${{ github.event.inputs.NEW_VERSION }}
+          TITLE_REGEX: Update version to ${{ env.NEW_VERSION }}
 
       - name: Cherry-pick the merge commit to new branch
         id: cherryPick

--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -26,10 +26,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Version: 2.3.4
-      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+      - name: Checkout staging branch
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
-          ref: main
+          ref: staging
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create branch for new pull request
+        run: |
+          git checkout -b cherry-pick-staging-${{ github.event.inputs.PULL_REQUEST_NUMBER }}
+          git push --set-upstream origin cherry-pick-staging-${{ github.event.inputs.PULL_REQUEST_NUMBER }}
 
       - name: Get merge commit for pull request
         id: getMergeCommit
@@ -38,17 +44,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PULL_REQUEST_NUMBER: ${{ github.event.inputs.PULL_REQUEST_NUMBER }}
 
-      # Version: 2.3.4
-      - name: Checkout merge commit
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
-        with:
-          ref: ${{ steps.getMergeCommit.outputs.MERGE_COMMIT_SHA }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Cherry-pick the merge commit to new branch
+        id: cherryPick
+        run: git cherry-pick ${{ steps.getMergeCommit.outputs.MERGE_COMMIT_SHA }} --mainline 1
+        continue-on-error: true
 
-      - name: Create branch for new pull request
+      # If there is a merge conflict, we'll just commit what we have,
+      # and the PR will be auto-assigned for someone to manually resolve the conflicts.
+      - name: If there is a merge conflict...
+        if: ${{ steps.cherryPick.outcome == 'failure' }}
         run: |
-          git checkout -b cherry-pick-staging-${{ github.event.inputs.PULL_REQUEST_NUMBER }}
-          git push --set-upstream origin cherry-pick-staging-${{ github.event.inputs.PULL_REQUEST_NUMBER }}
+          git add -A
+          git cherry-pick --continue
 
       - name: Create Pull Request
         id: createPullRequest
@@ -69,8 +76,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PULL_REQUEST_NUMBER: ${{ steps.createPullRequest.outputs.pr_number }}
 
-      - name: Auto-assign PR if it is not mergeable
-        if: ${{ steps.isPullRequestMergeable.outputs.IS_MERGEABLE == 'false' }}
+      - name: Auto-assign PR if there are merge conflicts
+        if: ${{ steps.cherryPick.outcome == 'failure' || steps.isPullRequestMergeable.outputs.IS_MERGEABLE == 'false' }}
         uses: actions-ecosystem/action-add-labels@a8ae047fee0ca28235f9764e1c478d2136dc15c1
         with:
           number: ${{ steps.createPullRequest.outputs.pr_number }}
@@ -78,18 +85,21 @@ jobs:
             Engineering
             Hourly
 
-      - name: If PR is not mergeable, comment with instructions for assignee
-        if: ${{ steps.isPullRequestMergeable.outputs.IS_MERGEABLE == 'false' }}
+      - name: If PR has merge conflicts, comment with instructions for assignee
+        if: ${{ steps.cherryPick.outcome == 'failure' || steps.isPullRequestMergeable.outputs.IS_MERGEABLE == 'false' }}
         uses: actions-ecosystem/action-create-comment@cd098164398331c50e7dfdd0dfa1b564a1873fac
         with:
           github_token: ${{ secrets.OS_BOTIFY_TOKEN }}
           number: ${{ steps.createPullRequest.outputs.pr_number }}
           body: |
-            This pull request has a merge conflict and could not be automatically merged. :disappointed:
+            This pull request has merge conflicts and can not be automatically merged. :disappointed:
             Please manually resolve the conflicts, push your changes, and then request another reviewer to review and merge.
+            **Important:** There may be conflicts that GitHub is not aware of, so please _carefully_ review this pull request before approving.
 
       # TODO: Once https://github.com/hmarr/auto-approve-action/pull/186 is merged, point back at the non-forked repo
       - name: Check for an auto approve
+        # Important: only auto-approve if there was no merge conflict!
+        if: ${{ steps.cherryPick.outcome == 'success' && steps.isPullRequestMergeable.outputs.IS_MERGEABLE == 'true' }}
         # Version: 2.0.0
         uses: roryabraham/auto-approve-action@6bb4a3dcf07664d0131e1c74a4bc6d0d8c849978
         with:
@@ -97,6 +107,8 @@ jobs:
           pull-request-number: ${{ steps.createPullRequest.outputs.pr_number }}
 
       - name: Check for an auto merge
+        # Important: only auto-merge if there was no merge conflict!
+        if: ${{ steps.cherryPick.outcome == 'success' && steps.isPullRequestMergeable.outputs.IS_MERGEABLE == 'true' }}
         # Version: 0.12.0
         uses: pascalgn/automerge-action@39d831e1bb389bd242626bc25d4060064a97181c
         env:

--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -94,7 +94,7 @@ jobs:
           body: |
             This pull request has merge conflicts and can not be automatically merged. :disappointed:
             Please manually resolve the conflicts, push your changes, and then request another reviewer to review and merge.
-            **Important:** There may be conflicts that GitHub is not aware of, so please _carefully_ review this pull request before approving.
+            **Important:** There may be conflicts that GitHub is not able to detect, so please _carefully_ review this pull request before approving.
 
       # TODO: Once https://github.com/hmarr/auto-approve-action/pull/186 is merged, point back at the non-forked repo
       - name: Check for an auto approve

--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -6,6 +6,9 @@ on:
       PULL_REQUEST_NUMBER:
         description: The number of a pull request to CP
         required: true
+      NEW_VERSION:
+        description: The new app version
+        required: true
 
 jobs:
   validateActor:
@@ -37,16 +40,24 @@ jobs:
           git checkout -b cherry-pick-staging-${{ github.event.inputs.PULL_REQUEST_NUMBER }}
           git push --set-upstream origin cherry-pick-staging-${{ github.event.inputs.PULL_REQUEST_NUMBER }}
 
-      - name: Get merge commit for pull request
-        id: getMergeCommit
+      - name: Get merge commit for CP pull request
+        id: getCPMergeCommit
         uses: Expensify/Expensify.cash/.github/actions/getMergeCommitForPullRequest@main
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PULL_REQUEST_NUMBER: ${{ github.event.inputs.PULL_REQUEST_NUMBER }}
 
+      - name: Get merge commit for version-bump pull request
+        id: getVersionBumpMergeCommit
+        uses: Expensify/Expensify.cash/.github/actions/getMergeCommitForPullRequest@main
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          USER: OSBotify
+          TITLE_REGEX: Update version to ${{ github.event.inputs.NEW_VERSION }}
+
       - name: Cherry-pick the merge commit to new branch
         id: cherryPick
-        run: git cherry-pick ${{ steps.getMergeCommit.outputs.MERGE_COMMIT_SHA }} --mainline 1
+        run: git cherry-pick ${{ steps.getCPMergeCommit.outputs.MERGE_COMMIT_SHA }} ${{ steps.getVersionBumpMergeCommit.MERGE_COMMIT_SHA }} --mainline 1
         continue-on-error: true
 
       # If there is a merge conflict, we'll just commit what we have,

--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Save correct NEW_VERSION to env
         run: |
           if [[ -z ${{ github.event.inputs.NEW_VERSION }} ]]; then
-            echo "NEW_VERSION=${{ needs.createNewVersion.outputs.NEW_VERSION }}
+            echo "NEW_VERSION=${{ needs.createNewVersion.outputs.NEW_VERSION }}" >> $GITHUB_ENV
             echo "New version is ${{ env.NEW_VERSION }}"
           else
             echo "NEW_VERSION=${{ github.event.inputs.NEW_VERSION }}" >> $GITHUB_ENV

--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -25,7 +25,7 @@ jobs:
           team: expensify-cash-deployers
 
   createNewVersion:
-    needs: validate
+    needs: validateActor
     runs-on: ubuntu-latest
     if: ${{ needs.validateActor.outputs.IS_DEPLOYER && github.event.inputs.NEW_VERSION == '' }}
     outputs:

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -55,7 +55,7 @@ jobs:
             :hand: This PR was not deployed to staging yet because QA is ongoing. It will be automatically deployed to staging after the next production release.
 
   version:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     needs: chooseDeployActions
     if: ${{ needs.chooseDeployActions.outputs.shouldCherryPick == 'true' || (needs.chooseDeployActions.outputs.isStagingDeployLocked == 'false' && needs.chooseDeployActions.outputs.isAutomatedPullRequest == 'false') }}
 

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -43,7 +43,7 @@ jobs:
   skipDeploy:
     runs-on: ubuntu-latest
     needs: chooseDeployActions
-    if: ${{ needs.chooseDeployActions.outputs.isStagingDeployLocked == 'true' && needs.chooseDeployActions.outputs.isAutomatedPullRequest == 'false' }}
+    if: ${{ needs.chooseDeployActions.outputs.isStagingDeployLocked == 'true' && needs.chooseDeployActions.outputs.isAutomatedPullRequest == 'false' && needs.chooseDeployActions.shouldCherryPick == 'false' }}
 
     steps:
       - name: Comment on deferred PR

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -87,14 +87,6 @@ jobs:
           WORKFLOW: updateProtectedBranch.yml
           INPUTS: '{ "TARGET_BRANCH": "staging" }'
 
-      - name: Cherry pick to staging
-        if: ${{ needs.chooseDeployActions.outputs.isStagingDeployLocked == 'true' && needs.chooseDeployActions.outputs.shouldCherryPick == 'true' }}
-        uses: Expensify/Expensify.cash/.github/actions/triggerWorkflowAndWait@main
-        with:
-          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
-          WORKFLOW: cherryPick.yml
-          INPUTS: '{ "PULL_REQUEST_NUMBER": "${{ needs.chooseDeployActions.outputs.mergedPullRequest }}" }'
-
       - name: Pull main to get the new version
         run: |
           git pull origin main
@@ -104,6 +96,14 @@ jobs:
       # Note: we need to create this tag but not push it, because of how GitUtils.getPullRequestsMergedBetween works
       - name: Tag version
         run: git tag ${{ env.NEW_VERSION }}
+
+      - name: Cherry pick to staging
+        if: ${{ needs.chooseDeployActions.outputs.isStagingDeployLocked == 'true' && needs.chooseDeployActions.outputs.shouldCherryPick == 'true' }}
+        uses: Expensify/Expensify.cash/.github/actions/triggerWorkflowAndWait@main
+        with:
+          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+          WORKFLOW: cherryPick.yml
+          INPUTS: '{ "PULL_REQUEST_NUMBER": "${{ needs.chooseDeployActions.outputs.mergedPullRequest }}", "NEW_VERSION": "${{ env.NEW_VERSION }}" }'
 
       - name: Update StagingDeployCash
         uses: Expensify/Expensify.cash/.github/actions/createOrUpdateStagingDeploy@main


### PR DESCRIPTION
### Details

This PR does three main things:

1. Updates the `cherryPick` workflow such that it:
    1. Creates a new `BUILD` version for the CP, if necessary. Note that this will only happen when the CP is performed manually by a user in the GH API, not for when a PR is merged with the `CP Staging` label.
    1. Checks out the staging branch
    1. Creates a new branch for the CP
    1. Finds the commits it needs to CP (namely, the `merge_commit_sha` of the PR we're CPing and the version-bump PR for the `BUILD` version that was just created + merged to master
    1. Uses the `git cherry-pick` command to CP those commits to the new branch
    1. Creates a new PR from that branch -> staging. It will merge it if there is no merge conflict, otherwise it will auto-assign it.
1. Updates the `getMergeCommitShaForPullRequest` action so we can search for pull requests w/ title matching a given pattern, created by a certain user.
1. Passes the new `BUILD` version to the `cherryPick` workflow.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/155229

### Tests
1. Lock the `StagingDeployCash`
1. Merge a pull request with an easily identifiable change (no `CP Staging` label). Call this PR A. As per usual, it _should not_ be deployed or added to the `StagingDeployCash`. A comment should appear on the PR stating that it will be deployed later.
1. Merge a pull request with an easily identifiable change with the `CP Staging` label on the PR. Call this PR B. A new version should be created and merged to main, and the `preDeploy` workflow should synchronously execute the `cherryPick.yml` workflow.
1. A staging deploy should occur, and a comment should appear on PR B stating that it was _cherry picked_ (not just deployed) to staging in the correct version.
1. Once the staging deploy completes, verify that PR A is not present on staging, but PR B is. This is where the easily-identifiable changes will come in handy.
1. Verify that PR B was added to the `StagingDeployCash`, but PR A was not.
1. Non-authorized actor: Use the GitHub UI to attempt to manually CP PR A to staging. The workflow should not complete. Verify that no staging deploy happens.
1. @AndrewGable or @roryabraham - Use the GitHub UI to attempt to manually CP PR A to staging. It should work and a staging deploy should occur.
1. Once the staging deploy completes, verify that PR A is present on staging.
1. Verify that PR A was added to the `StagingDeployCash`.
1. Create revert PRs to revert all the temporary changes. Give each the `CP Staging` label so the reverts are CP'd to staging. Merge them both to CP them to staging.
1. Close the `StagingDeployCash` to run a prod deploy. Verify that the latest staging version is deployed to production.


