### PR TITLE
New keyboard shortcut for new Group chat

### DIFF
--- a/src/libs/KeyboardShortcut/index.js
+++ b/src/libs/KeyboardShortcut/index.js
@@ -32,7 +32,7 @@ function bindHandlerToKeyupEvent(event) {
             }
             return true;
         });
-    
+
         // returns true if extra modifiers are pressed
         const pressedExtraModifiers = _.some(extraModifiers, (extraModifier) => {
             if (extraModifier === 'shift' && event.shiftKey) {
@@ -52,7 +52,7 @@ function bindHandlerToKeyupEvent(event) {
         if (!pressedModifiers || pressedExtraModifiers) {
             return;
         }
-    
+
         // If configured to do so, prevent input text control to trigger this event
         if (!callback.captureOnInputs && (
             event.target.nodeName === 'INPUT'
@@ -61,7 +61,7 @@ function bindHandlerToKeyupEvent(event) {
         )) {
             return;
         }
-    
+
         if (_.isFunction(callback.callback)) {
             callback.callback(event);
         }

--- a/src/libs/KeyboardShortcut/index.js
+++ b/src/libs/KeyboardShortcut/index.js
@@ -15,9 +15,8 @@ function bindHandlerToKeyupEvent(event) {
 
     // Loop over all the callbacks
     eventCallbacks.forEach((callback) => {
-        let extraModifiers = ['shift', 'control', 'alt', 'meta'];
+        const extraModifiers = _.difference(['shift', 'control', 'alt', 'meta'], callback.modifiers);
         const pressedModifiers = _.all(callback.modifiers, (modifier) => {
-            extraModifiers = _.without(extraModifiers, modifier);
             if (modifier === 'shift' && !event.shiftKey) {
                 return false;
             }

--- a/src/libs/KeyboardShortcut/index.js
+++ b/src/libs/KeyboardShortcut/index.js
@@ -15,7 +15,6 @@ function bindHandlerToKeyupEvent(event) {
 
     // Loop over all the callbacks
     eventCallbacks.forEach((callback) => {
-        const extraModifiers = _.difference(['shift', 'control', 'alt', 'meta'], callback.modifiers);
         const pressedModifiers = _.all(callback.modifiers, (modifier) => {
             if (modifier === 'shift' && !event.shiftKey) {
                 return false;
@@ -31,6 +30,8 @@ function bindHandlerToKeyupEvent(event) {
             }
             return true;
         });
+
+        const extraModifiers = _.difference(['shift', 'control', 'alt', 'meta'], callback.modifiers);
 
         // returns true if extra modifiers are pressed
         const pressedExtraModifiers = _.some(extraModifiers, (extraModifier) => {

--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -31,6 +31,7 @@ import {getPolicySummaries, getPolicyList} from '../../actions/Policy';
 import modalCardStyleInterpolator from './modalCardStyleInterpolator';
 import createCustomModalStackNavigator from './createCustomModalStackNavigator';
 import Permissions from '../../Permissions';
+import getOperatingSystem from '../../getOperatingSystem';
 
 // Main drawer navigator
 import MainDrawerNavigator from './MainDrawerNavigator';
@@ -155,10 +156,24 @@ class AuthScreens extends React.Component {
 
         Timing.end(CONST.TIMING.HOMEPAGE_INITIAL_RENDER);
 
-        // Listen for the Command+K key being pressed so the focus can be given to the chat switcher
-        KeyboardShortcut.subscribe('K', () => {
-            Navigation.navigate(ROUTES.SEARCH);
-        }, ['meta'], true);
+        // Listen for the key K being pressed so that focus can be given to
+        // the chat switcher, or new group chat
+        // based on the key modifiers pressed and the operating system
+        if (getOperatingSystem() === CONST.OS.MAC_OS) {
+            KeyboardShortcut.subscribe('K', () => {
+                Navigation.navigate(ROUTES.SEARCH);
+            }, ['meta'], true);
+            KeyboardShortcut.subscribe('K', () => {
+                Navigation.navigate(ROUTES.NEW_GROUP);
+            }, ['meta', 'shift'], true);
+        } else {
+            KeyboardShortcut.subscribe('K', () => {
+                Navigation.navigate(ROUTES.SEARCH);
+            }, ['control'], true);
+            KeyboardShortcut.subscribe('K', () => {
+                Navigation.navigate(ROUTES.NEW_GROUP);
+            }, ['control', 'shift'], true);
+        }
     }
 
     shouldComponentUpdate(nextProps) {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
cc @Beamanator 
## Details
OS specific shortcut using `libs/getOperatingSystem`
To open new group chat.
`Command + shift + K` for MacOS
`Control + shift + K` for Windows/Linux.

#### To not allow extra key modifiers being pressed
`const extraModifiers = _.difference(['shift', 'control', 'alt', 'meta'], callback.modifiers);`
And then return early if they're being pressed.

#### Subscribe K to open new group chat.

On subscribing the key K
```
KeyboardShortcut.subscribe('K', () => {
    Navigation.navigate(ROUTES.NEW_GROUP);
}, ['control', 'shift'], true);
```

Contains of [eventCallbacks](https://github.com/Expensify/Expensify.cash/blob/fffa33b5b2a21cea2180d441b73672d3e5bcdbe8/src/libs/KeyboardShortcut/index.js#L15) are shown below. Which is why I loop over it.

![image](https://user-images.githubusercontent.com/29673073/123421387-6eda3580-d5c5-11eb-823b-917b4572f586.png)

I also changed shortcut for search on Windows, 
from `Win + K` to `Control + K` as per the discussion on Slack.

## Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ #3349 
## Tests / QA
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

1. Login
2. - On Windows/ Linux, press `Cltr + Shift + K` to give focus to new group chat.
    - On MacOS, press `Command + Shift + K` to give focus to new group chat.

## Tested On
Don't have a Mac to test Desktop app. 
- [x] Web Windows
- [ ]  Web MacOS
- [ ] Desktop

 Not applicable (Mobile Web, iOS, Android)
### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

https://user-images.githubusercontent.com/29673073/123422380-caf18980-d5c6-11eb-8d13-a51ac4dd6fbc.mp4


#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
Don't have a mac :)