### PR TITLE
Test PR F - Make icons blue

### DIFF
--- a/src/styles/themes/default.js
+++ b/src/styles/themes/default.js
@@ -12,7 +12,7 @@ export default {
     sidebarHover: colors.blue,
     border: colors.gray2,
     borderFocus: colors.yellow,
-    icon: colors.gray3,
+    icon: colors.blue,
     iconSuccessFill: colors.green,
     textSupporting: colors.gray4,
     text: colors.dark,


### PR DESCRIPTION
This is a dummy PR as part of testing https://github.com/Expensify/Expensify.cash/pull/3216. It will soon be reverted.

### QA Steps
Verify that this PR has been reverted. App icons throughout the app should not be blue. You'll know if it hasn't been...