### PR TITLE
Translations for the options in the language selector

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -213,6 +213,10 @@ export default {
         receiveRelevantFeatureUpdatesAndExpensifyNews: 'Receive relevant feature updates and Expensify news',
         priorityMode: 'Priority Mode',
         language: 'Language',
+        languages: {
+            english: 'English',
+            spanish: 'Spanish',
+        },
     },
     signInPage: {
         expensifyDotCash: 'Expensify.cash',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -208,6 +208,10 @@ export default {
         receiveRelevantFeatureUpdatesAndExpensifyNews: 'Recibir noticias sobre Expensify y actualizaciones del producto',
         priorityMode: 'Modo Prioridad',
         language: 'Idioma',
+        languages: {
+            english: 'Inglés',
+            spanish: 'Español',
+        },
     },
     signInPage: {
         expensifyDotCash: 'Expensify.cash',

--- a/src/pages/settings/PreferencesPage.js
+++ b/src/pages/settings/PreferencesPage.js
@@ -60,11 +60,11 @@ const PreferencesPage = ({
     const localesToLanguages = {
         default: {
             value: 'en',
-            label: 'English',
+            label: translate('preferencesPage.languages.english'),
         },
         es: {
             value: 'es',
-            label: 'Spanish',
+            label: translate('preferencesPage.languages.spanish'),
         },
     };
 


### PR DESCRIPTION
### Details
I realized I forgot to include translations for the options in the language selector in https://github.com/Expensify/Expensify.cash/pull/3567. This PR fixes that

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/3518

### Tests
1. Open the preferences page.
2. Verify that the Language Picker component and its corresponding label render correctly.
3. Use the picker to change the language. Verify that the language is updated throughout the app. 

### QA Steps
Same as the above tests

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<img width="1198" alt="Screen Shot 2021-06-16 at 10 31 48 AM" src="https://user-images.githubusercontent.com/31285285/122149733-26b56780-ce8f-11eb-9b9d-bfbc505d7b96.png">
<img width="1792" alt="Screen Shot 2021-06-16 at 10 31 55 AM" src="https://user-images.githubusercontent.com/31285285/122149743-2a48ee80-ce8f-11eb-9ffa-d103e965bdf4.png">

![android](https://user-images.githubusercontent.com/31285285/122149804-3f258200-ce8f-11eb-86f7-86d5e13dce5a.jpeg)

![Simulator Screen Shot - iPhone 12 - 2021-06-16 at 10 35 26](https://user-images.githubusercontent.com/31285285/122149843-4e0c3480-ce8f-11eb-8b9d-386947b3cb4c.png)


