### PR TITLE
Fix auto focus input on iou pages

### DIFF
--- a/src/pages/iou/steps/IOUAmountPage.js
+++ b/src/pages/iou/steps/IOUAmountPage.js
@@ -3,6 +3,7 @@ import {
     View,
     Text,
     TouchableOpacity,
+    InteractionManager,
 } from 'react-native';
 import PropTypes from 'prop-types';
 import {withOnyx} from 'react-native-onyx';
@@ -47,13 +48,6 @@ const propTypes = {
     /** Window Dimensions Props */
     ...windowDimensionsPropTypes,
 
-    /** react-navigation object */
-    navigation: PropTypes.shape({
-
-        /** Allows us to add a listener for the navigation transition end */
-        addListener: PropTypes.func,
-    }).isRequired,
-
     /* Onyx Props */
 
     /** Holds data related to IOU view state, rather than the underlying IOU data. */
@@ -83,7 +77,7 @@ class IOUAmountPage extends React.Component {
     componentDidMount() {
         // Component is not initialized yet due to navigation transitions
         // Wait until interactions are complete before trying to focus or attach listener
-        this.props.navigation.addListener('transitionEnd', () => {
+        InteractionManager.runAfterInteractions(() => {
             // Setup and attach keypress handler for navigating to the next screen
             this.unsubscribe = KeyboardShortcut.subscribe('Enter', () => {
                 if (this.state.amount !== '') {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

cc @jasperhuangg 

### Details
<!-- Explanation of the change or anything fishy that is going on -->
For some reason, `this.props.navigation.addListener('transitionEnd', () => {` was not getting triggered from inside this page, so the input was never getting focused (`this.textInput.focus();`). We need `this.textInput.focus();` to be inside some "interaction finished" callback since navigating to the IOU pages (and other pages) has some navigation time, so `this.textInput` is not available immediately in `componentDidMount`.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes https://github.com/Expensify/Expensify.cash/issues/3253

### Tests
1. Log in to e.cash
2. Click on the + button
3. Click on Split bill or Request money.
4. Notice the input gets focused automatically

### QA Steps
Same as above

### Tested On

- [x] Web
- [x] Mobile Web (not needed b/c of number pad, but tested anyway)
- [x] Desktop
- [x] iOS (not needed, but tested anyway)
- [x] Android (not needed, but tested anyway)

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
https://user-images.githubusercontent.com/3885503/120290114-51fe5b00-c2c2-11eb-9874-f03b3bcb3c7f.mov

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
N/A (input shouldn't focus)

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

https://user-images.githubusercontent.com/3885503/120291132-452e3700-c2c3-11eb-83fc-ad3f821740da.mov

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
N/A (input shouldn't focus)

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
N/A (input shouldn't focus)
