### PR TITLE
[No QA] Checkout repo before attempting to update StagingDeployCash

### DIFF
--- a/.github/workflows/deployBlocker.yml
+++ b/.github/workflows/deployBlocker.yml
@@ -14,6 +14,10 @@ jobs:
     if: ${{ github.event.label.name == 'DeployBlockerCash' }}
 
     steps:
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Get URL, title, & number of new deploy blocker (issue)
         if: ${{ github.event_name == 'issues' }}
         run: |

--- a/.github/workflows/deployBlocker.yml
+++ b/.github/workflows/deployBlocker.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
+          fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get URL, title, & number of new deploy blocker (issue)


### PR DESCRIPTION

### Details
Yesterday I merged [a PR](https://github.com/Expensify/Expensify.cash/pull/3173) that uses a local git command to populate the deploy checklist (i.e: `git log ...`). However, this workflow does not checkout the repo, so the command fails because it's not run from inside a git repo.

This PR is a simple fix – just checkout the repo.

### Fixed Issues
Fixes failed workflow run: https://github.com/Expensify/Expensify.cash/runs/2860322010

### Tests
Merge, then retry the workflow from `main`.

### QA Steps
None.

### Tested On

N/A – GitHub only