### PR TITLE
Fix showing the IOU preview

### DIFF
--- a/src/components/ReportActionItemIOUAction.js
+++ b/src/components/ReportActionItemIOUAction.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {withOnyx} from 'react-native-onyx';
-import lodashGet from 'lodash/get';
 import ONYXKEYS from '../ONYXKEYS';
 import ReportActionItemIOUQuote from './ReportActionItemIOUQuote';
 import ReportActionPropTypes from '../pages/home/report/ReportActionPropTypes';
@@ -44,22 +43,22 @@ const defaultProps = {
 const ReportActionItemIOUAction = ({
     action,
     chatReportID,
-    chatReport,
     iouReport,
     isMostRecentIOUReportAction,
 }) => {
     const launchDetailsModal = () => {
         Navigation.navigate(ROUTES.getIouDetailsRoute(chatReportID, action.originalMessage.IOUReportID));
     };
-    const hasMultipleParticipants = lodashGet(chatReport, 'participants', []).length >= 2;
     return (
         <>
             <ReportActionItemIOUQuote
                 action={action}
-                shouldShowViewDetailsLink={!hasMultipleParticipants}
+                shouldShowViewDetailsLink={Boolean(action.originalMessage.IOUReportID)}
                 onViewDetailsPressed={launchDetailsModal}
             />
-            {isMostRecentIOUReportAction && (iouReport.hasOutstandingIOU) && (
+            {isMostRecentIOUReportAction
+            && iouReport.hasOutstandingIOU
+            && Boolean(action.originalMessage.IOUReportID) && (
                 <ReportActionItemIOUPreview
                     iouReportID={action.originalMessage.IOUReportID}
                     chatReportID={chatReportID}


### PR DESCRIPTION
Held on https://github.com/Expensify/Auth/pull/5632

## Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes https://github.com/Expensify/Expensify/issues/165671

### Tests
- Create an IOU split with only one other user
- Check you see the `Split $X with Y for Z` comment first in the chat, then the `Requested $X from Y for Z` with the `view details` link (and that the link works) and then the preview:
![image](https://user-images.githubusercontent.com/521248/120705798-8e93a780-c4b8-11eb-900a-02b0ebdfc65a.png)
- Create an IOU split with 2 other users
- Check it left the `Split $X with Y for Z` in the comment of the 3 way chat
![image](https://user-images.githubusercontent.com/521248/120706236-21344680-c4b9-11eb-9f01-a0e551dd47ac.png)
- Check it created the request in each of the user's 1:1 chats
![image](https://user-images.githubusercontent.com/521248/120706346-42953280-c4b9-11eb-9222-849a959bccb8.png)
![image](https://user-images.githubusercontent.com/521248/120706376-4d4fc780-c4b9-11eb-8e79-a116f4f291a0.png)

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

