### PR TITLE
Set default value for requestorAddressState in RequestorStep form

### DIFF
--- a/src/pages/ReimbursementAccount/RequestorStep.js
+++ b/src/pages/ReimbursementAccount/RequestorStep.js
@@ -28,7 +28,7 @@ class RequestorStep extends React.Component {
             lastName: lodashGet(props, ['achData', 'lastName'], ''),
             requestorAddressStreet: lodashGet(props, ['achData', 'requestorAddressStreet'], ''),
             requestorAddressCity: lodashGet(props, ['achData', 'requestorAddressCity'], ''),
-            requestorAddressState: lodashGet(props, ['achData', 'requestorAddressState'], ''),
+            requestorAddressState: lodashGet(props, ['achData', 'requestorAddressState']) || 'AK',
             requestorAddressZipCode: lodashGet(props, ['achData', 'requestorAddressZipCode'], ''),
             dob: lodashGet(props, ['achData', 'dob'], ''),
             ssnLast4: lodashGet(props, ['achData', 'ssnLast4'], ''),


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Set the default state if a user does not alter the state picker on the RequestStep form. Otherwise, they will be blocked from proceeding in the VBA setup flow with an error: `402 Missing requestorAddressState in additionalData`

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ https://github.com/Expensify/Expensify/issues/168661

### Tests
1. Navigate to `/bank-account/new`
2. Follow the instructions [here](https://stackoverflow.com/c/expensify/questions/342/525#525) to set up an open bank account
3. Once on the requestor information form, fill out all the details except for the state, leave this to the default value `AK`

![Screen Shot 2021-06-28 at 4 28 46 PM](https://user-images.githubusercontent.com/12268372/123636556-1194ed00-d82e-11eb-8076-8fb896485483.png)

4. Verify that you can proceed to the next step (i.e. Beneficial Owners) in the flow

![Screen Shot 2021-06-28 at 4 30 05 PM](https://user-images.githubusercontent.com/12268372/123636611-21accc80-d82e-11eb-92e0-d389c364885a.png)

### QA Steps
No QA

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
