### PR TITLE
[No QA] Push changes before trying to create CP branch

### DIFF
--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -120,6 +120,9 @@ jobs:
             echo "::set-output name=SHOULD_AUTOMERGE::false"
           fi
 
+      - name: Push changes to CP branch
+        run: git push
+
       - name: Create Pull Request
         id: createPullRequest
         # Version: 2.4.3


### PR DESCRIPTION

### Details
Need to push commits made on the CP branch to the remote before we can make a pull request.

### Fixed Issues
Fixes failed workflow run https://github.com/Expensify/Expensify.cash/runs/2787778611?check_suite_focus=true

### Tests
None.

### QA Steps
None.

### Tested on
n/a (GH only)