### PR TITLE
Update logic to account for middle names

### DIFF
--- a/src/pages/RequestCallPage.js
+++ b/src/pages/RequestCallPage.js
@@ -45,21 +45,20 @@ const propTypes = {
 class RequestCallPage extends Component {
     constructor(props) {
         super(props);
-
-        // The displayName defaults to the user's login if they haven't set a first and last name,
-        // which we can't use to prefill the input fields
-        const [firstName, lastName] = props.myPersonalDetails.displayName !== props.myPersonalDetails.login
-            ? props.myPersonalDetails.displayName.split(' ')
-            : [];
+        const {firstName, lastName} = this.getFirstAndLastName(
+            props.myPersonalDetails.login,
+            props.myPersonalDetails.displayName,
+        );
         this.state = {
-            firstName: firstName ?? '',
-            lastName: lastName ?? '',
+            firstName,
+            lastName,
             phoneNumber: this.getPhoneNumber(props.user.loginList) ?? '',
             isLoading: false,
         };
 
         this.onSubmit = this.onSubmit.bind(this);
         this.getPhoneNumber = this.getPhoneNumber.bind(this);
+        this.getFirstAndLastName = this.getFirstAndLastName.bind(this);
     }
 
     onSubmit() {
@@ -94,6 +93,28 @@ class RequestCallPage extends Component {
     getPhoneNumber(loginList) {
         const secondaryLogin = _.find(loginList, login => Str.isSMSLogin(login.partnerUserID));
         return secondaryLogin ? Str.removeSMSDomain(secondaryLogin.partnerUserID) : null;
+    }
+
+    /**
+     * Gets the first and last name from the displayName.
+     * If the login is the same as the displayName, then they don't exist,
+     * so we return empty strings instead.
+     * @param {String} login
+     * @param {String} displayName
+     *
+     * @returns {Object}
+     */
+    getFirstAndLastName(login, displayName) {
+        if (login === displayName) {
+            return {firstName: '', lastName: ''};
+        }
+
+        const firstSpaceIndex = displayName.indexOf(' ');
+        const lastSpaceIndex = displayName.lastIndexOf(' ');
+        return {
+            firstName: displayName.substring(0, firstSpaceIndex),
+            lastName: displayName.substring(lastSpaceIndex),
+        };
     }
 
     render() {

--- a/src/pages/RequestCallPage.js
+++ b/src/pages/RequestCallPage.js
@@ -102,16 +102,26 @@ class RequestCallPage extends Component {
      * @returns {Object}
      */
     getFirstAndLastName({login, displayName}) {
+        let firstName;
+        let lastName;
+
         if (login === displayName) {
-            return {firstName: '', lastName: ''};
+            firstName = '';
+            lastName = '';
+        } else {
+            const firstSpaceIndex = displayName.indexOf(' ');
+            const lastSpaceIndex = displayName.lastIndexOf(' ');
+
+            if (firstSpaceIndex === -1) {
+                firstName = displayName;
+                lastName = '';
+            } else {
+                firstName = displayName.substring(0, firstSpaceIndex);
+                lastName = displayName.substring(lastSpaceIndex);
+            }
         }
 
-        const firstSpaceIndex = displayName.indexOf(' ');
-        const lastSpaceIndex = displayName.lastIndexOf(' ');
-        return {
-            firstName: displayName.substring(0, firstSpaceIndex),
-            lastName: firstSpaceIndex !== lastSpaceIndex ? displayName.substring(lastSpaceIndex) : '',
-        };
+        return {firstName, lastName};
     }
 
     render() {

--- a/src/pages/RequestCallPage.js
+++ b/src/pages/RequestCallPage.js
@@ -113,7 +113,7 @@ class RequestCallPage extends Component {
         const lastSpaceIndex = displayName.lastIndexOf(' ');
         return {
             firstName: displayName.substring(0, firstSpaceIndex),
-            lastName: displayName.substring(lastSpaceIndex),
+            lastName: firstSpaceIndex !== lastSpaceIndex ? displayName.substring(lastSpaceIndex) : '',
         };
     }
 

--- a/src/pages/RequestCallPage.js
+++ b/src/pages/RequestCallPage.js
@@ -45,10 +45,7 @@ const propTypes = {
 class RequestCallPage extends Component {
     constructor(props) {
         super(props);
-        const {firstName, lastName} = this.getFirstAndLastName(
-            props.myPersonalDetails.login,
-            props.myPersonalDetails.displayName,
-        );
+        const {firstName, lastName} = this.getFirstAndLastName(props.myPersonalDetails);
         this.state = {
             firstName,
             lastName,
@@ -96,7 +93,7 @@ class RequestCallPage extends Component {
     }
 
     /**
-     * Gets the first and last name from the displayName.
+     * Gets the first and last name from the user's personal details.
      * If the login is the same as the displayName, then they don't exist,
      * so we return empty strings instead.
      * @param {String} login
@@ -104,7 +101,7 @@ class RequestCallPage extends Component {
      *
      * @returns {Object}
      */
-    getFirstAndLastName(login, displayName) {
+    getFirstAndLastName({login, displayName}) {
         if (login === displayName) {
             return {firstName: '', lastName: ''};
         }


### PR DESCRIPTION
### Details
The logic in the `RequestCallPage` was assuming that a user's display name would only include their first and last names, and wasn't accounting for names that were longer than 2 words. This PR fixes it to take the first and last names correctly, even for names that are longer than 2 words.

### Fixed Issues
N/A (see screenshot for the issue)
<img width="432" alt="Screen Shot 2021-06-28 at 8 59 09 PM" src="https://user-images.githubusercontent.com/31285285/123640387-b118a680-d853-11eb-89a1-4ceb64d1428d.png">



### Tests
1. Set a display name for yourself that's more than just two words.
2. Navigate to the request call page.
3. Verify that the last name form is prefilled correctly.

### QA Steps
1. Sign into vanniac27@pyjgoingtd.com with the password asdfASDF00.
2. Navigate to the chat with Concierge. Click the call button.
3. Verify that the first name input is auto-filled with "Name1", and the last name input is auto-filled with "Name3".

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
