### PR TITLE
[No QA] Move reproduction steps above expected/actual results in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Standard.md
+++ b/.github/ISSUE_TEMPLATE/Standard.md
@@ -7,14 +7,14 @@ labels: AutoAssignerTriage
 If you haven’t already, check out our [contributing guidelines](https://github.com/Expensify/ReactNativeChat/blob/main/CONTRIBUTING.md) for onboarding and email contributors@expensify.com to request to join our Slack channel!
 ___
 
+## Action Performed:
+Break down in numbered steps
+
 ## Expected Result:
 Describe what you think should've happened
 
 ## Actual Result:
 Describe what actually happened
-
-## Action Performed:
-Break down in numbered steps
 
 ## Workaround:
 Can the user still use Expensify without this being fixed? Have you informed them of the workaround?


### PR DESCRIPTION

### Details
The E.cash issue template has been bothering me for a while, the new ordering just makes a lot more sense:

- What you did
- What you expected to happen
- What actually happened

Instead of what we have now, which is more like:

- What you expected to happen
- What actually happened
- Oh yeah, what did you do to make this unexpected thing happen?

### Fixed Issues
n/a

### Tests
Make a new issue and verify that the changes in the template take effect.

### QA Steps
None.

### Tested On

n/a – GitHub only.