### PR TITLE
Preload locales to fix native crash

### DIFF
--- a/src/libs/DateUtils.js
+++ b/src/libs/DateUtils.js
@@ -1,5 +1,8 @@
-import moment from 'moment';
-import 'moment-timezone';
+import moment from 'moment-timezone';
+
+// IMPORTANT: load any locales (other than english) that might be passed to moment.locale()
+import 'moment/locale/es';
+
 import _ from 'underscore';
 import Onyx from 'react-native-onyx';
 import ONYXKEYS from '../ONYXKEYS';


### PR DESCRIPTION
### Details
I'm not sure why it was only an issue on native, or why it was not reproducible on a dev build, but this seems to fix the crash.

### Fixed Issues
$ https://github.com/Expensify/Expensify.cash/pull/3606

### Tests
1. Run `npm i -g ios-deploy`
1. Plug your phone into your computer (I was testing on a physical device - it may be reproducible on a sim, but I'm not sure).
1. Run `npm run ios --configuration Release --device "Target Device Name"`
1. Go to `Settings` -> `Preferences` and toggle the language picker. The app should not crash and the language should switch in the app.

### QA Steps
Go to `Settings` -> `Preferences` and toggle the language picker. The app should not crash and the language should switch in the app.

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [x] iOS
- [ ] Android

### Screenshots

#### Web
![image](https://user-images.githubusercontent.com/47436092/123350118-30823f00-d50f-11eb-8427-d87d779139c7.png)
![image](https://user-images.githubusercontent.com/47436092/123350159-409a1e80-d50f-11eb-8155-52c68e81613a.png)

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
https://user-images.githubusercontent.com/47436092/123349203-50fdc980-d50e-11eb-806e-10baccfa8c15.MP4

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
