### PR TITLE
Fix regression with default option selection

### DIFF
--- a/src/components/OptionsSelector.js
+++ b/src/components/OptionsSelector.js
@@ -114,10 +114,6 @@ class OptionsSelector extends Component {
      * @param {SyntheticEvent} e
      */
     handleKeyPress(e) {
-        if (this.props.disableArrowKeysActions) {
-            return;
-        }
-
         // We are mapping over all the options to combine them into a single array and also saving the section index
         // index within that section so we can navigate
         const allOptions = _.reduce(this.props.sections, (options, section, sectionIndex) => (
@@ -127,6 +123,10 @@ class OptionsSelector extends Component {
                 sectionIndex,
             }))]
         ), []);
+
+        if (this.props.disableArrowKeysActions && e.nativeEvent.key.startsWith('Arrow')) {
+            return;
+        }
 
         switch (e.nativeEvent.key) {
             case 'Enter': {


### PR DESCRIPTION
### Details
Thanks for the review! This PR addresses a regression with intended behavior, where pressing `return` while in the search box (for finding/selecting a group member) should select the first result being displayed without requiring the user to manually click the search result.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/3379

### Tests
Applicable to only the Browser and Desktop app:

1. Log in to e.cash app
2. Click on the FAB button on the bottom left (`+` button)
3. Click on `New Group`
4. Search for group members such that only one result is showing
4. Pressing the Up and Down arrow keys shouldn't select any result entries on the list
5. Pressing return at that point should select the sole group member that is being displayed.

### QA Steps
Applicable to only the Web and Desktop app:

1. Log in to e.cash app
2. Click on the FAB button on the bottom left (`+` button)
3. Click on `New Group`
4. Search for group members such that only one result is showing
5. Pressing return at that point should select that group member and clear the input field for search/selection of another group member

### Tested On

- [x] Web
- [ ] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android

Not applicable on the other platforms.

### Screenshots

#### Web / Desktop
<img width="387" alt="Screen Shot 2021-06-08 at 8 39 43 PM" src="https://user-images.githubusercontent.com/2438855/121186451-b0ff3980-c899-11eb-9747-cc20d2a923af.png">

<img width="390" alt="Screen Shot 2021-06-08 at 8 39 50 PM" src="https://user-images.githubusercontent.com/2438855/121186466-b492c080-c899-11eb-8ee2-36c9663a5851.png">

#### Mobile Web
N/A

#### iOS
N/A

#### Android
N/A