### PR TITLE
[No QA] Fix typo in skipDeploy conditional

### DIFF
--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -43,7 +43,7 @@ jobs:
   skipDeploy:
     runs-on: ubuntu-latest
     needs: chooseDeployActions
-    if: ${{ needs.chooseDeployActions.outputs.isStagingDeployLocked == 'true' && needs.chooseDeployActions.outputs.isAutomatedPullRequest == 'false' && needs.chooseDeployActions.shouldCherryPick == 'false' }}
+    if: ${{ needs.chooseDeployActions.outputs.isStagingDeployLocked == 'true' && needs.chooseDeployActions.outputs.isAutomatedPullRequest == 'false' && needs.chooseDeployActions.outputs.shouldCherryPick == 'false' }}
 
     steps:
       - name: Comment on deferred PR


### PR DESCRIPTION
### Context
Testing https://github.com/Expensify/Expensify.cash/pull/3216

### Fixes
Failed workflow run: https://github.com/Expensify/Expensify.cash/runs/2731722048?check_suite_focus=true

`skipDeploy` job should have run, but did not.

### Solution
There was a typo in the `if` conditional for that job. Fix the typo.

### Tests
1. Merge this PR.
1. It should not cause a staging deploy, not should it be added to the open `StagingDeployCash`.
1. It _should_ get a "deploy deferred" comment.