### PR TITLE
Changes in quote at Expensimark.js

### DIFF
--- a/node_modules/expensify-common/lib/ExpensiMark.js
+++ b/node_modules/expensify-common/lib/ExpensiMark.js
@@ -1,0 +1,333 @@
+import Str from './str';
+import TLD_REGEX from './tlds';
+
+const URL_WEBSITE_REGEX = `(https?:\\/\\/)?((?:www\\.)?[-a-z0-9]+?\\.)+(?:${TLD_REGEX})(?:\\:\\d{2,4}|\\b|(?=_))`;
+const URL_PATH_REGEX = '(?:\\/[-\\w$@.&+!*"\'(),=%~]*[-\\w~@:%)]|\\/)*';
+const URL_PARAM_REGEX = '(?:\\?[-\\w$@.&+!*"\'()\\/,=%{}:;\\[\\]\\|_]+)?';
+const URL_FRAGMENT_REGEX = '(?:#[-\\w$@.&+!*"\'()[\\],=%;\\/:~]*)?';
+const URL_REGEX = `(${URL_WEBSITE_REGEX}${URL_PATH_REGEX}(?:${URL_PARAM_REGEX}|${URL_FRAGMENT_REGEX})*)`;
+
+export default class ExpensiMark {
+    constructor() {
+        /**
+         * The list of regex replacements to do on a comment. Check the link regex is first so links are processed
+         * before other delimiters
+         *
+         * @type {Object[]}
+         */
+        this.rules = [
+            /**
+             * Apply the code-fence first so that we avoid replacing anything inside of it that we're not supposed to
+             * (aka any rule with the '(?![^<]*<\/pre>)' avoidance in it
+             */
+            {
+                name: 'codeFence',
+
+                // &#60; is a backtick symbol we are matching on three of them before then after a new line character
+                regex: /(&#x60;&#x60;&#x60;[\n]?)((?:(?![\n]?&#x60;&#x60;&#x60;)[\s\S])+)([\n]?&#x60;&#x60;&#x60;)/g,
+
+                // We're using a function here to perform an additional replace on the content
+                // inside the backticks because Android is not able to use <pre> tags and does
+                // not respect whitespace characters at all like HTML does. We do not want to mess
+                // with the new lines here since they need to be converted into <br>. And we don't
+                // want to do this anywhere else since that would break HTML.
+                // &nbsp; will create styling issues so use &#32;
+                replacement: (match, _, textWithinFences) => {
+                    const group = textWithinFences.replace(/(?:(?![\n\r])\s)/g, '&#32;');
+                    return `<pre>${group}</pre>`;
+                },
+            },
+
+            /**
+             * Apply inline code-block to avoid applying any other formatting rules inside of it,
+             * like we do for the multi-line code-blocks
+             */
+            {
+                name: 'inlineCodeBlock',
+
+                // Use the url escaped version of a backtick (`) symbol. Mobile platforms do not support lookbehinds,
+                // so capture the first and third group and place them in the replacement.
+                regex: /(\B|_)&#x60;(.*?)&#x60;(\B|_)(?![^<]*<\/pre>)/g,
+                replacement: '$1<code>$2</code>$3',
+            },
+
+            /**
+             * Converts markdown style links to anchor tags e.g. [Expensify](concierge@expensify.com)
+             * We need to convert before the auto email link rule and the manual link rule since it will not try to create a link
+             * from an existing anchor tag.
+             */
+            {
+                name: 'email',
+                regex: /\[([\w\\s\\d!?&#;]+)\]\(([a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z]+?(\.[a-zA-Z]{2,6})+)\)/gim,
+                replacement: '<a href="mailto:$2">$1</a>'
+            },
+
+            /**
+             * Converts markdown style links to anchor tags e.g. [Expensify](https://www.expensify.com)
+             * We need to convert before the autolink rule since it will not try to create a link
+             * from an existing anchor tag.
+             */
+            {
+                name: 'link',
+
+                process: (textToProcess, replacement) => {
+                    const regex = new RegExp(
+                        `\\[((?:[\\w\\s\\d!?&#;:\\/\\-\\.\\+=<>,@\\[\\]‘’“”]|(?:<code>.+<\\/code>))+)\\]\\(${URL_REGEX}\\)(?![^<]*(<\\/pre>|<\\/code>))`,
+                        'gi'
+                    );
+                    return this.modifyTextForUrlLinks(regex, textToProcess, replacement);
+                },
+
+                // We use a function here to check if there is already a https:// on the link.
+                // If there is not, we force the link to be absolute by prepending '//' to the target.
+                replacement: (match, g1, g2, g3) => (
+                    `<a href="${g3 && g3.includes('http') ? '' : 'http://'}${g2}" target="_blank">${g1}</a>`
+                ),
+            },
+
+            /**
+             * Automatically links emails that are not in a link. Runs before the autolinker as it will not link an
+             * email that is in a link
+             */
+            {
+                name: 'autoEmail',
+                regex: /(?![^<]*>|[^<>]*<\\)([_*~]*?)([a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z]+?(\.[a-zA-Z]{2,6})+)(?![^<]*(<\/pre>|<\/code>|<\/a>))/gim,
+                replacement: '<a href="mailto:$2">$2</a>'
+            },
+
+            /**
+             * Automatically link urls. Runs last of our linkers since we want anything manual to link before this,
+             * and we do not want to break emails.
+             */
+            {
+                name: 'autolink',
+
+                process: (textToProcess, replacement) => {
+                    const regex = new RegExp(
+                        `(?![^<]*>|[^<>]*<\\/)([_*~]*?)${URL_REGEX}\\1(?![^<]*(<\\/pre>|<\\/code>))`,
+                        'gi'
+                    );
+                    return this.modifyTextForUrlLinks(regex, textToProcess, replacement);
+                },
+
+                // We use a function here to check if there is already a https:// on the link.
+                // If there is not, we force the link to be absolute by prepending '//' to the target.
+                replacement: (match, g1, g2, g3) => (
+                    `${g1}<a href="${g3 && g3.includes('http') ? '' : 'http://'}${g2}" target="_blank">${g2}</a>${g1}`
+                ),
+            },
+            {
+                /**
+                 * Use \b in this case because it will match on words, letters,
+                 * and _: https://www.rexegg.com/regex-boundaries.html#wordboundary
+                 * The !_blank is to prevent the `target="_blank">` section of the
+                 * link replacement from being captured Additionally, something like
+                 * `\b\_([^<>]*?)\_\b` doesn't work because it won't replace
+                 * `_https://www.test.com_`
+                 */
+                name: 'italic',
+                regex: /(?!_blank">)\b_(.*?)_\b(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
+                replacement: '<em>$1</em>'
+            },
+            {
+                // Use \B in this case because \b doesn't match * or ~.
+                // \B will match everything that \b doesn't, so it works
+                // for * and ~: https://www.rexegg.com/regex-boundaries.html#notb
+                name: 'bold',
+                regex: /\B\*(.*?)\*\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
+                replacement: '<strong>$1</strong>'
+            },
+            {
+                name: 'strikethrough',
+                regex: /\B~(.*?)~\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
+                replacement: '<del>$1</del>'
+            },
+            {
+                // We also want to capture a blank line before or after the quote so that we do not add extra spaces.
+                // block quotes naturally appear on their own line. Blockquotes should not appear in code fences or
+                // inline code blocks.
+                name: 'quote',
+                process: (textToProcess, replacement) => {
+                    const regex = new RegExp(
+                        `((\n?^&gt; ?(?![^<]*(?:<\/pre>|<\/code>))([^\v\n\r]+))+)`,
+                        'gm'
+                    );
+                    return this.modifyTextForQuote(regex, textToProcess);
+                },
+            },
+            {
+                name: 'newline',
+                regex: /\n/g,
+                replacement: '<br>',
+            },
+        ];
+    }
+
+    /**
+     * Replaces markdown with html elements
+     *
+     * @param {String} text
+     *
+     * @returns {String}
+     */
+    replace(text) {
+        // This ensures that any html the user puts into the comment field shows as raw html
+        let replacedText = Str.safeEscape(text);
+
+        this.rules.forEach((rule) => {
+            // Pre-process text before applying regex
+            if (rule.pre) {
+                replacedText = rule.pre(replacedText);
+            }
+
+            if (rule.process) {
+                replacedText = rule.process(replacedText, rule.replacement);
+            } else {
+                replacedText = replacedText.replace(rule.regex, rule.replacement);
+            }
+
+            // Post-process text after applying regex
+            if (rule.post) {
+                replacedText = rule.post(replacedText);
+            }
+        });
+
+        return replacedText;
+    }
+
+    /**
+     * Checks matched URLs for validity and replace valid links with html elements
+     *
+     * @param {RegExp} regex
+     * @param {String} textToCheck
+     * @param {Function} replacement
+     *
+     * @returns {String}
+     */
+    modifyTextForUrlLinks(regex, textToCheck, replacement) {
+        let match = regex.exec(textToCheck);
+        let replacedText = '';
+        let startIndex = 0;
+        let abort = false;
+
+        while (match !== null) {
+            // we want to avoid matching email address domains
+            if ((match.index !== 0) && (textToCheck[match.index - 1] === '@')) {
+                abort = true;
+            }
+
+            // we want to avoid matching ending ) unless it is a closing parenthesis for the URL
+            if (textToCheck[(match.index + match[2].length) - 1] === ')' && !match[2].includes('(')) {
+                match[0] = match[0].substr(0, match[0].length - 1);
+                match[2] = match[2].substr(0, match[2].length - 1);
+            }
+
+            // remove extra ) parentheses
+            let brace = 0;
+            if (match[2][match[2].length - 1] === ')') {
+                for (let i = 0; i < match[2].length; i++) {
+                    if (match[2][i] === '(') {
+                        brace++;
+                    }
+                    if (match[2][i] === ')') {
+                        brace--;
+                    }
+                }
+                if (brace) {
+                    match[0] = match[0].substr(0, match[0].length + brace);
+                    match[2] = match[2].substr(0, match[2].length + brace);
+                }
+            }
+            replacedText = replacedText.concat(textToCheck.substr(startIndex, (match.index - startIndex)));
+
+            if (abort) {
+                replacedText = replacedText.concat(textToCheck.substr(match.index, (match[0].length)));
+            } else {
+                replacedText = replacedText.concat(replacement(match[0], match[1], match[2], match[3]));
+            }
+            startIndex = match.index + (match[0].length);
+
+            // Now we move to the next match that the js regex found in the text
+            match = regex.exec(textToCheck);
+        }
+        if (startIndex < textToCheck.length) replacedText = replacedText.concat(textToCheck.substr(startIndex));
+
+        return replacedText;
+    }
+
+
+    /**
+     * Modify text for Quotes replacing chevrons with html elements
+     *
+     * @param {RegExp} regex
+     * @param {String} textToCheck
+     *
+     * @returns {String}
+     */
+
+    modifyTextForQuote(regex, textToCheck) {
+        let replacedText = "";
+        let TextToFormat = "";
+        match = textToCheck.match(regex);
+
+        //if there's matches we need to modify the quotes
+        if (match !== null) {
+            //split the textToCheck in lines
+            let textSplitted = textToCheck.split('\n');
+            for (let i = 0; i < textSplitted.length; i++) {
+
+                //we only want to modify lines starting with &gt; 
+                if (textSplitted[i].substr(0, 4) == "&gt;") {
+
+                    //avoid blank lines starting with &gt;
+                    if (textSplitted[i].trim() !== "&gt;") {
+                        textSplitted[i] = textSplitted[i].substr(4, textSplitted[i].length);
+                        textSplitted[i] = textSplitted[i].trim();
+                        TextToFormat += textSplitted[i] + '\n';
+
+                    } else {
+
+                        //we need ensure that index i-1 >= 0
+                        if (i > 0) {
+
+                            //certificate that we will have only one blank row 
+                            if (textSplitted[i - 1].trim() !== "") {
+                                textSplitted[i] = textSplitted[i].substr(4, textSplitted[i].length);
+                                textSplitted[i] = textSplitted[i].trim();
+                                TextToFormat += textSplitted[i] + '\n';
+                            } else {
+
+                            //doesnt append to textToFormat if current index row and current index row -1 was blank
+                                textSplitted[i] = textSplitted[i].substr(4, textSplitted[i].length);
+                                textSplitted[i] = textSplitted[i].trim();
+                            }
+                        }
+                    }
+                } else {
+
+                    //make sure we will only modify if we have Text needed to be formatted for quote
+                    if (TextToFormat != "") {
+                        TextToFormat = TextToFormat.replace(/\n$/, "");
+                        replacedText += "<blockquote>" + TextToFormat + "</blockquote>";
+                        TextToFormat = "";
+                    }
+                    replacedText += textSplitted[i] + '\n';
+                }
+            }
+
+            //when loop ends we need the last quote to be formatted if we have quotes at last rows
+            if (TextToFormat != "") {
+                TextToFormat = TextToFormat.replace(/\n$/, "");
+                replacedText += "<blockquote>" + TextToFormat + "</blockquote>";
+            }
+
+            //replace all the blank lines between quotes, if there are only blank lines between them
+            replacedText = replacedText.replace(/(<\/blockquote>((\s*)+)<blockquote>)/g, "</blockquote><blockquote>");
+
+        } else {
+        //if we doesnt have matches make sure the function will return the same textToCheck
+            replacedText = textToCheck;
+        }
+        return replacedText;
+    }
+}


### PR DESCRIPTION
### Details
Created a process to quotes like what is done with `modifyTextForUrlLinks` at [ExpensiMark ](https://github.com/Expensify/expensify-common/blob/master/lib/ExpensiMark.js)module having a function to deal with quotes:

### Fixed Issues
https://github.com/Expensify/Expensify.cash/issues/2670

### Tests

1. Tested in the chat with these inputs:
```
> This is a one line quote

> This is a two line quote
> And this is the second line

> This is a three line quote
>
> With an empty line in the middle that has no space after the chevron

> This is another three line quote
>  
> But this time there's a space after the middle chevro
```
```
> This is another three-line quote
> 
>
>
> But this time there's a space after the middle chevron
```
--->

### QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input and paste the inputs above.
--->

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Android
![print1](https://user-images.githubusercontent.com/56851391/120740847-67de6c80-c4ca-11eb-96ad-51b1900a9f79.png)
![print2](https://user-images.githubusercontent.com/56851391/120740849-68770300-c4ca-11eb-90ac-b6bfccc549b5.png)

