### PR TITLE
Apply localization to all hard coded text in the Expensify.cash app

### DIFF
--- a/src/components/AttachmentPicker/index.native.js
+++ b/src/components/AttachmentPicker/index.native.js
@@ -145,8 +145,7 @@ class AttachmentPicker extends Component {
                             this.showGeneralAlert(response.error);
                             break;
                     }
-                    const errorDescription = this.props.translate('attachmentPicker.errorDuringAttachmentSelection');
-                    reject(new Error(`${errorDescription}: ${response.error}`));
+                    reject(new Error(`Error during attachment selection: ${response.error}`));
                 }
 
                 resolve(response);

--- a/src/components/AttachmentPicker/index.native.js
+++ b/src/components/AttachmentPicker/index.native.js
@@ -80,7 +80,7 @@ class AttachmentPicker extends Component {
             {
                 icon: Paperclip,
                 text: this.props.translate('attachmentPicker.chooseDocument'),
-                pickAttachment: this.showDocumentPicker,
+                pickAttachment: () => this.showDocumentPicker(),
             },
         ];
 

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -39,7 +39,6 @@ export default {
         attachmentError: 'Attachment Error',
         errorWhileSelectingAttachment: 'An error occurred while selecting an attachment, please try again',
         errorWhileSelectingCorruptedImage: 'An error occurred while selecting a corrupted attachment, please try another file',
-        errorDuringAttachmentSelection: 'Error during attachment selection',
         takePhoto: 'Take Photo',
         chooseFromGallery: 'Choose from Gallery',
         chooseDocument: 'Choose Document',

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -31,6 +31,7 @@ export default {
         contacts: 'Contacts',
         recents: 'Recents',
         close: 'Close',
+        settings: 'Settings',
     },
     attachmentPicker: {
         cameraPermissionRequired: 'Camera Permission Required',
@@ -156,7 +157,6 @@ export default {
         sendValidation: 'Send Validation',
     },
     initialSettingsPage: {
-        settings: 'Settings',
         about: 'About',
         aboutPage: {
             description: 'Expensify.cash is built by a community of open source developers from around the world. Come help us build the next generation of Expensify.',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -29,6 +29,7 @@ export default {
         delete: 'Eliminar',
         contacts: 'Contactos',
         recents: 'Recientes',
+        settings: 'Configuración',
     },
     attachmentPicker: {
         cameraPermissionRequired: 'Se necesita permiso para usar la cámara',
@@ -153,7 +154,6 @@ export default {
         sendValidation: 'Enviar validación',
     },
     initialSettingsPage: {
-        settings: 'Configuración',
         about: 'Acerca de',
         aboutPage: {
             description: 'Expensify.cash está desarrollado por una comunidad de desarrolladores open source de todo el mundo. Ayúdanos a construir la próxima generación de Expensify.',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -37,7 +37,6 @@ export default {
         attachmentError: 'Error al adjuntar archivo',
         errorWhileSelectingAttachment: 'Ha ocurrido un error al seleccionar un adjunto, por favor inténtalo de nuevo',
         errorWhileSelectingCorruptedImage: 'Ha ocurrido un error al seleccionar un adjunto corrupto, por favor intentalo con otro archivo',
-        errorDuringAttachmentSelection: 'Error al seleccionar un archivo adjunto',
         takePhoto: 'Hacer una Foto',
         chooseFromGallery: 'Elegir de la galería',
         chooseDocument: 'Elegir Documento',

--- a/src/pages/settings/InitialPage.js
+++ b/src/pages/settings/InitialPage.js
@@ -106,7 +106,7 @@ const InitialSettingsPage = ({
     return (
         <ScreenWrapper>
             <HeaderWithCloseButton
-                title={translate('initialSettingsPage.settings')}
+                title={translate('common.settings')}
                 onCloseButtonPress={() => Navigation.dismissModal(true)}
             />
             <ScrollView style={[styles.settingsPageBackground]} bounces={false}>


### PR DESCRIPTION

### Details
Fixes some issues that were discovered in [this](https://github.com/Expensify/Expensify.cash/pull/2718) pull-request. 
1. `this` reference is lost in `showDocumentPicker`
2. No such key `common.settings` in languages/en
3. The error in `showDocumentPicker` is only printed on the console, it's not intended to be seen by the end user
and it does not need translated prefix

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/2408

