### PR TITLE
Update the height of Edit profile button

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -12,6 +12,9 @@ const propTypes = {
     /** The text for the button label */
     text: PropTypes.string,
 
+    /** Small sized button */
+    small: PropTypes.bool,
+
     /** Large sized button */
     large: PropTypes.bool,
 
@@ -53,6 +56,7 @@ const defaultProps = {
     text: '',
     isLoading: false,
     isDisabled: false,
+    small: false,
     large: false,
     onPress: () => {},
     style: [],
@@ -81,6 +85,7 @@ const Button = (props) => {
                     selectable={false}
                     style={[
                         styles.buttonText,
+                        props.small && styles.buttonSmallText,
                         props.large && styles.buttonLargeText,
                         props.success && styles.buttonSuccessText,
                         props.danger && styles.buttonDangerText,
@@ -105,6 +110,7 @@ const Button = (props) => {
                     shouldDim={pressed}
                     style={[
                         styles.button,
+                        props.small ? styles.buttonSmall : undefined,
                         props.large ? styles.buttonLarge : undefined,
                         props.success ? styles.buttonSuccess : undefined,
                         props.danger ? styles.buttonDanger : undefined,

--- a/src/pages/settings/Profile/ProfilePage.js
+++ b/src/pages/settings/Profile/ProfilePage.js
@@ -279,6 +279,7 @@ class ProfilePage extends Component {
                             {({openPicker}) => (
                                 <>
                                     <Button
+                                        small
                                         style={[styles.alignSelfCenter, styles.mt3]}
                                         onPress={() => this.setState({isEditPhotoMenuVisible: true})}
                                         ContentComponent={() => (

--- a/src/pages/settings/Profile/ProfilePage.js
+++ b/src/pages/settings/Profile/ProfilePage.js
@@ -286,7 +286,13 @@ class ProfilePage extends Component {
                                             <View style={[styles.flexRow]}>
                                                 <Icon src={DownArrow} />
                                                 <View style={styles.justifyContentCenter}>
-                                                    <Text style={[styles.headerText, styles.ml2]}>
+                                                    <Text
+                                                        style={[
+                                                            styles.headerText,
+                                                            styles.buttonSmallText,
+                                                            styles.ml2,
+                                                        ]}
+                                                    >
                                                         {this.props.translate('profilePage.editPhoto')}
                                                     </Text>
                                                 </View>

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -170,17 +170,17 @@ const styles = {
         paddingLeft: 12,
     },
 
-    buttonLargeText: {
-        fontSize: variables.fontSizeLarge,
-        lineHeight: 18,
+    buttonSmallText: {
+        fontSize: variables.fontSizeSmall,
+        lineHeight: 16,
         fontFamily: fontFamily.GTA_BOLD,
         fontWeight: fontWeightBold,
         textAlign: 'center',
     },
 
-    buttonSmallText: {
-        fontSize: variables.fontSizeSmall,
-        lineHeight: 16,
+    buttonLargeText: {
+        fontSize: variables.fontSizeLarge,
+        lineHeight: 18,
         fontFamily: fontFamily.GTA_BOLD,
         fontWeight: fontWeightBold,
         textAlign: 'center',


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR is adding a `small` option to Button component (styles already exist) and updates the `Edit profile` button in Profile part of Settings to be 28px tall instead of 40px.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ https://github.com/Expensify/Expensify.cash/issues/2434

### Tests
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->
1. Run the app
2. Click on the profile icon
3. Click on profile
4. Make sure the `Edit profile` button is 28px tall

### QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

Same as testing except of visiting staging or production version of the app.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
![image](https://user-images.githubusercontent.com/36083550/124168920-989bcc80-da9d-11eb-867a-82aa056c57a2.png)



#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
![simulator_screenshot_C41CFD88-3CAE-4386-B082-8E4A9F9B47C3](https://user-images.githubusercontent.com/36083550/124169099-b79a5e80-da9d-11eb-86bd-ee9c3579149d.png)


#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
![image](https://user-images.githubusercontent.com/36083550/124168986-a0f40780-da9d-11eb-811c-4755357d7f60.png)



#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

![simulator_screenshot_AB719E40-ACEA-42D3-83DE-0C8A5D72C248](https://user-images.githubusercontent.com/36083550/124169715-76567e80-da9e-11eb-9121-77269e5de681.png)

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
