### PR TITLE
Rename AddBankAccountPage to AddPersonalBankAccountPage

### DIFF
--- a/src/ROUTES.js
+++ b/src/ROUTES.js
@@ -8,7 +8,7 @@ import {addTrailingForwardSlash} from './libs/Url';
 const REPORT = 'r';
 
 export default {
-    ADD_BANK_ACCOUNT: 'add-bank-account',
+    ADD_PERSONAL_BANK_ACCOUNT: 'add-personal-bank-account',
     HOME: '',
     SETTINGS: 'settings',
     SETTINGS_PROFILE: 'settings/profile',

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -255,9 +255,9 @@ export default {
         enterPassword: 'Enter a password',
         setPassword: 'Set Password',
     },
-    addBankAccountPage: {
+    addPersonalBankAccountPage: {
         enterPassword: 'Enter password',
-        addBankAccount: 'Add a Bank Account',
+        addPersonalBankAccount: 'Add Bank Account',
         alreadyAdded: 'This account has already been added.',
         selectAccount: 'Select an account:',
     },

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -251,9 +251,9 @@ export default {
         enterPassword: 'Escribe una contraseña',
         setPassword: 'Configura tu Contraseña',
     },
-    addBankAccountPage: {
+    addPersonalBankAccountPage: {
         enterPassword: 'Escribe una contraseña',
-        addBankAccount: 'Agregar una cuenta bancaria',
+        addPersonalBankAccount: 'Agregar cuenta bancaria',
         alreadyAdded: 'Esta cuenta ya ha sido agregada.',
         selectAccount: 'Selecciona una cuenta:',
     },

--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -49,7 +49,7 @@ import {
     NewChatModalStackNavigator,
     SettingsModalStackNavigator,
     EnablePaymentsStackNavigator,
-    AddBankAccountModalStackNavigator,
+    AddPersonalBankAccountModalStackNavigator,
 } from './ModalStackNavigators';
 import SCREENS from '../../../SCREENS';
 import Timers from '../../Timers';
@@ -266,9 +266,9 @@ class AuthScreens extends React.Component {
                     component={IOUDetailsModalStackNavigator}
                 />
                 <RootStack.Screen
-                    name="AddBankAccount"
+                    name="AddPersonalBankAccount"
                     options={modalScreenOptions}
-                    component={AddBankAccountModalStackNavigator}
+                    component={AddPersonalBankAccountModalStackNavigator}
                     listeners={modalScreenListeners}
                 />
             </RootStack.Navigator>

--- a/src/libs/Navigation/AppNavigator/ModalStackNavigators.js
+++ b/src/libs/Navigation/AppNavigator/ModalStackNavigators.js
@@ -20,7 +20,7 @@ import SettingsAddSecondaryLoginPage from '../../../pages/settings/AddSecondaryL
 import IOUCurrencySelection from '../../../pages/iou/IOUCurrencySelection';
 import ReportParticipantsPage from '../../../pages/ReportParticipantsPage';
 import EnablePaymentsPage from '../../../pages/EnablePayments';
-import AddBankAccountPage from '../../../pages/AddBankAccountPage';
+import AddPersonalBankAccountPage from '../../../pages/AddPersonalBankAccountPage';
 
 const defaultSubRouteOptions = {
     cardStyle: styles.navigationScreenCardStyle,
@@ -147,9 +147,9 @@ const EnablePaymentsStackNavigator = createModalStackNavigator([{
     name: 'EnablePayments_Root',
 }]);
 
-const AddBankAccountModalStackNavigator = createModalStackNavigator([{
-    Component: AddBankAccountPage,
-    name: 'AddBankAccount_Root',
+const AddPersonalBankAccountModalStackNavigator = createModalStackNavigator([{
+    Component: AddPersonalBankAccountPage,
+    name: 'AddPersonalBankAccount_Root',
 }]);
 
 export {
@@ -163,5 +163,5 @@ export {
     NewChatModalStackNavigator,
     SettingsModalStackNavigator,
     EnablePaymentsStackNavigator,
-    AddBankAccountModalStackNavigator,
+    AddPersonalBankAccountModalStackNavigator,
 };

--- a/src/libs/Navigation/linkingConfig.js
+++ b/src/libs/Navigation/linkingConfig.js
@@ -104,9 +104,9 @@ export default {
                     IOU_Details_Root: ROUTES.IOU_DETAILS_WITH_IOU_REPORT_ID,
                 },
             },
-            AddBankAccount: {
+            AddPersonalBankAccount: {
                 screens: {
-                    AddBankAccount_Root: ROUTES.ADD_BANK_ACCOUNT,
+                    AddPersonalBankAccount_Root: ROUTES.ADD_PERSONAL_BANK_ACCOUNT,
                 },
             },
             EnablePayments: {

--- a/src/pages/AddPersonalBankAccountPage.js
+++ b/src/pages/AddPersonalBankAccountPage.js
@@ -50,7 +50,7 @@ const defaultProps = {
     },
 };
 
-class AddBankAccountPage extends React.Component {
+class AddPersonalBankAccountPage extends React.Component {
     constructor(props) {
         super(props);
 
@@ -88,7 +88,7 @@ class AddBankAccountPage extends React.Component {
         return (
             <ScreenWrapper>
                 <HeaderWithCloseButton
-                    title={this.props.translate('addBankAccountPage.addBankAccount')}
+                    title={this.props.translate('addPersonalBankAccountPage.addPersonalBankAccount')}
                     onCloseButtonPress={() => Navigation.dismissModal()}
                 />
                 {(!this.props.plaidLinkToken || this.props.plaidBankAccounts.loading)
@@ -111,7 +111,7 @@ class AddBankAccountPage extends React.Component {
                 {accounts.length > 0 && (
                     <View>
                         <View style={[styles.m5]}>
-                            <Text>{this.props.translate('addBankAccountPage.selectAccount')}</Text>
+                            <Text>{this.props.translate('addPersonalBankAccountPage.selectAccount')}</Text>
                         </View>
                         {_.map(accounts, (account, index) => (
                             <React.Fragment
@@ -136,7 +136,7 @@ class AddBankAccountPage extends React.Component {
                                 />
                                 {account.alreadyExists && (
                                     <Text style={[styles.ml5]}>
-                                        {this.props.translate('addBankAccountPage.alreadyAdded')}
+                                        {this.props.translate('addPersonalBankAccountPage.alreadyAdded')}
                                     </Text>
                                 )}
                             </React.Fragment>
@@ -145,7 +145,7 @@ class AddBankAccountPage extends React.Component {
                             {!_.isUndefined(this.state.selectedIndex) && (
                                 <>
                                     <Text style={[styles.formLabel]}>
-                                        {this.props.translate('addBankAccountPage.enterPassword')}
+                                        {this.props.translate('addPersonalBankAccountPage.enterPassword')}
                                     </Text>
                                     <TextInput
                                         secureTextEntry
@@ -174,8 +174,8 @@ class AddBankAccountPage extends React.Component {
     }
 }
 
-AddBankAccountPage.propTypes = propTypes;
-AddBankAccountPage.defaultProps = defaultProps;
+AddPersonalBankAccountPage.propTypes = propTypes;
+AddPersonalBankAccountPage.defaultProps = defaultProps;
 
 export default compose(
     withLocalize,
@@ -187,4 +187,4 @@ export default compose(
             key: ONYXKEYS.PLAID_BANK_ACCOUNTS,
         },
     }),
-)(AddBankAccountPage);
+)(AddPersonalBankAccountPage);


### PR DESCRIPTION
### Details
- Since we are adding a new flow for adding a "verified" bank account to E.cash we'll want to differentiate between the modal that adds a personal bank account and the one that adds business bank account.
- Adds a minor copy change to match new mockups

### Fixed Issues
No Issue Prep for N5.5

### Tests
1. Navigate to `/add-personal-bank-account`
2. Verify the "Add Bank Account" right side panel opens

### QA Steps
No QA - as this flow isn't used by anything yet

### Tested On

- [x] Web

Skipping the other platforms as the changes are just in name so web is enough to prove things worked IMO.

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
![2021-06-08_10-40-04](https://user-images.githubusercontent.com/32969087/121254433-f265f980-c845-11eb-8054-8168a4e0cfd8.png)
![2021-06-08_10-40-06](https://user-images.githubusercontent.com/32969087/121254439-f4c85380-c845-11eb-81db-a64d32fc6c6f.png)