### PR TITLE
Skip most PR checks on automated pull requests

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,40 +1,40 @@
 name: CLA Assistant
 
 on:
-    issue_comment:
-        types: [created]
-    pull_request_target:
-        types: [opened, closed, synchronize]
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
 
 jobs:
-    CLA:
-        runs-on: ubuntu-latest
-        # This job only runs for pull request comments or pull request target events (not issue comments)
-        # It does not run for pull requests created by OSBotify
-        if: ${{ github.event.issue.pull_request || (github.event_name == 'pull_request_target' && github.event.pull_request.user.login != 'OSBotify') }}
-        steps:
-            - uses: actions-ecosystem/action-regex-match@9c35fe9ac1840239939c59e5db8839422eed8a73
-              id: sign
-              with:
-                text: ${{ github.event.comment.body }}
-                regex: '\s*I have read the CLA Document and I hereby sign the CLA\s*'
-            - uses: actions-ecosystem/action-regex-match@9c35fe9ac1840239939c59e5db8839422eed8a73
-              id: recheck
-              with:
-                text: ${{ github.event.comment.body }}
-                regex: '\s*recheck\s*'
-            - name: CLA Assistant
-              if: ${{ steps.recheck.outputs.match != '' || steps.sign.outputs.match != '' }} || github.event_name == 'pull_request_target'
-              # Version: 2.1.2-beta
-              uses: cla-assistant/github-action@948230deb0d44dd38957592f08c6bd934d96d0cf
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  PERSONAL_ACCESS_TOKEN : ${{ secrets.CLA_BOTIFY_TOKEN }}
-              with:
-                  path-to-signatures: '${{ github.repository }}/cla.json'
-                  path-to-document: 'https://github.com/${{ github.repository }}/blob/main/CLA.md'
-                  branch: 'master'
-                  remote-organization-name: 'Expensify'
-                  remote-repository-name: 'CLA'
-                  lock-pullrequest-aftermerge: false
-                  allowlist: OSBotify,snyk-bot
+  CLA:
+    runs-on: ubuntu-latest
+    # This job only runs for pull request comments or pull request target events (not issue comments)
+    # It does not run for pull requests created by OSBotify
+    if: ${{ github.event.issue.pull_request || (github.event_name == 'pull_request_target' && github.event.pull_request.user.login != 'OSBotify') }}
+    steps:
+        - uses: actions-ecosystem/action-regex-match@9c35fe9ac1840239939c59e5db8839422eed8a73
+          id: sign
+          with:
+            text: ${{ github.event.comment.body }}
+            regex: '\s*I have read the CLA Document and I hereby sign the CLA\s*'
+        - uses: actions-ecosystem/action-regex-match@9c35fe9ac1840239939c59e5db8839422eed8a73
+          id: recheck
+          with:
+            text: ${{ github.event.comment.body }}
+            regex: '\s*recheck\s*'
+        - name: CLA Assistant
+          if: ${{ steps.recheck.outputs.match != '' || steps.sign.outputs.match != '' }} || github.event_name == 'pull_request_target'
+          # Version: 2.1.2-beta
+          uses: cla-assistant/github-action@948230deb0d44dd38957592f08c6bd934d96d0cf
+          env:
+              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              PERSONAL_ACCESS_TOKEN : ${{ secrets.CLA_BOTIFY_TOKEN }}
+          with:
+              path-to-signatures: '${{ github.repository }}/cla.json'
+              path-to-document: 'https://github.com/${{ github.repository }}/blob/main/CLA.md'
+              branch: 'master'
+              remote-organization-name: 'Expensify'
+              remote-repository-name: 'CLA'
+              lock-pullrequest-aftermerge: false
+              allowlist: OSBotify,snyk-bot

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,52 +1,53 @@
 name: E2E iOS Tests
 
 on:
-    pull_request:
-        types: [opened, synchronize]
-        branches-ignore: [staging, production]
+  pull_request:
+    types: [opened, synchronize]
+    branches-ignore: [staging, production]
 
 env:
-    DEVELOPER_DIR: /Applications/Xcode_12.3.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_12.3.app/Contents/Developer
 
 jobs:
-    test:
-        runs-on: macos-latest
-        steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-ruby@v1
-              with:
-                ruby-version: '2.7'
+  test:
+    if: github.actor != 'OSBotify'
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.7'
 
-            - name: Install bundler
-              run: gem install bundler
+      - name: Install bundler
+        run: gem install bundler
 
-            - name: Install gems
-              run: bundle install
+      - name: Install gems
+        run: bundle install
 
-            - name: Install node packages
-              uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
-              with:
-                timeout_minutes: 10
-                max_attempts: 5
-                command: npm ci
+      - name: Install node packages
+        uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
+        with:
+          timeout_minutes: 10
+          max_attempts: 5
+          command: npm ci
 
-            - name: Install detox
-              run: npm install -g detox-cli
+      - name: Install detox
+        run: npm install -g detox-cli
 
-            - name: Install cocoapods
-              uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
-              with:
-                timeout_minutes: 15
-                max_attempts: 3
-                command: cd ios && pod install --repo-update
+      - name: Install cocoapods
+        uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          command: cd ios && pod install --repo-update
 
-            - name: Install brew depdencies
-              run: |
-                brew tap wix/brew
-                brew install applesimutils
+      - name: Install brew depdencies
+        run: |
+          brew tap wix/brew
+          brew install applesimutils
 
-            - name: Build tests
-              run: detox build --configuration ios.sim.release
+      - name: Build tests
+        run: detox build --configuration ios.sim.release
 
-            - name: Run tests
-              run: detox test --configuration ios.sim.release --cleanup --debug-synchronization 200 --loglevel trace
+      - name: Run tests
+        run: detox test --configuration ios.sim.release --cleanup --debug-synchronization 200 --loglevel trace

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,35 +1,36 @@
 name: Lint JavaScript
 
 on:
-    pull_request:
-        types: [opened, synchronize]
-        branches-ignore: [staging, production]
+  pull_request:
+    types: [opened, synchronize]
+    branches-ignore: [staging, production]
 
 jobs:
-    lint:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v2
+  lint:
+    if: github.actor != 'OSBotify'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
 
-            - uses: actions/cache@v2
-              with:
-                  path: ~/.npm
-                  key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-node-
+      - uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+              ${{ runner.os }}-node-
 
-            - name: Setup Node
-              uses: actions/setup-node@v1
-              with:
-                  node-version: '14.x'
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
 
-            - name: Install node packages
-              uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
-              with:
-                timeout_minutes: 10
-                max_attempts: 5
-                command: npm ci
+      - name: Install node packages
+        uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
+        with:
+          timeout_minutes: 10
+          max_attempts: 5
+          command: npm ci
 
-            - run: npm run lint
-              env:
-                  CI: true
+      - run: npm run lint
+        env:
+          CI: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,28 +1,29 @@
 name: Jest Unit Tests
 
 on:
-    pull_request:
-        types: [opened, synchronize]
-        branches-ignore: [staging, production]
+  pull_request:
+    types: [opened, synchronize]
+    branches-ignore: [staging, production]
 
 jobs:
-    test:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v2
+  test:
+    if: github.actor != 'OSBotify'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
 
-            - name: Use Node.js
-              uses: actions/setup-node@v1
-              with:
-                node-version: '14.x'
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
 
-            - name: Install node packages
-              uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
-              with:
-                  timeout_minutes: 10
-                  max_attempts: 5
-                  command: npm ci
+      - name: Install node packages
+        uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
+        with:
+          timeout_minutes: 10
+          max_attempts: 5
+          command: npm ci
 
-            - run: npm run test
-              env:
-                  CI: true
+      - run: npm run test
+        env:
+          CI: true

--- a/.github/workflows/validateGithubActions.yml
+++ b/.github/workflows/validateGithubActions.yml
@@ -1,32 +1,33 @@
 name: Validate Github Actions
 
 on:
-    pull_request:
-        types: [opened, synchronize]
-        branches-ignore: [staging, production]
+  pull_request:
+    types: [opened, synchronize]
+    branches-ignore: [staging, production]
 
 jobs:
-    verify:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v2
+  verify:
+    if: github.actor != 'OSBotify'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
 
-            - name: Use Node.js
-              uses: actions/setup-node@v1
-              with:
-                node-version: '14.x'
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
 
-            - name: Install node packages
-              uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
-              with:
-                  timeout_minutes: 10
-                  max_attempts: 5
-                  command: npm ci
+      - name: Install node packages
+        uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
+        with:
+          timeout_minutes: 10
+          max_attempts: 5
+          command: npm ci
 
-            # Rebuild all the actions on this branch and check for a diff. Fail if there is one,
-            # because that would be a sign that the PR author did not rebuild the Github Actions
-            - name: Verify Javascript Action Builds
-              run: ./.github/scripts/verifyActions.sh
+      # Rebuild all the actions on this branch and check for a diff. Fail if there is one,
+      # because that would be a sign that the PR author did not rebuild the Github Actions
+      - name: Verify Javascript Action Builds
+        run: ./.github/scripts/verifyActions.sh
 
-            - name: Validate actions and workflows
-              run: npm run gh-actions-validate
+      - name: Validate actions and workflows
+        run: npm run gh-actions-validate

--- a/.github/workflows/verifyPodfile.yml
+++ b/.github/workflows/verifyPodfile.yml
@@ -1,26 +1,27 @@
 name: Verify Podfile
 
 on:
-    pull_request:
-        types: [opened, synchronize]
-        branches-ignore: [staging, production]
+  pull_request:
+    types: [opened, synchronize]
+    branches-ignore: [staging, production]
 
 jobs:
-    verify:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v2
+  verify:
+    if: github.actor != 'OSBotify'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
 
-            - name: Use Node.js
-              uses: actions/setup-node@v1
-              with:
-                node-version: '14.x'
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
 
-            - name: Install node packages
-              uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
-              with:
-                  timeout_minutes: 10
-                  max_attempts: 5
-                  command: npm ci
+      - name: Install node packages
+        uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
+        with:
+          timeout_minutes: 10
+          max_attempts: 5
+          command: npm ci
 
-            - run: ./.github/scripts/verifyPodfile.sh
+      - run: ./.github/scripts/verifyPodfile.sh


### PR DESCRIPTION
### Details
Just a small optimization for GH Actions to skip checks on automated pull requests. This is not super important, but has at least three potential benefits:

1. Less noise in the GHA console.
1. Less likely to run into rate-limits or throttling with the number of concurrent workflow runs.
1. Generally less load on GH servers hopefully leads to faster actions in the aggregate.

Also cleans up indentation on these files to be two spaces, which we've standardized on in our other `.yml` workflows.

### Fixed Issues
n/a

### Tests
The checks on this PR should run. When merged, the checks on the version-bump PR should be skipped. Create another PR, and the PR checks should run.

### QA Steps
None

### Tested On

GitHub only