### PR TITLE
Display phone number on DetailsPage for SMS logins with display names

### DIFF
--- a/src/pages/DetailsPage.js
+++ b/src/pages/DetailsPage.js
@@ -39,6 +39,23 @@ const propTypes = {
     ...withLocalizePropTypes,
 };
 
+/**
+ * Gets the phone number to display for SMS logins
+ *
+ * @param {String} login
+ * @param {String} displayName
+ * @returns {String}
+ */
+const getPhoneNumber = (login, displayName) => {
+    // If the user hasn't set a displayName, it is set to their phone number, so use that
+    if (Str.isValidPhone(displayName)) {
+        return displayName;
+    }
+
+    // If the user has set a displayName, get the phone number from the SMS login
+    return Str.removeSMSDomain(login);
+};
+
 const DetailsPage = ({
     personalDetails, route, translate, toLocalPhone,
 }) => {
@@ -87,7 +104,7 @@ const DetailsPage = ({
                                     </Text>
                                     <Text style={[styles.textP]} numberOfLines={1}>
                                         {isSMSLogin
-                                            ? toLocalPhone(details.displayName)
+                                            ? toLocalPhone(getPhoneNumber(details.login, details.displayName))
                                             : details.login}
                                     </Text>
                                 </View>

--- a/src/pages/DetailsPage.js
+++ b/src/pages/DetailsPage.js
@@ -42,18 +42,19 @@ const propTypes = {
 /**
  * Gets the phone number to display for SMS logins
  *
- * @param {String} login
- * @param {String} displayName
+ * @param {Object} details
+ * @param {String} details.login
+ * @param {String} details.displayName
  * @returns {String}
  */
-const getPhoneNumber = (login, displayName) => {
+const getPhoneNumber = (details) => {
     // If the user hasn't set a displayName, it is set to their phone number, so use that
-    if (Str.isValidPhone(displayName)) {
-        return displayName;
+    if (Str.isValidPhone(details.displayName)) {
+        return details.displayName;
     }
 
     // If the user has set a displayName, get the phone number from the SMS login
-    return Str.removeSMSDomain(login);
+    return Str.removeSMSDomain(details.login);
 };
 
 const DetailsPage = ({
@@ -104,7 +105,7 @@ const DetailsPage = ({
                                     </Text>
                                     <Text style={[styles.textP]} numberOfLines={1}>
                                         {isSMSLogin
-                                            ? toLocalPhone(getPhoneNumber(details.login, details.displayName))
+                                            ? toLocalPhone(getPhoneNumber(details))
                                             : details.login}
                                     </Text>
                                 </View>


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
If an SMS user doesn't set a displayName, it will be set to their phone number, so we were using displayName to display the user's phone number on the DetailsPage. However, this means we'd also show the displayName if the user had one set, so this PR ensures we always show the proper phone number for SMS users with and without an updated displayName.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes https://github.com/Expensify/Expensify.cash/issues/3575

### Tests/QA
1. Log into e.cash and search for a user with a phone number login (SMS) that hasn't set a displayName yet, click on their profile icon and confirm that the `Phone Number` field shows their local phone number
2. Search for a user with a phone number login (SMS) that has set a displayName, click on their profile icon and confirm that the `Phone Number` field shows their local phone number
3. Search for a user with an email login that hasn't set a displayName, click on their profile icon and confirm that the `Email` field shows instead of the `Phone Number` field, and their email is shown
4. Search for a user with an email login that has set a displayName, click on their profile icon and confirm that the `Email` field shows instead of the `Phone Number` field, and their email shows up

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web/Mobile Web
| Email without DisplayName | Email with DisplayName | SMS without DisplayName | SMS with DisplayName |
|---|---|---|---|
| ![image](https://user-images.githubusercontent.com/3981102/123036561-22fb7680-d3a2-11eb-8400-3f17c4731dde.png) | ![image](https://user-images.githubusercontent.com/3981102/123037339-58ed2a80-d3a3-11eb-9f12-1de7b2c2c0b2.png) | ![image](https://user-images.githubusercontent.com/3981102/123036600-30b0fc00-d3a2-11eb-8078-ef60fc4e5706.png) | ![image](https://user-images.githubusercontent.com/3981102/123036617-360e4680-d3a2-11eb-8a22-728431764bdf.png) |

#### Desktop
| Email without DisplayName | Email with DisplayName | SMS without DisplayName | SMS with DisplayName |
|---|---|---|---|
| ![image](https://user-images.githubusercontent.com/3981102/123037196-16c3e900-d3a3-11eb-9c52-b9868c75645b.png) | ![image](https://user-images.githubusercontent.com/3981102/123037204-1b889d00-d3a3-11eb-8952-797e9ccf9e56.png) | ![image](https://user-images.githubusercontent.com/3981102/123037219-22afab00-d3a3-11eb-94ef-bc4c2c08ae84.png) | ![image](https://user-images.githubusercontent.com/3981102/123037224-26433200-d3a3-11eb-9043-2150bc3f2a45.png) |

#### iOS/Android
| Email without DisplayName | Email with DisplayName | SMS without DisplayName | SMS with DisplayName |
|---|---|---|---|
| ![image](https://user-images.githubusercontent.com/3981102/123036935-b3d25200-d3a2-11eb-8c8d-9d10ea7a9f54.png) | ![image](https://user-images.githubusercontent.com/3981102/123036950-b9c83300-d3a2-11eb-8084-b0e81e18669f.png) | ![image](https://user-images.githubusercontent.com/3981102/123036962-bf257d80-d3a2-11eb-9ebe-4efa7fd30759.png) | ![image](https://user-images.githubusercontent.com/3981102/123036979-c2b90480-d3a2-11eb-97c9-e4eebb2b3b46.png) |
