### PR TITLE
Fix IOU currency picker crash

### DIFF
--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -170,10 +170,10 @@ Onyx.connect({
  *
  * @param {String} searchValue
  * @param {String} searchText
- * @param {Set<String>} participantNames
+ * @param {Set<String>} [participantNames]
  * @returns {Boolean}
  */
-function isSearchStringMatch(searchValue, searchText, participantNames) {
+function isSearchStringMatch(searchValue, searchText, participantNames = new Set()) {
     const searchWords = searchValue
         .replace(/,/g, ' ')
         .split(' ')


### PR DESCRIPTION
### Details
Just needed to make the third arg of this function optional to prevent the crash.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/165845

### Tests / QA Steps
1. Click/tap the + icon and select request money or split bill
1. Click/tap the currency symbol on the IOUAmount page
1. Click/tap in the search box on the currency page
1. The app should not crash. You should be able to search and select new currencies. There should be no JS errors in the console.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [ ] Android

### Screenshots
#### Web
![image](https://user-images.githubusercontent.com/47436092/120534264-7d527a00-c396-11eb-9bbc-f87aeace05dc.png)

#### Mobile Web
![image](https://user-images.githubusercontent.com/47436092/120534651-f2be4a80-c396-11eb-85bb-1378334a79d6.png)

#### Desktop
![image](https://user-images.githubusercontent.com/47436092/120535966-7167b780-c398-11eb-938c-a7f297fbc4de.png)

#### iOS
![image](https://user-images.githubusercontent.com/47436092/120535624-1635c500-c398-11eb-9d1a-5b92a4c24c6d.png)

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
