### PR TITLE
Add notification preference to simplified report object

### DIFF
--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -171,6 +171,9 @@ function getSimplifiedReportObject(report) {
         ? getChatReportName(report, chatType)
         : report.reportName;
     const lastActorEmail = lodashGet(lastReportAction, 'accountEmail', '');
+    const notificationPreference = isDefaultRoom({chatType})
+        ? lodashGet(report, ['reportNameValuePairs', 'notificationPreferences', currentUserAccountID], 'daily')
+        : '';
 
     return {
         reportID: report.reportID,
@@ -191,6 +194,7 @@ function getSimplifiedReportObject(report) {
         lastMessageText: isLastMessageAttachment ? '[Attachment]' : lastMessageText,
         lastActorEmail,
         hasOutstandingIOU: false,
+        notificationPreference,
     };
 }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
@thienlnam please review

### Details
Just start adding the `notificationPreference` to the `simplifiedReportObject` for a user if they have one set on a default chat room.

### Fixed Issues
For https://github.com/Expensify/Expensify/issues/161781

### Tests
- Added a `notificationPreference` to a report for a user, made sure that the particular preference was shown in the report object in the local storage for the app:
<img width="1327" alt="Screen Shot 2021-06-24 at 2 51 28 PM" src="https://user-images.githubusercontent.com/4741899/123340177-a8953880-d500-11eb-977f-738fda75f8c5.png">

- Checked the local storage for a chat without any preference, made sure it defaulted to daily:
<img width="1325" alt="Screen Shot 2021-06-24 at 2 51 46 PM" src="https://user-images.githubusercontent.com/4741899/123340219-b9de4500-d500-11eb-9b56-6503267164db.png">

- Checked the local storage for a DM, made sure it had nothing under `notificationPreference`
<img width="1325" alt="Screen Shot 2021-06-24 at 2 51 00 PM" src="https://user-images.githubusercontent.com/4741899/123340276-ce224200-d500-11eb-934d-fcd72301e7f0.png">

### QA Steps
- None

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android
