### PR TITLE
Fix line breaks in homepage links

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -220,7 +220,7 @@ export default {
         phrase2: 'terms of service',
         phrase3: 'and',
         phrase4: 'privacy policy',
-        phrase5: '. Money transmission is provided by Expensify Payments LLC (NMLS ID:2017010) pursuant to its',
+        phrase5: 'Money transmission is provided by Expensify Payments LLC (NMLS ID:2017010) pursuant to its',
         phrase6: 'licenses',
     },
     passwordForm: {

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -216,7 +216,7 @@ export default {
         phrase2: 'términos de servicio',
         phrase3: 'y',
         phrase4: 'política de privacidad',
-        phrase5: '. El envío de dinero es brindado por Expensify Payments LLC (NMLS ID:2017010) de conformidad con sus',
+        phrase5: 'El envío de dinero es brindado por Expensify Payments LLC (NMLS ID:2017010) de conformidad con sus',
         phrase6: 'licencias',
     },
     passwordForm: {

--- a/src/pages/signin/TermsAndLicenses/TermsWithLicenses.js
+++ b/src/pages/signin/TermsAndLicenses/TermsWithLicenses.js
@@ -22,13 +22,17 @@ const TermsWithLicenses = ({translate}) => (
         <TextLink style={[styles.loginTermsText]} href={CONST.PRIVACY_URL}>
             {translate('termsOfUse.phrase4')}
         </TextLink>
-        <Text style={[styles.loginTermsText]}>
-            {translate('termsOfUse.phrase5')}
-        </Text>
-        <TextLink style={[styles.loginTermsText]} href={CONST.LICENSES_URL}>
-            {translate('termsOfUse.phrase6')}
-        </TextLink>
         <Text style={[styles.loginTermsText]}>.</Text>
+        <Text>
+            <Text style={[styles.loginTermsText]}>
+                {translate('termsOfUse.phrase5')}
+                {' '}
+            </Text>
+            <TextLink style={[styles.loginTermsText]} href={CONST.LICENSES_URL}>
+                {translate('termsOfUse.phrase6')}
+            </TextLink>
+            <Text style={[styles.loginTermsText]}>.</Text>
+        </Text>
     </View>
 );
 


### PR DESCRIPTION
@roryabraham @arielgreen 

### Details
Fixed the line break after the privacy policy link and before licences links by putting them into a Text component. This change affects only web and mobile web.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/3100

### Tests
Verified terms of service and privacy policy links are accessible via keyboard from Safari and Chrome on MacOS when VoiceOver is enabled.

### QA Steps

- Enable VoiceOver on MacOS
- Open e.cash website on a browser
- Verify that there is no line break after the privacy policy link and before licences links
- Navigate on the webpage via arrow keys and check if links are clickable.

### Tested On

- [X] Web
- [X] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots

#### Web

https://user-images.githubusercontent.com/3853003/121440982-d87d0180-c980-11eb-8be0-9235b0457a4f.mov
