### PR TITLE
Clean up multiple subscriptions of preferredLocale

### DIFF
--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -7,7 +7,7 @@ import Str from 'expensify-common/lib/str';
 import ONYXKEYS from '../ONYXKEYS';
 import CONST from '../CONST';
 import {getReportParticipantsTitle, isDefaultRoom} from './reportUtils';
-import {translate} from './translate';
+import {getPreferredLocale, translate} from './translate';
 import Permissions from './Permissions';
 import md5 from './md5';
 
@@ -27,12 +27,6 @@ let countryCodeByIP;
 Onyx.connect({
     key: ONYXKEYS.COUNTRY_CODE,
     callback: val => countryCodeByIP = val || 1,
-});
-
-let preferredLocale;
-Onyx.connect({
-    key: ONYXKEYS.PREFERRED_LOCALE,
-    callback: val => preferredLocale = val || CONST.DEFAULT_LOCALE,
 });
 
 const policies = {};
@@ -585,12 +579,12 @@ function getSidebarOptions(reports, personalDetails, draftComments, activeReport
  */
 function getHeaderMessage(hasSelectableOptions, hasUserToInvite, searchValue, maxParticipantsReached = false) {
     if (maxParticipantsReached) {
-        return translate(preferredLocale, 'messages.maxParticipantsReached');
+        return translate(getPreferredLocale(), 'messages.maxParticipantsReached');
     }
 
     if (!hasSelectableOptions && !hasUserToInvite) {
         if (/^\d+$/.test(searchValue)) {
-            return translate(preferredLocale, 'messages.noPhoneNumber');
+            return translate(getPreferredLocale(), 'messages.noPhoneNumber');
         }
 
         return searchValue;

--- a/src/libs/actions/Policy.js
+++ b/src/libs/actions/Policy.js
@@ -7,7 +7,7 @@ import ONYXKEYS from '../../ONYXKEYS';
 import {formatPersonalDetails} from './PersonalDetails';
 import Growl from '../Growl';
 import CONST from '../../CONST';
-import {translate} from '../translate';
+import {getPreferredLocale, translate} from '../translate';
 import Navigation from '../Navigation/Navigation';
 import ROUTES from '../../ROUTES';
 
@@ -17,16 +17,6 @@ Onyx.connect({
     callback: (val, key) => {
         if (val && key) {
             allPolicies[key] = {...allPolicies[key], ...val};
-        }
-    },
-});
-
-let translateLocal = (phrase, variables) => translate(CONST.DEFAULT_LOCALE, phrase, variables);
-Onyx.connect({
-    key: ONYXKEYS.PREFERRED_LOCALE,
-    callback: (preferredLocale) => {
-        if (preferredLocale) {
-            translateLocal = (phrase, variables) => translate(preferredLocale, phrase, variables);
         }
     },
 });
@@ -137,9 +127,9 @@ function invite(login, welcomeNote, policyID) {
             Onyx.set(key, policyDataWithoutLogin);
 
             // Show the user feedback that the addition failed
-            let errorMessage = translateLocal('workspace.invite.genericFailureMessage');
+            let errorMessage = translate(getPreferredLocale(), 'workspace.invite.genericFailureMessage');
             if (data.jsonCode === 402) {
-                errorMessage += ` ${translateLocal('workspace.invite.pleaseEnterValidLogin')}`;
+                errorMessage += ` ${translate(getPreferredLocale(), 'workspace.invite.pleaseEnterValidLogin')}`;
             }
 
             Growl.show(errorMessage, CONST.GROWL.ERROR, 5000);
@@ -156,7 +146,7 @@ function create(name) {
         .then((response) => {
             if (response.jsonCode !== 200) {
                 // Show the user feedback
-                const errorMessage = translateLocal('workspace.new.genericFailureMessage');
+                const errorMessage = translate(getPreferredLocale(), 'workspace.new.genericFailureMessage');
                 Growl.show(errorMessage, CONST.GROWL.ERROR, 5000);
                 return;
             }

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -22,7 +22,7 @@ import {isDefaultRoom, isReportMessageAttachment, sortReportsByLastVisited} from
 import Timers from '../Timers';
 import {dangerouslyGetReportActionsMaxSequenceNumber, isReportMissingActions} from './ReportActions';
 import Growl from '../Growl';
-import {translate} from '../translate';
+import {getPreferredLocale, translate} from '../translate';
 
 let currentUserEmail;
 let currentUserAccountID;
@@ -55,16 +55,6 @@ Onyx.connect({
     callback: (val) => {
         if (val && val.reportID) {
             allReports[val.reportID] = val;
-        }
-    },
-});
-
-let translateLocal = (phrase, variables) => translate(CONST.DEFAULT_LOCALE, phrase, variables);
-Onyx.connect({
-    key: ONYXKEYS.PREFERRED_LOCALE,
-    callback: (preferredLocale) => {
-        if (preferredLocale) {
-            translateLocal = (phrase, variables) => translate(preferredLocale, phrase, variables);
         }
     },
 });
@@ -1064,7 +1054,7 @@ function addAction(reportID, text, file) {
     })
         .then((response) => {
             if (response.jsonCode === 408) {
-                Growl.show(translateLocal('reportActionCompose.fileUploadFailed'), CONST.GROWL.ERROR);
+                Growl.show(translate(getPreferredLocale(), 'reportActionCompose.fileUploadFailed'), CONST.GROWL.ERROR);
                 Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`, {
                     [optimisticReportActionID]: null,
                 });

--- a/src/libs/translate.js
+++ b/src/libs/translate.js
@@ -1,9 +1,30 @@
 import lodashGet from 'lodash/get';
 import Str from 'expensify-common/lib/str';
+import Onyx from 'react-native-onyx';
 import Log from './Log';
 import Config from '../CONFIG';
 import translations from '../languages/translations';
 import CONST from '../CONST';
+import ONYXKEYS from '../ONYXKEYS';
+
+/** Subscribe to the preferredLocale key so exports that do not use withLocalize can easily access the preferredLocale.
+ *
+ * @type {string}
+ */
+let preferredLocale = CONST.DEFAULT_LOCALE;
+Onyx.connect({
+    key: ONYXKEYS.PREFERRED_LOCALE,
+    callback: val => preferredLocale = val || CONST.DEFAULT_LOCALE,
+});
+
+/**
+ * Return the preferred locale
+ *
+ * @returns {String}
+ */
+function getPreferredLocale() {
+    return preferredLocale;
+}
 
 /**
  * Return translated string for given locale and phrase
@@ -54,8 +75,6 @@ function translate(locale = CONST.DEFAULT_LOCALE, phrase, variables = {}) {
 }
 
 export {
-
-    // Ignoring this lint error in case of we want to export more functions from this library
-    // eslint-disable-next-line import/prefer-default-export
     translate,
+    getPreferredLocale,
 };

--- a/src/pages/settings/PreferencesPage.js
+++ b/src/pages/settings/PreferencesPage.js
@@ -18,6 +18,7 @@ import Switch from '../../components/Switch';
 import Picker from '../../components/Picker';
 import withLocalize, {withLocalizePropTypes} from '../../components/withLocalize';
 import compose from '../../libs/compose';
+import {getPreferredLocale} from '../../libs/translate';
 
 const propTypes = {
     /** The chat priority mode */
@@ -38,7 +39,7 @@ const propTypes = {
 const defaultProps = {
     priorityMode: CONST.PRIORITY_MODE.DEFAULT,
     user: {},
-    preferredLocale: CONST.DEFAULT_LOCALE,
+    preferredLocale: getPreferredLocale(),
 };
 
 const PreferencesPage = ({


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This PR removes subscriptions to `ONYXKEYS.PREFERRED_LOCALE` that are outside of withLocalize in favor of one `translate` function.

### Fixed Issues
Follow-up to a discussion from https://github.com/Expensify/Expensify.cash/pull/3463#discussion_r651482715

### Tests
TBD

### QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
