### PR TITLE
#2973 set input height to 42

### DIFF
--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -260,7 +260,7 @@ const styles = {
             borderWidth: 1,
             borderColor: themeColors.border,
             color: themeColors.text,
-            height: variables.componentSizeNormal,
+            height: variables.inputComponentSizeNormal,
             opacity: 1,
         },
         inputWeb: {
@@ -275,7 +275,7 @@ const styles = {
             borderColor: themeColors.border,
             color: themeColors.text,
             appearance: 'none',
-            height: variables.componentSizeNormal,
+            height: variables.inputComponentSizeNormal,
             opacity: 1,
             cursor: 'pointer',
         },
@@ -290,7 +290,7 @@ const styles = {
             borderRadius: variables.componentBorderRadius,
             borderColor: themeColors.border,
             color: themeColors.text,
-            height: variables.componentSizeNormal,
+            height: variables.inputComponentSizeNormal,
             opacity: 1,
         },
         iconContainer: {
@@ -382,7 +382,7 @@ const styles = {
     textInput: {
         backgroundColor: themeColors.componentBG,
         borderRadius: variables.componentBorderRadiusNormal,
-        height: variables.componentSizeNormal,
+        height: variables.inputComponentSizeNormal,
         borderColor: themeColors.border,
         borderWidth: 1,
         color: themeColors.text,

--- a/src/styles/variables.js
+++ b/src/styles/variables.js
@@ -2,6 +2,7 @@ export default {
     contentHeaderHeight: 65,
     componentSizeSmall: 28,
     componentSizeNormal: 40,
+    inputComponentSizeNormal: 42,
     componentSizeLarge: 52,
     componentBorderRadius: 8,
     componentBorderRadiusSmall: 4,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Creates a new variable for input height and applies it to `TextInput` and `Picker` components.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ #2973 

### Tests / QA Steps
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

#### iOS
Preferred iOS version is <13, ideally to validate that the issue is fixed you need a device or an emulator where the issue described in the original issue #2973 is reproduced. iOS 12.4 + iPhone 8 is what I used.
1. Find any single-line non-password text input in the app (email field on login page or name fields in profile settings)
2. Type a value that doesn't fit the width of the input
3. Verify that, as you are typing, the text input's horizontal scroll is adjusted to show the last character, if needed

#### All platforms
1. Logout
2. Make sure there are no visual defects caused by increased text input size on login form text inputs
3. Login
4. Select any chat
5. Check for visual defects on message compose box
6. Click the search icon (on mobile you need to tap the back icon)
7. Check for visual defects on search text input
8. Tap your profile icon
9. Check for visual defects on text input and picker elements under Profile and Preferences sub menus

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
<img width="921" alt="Screen Shot 2021-06-29 at 22 29 00" src="https://user-images.githubusercontent.com/64093836/123858511-47b89680-d92c-11eb-95a3-cf64e4116f39.png">

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
<img width="420" alt="Screen Shot 2021-06-29 at 22 34 46" src="https://user-images.githubusercontent.com/64093836/123858591-5b63fd00-d92c-11eb-80e1-8ae15de08e55.png">

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
<img width="921" alt="Screen Shot 2021-06-29 at 22 34 46" src="https://user-images.githubusercontent.com/64093836/123858610-63bc3800-d92c-11eb-9af1-785fefaa778b.png">

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

https://user-images.githubusercontent.com/64093836/123858596-5f901a80-d92c-11eb-9fa3-10d27f74405e.mp4


#### Android
<!-- Insert screenshots of your changes on the Android platform-->
<img width="420" alt="Screen Shot 2021-06-29 at 22 34 46" src="https://user-images.githubusercontent.com/64093836/123861344-bb0fd780-d92f-11eb-81bc-b40c4cf4c508.png">
