### PR TITLE
Change order of global create menu

### DIFF
--- a/src/pages/home/sidebar/SidebarScreen.js
+++ b/src/pages/home/sidebar/SidebarScreen.js
@@ -116,6 +116,11 @@ class SidebarScreen extends Component {
                                     text: this.props.translate('sidebarScreen.newChat'),
                                     onSelected: () => Navigation.navigate(ROUTES.NEW_CHAT),
                                 },
+                                {
+                                    icon: Users,
+                                    text: this.props.translate('sidebarScreen.newGroup'),
+                                    onSelected: () => Navigation.navigate(ROUTES.NEW_GROUP),
+                                },
                                 ...(Permissions.canUseIOU(this.props.betas) ? [
                                     {
                                         icon: MoneyCircle,
@@ -123,11 +128,6 @@ class SidebarScreen extends Component {
                                         onSelected: () => Navigation.navigate(ROUTES.IOU_REQUEST),
                                     },
                                 ] : []),
-                                {
-                                    icon: Users,
-                                    text: this.props.translate('sidebarScreen.newGroup'),
-                                    onSelected: () => Navigation.navigate(ROUTES.NEW_GROUP),
-                                },
                                 ...(Permissions.canUseIOU(this.props.betas) ? [
                                     {
                                         icon: Receipt,


### PR DESCRIPTION

### Details
Coming from [here](https://expensify.slack.com/archives/C03U7DCU4/p1624556104314500)

### Fixed Issues
none - just slack

### Tests / QA Steps
1. Hit the big green `+`
1. Make sure the order of menu items is:
    1. New Chat
    1. New Group
    1. Request Money (if applicable)
    1. Split Bill (if applicable)
    1. New Workspace (if applicable)

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots

#### Web
![image](https://user-images.githubusercontent.com/47436092/123308982-34936a00-d4d9-11eb-9d91-2611bfb1647e.png)

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
