### PR TITLE
Display full-screen loading indicator while fetching currency data

### DIFF
--- a/src/Expensify.js
+++ b/src/Expensify.js
@@ -29,7 +29,9 @@ Onyx.init({
         [ONYXKEYS.SESSION]: {loading: false, shouldShowComposeInput: true},
         [ONYXKEYS.ACCOUNT]: CONST.DEFAULT_ACCOUNT_DATA,
         [ONYXKEYS.NETWORK]: {isOffline: false},
-        [ONYXKEYS.IOU]: {loading: false, error: false, creatingIOUTransaction: false},
+        [ONYXKEYS.IOU]: {
+            loading: false, error: false, creatingIOUTransaction: false, isRetrievingCurrency: false,
+        },
     },
     registerStorageEventListener: (onStorageEvent) => {
         listenToStorageEvents(onStorageEvent);

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -256,7 +256,7 @@ function fetchCurrencyPreferences() {
     const coords = {};
     let currency = '';
 
-    Onyx.merge(ONYXKEYS.MY_PERSONAL_DETAILS, {
+    Onyx.merge(ONYXKEYS.IOU, {
         isRetrievingCurrency: true,
     });
 
@@ -275,7 +275,7 @@ function fetchCurrencyPreferences() {
         })
         .catch(error => console.debug(`Error fetching currency preference: , ${error}`))
         .finally(() => {
-            Onyx.merge(ONYXKEYS.MY_PERSONAL_DETAILS, {
+            Onyx.merge(ONYXKEYS.IOU, {
                 isRetrievingCurrency: false,
             });
         });

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -256,6 +256,10 @@ function fetchCurrencyPreferences() {
     const coords = {};
     let currency = '';
 
+    Onyx.merge(ONYXKEYS.MY_PERSONAL_DETAILS, {
+        isRetrievingCurrency: true,
+    });
+
     API.GetPreferredCurrency({...coords})
         .then((data) => {
             currency = data.currency;
@@ -269,7 +273,12 @@ function fetchCurrencyPreferences() {
                     preferredCurrencySymbol: currencyList[currency].symbol,
                 });
         })
-        .catch(error => console.debug(`Error fetching currency preference: , ${error}`));
+        .catch(error => console.debug(`Error fetching currency preference: , ${error}`))
+        .finally(() => {
+            Onyx.merge(ONYXKEYS.MY_PERSONAL_DETAILS, {
+                isRetrievingCurrency: false,
+            });
+        });
 }
 
 /**

--- a/src/pages/iou/IOUModal.js
+++ b/src/pages/iou/IOUModal.js
@@ -53,10 +53,7 @@ const propTypes = {
         /** Whether or not transaction creation has resulted to error */
         error: PropTypes.bool,
 
-        // is loading
-        loading: PropTypes.bool,
-
-        // Loading
+        /** Flag to show a loading indicator and avoid showing a previously selected currency */
         isRetrievingCurrency: PropTypes.bool,
     }).isRequired,
 

--- a/src/pages/iou/IOUModal.js
+++ b/src/pages/iou/IOUModal.js
@@ -43,9 +43,6 @@ const propTypes = {
 
         // Currency Symbol of the Preferred Currency
         preferredCurrencySymbol: PropTypes.string,
-
-        // Loading
-        isRetrievingCurrency: PropTypes.bool,
     }),
 
     // Holds data related to IOU view state, rather than the underlying IOU data.
@@ -58,6 +55,9 @@ const propTypes = {
 
         // is loading
         loading: PropTypes.bool,
+
+        // Loading
+        isRetrievingCurrency: PropTypes.bool,
     }).isRequired,
 
     /** Personal details of all the users */
@@ -307,9 +307,9 @@ class IOUModal extends Component {
                         </View>
                         <View style={[styles.pRelative, styles.flex1]}>
                             <FullScreenLoadingIndicator
-                                visible={!didScreenTransitionEnd || this.props.myPersonalDetails.isRetrievingCurrency}
+                                visible={!didScreenTransitionEnd || this.props.iou.isRetrievingCurrency}
                             />
-                            {didScreenTransitionEnd && !this.props.myPersonalDetails.isRetrievingCurrency && (
+                            {didScreenTransitionEnd && !this.props.iou.isRetrievingCurrency && (
                                 <>
                                     {currentStep === Steps.IOUAmount && (
                                         <IOUAmountPage

--- a/src/pages/iou/IOUModal.js
+++ b/src/pages/iou/IOUModal.js
@@ -43,6 +43,9 @@ const propTypes = {
 
         // Currency Symbol of the Preferred Currency
         preferredCurrencySymbol: PropTypes.string,
+
+        // Loading
+        isRetrievingCurrency: PropTypes.bool,
     }),
 
     // Holds data related to IOU view state, rather than the underlying IOU data.
@@ -303,8 +306,10 @@ class IOUModal extends Component {
                             </View>
                         </View>
                         <View style={[styles.pRelative, styles.flex1]}>
-                            <FullScreenLoadingIndicator visible={!didScreenTransitionEnd} />
-                            {didScreenTransitionEnd && (
+                            <FullScreenLoadingIndicator
+                                visible={!didScreenTransitionEnd || this.props.myPersonalDetails.isRetrievingCurrency}
+                            />
+                            {didScreenTransitionEnd && !this.props.myPersonalDetails.isRetrievingCurrency && (
                                 <>
                                     {currentStep === Steps.IOUAmount && (
                                         <IOUAmountPage


### PR DESCRIPTION
### Details
Display full-screen loading indicator while fetching currency data to avoid flashing the previous currency in the Request money dialog.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/3560

### Tests
1. Open Request money dialog
2. Tap on the currency sign (€ for me).
3. Select another currency (AUD, for example).
4. Close the Request money dialog
5. Open the Request money dialog again. It should display the original currency (€ in my case) without showing the other one first.

### QA Steps
1. Open Request money dialog
2. Tap on the currency sign (€ for me).
3. Select another currency (AUD, for example).
4. Close the Request money dialog
5. Open the Request money dialog again. It should display the original currency (€ in my case) without showing the other one first.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web

https://user-images.githubusercontent.com/6759612/121883406-fdbb9800-cd11-11eb-8bd6-3c6c3a4f4319.mov

#### Mobile Web

https://user-images.githubusercontent.com/6759612/121888146-ec758a00-cd17-11eb-95c2-7d6fbea69d9e.mov

#### Desktop

https://user-images.githubusercontent.com/6759612/121888554-6f96e000-cd18-11eb-8c95-3765a5bc28a1.mov

#### iOS

https://user-images.githubusercontent.com/6759612/121889694-d7015f80-cd19-11eb-939b-71ef21c412ad.mov

#### Android
<!-- Insert screenshots of your changes on the Android platform-->

https://user-images.githubusercontent.com/6759612/121890158-52fba780-cd1a-11eb-8f38-1ad963a4d13c.mov

