### PR TITLE
Feature: Send image with text via composer

### DIFF
--- a/src/components/AttachmentModal.js
+++ b/src/components/AttachmentModal.js
@@ -118,7 +118,7 @@ class AttachmentModal extends PureComponent {
                 >
                     <HeaderWithCloseButton
                         title={this.props.isUploadingAttachment
-                            ? this.props.translate('reportActionCompose.uploadAttachment')
+                            ? this.props.translate('reportActionCompose.sendAttachment')
                             : this.props.translate('common.attachment')}
                         shouldShowBorderBottom
                         shouldShowDownloadButton
@@ -137,7 +137,7 @@ class AttachmentModal extends PureComponent {
                             success
                             style={[styles.buttonConfirm]}
                             textStyles={[styles.buttonConfirmText]}
-                            text={this.props.translate('common.upload')}
+                            text={this.props.translate('common.send')}
                             onPress={this.submitAndClose}
                         />
                     )}

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -2,7 +2,6 @@
 export default {
     common: {
         cancel: 'Cancel',
-        upload: 'Upload',
         yes: 'Yes',
         no: 'No',
         attachment: 'Attachment',

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -49,6 +49,7 @@ export default {
         invite: 'Invite',
         iAcceptThe: 'I accept the ',
         passwordCannotBeBlank: 'Password cannot be blank',
+        send: 'Send',
     },
     attachmentPicker: {
         cameraPermissionRequired: 'Camera Permission Required',
@@ -92,7 +93,7 @@ export default {
         phrase3: 'Your payments get to you as fast as you can get your point across.',
     },
     reportActionCompose: {
-        uploadAttachment: 'Upload Attachment',
+        sendAttachment: 'Send Attachment',
         addAttachment: 'Add Attachment',
         writeSomething: 'Write something...',
         youAppearToBeOffline: 'You appear to be offline.',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -2,7 +2,6 @@
 export default {
     common: {
         cancel: 'Cancelar',
-        upload: 'Subir',
         yes: 'Si',
         no: 'No',
         attachment: 'Archivo Adjunto',
@@ -45,6 +44,7 @@ export default {
         invite: 'Invitar',
         iAcceptThe: 'Acepto los ',
         passwordCannotBeBlank: 'La contraseña no puede estar vacía',
+        send: 'Enviar',
     },
     attachmentPicker: {
         cameraPermissionRequired: 'Se necesita permiso para usar la cámara',
@@ -88,7 +88,7 @@ export default {
         phrase3: 'Tus pagos llegan tan rápido como tus mensajes.',
     },
     reportActionCompose: {
-        uploadAttachment: 'Subir Archivo Adjunto',
+        sendAttachment: 'Enviar adjunto',
         addAttachment: 'Agregar Archivo Adjunto',
         writeSomething: 'Escribe algo...',
         youAppearToBeOffline: 'Parece que estás desconectado.',

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -403,6 +403,7 @@ class ReportActionCompose extends React.Component {
                     <AttachmentModal
                         isUploadingAttachment
                         onConfirm={(file) => {
+                            this.submitForm();
                             addAction(this.props.reportID, '', file);
                             this.setTextInputShouldClear(false);
                         }}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes #2258

### Tests | QA Steps
1. Open E.cash.
2. Open any conversation.
3. Type any message in the composer but don't send it.
4. Add an attachment from the plus menu.
5. Button should say send and After clicking send text should be posted followed by that image.
6. Repeat all the above steps in each platform.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

https://user-images.githubusercontent.com/24370807/122802126-9dfd5800-d2e2-11eb-9a94-ad43b555c4b0.mp4


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

https://user-images.githubusercontent.com/24370807/122808422-81651e00-d2ea-11eb-86d1-02ba33b6ff63.mp4


#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

https://user-images.githubusercontent.com/24370807/122802143-a190df00-d2e2-11eb-81a9-c3d48076df26.mp4


#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

https://user-images.githubusercontent.com/24370807/122808446-87f39580-d2ea-11eb-83f4-2c268010d8c4.mp4


#### Android
<!-- Insert screenshots of your changes on the Android platform-->

https://user-images.githubusercontent.com/24370807/122802148-a48bcf80-d2e2-11eb-9b4c-3591c6ad0428.mp4

