### PR TITLE
[IS-3218] Fixed cursor issue on edit comment box

### DIFF
--- a/src/pages/home/report/ReportActionItemMessageEdit.js
+++ b/src/pages/home/report/ReportActionItemMessageEdit.js
@@ -36,10 +36,24 @@ class ReportActionItemMessageEdit extends React.Component {
         this.debouncedSaveDraft = _.debounce(this.debouncedSaveDraft.bind(this), 1000, true);
         this.publishDraft = this.publishDraft.bind(this);
         this.triggerSaveOrCancel = this.triggerSaveOrCancel.bind(this);
+        this.onSelectionChange = this.onSelectionChange.bind(this);
 
         this.state = {
             draft: this.props.draftMessage,
+            selection: {
+                start: this.props.draftMessage.length,
+                end: this.props.draftMessage.length,
+            },
         };
+    }
+
+    /**
+     * Update Selection on change cursor position.
+     *
+     * @param {Event} e
+     */
+    onSelectionChange(e) {
+        this.setState({selection: e.nativeEvent.selection});
     }
 
     /**
@@ -109,6 +123,8 @@ class ReportActionItemMessageEdit extends React.Component {
                             toggleReportActionComposeView(false);
                         }}
                         autoFocus
+                        selection={this.state.selection}
+                        onSelectionChange={this.onSelectionChange}
                     />
                 </View>
                 <View style={[styles.flexRow, styles.mt1]}>


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes https://github.com/Expensify/Expensify.cash/issues/3218

### Tests
### QA Steps

1. Navigate to a conversation in e.cash
2. Hover over an owned message and click on the edit comment option in the menu
3. or
4. Tap up arrow key to edit the previous comment.
5. See the cursor is set to the end of the message.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
https://user-images.githubusercontent.com/31027036/121220923-ed02b200-c839-11eb-9e77-dd82217bee38.mov


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
https://user-images.githubusercontent.com/31027036/121222217-30a9eb80-c83b-11eb-9f67-067fec4a0878.mov


#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
https://user-images.githubusercontent.com/31027036/121220190-41596200-c839-11eb-86d5-88d98d6074c1.mov


#### Android
<!-- Insert screenshots of your changes on the Android platform-->
https://user-images.githubusercontent.com/31027036/121222923-d3fb0080-c83b-11eb-98f0-592d4bcedbe8.mp4

