### PR TITLE
Test PR A - Change blue to magenta

### DIFF
--- a/src/styles/colors.js
+++ b/src/styles/colors.js
@@ -6,7 +6,7 @@ export default {
     gray4: '#7D8B8F',
     dark: '#0b1b34',
     black: '#000000',
-    blue: '#0185ff',
+    blue: '#a83298',
     green: '#03d47c',
     greenHover: '#03c775',
     red: '#fc3826',


### PR DESCRIPTION
This is a dummy PR as part of testing https://github.com/Expensify/Expensify.cash/pull/3216. It will soon be reverted.

### QA Steps
Verify that this PR has been reverted - blue should be blue, not magenta.