### PR TITLE
Fix random warnings

### DIFF
--- a/src/Expensify.js
+++ b/src/Expensify.js
@@ -1,10 +1,11 @@
 import lodashGet from 'lodash/get';
 import PropTypes from 'prop-types';
 import React, {PureComponent} from 'react';
-import {View, StatusBar, AppState} from 'react-native';
+import {View, AppState} from 'react-native';
 import Onyx, {withOnyx} from 'react-native-onyx';
 
 import BootSplash from './libs/BootSplash';
+import StatusBar from './libs/StatusBar';
 import listenToStorageEvents from './libs/listenToStorageEvents';
 import * as ActiveClientManager from './libs/ActiveClientManager';
 import ONYXKEYS from './ONYXKEYS';

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -10,7 +10,7 @@ import OpacityView from './OpacityView';
 
 const propTypes = {
     /** The text for the button label */
-    text: PropTypes.string.isRequired,
+    text: PropTypes.string,
 
     /** Indicates whether the button should be disabled and in the loading state */
     isLoading: PropTypes.bool,
@@ -44,6 +44,7 @@ const propTypes = {
 };
 
 const defaultProps = {
+    text: '',
     isLoading: false,
     isDisabled: false,
     onPress: () => {},

--- a/src/libs/StatusBar/index.android.js
+++ b/src/libs/StatusBar/index.android.js
@@ -1,0 +1,4 @@
+import {StatusBar} from 'react-native';
+
+// Just export StatusBar – no changes.
+export default StatusBar;

--- a/src/libs/StatusBar/index.js
+++ b/src/libs/StatusBar/index.js
@@ -1,0 +1,6 @@
+import {StatusBar} from 'react-native';
+
+// Overwrite setTranslucent to suppress a warning on iOS
+StatusBar.setTranslucent = () => {};
+
+export default StatusBar;

--- a/src/pages/settings/AboutPage.js
+++ b/src/pages/settings/AboutPage.js
@@ -108,7 +108,7 @@ const AboutPage = ({translate, session}) => {
                     </View>
                     {menuItems.map(item => (
                         <MenuItem
-                            key={item.title}
+                            key={item.translationKey}
                             title={translate(item.translationKey)}
                             icon={item.icon}
                             iconRight={item.iconRight}
@@ -156,7 +156,7 @@ const AboutPage = ({translate, session}) => {
 };
 
 AboutPage.propTypes = propTypes;
-AboutPage.displayName = 'PreferencesPage';
+AboutPage.displayName = 'AboutPage';
 
 export default compose(
     withLocalize,

--- a/src/pages/settings/AppDownloadLinks.js
+++ b/src/pages/settings/AppDownloadLinks.js
@@ -49,7 +49,7 @@ const AppDownloadLinksPage = ({translate}) => {
             <ScrollView style={[styles.mt5]} bounces={false}>
                 {menuItems.map(item => (
                     <MenuItem
-                        key={item.title}
+                        key={item.translationKey}
                         title={translate(item.translationKey)}
                         icon={item.icon}
                         iconRight={item.iconRight}
@@ -63,7 +63,7 @@ const AppDownloadLinksPage = ({translate}) => {
 };
 
 AppDownloadLinksPage.propTypes = propTypes;
-AppDownloadLinksPage.displayName = 'PreferencesPage';
+AppDownloadLinksPage.displayName = 'AppDownloadLinksPage';
 
 export default compose(
     withLocalize,

--- a/src/pages/settings/InitialPage.js
+++ b/src/pages/settings/InitialPage.js
@@ -135,7 +135,7 @@ const InitialSettingsPage = ({
                     </View>
                     {menuItems.map(item => (
                         <MenuItem
-                            key={item.title}
+                            key={item.translationKey}
                             title={translate(item.translationKey)}
                             icon={item.icon}
                             onPress={() => item.action()}

--- a/src/pages/settings/InitialPage.js
+++ b/src/pages/settings/InitialPage.js
@@ -138,7 +138,7 @@ const InitialSettingsPage = ({
                             key={item.translationKey}
                             title={translate(item.translationKey)}
                             icon={item.icon}
-                            onPress={() => item.action()}
+                            onPress={item.action}
                             shouldShowRightIcon
                         />
                     ))}

--- a/src/pages/settings/Profile/ProfilePage.js
+++ b/src/pages/settings/Profile/ProfilePage.js
@@ -384,7 +384,7 @@ class ProfilePage extends Component {
                         <Checkbox
                             label={this.props.translate('profilePage.setMyTimezoneAutomatically')}
                             isChecked={this.state.isAutomaticTimezone}
-                            onClick={this.setAutomaticTimezone}
+                            onPress={this.setAutomaticTimezone}
                         />
                     </ScrollView>
                     <FixedFooter>


### PR DESCRIPTION

### Details
Just killing some annoying console warnings – not really fixing any known bugs.

### Fixed Issues
Fixes n/a

### Tests
1. Run the iOS app, verify that you don't see the aggravating `setTranslucent is android-only` warning.
1. Go to the various settings pages, verify that you don't see `List items should have a unique key` warnings.

### QA Steps
None (covered by regression tests)
