### PR TITLE
Fixed delete action on context menu

### DIFF
--- a/src/pages/home/report/ReportActionContextMenu.js
+++ b/src/pages/home/report/ReportActionContextMenu.js
@@ -44,7 +44,7 @@ const propTypes = {
     hidePopover: PropTypes.func.isRequired,
 
     /** Function to show the delete Action confirmation modal */
-    showDeleteModal: PropTypes.func.isRequired,
+    showDeleteConfirmModal: PropTypes.func.isRequired,
 
     ...withLocalizePropTypes,
 };
@@ -137,11 +137,11 @@ class ReportActionContextMenu extends React.Component {
                 shouldShow: () => canDeleteReportAction(this.props.reportAction),
                 onPress: () => {
                     if (this.props.isMini) {
-                        // No popover to hide, call showDeleteModal immediately
-                        this.props.showDeleteModal();
+                        // No popover to hide, call showDeleteConfirmModal immediately
+                        this.props.showDeleteConfirmModal();
                     } else {
-                        // Hide popover, then call showDeleteModal
-                        this.hidePopover(false, this.props.showDeleteModal);
+                        // Hide popover, then call showDeleteConfirmModal
+                        this.hidePopover(false, this.props.showDeleteConfirmModal);
                     }
                 },
             },

--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -91,7 +91,7 @@ class ReportActionItem extends Component {
         this.measureContextMenuAnchorPosition = this.measureContextMenuAnchorPosition.bind(this);
         this.confirmDeleteAndHideModal = this.confirmDeleteAndHideModal.bind(this);
         this.hideDeleteConfirmModal = this.hideDeleteConfirmModal.bind(this);
-        this.showDeleteModal = this.showDeleteModal.bind(this);
+        this.showDeleteConfirmModal = this.showDeleteConfirmModal.bind(this);
     }
 
     componentDidMount() {
@@ -192,7 +192,6 @@ class ReportActionItem extends Component {
      * @param {Function} onHideCallback Callback to be called after popover is completely hidden
      */
     hidePopover(onHideCallback) {
-        console.debug(onHideCallback);
         if (_.isFunction(onHideCallback)) {
             this.onPopoverHide = onHideCallback;
         }
@@ -213,7 +212,7 @@ class ReportActionItem extends Component {
                 reportID={this.props.reportID}
                 reportAction={this.props.action}
                 hidePopover={this.hidePopover}
-                showDeleteModal={this.showDeleteModal}
+                showDeleteConfirmModal={this.showDeleteConfirmModal}
             />
         );
     }
@@ -232,7 +231,7 @@ class ReportActionItem extends Component {
      *
      * @memberof ReportActionItem
      */
-    showDeleteModal() {
+    showDeleteConfirmModal() {
         this.setState({isDeleteCommentConfirmModalVisible: true});
     }
 
@@ -302,7 +301,7 @@ class ReportActionItem extends Component {
                                         draftMessage={this.props.draftMessage}
                                         hidePopover={this.hidePopover}
                                         isMini
-                                        showDeleteModal={this.showDeleteModal}
+                                        showDeleteConfirmModal={this.showDeleteConfirmModal}
                                     />
                                 </View>
                             </View>
@@ -326,7 +325,7 @@ class ReportActionItem extends Component {
                         reportAction={this.props.action}
                         draftMessage={this.props.draftMessage}
                         hidePopover={this.hidePopover}
-                        showDeleteModal={this.showDeleteModal}
+                        showDeleteConfirmModal={this.showDeleteConfirmModal}
                     />
                 </PopoverWithMeasuredContent>
                 <ConfirmModal


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Moving the ConfrimModal up the component tree so that it does not close with the Context Menu itself.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ Fixes #3767

### Tests |  QA Steps
1. Open any conversation on E.cash.
2. Now send a message.
3. Wait for the Delete action to become active.
4. Try to delete the message from the Hover menu, the message should be deleted.
5. Send another message.
6. Wait for the delete action to become active.
7. Try to delete the message from the Context Menu, the message should be deleted.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

https://user-images.githubusercontent.com/24370807/123986172-b573c980-d9e3-11eb-8879-a9a864fe5bf1.mp4


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

https://user-images.githubusercontent.com/24370807/123986194-ba387d80-d9e3-11eb-8c23-b38dac415ea2.mp4


#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

https://user-images.githubusercontent.com/24370807/124058311-c43f9800-da46-11eb-92e2-90c239ae515c.mp4


#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->

https://user-images.githubusercontent.com/24370807/123986255-c6bcd600-d9e3-11eb-8199-7d27b22f8971.mp4

