### PR TITLE
[No QA] Make GitHub Actions build asynchronously

### DIFF
--- a/.github/scripts/buildActions.sh
+++ b/.github/scripts/buildActions.sh
@@ -28,12 +28,26 @@ declare -r NOTE_DONT_EDIT='/**
  */
 '
 
-for ACTION in "${GITHUB_ACTIONS[@]}"; do
-    # Build the action
-    ACTION_DIR=$(dirname "$ACTION")
-    ncc build "$ACTION" -o "$ACTION_DIR"
+# This stores all the process IDs of the ncc commands so they can run in parallel
+declare ASYNC_BUILDS
 
-    # Prepend the warning note to the top of the compiled file
-    OUTPUT_FILE="$ACTION_DIR/index.js"
-    echo "$NOTE_DONT_EDIT$(cat "$OUTPUT_FILE")" > "$OUTPUT_FILE"
+for ((i=0; i < ${#GITHUB_ACTIONS[@]}; i++)); do
+  ACTION=${GITHUB_ACTIONS[$i]}
+  ACTION_DIR=$(dirname "$ACTION")
+
+  # Build the action in the background
+  ncc build "$ACTION" -o "$ACTION_DIR" &
+  ASYNC_BUILDS[$i]=$!
+done
+
+for ((i=0; i < ${#GITHUB_ACTIONS[@]}; i++)); do
+  ACTION=${GITHUB_ACTIONS[$i]}
+  ACTION_DIR=$(dirname "$ACTION")
+
+  # Wait for the background build to finish
+  wait ${ASYNC_BUILDS[$i]}
+
+  # Prepend the warning note to the top of the compiled file
+  OUTPUT_FILE="$ACTION_DIR/index.js"
+  echo "$NOTE_DONT_EDIT$(cat "$OUTPUT_FILE")" > "$OUTPUT_FILE"
 done


### PR DESCRIPTION


### Details
...Just something I worked on during a flight, mostly to get some much-needed practice with bash scripting. But still a nice time-saver!

This PR makes the GitHub Actions build script asynchronous, and it's considerably faster now.

### Fixed Issues
n/a

### Tests
Testing this was a pretty interesting task, and I mostly wanted to test two things:

1. Does it produce the same output?
1. Does it actually run faster?

#### To verify that the output is the same, I did the following:

1. Starting from an up-to-date main branch, create a test branch: `git checkout temp-test`
1. Make some changes to `.github/libs/GithubUtils.js`. This file is used by many GHA, so it's a good way to test the build script.
1. Run `npm run gh-actions-build`, then commit the changes.
1. `git checkout main && git checkout Rory-AsyncGHActionsBuilds`
1. Make the same changes to `.github/libs/GithubUtils.js`.
1. Run `npm run gh-actions-build` again
1. Run `git diff temp-test..`. There should be no diff.
1. Cleanup by deleting your test branch: `git checkout main && git branch -D temp-test`

#### To verify that the script actually runs the build faster:

1. Add the following function to your bash profile (or just copy/paste it into your shell):

    ```bash
    # This is a basic shell utility to benchmark a bash command
    # @param $1 – The command to run
    # @param $2 - The number of time to run the command for benchmarking purposes
    function benchmark(){
      if [ -z "$1" ]; then
        echo "[Benchmark Err] – No command input"
        exit 1
      fi
      
      if [ -z "$2" ]; then
        echo "[Benchmark Err] – No number input"
        exit 1
      fi
      
      if [ "$2" -le 0 ]; then
        echo "[Benchmark Err] – Invalid number of uses – must be greater than 0"
        exit 1
      fi
      
      time eval "
          for ((i = 0; i < $2; i++)); do
            $1 &>/dev/null
          done
      "
    }
    ```

1. Then from an up-to-date main, run:

    ```bash
    > benchmark ./.github/scripts/buildActions.sh 1 
    
    real    0m15.119s
    user    0m20.259s
    sys     0m1.898s
    
    > benchmark ./.github/scripts/buildActions.sh 10
    
    real    2m38.679s
    user    3m32.631s
    sys     0m20.456s
    ```

1. Then on `Rory-AsyncGHActionsBuilds` run:

    ```bash
    > benchmark ./.github/scripts/buildActions.sh 1
    
    real    0m5.416s
    user    0m26.921s
    sys     0m2.615s
    
    > benchmark ./.github/scripts/buildActions.sh 10
    
    real    0m53.952s
    user    4m24.140s
    sys     0m24.770s
    ```

It's not a perfect experiment, but it does appear to be definitively faster – roughly 1/3 the execution time of a synchronous build.

### Tested On

n/a – bash only