### PR TITLE
3272 update message date overnight

### DIFF
--- a/src/ONYXKEYS.js
+++ b/src/ONYXKEYS.js
@@ -21,6 +21,9 @@ export default {
     // What the active route is for our navigator. Global route that determines what views to display.
     CURRENT_URL: 'currentURL',
 
+    // Stores current date
+    CURRENT_DATE: 'currentDate',
+
     // Currently viewed reportID
     CURRENTLY_VIEWED_REPORTID: 'currentlyViewedReportID',
 

--- a/src/libs/DateUtils.js
+++ b/src/libs/DateUtils.js
@@ -89,11 +89,30 @@ function timestampToRelative(locale, timestamp) {
 }
 
 /**
+ * A throttled version of a function that updates the current date in Onyx store
+ */
+const updateCurrentDate = _.throttle(() => {
+    const currentDate = moment().format('YYYY-MM-DD');
+    Onyx.set(ONYXKEYS.CURRENT_DATE, currentDate);
+}, 1000 * 60 * 60 * 3); // 3 hours
+
+/**
+ * Initialises the event listeners that trigger the current date update
+ */
+function startCurrentDateUpdater() {
+    const trackedEvents = ['mousemove', 'touchstart', 'keydown', 'scroll'];
+    trackedEvents.forEach((eventName) => {
+        document.addEventListener(eventName, updateCurrentDate);
+    });
+}
+
+/**
  * @namespace DateUtils
  */
 const DateUtils = {
     timestampToRelative,
     timestampToDateTime,
+    startCurrentDateUpdater,
 };
 
 export default DateUtils;

--- a/src/pages/home/report/ReportActionItemDate.js
+++ b/src/pages/home/report/ReportActionItemDate.js
@@ -1,8 +1,11 @@
 import React, {memo} from 'react';
 import PropTypes from 'prop-types';
 import {Text} from 'react-native';
+import {withOnyx} from 'react-native-onyx';
 import styles from '../../../styles/styles';
 import withLocalize, {withLocalizePropTypes} from '../../../components/withLocalize';
+import compose from '../../../libs/compose';
+import ONYXKEYS from '../../../ONYXKEYS';
 
 const propTypes = {
     /** UTC timestamp for when the action was created */
@@ -19,4 +22,12 @@ const ReportActionItemDate = props => (
 ReportActionItemDate.propTypes = propTypes;
 ReportActionItemDate.displayName = 'ReportActionItemDate';
 
-export default withLocalize(memo(ReportActionItemDate));
+export default compose(
+    withLocalize,
+    withOnyx({
+        currentDate: {
+            key: ONYXKEYS.CURRENT_DATE,
+        },
+    }),
+    memo,
+)(ReportActionItemDate);

--- a/src/setup/index.desktop.js
+++ b/src/setup/index.desktop.js
@@ -2,6 +2,7 @@ import {AppRegistry} from 'react-native';
 import {ipcRenderer} from 'electron';
 import Config from '../CONFIG';
 import LocalNotification from '../libs/Notification/LocalNotification';
+import DateUtils from '../libs/DateUtils';
 
 
 export default function () {
@@ -12,4 +13,7 @@ export default function () {
     ipcRenderer.on('update-downloaded', () => {
         LocalNotification.showUpdateAvailableNotification();
     });
+
+    // Start current date updater
+    DateUtils.startCurrentDateUpdater();
 }

--- a/src/setup/index.website.js
+++ b/src/setup/index.website.js
@@ -2,8 +2,10 @@ import {AppRegistry} from 'react-native';
 import checkForUpdates from '../libs/checkForUpdates';
 import Config from '../CONFIG';
 import HttpUtils from '../libs/HttpUtils';
+import DateUtils from '../libs/DateUtils';
 import {version as currentVersion} from '../../package.json';
 import Visibility from '../libs/Visibility';
+
 
 /**
  * Download the latest app version from the server, and if it is different than the current one,
@@ -56,4 +58,7 @@ export default function () {
     if (Config.IS_IN_PRODUCTION) {
         checkForUpdates(webUpdater());
     }
+
+    // Start current date updater
+    DateUtils.startCurrentDateUpdater();
 }

--- a/src/setup/index.website.js
+++ b/src/setup/index.website.js
@@ -6,7 +6,6 @@ import DateUtils from '../libs/DateUtils';
 import {version as currentVersion} from '../../package.json';
 import Visibility from '../libs/Visibility';
 
-
 /**
  * Download the latest app version from the server, and if it is different than the current one,
  * then refresh. If the page is visibile, prompt the user to refresh.


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Adds a new Onyx store key for current date. The value is updated via a function throttled by 3 hours that is called on user interaction. That value is passed into `ReportActionItemDate` component as a prop, so it re-renders when the prop changes, causing the `timestampToDate` to be recalculated.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes #3272

### Tests
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

1. Change the throttle duration from 3 hours to 15 seconds in `DateUtils.js` `updateCurrentDate` function
2. Open a chat
3. Send a message
4. Change local time on your system to 23:59:50
5. Within 15 seconds of moving your mouse around the "Today" next to the message should be updated to "Yesterday"

**!!! Important !!!** Don't mouse over the message itself. From my observations, It causes a re-render that is unrelated to this PR and doesn't validate that my code works. To validate this PR, please move the mouse cursor around the LHN section or other messages.

### QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

1. Send a message
2. Leave the app open overnight
3. The day after move the mouse over the app and the "Today" next to the message should be updated to "Yesterday" (at least 3 hours must pass since last interaction with the app)

**!!! Important !!!** Don't mouse over the message itself. From my observations, It causes a re-render that is unrelated to this PR and doesn't validate that my code works. To validate this PR, please move the mouse cursor around the LHN section or other messages.

### Tested On

The change only affects web and desktop.

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

Videos of development tests. With manual system time change and a throttle timer of 15 seconds. Find system time in top right corner.

#### Web
<!-- Insert screenshots of your changes on the web platform-->

https://user-images.githubusercontent.com/64093836/121804186-c97ea380-cc4d-11eb-8797-5bfb469ecd0a.mp4



#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->


https://user-images.githubusercontent.com/64093836/121804189-cd122a80-cc4d-11eb-9091-df15ef9fcbe1.mp4


#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

https://user-images.githubusercontent.com/64093836/121804193-d00d1b00-cc4d-11eb-8d17-70257acc16e0.mp4


#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
