### PR TITLE
Start including betas in the call to getSidebarOptions

### DIFF
--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -551,9 +551,17 @@ function getNewGroupOptions(
  * @param {Object} draftComments
  * @param {Number} activeReportID
  * @param {String} priorityMode
+ * @param {Array<String>} betas
  * @returns {Object}
  */
-function getSidebarOptions(reports, personalDetails, draftComments, activeReportID, priorityMode) {
+function getSidebarOptions(
+    reports,
+    personalDetails,
+    draftComments,
+    activeReportID,
+    priorityMode,
+    betas,
+) {
     let sideBarOptions = {
         prioritizePinnedReports: true,
     };
@@ -565,6 +573,7 @@ function getSidebarOptions(reports, personalDetails, draftComments, activeReport
     }
 
     return getOptions(reports, personalDetails, draftComments, activeReportID, {
+        betas,
         includeRecentReports: true,
         includeMultipleParticipantReports: true,
         maxRecentReportsToShow: 0, // Unlimited

--- a/src/pages/home/sidebar/SidebarLinks.js
+++ b/src/pages/home/sidebar/SidebarLinks.js
@@ -112,6 +112,7 @@ class SidebarLinks extends React.Component {
             this.props.draftComments,
             activeReportID,
             this.props.priorityMode,
+            this.props.betas,
         );
 
         const sections = [{
@@ -217,6 +218,9 @@ export default compose(
         },
         isSyncingData: {
             key: ONYXKEYS.IS_LOADING_AFTER_RECONNECT,
+        },
+        betas: {
+            key: ONYXKEYS.BETAS,
         },
     }),
 )(SidebarLinks);


### PR DESCRIPTION
@TomatoToaster please review

### Details
This fixes the issue of the `#admins` rooms not showing up in the LHN. It's because the `betas` param was not being passed to `getSidebarOptions`. Thus, it was mistakenly assumed that we were not on the beta.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
- N/A just noticed in the public testing of the default rooms.

### Tests
- Send a message in a default room (#admins or #announce), make sure that the default room shows up in the LHN:
<img width="548" alt="Screen Shot 2021-06-30 at 1 37 49 PM" src="https://user-images.githubusercontent.com/4741899/124029154-aff98d80-d9a9-11eb-8d98-f4ec6384248b.png">
