### PR TITLE
Use hrefAttrs for links

### DIFF
--- a/src/components/AnchorForCommentsOnly/BaseAnchorForCommentsOnly/index.js
+++ b/src/components/AnchorForCommentsOnly/BaseAnchorForCommentsOnly/index.js
@@ -17,8 +17,7 @@ const BaseAnchorForCommentsOnly = ({
         style={StyleSheet.flatten(style)}
         accessibilityRole="link"
         href={href}
-        rel={rel}
-        target={target}
+        hrefAttrs={{rel, target}}
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...props}
     >


### PR DESCRIPTION
### Details
`link` and `rel` attributes must be passed via `hrefAttrs` as per https://necolas.github.io/react-native-web/docs/accessibility/#links

### Fixed Issues (Comment)
https://github.com/Expensify/Expensify.cash/pull/3215#issuecomment-857832515

### Tests
### QA Steps
1. Send a link as a comment
2. Tap that link
3. Verify it opens in a new tab

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
