### PR TITLE
[NO QA] Set up the request call API functions

### DIFF
--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -940,6 +940,21 @@ function Policy_Create(parameters) {
     return Network.post(commandName, parameters);
 }
 
+/**
+ * @param {Object} parameters
+ * @param {String} parameters.taskID
+ * @param {String} parameters.policyID
+ * @param {String} parameters.firstName
+ * @param {String} parameters.lastName
+ * @param {String} parameters.phoneNumber
+ * @returns {Promise}
+ */
+function Inbox_CallUser(parameters) {
+    const commandName = 'Inbox_CallUser';
+    requireParameters(['taskID', 'policyID', 'firstName', 'lastName', 'phoneNumber'], parameters, commandName);
+    return Network.post(commandName, parameters);
+}
+
 export {
     Authenticate,
     BankAccount_Create,
@@ -956,6 +971,7 @@ export {
     GetPolicySummaryList,
     GetRequestCountryCode,
     Graphite_Timer,
+    Inbox_CallUser,
     Log,
     PayIOU,
     PayWithWallet,

--- a/src/libs/actions/Inbox.js
+++ b/src/libs/actions/Inbox.js
@@ -1,0 +1,14 @@
+import {Inbox_CallUser} from '../API';
+
+function requestConciergeDMCall(policyID, firstName, lastName, phoneNumber) {
+    return Inbox_CallUser({
+        policyID,
+        firstName,
+        lastName,
+        phoneNumber,
+        taskID: 'ExpensifyCashConciergeDM',
+    });
+}
+
+// eslint-disable-next-line import/prefer-default-export
+export {requestConciergeDMCall};


### PR DESCRIPTION
### Details
This PR includes some utility functions that will be used when implementing Adding Guides Calling to Expensify.cash. Specifically, it includes an API function that calls [`Inbox_CallUser`](https://github.com/Expensify/Web-Expensify/blob/721d1038046e88b4b3f4ffe52f271dab0e90d173/api.php#L389), and a corresponding action that calls this API function.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/167897

### Tests
N/A

### QA Steps
N/A

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
N/A