### PR TITLE
[NO QA]Feature: Critical Error Handling

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,14 +1,13 @@
 import React from 'react';
 import {SafeAreaProvider} from 'react-native-safe-area-context';
-
 import CustomStatusBar from './components/CustomStatusBar';
-import Expensify from './Expensify';
 import ErrorBoundary from './components/ErrorBoundary';
+import Expensify from './Expensify';
 
 const App = () => (
     <SafeAreaProvider>
         <CustomStatusBar />
-        <ErrorBoundary errorMessage="[App] A Crash was intercepted by the main error boundary">
+        <ErrorBoundary errorMessage="E.cash crash caught by error boundary">
             <Expensify />
         </ErrorBoundary>
     </SafeAreaProvider>

--- a/src/App.js
+++ b/src/App.js
@@ -1,12 +1,16 @@
 import React from 'react';
 import {SafeAreaProvider} from 'react-native-safe-area-context';
+
 import CustomStatusBar from './components/CustomStatusBar';
 import Expensify from './Expensify';
+import ErrorBoundary from './components/ErrorBoundary';
 
 const App = () => (
     <SafeAreaProvider>
         <CustomStatusBar />
-        <Expensify />
+        <ErrorBoundary errorMessage="[App] A Crash was intercepted by the main error boundary">
+            <Expensify />
+        </ErrorBoundary>
     </SafeAreaProvider>
 );
 

--- a/src/components/ErrorBoundary.js
+++ b/src/components/ErrorBoundary.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import crashlytics from '@react-native-firebase/crashlytics';
+
+import Log from '../libs/Log';
+
+const propTypes = {
+    /* An message posted to the server (along with the error) when this component intercepts an error */
+    errorMessage: PropTypes.string.isRequired,
+
+    /* Actual content wrapped by this error boundary */
+    children: PropTypes.node.isRequired,
+};
+
+/**
+ * This component captures an error in the child component tree and logs it to the server
+ * It can be used to wrap the entire app as well as to wrap specific parts for more granularity
+ * @see {@link https://reactjs.org/docs/error-boundaries.html#where-to-place-error-boundaries}
+ */
+class ErrorBoundary extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {hasError: false};
+    }
+
+    static getDerivedStateFromError() {
+        // Update state so the next render will show the fallback UI.
+        return {hasError: true};
+    }
+
+    componentDidCatch(error, errorInfo) {
+        // Log the error to the server
+        Log.info(this.props.errorMessage, true, {error, errorInfo});
+
+        // Since the error was handled we need to manually tell crashlytics about it
+        crashlytics().log(`errorInfo: ${errorInfo}`);
+        crashlytics().recordError(error);
+    }
+
+    render() {
+        if (this.state.hasError) {
+            // For the moment we've decided not to render any fallback UI
+            return null;
+        }
+
+        return this.props.children;
+    }
+}
+
+ErrorBoundary.propTypes = propTypes;
+
+export default ErrorBoundary;

--- a/src/components/ErrorBoundary/BaseErrorBoundary.js
+++ b/src/components/ErrorBoundary/BaseErrorBoundary.js
@@ -1,15 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import crashlytics from '@react-native-firebase/crashlytics';
-
-import Log from '../libs/Log';
 
 const propTypes = {
-    /* An message posted to the server (along with the error) when this component intercepts an error */
+    /* A message posted to `logError` (along with error data) when this component intercepts an error */
     errorMessage: PropTypes.string.isRequired,
+
+    /* A function to perform the actual logging since different platforms support different tools */
+    logError: PropTypes.func,
 
     /* Actual content wrapped by this error boundary */
     children: PropTypes.node.isRequired,
+};
+
+const defaultProps = {
+    logError: () => {},
 };
 
 /**
@@ -17,7 +21,7 @@ const propTypes = {
  * It can be used to wrap the entire app as well as to wrap specific parts for more granularity
  * @see {@link https://reactjs.org/docs/error-boundaries.html#where-to-place-error-boundaries}
  */
-class ErrorBoundary extends React.Component {
+class BaseErrorBoundary extends React.Component {
     constructor(props) {
         super(props);
         this.state = {hasError: false};
@@ -29,12 +33,7 @@ class ErrorBoundary extends React.Component {
     }
 
     componentDidCatch(error, errorInfo) {
-        // Log the error to the server
-        Log.info(this.props.errorMessage, true, {error, errorInfo});
-
-        // Since the error was handled we need to manually tell crashlytics about it
-        crashlytics().log(`errorInfo: ${errorInfo}`);
-        crashlytics().recordError(error);
+        this.props.logError(this.props.errorMessage, error, errorInfo);
     }
 
     render() {
@@ -47,6 +46,7 @@ class ErrorBoundary extends React.Component {
     }
 }
 
-ErrorBoundary.propTypes = propTypes;
+BaseErrorBoundary.propTypes = propTypes;
+BaseErrorBoundary.defaultProps = defaultProps;
 
-export default ErrorBoundary;
+export default BaseErrorBoundary;

--- a/src/components/ErrorBoundary/index.js
+++ b/src/components/ErrorBoundary/index.js
@@ -3,7 +3,7 @@ import Log from '../../libs/Log';
 
 BaseErrorBoundary.defaultProps.logError = (errorMessage, error, errorInfo) => {
     // Log the error to the server
-    Log.alert(errorMessage, 10, {error: error.message, errorInfo});
+    Log.alert(errorMessage, 0, {error: error.message, errorInfo}, false);
 };
 
 export default BaseErrorBoundary;

--- a/src/components/ErrorBoundary/index.js
+++ b/src/components/ErrorBoundary/index.js
@@ -3,7 +3,7 @@ import Log from '../../libs/Log';
 
 BaseErrorBoundary.defaultProps.logError = (errorMessage, error, errorInfo) => {
     // Log the error to the server
-    Log.info(errorMessage, true, {error, errorInfo});
+    Log.alert(errorMessage, 10, {error, errorInfo});
 };
 
 export default BaseErrorBoundary;

--- a/src/components/ErrorBoundary/index.js
+++ b/src/components/ErrorBoundary/index.js
@@ -3,7 +3,7 @@ import Log from '../../libs/Log';
 
 BaseErrorBoundary.defaultProps.logError = (errorMessage, error, errorInfo) => {
     // Log the error to the server
-    Log.alert(errorMessage, 10, {error, errorInfo});
+    Log.alert(errorMessage, 10, {error: error.message, errorInfo});
 };
 
 export default BaseErrorBoundary;

--- a/src/components/ErrorBoundary/index.js
+++ b/src/components/ErrorBoundary/index.js
@@ -1,0 +1,9 @@
+import BaseErrorBoundary from './BaseErrorBoundary';
+import Log from '../../libs/Log';
+
+BaseErrorBoundary.defaultProps.logError = (errorMessage, error, errorInfo) => {
+    // Log the error to the server
+    Log.info(errorMessage, true, {error, errorInfo});
+};
+
+export default BaseErrorBoundary;

--- a/src/components/ErrorBoundary/index.native.js
+++ b/src/components/ErrorBoundary/index.native.js
@@ -5,7 +5,7 @@ import Log from '../../libs/Log';
 
 BaseErrorBoundary.defaultProps.logError = (errorMessage, error, errorInfo) => {
     // Log the error to the server
-    Log.alert(errorMessage, 10, {error, errorInfo});
+    Log.alert(errorMessage, 10, {error: error.message, errorInfo});
 
     /* On native we also log the error to crashlytics
     * Since the error was handled we need to manually tell crashlytics about it */

--- a/src/components/ErrorBoundary/index.native.js
+++ b/src/components/ErrorBoundary/index.native.js
@@ -1,0 +1,16 @@
+import crashlytics from '@react-native-firebase/crashlytics';
+
+import BaseErrorBoundary from './BaseErrorBoundary';
+import Log from '../../libs/Log';
+
+BaseErrorBoundary.defaultProps.logError = (errorMessage, error, errorInfo) => {
+    // Log the error to the server
+    Log.info(this.props.errorMessage, true, {error, errorInfo});
+
+    /* On native we also log the error to crashlytics
+    * Since the error was handled we need to manually tell crashlytics about it */
+    crashlytics().log(`errorInfo: ${errorInfo}`);
+    crashlytics().recordError(error);
+};
+
+export default BaseErrorBoundary;

--- a/src/components/ErrorBoundary/index.native.js
+++ b/src/components/ErrorBoundary/index.native.js
@@ -9,7 +9,7 @@ BaseErrorBoundary.defaultProps.logError = (errorMessage, error, errorInfo) => {
 
     /* On native we also log the error to crashlytics
     * Since the error was handled we need to manually tell crashlytics about it */
-    crashlytics().log(`errorInfo: ${errorInfo}`);
+    crashlytics().log(`errorInfo: ${JSON.stringify(errorInfo)}`);
     crashlytics().recordError(error);
 };
 

--- a/src/components/ErrorBoundary/index.native.js
+++ b/src/components/ErrorBoundary/index.native.js
@@ -5,7 +5,7 @@ import Log from '../../libs/Log';
 
 BaseErrorBoundary.defaultProps.logError = (errorMessage, error, errorInfo) => {
     // Log the error to the server
-    Log.alert(errorMessage, 10, {error: error.message, errorInfo});
+    Log.alert(errorMessage, 0, {error: error.message, errorInfo}, false);
 
     /* On native we also log the error to crashlytics
     * Since the error was handled we need to manually tell crashlytics about it */

--- a/src/components/ErrorBoundary/index.native.js
+++ b/src/components/ErrorBoundary/index.native.js
@@ -5,7 +5,7 @@ import Log from '../../libs/Log';
 
 BaseErrorBoundary.defaultProps.logError = (errorMessage, error, errorInfo) => {
     // Log the error to the server
-    Log.info(this.props.errorMessage, true, {error, errorInfo});
+    Log.alert(errorMessage, 10, {error, errorInfo});
 
     /* On native we also log the error to crashlytics
     * Since the error was handled we need to manually tell crashlytics about it */

--- a/tests/unit/loginTest.js
+++ b/tests/unit/loginTest.js
@@ -9,6 +9,11 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import App from '../../src/App';
 
+jest.mock('@react-native-firebase/crashlytics', () => ({
+    log: jest.fn(),
+    recordError: jest.fn(),
+}));
+
 describe('AppComponent', () => {
     it('renders correctly', () => {
         renderer.create(<App />);

--- a/tests/unit/loginTest.js
+++ b/tests/unit/loginTest.js
@@ -9,7 +9,9 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import App from '../../src/App';
 
-jest.mock('@react-native-firebase/crashlytics', () => ({
+/* <App> uses <ErrorBoundary> and we need to mock the imported crashlytics module
+* due to an error that happens otherwise https://github.com/invertase/react-native-firebase/issues/2475 */
+jest.mock('@react-native-firebase/crashlytics', () => () => ({
     log: jest.fn(),
     recordError: jest.fn(),
 }));


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
@Jag96 

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Created a new `ErrorBoundary` component
This component can serve to warp the whole app, or specific parts like documented here: https://reactjs.org/docs/error-boundaries.html#where-to-place-error-boundaries

`@react-native-firebase/crashlytics` is available only for iOS and Android so a platform specific component was created to handle the logging - Android and iOS would log to E.cash server and crashlytics, while desktop and web would log only to the E.cash server (Reference: https://github.com/invertase/react-native-firebase/issues/1530)

Wrapped the main component `Expensify` with `ErrorBoundary`
For the moment we're not rendering fallback UI, but just log the error that crashed React to the server and crashlytics

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes #3339

### Tests
To test this you can trigger an exception in the render method of some component
In my sample video (iOS screenshots section) I've changed `ReportScreen` to throw an error when a specific report is opened

### QA Steps
N/A

### Tested On
I've verified the app starts and works on these platforms

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
![image](https://user-images.githubusercontent.com/12156624/121598759-ce273a00-ca4a-11eb-8c12-87f4620db9e1.png)

#### Mobile Web
![image](https://user-images.githubusercontent.com/12156624/121598832-e4cd9100-ca4a-11eb-8be3-71fe89786e63.png)

#### Desktop
![image](https://user-images.githubusercontent.com/12156624/121599273-7b9a4d80-ca4b-11eb-9fcc-ed5e5b997f81.png)

#### iOS
https://user-images.githubusercontent.com/12156624/121593372-869daf80-ca44-11eb-8d2c-7b587ffaf6fc.mov

#### Android
![image](https://user-images.githubusercontent.com/12156624/121593963-24917a00-ca45-11eb-9a23-fe5a5907483e.png)
