### PR TITLE
Debounce search page and reduce number of tooltips created

### DIFF
--- a/src/pages/SearchPage.js
+++ b/src/pages/SearchPage.js
@@ -1,3 +1,4 @@
+import _ from 'underscore';
 import React, {Component} from 'react';
 import {View} from 'react-native';
 import PropTypes from 'prop-types';
@@ -64,6 +65,9 @@ class SearchPage extends Component {
         Timing.start(CONST.TIMING.SEARCH_RENDER);
 
         this.selectReport = this.selectReport.bind(this);
+        this.onChangeText = this.onChangeText.bind(this);
+        this.debouncedUpdateOptions = _.debounce(this.updateOptions.bind(this), 300);
+
         const {
             recentReports,
             personalDetails,
@@ -85,6 +89,10 @@ class SearchPage extends Component {
 
     componentDidMount() {
         Timing.end(CONST.TIMING.SEARCH_RENDER);
+    }
+
+    onChangeText(searchValue = '') {
+        this.setState({searchValue}, this.debouncedUpdateOptions);
     }
 
     /**
@@ -110,6 +118,24 @@ class SearchPage extends Component {
         }
 
         return sections;
+    }
+
+    updateOptions() {
+        const {
+            recentReports,
+            personalDetails,
+            userToInvite,
+        } = getSearchOptions(
+            this.props.reports,
+            this.props.personalDetails,
+            this.state.searchValue,
+            this.props.betas,
+        );
+        this.setState({
+            userToInvite,
+            recentReports,
+            personalDetails,
+        });
     }
 
     /**
@@ -158,24 +184,7 @@ class SearchPage extends Component {
                                 sections={sections}
                                 value={this.state.searchValue}
                                 onSelectRow={this.selectReport}
-                                onChangeText={(searchValue = '') => {
-                                    const {
-                                        recentReports,
-                                        personalDetails,
-                                        userToInvite,
-                                    } = getSearchOptions(
-                                        this.props.reports,
-                                        this.props.personalDetails,
-                                        searchValue,
-                                        this.props.betas,
-                                    );
-                                    this.setState({
-                                        searchValue,
-                                        userToInvite,
-                                        recentReports,
-                                        personalDetails,
-                                    });
-                                }}
+                                onChangeText={this.onChangeText}
                                 headerMessage={headerMessage}
                                 hideSectionHeaders
                                 hideAdditionalOptionStates

--- a/src/pages/home/sidebar/OptionRow.js
+++ b/src/pages/home/sidebar/OptionRow.js
@@ -129,7 +129,10 @@ const OptionRow = ({
     const focusedBackgroundColor = styles.sidebarLinkActive.backgroundColor;
     const isMultipleParticipant = lodashGet(option, 'participantsList.length', 0) > 1;
     const displayNamesWithTooltips = _.map(
-        option.participantsList,
+
+        // We only create tooltips for the first 10 users or so since some reports have hundreds of users causing
+        // performance to degrade.
+        option.participantsList.slice(0, 10),
         ({displayName, firstName, login}) => {
             const displayNameTrimmed = Str.isSMSLogin(login) ? toLocalPhone(displayName) : displayName;
 


### PR DESCRIPTION
### Details
Noticed we were creating a ton of tooltips for the "rooms" that are returning in search results. Sometimes 100+ tooltips which caused performance to degrade. Also added some debounce in since we are filtering the options rather often and triggering re-renders. When we can wait until the user is done typing to do this.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/3601

### Tests
### QA Steps
1. Command + k to bring up search function
2. Verify typing is smooth
3. Verify search results appear reasonably fast

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
