### PR TITLE
Test PR B - Change borderFocus from blue to yellow

### DIFF
--- a/src/styles/themes/default.js
+++ b/src/styles/themes/default.js
@@ -11,7 +11,7 @@ export default {
     sidebar: colors.gray1,
     sidebarHover: colors.white,
     border: colors.gray2,
-    borderFocus: colors.blue,
+    borderFocus: colors.yellow,
     icon: colors.gray3,
     iconSuccessFill: colors.green,
     textSupporting: colors.gray4,


### PR DESCRIPTION
This is a dummy PR as part of testing https://github.com/Expensify/Expensify.cash/pull/3216. It will soon be reverted.

### QA Steps
Verify that this PR has been reverted. Focus the main text input, and the border should be blue, not yellow.