### PR TITLE
Fix: Tooltip and message date position

### DIFF
--- a/src/components/DisplayNames/index.js
+++ b/src/components/DisplayNames/index.js
@@ -95,7 +95,7 @@ class DisplayNames extends PureComponent {
                             <Tooltip
                                 key={index}
                                 text={tooltip}
-                                containerStyle={styles.dInline}
+                                containerStyles={[styles.dInline]}
                                 shiftHorizontal={() => this.getTooltipShiftX(index)}
                             >
                                 {/*  // We need to get the refs to all the names which will be used to correct

--- a/src/components/Hoverable/HoverablePropTypes.js
+++ b/src/components/Hoverable/HoverablePropTypes.js
@@ -9,7 +9,7 @@ const propTypes = {
 
     /** Styles to be assigned to the Hoverable Container */
     // eslint-disable-next-line react/forbid-prop-types
-    containerStyle: PropTypes.object,
+    containerStyles: PropTypes.arrayOf(PropTypes.object),
 
     /** Function that executes when the mouse moves over the children. */
     onHoverIn: PropTypes.func,
@@ -22,7 +22,7 @@ const propTypes = {
 };
 
 const defaultProps = {
-    containerStyle: {},
+    containerStyles: [],
     onHoverIn: () => {},
     onHoverOut: () => {},
     resetsOnClickOutside: false,

--- a/src/components/Hoverable/index.js
+++ b/src/components/Hoverable/index.js
@@ -80,7 +80,7 @@ class Hoverable extends Component {
     render() {
         return (
             <View
-                style={this.props.containerStyle}
+                style={this.props.containerStyles}
                 ref={el => this.wrapperView = el}
                 onMouseEnter={() => this.setIsHovered(true)}
                 onMouseLeave={() => this.setIsHovered(false)}

--- a/src/components/Tooltip/TooltipPropTypes.js
+++ b/src/components/Tooltip/TooltipPropTypes.js
@@ -6,7 +6,7 @@ const propTypes = {
     text: PropTypes.string.isRequired,
 
     /** Styles to be assigned to the Tooltip wrapper views */
-    containerStyle: PropTypes.object,
+    containerStyles: PropTypes.arrayOf(PropTypes.object),
 
     /** Children to wrap with Tooltip. */
     children: PropTypes.node.isRequired,
@@ -26,6 +26,7 @@ const propTypes = {
 const defaultProps = {
     shiftHorizontal: 0,
     shiftVertical: 0,
+    containerStyles: [],
 };
 
 export {

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -175,13 +175,13 @@ class Tooltip extends PureComponent {
                 />
                 )}
                 <Hoverable
-                    containerStyle={this.props.containerStyle}
+                    containerStyles={this.props.containerStyles}
                     onHoverIn={this.showTooltip}
                     onHoverOut={this.hideTooltip}
                 >
                     <View
                         ref={el => this.wrapperView = el}
-                        style={this.props.containerStyle}
+                        style={this.props.containerStyles}
                     >
                         {this.props.children}
                     </View>

--- a/src/components/Tooltip/index.native.js
+++ b/src/components/Tooltip/index.native.js
@@ -5,21 +5,33 @@ import PropTypes from 'prop-types';
 // We can't use the common component for the Tooltip as Web implementation uses DOM specific method to
 // render the View which is not present on the Mobile.
 const propTypes = {
-    children: PropTypes.element,
+    /** Styles to be assigned to the Tooltip wrapper views */
+    // eslint-disable-next-line react/forbid-prop-types
+    containerStyle: PropTypes.object,
+
+    /** Children to wrap with Tooltip. */
+    children: PropTypes.node.isRequired,
+};
+
+const defaultProps = {
+    containerStyle: {},
 };
 
 /**
- * There is no native support for the Hover on the Mobile platform so we just return the enclosing childrens
+ * There is no native support for the Hover on the Mobile platform, but as we use the Tooltip as a
+ * container we must past pass that containerStyle to a simple View in order to avoid different
+ * styles across platforms.
  * @param {propTypes} props
  * @returns {ReactNodeLike}
  */
-const Tooltip = (props) => {
-    console.log(props.containerStyle);
-    return (
+const Tooltip = props => (
     <View style={props.containerStyle}>
         {props.children}
-        </View>)}
+    </View>
+);
+
 
 Tooltip.propTypes = propTypes;
+Tooltip.defaultProps = defaultProps;
 Tooltip.displayName = 'Tooltip';
 export default Tooltip;

--- a/src/components/Tooltip/index.native.js
+++ b/src/components/Tooltip/index.native.js
@@ -25,11 +25,10 @@ const defaultProps = {
  * @returns {ReactNodeLike}
  */
 const Tooltip = props => (
-    <View style={[props.containerStyles]}>
+    <View style={props.containerStyles}>
         {props.children}
     </View>
 );
-
 
 Tooltip.propTypes = propTypes;
 Tooltip.defaultProps = defaultProps;

--- a/src/components/Tooltip/index.native.js
+++ b/src/components/Tooltip/index.native.js
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 // render the View which is not present on the Mobile.
 const propTypes = {
     /** Styles to be assigned to the Tooltip wrapper views */
-    // eslint-disable-next-line react/forbid-prop-types
     containerStyles: PropTypes.arrayOf(PropTypes.object),
 
     /** Children to wrap with Tooltip. */

--- a/src/components/Tooltip/index.native.js
+++ b/src/components/Tooltip/index.native.js
@@ -1,3 +1,5 @@
+import React from 'react';
+import {View} from 'react-native';
 import PropTypes from 'prop-types';
 
 // We can't use the common component for the Tooltip as Web implementation uses DOM specific method to
@@ -11,7 +13,12 @@ const propTypes = {
  * @param {propTypes} props
  * @returns {ReactNodeLike}
  */
-const Tooltip = props => props.children;
+const Tooltip = (props) => {
+    console.log(props.containerStyle);
+    return (
+    <View style={props.containerStyle}>
+        {props.children}
+        </View>)}
 
 Tooltip.propTypes = propTypes;
 Tooltip.displayName = 'Tooltip';

--- a/src/components/Tooltip/index.native.js
+++ b/src/components/Tooltip/index.native.js
@@ -17,9 +17,6 @@ const defaultProps = {
 };
 
 /**
- * There is no native support for the Hover on the Mobile platform, but as we use the Tooltip as a
- * container we must past pass that containerStyle to a simple View in order to avoid different
- * styles across platforms.
  * @param {propTypes} props
  * @returns {ReactNodeLike}
  */

--- a/src/components/Tooltip/index.native.js
+++ b/src/components/Tooltip/index.native.js
@@ -7,14 +7,14 @@ import PropTypes from 'prop-types';
 const propTypes = {
     /** Styles to be assigned to the Tooltip wrapper views */
     // eslint-disable-next-line react/forbid-prop-types
-    containerStyle: PropTypes.object,
+    containerStyles: PropTypes.arrayOf(PropTypes.object),
 
     /** Children to wrap with Tooltip. */
     children: PropTypes.node.isRequired,
 };
 
 const defaultProps = {
-    containerStyle: {},
+    containerStyles: [],
 };
 
 /**
@@ -25,7 +25,7 @@ const defaultProps = {
  * @returns {ReactNodeLike}
  */
 const Tooltip = props => (
-    <View style={props.containerStyle}>
+    <View style={[props.containerStyles]}>
         {props.children}
     </View>
 );

--- a/src/pages/home/report/ReportActionItemFragment.js
+++ b/src/pages/home/report/ReportActionItemFragment.js
@@ -83,7 +83,7 @@ class ReportActionItemFragment extends React.PureComponent {
                     );
             case 'TEXT':
                 return (
-                    <Tooltip text={tooltipText} containerStyles={[styles.flexShrink1]}>
+                    <Tooltip text={tooltipText} >
                         <Text
                             selectable
                             numberOfLines={this.props.isSingleLine ? 1 : undefined}

--- a/src/pages/home/report/ReportActionItemFragment.js
+++ b/src/pages/home/report/ReportActionItemFragment.js
@@ -83,7 +83,7 @@ class ReportActionItemFragment extends React.PureComponent {
                     );
             case 'TEXT':
                 return (
-                    <Tooltip text={tooltipText} >
+                    <Tooltip text={tooltipText}>
                         <Text
                             selectable
                             numberOfLines={this.props.isSingleLine ? 1 : undefined}

--- a/src/pages/home/report/ReportActionItemFragment.js
+++ b/src/pages/home/report/ReportActionItemFragment.js
@@ -83,7 +83,7 @@ class ReportActionItemFragment extends React.PureComponent {
                     );
             case 'TEXT':
                 return (
-                    <Tooltip text={tooltipText} containerStyle={styles.w100}>
+                    <Tooltip text={tooltipText} containerStyle={styles.flexShrink1}>
                         <Text
                             selectable
                             numberOfLines={this.props.isSingleLine ? 1 : undefined}

--- a/src/pages/home/report/ReportActionItemFragment.js
+++ b/src/pages/home/report/ReportActionItemFragment.js
@@ -83,7 +83,7 @@ class ReportActionItemFragment extends React.PureComponent {
                     );
             case 'TEXT':
                 return (
-                    <Tooltip text={tooltipText} containerStyle={styles.flexShrink1}>
+                    <Tooltip text={tooltipText} containerStyles={[styles.flexShrink1]}>
                         <Text
                             selectable
                             numberOfLines={this.props.isSingleLine ? 1 : undefined}

--- a/src/pages/home/report/ReportActionItemSingle.js
+++ b/src/pages/home/report/ReportActionItemSingle.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View, Pressable, TouchableWithoutFeedback} from 'react-native';
+import {View, Pressable} from 'react-native';
 import {withOnyx} from 'react-native-onyx';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
@@ -85,7 +85,6 @@ const ReportActionItemSingle = ({
                             />
                         ))}
                     </Pressable>
-                    
                     <ReportActionItemDate timestamp={action.timestamp} />
                 </View>
                 {children}

--- a/src/pages/home/report/ReportActionItemSingle.js
+++ b/src/pages/home/report/ReportActionItemSingle.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View, Pressable} from 'react-native';
+import {View, Pressable, TouchableWithoutFeedback} from 'react-native';
 import {withOnyx} from 'react-native-onyx';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
@@ -73,7 +73,7 @@ const ReportActionItemSingle = ({
             </Pressable>
             <View style={[styles.chatItemRight]}>
                 <View style={[styles.chatItemMessageHeader]}>
-                    <Pressable onPress={() => showUserDetails(action.actorEmail)}>
+                    <Pressable style={[styles.flexShrink1]} onPress={() => showUserDetails(action.actorEmail)}>
                         {_.map(personArray, (fragment, index) => (
                             <ReportActionItemFragment
                                 key={`person-${action.sequenceNumber}-${index}`}
@@ -85,6 +85,7 @@ const ReportActionItemSingle = ({
                             />
                         ))}
                     </Pressable>
+                    
                     <ReportActionItemDate timestamp={action.timestamp} />
                 </View>
                 {children}

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -875,7 +875,7 @@ const styles = {
         alignItems: 'center',
         display: 'flex',
         flexDirection: 'row',
-        flexWrap: 'wrap',
+        flexWrap: 'nowrap',
     },
 
     chatItemMessageHeaderSender: {
@@ -890,6 +890,7 @@ const styles = {
     },
 
     chatItemMessageHeaderTimestamp: {
+        flexShrink: 0,
         color: themeColors.textSupporting,
         fontSize: variables.fontSizeSmall,
         height: 24,

--- a/src/styles/utilities/flex.js
+++ b/src/styles/utilities/flex.js
@@ -87,4 +87,8 @@ export default {
     flexGrow4: {
         flexGrow: 4,
     },
+    
+    flexShrink1: {
+        flexShrink: 1,
+    },
 };

--- a/src/styles/utilities/flex.js
+++ b/src/styles/utilities/flex.js
@@ -87,7 +87,7 @@ export default {
     flexGrow4: {
         flexGrow: 4,
     },
-    
+
     flexShrink1: {
         flexShrink: 1,
     },


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
1. Style changes to make the Tooltip responsive instead of fix width.
2. Apply the Tooltip containerStyle in index.native.js for consistency across platforms
3. Fixes the message timestamp to the same line as the displayName

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Fixes [an issue with the below PR ](https://github.com/Expensify/Expensify.cash/pull/3830#issuecomment-872556352) where the Tooltip and the Timestamp of a message would me misplaced.
$ PR #3830 

### Tests
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->
1. Open any chat
2. Check that the timestamp is line with the displayName
3. Hoover over the displayName
4. The Tooltip should show close to your cursor


### QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->
Same as above.
### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
https://user-images.githubusercontent.com/53711423/125451787-291abf84-df6d-4de2-a7e2-4b577aef5220.mov


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

https://user-images.githubusercontent.com/53711423/125451822-1b42ce10-4169-49e3-a811-f310c0b4bb3b.mp4



#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

https://user-images.githubusercontent.com/53711423/125451839-824bee7e-cab9-4be4-a334-840f298ffbdc.mov




#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

https://user-images.githubusercontent.com/53711423/125451846-375d8db5-0714-4352-9fa7-cab7fb327130.mp4




#### Android
<!-- Insert screenshots of your changes on the Android platform-->

https://user-images.githubusercontent.com/53711423/125451860-1cf24716-b4d6-40f4-8f86-d09898cb0b87.mp4


