### PR TITLE
#3102 add accessibility role and label to close button

### DIFF
--- a/src/components/HeaderWithCloseButton.js
+++ b/src/components/HeaderWithCloseButton.js
@@ -7,6 +7,8 @@ import styles from '../styles/styles';
 import Header from './Header';
 import Icon from './Icon';
 import {Close, Download, BackArrow} from './Icon/Expensicons';
+import compose from '../libs/compose';
+import withLocalize, {withLocalizePropTypes} from './withLocalize';
 
 const propTypes = {
     /** Title of the Header */
@@ -29,6 +31,8 @@ const propTypes = {
 
     /** Whether we should show a download button */
     shouldShowDownloadButton: PropTypes.bool,
+
+    ...withLocalizePropTypes,
 };
 
 const defaultProps = {
@@ -76,6 +80,8 @@ const HeaderWithCloseButton = props => (
                 <TouchableOpacity
                     onPress={props.onCloseButtonPress}
                     style={[styles.touchableButtonImage]}
+                    accessibilityRole="button"
+                    accessibilityLabel={props.translate('common.close')}
                 >
                     <Icon src={Close} />
                 </TouchableOpacity>
@@ -88,4 +94,4 @@ HeaderWithCloseButton.propTypes = propTypes;
 HeaderWithCloseButton.defaultProps = defaultProps;
 HeaderWithCloseButton.displayName = 'HeaderWithCloseButton';
 
-export default HeaderWithCloseButton;
+export default compose(withLocalize)(HeaderWithCloseButton);

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -29,6 +29,7 @@ export default {
         delete: 'Delete',
         contacts: 'Contacts',
         recents: 'Recents',
+        close: 'Close',
     },
     attachmentPicker: {
         cameraPermissionRequired: 'Camera Permission Required',

--- a/src/pages/iou/IOUModal.js
+++ b/src/pages/iou/IOUModal.js
@@ -294,6 +294,8 @@ class IOUModal extends Component {
                                     <TouchableOpacity
                                         onPress={() => Navigation.dismissModal()}
                                         style={[styles.touchableButtonImage]}
+                                        accessibilityRole="button"
+                                        accessibilityLabel={this.props.translate('common.close')}
                                     >
                                         <Icon src={Close} />
                                     </TouchableOpacity>


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Simple addition off accessibility props.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes #3102 


<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### Tests / QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

1. Turn on Screen Reader or Voiceover
2. Launch the Expensify.cash app or website
3. Swipe or click into any menu that has an X "close" button. For example:
( + ) > New Chat > X
( + ) > Request Money > X
( + ) > New Group > X
tap avatar icon > X
tap search mag icon > X
4. Make sure that the X "Close" button has a role and a label.

### Tested On

- [x] Web - Windows/JAWS/Firefox - MACOs/Voiceover/Safari
- [x] Mobile Web
- [x] Desktop - Voiceover
- [ ] iOS - iOS/Voiceover
- [x] Android - Android/Talkback

I do not own a physical iPhone and there is no Voiceover on iOS simulator, so I am unable to test accessibility features on  iOS app.

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

https://user-images.githubusercontent.com/64093836/120702803-2b584400-c4bd-11eb-8f0c-d3b0ddc81355.mp4

https://user-images.githubusercontent.com/64093836/120702883-4925a900-c4bd-11eb-8f2e-587a529f8f26.mp4



#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

https://user-images.githubusercontent.com/64093836/120704708-9c006000-c4bf-11eb-9489-4e1254e1635f.mp4


#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

https://user-images.githubusercontent.com/64093836/120705402-732c9a80-c4c0-11eb-9543-796702a491d5.mp4

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->

https://user-images.githubusercontent.com/64093836/120703403-ec76be00-c4bd-11eb-84e8-3405efb04b03.mp4

