### PR TITLE
Default participantsList to empty array to prevent crash in IOU feature

### DIFF
--- a/src/pages/home/sidebar/OptionRow.js
+++ b/src/pages/home/sidebar/OptionRow.js
@@ -132,7 +132,7 @@ const OptionRow = ({
 
         // We only create tooltips for the first 10 users or so since some reports have hundreds of users causing
         // performance to degrade.
-        option.participantsList.slice(0, 10),
+        (option.participantsList || []).slice(0, 10),
         ({displayName, firstName, login}) => {
             const displayNameTrimmed = Str.isSMSLogin(login) ? toLocalPhone(displayName) : displayName;
 


### PR DESCRIPTION
### Details
Defaults `participantsList` to an empty array preventing crash described in issue cc @Julesssss 

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/167732

### Tests
### QA Steps
1. Create an IOU using the '+' icon within a chat
2. Enter Amount and proceed to next screen
3. Verify the app does not crash

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
