### PR TITLE
[No QA] Use regular function instead of arrow function

### DIFF
--- a/src/components/PressableWithSecondaryInteraction/index.js
+++ b/src/components/PressableWithSecondaryInteraction/index.js
@@ -15,6 +15,7 @@ class PressableWithSecondaryInteraction extends Component {
         super(props);
 
         this.executeSecondaryInteractionOnContextMenu = this.executeSecondaryInteractionOnContextMenu.bind(this);
+        this.preventDefault = this.preventDefault.bind(this);
     }
 
     componentDidMount() {
@@ -34,7 +35,7 @@ class PressableWithSecondaryInteraction extends Component {
      * @param {touchstart} e - TouchEvent.
      * https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent
      */
-    preventDefault = (e) => {
+    preventDefault(e) {
         e.preventDefault();
     }
 


### PR DESCRIPTION

### Details
Following-up on https://github.com/Expensify/Expensify.cash/pull/3659. I didn't notice that that PR used an arrow function as a class member, which is something we don't do anywhere else in our codebase. This cleans it up to follow the standard pattern.

### Fixed Issues
n/a

### Tests
None.

### QA Steps
None.