### PR TITLE
Don't try to JSON parse non-JSON inputs

### DIFF
--- a/.github/actions/getMergeCommitForPullRequest/getMergeCommitForPullRequest.js
+++ b/.github/actions/getMergeCommitForPullRequest/getMergeCommitForPullRequest.js
@@ -9,8 +9,8 @@ const DEFAULT_PAYLOAD = {
 };
 
 const pullRequestNumber = ActionUtils.getJSONInput('PULL_REQUEST_NUMBER', {required: false}, null);
-const user = ActionUtils.getJSONInput('USER', {required: false}, null);
-const titleRegex = ActionUtils.getJSONInput('TITLE_REGEX', {required: false}, null);
+const user = core.getInput('USER', {required: false});
+const titleRegex = core.getInput('TITLE_REGEX', {required: false});
 
 if (pullRequestNumber) {
     console.log(`Looking for pull request w/ number: ${pullRequestNumber}`);

--- a/.github/actions/getMergeCommitForPullRequest/index.js
+++ b/.github/actions/getMergeCommitForPullRequest/index.js
@@ -19,8 +19,8 @@ const DEFAULT_PAYLOAD = {
 };
 
 const pullRequestNumber = ActionUtils.getJSONInput('PULL_REQUEST_NUMBER', {required: false}, null);
-const user = ActionUtils.getJSONInput('USER', {required: false}, null);
-const titleRegex = ActionUtils.getJSONInput('TITLE_REGEX', {required: false}, null);
+const user = core.getInput('USER', {required: false});
+const titleRegex = core.getInput('TITLE_REGEX', {required: false});
 
 if (pullRequestNumber) {
     console.log(`Looking for pull request w/ number: ${pullRequestNumber}`);


### PR DESCRIPTION

### Details
We were attempting to JSON-parse non-JSON inputs

### Fixed Issues
Fixes failed workflow run: https://github.com/Expensify/Expensify.cash/actions/runs/900866458

### Tests
Attempt to CP another PR
