### PR TITLE
Add Paypal username save confirmation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23126,7 +23126,8 @@
     "ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
     },
     "inline-style-parser": {
       "version": "0.1.1",

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -199,6 +199,7 @@ export default {
         payPalMe: 'PayPal.me/',
         yourPayPalUsername: 'Your PayPal username',
         addPayPalAccount: 'Add PayPal Account',
+        growlMessageOnSave: 'Your PayPal username was successfully added',
     },
     preferencesPage: {
         mostRecent: 'Most Recent',

--- a/src/pages/settings/PaymentsPage.js
+++ b/src/pages/settings/PaymentsPage.js
@@ -15,6 +15,7 @@ import styles from '../../styles/styles';
 import withLocalize, {withLocalizePropTypes} from '../../components/withLocalize';
 import compose from '../../libs/compose';
 import Button from '../../components/Button';
+import Growl from '../../libs/Growl';
 
 const propTypes = {
     /** Username for PayPal.Me */
@@ -54,6 +55,7 @@ class PaymentsPage extends React.Component {
      */
     setPayPalMeUsername() {
         NameValuePair.set(CONST.NVP.PAYPAL_ME_ADDRESS, this.state.payPalMeUsername, ONYXKEYS.NVP_PAYPAL_ME_ADDRESS);
+        Growl.show(this.props.translate('paymentsPage.growlMessageOnSave'), CONST.GROWL.SUCCESS, 3000);
     }
 
     render() {
@@ -78,10 +80,12 @@ class PaymentsPage extends React.Component {
                             value={this.state.payPalMeUsername}
                             placeholder={this.props.translate('paymentsPage.yourPayPalUsername')}
                             onChangeText={text => this.setState({payPalMeUsername: text})}
+                            editable={!this.props.payPalMeUsername}
                         />
                     </View>
                     <Button
                         success
+                        isDisabled={this.props.payPalMeUsername}
                         onPress={this.setPayPalMeUsername}
                         style={[styles.mt3]}
                         text={this.props.translate('paymentsPage.addPayPalAccount')}

--- a/src/pages/settings/PaymentsPage.js
+++ b/src/pages/settings/PaymentsPage.js
@@ -76,6 +76,8 @@ class PaymentsPage extends React.Component {
                             {this.props.translate('paymentsPage.payPalMe')}
                         </Text>
                         <TextInput
+                            autoCompleteType="off"
+                            autoCorrect={false}
                             style={[styles.textInput]}
                             value={this.state.payPalMeUsername}
                             placeholder={this.props.translate('paymentsPage.yourPayPalUsername')}


### PR DESCRIPTION
### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes https://github.com/Expensify/Expensify.cash/issues/3390

### Tests
1. Log into an account in Expensify.cash without a Paypal username set.
2. Enter a Paypal username (it can be any string).
3. Click "Add PayPal Account", verify a growl message appears.
4. Also verify that the input and button both become disabled.

### QA Steps
Same as the above tests

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web

https://user-images.githubusercontent.com/31285285/120959963-832cce80-c78d-11eb-9ac2-41fb414829bc.mp4



#### Mobile Web

https://user-images.githubusercontent.com/31285285/120959976-8922af80-c78d-11eb-9a83-41195fce77c0.mp4



#### Desktop

https://user-images.githubusercontent.com/31285285/120959995-8d4ecd00-c78d-11eb-895d-73fef47a8459.mp4



#### iOS

https://user-images.githubusercontent.com/31285285/120960002-917aea80-c78d-11eb-81c9-e868e751c744.mp4



#### Android

https://user-images.githubusercontent.com/31285285/120960012-9475db00-c78d-11eb-98d0-986a0175eb16.mp4


