### PR TITLE
[No QA] Single brackets not double brackets

### DIFF
--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Save correct NEW_VERSION to env
         run: |
-          if [[ -z ${{ github.event.inputs.NEW_VERSION }} ]]; then
+          if [ -z ${{ github.event.inputs.NEW_VERSION }} ]; then
             echo "NEW_VERSION=${{ needs.createNewVersion.outputs.NEW_VERSION }}" >> $GITHUB_ENV
             echo "New version is ${{ env.NEW_VERSION }}"
           else


### PR DESCRIPTION
### Details
Incorrect bash operator

### Fixed Issues
Fixes failed workflow run: https://github.com/Expensify/Expensify.cash/runs/2787308706?check_suite_focus=true

### Tests
Merge-to-test 🙃 

But I did do some local testing in my ubuntu VM:

```bash
vagrant@expensidev2004:/vagrant/Expensify.cash$ if [[ -z ]]; then echo "empty"; else echo "not empty"; fi;
bash: unexpected argument `]]' to conditional unary operator
bash: syntax error near `;'
vagrant@expensidev2004:/vagrant/Expensify.cash$ if [ -z ]; then echo "empty"; else echo "not empty"; fi;
empty
vagrant@expensidev2004:/vagrant/Expensify.cash$ if [ -z 1.0.61-1 ]; then echo "empty"; else echo "not empty"; fi;
not empty

```

### QA Steps
None.

### Tested On

To be tested on GitHub only.