### PR TITLE
Make titleRegex an actual regex not a string

### DIFF
--- a/.github/actions/getMergeCommitForPullRequest/getMergeCommitForPullRequest.js
+++ b/.github/actions/getMergeCommitForPullRequest/getMergeCommitForPullRequest.js
@@ -10,7 +10,7 @@ const DEFAULT_PAYLOAD = {
 
 const pullRequestNumber = ActionUtils.getJSONInput('PULL_REQUEST_NUMBER', {required: false}, null);
 const user = core.getInput('USER', {required: false});
-const titleRegex = core.getInput('TITLE_REGEX', {required: false});
+let titleRegex = core.getInput('TITLE_REGEX', {required: false});
 
 if (pullRequestNumber) {
     console.log(`Looking for pull request w/ number: ${pullRequestNumber}`);
@@ -21,6 +21,7 @@ if (user) {
 }
 
 if (titleRegex) {
+    titleRegex = new RegExp(titleRegex);
     console.log(`Looking for pull request w/ title matching: ${titleRegex.toString()}`);
 }
 

--- a/.github/actions/getMergeCommitForPullRequest/index.js
+++ b/.github/actions/getMergeCommitForPullRequest/index.js
@@ -20,7 +20,7 @@ const DEFAULT_PAYLOAD = {
 
 const pullRequestNumber = ActionUtils.getJSONInput('PULL_REQUEST_NUMBER', {required: false}, null);
 const user = core.getInput('USER', {required: false});
-const titleRegex = core.getInput('TITLE_REGEX', {required: false});
+let titleRegex = core.getInput('TITLE_REGEX', {required: false});
 
 if (pullRequestNumber) {
     console.log(`Looking for pull request w/ number: ${pullRequestNumber}`);
@@ -31,6 +31,7 @@ if (user) {
 }
 
 if (titleRegex) {
+    titleRegex = new RegExp(titleRegex);
     console.log(`Looking for pull request w/ title matching: ${titleRegex.toString()}`);
 }
 


### PR DESCRIPTION

### Details
We were trying to do `titleRegex.test(something)`, when `titleRegex` was just a string, not a `RegExp`

### Fixed Issues
Fixes failed workflow run: https://github.com/Expensify/Expensify.cash/runs/2732324613?check_suite_focus=true

### Tests
Merge this pull request, then try to CP another pull request.