### PR TITLE
Don't focus input until screen transition has ended

### DIFF
--- a/src/pages/settings/AddSecondaryLoginPage.js
+++ b/src/pages/settings/AddSecondaryLoginPage.js
@@ -68,10 +68,19 @@ class AddSecondaryLoginPage extends Component {
         this.state = {
             login: '',
             password: '',
+            didScreenTransitionEnd: false,
         };
         this.formType = props.route.params.type;
         this.submitForm = this.submitForm.bind(this);
         this.validateForm = this.validateForm.bind(this);
+
+        this.phoneNumberInputRef = null;
+    }
+
+    componentDidUpdate(prevProps, prevState) {
+        if (!prevState.didScreenTransitionEnd && this.state.didScreenTransitionEnd) {
+            this.phoneNumberInputRef.focus();
+        }
     }
 
     componentWillUnmount() {
@@ -103,68 +112,75 @@ class AddSecondaryLoginPage extends Component {
     render() {
         return (
             <ScreenWrapper>
-                <KeyboardAvoidingView>
-                    <HeaderWithCloseButton
-                        title={this.props.translate(this.formType === CONST.LOGIN_TYPE.PHONE
-                            ? 'addSecondaryLoginPage.addPhoneNumber'
-                            : 'addSecondaryLoginPage.addEmailAddress')}
-                        shouldShowBackButton
-                        onBackButtonPress={() => Navigation.navigate(ROUTES.SETTINGS_PROFILE)}
-                        onCloseButtonPress={() => Navigation.dismissModal()}
-                    />
-                    <ScrollView style={styles.flex1} contentContainerStyle={styles.p5}>
-                        <Text style={[styles.mb6, styles.textP]}>
-                            {this.props.translate(this.formType === CONST.LOGIN_TYPE.PHONE
-                                ? 'addSecondaryLoginPage.enterPreferredPhoneNumberToSendValidationLink'
-                                : 'addSecondaryLoginPage.enterPreferredEmailToSendValidationLink')}
-                        </Text>
-                        <View style={styles.mb6}>
-                            <Text style={[styles.mb1, styles.formLabel]}>
-                                {this.props.translate(this.formType === CONST.LOGIN_TYPE.PHONE
-                                    ? 'common.phoneNumber'
-                                    : 'profilePage.emailAddress')}
-                            </Text>
-                            <TextInput
-                                style={styles.textInput}
-                                value={this.state.login}
-                                onChangeText={login => this.setState({login})}
-                                autoFocus
-                                keyboardType={this.formType === CONST.LOGIN_TYPE.PHONE
-                                    ? CONST.KEYBOARD_TYPE.PHONE_PAD : undefined}
-                                returnKeyType="done"
+                {({didScreenTransitionEnd}) => {
+                    if (didScreenTransitionEnd && !this.state.didScreenTransitionEnd) {
+                        this.setState({didScreenTransitionEnd});
+                    }
+                    return (
+                        <KeyboardAvoidingView>
+                            <HeaderWithCloseButton
+                                title={this.props.translate(this.formType === CONST.LOGIN_TYPE.PHONE
+                                    ? 'addSecondaryLoginPage.addPhoneNumber'
+                                    : 'addSecondaryLoginPage.addEmailAddress')}
+                                shouldShowBackButton
+                                onBackButtonPress={() => Navigation.navigate(ROUTES.SETTINGS_PROFILE)}
+                                onCloseButtonPress={() => Navigation.dismissModal()}
                             />
-                        </View>
-                        <View style={styles.mb6}>
-                            <Text style={[styles.mb1, styles.formLabel]}>
-                                {this.props.translate('common.password')}
-                            </Text>
-                            <TextInput
-                                style={styles.textInput}
-                                value={this.state.password}
-                                onChangeText={password => this.setState({password})}
-                                secureTextEntry
-                                autoCompleteType="password"
-                                textContentType="password"
-                                onSubmitEditing={this.submitForm}
-                            />
-                        </View>
-                        {!_.isEmpty(this.props.user.error) && (
-                            <Text style={styles.formError}>
-                                {this.props.user.error}
-                            </Text>
-                        )}
-                    </ScrollView>
-                    <FixedFooter style={[styles.flexGrow0]}>
-                        <Button
-                            success
-                            style={[styles.mb2]}
-                            isDisabled={this.validateForm()}
-                            isLoading={this.props.user.loading}
-                            text={this.props.translate('addSecondaryLoginPage.sendValidation')}
-                            onPress={this.submitForm}
-                        />
-                    </FixedFooter>
-                </KeyboardAvoidingView>
+                            <ScrollView style={styles.flex1} contentContainerStyle={styles.p5}>
+                                <Text style={[styles.mb6, styles.textP]}>
+                                    {this.props.translate(this.formType === CONST.LOGIN_TYPE.PHONE
+                                        ? 'addSecondaryLoginPage.enterPreferredPhoneNumberToSendValidationLink'
+                                        : 'addSecondaryLoginPage.enterPreferredEmailToSendValidationLink')}
+                                </Text>
+                                <View style={styles.mb6}>
+                                    <Text style={[styles.mb1, styles.formLabel]}>
+                                        {this.props.translate(this.formType === CONST.LOGIN_TYPE.PHONE
+                                            ? 'common.phoneNumber'
+                                            : 'profilePage.emailAddress')}
+                                    </Text>
+                                    <TextInput
+                                        ref={e => this.phoneNumberInputRef = e}
+                                        style={styles.textInput}
+                                        value={this.state.login}
+                                        onChangeText={login => this.setState({login})}
+                                        keyboardType={this.formType === CONST.LOGIN_TYPE.PHONE
+                                            ? CONST.KEYBOARD_TYPE.PHONE_PAD : undefined}
+                                        returnKeyType="done"
+                                    />
+                                </View>
+                                <View style={styles.mb6}>
+                                    <Text style={[styles.mb1, styles.formLabel]}>
+                                        {this.props.translate('common.password')}
+                                    </Text>
+                                    <TextInput
+                                        style={styles.textInput}
+                                        value={this.state.password}
+                                        onChangeText={password => this.setState({password})}
+                                        secureTextEntry
+                                        autoCompleteType="password"
+                                        textContentType="password"
+                                        onSubmitEditing={this.submitForm}
+                                    />
+                                </View>
+                                {!_.isEmpty(this.props.user.error) && (
+                                    <Text style={styles.formError}>
+                                        {this.props.user.error}
+                                    </Text>
+                                )}
+                            </ScrollView>
+                            <FixedFooter style={[styles.flexGrow0]}>
+                                <Button
+                                    success
+                                    style={[styles.mb2]}
+                                    isDisabled={this.validateForm()}
+                                    isLoading={this.props.user.loading}
+                                    text={this.props.translate('addSecondaryLoginPage.sendValidation')}
+                                    onPress={this.submitForm}
+                                />
+                            </FixedFooter>
+                        </KeyboardAvoidingView>
+                    );
+                }}
             </ScreenWrapper>
         );
     }

--- a/src/pages/settings/AddSecondaryLoginPage.js
+++ b/src/pages/settings/AddSecondaryLoginPage.js
@@ -68,19 +68,12 @@ class AddSecondaryLoginPage extends Component {
         this.state = {
             login: '',
             password: '',
-            didScreenTransitionEnd: false,
         };
         this.formType = props.route.params.type;
         this.submitForm = this.submitForm.bind(this);
         this.validateForm = this.validateForm.bind(this);
 
         this.phoneNumberInputRef = null;
-    }
-
-    componentDidUpdate(prevProps, prevState) {
-        if (!prevState.didScreenTransitionEnd && this.state.didScreenTransitionEnd) {
-            this.phoneNumberInputRef.focus();
-        }
     }
 
     componentWillUnmount() {
@@ -111,76 +104,69 @@ class AddSecondaryLoginPage extends Component {
 
     render() {
         return (
-            <ScreenWrapper>
-                {({didScreenTransitionEnd}) => {
-                    if (didScreenTransitionEnd && !this.state.didScreenTransitionEnd) {
-                        this.setState({didScreenTransitionEnd});
-                    }
-                    return (
-                        <KeyboardAvoidingView>
-                            <HeaderWithCloseButton
-                                title={this.props.translate(this.formType === CONST.LOGIN_TYPE.PHONE
-                                    ? 'addSecondaryLoginPage.addPhoneNumber'
-                                    : 'addSecondaryLoginPage.addEmailAddress')}
-                                shouldShowBackButton
-                                onBackButtonPress={() => Navigation.navigate(ROUTES.SETTINGS_PROFILE)}
-                                onCloseButtonPress={() => Navigation.dismissModal()}
+            <ScreenWrapper onTransitionEnd={() => this.phoneNumberInputRef.focus()}>
+                <KeyboardAvoidingView>
+                    <HeaderWithCloseButton
+                        title={this.props.translate(this.formType === CONST.LOGIN_TYPE.PHONE
+                            ? 'addSecondaryLoginPage.addPhoneNumber'
+                            : 'addSecondaryLoginPage.addEmailAddress')}
+                        shouldShowBackButton
+                        onBackButtonPress={() => Navigation.navigate(ROUTES.SETTINGS_PROFILE)}
+                        onCloseButtonPress={() => Navigation.dismissModal()}
+                    />
+                    <ScrollView style={styles.flex1} contentContainerStyle={styles.p5}>
+                        <Text style={[styles.mb6, styles.textP]}>
+                            {this.props.translate(this.formType === CONST.LOGIN_TYPE.PHONE
+                                ? 'addSecondaryLoginPage.enterPreferredPhoneNumberToSendValidationLink'
+                                : 'addSecondaryLoginPage.enterPreferredEmailToSendValidationLink')}
+                        </Text>
+                        <View style={styles.mb6}>
+                            <Text style={[styles.mb1, styles.formLabel]}>
+                                {this.props.translate(this.formType === CONST.LOGIN_TYPE.PHONE
+                                    ? 'common.phoneNumber'
+                                    : 'profilePage.emailAddress')}
+                            </Text>
+                            <TextInput
+                                ref={e => this.phoneNumberInputRef = e}
+                                style={styles.textInput}
+                                value={this.state.login}
+                                onChangeText={login => this.setState({login})}
+                                keyboardType={this.formType === CONST.LOGIN_TYPE.PHONE
+                                    ? CONST.KEYBOARD_TYPE.PHONE_PAD : undefined}
+                                returnKeyType="done"
                             />
-                            <ScrollView style={styles.flex1} contentContainerStyle={styles.p5}>
-                                <Text style={[styles.mb6, styles.textP]}>
-                                    {this.props.translate(this.formType === CONST.LOGIN_TYPE.PHONE
-                                        ? 'addSecondaryLoginPage.enterPreferredPhoneNumberToSendValidationLink'
-                                        : 'addSecondaryLoginPage.enterPreferredEmailToSendValidationLink')}
-                                </Text>
-                                <View style={styles.mb6}>
-                                    <Text style={[styles.mb1, styles.formLabel]}>
-                                        {this.props.translate(this.formType === CONST.LOGIN_TYPE.PHONE
-                                            ? 'common.phoneNumber'
-                                            : 'profilePage.emailAddress')}
-                                    </Text>
-                                    <TextInput
-                                        ref={e => this.phoneNumberInputRef = e}
-                                        style={styles.textInput}
-                                        value={this.state.login}
-                                        onChangeText={login => this.setState({login})}
-                                        keyboardType={this.formType === CONST.LOGIN_TYPE.PHONE
-                                            ? CONST.KEYBOARD_TYPE.PHONE_PAD : undefined}
-                                        returnKeyType="done"
-                                    />
-                                </View>
-                                <View style={styles.mb6}>
-                                    <Text style={[styles.mb1, styles.formLabel]}>
-                                        {this.props.translate('common.password')}
-                                    </Text>
-                                    <TextInput
-                                        style={styles.textInput}
-                                        value={this.state.password}
-                                        onChangeText={password => this.setState({password})}
-                                        secureTextEntry
-                                        autoCompleteType="password"
-                                        textContentType="password"
-                                        onSubmitEditing={this.submitForm}
-                                    />
-                                </View>
-                                {!_.isEmpty(this.props.user.error) && (
-                                    <Text style={styles.formError}>
-                                        {this.props.user.error}
-                                    </Text>
-                                )}
-                            </ScrollView>
-                            <FixedFooter style={[styles.flexGrow0]}>
-                                <Button
-                                    success
-                                    style={[styles.mb2]}
-                                    isDisabled={this.validateForm()}
-                                    isLoading={this.props.user.loading}
-                                    text={this.props.translate('addSecondaryLoginPage.sendValidation')}
-                                    onPress={this.submitForm}
-                                />
-                            </FixedFooter>
-                        </KeyboardAvoidingView>
-                    );
-                }}
+                        </View>
+                        <View style={styles.mb6}>
+                            <Text style={[styles.mb1, styles.formLabel]}>
+                                {this.props.translate('common.password')}
+                            </Text>
+                            <TextInput
+                                style={styles.textInput}
+                                value={this.state.password}
+                                onChangeText={password => this.setState({password})}
+                                secureTextEntry
+                                autoCompleteType="password"
+                                textContentType="password"
+                                onSubmitEditing={this.submitForm}
+                            />
+                        </View>
+                        {!_.isEmpty(this.props.user.error) && (
+                            <Text style={styles.formError}>
+                                {this.props.user.error}
+                            </Text>
+                        )}
+                    </ScrollView>
+                    <FixedFooter style={[styles.flexGrow0]}>
+                        <Button
+                            success
+                            style={[styles.mb2]}
+                            isDisabled={this.validateForm()}
+                            isLoading={this.props.user.loading}
+                            text={this.props.translate('addSecondaryLoginPage.sendValidation')}
+                            onPress={this.submitForm}
+                        />
+                    </FixedFooter>
+                </KeyboardAvoidingView>
             </ScreenWrapper>
         );
     }

--- a/src/pages/settings/AddSecondaryLoginPage.js
+++ b/src/pages/settings/AddSecondaryLoginPage.js
@@ -104,7 +104,12 @@ class AddSecondaryLoginPage extends Component {
 
     render() {
         return (
-            <ScreenWrapper onTransitionEnd={() => this.phoneNumberInputRef.focus()}>
+            <ScreenWrapper onTransitionEnd={() => {
+                if (this.phoneNumberInputRef) {
+                    this.phoneNumberInputRef.focus();
+                }
+            }}
+            >
                 <KeyboardAvoidingView>
                     <HeaderWithCloseButton
                         title={this.props.translate(this.formType === CONST.LOGIN_TYPE.PHONE
@@ -127,7 +132,7 @@ class AddSecondaryLoginPage extends Component {
                                     : 'profilePage.emailAddress')}
                             </Text>
                             <TextInput
-                                ref={e => this.phoneNumberInputRef = e}
+                                ref={el => this.phoneNumberInputRef = el}
                                 style={styles.textInput}
                                 value={this.state.login}
                                 onChangeText={login => this.setState({login})}


### PR DESCRIPTION
### Details
Don't focus the input until the screen transition animation has completed.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/3604

### Tests / QA Steps
1. Go to staging.expensify.cash and login
2. Tap avatar
3. Tap profile
4. Tap add phone number
5. Verify that the screen transitions normally. The phone number input should focus, but on iOS Safari the keyboard input may not open. Apple purposely prevents this for non-user-triggered events. I could not find a workaround, but we shouldn't block here.

### Tested on
- [x] Web
- [x] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
#### Web
![image](https://user-images.githubusercontent.com/47436092/122972971-91f6b200-d345-11eb-9a21-5cd99f1d1e22.png)

#### Mobile Web
![image](https://user-images.githubusercontent.com/47436092/122973003-9ae78380-d345-11eb-9d96-ed4bee702dde.png)

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
