### PR TITLE
Remove SMS domains from tooltips

### DIFF
--- a/src/pages/home/HeaderView.js
+++ b/src/pages/home/HeaderView.js
@@ -65,7 +65,7 @@ const HeaderView = (props) => {
 
             return {
                 displayName: (isMultipleParticipant ? firstName : displayNameTrimmed) || Str.removeSMSDomain(login),
-                tooltip: login,
+                tooltip: Str.removeSMSDomain(login),
             };
         },
     );

--- a/src/pages/home/sidebar/OptionRow.js
+++ b/src/pages/home/sidebar/OptionRow.js
@@ -135,7 +135,7 @@ const OptionRow = ({
 
             return {
                 displayName: (isMultipleParticipant ? firstName : displayNameTrimmed) || Str.removeSMSDomain(login),
-                tooltip: login,
+                tooltip: Str.removeSMSDomain(login),
             };
         },
     );


### PR DESCRIPTION
### Details
Removes the `@expensify.sms` from phone numbers in tooltips

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/3574

### Tests / QA Steps
1. Sign into an account
2. Start or navigate to a chat with a user that has an SMS login.
3. Hover their name in the LHN
4. _Verify_ the tooltip does not contain `@expensify.sms`
5. Hover their name in the Header
6. _Verify_ the tooltip does not contain `@expensify.sms`

### Tested On

- [x] Web
- [ ] Mobile Web - Tooltips do not exist on mobile
- [x] Desktop
- [ ] iOS - Tooltips do not exist on mobile
- [ ] Android - Tooltips do not exist on mobile

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
![image](https://user-images.githubusercontent.com/22447860/121931842-fd62d300-ccf8-11eb-9185-c1b02e3373dc.png)
![image](https://user-images.githubusercontent.com/22447860/121931853-018ef080-ccf9-11eb-8b0d-b2713982e7f8.png)

#### Mobile Web
Tooltips do not exist on mobile

#### Desktop
![image](https://user-images.githubusercontent.com/22447860/121931886-0a7fc200-ccf9-11eb-97d5-1e4b221b1666.png)
![image](https://user-images.githubusercontent.com/22447860/121931911-110e3980-ccf9-11eb-81ef-eb9dd2f5c851.png)

#### iOS
Tooltips do not exist on mobile

#### Android
Tooltips do not exist on mobile
