### PR TITLE
htmlDecode text before copying

### DIFF
--- a/src/pages/home/report/ReportActionContextMenu.js
+++ b/src/pages/home/report/ReportActionContextMenu.js
@@ -4,6 +4,7 @@ import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import lodashGet from 'lodash/get';
 import {withOnyx} from 'react-native-onyx';
+import Str from 'expensify-common/lib/str';
 import {
     Clipboard as ClipboardIcon, LinkCopy, Mail, Pencil, Trashcan, Checkmark,
 } from '../../../components/Icon/Expensicons';
@@ -88,7 +89,7 @@ class ReportActionContextMenu extends React.Component {
                 onPress: () => {
                     const message = _.last(lodashGet(this.props.reportAction, 'message', null));
                     const html = lodashGet(message, 'html', '');
-                    const text = props.selection || lodashGet(message, 'text', '');
+                    const text = Str.htmlDecode(props.selection || lodashGet(message, 'text', ''));
                     const isAttachment = _.has(this.props.reportAction, 'isAttachment')
                         ? this.props.reportAction.isAttachment
                         : isReportMessageAttachment(text);


### PR DESCRIPTION
### Details
Using the copy button would copy the actual message contents, which are HTML encoded since we store the raw HTML for each report action. This adds HTML decoding before we save the text to the clipboard.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/3217

### Tests
1. Send a message with special characters (<, >, ¥). Just hold any combination of [Option] and/or [Shift] and run your fingers across the entire keyword.
```
√©¥˙∆˜´Î˛ÎÏ˝◊ı˝Ó˜Ô¥∫å><≥≤˘¯˘˜ı◊ÏÎˇ˝◊ıÓÔ˜ÓÁÏŒ„´‰ˇÁ¨ˆÔÓ˝ÏÎç√∫˜
```
2. Copy the message using the button in the report action context menu.
3. Paste the message into the compose box. Verify it displays the same as when you sent it. Then send it and verify it also displays the same.

### QA Steps
Same as the above tests.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web
https://user-images.githubusercontent.com/31285285/120162273-cc7b9c00-c22a-11eb-90ba-9e1b60f8b51f.mp4



#### Mobile Web
https://user-images.githubusercontent.com/31285285/120162344-dd2c1200-c22a-11eb-8238-45d27700c20e.mp4



#### Desktop
https://user-images.githubusercontent.com/31285285/120162292-d2717d00-c22a-11eb-9286-298d81131b3e.mp4



#### iOS
https://user-images.githubusercontent.com/31285285/120162314-d7363100-c22a-11eb-8473-76983b5c1a1a.mp4


#### Android
https://user-images.githubusercontent.com/31285285/120162374-e3ba8980-c22a-11eb-8ff8-c1cee97c349f.mp4


