### PR TITLE
Revert suppression of touchstart to fix regressions

### DIFF
--- a/src/components/PressableWithSecondaryInteraction/index.js
+++ b/src/components/PressableWithSecondaryInteraction/index.js
@@ -15,7 +15,6 @@ class PressableWithSecondaryInteraction extends Component {
         super(props);
 
         this.executeSecondaryInteractionOnContextMenu = this.executeSecondaryInteractionOnContextMenu.bind(this);
-        this.preventDefault = this.preventDefault.bind(this);
     }
 
     componentDidMount() {
@@ -23,20 +22,10 @@ class PressableWithSecondaryInteraction extends Component {
             this.props.forwardedRef(this.pressableRef);
         }
         this.pressableRef.addEventListener('contextmenu', this.executeSecondaryInteractionOnContextMenu);
-        this.pressableRef.addEventListener('touchstart', this.preventDefault);
     }
 
     componentWillUnmount() {
         this.pressableRef.removeEventListener('contextmenu', this.executeSecondaryInteractionOnContextMenu);
-        this.pressableRef.removeEventListener('touchstart', this.preventDefault);
-    }
-
-    /**
-     * @param {touchstart} e - TouchEvent.
-     * https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent
-     */
-    preventDefault(e) {
-        e.preventDefault();
     }
 
     /**


### PR DESCRIPTION
### Details
Partially reverts https://github.com/Expensify/Expensify.cash/pull/3659/files, particularly [this commit](https://github.com/Expensify/Expensify.cash/commit/a1f2c94cec417a14fac29c2327cac5928cee3196) to fix two major regressions (my fault for not noticing during my testing).

### Fixed Issues
$ https://github.com/Expensify/Expensify.cash/issues/3806

### Tests / QA Steps
1. Verify that you can scroll through a chat on mobile web.
1. Verify that you can open the "edit chat" input, then close it too.

### Tested On

- [x] Web
- [x] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
#### Web
![image](https://user-images.githubusercontent.com/47436092/123882351-7c602a00-d8fb-11eb-8fd4-fbda533b8564.png)

#### Mobile Web
![image](https://user-images.githubusercontent.com/47436092/123882506-c34e1f80-d8fb-11eb-9ba1-91ba986cab93.png)

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
