### PR TITLE
Add capturing event listeners to the KeyboardShortcut library

### DIFF
--- a/src/libs/KeyboardShortcut/index.js
+++ b/src/libs/KeyboardShortcut/index.js
@@ -51,8 +51,8 @@ function bindHandlerToKeyupEvent(event) {
 }
 
 // Make sure we don't add multiple listeners
-document.removeEventListener('keydown', bindHandlerToKeyupEvent);
-document.addEventListener('keydown', bindHandlerToKeyupEvent);
+document.removeEventListener('keydown', bindHandlerToKeyupEvent, {capture: true});
+document.addEventListener('keydown', bindHandlerToKeyupEvent, {capture: true});
 
 /**
  * Module storing the different keyboard shortcut


### PR DESCRIPTION
Shoutout to @HorusGoul for figuring this out. In [the slack thread](https://expensify.slack.com/archives/C03TQ48KC/p1623429012170300) you made it sound like we should always have capturing event listeners, unless we specifically want to enable bubbling for certain events. I wasn't sure of the potential side-effects of preventing event bubbling by default, so I opted for the minimum change that resolves the current issue. Feel free to follow-up with any thoughts regarding other events which should not bubble.

### Details
TBH I'm not 100% clear on _why_ this fixes the linked issue, but shoutout to @HorusGoul for finding this! It works! 🎉 

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/3512

### Tests / QA Steps (Web/Desktop only)
1. When the main `ReportActionCompose` is focused, hit `CMD+K`.
2. The chat switcher should open and the search bar in the chat switcher should be focused.
3. Hit `Esc` and the chat switcher should hide.

### Tested On

- [x] Web
- [ ] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
#### Web
![image](https://user-images.githubusercontent.com/47436092/121736443-6dc8e480-caac-11eb-9ae6-55aa99de1c11.png)

#### Mobile Web
n/a

#### Desktop
![image](https://user-images.githubusercontent.com/47436092/121736627-a8cb1800-caac-11eb-980c-830f442eac66.png)

#### iOS
n/a

#### Android
n/a
