### PR TITLE
accessibility improvements for Search, My Settings, and New Chat

### DIFF
--- a/src/components/FAB/FAB.js
+++ b/src/components/FAB/FAB.js
@@ -59,6 +59,8 @@ class FAB extends PureComponent {
 
         return (
             <AnimatedPressable
+                accessibilityLabel={this.props.accessibilityLabel}
+                accessibilityRole={this.props.accessibilityRole}
                 onPress={this.props.onPress}
                 style={[
                     styles.floatingActionButton,

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -98,6 +98,10 @@ export default {
     sidebarScreen: {
         newChat: 'New Chat',
         newGroup: 'New Group',
+        headerChat: 'Chats',
+        buttonSearch: 'Search',
+        buttonMySettings: 'My Settings',
+        fabNewChat: 'New Chat(Floating Action)',
     },
     iou: {
         amount: 'Amount',

--- a/src/pages/home/sidebar/SidebarLinks.js
+++ b/src/pages/home/sidebar/SidebarLinks.js
@@ -20,6 +20,8 @@ import KeyboardSpacer from '../../../components/KeyboardSpacer';
 import CONST from '../../../CONST';
 import {participantPropTypes} from './optionPropTypes';
 import themeColors from '../../../styles/themes/default';
+import withLocalize, {withLocalizePropTypes} from '../../../components/withLocalize';
+
 
 const propTypes = {
     /** Toggles the navigation menu open and closed */
@@ -74,6 +76,8 @@ const propTypes = {
 
     // Whether we are syncing app data
     isSyncingData: PropTypes.bool,
+
+    ...withLocalizePropTypes,
 };
 
 const defaultProps = {
@@ -132,7 +136,9 @@ class SidebarLinks extends React.Component {
                 >
                     <Header
                         textSize="large"
-                        title="Chats"
+                        title={this.props.translate('sidebarScreen.headerChat')}
+                        accessibilityLabel={this.props.translate('sidebarScreen.headerChat')}
+                        accessibilityRole="text"
                         shouldShowEnvironmentBadge
                     />
                     <TouchableOpacity

--- a/src/pages/home/sidebar/SidebarLinks.js
+++ b/src/pages/home/sidebar/SidebarLinks.js
@@ -142,6 +142,8 @@ class SidebarLinks extends React.Component {
                         shouldShowEnvironmentBadge
                     />
                     <TouchableOpacity
+                        accessibilityLabel={this.props.translate('sidebarScreen.buttonSearch')}
+                        accessibilityRole="button"
                         style={[styles.flexRow, styles.ph5]}
                         onPress={this.showSearchPage}
                     >

--- a/src/pages/home/sidebar/SidebarLinks.js
+++ b/src/pages/home/sidebar/SidebarLinks.js
@@ -150,6 +150,8 @@ class SidebarLinks extends React.Component {
                         <Icon src={MagnifyingGlass} />
                     </TouchableOpacity>
                     <TouchableOpacity
+                        accessibilityLabel={this.props.translate('sidebarScreen.buttonMySettings')}
+                        accessibilityRole="button"
                         onPress={this.props.onAvatarClick}
                     >
                         <AvatarWithIndicator
@@ -188,6 +190,7 @@ SidebarLinks.propTypes = propTypes;
 SidebarLinks.defaultProps = defaultProps;
 
 export default compose(
+    withLocalize,
     withOnyx({
         reports: {
             key: ONYXKEYS.COLLECTION.REPORT,

--- a/src/pages/home/sidebar/SidebarScreen.js
+++ b/src/pages/home/sidebar/SidebarScreen.js
@@ -90,6 +90,8 @@ class SidebarScreen extends Component {
                                 isSmallScreenWidth={this.props.isSmallScreenWidth}
                             />
                             <FAB
+                                accessibilityLabel={this.props.translate('sidebarScreen.fabNewChat')}
+                                accessibilityRole="menu"
                                 isActive={this.state.isCreateMenuActive}
                                 onPress={this.toggleCreateMenu}
                             />


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
In the chat list, "Search", "My Settings", "New Chat(Floating Action)" will have defined accessibility roles and labels now.

### Fixed Issues
Fixes #3101 

### Tests / QA Steps
1. Launch the app/webapp
2. Prerequisite: Turn ON the Screen reader / VoiceOver.
3. Mobile: Navigate using Swipe gesture(From Left to Right) and verily.
    Web: Navigate the page using arrow keys then verify.

### Tested On

- [x] Web
- [X] Mobile Web
- [X] Desktop
- [X] iOS
- [X] Android

### Screenshots

#### Web

<img width="806" alt="Screen Shot 2021-06-02 at 13 36 53" src="https://user-images.githubusercontent.com/6712795/120440057-36ba4b00-c3a9-11eb-953b-6c2597f895c0.png">

<img width="806" alt="Screen Shot 2021-06-02 at 13 37 06" src="https://user-images.githubusercontent.com/6712795/120440082-3de15900-c3a9-11eb-8702-818d0b1076fd.png">

<img width="807" alt="Screen Shot 2021-06-02 at 13 37 20" src="https://user-images.githubusercontent.com/6712795/120440113-45086700-c3a9-11eb-8fb5-cdb0b80085aa.png">

<img width="571" alt="Screen Shot 2021-06-02 at 13 37 35" src="https://user-images.githubusercontent.com/6712795/120440141-4c2f7500-c3a9-11eb-8888-09140a4c91c1.png">

