### PR TITLE
Fixed swipe on composer

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -223,6 +223,8 @@ const CONST = {
     EMOJI_PICKER_ITEM_HEIGHT: 40,
     EMOJI_PICKER_HEADER_HEIGHT: 38,
 
+    COMPOSER_MAX_HEIGHT: 116,
+
     EMAIL: {
         CHRONOS: 'chronos@expensify.com',
         CONCIERGE: 'concierge@expensify.com',

--- a/src/components/SwipeableView/index.native.js
+++ b/src/components/SwipeableView/index.native.js
@@ -1,6 +1,7 @@
 import React, {PureComponent} from 'react';
 import {PanResponder, View} from 'react-native';
 import PropTypes from 'prop-types';
+import CONST from '../../CONST';
 
 const propTypes = {
     children: PropTypes.element.isRequired,
@@ -13,12 +14,19 @@ class SwipeableView extends PureComponent {
     constructor(props) {
         super(props);
 
-        const minimumPixelDistance = 3;
+        const minimumPixelDistance = CONST.COMPOSER_MAX_HEIGHT;
+        this.oldY = 0;
         this.panResponder = PanResponder.create({
 
             // The PanResponder gets focus only when the y-axis movement is over minimumPixelDistance
+            // & swip direction is downwards
             onMoveShouldSetPanResponderCapture:
-            (_event, gestureState) => gestureState.dy > minimumPixelDistance,
+            (_event, gestureState) => {
+                if ((gestureState.dy - this.oldY) > 0 && gestureState.dy > minimumPixelDistance) {
+                    return true;
+                }
+                this.oldY = gestureState.dy;
+            },
 
             // Calls the callback when the swipe down is released; after the completion of the gesture
             onPanResponderRelease: this.props.onSwipeDown,

--- a/src/components/TextInputFocusable/index.android.js
+++ b/src/components/TextInputFocusable/index.android.js
@@ -3,6 +3,7 @@ import {TextInput} from 'react-native';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
 import themeColors from '../../styles/themes/default';
+import CONST from '../../CONST';
 
 /**
  * On native layers we like to have the Text Input not focused so the user can read new chats without they keyboard in
@@ -61,7 +62,7 @@ class TextInputFocusable extends React.Component {
             <TextInput
                 placeholderTextColor={themeColors.placeholderText}
                 ref={el => this.textInput = el}
-                maxHeight={116}
+                maxHeight={CONST.COMPOSER_MAX_HEIGHT}
                 rejectResponderTermination={false}
                 editable={!this.props.isDisabled}
                 /* eslint-disable-next-line react/jsx-props-no-spreading */

--- a/src/components/TextInputFocusable/index.ios.js
+++ b/src/components/TextInputFocusable/index.ios.js
@@ -3,6 +3,7 @@ import {TextInput} from 'react-native';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
 import themeColors from '../../styles/themes/default';
+import CONST from '../../CONST';
 
 /**
  * On native layers we like to have the Text Input not focused so the user can read new chats without they keyboard in
@@ -73,7 +74,7 @@ class TextInputFocusable extends React.Component {
             <TextInput
                 placeholderTextColor={themeColors.placeholderText}
                 ref={el => this.textInput = el}
-                maxHeight={116}
+                maxHeight={CONST.COMPOSER_MAX_HEIGHT}
                 rejectResponderTermination={false}
                 editable={!this.props.isDisabled}
                 /* eslint-disable-next-line react/jsx-props-no-spreading */


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes #3323

### Tests | QA Steps
1. Log in on the mobile app.
2. Navigate to a conversation.
3. Tap on compose box and write a long message (long enough to enable scrolling).
4. Scroll the message to the top.
5. You should be able to scroll the message without closing the Keyboard.
6. Now swipe downwards with at least a distance equal to the height of the composer. The keyboard should close.


### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

https://user-images.githubusercontent.com/24370807/123146215-45ad8e00-d47b-11eb-8cd9-4f3f8d6c5b9d.mp4


#### Android
<!-- Insert screenshots of your changes on the Android platform-->

https://user-images.githubusercontent.com/24370807/123144764-a9cf5280-d479-11eb-87f8-9b1270e22f52.mp4

