### PR TITLE
Improve error message when attempting to run the iOS app alongside the desktop and web in development

### DIFF
--- a/config/checkPort.js
+++ b/config/checkPort.js
@@ -3,29 +3,26 @@ const net = require('net');
 function checkPort(port, host) {
     return new Promise((resolve, reject) => {
         const server = net.createServer();
-
         server.once('error', (err) => {
-            if (err.code !== 'EADDRINUSE') { return reject(err); }
+            if (err.code !== 'EADDRINUSE') {
+                return reject(err);
+            }
 
             reject(err);
         });
-
         server.once('listening', () => {
-            server.once('close', () => { resolve(false); });
+            server.once('close', () => resolve(false));
             server.close();
         });
-
         server.listen(port, host);
     });
 }
 
 const inputPort = Number(process.argv.slice(2)[0]);
-
 if (Number.isNaN(inputPort) || inputPort < 0 || inputPort > 65535) {
     console.error('This command requires an argument that must be a number [0-65535]\n');
     process.exit(1);
 }
-
 
 Promise.all([
     checkPort(inputPort, 'localhost'),
@@ -38,6 +35,5 @@ Promise.all([
             `The port ${inputPort} is currently in use.`,
             `You can run \`lsof -i :${inputPort}\` to see which program is using it.\n`,
         );
-
         process.exit(1);
     });

--- a/config/checkPort.js
+++ b/config/checkPort.js
@@ -1,0 +1,43 @@
+const net = require('net');
+
+function checkPort(port, host) {
+    return new Promise((resolve, reject) => {
+        const server = net.createServer();
+
+        server.once('error', (err) => {
+            if (err.code !== 'EADDRINUSE') { return reject(err); }
+
+            reject(err);
+        });
+
+        server.once('listening', () => {
+            server.once('close', () => { resolve(false); });
+            server.close();
+        });
+
+        server.listen(port, host);
+    });
+}
+
+const inputPort = Number(process.argv.slice(2)[0]);
+
+if (Number.isNaN(inputPort) || inputPort < 0 || inputPort > 65535) {
+    console.error('This command requires an argument that must be a number [0-65535]\n');
+    process.exit(1);
+}
+
+
+Promise.all([
+    checkPort(inputPort, 'localhost'),
+    checkPort(inputPort, '127.0.0.1'),
+    checkPort(inputPort, '0.0.0.0'),
+])
+    .then(() => process.exit(0))
+    .catch(() => {
+        console.error(
+            `The port ${inputPort} is currently in use.`,
+            `You can run \`lsof -i :${inputPort}\` to see which program is using it.\n`,
+        );
+
+        process.exit(1);
+    });

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "android": "react-native run-android",
-    "ios": "react-native run-ios",
-    "ipad": "react-native run-ios --simulator=\"iPad Pro (12.9-inch) (4th generation)\"",
-    "ipad-sm": "react-native run-ios --simulator=\"iPad Pro (9.7-inch)\"",
+    "android": "npm run check-port -- 8081 && react-native run-android",
+    "ios": "npm run check-port -- 8081 && react-native run-ios",
+    "ipad": "npm run check-port -- 8081 && react-native run-ios --simulator=\"iPad Pro (12.9-inch) (4th generation)\"",
+    "ipad-sm": "npm run check-port -- 8081 && react-native run-ios --simulator=\"iPad Pro (9.7-inch)\"",
     "desktop": "node desktop/start.js",
     "start": "react-native start",
     "web": "node web/proxy.js & webpack-dev-server --open --config config/webpack/webpack.dev.js",
@@ -29,7 +29,8 @@
     "storybook-build": "build-storybook -o dist/docs",
     "gh-actions-build": "./.github/scripts/buildActions.sh",
     "gh-actions-validate": "./.github/scripts/validateActionsAndWorkflows.sh",
-    "analyze-packages": "ANALYZE_BUNDLE=true webpack --config config/webpack/webpack.prod.js"
+    "analyze-packages": "ANALYZE_BUNDLE=true webpack --config config/webpack/webpack.prod.js",
+    "check-port": "node config/checkPort.js"
   },
   "dependencies": {
     "@formatjs/intl-getcanonicallocales": "^1.5.8",


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
@marcaaron 

### Details
Adds a script to check if a port is running. Then we use this script to check if the port 8081 is already in use before trying to run the ios or android app during development. If the port is occupied by another process, it will print an error.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes https://github.com/Expensify/Expensify/issues/157479

### Tests
1. Run `npm run desktop`
2. Run `npm run web`
3. Run `npm run ios`
4. Check that it prints this error:

![image](https://user-images.githubusercontent.com/6759612/122960627-df920f80-d383-11eb-8111-3b6953c4cabe.png)

5. Now close the processes for desktop and web.
6. Run `npm run ios` again
7. The app should launch successfully.

### QA Steps
1. Run `npm run desktop`
2. Run `npm run web`
3. Run `npm run ios`
4. Check that it prints this error:

![image](https://user-images.githubusercontent.com/6759612/122960627-df920f80-d383-11eb-8111-3b6953c4cabe.png)

5. Now close the processes for desktop and web.
6. Run `npm run ios` again
7. The app should launch successfully.


### Tested On

- [x] Mac OS
- [ ] Linux
- [ ] Windows

### Screenshots
![image](https://user-images.githubusercontent.com/6759612/122960753-05b7af80-d384-11eb-9e84-851eccc48168.png)

