### PR TITLE
Auto open keyboard on Password and Payment pages

### DIFF
--- a/src/pages/settings/PasswordPage.js
+++ b/src/pages/settings/PasswordPage.js
@@ -52,6 +52,7 @@ class PasswordPage extends Component {
         };
 
         this.handleChangePassword = this.handleChangePassword.bind(this);
+        this.currentPasswordInputRef = null;
     }
 
     componentWillUnmount() {
@@ -69,7 +70,12 @@ class PasswordPage extends Component {
 
     render() {
         return (
-            <ScreenWrapper>
+            <ScreenWrapper onTransitionEnd={() => {
+                if (this.currentPasswordInputRef) {
+                    this.currentPasswordInputRef.focus();
+                }
+            }}
+            >
                 <KeyboardAvoidingView>
                     <HeaderWithCloseButton
                         title={this.props.translate('passwordPage.changePassword')}
@@ -86,12 +92,14 @@ class PasswordPage extends Component {
                                 {`${this.props.translate('passwordPage.currentPassword')}*`}
                             </Text>
                             <TextInput
+                                ref={el => this.currentPasswordInputRef = el}
                                 secureTextEntry
                                 autoCompleteType="password"
                                 textContentType="password"
                                 style={styles.textInput}
                                 value={this.state.currentPassword}
                                 onChangeText={currentPassword => this.setState({currentPassword})}
+                                returnKeyType="done"
                             />
                         </View>
                         <View style={styles.mb6}>

--- a/src/pages/settings/PaymentsPage.js
+++ b/src/pages/settings/PaymentsPage.js
@@ -38,6 +38,7 @@ class PaymentsPage extends React.Component {
             payPalMeUsername: props.payPalMeUsername,
         };
         this.setPayPalMeUsername = this.setPayPalMeUsername.bind(this);
+        this.paypalUsernameInputRef = null;
     }
 
     componentDidMount() {
@@ -62,7 +63,12 @@ class PaymentsPage extends React.Component {
 
     render() {
         return (
-            <ScreenWrapper>
+            <ScreenWrapper onTransitionEnd={() => {
+                if (this.paypalUsernameInputRef) {
+                    this.paypalUsernameInputRef.focus();
+                }
+            }}
+            >
                 <KeyboardAvoidingView>
                     <HeaderWithCloseButton
                         title={this.props.translate('common.payments')}
@@ -79,6 +85,7 @@ class PaymentsPage extends React.Component {
                                 {this.props.translate('paymentsPage.payPalMe')}
                             </Text>
                             <TextInput
+                                ref={el => this.paypalUsernameInputRef = el}
                                 autoCompleteType="off"
                                 autoCorrect={false}
                                 style={[styles.textInput]}
@@ -86,6 +93,7 @@ class PaymentsPage extends React.Component {
                                 placeholder={this.props.translate('paymentsPage.yourPayPalUsername')}
                                 onChangeText={text => this.setState({payPalMeUsername: text})}
                                 editable={!this.props.payPalMeUsername}
+                                returnKeyType="done"
                             />
                         </View>
                     </View>


### PR DESCRIPTION
cc @chiragsalian 

### Fixed Issues
$ https://github.com/Expensify/Expensify.cash/issues/3386

### Tests
1. Open the app and login.
2. Go to `Settings > Profile > Add Phone Number`
3. Verify that the keyboard opens automatically.
4. Repeat step 3 in `Settings > Change Password` and `Settings > Payments`

### QA Steps
1. Open the app and login.
2. Go to `Settings > Profile > Add Phone Number`
3. Verify that the keyboard opens automatically.
4. Repeat step 3 in `Settings > Change Password` and `Settings > Payments`

### Tested On

- [ ] Web
- [X] Mobile Web
- [ ] Desktop
- [X] iOS
- [X] Android

### Screenshots

#### Mobile Web

https://user-images.githubusercontent.com/22219519/124017558-167bad00-d9a4-11eb-96ae-b13ba22d6f8e.mov

#### iOS

https://user-images.githubusercontent.com/22219519/124017581-1e3b5180-d9a4-11eb-9206-71f329250b22.mov

#### Android

https://user-images.githubusercontent.com/22219519/124017748-517de080-d9a4-11eb-9a33-6b5fb290543a.mov


