### PR TITLE
Add missing spanish tranlsation

### DIFF
--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -114,6 +114,7 @@ export default {
         requestMoney: 'Pedir Dinero',
         pay: 'Pagar',
         viewDetails: 'Ver detalles',
+        settleExpensify: 'Pagar con Expensify',
         settleElsewhere: 'Voy a pagar de otra forma',
         decline: 'Rechazar',
         settlePaypalMe: 'Pagar con PayPal.me',


### PR DESCRIPTION
Just realized this translation was missing

### Tests
- Change the language of the app to spanish
- Check the copy for the `pay with expensify button` (pagar con expensify)

### QA Steps
No
### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

