### PR TITLE
Menu auto close

### DIFF
--- a/src/pages/home/report/ReportActionContextMenu.js
+++ b/src/pages/home/report/ReportActionContextMenu.js
@@ -60,6 +60,7 @@ class ReportActionContextMenu extends React.Component {
         this.confirmDeleteAndHideModal = this.confirmDeleteAndHideModal.bind(this);
         this.hideDeleteConfirmModal = this.hideDeleteConfirmModal.bind(this);
         this.getActionText = this.getActionText.bind(this);
+        this.hidePopover = this.hidePopover.bind(this);
 
         // A list of all the context actions in this menu.
         this.contextActions = [
@@ -86,6 +87,7 @@ class ReportActionContextMenu extends React.Component {
                     } else {
                         Clipboard.setString(html);
                     }
+                    this.hidePopover(true);
                 },
             },
 
@@ -104,6 +106,7 @@ class ReportActionContextMenu extends React.Component {
                 onPress: () => {
                     updateLastReadActionID(this.props.reportID, this.props.reportAction.sequenceNumber);
                     setNewMarkerPosition(this.props.reportID, this.props.reportAction.sequenceNumber);
+                    this.hidePopover(true);
                 },
             },
 
@@ -112,7 +115,7 @@ class ReportActionContextMenu extends React.Component {
                 icon: Pencil,
                 shouldShow: () => canEditReportAction(this.props.reportAction),
                 onPress: () => {
-                    this.props.hidePopover();
+                    this.hidePopover();
                     saveReportActionDraft(
                         this.props.reportID,
                         this.props.reportAction.reportActionID,
@@ -124,7 +127,9 @@ class ReportActionContextMenu extends React.Component {
                 text: this.props.translate('reportActionContextMenu.deleteComment'),
                 icon: Trashcan,
                 shouldShow: () => canEditReportAction(this.props.reportAction),
-                onPress: () => this.setState({isDeleteCommentConfirmModalVisible: true}),
+                onPress: () => {
+                    this.setState({isDeleteCommentConfirmModalVisible: true});
+                },
             },
         ];
 
@@ -152,6 +157,20 @@ class ReportActionContextMenu extends React.Component {
 
     hideDeleteConfirmModal() {
         this.setState({isDeleteCommentConfirmModalVisible: false});
+    }
+
+    /**
+     * Hide the Menu
+     *
+     * @param {Boolean} delay whether the meanu should close after a delay
+     * @memberof ReportActionContextMenu
+     */
+    hidePopover(delay) {
+        if (!delay) {
+            this.props.hidePopover();
+            return;
+        }
+        setTimeout(this.props.hidePopover, 800);
     }
 
     render() {

--- a/src/pages/home/report/ReportActionContextMenu.js
+++ b/src/pages/home/report/ReportActionContextMenu.js
@@ -164,11 +164,11 @@ class ReportActionContextMenu extends React.Component {
     /**
      * Hide the Menu
      *
-     * @param {Boolean} delay whether the meanu should close after a delay
+     * @param {Boolean} shouldDelay whether the meanu should close after a delay
      * @memberof ReportActionContextMenu
      */
-    hidePopover(delay) {
-        if (!delay) {
+    hidePopover(shouldDelay) {
+        if (!shouldDelay) {
             this.props.hidePopover();
             return;
         }

--- a/src/pages/home/report/ReportActionContextMenu.js
+++ b/src/pages/home/report/ReportActionContextMenu.js
@@ -153,10 +153,12 @@ class ReportActionContextMenu extends React.Component {
     confirmDeleteAndHideModal() {
         deleteReportComment(this.props.reportID, this.props.reportAction);
         this.setState({isDeleteCommentConfirmModalVisible: false});
+        this.hidePopover();
     }
 
     hideDeleteConfirmModal() {
         this.setState({isDeleteCommentConfirmModalVisible: false});
+        this.hidePopover();
     }
 
     /**

--- a/src/pages/home/report/ReportActionContextMenu.js
+++ b/src/pages/home/report/ReportActionContextMenu.js
@@ -162,9 +162,9 @@ class ReportActionContextMenu extends React.Component {
     }
 
     /**
-     * Hide the Menu
+     * Hides the popover menu with an optional delay
      *
-     * @param {Boolean} shouldDelay whether the meanu should close after a delay
+     * @param {Boolean} shouldDelay whether the menu should close after a delay
      * @memberof ReportActionContextMenu
      */
     hidePopover(shouldDelay) {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
1. Added a delay of 800ms to auto-close the menu for `Mark as Unread`, `Copy to Clipboard` ContextMenu actions.
2. Menu closes on `Edit Comment` action.
3. Menu closes when we either confirm or cancel the `Delete Comment` action via Confirm Modal.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes #3187

### Tests
1. Open any chat.
2. Send a message.
3. Wait for few minutes, then right-click over the Chat message.
4. Click `Copy to clipboard`, Menu should close after some time automatically.
5. Right-click over the message,  then select `mark unread`. The menu should close after some time automatically.

### QA Steps (Web/Desktop)
1. Open E.cash on the web.
2. Open any existing chat.
3. Send a new message.
4. Wait for few seconds.
5. Now Right-click on the message. On the Context menu, select either `Copy to Clipboard` or `Mark as Unread`. 
6. Menu should close after a small delay. 

### QA Steps (M-Web/Android/IOS)

1. Open E.cash on the web.
2. Open any existing chat.
3. Send a new message.
4. Wait for few seconds.
5. Hold Press on the message. On the Context menu, select either `Copy to Clipboard` or `Mark as Unread`. 
6. Menu should close after a small delay. 



### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web 
<!-- Insert screenshots of your changes on the web platform-->


https://user-images.githubusercontent.com/24370807/120876251-5631bd80-c5cd-11eb-9525-bba5334612ca.mp4


### Desktop

https://user-images.githubusercontent.com/24370807/121077090-d128ed00-c7f4-11eb-8cfc-68229732fd83.mp4



#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

https://user-images.githubusercontent.com/24370807/121076128-ad18dc00-c7f3-11eb-884e-8d826bb2793d.mp4


#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

https://user-images.githubusercontent.com/24370807/121078615-cff8bf80-c7f6-11eb-8e3e-11083ab366d2.mp4


#### Android
<!-- Insert screenshots of your changes on the Android platform-->

https://user-images.githubusercontent.com/24370807/120876265-6ea1d800-c5cd-11eb-897c-10da83b0c691.mp4

