### PR TITLE
[No QA] Fix StagingDeployCash isAutomatedPullRequest check

### DIFF
--- a/.github/actions/checkDeployBlockers/index.js
+++ b/.github/actions/checkDeployBlockers/index.js
@@ -291,6 +291,7 @@ class GithubUtils {
         return this.octokit.pulls.list({
             owner: GITHUB_OWNER,
             repo: EXPENSIFY_CASH_REPO,
+            state: 'all',
             per_page: 100,
         })
             .then(({data}) => {

--- a/.github/actions/createOrUpdateStagingDeploy/createOrUpdateStagingDeploy.js
+++ b/.github/actions/createOrUpdateStagingDeploy/createOrUpdateStagingDeploy.js
@@ -80,9 +80,9 @@ const run = function () {
             console.log('Parsed the following data from the current StagingDeployCash:', currentStagingDeployCashData);
             currentStagingDeployCashIssueNumber = currentStagingDeployCashData.number;
 
-            const newDeployBlockers = _.map(deployBlockerResponse.data, ({url}) => ({
-                url,
-                number: GithubUtils.getIssueOrPullRequestNumberFromURL(url),
+            const newDeployBlockers = _.map(deployBlockerResponse.data, ({html_url}) => ({
+                url: html_url,
+                number: GithubUtils.getIssueOrPullRequestNumberFromURL(html_url),
                 isResolved: false,
             }));
 

--- a/.github/actions/createOrUpdateStagingDeploy/index.js
+++ b/.github/actions/createOrUpdateStagingDeploy/index.js
@@ -90,9 +90,9 @@ const run = function () {
             console.log('Parsed the following data from the current StagingDeployCash:', currentStagingDeployCashData);
             currentStagingDeployCashIssueNumber = currentStagingDeployCashData.number;
 
-            const newDeployBlockers = _.map(deployBlockerResponse.data, ({url}) => ({
-                url,
-                number: GithubUtils.getIssueOrPullRequestNumberFromURL(url),
+            const newDeployBlockers = _.map(deployBlockerResponse.data, ({html_url}) => ({
+                url: html_url,
+                number: GithubUtils.getIssueOrPullRequestNumberFromURL(html_url),
                 isResolved: false,
             }));
 
@@ -413,6 +413,7 @@ class GithubUtils {
         return this.octokit.pulls.list({
             owner: GITHUB_OWNER,
             repo: EXPENSIFY_CASH_REPO,
+            state: 'all',
             per_page: 100,
         })
             .then(({data}) => {

--- a/.github/actions/getMergeCommitForPullRequest/index.js
+++ b/.github/actions/getMergeCommitForPullRequest/index.js
@@ -319,6 +319,7 @@ class GithubUtils {
         return this.octokit.pulls.list({
             owner: GITHUB_OWNER,
             repo: EXPENSIFY_CASH_REPO,
+            state: 'all',
             per_page: 100,
         })
             .then(({data}) => {

--- a/.github/actions/getReleaseBody/index.js
+++ b/.github/actions/getReleaseBody/index.js
@@ -262,6 +262,7 @@ class GithubUtils {
         return this.octokit.pulls.list({
             owner: GITHUB_OWNER,
             repo: EXPENSIFY_CASH_REPO,
+            state: 'all',
             per_page: 100,
         })
             .then(({data}) => {

--- a/.github/actions/isPullRequestMergeable/index.js
+++ b/.github/actions/isPullRequestMergeable/index.js
@@ -265,6 +265,7 @@ class GithubUtils {
         return this.octokit.pulls.list({
             owner: GITHUB_OWNER,
             repo: EXPENSIFY_CASH_REPO,
+            state: 'all',
             per_page: 100,
         })
             .then(({data}) => {

--- a/.github/actions/isStagingDeployLocked/index.js
+++ b/.github/actions/isStagingDeployLocked/index.js
@@ -241,6 +241,7 @@ class GithubUtils {
         return this.octokit.pulls.list({
             owner: GITHUB_OWNER,
             repo: EXPENSIFY_CASH_REPO,
+            state: 'all',
             per_page: 100,
         })
             .then(({data}) => {

--- a/.github/actions/markPullRequestsAsDeployed/index.js
+++ b/.github/actions/markPullRequestsAsDeployed/index.js
@@ -315,6 +315,7 @@ class GithubUtils {
         return this.octokit.pulls.list({
             owner: GITHUB_OWNER,
             repo: EXPENSIFY_CASH_REPO,
+            state: 'all',
             per_page: 100,
         })
             .then(({data}) => {

--- a/.github/actions/reopenIssueWithComment/index.js
+++ b/.github/actions/reopenIssueWithComment/index.js
@@ -254,6 +254,7 @@ class GithubUtils {
         return this.octokit.pulls.list({
             owner: GITHUB_OWNER,
             repo: EXPENSIFY_CASH_REPO,
+            state: 'all',
             per_page: 100,
         })
             .then(({data}) => {

--- a/.github/actions/triggerWorkflowAndWait/index.js
+++ b/.github/actions/triggerWorkflowAndWait/index.js
@@ -405,6 +405,7 @@ class GithubUtils {
         return this.octokit.pulls.list({
             owner: GITHUB_OWNER,
             repo: EXPENSIFY_CASH_REPO,
+            state: 'all',
             per_page: 100,
         })
             .then(({data}) => {

--- a/.github/libs/GithubUtils.js
+++ b/.github/libs/GithubUtils.js
@@ -203,6 +203,7 @@ class GithubUtils {
         return this.octokit.pulls.list({
             owner: GITHUB_OWNER,
             repo: EXPENSIFY_CASH_REPO,
+            state: 'all',
             per_page: 100,
         })
             .then(({data}) => {

--- a/tests/unit/createOrUpdateStagingDeployTest.js
+++ b/tests/unit/createOrUpdateStagingDeployTest.js
@@ -144,19 +144,19 @@ describe('createOrUpdateStagingDeployCash', () => {
 
         const currentOpenDeployBlockers = [
             {
-                url: 'https://github.com/Expensify/Expensify.cash/pull/6',
+                html_url: 'https://github.com/Expensify/Expensify.cash/pull/6',
                 number: 6,
                 state: 'open',
                 labels: [LABELS.DEPLOY_BLOCKER_CASH],
             },
             {
-                url: 'https://github.com/Expensify/Expensify.cash/issues/9',
+                html_url: 'https://github.com/Expensify/Expensify.cash/issues/9',
                 number: 9,
                 state: 'open',
                 labels: [LABELS.DEPLOY_BLOCKER_CASH],
             },
             {
-                url: 'https://github.com/Expensify/Expensify.cash/issues/10',
+                html_url: 'https://github.com/Expensify/Expensify.cash/issues/10',
                 number: 10,
                 state: 'open',
                 labels: [LABELS.DEPLOY_BLOCKER_CASH],
@@ -196,13 +196,13 @@ describe('createOrUpdateStagingDeployCash', () => {
                         data: [
                             ...currentOpenDeployBlockers,
                             {
-                                url: 'https://github.com/Expensify/Expensify.cash/issues/11', // New
+                                html_url: 'https://github.com/Expensify/Expensify.cash/issues/11', // New
                                 number: 11,
                                 state: 'open',
                                 labels: [LABELS.DEPLOY_BLOCKER_CASH],
                             },
                             {
-                                url: 'https://github.com/Expensify/Expensify.cash/issues/12', // New
+                                html_url: 'https://github.com/Expensify/Expensify.cash/issues/12', // New
                                 number: 12,
                                 state: 'open',
                                 labels: [LABELS.DEPLOY_BLOCKER_CASH],
@@ -246,13 +246,13 @@ describe('createOrUpdateStagingDeployCash', () => {
                         data: [
                             ...currentOpenDeployBlockers,
                             {
-                                url: 'https://github.com/Expensify/Expensify.cash/issues/11', // New
+                                html_url: 'https://github.com/Expensify/Expensify.cash/issues/11', // New
                                 number: 11,
                                 state: 'open',
                                 labels: [LABELS.DEPLOY_BLOCKER_CASH],
                             },
                             {
-                                url: 'https://github.com/Expensify/Expensify.cash/issues/12', // New
+                                html_url: 'https://github.com/Expensify/Expensify.cash/issues/12', // New
                                 number: 12,
                                 state: 'open',
                                 labels: [LABELS.DEPLOY_BLOCKER_CASH],


### PR DESCRIPTION

### Details
Following-up on https://github.com/Expensify/Expensify.cash/pull/3173

It's mostly working, but there are two remaining issues that are resolved by this PR:

1. Use the `html_url` instead of the `url` –> we want the html url not the API url
1. The ever-so-common pitfall (this is my second time fixing today!) that by default `list`ing things from the GitHub API by will default only return open things. But in this case we want to check for PRs in any state.

### Fixed Issues
Fixes borked `StagingDeployCash` here: https://github.com/Expensify/Expensify.cash/issues/3593

### Tests
Merge to test. I also updated the unit tests here.

### QA Steps
None.

### Tested On

N/A – GitHub only