### PR TITLE
Use plain fetch instead of git switch

### DIFF
--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -102,8 +102,7 @@ jobs:
       - name: Cherry-pick the merge commits to new branch
         id: cherryPick
         run: |
-          git switch main
-          git checkout -
+          git fetch
           git cherry-pick ${{ steps.getCPMergeCommit.outputs.MERGE_COMMIT_SHA }} ${{ steps.getVersionBumpMergeCommit.outputs.MERGE_COMMIT_SHA }} --mainline 1
         continue-on-error: true
 


### PR DESCRIPTION

### Details
I misunderstood `git switch` – it doesn't perform a `git fetch` if the branch doesn't exist locally.

### Fixed Issues
Fixes failed workflow run: https://github.com/Expensify/Expensify.cash/runs/2732710826?check_suite_focus=true

### Tests
Merge this PR then try to CP another dummy PR.