### PR TITLE
Display a message when no emojis are found in search

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -55,6 +55,7 @@ export default {
         dateFormat: 'YYYY-MM-DD',
         send: 'Send',
         notifications: 'Notifications',
+        noResultsFound: 'No results found',
     },
     attachmentPicker: {
         cameraPermissionRequired: 'Camera Permission Required',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -51,6 +51,7 @@ export default {
         dateFormat: 'AAAA-MM-DD',
         send: 'Enviar',
         notifications: 'Notificaciones',
+        noResultsFound: 'No se han encontrado resultados',
     },
     attachmentPicker: {
         cameraPermissionRequired: 'Se necesita permiso para usar la cámara',

--- a/src/pages/home/report/EmojiPickerMenu/index.js
+++ b/src/pages/home/report/EmojiPickerMenu/index.js
@@ -326,17 +326,34 @@ class EmojiPickerMenu extends Component {
                         />
                     </View>
                 )}
-                <FlatList
-                    ref={el => this.emojiList = el}
-                    data={this.state.filteredEmojis}
-                    renderItem={this.renderItem}
-                    keyExtractor={item => `emoji_picker_${item.code}`}
-                    numColumns={this.numColumns}
-                    style={styles.emojiPickerList}
-                    extraData={[this.state.filteredEmojis, this.state.highlightedIndex]}
-                    stickyHeaderIndices={this.state.headerIndices}
-                    onScroll={e => this.currentScrollOffset = e.nativeEvent.contentOffset.y}
-                />
+                {this.state.filteredEmojis.length === 0
+                    ? (
+                        <Text
+                            style={[
+                                styles.textP,
+                                styles.disabledText,
+                                styles.emojiPickerList,
+                                styles.dFlex,
+                                styles.alignItemsCenter,
+                                styles.justifyContentCenter,
+                            ]}
+                        >
+                            {this.props.translate('common.noResultsFound')}
+                        </Text>
+                    )
+                    : (
+                        <FlatList
+                            ref={el => this.emojiList = el}
+                            data={this.state.filteredEmojis}
+                            renderItem={this.renderItem}
+                            keyExtractor={item => `emoji_picker_${item.code}`}
+                            numColumns={this.numColumns}
+                            style={styles.emojiPickerList}
+                            extraData={[this.state.filteredEmojis, this.state.highlightedIndex]}
+                            stickyHeaderIndices={this.state.headerIndices}
+                            onScroll={e => this.currentScrollOffset = e.nativeEvent.contentOffset.y}
+                        />
+                    )}
             </View>
         );
     }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

Added noResultsFound to the common key in languages.
- English: "No results found"
- Spanish: "No se han encontrado resultados" (Confirmed the translation [in slack](https://expensify.slack.com/archives/C01GTK53T8Q/p1625260986422600))


If `filteredEmojis.length` is 0, show `noResultsFound`, else show the emoji list.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ #3861 

### Tests / QA
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### Tested On
Don't have a Mac to test iOS, Desktop app.
- [x] Web
- [x] Mobile Web
- [ ] Desktop
- [ ] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
<img src="https://user-images.githubusercontent.com/29673073/124327181-5b643700-db90-11eb-9eaa-44df9239a47b.png" height="400">
<img src="https://user-images.githubusercontent.com/29673073/124328280-fdd0ea00-db91-11eb-9ca3-4c645dfc9d9a.png" height="400">

#### Mobile Web
No search in mobile

<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
<img src="https://user-images.githubusercontent.com/29673073/124328590-97000080-db92-11eb-8877-56488934dac6.jpeg" height="300">


#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
No search in mobile

<!-- Insert screenshots of your changes on the Android platform-->
<img src="https://user-images.githubusercontent.com/29673073/124328594-99625a80-db92-11eb-8dec-9433cd8d8949.jpeg" height="300">