### PR TITLE
Upgrade the urbanairship-react-native package

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -756,9 +756,9 @@ SPEC CHECKSUMS:
   Onfido: 116a268e4cb8b767c15285e8071c2e8304673cdf
   onfido-react-native-sdk: b8f1b7cbe1adab6479d735275772390161630dcd
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
-  Permission-LocationAccuracy: 76669f87b4c276f5ae803cc0ddd1862a4c0e9dd8
-  Permission-LocationAlways: a274bc04bb386068782468dbdaca3859f51634ca
-  Permission-LocationWhenInUse: 3a2b0dbc167d79e8e920a4377ff9520cdc108407
+  Permission-LocationAccuracy: e8adff9ede1b23b43b7054a4500113d515fc87a8
+  Permission-LocationAlways: 7f7f373d086af7a81b2f4f20d65d29266ca2043b
+  Permission-LocationWhenInUse: 3ae82a9feb5da4e94e386dba17c7dd3531af9feb
   Plaid: c02276ccc630a726a9ed790bf923d29839ff4017
   PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
@@ -773,15 +773,15 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 124e8f99992490d0d13e0649d950d3e1aae06fe9
   React-jsinspector: 500a59626037be5b3b3d89c5151bc3baa9abf1a9
   react-native-config: d8b45133fd13d4f23bd2064b72f6e2c08b2763ed
-  react-native-document-picker: 0bba80cc56caab1f67dbaa81ff557e3a9b7f2b9f
+  react-native-document-picker: b3e78a8f7fef98b5cb069f20fc35797d55e68e28
   react-native-geolocation-service: 7c9436da6dfdecd9526c62eac62ea2bc3f0cc8ea
-  react-native-image-picker: c6d75c4ab2cf46f9289f341242b219cb3c1180d3
-  react-native-netinfo: 30fb89fa913c342be82a887b56e96be6d71201dd
+  react-native-image-picker: 32d1ad2c0024ca36161ae0d5c2117e2d6c441f11
+  react-native-netinfo: 52cf0ee8342548a485e28f4b09e56b477567244d
   react-native-pdf: 4b5a9e4465a6a3b399e91dc4838eb44ddf716d1f
-  react-native-plaid-link-sdk: 59b7376efca9f00e9693321c5cf7c6ab2c567635
-  react-native-progress-bar-android: be43138ab7da30d51fc038bafa98e9ed594d0c40
-  react-native-progress-view: 21b1e29e70c7559c16c9e0a04c4adc19fce6ede2
-  react-native-safe-area-context: 79fea126c6830c85f65947c223a5e3058a666937
+  react-native-plaid-link-sdk: 1a6593e2d3d790e8113c29178d883eb883f8c032
+  react-native-progress-bar-android: ce95a69f11ac580799021633071368d08aaf9ad8
+  react-native-progress-view: 5816e8a6be812c2b122c6225a2a3db82d9008640
+  react-native-safe-area-context: 01158a92c300895d79dee447e980672dc3fb85a6
   React-perflogger: aad6d4b4a267936b3667260d1f649b6f6069a675
   React-RCTActionSheet: fc376be462c9c8d6ad82c0905442fd77f82a9d2a
   React-RCTAnimation: ba0a1c3a2738be224a08092fa7f1b444ab77d309
@@ -795,16 +795,16 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: ff951a0c241bfaefc4940a3f1f1a229e7cb32fa6
   ReactCommon: bedc99ed4dae329c4fcf128d0c31b9115e5365ca
   rn-fetch-blob: f065bb7ab7fb48dd002629f8bdcb0336602d3cba
-  RNBootSplash: 24175aa28fe203b10c48dc34e78d946fd33c77af
-  RNCAsyncStorage: b03032fdbdb725bea0bd9e5ec5a7272865ae7398
-  RNCClipboard: 41d8d918092ae8e676f18adada19104fa3e68495
-  RNCMaskedView: fc29d354a40316a990e8fb46391f08aea829c3aa
+  RNBootSplash: 3123ba68fe44d8be09a014e89cc8f0f55b68a521
+  RNCAsyncStorage: cb9a623793918c6699586281f0b51cbc38f046f9
+  RNCClipboard: 5e299c6df8e0c98f3d7416b86ae563d3a9f768a3
+  RNCMaskedView: 138134c4d8a9421b4f2bf39055a79aa05c2d47b1
   RNCPicker: 6780c753e9e674065db90d9c965920516402579d
   RNFBAnalytics: 2dc4dd9e2445faffca041b10447a23a71dcdabf8
   RNFBApp: 7eacc7da7ab19f96c05e434017d44a9f09410da8
   RNFBCrashlytics: 4870c14cf8833053b6b5648911abefe1923854d2
   RNGestureHandler: 9b7e605a741412e20e13c512738a31bd1611759b
-  RNPermissions: 4c8a37b4dde50f1f152bf8cd08c4a43d2355829e
+  RNPermissions: eb94f9fdc0a8ecd02fcce0676d56ffb1395d41e1
   RNReanimated: b8c8004b43446e3c2709fe64b2b41072f87428ad
   RNScreens: e8e8dd0588b5da0ab57dcca76ab9b2d8987757e0
   RNSVG: ce9d996113475209013317e48b05c21ee988d42e

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
-  - Airship (14.2.0):
-    - Airship/Automation (= 14.2.0)
-    - Airship/Core (= 14.2.0)
-    - Airship/ExtendedActions (= 14.2.0)
-    - Airship/MessageCenter (= 14.2.0)
-  - Airship/Automation (14.2.0):
+  - Airship (14.3.0):
+    - Airship/Automation (= 14.3.0)
+    - Airship/Core (= 14.3.0)
+    - Airship/ExtendedActions (= 14.3.0)
+    - Airship/MessageCenter (= 14.3.0)
+  - Airship/Automation (14.3.0):
     - Airship/Core
-  - Airship/Core (14.2.0)
-  - Airship/ExtendedActions (14.2.0):
+  - Airship/Core (14.3.0)
+  - Airship/ExtendedActions (14.3.0):
     - Airship/Core
-  - Airship/MessageCenter (14.2.0):
+  - Airship/MessageCenter (14.3.0):
     - Airship/Core
   - boost-for-react-native (1.63.0)
   - CocoaAsyncSocket (7.6.5)
@@ -494,8 +494,8 @@ PODS:
     - React-Core
   - RNSVG (12.1.0):
     - React
-  - urbanairship-react-native (10.0.0):
-    - Airship (= 14.2.0)
+  - urbanairship-react-native (11.0.1):
+    - Airship (= 14.3.0)
     - React-Core
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
@@ -728,12 +728,12 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  Airship: 02ad73780f9eed21870e36b0aaab327acda6a102
+  Airship: 7609d263d3a207f112d6db066af5852b80af6819
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: cde416483dac037923206447da6e1454df403714
+  DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 7b423f9e248eae65987838148c36eec1dbfe0b53
-  FBReactNativeSpec: 884d4cc2b011759361797a4035c47e10099393b5
+  FBReactNativeSpec: 825b0f0851f5cc5c6268a920286281f62fc96c37
   Firebase: c23a36d9e4cdf7877dfcba8dd0c58add66358999
   FirebaseAnalytics: 3bb096873ee0d7fa4b6c70f5e9166b6da413cc7f
   FirebaseCore: d3a978a3cfa3240bf7e4ba7d137fdf5b22b628ec
@@ -747,7 +747,7 @@ SPEC CHECKSUMS:
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
   Flipper-RSocket: 127954abe8b162fcaf68d2134d34dc2bd7076154
   FlipperKit: 8a20b5c5fcf9436cac58551dc049867247f64b00
-  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
+  glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   GoogleAppMeasurement: a6a3a066369828db64eda428cb2856dc1cdc7c4e
   GoogleDataTransport: f56af7caa4ed338dc8e138a5d7c5973e66440833
   GoogleUtilities: 7f2f5a07f888cdb145101d6042bc4422f57e70b3
@@ -756,9 +756,9 @@ SPEC CHECKSUMS:
   Onfido: 116a268e4cb8b767c15285e8071c2e8304673cdf
   onfido-react-native-sdk: b8f1b7cbe1adab6479d735275772390161630dcd
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
-  Permission-LocationAccuracy: e8adff9ede1b23b43b7054a4500113d515fc87a8
-  Permission-LocationAlways: 7f7f373d086af7a81b2f4f20d65d29266ca2043b
-  Permission-LocationWhenInUse: 3ae82a9feb5da4e94e386dba17c7dd3531af9feb
+  Permission-LocationAccuracy: 76669f87b4c276f5ae803cc0ddd1862a4c0e9dd8
+  Permission-LocationAlways: a274bc04bb386068782468dbdaca3859f51634ca
+  Permission-LocationWhenInUse: 3a2b0dbc167d79e8e920a4377ff9520cdc108407
   Plaid: c02276ccc630a726a9ed790bf923d29839ff4017
   PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
@@ -773,15 +773,15 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 124e8f99992490d0d13e0649d950d3e1aae06fe9
   React-jsinspector: 500a59626037be5b3b3d89c5151bc3baa9abf1a9
   react-native-config: d8b45133fd13d4f23bd2064b72f6e2c08b2763ed
-  react-native-document-picker: b3e78a8f7fef98b5cb069f20fc35797d55e68e28
+  react-native-document-picker: 0bba80cc56caab1f67dbaa81ff557e3a9b7f2b9f
   react-native-geolocation-service: 7c9436da6dfdecd9526c62eac62ea2bc3f0cc8ea
-  react-native-image-picker: 32d1ad2c0024ca36161ae0d5c2117e2d6c441f11
-  react-native-netinfo: 52cf0ee8342548a485e28f4b09e56b477567244d
+  react-native-image-picker: c6d75c4ab2cf46f9289f341242b219cb3c1180d3
+  react-native-netinfo: 30fb89fa913c342be82a887b56e96be6d71201dd
   react-native-pdf: 4b5a9e4465a6a3b399e91dc4838eb44ddf716d1f
-  react-native-plaid-link-sdk: 1a6593e2d3d790e8113c29178d883eb883f8c032
-  react-native-progress-bar-android: ce95a69f11ac580799021633071368d08aaf9ad8
-  react-native-progress-view: 5816e8a6be812c2b122c6225a2a3db82d9008640
-  react-native-safe-area-context: 01158a92c300895d79dee447e980672dc3fb85a6
+  react-native-plaid-link-sdk: 59b7376efca9f00e9693321c5cf7c6ab2c567635
+  react-native-progress-bar-android: be43138ab7da30d51fc038bafa98e9ed594d0c40
+  react-native-progress-view: 21b1e29e70c7559c16c9e0a04c4adc19fce6ede2
+  react-native-safe-area-context: 79fea126c6830c85f65947c223a5e3058a666937
   React-perflogger: aad6d4b4a267936b3667260d1f649b6f6069a675
   React-RCTActionSheet: fc376be462c9c8d6ad82c0905442fd77f82a9d2a
   React-RCTAnimation: ba0a1c3a2738be224a08092fa7f1b444ab77d309
@@ -795,20 +795,20 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: ff951a0c241bfaefc4940a3f1f1a229e7cb32fa6
   ReactCommon: bedc99ed4dae329c4fcf128d0c31b9115e5365ca
   rn-fetch-blob: f065bb7ab7fb48dd002629f8bdcb0336602d3cba
-  RNBootSplash: 3123ba68fe44d8be09a014e89cc8f0f55b68a521
-  RNCAsyncStorage: cb9a623793918c6699586281f0b51cbc38f046f9
-  RNCClipboard: 5e299c6df8e0c98f3d7416b86ae563d3a9f768a3
-  RNCMaskedView: 138134c4d8a9421b4f2bf39055a79aa05c2d47b1
+  RNBootSplash: 24175aa28fe203b10c48dc34e78d946fd33c77af
+  RNCAsyncStorage: b03032fdbdb725bea0bd9e5ec5a7272865ae7398
+  RNCClipboard: 41d8d918092ae8e676f18adada19104fa3e68495
+  RNCMaskedView: fc29d354a40316a990e8fb46391f08aea829c3aa
   RNCPicker: 6780c753e9e674065db90d9c965920516402579d
   RNFBAnalytics: 2dc4dd9e2445faffca041b10447a23a71dcdabf8
   RNFBApp: 7eacc7da7ab19f96c05e434017d44a9f09410da8
   RNFBCrashlytics: 4870c14cf8833053b6b5648911abefe1923854d2
   RNGestureHandler: 9b7e605a741412e20e13c512738a31bd1611759b
-  RNPermissions: eb94f9fdc0a8ecd02fcce0676d56ffb1395d41e1
+  RNPermissions: 4c8a37b4dde50f1f152bf8cd08c4a43d2355829e
   RNReanimated: b8c8004b43446e3c2709fe64b2b41072f87428ad
   RNScreens: e8e8dd0588b5da0ab57dcca76ab9b2d8987757e0
   RNSVG: ce9d996113475209013317e48b05c21ee988d42e
-  urbanairship-react-native: dfb6dc22b2f41ccaadd636b73d51b448cd1b2bbc
+  urbanairship-react-native: d415a12e67ba93bf3ce914df9a310b66a88a5cc3
   Yoga: a7de31c64fe738607e7a3803e3f591a4b1df7393
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -38431,9 +38431,9 @@
       }
     },
     "urbanairship-react-native": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/urbanairship-react-native/-/urbanairship-react-native-10.0.0.tgz",
-      "integrity": "sha512-0vJ6K+KnGeB5vJujFzfWXc7x+nFkdELj4TSOBkfW0VfxrQpojIXmOdXt0GHWOUOVTzFj2iA25qkfcSAaImQeGw=="
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/urbanairship-react-native/-/urbanairship-react-native-11.0.1.tgz",
+      "integrity": "sha512-QNXz655hBveFSv5kMFivhUkpHopt0ojIFCWEP+H0vssKjrO8z0xDmlM6Gd4aeUT63nwTaAUbH7zU8qTLFFrs+w=="
     },
     "uri-js": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "rn-fetch-blob": "^0.12.0",
     "save": "^2.4.0",
     "underscore": "^1.10.2",
-    "urbanairship-react-native": "^10.0.0"
+    "urbanairship-react-native": "^11.0.1"
   },
   "devDependencies": {
     "@actions/core": "^1.2.6",


### PR DESCRIPTION
### Details
This PR updates the urbanairship-react-native package to fix an issue where removing all listeners (PushNotification.deregister) throws an error in the old package.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/3503

### Tests
1. Sign into an account and then sign out, confirm the apps don't crash

While testing this, I noticed that the TestFlight build sent push notifications properly, but when building to a physical device (iOS since I don't have an Android) the push notifications never came through. I confirmed that the same behavior happens when building to my device using the same version that is on the TestFlight (where pushes are working fine), so this may have to be fully confirmed when the build is on the TF. cc @roryabraham and @sketchydroide to confirm since you both have tested this before.

### QA Steps
On the testflight build, sign into an account on iOS and Android then background the app. On another account, send a message to that account and confirm you receive a push notification.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

