### PR TITLE
fix: picker an arrow navigation

### DIFF
--- a/src/pages/home/report/EmojiPickerMenu/index.js
+++ b/src/pages/home/report/EmojiPickerMenu/index.js
@@ -97,18 +97,6 @@ class EmojiPickerMenu extends Component {
         if (document) {
             this.keyDownHandler = (keyBoardEvent) => {
                 if (keyBoardEvent.key.startsWith('Arrow')) {
-                    // Arrow Down enable arrow navigation
-                    if (this.searchInput.isFocused()) {
-                        if (keyBoardEvent.key !== 'ArrowDown') {
-                            return;
-                        }
-                        this.searchInput.blur();
-                    }
-
-                    // Depending on the position of the highlighted emoji after moving and rendering,
-                    // toggle which arrow keys can affect the cursor position in the search input.
-                    this.toggleArrowKeysOnSearchInput(keyBoardEvent);
-
                     // Move the highlight when arrow keys are pressed
                     this.highlightAdjacentEmoji(keyBoardEvent.key);
                 }
@@ -260,27 +248,6 @@ class EmojiPickerMenu extends Component {
 
         // Remove sticky header indices. There are no headers while searching and we don't want to make emojis sticky
         this.setState({filteredEmojis: newFilteredEmojiList, headerIndices: [], highlightedIndex: 0});
-    }
-
-    /**
-     * Toggles which arrow keys can affect the cursor in the search input,
-     * depending on whether the arrow keys will affect the index of the highlighted emoji.
-     *
-     * @param {KeyboardEvent} arrowKeyBoardEvent
-     */
-    toggleArrowKeysOnSearchInput(arrowKeyBoardEvent) {
-        let keysToIgnore = ['ArrowDown', 'ArrowRight', 'ArrowLeft', 'ArrowUp'];
-        if (this.state.highlightedIndex === 0 && this.state.filteredEmojis.length) {
-            keysToIgnore = ['ArrowDown', 'ArrowRight'];
-        } else if (this.state.highlightedIndex === this.state.filteredEmojis.length - 1) {
-            keysToIgnore = ['ArrowLeft', 'ArrowUp'];
-        }
-
-        // Moving the cursor is the default behavior for arrow key presses while an input is focused,
-        // so prevent it
-        if (keysToIgnore.includes(arrowKeyBoardEvent.key)) {
-            arrowKeyBoardEvent.preventDefault();
-        }
     }
 
     /**

--- a/src/pages/home/report/EmojiPickerMenu/index.js
+++ b/src/pages/home/report/EmojiPickerMenu/index.js
@@ -118,7 +118,8 @@ class EmojiPickerMenu extends Component {
                 }
             };
 
-            // Keyboard events are not bubbling in RN-Web
+            // Keyboard events are not bubbling on TextInput in RN-Web, Bubbling was needed for this event to trigger
+            // event is attached to document. To fix this attach event in Capture phase.
             document.addEventListener('keydown', this.keyDownHandler, true);
 
             // Re-enable pointer events and hovering over EmojiPickerItems when the mouse moves

--- a/src/pages/home/report/EmojiPickerMenu/index.js
+++ b/src/pages/home/report/EmojiPickerMenu/index.js
@@ -61,7 +61,6 @@ class EmojiPickerMenu extends Component {
         this.filterEmojis = _.debounce(this.filterEmojis.bind(this), 300);
         this.highlightAdjacentEmoji = this.highlightAdjacentEmoji.bind(this);
         this.scrollToHighlightedIndex = this.scrollToHighlightedIndex.bind(this);
-        this.toggleArrowKeysOnSearchInput = this.toggleArrowKeysOnSearchInput.bind(this);
         this.setupEventHandlers = this.setupEventHandlers.bind(this);
         this.cleanupEventHandlers = this.cleanupEventHandlers.bind(this);
         this.renderItem = this.renderItem.bind(this);
@@ -125,7 +124,7 @@ class EmojiPickerMenu extends Component {
      */
     cleanupEventHandlers() {
         if (document) {
-            document.removeEventListener('keydown', this.keyDownHandler);
+            document.removeEventListener('keydown', this.keyDownHandler, true);
             document.removeEventListener('mousemove', this.mouseMoveHandler);
         }
     }
@@ -138,11 +137,17 @@ class EmojiPickerMenu extends Component {
         const firstNonHeaderIndex = this.state.filteredEmojis.length === this.emojis.length ? this.numColumns : 0;
 
         // Arrow Down enable arrow navigation when search is focused
-        if (this.searchInput.isFocused() && this.state.filteredEmojis.length) {
+        if (this.searchInput && this.searchInput.isFocused() && this.state.filteredEmojis.length) {
             if (arrowKey !== 'ArrowDown') {
                 return;
             }
             this.searchInput.blur();
+
+            // We only want to hightlight the Emoji if none was highlighted already
+            // If we already have a highlighted Emoji, lets just skip the first navigation
+            if (this.state.highlightedIndex !== -1) {
+                return;
+            }
         }
 
         // If nothing is highlighted and an arrow key is pressed
@@ -185,6 +190,10 @@ class EmojiPickerMenu extends Component {
                     -this.numColumns,
                     () => this.state.highlightedIndex - this.numColumns < firstNonHeaderIndex,
                     () => {
+                        if (!this.searchInput) {
+                            return;
+                        }
+
                         // Reaching start of the list, arrow up set the focus to searchInput.
                         this.searchInput.focus();
                         newIndex = -1;

--- a/src/pages/home/report/EmojiPickerMenu/index.js
+++ b/src/pages/home/report/EmojiPickerMenu/index.js
@@ -98,11 +98,23 @@ class EmojiPickerMenu extends Component {
                 if (keyBoardEvent.key.startsWith('Arrow')) {
                     // Move the highlight when arrow keys are pressed
                     this.highlightAdjacentEmoji(keyBoardEvent.key);
+                    return;
                 }
 
                 // Select the currently highlighted emoji if enter is pressed
                 if (keyBoardEvent.key === 'Enter' && this.state.highlightedIndex !== -1) {
                     this.props.onEmojiSelected(this.state.filteredEmojis[this.state.highlightedIndex].code);
+                    return;
+                }
+
+                // We allow typing in the search box if any key is pressed apart from Arrow keys.
+                if (this.searchInput && !this.searchInput.isFocused()) {
+                    this.setState({selectTextOnFocus: false});
+                    this.searchInput.value = '';
+                    this.searchInput.focus();
+
+                    // Re-enable selection on the searchInput
+                    this.setState({selectTextOnFocus: true});
                 }
             };
 
@@ -326,6 +338,7 @@ class EmojiPickerMenu extends Component {
                             defaultValue=""
                             ref={el => this.searchInput = el}
                             autoFocus
+                            selectTextOnFocus={this.state.selectTextOnFocus}
                         />
                     </View>
                 )}

--- a/src/pages/home/report/EmojiPickerMenu/index.js
+++ b/src/pages/home/report/EmojiPickerMenu/index.js
@@ -97,6 +97,14 @@ class EmojiPickerMenu extends Component {
         if (document) {
             this.keyDownHandler = (keyBoardEvent) => {
                 if (keyBoardEvent.key.startsWith('Arrow')) {
+                    // Arrow Down enable arrow navigation
+                    if (this.searchInput.isFocused()) {
+                        if (keyBoardEvent.key !== 'ArrowDown') {
+                            return;
+                        }
+                        this.searchInput.blur();
+                    }
+
                     // Depending on the position of the highlighted emoji after moving and rendering,
                     // toggle which arrow keys can affect the cursor position in the search input.
                     this.toggleArrowKeysOnSearchInput(keyBoardEvent);
@@ -110,7 +118,9 @@ class EmojiPickerMenu extends Component {
                     this.props.onEmojiSelected(this.state.filteredEmojis[this.state.highlightedIndex].code);
                 }
             };
-            document.addEventListener('keydown', this.keyDownHandler);
+
+            // Keyboard events are not bubbling in RN-Web
+            document.addEventListener('keydown', this.keyDownHandler, true);
 
             // Re-enable pointer events and hovering over EmojiPickerItems when the mouse moves
             this.mouseMoveHandler = () => {

--- a/src/pages/home/report/EmojiPickerMenu/index.js
+++ b/src/pages/home/report/EmojiPickerMenu/index.js
@@ -137,6 +137,14 @@ class EmojiPickerMenu extends Component {
     highlightAdjacentEmoji(arrowKey) {
         const firstNonHeaderIndex = this.state.filteredEmojis.length === this.emojis.length ? this.numColumns : 0;
 
+        // Arrow Down enable arrow navigation when search is focused
+        if (this.searchInput.isFocused() && this.state.filteredEmojis.length) {
+            if (arrowKey !== 'ArrowDown') {
+                return;
+            }
+            this.searchInput.blur();
+        }
+
         // If nothing is highlighted and an arrow key is pressed
         // select the first emoji
         if (this.state.highlightedIndex === -1) {
@@ -146,8 +154,9 @@ class EmojiPickerMenu extends Component {
         }
 
         let newIndex = this.state.highlightedIndex;
-        const move = (steps, boundsCheck) => {
+        const move = (steps, boundsCheck, onBoundReached = () => {}) => {
             if (boundsCheck()) {
+                onBoundReached();
                 return;
             }
 
@@ -172,7 +181,15 @@ class EmojiPickerMenu extends Component {
                 move(1, () => this.state.highlightedIndex + 1 > this.state.filteredEmojis.length - 1);
                 break;
             case 'ArrowUp':
-                move(-this.numColumns, () => this.state.highlightedIndex - this.numColumns < firstNonHeaderIndex);
+                move(
+                    -this.numColumns,
+                    () => this.state.highlightedIndex - this.numColumns < firstNonHeaderIndex,
+                    () => {
+                        // Reaching start of the list, arrow up set the focus to searchInput.
+                        this.searchInput.focus();
+                        newIndex = -1;
+                    },
+                );
                 break;
             default:
                 break;

--- a/src/pages/home/report/EmojiPickerMenu/index.js
+++ b/src/pages/home/report/EmojiPickerMenu/index.js
@@ -119,7 +119,7 @@ class EmojiPickerMenu extends Component {
             };
 
             // Keyboard events are not bubbling on TextInput in RN-Web, Bubbling was needed for this event to trigger
-            // event is attached to document. To fix this attach event in Capture phase.
+            // event handler attached to document root. To fix this, trigger event handler in Capture phase.
             document.addEventListener('keydown', this.keyDownHandler, true);
 
             // Re-enable pointer events and hovering over EmojiPickerItems when the mouse moves


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
1. https://github.com/Expensify/Expensify.cash/issues/3858#issuecomment-873079314
2. https://github.com/Expensify/Expensify.cash/issues/3858#issuecomment-873122883

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ Fixes #3858

### Tests | QA Steps

1. Navigate to e.cash
2. Navigate to a conversation
3. Click on the emoji icon
4. Type something in the search box
5. Press the down arrow key to navigate through the options.
6. when at the top of the emoji list, press the Up arrow to focus the search Input.


### Tested On

- [x] Web (Affected Platform)
- [ ] Mobile Web
- [x] Desktop (Affected Platform)
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

https://user-images.githubusercontent.com/24370807/124370305-9a2ee580-dc93-11eb-90af-8c96ccdda73e.mp4


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
