### PR TITLE
Get history from main branch before CPing

### DIFF
--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -99,9 +99,12 @@ jobs:
           USER: OSBotify
           TITLE_REGEX: Update version to ${{ env.NEW_VERSION }}
 
-      - name: Cherry-pick the merge commit to new branch
+      - name: Cherry-pick the merge commits to new branch
         id: cherryPick
-        run: git cherry-pick ${{ steps.getCPMergeCommit.outputs.MERGE_COMMIT_SHA }} ${{ steps.getVersionBumpMergeCommit.MERGE_COMMIT_SHA }} --mainline 1
+        run: |
+          git switch main
+          git checkout -
+          git cherry-pick ${{ steps.getCPMergeCommit.outputs.MERGE_COMMIT_SHA }} ${{ steps.getVersionBumpMergeCommit.outputs.MERGE_COMMIT_SHA }} --mainline 1
         continue-on-error: true
 
       # If there is a merge conflict, we'll just commit what we have,


### PR DESCRIPTION

### Details
Testing https://github.com/Expensify/Expensify.cash/pull/3216, we found in [this failed workflow](https://github.com/Expensify/Expensify.cash/runs/2732579896?check_suite_focus=true) that the CP failed because it does not have the Git history from the main branch. There was also a typo which was causing one of the commit hashes we're CPing to not be included. 

### Fixed Issues
Fixes failed workflow run: https://github.com/Expensify/Expensify.cash/runs/2732579896?check_suite_focus=true

### Tests
After merging this, try to CP another test PR.
