### PR TITLE
Fix isDisabled check for the payments button

### DIFF
--- a/src/pages/settings/PaymentsPage.js
+++ b/src/pages/settings/PaymentsPage.js
@@ -92,7 +92,7 @@ class PaymentsPage extends React.Component {
                     <FixedFooter>
                         <Button
                             success
-                            isDisabled={this.props.payPalMeUsername}
+                            isDisabled={Boolean(this.props.payPalMeUsername)}
                             onPress={this.setPayPalMeUsername}
                             style={[styles.mt3]}
                             text={this.props.translate('paymentsPage.addPayPalAccount')}

--- a/src/pages/settings/PaymentsPage.js
+++ b/src/pages/settings/PaymentsPage.js
@@ -92,7 +92,7 @@ class PaymentsPage extends React.Component {
                     <FixedFooter>
                         <Button
                             success
-                            isDisabled={!this.state.payPalMeUsername}
+                            isDisabled={this.props.payPalMeUsername}
                             onPress={this.setPayPalMeUsername}
                             style={[styles.mt3]}
                             text={this.props.translate('paymentsPage.addPayPalAccount')}


### PR DESCRIPTION
### Details
See linked issue

### Fixed Issues
$ https://github.com/Expensify/Expensify.cash/issues/3609

### Tests/QA
1. Sign into an account. Navigate to the payments page `<baseURL>/settings/payments`
2. Set a Paypal username.
3. Verify that the button is disabled once you've set one, and the input isn't editable
4. Sign into the same account but on a different client and navigate to the payments page. Verify that the payment button is disabled and the input isn't editable.

### Tested On

- [x] Web
- [ ] Mobile Web
- [x] Desktop
- [x] iOS
- [ ] Android

### Screenshots
#### Desktop
https://user-images.githubusercontent.com/31285285/123745184-79a50b00-d8e2-11eb-9820-9ddbec6f4916.mp4

#### iOS
https://user-images.githubusercontent.com/31285285/123745197-7dd12880-d8e2-11eb-9e2c-ba707587ad63.mp4

#### Web
https://user-images.githubusercontent.com/31285285/123745200-7e69bf00-d8e2-11eb-9956-9504f7cd7fc6.mp4

