### PR TITLE
Set default currency for IOUBadge

### DIFF
--- a/src/components/IOUBadge.js
+++ b/src/components/IOUBadge.js
@@ -6,6 +6,7 @@ import ONYXKEYS from '../ONYXKEYS';
 import styles from '../styles/styles';
 import compose from '../libs/compose';
 import withLocalize, {withLocalizePropTypes} from './withLocalize';
+import CONST from '../CONST';
 
 const propTypes = {
     /** IOU Report data object */
@@ -29,6 +30,7 @@ const defaultProps = {
     iouReport: {
         total: 0,
         ownerEmail: null,
+        currency: CONST.CURRENCY.USD,
     },
 };
 

--- a/src/components/IOUBadge.js
+++ b/src/components/IOUBadge.js
@@ -16,6 +16,9 @@ const propTypes = {
 
         /** The owner of the IOUReport */
         ownerEmail: PropTypes.string,
+
+        /** The currency of the IOUReport */
+        currency: PropTypes.string,
     }),
 
     /** Session of currently logged in user */


### PR DESCRIPTION
@roryabraham will you please review this

### Details
This PR fixes an issue that I found while testing https://github.com/Expensify/react-native-onyx/pull/76#pullrequestreview-676561010. Currency does not have a default value, so if the IOUReport isn't done fetching before we try to display the IOUBadge, we can get a white screen on Web and Desktop. We also have default values for the other iouReport props in the IOUBadge, so we should add one for currency anyway.

### Tests/QA
1. Sign into an account with an IOU
2. Confirm the chats load normally and there isn't a white screen

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
N/A