### PR TITLE
Use `VERSION_CODE` instead of `VERSION`

### DIFF
--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -58,7 +58,7 @@ jobs:
         if: ${{ env.SHOULD_DEPLOY_PRODUCTION == 'true' }}
         run: bundle exec fastlane android production
         env:
-          VERSION_CODE: ${{ env.VERSION_CODE }}
+          VERSION: ${{ env.VERSION_CODE }}
 
   desktop:
     name: Build and deploy Desktop

--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -58,7 +58,7 @@ jobs:
         if: ${{ env.SHOULD_DEPLOY_PRODUCTION == 'true' }}
         run: bundle exec fastlane android production
         env:
-          VERSION: ${{ env.VERSION_CODE }}
+          VERSION_CODE: ${{ env.VERSION_CODE }}
 
   desktop:
     name: Build and deploy Desktop

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -55,7 +55,7 @@ platform :android do
     upload_to_play_store(
       package_name: "com.expensify.chat",
       json_key: './android/app/android-fastlane-json-key.json',
-      version_code: ENV["VERSION_CODE"].to_i,
+      version_code: ENV["VERSION"].to_i,
       track: 'internal',
       track_promote_to: 'production',
       rollout: '1.0',


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Changes the ENV variable to the correct name `VERSION_CODE` in the platform deploy workflow.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/2918

### Tests
1. Run a production Android deploy
2. Verify the version_code is not `0`