### PR TITLE
Allow those in defaultRooms beta to also load policies

### DIFF
--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -136,7 +136,7 @@ class AuthScreens extends React.Component {
         fetchCountryCodeByRequestIP();
         UnreadIndicatorUpdater.listenForReportChanges();
 
-        if (Permissions.canUseFreePlan(this.props.betas)) {
+        if (Permissions.canUseFreePlan(this.props.betas) || Permissions.canUseDefaultRooms(this.props.betas)) {
             getPolicySummaries();
             getPolicyList();
         }

--- a/src/libs/Permissions.js
+++ b/src/libs/Permissions.js
@@ -32,7 +32,7 @@ function canUseIOU(betas) {
  * @returns {Boolean}
  */
 function canUsePayWithExpensify(betas) {
-    return _.contains(betas, CONST.BETAS.PAY_WITH_EXPENSIFY) || canUseAllBetas();
+    return _.contains(betas, CONST.BETAS.PAY_WITH_EXPENSIFY) || canUseAllBetas(betas);
 }
 
 /**
@@ -40,7 +40,7 @@ function canUsePayWithExpensify(betas) {
  * @returns {Boolean}
  */
 function canUseFreePlan(betas) {
-    return _.contains(betas, CONST.BETAS.FREE_PLAN) || canUseAllBetas();
+    return _.contains(betas, CONST.BETAS.FREE_PLAN) || canUseAllBetas(betas);
 }
 
 /**
@@ -48,7 +48,7 @@ function canUseFreePlan(betas) {
  * @returns {Boolean}
  */
 function canUseDefaultRooms(betas) {
-    return _.contains(betas, CONST.BETAS.DEFAULT_ROOMS) || canUseAllBetas();
+    return _.contains(betas, CONST.BETAS.DEFAULT_ROOMS) || canUseAllBetas(betas);
 }
 
 export default {


### PR DESCRIPTION
@Jag96, please review when you get the chance
CC: @marcaaron, @yuwenmemon 

### Details
We recently restricted loading policy data to those in the freePlan beta, but this is also necessary for defaultRooms so let's let both users access this. 

ALSO, we aren't looking for the `all` flag in some of the newer betas, so this fixes that too. This will allow expensifail (including applause) accounts to access all betas as intended in ecash.

### Fixed Issues
related to https://github.com/Expensify/Expensify/issues/161777

### Tests
This isn't something you can really test locally without manually editing the beta code anyway. This will be really quick to test in staging/prod.


### QA Steps
This needs to be tested internally (reach out to @TomatoToaster or amal@expensify.com on ecash and he can do it quickly).
1. On your expensifail account verify that you can see policies load in Application -> Local Stoarage
2. Do the same for your expensify account and verify that the defaultRooms don't say `Unknown Policy`, but actually have the right policy name on them (see screenshots).

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
GOOD:
![image](https://user-images.githubusercontent.com/19364431/123690899-f40e5600-d822-11eb-9754-6efc65b9c17f.png)


BAD:
![image](https://user-images.githubusercontent.com/19364431/123690872-ece74800-d822-11eb-864c-47743d81700b.png)

