### PR TITLE
IOU requests failing for certain decimal amounts

### DIFF
--- a/src/libs/actions/IOU.js
+++ b/src/libs/actions/IOU.js
@@ -67,7 +67,7 @@ function getIOUReportsForNewTransaction(requestParams) {
 /**
  * Creates IOUSplit Transaction
  * @param {Object} params
- * @param {String} params.amount
+ * @param {Number} params.amount
  * @param {String} params.comment
  * @param {String} params.currency
  * @param {String} params.debtorEmail
@@ -86,7 +86,7 @@ function createIOUTransaction(params) {
  * @param {Object} params
  * @param {Array} params.splits
  * @param {String} params.comment
- * @param {String} params.amount
+ * @param {Number} params.amount
  * @param {String} params.currency
  */
 function createIOUSplit(params) {

--- a/src/pages/iou/IOUModal.js
+++ b/src/pages/iou/IOUModal.js
@@ -247,7 +247,7 @@ class IOUModal extends Component {
                 comment: this.state.comment,
 
                 // should send in cents to API
-                amount: this.state.amount * 100,
+                amount: Math.round(this.state.amount * 100),
                 currency: this.state.selectedCurrency.currencyCode,
                 splits,
             });
@@ -258,7 +258,7 @@ class IOUModal extends Component {
             comment: this.state.comment,
 
             // should send in cents to API
-            amount: this.state.amount * 100,
+            amount: Math.round(this.state.amount * 100),
             currency: this.state.selectedCurrency.currencyCode,
             debtorEmail: this.state.participants[0].login,
         });


### PR DESCRIPTION
### Details

IOU requests were failing for certain amounts, due to a Javascript type issue. This PR simply updates the API params to pass the expected amount type (int).

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/166578

### Tests

- Create multiple IOU requests and splits, with the following amounts, in any currency
```
1.11-1.19
1.22
1.33
2.22
``` 
- Ensure that the IOU Request completes successfully, and you are not presented with an infinite loading spinner

![Screenshot 2021-06-08 at 15 13 58](https://user-images.githubusercontent.com/10736861/121201111-30761400-c86c-11eb-9c8a-f6088904ff3a.png)


### QA Steps

- Run above tests

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web

![Screenshot 2021-06-08 at 15 13 58](https://user-images.githubusercontent.com/10736861/121201199-3ec43000-c86c-11eb-8a50-cd29596131fc.png)

#### Mobile Web
![Simulator Screen Shot - iPhone 11 - 2021-06-08 at 15 26 53](https://user-images.githubusercontent.com/10736861/121203532-15a49f00-c86e-11eb-8496-a9466744f137.png)

#### Desktop

<img width="1193" alt="Screenshot 2021-06-08 at 15 29 29" src="https://user-images.githubusercontent.com/10736861/121203854-5997a400-c86e-11eb-9489-6ab76b9253de.png">

#### iOS
![Simulator Screen Shot - iPhone 11 - 2021-06-08 at 15 24 14](https://user-images.githubusercontent.com/10736861/121203469-09b8dd00-c86e-11eb-9881-bfa131f930e8.png)

#### Android

![device-2021-06-08-155424](https://user-images.githubusercontent.com/10736861/121208266-d8daa700-c871-11eb-966c-be82ed8030bb.png)
