### PR TITLE
fix: Document Picker crash on IOS

### DIFF
--- a/src/components/AttachmentPicker/index.native.js
+++ b/src/components/AttachmentPicker/index.native.js
@@ -227,7 +227,7 @@ class AttachmentPicker extends Component {
                 .then(this.pickAttachment)
                 .catch(console.error)
                 .finally(() => delete this.onModalHide),
-            10,
+            200,
         );
 
         this.close();


### PR DESCRIPTION



<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
We had to put a delay between modal is closed and picker opens the document chooser.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes #3543

### Tests | QA Steps
1. Open any conversation on E.cash mobile app.
2. click Add attachment from plus icon.
3. Select the add attachment option and 

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
https://user-images.githubusercontent.com/24370807/121937835-bd3b3900-cd68-11eb-9288-207129a925c7.mp4
#### Android
<!-- Insert screenshots of your changes on the Android platform-->

https://user-images.githubusercontent.com/24370807/121937827-b90f1b80-cd68-11eb-98d5-5c9bfb260b8f.mp4

