### PR TITLE
Quit early when persistedRequests is empty

### DIFF
--- a/src/libs/Network.js
+++ b/src/libs/Network.js
@@ -32,15 +32,15 @@ let didLoadPersistedRequests;
 Onyx.connect({
     key: ONYXKEYS.NETWORK_REQUEST_QUEUE,
     callback: (persistedRequests) => {
-        if (didLoadPersistedRequests || !persistedRequests || persistedRequests.length === 0) {
+        if (didLoadPersistedRequests || !persistedRequests) {
             return;
         }
 
         // Merge the persisted requests with the requests in memory then clear out the queue as we only need to load
         // this once when the app initializes
         networkRequestQueue = [...networkRequestQueue, ...persistedRequests];
-        Onyx.set(ONYXKEYS.NETWORK_REQUEST_QUEUE, []);
         didLoadPersistedRequests = true;
+        Onyx.set(ONYXKEYS.NETWORK_REQUEST_QUEUE, []);
     },
 });
 

--- a/src/libs/Network.js
+++ b/src/libs/Network.js
@@ -32,7 +32,7 @@ let didLoadPersistedRequests;
 Onyx.connect({
     key: ONYXKEYS.NETWORK_REQUEST_QUEUE,
     callback: (persistedRequests) => {
-        if (didLoadPersistedRequests || !persistedRequests) {
+        if (didLoadPersistedRequests || !persistedRequests || persistedRequests.length === 0) {
             return;
         }
 


### PR DESCRIPTION
@Dal-Papa, please review when you get the chance
CC: @marcaaron, in case I'm misunderstanding how this is supposed to work.

### Details
This callback was looping too quickly because of this line (which recursively calls the callback function it's in): https://github.com/Expensify/Expensify.cash/blob/afb44ff4667bb5686c81c074097af60c26913a5c/src/libs/Network.js#L42

The actual implementation of this function doesn't change. If `persistedRequests` is empty, `networkRequestQueue = [...networkRequestQueue, ...persistedRequests];` becomes `networkRequestQueue = [...networkRequestQueue, ...[]];` which essentially does nothing over and over again.



My theory for why this hasn't happened before is that Onyx wasn't fast enough to finish the `Onyx.set(..., [])` before the `didLoadPersistedRequests = true` line right after it. If it was slow, that would be set to true and this would exit early as expected. Alternatively we could swap line 42 and 43, but I think this change makes more sense.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/3485

### Tests
Did QA on each of the platforms (couldn't get android to work with the offline mode though I can't do that with production either, so I think that's due to my  VM)

### QA Steps
In each respective platform (specifically iOS is broken),
1. Verify you can go into offline mode and navigate around the app
2. Send a message in offline mode.
3. Verify that the message is sent when you go back online.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [ ] Android

### Screenshots


![image](https://user-images.githubusercontent.com/19364431/121507835-011def00-c9b3-11eb-90f2-e959e1becfb1.png)
