### PR TITLE
CSS Hack to fix safari text inputs

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -25,6 +25,9 @@
         #drag-area {
             -webkit-app-region: drag;
         }
+        input[type=text] {
+            -webkit-user-select: text !important;
+        }
     </style>
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1">
     <link rel="shortcut icon" id="favicon" href="/favicon.png">


### PR DESCRIPTION
### Details
For some reason the `userSelect` property is being overridden by react-native-web internals for text inputs. This CSS hack solves the problem and doesn't seem to introduce any others.

We should really consider filing a bug report in react-native-web, unless I'm gravely misunderstanding why `TextInput` components should by default (and in fact, in all cases) have the property `user-select: none`.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/3598

### Tests / QA Steps
1. Run the app in Safari
1. Hit the `+` icon in the `ReportActionCompose` and choose `Request Money`/`Split Bill`.
1. Enter an amount for the request, and hit `Next`
1. Verify that you can enter a value into the text input above "What's it for?"

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
#### Web
Still working on Chrome:

![image](https://user-images.githubusercontent.com/47436092/122258669-2795cb80-ce86-11eb-9602-83fd5fd103f8.png)

Also working on Safari:

![image](https://user-images.githubusercontent.com/47436092/122258712-37151480-ce86-11eb-8609-49c9aef46c73.png)

#### Mobile Web
![image](https://user-images.githubusercontent.com/47436092/122262718-8c532500-ce8a-11eb-90e6-1ff9661a237e.png)

#### Desktop
![image](https://user-images.githubusercontent.com/47436092/122262964-c8868580-ce8a-11eb-87a1-bffcc8bde31c.png)

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
