### PR TITLE
Added language selector in the preferences page

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -212,6 +212,7 @@ export default {
         notifications: 'Notifications',
         receiveRelevantFeatureUpdatesAndExpensifyNews: 'Receive relevant feature updates and Expensify news',
         priorityMode: 'Priority Mode',
+        language: 'Language',
     },
     signInPage: {
         expensifyDotCash: 'Expensify.cash',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -207,6 +207,9 @@ export default {
         notifications: 'Notificaciones',
         receiveRelevantFeatureUpdatesAndExpensifyNews: 'Recibir noticias sobre Expensify y actualizaciones del producto',
         priorityMode: 'Modo Prioridad',
+
+        // TODO
+        language: '????',
     },
     signInPage: {
         expensifyDotCash: 'Expensify.cash',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -207,9 +207,7 @@ export default {
         notifications: 'Notificaciones',
         receiveRelevantFeatureUpdatesAndExpensifyNews: 'Recibir noticias sobre Expensify y actualizaciones del producto',
         priorityMode: 'Modo Prioridad',
-
-        // TODO
-        language: '????',
+        language: 'Idioma',
     },
     signInPage: {
         expensifyDotCash: 'Expensify.cash',

--- a/src/pages/settings/PreferencesPage.js
+++ b/src/pages/settings/PreferencesPage.js
@@ -94,7 +94,6 @@ const PreferencesPage = ({
                             />
                         </View>
                     </View>
-
                     <Text style={[styles.formLabel]} numberOfLines={1}>
                         {translate('preferencesPage.priorityMode')}
                     </Text>
@@ -111,7 +110,6 @@ const PreferencesPage = ({
                     <Text style={[styles.textLabel, styles.colorMuted, styles.mb6]}>
                         {priorityModes[priorityMode].description}
                     </Text>
-
                     <Text style={[styles.formLabel]} numberOfLines={1}>
                         {translate('preferencesPage.language')}
                     </Text>

--- a/src/pages/settings/PreferencesPage.js
+++ b/src/pages/settings/PreferencesPage.js
@@ -57,7 +57,7 @@ const PreferencesPage = ({
         },
     };
 
-    const locales = {
+    const localesToLanguages = {
         default: {
             value: 'en',
             label: 'English',
@@ -118,7 +118,7 @@ const PreferencesPage = ({
                     <View style={[styles.mb2]}>
                         <Picker
                             onChange={locale => Onyx.merge(ONYXKEYS.PREFERRED_LOCALE, locale)}
-                            items={Object.values(locales)}
+                            items={Object.values(localesToLanguages)}
                             value={preferredLocale}
                             icon={() => <Icon src={DownArrow} />}
                         />

--- a/src/pages/settings/PreferencesPage.js
+++ b/src/pages/settings/PreferencesPage.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {View} from 'react-native';
-import {withOnyx} from 'react-native-onyx';
+import Onyx, {withOnyx} from 'react-native-onyx';
 import PropTypes from 'prop-types';
 
 import HeaderWithCloseButton from '../../components/HeaderWithCloseButton';
@@ -31,6 +31,9 @@ const propTypes = {
     }),
 
     ...withLocalizePropTypes,
+
+    // Indicates which locale the user currently has selected
+    preferredLocale: PropTypes.string.isRequired,
 };
 
 const defaultProps = {
@@ -38,7 +41,9 @@ const defaultProps = {
     user: {},
 };
 
-const PreferencesPage = ({priorityMode, user, translate}) => {
+const PreferencesPage = ({
+    priorityMode, user, translate, preferredLocale,
+}) => {
     const priorityModes = {
         default: {
             value: CONST.PRIORITY_MODE.DEFAULT,
@@ -49,6 +54,17 @@ const PreferencesPage = ({priorityMode, user, translate}) => {
             value: CONST.PRIORITY_MODE.GSD,
             label: translate('preferencesPage.focus'),
             description: translate('preferencesPage.focusModeDescription'),
+        },
+    };
+
+    const locales = {
+        default: {
+            value: 'en',
+            label: 'English',
+        },
+        es: {
+            value: 'es',
+            label: 'Spanish',
         },
     };
 
@@ -78,6 +94,7 @@ const PreferencesPage = ({priorityMode, user, translate}) => {
                             />
                         </View>
                     </View>
+
                     <Text style={[styles.formLabel]} numberOfLines={1}>
                         {translate('preferencesPage.priorityMode')}
                     </Text>
@@ -91,9 +108,21 @@ const PreferencesPage = ({priorityMode, user, translate}) => {
                             icon={() => <Icon src={DownArrow} />}
                         />
                     </View>
-                    <Text style={[styles.textLabel, styles.colorMuted]}>
+                    <Text style={[styles.textLabel, styles.colorMuted, styles.mb6]}>
                         {priorityModes[priorityMode].description}
                     </Text>
+
+                    <Text style={[styles.formLabel]} numberOfLines={1}>
+                        {translate('preferencesPage.language')}
+                    </Text>
+                    <View style={[styles.mb2]}>
+                        <Picker
+                            onChange={locale => Onyx.merge(ONYXKEYS.PREFERRED_LOCALE, locale)}
+                            items={Object.values(locales)}
+                            value={preferredLocale}
+                            icon={() => <Icon src={DownArrow} />}
+                        />
+                    </View>
                 </View>
             </View>
         </ScreenWrapper>


### PR DESCRIPTION
### Details
We need a language selector in the preference page to test out the Spanish translations. This fixes that.

### Fixed Issues
$ https://github.com/Expensify/Expensify.cash/issues/3518

### Tests
1. Open the preferences page.
2. Verify that the Language Picker component and its corresponding label render correctly.
3. Use the picker to change the language. Verify that the language is updated throughout the app. 

### QA Steps
Same as the above tests

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<img width="1198" alt="Screen Shot 2021-06-16 at 10 31 48 AM" src="https://user-images.githubusercontent.com/31285285/122149733-26b56780-ce8f-11eb-9b9d-bfbc505d7b96.png">
<img width="1792" alt="Screen Shot 2021-06-16 at 10 31 55 AM" src="https://user-images.githubusercontent.com/31285285/122149743-2a48ee80-ce8f-11eb-9ffa-d103e965bdf4.png">

![android](https://user-images.githubusercontent.com/31285285/122149804-3f258200-ce8f-11eb-86f7-86d5e13dce5a.jpeg)

![Simulator Screen Shot - iPhone 12 - 2021-06-16 at 10 35 26](https://user-images.githubusercontent.com/31285285/122149843-4e0c3480-ce8f-11eb-8b9d-386947b3cb4c.png)


