### PR TITLE
[No QA] Add a beta for the free plan

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -11,6 +11,7 @@ const CONST = {
         CHRONOS_IN_CASH: 'chronosInCash',
         IOU: 'IOU',
         PAY_WITH_EXPENSIFY: 'payWithExpensify',
+        FREE_PLAN: 'freePlan',
     },
     BUTTON_STATES: {
         DEFAULT: 'default',

--- a/src/libs/Permissions.js
+++ b/src/libs/Permissions.js
@@ -39,8 +39,16 @@ function canUsePayWithExpensify() {
     return _.contains(betas, CONST.BETAS.PAY_WITH_EXPENSIFY) || canUseAllBetas();
 }
 
+/**
+ * @returns {Boolean}
+ */
+function canUseFreePlan() {
+    return _.contains(betas, CONST.BETAS.FREE_PLAN) || canUseAllBetas();
+}
+
 export default {
     canUseChronos,
     canUseIOU,
     canUsePayWithExpensify,
+    canUseFreePlan,
 };


### PR DESCRIPTION
This is needed for n5.5, the free plan. Nothing uses this yet, it will be tested in future PRs.

### Fixed Issues
Part of https://github.com/Expensify/Expensify/issues/166446

### Tests
None

### QA Steps
None

### Tested On
n/a

### Screenshots
n/a