### PR TITLE
Fix versionCode regex to work on ubuntu

### DIFF
--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -48,7 +48,7 @@ jobs:
           LARGE_SECRET_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
 
       - name: Set version in ENV
-        run: echo "VERSION_CODE=$(grep -o 'versionCode\s\+\d\+' android/app/build.gradle | awk '{ print $2 }')" >> $GITHUB_ENV
+        run: echo "VERSION_CODE=$(grep -o 'versionCode\s\+[0-9]\+' android/app/build.gradle | awk '{ print $2 }')" >> $GITHUB_ENV
 
       - name: Run Fastlane beta
         if: ${{ env.SHOULD_DEPLOY_PRODUCTION == 'false' }}


### PR DESCRIPTION
cc @Jag96 

### Details
Apparently GNU grep's basic regex type doesn't treat`\d` as a special character for `[0-9]`

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/2918

### Tests
Run a production deploy and see if it works 🙃 

I did some local testing to confirm this produces the correct output from the Expensidev/Expensify.cash directory both on macOS and in my ubuntu VM:

![image](https://user-images.githubusercontent.com/47436092/121273644-88694680-c87d-11eb-873d-456adf7e2718.png)

