### PR TITLE
Cache node_modules/gems/pods in workflows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,8 +18,15 @@ jobs:
         with:
           ruby-version: '2.7'
 
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+
       - name: Install bundler
-        run: gem install bundler
+        run: |
+          bundle config path vendor/bundle
+          gem install bundler
 
       - name: Install gems
         run: bundle install
@@ -42,6 +49,11 @@ jobs:
 
       - name: Install detox
         run: npm install -g detox-cli
+
+      - uses: actions/cache@v2
+        with:
+          path: ios/Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
 
       - name: Install cocoapods
         uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,6 +24,15 @@ jobs:
       - name: Install gems
         run: bundle install
 
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+
       - name: Install node packages
         uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,17 +12,19 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-              ${{ runner.os }}-node-
-
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
           node-version: '14.x'
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install node packages
         uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb

--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -176,6 +176,11 @@ jobs:
           max_attempts: 5
           command: npm ci
 
+      - uses: actions/cache@v2
+        with:
+          path: ios/Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
+
       - name: Install cocoapods
         run: cd ios && pod install
 

--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -30,6 +30,15 @@ jobs:
       - name: Install gems
         run: bundle install
 
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+
       - name: Install node packages
         uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
         with:
@@ -71,6 +80,15 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '14.x'
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install node packages
         uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
@@ -127,6 +145,15 @@ jobs:
 
       - name: Install gems
         run: bundle install
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install node packages
         uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
@@ -199,6 +226,15 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install node packages
         uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb

--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -24,8 +24,15 @@ jobs:
         with:
           ruby-version: '2.7'
 
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+
       - name: Install bundler
-        run: gem install bundler
+        run: |
+          bundle config path vendor/bundle
+          gem install bundler
 
       - name: Install gems
         run: bundle install
@@ -140,8 +147,15 @@ jobs:
         with:
           ruby-version: '2.7'
 
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+
       - name: Install bundler
-        run: gem install bundler
+        run: |
+          bundle config path vendor/bundle
+          gem install bundler
 
       - name: Install gems
         run: bundle install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,15 @@ jobs:
         with:
           node-version: '14.x'
 
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+
       - name: Install node packages
         uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
         with:

--- a/.github/workflows/validateGithubActions.yml
+++ b/.github/workflows/validateGithubActions.yml
@@ -17,6 +17,15 @@ jobs:
         with:
           node-version: '14.x'
 
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+
       - name: Install node packages
         uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
         with:

--- a/.github/workflows/verifyPodfile.yml
+++ b/.github/workflows/verifyPodfile.yml
@@ -17,6 +17,15 @@ jobs:
         with:
           node-version: '14.x'
 
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+
       - name: Install node packages
         uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
         with:


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Cache `node_modules` in all tasks that install npm packages to speedup workflows

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes #3627 

### Tests / QA Steps
1. Merge this PR
1. Verify that tests happen as they should, but with caching.

### Tested On

n/a – GitHub only.