### PR TITLE
[No QA] Fetch StagingDeployCash issues in all states

### DIFF
--- a/.github/actions/createOrUpdateStagingDeploy/createOrUpdateStagingDeploy.js
+++ b/.github/actions/createOrUpdateStagingDeploy/createOrUpdateStagingDeploy.js
@@ -17,13 +17,13 @@ const run = function () {
             owner: GithubUtils.GITHUB_OWNER,
             repo: GithubUtils.EXPENSIFY_CASH_REPO,
             labels: GithubUtils.STAGING_DEPLOY_CASH_LABEL,
+            state: 'all',
         }),
         GithubUtils.octokit.issues.listForRepo({
             log: console,
             owner: GithubUtils.GITHUB_OWNER,
             repo: GithubUtils.EXPENSIFY_CASH_REPO,
             labels: GithubUtils.DEPLOY_BLOCKER_CASH_LABEL,
-            state: 'open',
         }),
     ])
         .then((results) => {

--- a/.github/actions/createOrUpdateStagingDeploy/index.js
+++ b/.github/actions/createOrUpdateStagingDeploy/index.js
@@ -27,13 +27,13 @@ const run = function () {
             owner: GithubUtils.GITHUB_OWNER,
             repo: GithubUtils.EXPENSIFY_CASH_REPO,
             labels: GithubUtils.STAGING_DEPLOY_CASH_LABEL,
+            state: 'all',
         }),
         GithubUtils.octokit.issues.listForRepo({
             log: console,
             owner: GithubUtils.GITHUB_OWNER,
             repo: GithubUtils.EXPENSIFY_CASH_REPO,
             labels: GithubUtils.DEPLOY_BLOCKER_CASH_LABEL,
-            state: 'open',
         }),
     ])
         .then((results) => {


### PR DESCRIPTION

### Details
Following up on https://github.com/Expensify/Expensify.cash/pull/3173. I always forget that the default value of the `state` parameter is `open`, not `all`. So `octokit.issues.listForRepo` by default only gets open issues.

### Fixed Issues
Failed workflow run: https://github.com/Expensify/Expensify.cash/runs/2851543811?check_suite_focus=true

### Tests
Merge to test!

### QA Steps
None.

### Tested On

N/A – GitHub only.