### PR TITLE
Fix language selector

### DIFF
--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -162,7 +162,7 @@ Onyx.connect({
 
 Onyx.connect({
     key: ONYXKEYS.PREFERRED_LOCALE,
-    callback: val => preferredLocale = val || 'en',
+    callback: val => preferredLocale = val || CONST.DEFAULT_LOCALE,
 });
 
 /**

--- a/src/libs/actions/App.js
+++ b/src/libs/actions/App.js
@@ -8,7 +8,15 @@ function setCurrentURL(url) {
     Onyx.set(ONYXKEYS.CURRENT_URL, url);
 }
 
+/**
+ * @param {String} locale
+ */
+function setLocale(locale) {
+    console.log('RORY_DEBUG setting locale to:', locale);
+    Onyx.set(ONYXKEYS.PREFERRED_LOCALE, locale);
+}
+
 export {
-    // eslint-disable-next-line import/prefer-default-export
     setCurrentURL,
+    setLocale,
 };

--- a/src/libs/actions/App.js
+++ b/src/libs/actions/App.js
@@ -12,7 +12,6 @@ function setCurrentURL(url) {
  * @param {String} locale
  */
 function setLocale(locale) {
-    console.log('RORY_DEBUG setting locale to:', locale);
     Onyx.set(ONYXKEYS.PREFERRED_LOCALE, locale);
 }
 

--- a/src/pages/settings/PreferencesPage.js
+++ b/src/pages/settings/PreferencesPage.js
@@ -1,6 +1,7 @@
+import _ from 'underscore';
 import React from 'react';
 import {View} from 'react-native';
-import Onyx, {withOnyx} from 'react-native-onyx';
+import {withOnyx} from 'react-native-onyx';
 import PropTypes from 'prop-types';
 
 import HeaderWithCloseButton from '../../components/HeaderWithCloseButton';
@@ -12,6 +13,7 @@ import Text from '../../components/Text';
 import NameValuePair from '../../libs/actions/NameValuePair';
 import CONST from '../../CONST';
 import {setExpensifyNewsStatus} from '../../libs/actions/User';
+import {setLocale} from '../../libs/actions/App';
 import ScreenWrapper from '../../components/ScreenWrapper';
 import Switch from '../../components/Switch';
 import Picker from '../../components/Picker';
@@ -28,15 +30,16 @@ const propTypes = {
         expensifyNewsStatus: PropTypes.bool,
     }),
 
-    ...withLocalizePropTypes,
+    /** Indicates which locale the user currently has selected */
+    preferredLocale: PropTypes.string,
 
-    // Indicates which locale the user currently has selected
-    preferredLocale: PropTypes.string.isRequired,
+    ...withLocalizePropTypes,
 };
 
 const defaultProps = {
     priorityMode: CONST.PRIORITY_MODE.DEFAULT,
     user: {},
+    preferredLocale: CONST.DEFAULT_LOCALE,
 };
 
 const PreferencesPage = ({
@@ -112,7 +115,11 @@ const PreferencesPage = ({
                     </Text>
                     <View style={[styles.mb2]}>
                         <Picker
-                            onChange={locale => Onyx.merge(ONYXKEYS.PREFERRED_LOCALE, locale)}
+                            onChange={(locale) => {
+                                if (locale !== preferredLocale) {
+                                    setLocale(locale);
+                                }
+                            }}
                             items={Object.values(localesToLanguages)}
                             value={preferredLocale}
                         />
@@ -135,6 +142,9 @@ export default compose(
         },
         user: {
             key: ONYXKEYS.USER,
+        },
+        preferredLocale: {
+            key: ONYXKEYS.PREFERRED_LOCALE,
         },
     }),
 )(PreferencesPage);

--- a/src/pages/settings/PreferencesPage.js
+++ b/src/pages/settings/PreferencesPage.js
@@ -1,4 +1,3 @@
-import _ from 'underscore';
 import React from 'react';
 import {View} from 'react-native';
 import {withOnyx} from 'react-native-onyx';


### PR DESCRIPTION
cc @jasperhuangg 

### Details
There were a few issues here:

1. The `preferences` prop was not being provided
1. We were using `Onyx.merge` instead of `Onyx.set` (not a problem per-se but weird for a value that's just a singular string)
1. We were using `Onyx.merge` inline in a component callback instead of via an action.
1. The `Picker` component is infuriating and triggers the `onChange` callback multiple times.

I'm not 100% sure what was causing the crash, but _after hooking up `preferredLocale` via Onyx, I was getting an infinite loop where:

1. User triggers `onChange` to update preferred locale in Onyx
1. Onyx updates preferred locale in Picker
1. `onChange` is triggered again (because the `preferredLocale` had changed), and this would restart the loop. 

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/pull/3606

### Tests / QA Steps
1. Open `Settings` -> `Preferences`, and toggle the preferred locale.
1. Verify that the language of the app switches from English -> Spanish, or vice-versa.
1. Repeat the previous two steps.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [ ] Android

### Screenshots
#### Web
![image](https://user-images.githubusercontent.com/47436092/122430566-920f4000-cf48-11eb-8a25-1e51d6fbb98a.png)
![image](https://user-images.githubusercontent.com/47436092/122430605-9b98a800-cf48-11eb-859e-17625d98c06b.png)

#### Mobile Web
![image](https://user-images.githubusercontent.com/47436092/122430973-e3b7ca80-cf48-11eb-8926-6a6baab93753.png)
![image](https://user-images.githubusercontent.com/47436092/122431009-ec100580-cf48-11eb-957b-2ecc33273b26.png)

#### Desktop
![image](https://user-images.githubusercontent.com/47436092/122431531-66408a00-cf49-11eb-8d27-5a2c13de29bc.png)
![image](https://user-images.githubusercontent.com/47436092/122431571-6e98c500-cf49-11eb-84d1-5c83f4d2398b.png)

#### iOS
![image](https://user-images.githubusercontent.com/47436092/122430736-b1a66880-cf48-11eb-83e2-edbe31c8d7fb.png)
![image](https://user-images.githubusercontent.com/47436092/122430774-ba973a00-cf48-11eb-8754-52df5979c140.png)

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
