### PR TITLE
Change blocked from concierge prop default to empty object

### DIFF
--- a/src/libs/actions/User.js
+++ b/src/libs/actions/User.js
@@ -77,7 +77,7 @@ function getUserDetails() {
             Onyx.merge(ONYXKEYS.NVP_PAYPAL_ME_ADDRESS, payPalMeAddress);
 
             // Update the blockedFromConcierge NVP
-            const blockedFromConcierge = lodashGet(response, `nameValuePairs.${CONST.NVP.BLOCKED_FROM_CONCIERGE}`, '');
+            const blockedFromConcierge = lodashGet(response, `nameValuePairs.${CONST.NVP.BLOCKED_FROM_CONCIERGE}`, {});
             Onyx.merge(ONYXKEYS.NVP_BLOCKED_FROM_CONCIERGE, blockedFromConcierge);
         });
 }

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -400,7 +400,7 @@ class ReportActionCompose extends React.Component {
         const isConciergeChat = this.props.report.participants
             && this.props.report.participants.includes(CONST.EMAIL.CONCIERGE);
         let isBlockedFromConcierge = false;
-        if (isConciergeChat && this.props.blockedFromConcierge) {
+        if (isConciergeChat && !_.isEmpty(this.props.blockedFromConcierge)) {
             isBlockedFromConcierge = User.isBlockedFromConcierge(this.props.blockedFromConcierge.expiresAt);
         }
 


### PR DESCRIPTION
### Details
Just fixing a mistake from another PR

### Fixed Issues
https://github.com/Expensify/Expensify.cash/pull/2932#issuecomment-867247785

### Tests/QA Steps
1. Log in to e.cash on an account that is not blocked 
2. Go to the concierge chat
3. Check the console and make sure you don't see this error 
```
Invalid prop `blockedFromConcierge` of type `string` supplied to `ReportActionCompose`, expected `object`.
    in ReportActionCompose (at withOnyx.js:154)
    ```