### PR TITLE
[No QA] Add the enableCardAfterVerified param to additionalData

### DIFF
--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -869,7 +869,7 @@ function BankAccount_Validate(parameters) {
 function BankAccount_SetupWithdrawal(parameters) {
     const commandName = 'BankAccount_SetupWithdrawal';
     let allowedParameters = [
-        'currentStep', 'policyID', 'bankAccountID', 'useOnfido', 'errorAttemptsCount',
+        'currentStep', 'policyID', 'bankAccountID', 'useOnfido', 'errorAttemptsCount', 'enableCardAfterVerified',
 
         // data from bankAccount step:
         'setupType', 'routingNumber', 'accountNumber', 'addressName', 'plaidAccountID', 'ownershipType', 'isSavings',

--- a/src/libs/actions/BankAccounts.js
+++ b/src/libs/actions/BankAccounts.js
@@ -569,7 +569,16 @@ function setupWithdrawalAccount(data) {
     let nextStep;
     Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {loading: true});
 
-    const newACHData = {...reimbursementAccountInSetup, ...data};
+    const newACHData = {
+        ...reimbursementAccountInSetup,
+        ...data,
+
+        // This param tells Web-Secure that this bank account is from NewDot so we can modify links back to the correct
+        // app in any communications. It also will be used to provision a customer for the Expensify card automatically
+        // once their bank account is successfully validated.
+        enableCardAfterVerified: true,
+    };
+
     if (data && !_.isUndefined(data.isSavings)) {
         newACHData.isSavings = Boolean(data.isSavings);
     }


### PR DESCRIPTION
### Details
cc @ctkochan22 

This should HOLD on https://github.com/Expensify/Auth/pull/5709 to merge + deploy

### Fixed Issues
https://github.com/Expensify/Expensify/issues/168429

### Tests
1. Make sure Auth is built with the PR above
2. Set up a VBA in E.cash
3. Inspect the `additionalData` JSON and verify the `enableCardAfterVerified` param is present

### QA Steps
❌ 

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
