### PR TITLE
Jules iou show paid preview

### DIFF
--- a/src/components/ReportActionItemIOUAction.js
+++ b/src/components/ReportActionItemIOUAction.js
@@ -6,9 +6,7 @@ import ReportActionItemIOUQuote from './ReportActionItemIOUQuote';
 import ReportActionPropTypes from '../pages/home/report/ReportActionPropTypes';
 import ReportActionItemIOUPreview from './ReportActionItemIOUPreview';
 import Navigation from '../libs/Navigation/Navigation';
-import compose from '../libs/compose';
 import ROUTES from '../ROUTES';
-import CONST from '../CONST';
 
 const propTypes = {
     /** All the data of the action */
@@ -26,28 +24,19 @@ const propTypes = {
         /** The participants of this report */
         participants: PropTypes.arrayOf(PropTypes.string),
     }),
-
-    /** iouReport associated with this iouAction */
-    iouReport: PropTypes.shape({
-        /** Does the iouReport have an outstanding IOU? */
-        hasOutstandingIOU: PropTypes.bool,
-    }),
 };
 
 const defaultProps = {
     chatReport: {
         participants: [],
     },
-    iouReport: {},
 };
 
 const ReportActionItemIOUAction = ({
     action,
     chatReportID,
-    iouReport,
     isMostRecentIOUReportAction,
 }) => {
-    const isIOUPaid = iouReport.stateNum === CONST.REPORT.STATE_NUM.SUBMITTED && iouReport.total !== 0;
     const launchDetailsModal = () => {
         Navigation.navigate(ROUTES.getIouDetailsRoute(chatReportID, action.originalMessage.IOUReportID));
     };
@@ -73,15 +62,8 @@ ReportActionItemIOUAction.propTypes = propTypes;
 ReportActionItemIOUAction.defaultProps = defaultProps;
 ReportActionItemIOUAction.displayName = 'ReportActionItemIOUAction';
 
-export default compose(
-    withOnyx({
-        chatReport: {
-            key: ({chatReportID}) => `${ONYXKEYS.COLLECTION.REPORT}${chatReportID}`,
-        },
-    }),
-    withOnyx({
-        iouReport: {
-            key: ({chatReport}) => `${ONYXKEYS.COLLECTION.REPORT_IOUS}${chatReport.iouReportID}`,
-        },
-    }),
-)(ReportActionItemIOUAction);
+export default withOnyx({
+    chatReport: {
+        key: ({chatReportID}) => `${ONYXKEYS.COLLECTION.REPORT}${chatReportID}`,
+    },
+})(ReportActionItemIOUAction);

--- a/src/components/ReportActionItemIOUAction.js
+++ b/src/components/ReportActionItemIOUAction.js
@@ -47,6 +47,7 @@ const ReportActionItemIOUAction = ({
     iouReport,
     isMostRecentIOUReportAction,
 }) => {
+    const isIOUPaid = iouReport.stateNum === CONST.REPORT.STATE_NUM.SUBMITTED && iouReport.total !== 0;
     const launchDetailsModal = () => {
         Navigation.navigate(ROUTES.getIouDetailsRoute(chatReportID, action.originalMessage.IOUReportID));
     };
@@ -62,6 +63,7 @@ const ReportActionItemIOUAction = ({
                     iouReportID={action.originalMessage.IOUReportID}
                     chatReportID={chatReportID}
                     onPayButtonPressed={launchDetailsModal}
+                    shouldHidePayButton={isIOUPaid}
                 />
             )}
         </>

--- a/src/components/ReportActionItemIOUAction.js
+++ b/src/components/ReportActionItemIOUAction.js
@@ -63,7 +63,6 @@ const ReportActionItemIOUAction = ({
                     iouReportID={action.originalMessage.IOUReportID}
                     chatReportID={chatReportID}
                     onPayButtonPressed={launchDetailsModal}
-                    shouldHidePayButton={isIOUPaid}
                 />
             )}
         </>

--- a/src/components/ReportActionItemIOUAction.js
+++ b/src/components/ReportActionItemIOUAction.js
@@ -8,6 +8,7 @@ import ReportActionItemIOUPreview from './ReportActionItemIOUPreview';
 import Navigation from '../libs/Navigation/Navigation';
 import compose from '../libs/compose';
 import ROUTES from '../ROUTES';
+import CONST from '../CONST';
 
 const propTypes = {
     /** All the data of the action */
@@ -56,9 +57,7 @@ const ReportActionItemIOUAction = ({
                 shouldShowViewDetailsLink={Boolean(action.originalMessage.IOUReportID)}
                 onViewDetailsPressed={launchDetailsModal}
             />
-            {isMostRecentIOUReportAction
-            && iouReport.hasOutstandingIOU
-            && Boolean(action.originalMessage.IOUReportID) && (
+            {isMostRecentIOUReportAction && Boolean(action.originalMessage.IOUReportID) && (
                 <ReportActionItemIOUPreview
                     iouReportID={action.originalMessage.IOUReportID}
                     chatReportID={chatReportID}

--- a/src/components/ReportActionItemIOUPreview.js
+++ b/src/components/ReportActionItemIOUPreview.js
@@ -18,6 +18,7 @@ import withLocalize, {withLocalizePropTypes} from './withLocalize';
 import {fetchIOUReportByID} from '../libs/actions/Report';
 import themeColors from '../styles/themes/default';
 import Icon from './Icon';
+import CONST from '../CONST';
 import {Checkmark} from './Icon/Expensicons';
 
 const propTypes = {
@@ -139,7 +140,9 @@ const ReportActionItemIOUPreview = ({
                                 ? translate('iou.owes', {manager: managerName, owner: ownerName})
                                 : translate('iou.paid', {manager: managerName, owner: ownerName})}
                         </Text>
-                        {(isCurrentUserManager && !shouldHidePayButton && (
+                        {(isCurrentUserManager
+                            && !shouldHidePayButton
+                            && iouReport.stateNum === CONST.REPORT.STATE_NUM.PROCESSING && (
                             <TouchableOpacity
                                 style={[styles.buttonSmall, styles.buttonSuccess, styles.mt4]}
                                 onPress={onPayButtonPressed}

--- a/src/components/ReportActionItemIOUPreview.js
+++ b/src/components/ReportActionItemIOUPreview.js
@@ -82,6 +82,14 @@ const ReportActionItemIOUPreview = ({
     onPayButtonPressed,
     translate,
 }) => {
+    // Usually the parent determines whether the IOU Preview is displayed. But as the iouReport total cannot be known
+    // until it is stored locally, we need to make this check within the Component after retrieving it. This allows us
+    // to handle the loading UI from within this Component instead of needing to declare it within each parent, which
+    // would duplicate and complicate the logic
+    if (iouReport.total === 0) {
+        return null;
+    }
+
     const sessionEmail = lodashGet(session, 'email', null);
     const managerEmail = iouReport.managerEmail || '';
     const ownerEmail = iouReport.ownerEmail || '';

--- a/src/pages/iou/IOUDetailsModal.js
+++ b/src/pages/iou/IOUDetailsModal.js
@@ -202,8 +202,6 @@ class IOUDetailsModal extends Component {
             [CONST.IOU.PAYMENT_TYPE.ELSEWHERE]: this.props.translate('iou.settleElsewhere'),
         };
         const selectedPaymentType = paymentTypeTextOptions[this.state.paymentType];
-        const isIOUPaid = this.props.iouReport.stateNum === CONST.REPORT.STATE_NUM.SUBMITTED
-            && this.props.iouReport.total !== 0;
         return (
             <ScreenWrapper>
                 <HeaderWithCloseButton
@@ -213,14 +211,12 @@ class IOUDetailsModal extends Component {
                 {reportIsLoading ? <ActivityIndicator color={themeColors.text} /> : (
                     <View style={[styles.flex1, styles.justifyContentBetween]}>
                         <ScrollView contentContainerStyle={styles.iouDetailsContainer}>
-                            {(this.props.iouReport.hasOutstandingIOU || isIOUPaid) && (
-                                <ReportActionItemIOUPreview
-                                    iou={this.props.iouReport}
-                                    chatReportID={Number(this.props.route.params.chatReportID)}
-                                    iouReportID={Number(this.props.route.params.iouReportID)}
-                                    shouldHidePayButton
-                                />
-                            )}
+                            <ReportActionItemIOUPreview
+                                iou={this.props.iouReport}
+                                chatReportID={Number(this.props.route.params.chatReportID)}
+                                iouReportID={Number(this.props.route.params.iouReportID)}
+                                shouldHidePayButton
+                            />
                             <IOUTransactions
                                 chatReportID={Number(this.props.route.params.chatReportID)}
                                 iouReportID={Number(this.props.route.params.iouReportID)}

--- a/src/pages/iou/IOUDetailsModal.js
+++ b/src/pages/iou/IOUDetailsModal.js
@@ -202,6 +202,8 @@ class IOUDetailsModal extends Component {
             [CONST.IOU.PAYMENT_TYPE.ELSEWHERE]: this.props.translate('iou.settleElsewhere'),
         };
         const selectedPaymentType = paymentTypeTextOptions[this.state.paymentType];
+        const isIOUPaid = this.props.iouReport.stateNum === CONST.REPORT.STATE_NUM.SUBMITTED
+            && this.props.iouReport.total !== 0;
         return (
             <ScreenWrapper>
                 <HeaderWithCloseButton
@@ -211,7 +213,7 @@ class IOUDetailsModal extends Component {
                 {reportIsLoading ? <ActivityIndicator color={themeColors.text} /> : (
                     <View style={[styles.flex1, styles.justifyContentBetween]}>
                         <ScrollView contentContainerStyle={styles.iouDetailsContainer}>
-                            {(this.props.iouReport.hasOutstandingIOU) && (
+                            {(this.props.iouReport.hasOutstandingIOU || isIOUPaid) && (
                                 <ReportActionItemIOUPreview
                                     iou={this.props.iouReport}
                                     chatReportID={Number(this.props.route.params.chatReportID)}


### PR DESCRIPTION
### Details
Fixes regression where the IOUPreview would not display after a report was paid. It also fixes an issue where the 'Pay' button was displayed incorrectly after it had already been paid 

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/166443

### Tests
_Ensure you are testing against the latest Auth/Web-E changes_
- Create an IOU Request of any amount
- The user who created the IOU should NOT see a 'Pay' button within the IOU Preview
- The user who received the IOU should see a 'Pay' button within the IOU Preview

![Screenshot 2021-06-07 at 18 13 53](https://user-images.githubusercontent.com/10736861/121061977-72478180-c7bc-11eb-903f-2f9378848da9.png)

- Now, as the user who received the first IOU, send an IOU back to the original sender for the same amount
- Both users should NOT see the IOU Preview

![Screenshot 2021-06-07 at 18 17 22](https://user-images.githubusercontent.com/10736861/121062347-dcf8bd00-c7bc-11eb-9e9d-2822c463193c.png)

- As any user, create a final IOU Request of any amount
- As the other user, settle it using the 'I'll settle it elsewhere' option

![Screenshot 2021-06-07 at 18 20 21](https://user-images.githubusercontent.com/10736861/121062535-16312d00-c7bd-11eb-9aa6-72eede9a0a58.png)

- As both users, you should see the 'User paid user' message within the preview, in both the chat and details page

![Screenshot 2021-06-07 at 18 23 05](https://user-images.githubusercontent.com/10736861/121062867-82ac2c00-c7bd-11eb-91a2-3370eb9f881c.png)


### QA Steps
Run above tests


### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web
![Screenshot 2021-06-07 at 18 23 05](https://user-images.githubusercontent.com/10736861/121062956-a4a5ae80-c7bd-11eb-9b60-58fc49c36940.png)

#### Mobile Web

![Simulator Screen Shot - iPhone 11 - 2021-06-07 at 18 36 35](https://user-images.githubusercontent.com/10736861/121064338-598c9b00-c7bf-11eb-8478-279d53e78b5a.png)


#### Desktop

![Screenshot 2021-06-07 at 18 38 52](https://user-images.githubusercontent.com/10736861/121064548-a4a6ae00-c7bf-11eb-9b74-fa514f1c7739.png)


#### iOS
![Simulator Screen Shot - iPhone 11 - 2021-06-07 at 18 35 55](https://user-images.githubusercontent.com/10736861/121064261-3cf06300-c7bf-11eb-8d4c-54617db7cae3.png)


#### Android

![device-2021-06-07-190134](https://user-images.githubusercontent.com/10736861/121067327-d2412680-c7c2-11eb-9841-d30498e8c5f1.png)

