### PR TITLE
Retreive all PRs, not just open ones

### DIFF
--- a/.github/actions/getMergeCommitForPullRequest/getMergeCommitForPullRequest.js
+++ b/.github/actions/getMergeCommitForPullRequest/getMergeCommitForPullRequest.js
@@ -59,7 +59,10 @@ if (pullRequestNumber) {
         .then(({data}) => outputMergeCommitHash(data))
         .catch(handleUnknownError);
 } else {
-    GithubUtils.octokit.pulls.list(DEFAULT_PAYLOAD)
+    GithubUtils.octokit.pulls.list({
+        ...DEFAULT_PAYLOAD,
+        state: 'all',
+    })
         .then(({data}) => {
             const matchingPR = _.find(data, PR => PR.user.login === user && titleRegex.test(PR.title));
             outputMergeCommitHash(matchingPR);

--- a/.github/actions/getMergeCommitForPullRequest/index.js
+++ b/.github/actions/getMergeCommitForPullRequest/index.js
@@ -69,7 +69,10 @@ if (pullRequestNumber) {
         .then(({data}) => outputMergeCommitHash(data))
         .catch(handleUnknownError);
 } else {
-    GithubUtils.octokit.pulls.list(DEFAULT_PAYLOAD)
+    GithubUtils.octokit.pulls.list({
+        ...DEFAULT_PAYLOAD,
+        state: 'all',
+    })
         .then(({data}) => {
             const matchingPR = _.find(data, PR => PR.user.login === user && titleRegex.test(PR.title));
             outputMergeCommitHash(matchingPR);


### PR DESCRIPTION

### Details
By default, `octokit.pulls.list` only returns open PRs, but we want to search closed ones too.

### Fixed Issues
Fixes failed workflow run: https://github.com/Expensify/Expensify.cash/runs/2732433160?check_suite_focus=true

### Tests
After merging this, attempt to CP another PR.