### PR TITLE
Add isDestroyed check

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -228,7 +228,7 @@ const mainWindow = (() => {
             ipcMain.on(ELECTRON_EVENTS.REQUEST_VISIBILITY, (event) => {
                 // This is how synchronous messages work in Electron
                 // eslint-disable-next-line no-param-reassign
-                event.returnValue = browserWindow && browserWindow.isFocused();
+                event.returnValue = browserWindow && !browserWindow.isDestroyed() && browserWindow.isFocused();
             });
 
             // This allows the renderer process to bring the app


### PR DESCRIPTION

### Details
I think what was happening is:

1. Synchronous request is made from renderer process -> main process [here](https://github.com/Expensify/Expensify.cash/blob/a1ae2bf93dcfda522cf267162bf6b115beaa67bc/src/libs/Visibility/index.js#L16)
1. User quits the app, and the main process destroys the `browserWindow`
1. The main process isn't dead yet, and it tries to process the request from the renderer process. It calls `browserWindow.isFocused()`, but the `browserWindow` is destroyed, so it doesn't work. But we know if the window is destroyed then it's not focused, so we return false.

What I don't get is:

1. Why wasn't this happening pre-update?
1. Why does `browserWindow.isDestroyed()` work, but `browserWindow.isFocused` does not?

Anyways, I _thought_ I fixed this once before, but I don't have reliable reproduction steps – I believe this issue depends on the race condition described above. Nonetheless, I am unable to reproduce the error after this change, where I was able to reproduce it sometimes before this change. So I think it works 🤷 

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/3388

### Tests / QA Steps
1. Open the desktop app
1. (optional) Wait about 10 seconds, and switch between chats a few times. _Right_ after switching chats...
1. Hit `CMD + Q` to quit the desktop app. Verify that there is no JavaScript error dialog.

As stated above, I don't have very reliable reproduction steps, so repeat the above steps a few times to verify that the problem is really gone.

### Tested On

- [ ] Web
- [ ] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android