### PR TITLE
Fixed picker scroll glitch

### DIFF
--- a/src/pages/home/report/EmojiPickerMenu/index.js
+++ b/src/pages/home/report/EmojiPickerMenu/index.js
@@ -65,12 +65,12 @@ class EmojiPickerMenu extends Component {
         this.setupEventHandlers = this.setupEventHandlers.bind(this);
         this.cleanupEventHandlers = this.cleanupEventHandlers.bind(this);
         this.renderItem = this.renderItem.bind(this);
+        this.currentScrollOffset = 0;
 
         this.state = {
             filteredEmojis: this.emojis,
             headerIndices: this.unfilteredHeaderIndices,
             highlightedIndex: -1,
-            currentScrollOffset: 0,
             arePointerEventsDisabled: false,
         };
     }
@@ -210,13 +210,13 @@ class EmojiPickerMenu extends Component {
         const offsetAtEmojiTop = offsetAtEmojiBottom - CONST.EMOJI_PICKER_ITEM_HEIGHT;
 
         // Scroll to fit the entire highlighted emoji into the window if we need to
-        let targetOffset = this.state.currentScrollOffset;
-        if (offsetAtEmojiBottom - this.state.currentScrollOffset >= CONST.NON_NATIVE_EMOJI_PICKER_LIST_HEIGHT) {
+        let targetOffset = this.currentScrollOffset;
+        if (offsetAtEmojiBottom - this.currentScrollOffset >= CONST.NON_NATIVE_EMOJI_PICKER_LIST_HEIGHT) {
             targetOffset = offsetAtEmojiBottom - CONST.NON_NATIVE_EMOJI_PICKER_LIST_HEIGHT;
-        } else if (offsetAtEmojiTop - CONST.EMOJI_PICKER_ITEM_HEIGHT <= this.state.currentScrollOffset) {
+        } else if (offsetAtEmojiTop - CONST.EMOJI_PICKER_ITEM_HEIGHT <= this.currentScrollOffset) {
             targetOffset = offsetAtEmojiTop - CONST.EMOJI_PICKER_ITEM_HEIGHT;
         }
-        if (targetOffset !== this.state.currentScrollOffset) {
+        if (targetOffset !== this.currentScrollOffset) {
             // Disable pointer events so that onHover doesn't get triggered when the items move while we're scrolling
             if (!this.state.arePointerEventsDisabled) {
                 this.setState({arePointerEventsDisabled: true});
@@ -335,7 +335,7 @@ class EmojiPickerMenu extends Component {
                     style={styles.emojiPickerList}
                     extraData={[this.state.filteredEmojis, this.state.highlightedIndex]}
                     stickyHeaderIndices={this.state.headerIndices}
-                    onScroll={e => this.setState({currentScrollOffset: e.nativeEvent.contentOffset.y})}
+                    onScroll={e => this.currentScrollOffset = e.nativeEvent.contentOffset.y}
                 />
             </View>
         );


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
 A detailed explanation of the issue & this PR's solution, can be found here https://github.com/Expensify/Expensify.cash/issues/3023#issuecomment-854886532

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes #3023

### Tests 
1. Open Emoji Picker.
2. Scrolled to the end of the emojis list.
3. Scrolled up & own many times to see if the glitch exists anymore.
4. Used Arrow keys to navigate the emojis.

### QA Steps
1. Open E.cash.
2. Open any chat.
3. Open the Emoji picker from the composer.
4. Scroll to the end of the Emoji List.
5. when the end is reached, there should not be a scroll glitch like 

	https://user-images.githubusercontent.com/44479856/118901476-606f6e80-b8e1-11eb-8936-22c29239237c.mp4

### Tested On

- [x] Web
- [x] Mobile Web (only Affected Platform)
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

https://user-images.githubusercontent.com/24370807/120854648-13ef8880-c59b-11eb-91ed-62967ebef444.mp4


#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
