### PR TITLE
chg: Block context menu on message being edited

### DIFF
--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -165,6 +165,10 @@ class ReportActionItem extends Component {
      * @param {string} [selection] - A copy text.
      */
     showPopover(event, selection) {
+        // Block menu on the message being Edited
+        if (this.props.draftMessage) {
+            return;
+        }
         const nativeEvent = event.nativeEvent || {};
         this.selection = selection;
         this.capturePressLocation(nativeEvent).then(() => {
@@ -261,6 +265,7 @@ class ReportActionItem extends Component {
                                     isVisible={
                                         hovered
                                         && !this.state.isPopoverVisible
+                                        && !this.props.draftMessage
                                     }
                                     draftMessage={this.props.draftMessage}
                                     hidePopover={this.hidePopover}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
If the message is being edited, we check for the draft message on that message Item and if there is a draft, we block the context menu from showing up.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes #3677

### Tests |  QA Steps
1. Open any conversation on E.cash.
2. Click Edit message from the context menu on any message.
3. When the Edit box is visible. try to open the context menu on the message being edited.
4. menu should not open.
5. repeat all the above steps on each platfrom.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

https://user-images.githubusercontent.com/24370807/122616930-f77a4280-d0a8-11eb-8790-65c1ff551564.mp4


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

https://user-images.githubusercontent.com/24370807/122616937-fa753300-d0a8-11eb-93d0-280bc51acc73.mp4


#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->

https://user-images.githubusercontent.com/24370807/122616943-fe08ba00-d0a8-11eb-8b6d-e190735bdefb.mp4

