### PR TITLE
Change green to cyan

### DIFF
--- a/src/styles/colors.js
+++ b/src/styles/colors.js
@@ -7,7 +7,7 @@ export default {
     dark: '#0b1b34',
     black: '#000000',
     blue: '#a83298',
-    green: '#03d47c',
+    green: '#32a8a6',
     greenHover: '#03c775',
     red: '#fc3826',
     yellow: '#fed607',


### PR DESCRIPTION
This is a dummy PR as part of testing https://github.com/Expensify/Expensify.cash/pull/3216. It will soon be reverted.

### QA Steps
Verify that this PR has been reverted. The big floating `+` button should be green, not cyan.