### PR TITLE
Send the sequenceNumber when deleting a report comment

### DIFF
--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -1073,9 +1073,10 @@ function addAction(reportID, text, file) {
  */
 function deleteReportComment(reportID, reportAction) {
     // Optimistic Response
+    const sequenceNumber = reportAction.sequenceNumber;
     const reportActionsToMerge = {};
     const oldMessage = {...reportAction.message};
-    reportActionsToMerge[reportAction.sequenceNumber] = {
+    reportActionsToMerge[sequenceNumber] = {
         ...reportAction,
         message: [
             {
@@ -1093,11 +1094,12 @@ function deleteReportComment(reportID, reportAction) {
         reportID,
         reportActionID: reportAction.reportActionID,
         reportComment: '',
+        sequenceNumber,
     })
         .then((response) => {
             if (response.jsonCode !== 200) {
                 // Reverse Optimistic Response
-                reportActionsToMerge[reportAction.sequenceNumber] = {
+                reportActionsToMerge[sequenceNumber] = {
                     ...reportAction,
                     message: oldMessage,
                 };


### PR DESCRIPTION
### Details
When making a call to the API to delete a report comment, we were not sending the `sequenceNumber`. On the API front, if no `sequenceNumber` is provided, we default to `-1`. The `Pusher` event that would be sent when a comment gets deleted on one device would have a `sequenceNumber` of `-1`, hence the comment could not be found or deleted. 

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/3524

### Tests

1. Login into account A on 2 devices. (or tabs/browsers that don't share local storage)
2. Login into account B on another devices or incognito window.
3. Send a message from account A to account B.
4. You will see it on both second screen for account A and screen for account B.
5. Delete the message you've just sent as account A.
6. The message will still be on both second screen for account A and screen for account B.

### QA Steps
Same as tests

### Tested On

- [x] Web
- [ ] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web & Desktop
Web (Safari) on the left, Desktop on the right
![screencast 2021-06-23 18-46-36_small](https://user-images.githubusercontent.com/1805746/123138451-53e8b380-d455-11eb-8bf3-f30966cd12d9.gif)

<!--
#### Mobile Web Insert screenshots of your changes on the web platform (from a mobile browser)

#### Desktop

#### iOS

#### Android
-->
