### PR TITLE
Fix NotificationResponse race condition

### DIFF
--- a/src/libs/Notification/PushNotification/index.native.js
+++ b/src/libs/Notification/PushNotification/index.native.js
@@ -32,15 +32,6 @@ function pushNotificationEventCallback(eventType, notification) {
         return;
     }
 
-    // If a push notification is received while the app is in foreground,
-    // we'll assume pusher is connected so we'll ignore is and not fetch the same data twice.
-    // However, we will allow NotificationResponse events through, so that tapping on a foreground notification
-    // will take you to the relevant report.
-    if (AppState.currentState === 'active') {
-        console.debug('[PUSH_NOTIFICATION] Push received while app is in foreground, not executing any callback.');
-        return;
-    }
-
     if (!payload.type) {
         console.debug('[PUSH_NOTIFICATION] No type value provided in payload, not executing any callback.');
         return;
@@ -83,6 +74,13 @@ function register(accountID) {
 
     // Setup event listeners
     UrbanAirship.addListener(EventType.PushReceived, (notification) => {
+        // If a push notification is received while the app is in foreground,
+        // we'll assume pusher is connected so we'll ignore it and not write the same data twice.
+        if (AppState.currentState === 'active') {
+            console.debug('[PUSH_NOTIFICATION] Push received while app is in foreground, not executing any callback.');
+            return;
+        }
+
         pushNotificationEventCallback(EventType.PushReceived, notification);
     });
 


### PR DESCRIPTION
### Details
For a while, the callback for the `NotificationResponse` event (i.e: when a push notification is tapped) was usually not being executed. The previous code falsely assumed that the `NotificationResponse` callback would happen while the app was still in the background, because it is when the event occurs. It did rarely happen this way, because there was a race condition in play between these two responses to this event:

1. The OS natively brings the app to the foreground.
1. The JavaScript callback is executed.

The native OS response is almost always faster, so by the time the JS callback executes, the app is in the foreground and we skipped the callback. Instead, we'll only skip the callback for `PushReceived` events that happen when the app is in the foreground.

### Fixed Issues
Fixes (partial) https://github.com/Expensify/Expensify/issues/158830

### Tests / QA Steps
0. (iOS dev only) Launch the app on a physical iPhone device. [(SO)](https://stackoverflow.com/c/expensify/questions/6735)
1. Log into the app on mobile as user A.
1. Log into the app on another platform as user B.
1. As user A, open a chat between A and a user other than B.
1. As user A, background the mobile app
1. As user B, send a message to user A.
1. Verify that a push notification appears for user A.
1. Tap on the notification. Verify that the app opens to the chat between user A and user B (a different chat than you had open when you backgrounded the app).

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [x] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
https://user-images.githubusercontent.com/47436092/123183860-52b08a00-d447-11eb-85e4-7c5bdfec74df.MP4

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
