### PR TITLE
Feature: Show local time for User in 1:1 chat

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -105,6 +105,7 @@ export default {
         blockedFromConcierge: 'Communication is barred',
         youAppearToBeOffline: 'You appear to be offline.',
         fileUploadFailed: 'Upload Failed. File is not supported.',
+        localTime: ({user, time}) => `It's ${time} for ${user}`,
     },
     reportActionContextMenu: {
         copyToClipboard: 'Copy to Clipboard',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -100,6 +100,7 @@ export default {
         writeSomething: 'Escribe algo...',
         blockedFromConcierge: 'Comunicación no permitida',
         youAppearToBeOffline: 'Parece que estás desconectado.',
+        localTime: ({user, time}) => `Son las ${time} para ${user}`,
     },
     reportActionContextMenu: {
         copyToClipboard: 'Copiar al Portapapeles',

--- a/src/pages/home/report/ParticipantLocalTime.js
+++ b/src/pages/home/report/ParticipantLocalTime.js
@@ -50,6 +50,10 @@ class ParticipantLocalTime extends React.Component {
         // Moment.format does not return AM or PM values immediately.
         // So we have to wait until we are ready before showing the time to the user
         const isReportRecipientLocalTimeReady = this.state.localTime.toString().match(/(A|P)M/ig);
+        const reportRecipientDisplayName = this.props.participant.firstName
+            || (Str.isSMSLogin(this.props.participant.login)
+                ? this.props.toLocalPhone(this.props.participant.displayName)
+                : this.props.participant.displayName);
 
         return (
             isReportRecipientLocalTimeReady ? (
@@ -62,10 +66,7 @@ class ParticipantLocalTime extends React.Component {
                         {this.props.translate(
                             'reportActionCompose.localTime',
                             {
-                                user: this.props.participant.firstName
-                                    || (Str.isSMSLogin(this.props.participant.login)
-                                        ? this.props.toLocalPhone(this.props.participant.displayName)
-                                        : this.props.participant.displayName),
+                                user: reportRecipientDisplayName,
                                 time: this.state.localTime,
                             },
                         )}

--- a/src/pages/home/report/ParticipantLocalTime.js
+++ b/src/pages/home/report/ParticipantLocalTime.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import {
+    View,
+} from 'react-native';
+import lodashGet from 'lodash/get';
+import moment from 'moment';
+import Str from 'expensify-common/lib/str';
+import styles from '../../../styles/styles';
+import withLocalize, {withLocalizePropTypes} from '../../../components/withLocalize';
+import {participantPropTypes} from '../sidebar/optionPropTypes';
+import ExpensiText from '../../../components/Text';
+import Timers from '../../../libs/Timers';
+
+const propTypes = {
+    /** Personal details of the participant */
+    participant: participantPropTypes.isRequired,
+
+    ...withLocalizePropTypes,
+};
+
+class ParticipantLocalTime extends React.Component {
+    constructor(props) {
+        super(props);
+        this.getParticipantLocalTime = this.getParticipantLocalTime.bind(this);
+        this.state = {
+            localTime: this.getParticipantLocalTime(),
+        };
+    }
+
+    componentDidMount() {
+        this.timer = Timers.register(setInterval(() => {
+            this.setState({
+                localTime: this.getParticipantLocalTime(),
+            });
+        }, 1000));
+    }
+
+    componentWillUnmount() {
+        clearInterval(this.timer);
+        clearInterval(this.readyTimer);
+    }
+
+    getParticipantLocalTime() {
+        const reportRecipientTimezone = lodashGet(this.props.participant, 'timezone', {});
+        return moment().tz(reportRecipientTimezone.selected).format('LT');
+    }
+
+
+    render() {
+        // Moment.format does not return AM or PM values immediately.
+        // So we have to wait until we are ready before showing the time to the user
+        const isReportRecipientLocalTimeReady = this.state.localTime.toString().match(/(A|P)M/ig);
+
+        return (
+            isReportRecipientLocalTimeReady ? (
+                <View style={[styles.chatItemComposeSecondaryRow]}>
+                    <ExpensiText style={[
+                        styles.chatItemComposeSecondaryRowSubText,
+                        styles.chatItemComposeSecondaryRowOffset,
+                    ]}
+                    >
+                        {this.props.translate(
+                            'reportActionCompose.localTime',
+                            {
+                                user: this.props.participant.firstName
+                                    || (Str.isSMSLogin(this.props.participant.login)
+                                        ? this.props.toLocalPhone(this.props.participant.displayName)
+                                        : this.props.participant.displayName),
+                                time: this.state.localTime,
+                            },
+                        )}
+                    </ExpensiText>
+                </View>
+            )
+                : <View style={[styles.chatItemComposeSecondaryRow]} />
+        );
+    }
+}
+
+ParticipantLocalTime.propTypes = propTypes;
+
+export default withLocalize(ParticipantLocalTime);

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -12,7 +12,6 @@ import {withNavigationFocus} from '@react-navigation/compat';
 import _ from 'underscore';
 import lodashGet from 'lodash/get';
 import {withOnyx} from 'react-native-onyx';
-import moment from 'moment';
 import styles, {getButtonBackgroundColorStyle, getIconFillColor} from '../../../styles/styles';
 import themeColors from '../../../styles/themes/default';
 import TextInputFocusable from '../../../components/TextInputFocusable';
@@ -55,8 +54,8 @@ import ReportActionPropTypes from './ReportActionPropTypes';
 import {canEditReportAction} from '../../../libs/reportUtils';
 import ReportActionComposeFocusManager from '../../../libs/ReportActionComposeFocusManager';
 import {participantPropTypes} from '../sidebar/optionPropTypes';
-import ExpensiText from '../../../components/Text';
 import currentUserPersonalDetailsPropsTypes from '../../settings/Profile/currentUserPersonalDetailsPropsTypes';
+import ParticipantLocalTime from './ParticipantLocalTime';
 
 const propTypes = {
     /** Beta features list */
@@ -408,12 +407,10 @@ class ReportActionCompose extends React.Component {
         const reportRecipient = this.props.personalDetails[reportParticipants[0]];
         const currentUserTimezone = lodashGet(this.props.myPersonalDetails, 'timezone', {});
         const reportRecipientTimezone = lodashGet(reportRecipient, 'timezone', {});
-        console.debug(reportRecipientTimezone);
-        const reportRecipientLocalTime = moment().tz(reportRecipientTimezone.selected).format('LT');
-        const shouldShowReportRecipientLocalTime = !hasMultipleParticipants
+        const shouldShowReportRecipientLocalTime = !hasConciergeParticipant
+            && !hasMultipleParticipants
             && reportRecipientTimezone
             && currentUserTimezone.selected !== reportRecipientTimezone.selected;
-        const isReportRecipientLocalTimeReady = reportRecipientLocalTime.toString().match(/(A|P)M/ig);
 
         // Prevents focusing and showing the keyboard while the drawer is covering the chat.
         const isComposeDisabled = this.props.isDrawerOpen && this.props.isSmallScreenWidth;
@@ -431,21 +428,7 @@ class ReportActionCompose extends React.Component {
         return (
             <View style={[styles.chatItemCompose]}>
                 {shouldShowReportRecipientLocalTime
-                    && (isReportRecipientLocalTimeReady ? (
-                        <View style={[styles.chatItemComposeSecondaryRow]}>
-                            <ExpensiText style={[
-                                styles.chatItemComposeSecondaryRowSubText,
-                                styles.chatItemComposeSecondaryRowOffset,
-                            ]}
-                            >
-                                {reportRecipientLocalTime}
-                                {' '}
-                                {this.props.translate('detailsPage.localTime')}
-                            </ExpensiText>
-                        </View>
-                    )
-                        : <View style={[styles.chatItemComposeSecondaryRow]} />
-                    )}
+                    && <ParticipantLocalTime participant={reportRecipient} />}
                 <View style={[
                     (this.state.isFocused || this.state.isDraggingOver)
                         ? styles.chatItemComposeBoxFocusedColor

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -409,6 +409,7 @@ class ReportActionCompose extends React.Component {
         const reportRecipientTimezone = lodashGet(reportRecipient, 'timezone', {});
         const shouldShowReportRecipientLocalTime = !hasConciergeParticipant
             && !hasMultipleParticipants
+            && reportRecipient
             && reportRecipientTimezone
             && currentUserTimezone.selected !== reportRecipientTimezone.selected;
 

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -427,7 +427,11 @@ class ReportActionCompose extends React.Component {
             : this.props.translate('reportActionCompose.writeSomething');
 
         return (
-            <View style={[styles.chatItemCompose]}>
+            <View style={[
+                styles.chatItemCompose,
+                shouldShowReportRecipientLocalTime && styles.chatItemComposeWithFirstRow,
+            ]}
+            >
                 {shouldShowReportRecipientLocalTime
                     && <ParticipantLocalTime participant={reportRecipient} />}
                 <View style={[

--- a/src/pages/home/sidebar/optionPropTypes.js
+++ b/src/pages/home/sidebar/optionPropTypes.js
@@ -9,6 +9,9 @@ const participantPropTypes = PropTypes.shape({
 
     // Avatar url of participant
     avatar: PropTypes.string,
+
+    /** First Name of the participant */
+    firstName: PropTypes.string,
 });
 
 const optionPropTypes = PropTypes.shape({

--- a/src/pages/settings/Profile/ProfilePage.js
+++ b/src/pages/settings/Profile/ProfilePage.js
@@ -34,37 +34,13 @@ import FixedFooter from '../../../components/FixedFooter';
 import Growl from '../../../libs/Growl';
 import FullNameInputRow from '../../../components/FullNameInputRow';
 import CheckboxWithLabel from '../../../components/CheckboxWithLabel';
+import currentUserPersonalDetailsPropsTypes from './currentUserPersonalDetailsPropsTypes';
 
 const propTypes = {
     /* Onyx Props */
 
     /** The personal details of the person who is logged in */
-    myPersonalDetails: PropTypes.shape({
-        /** Email/Phone login of the current user from their personal details */
-        login: PropTypes.string,
-
-        /** Display first name of the current user from their personal details */
-        firstName: PropTypes.string,
-
-        /** Display last name of the current user from their personal details */
-        lastName: PropTypes.string,
-
-        /** Avatar URL of the current user from their personal details */
-        avatar: PropTypes.string,
-
-        /** Pronouns of the current user from their personal details */
-        pronouns: PropTypes.string,
-
-        /** Timezone of the current user from their personal details */
-        timezone: PropTypes.shape({
-
-            /** Value of selected timezone */
-            selected: PropTypes.string,
-
-            /** Whether timezone is automatically set */
-            automatic: PropTypes.bool,
-        }),
-    }),
+    myPersonalDetails: PropTypes.shape(currentUserPersonalDetailsPropsTypes),
 
     /** The details about the user that is signed in */
     user: PropTypes.shape({

--- a/src/pages/settings/Profile/currentUserPersonalDetailsPropsTypes.js
+++ b/src/pages/settings/Profile/currentUserPersonalDetailsPropsTypes.js
@@ -1,0 +1,31 @@
+import PropTypes from 'prop-types';
+
+/** The personal details of the person who is logged in */
+const currentUserPersonalDetailsPropsTypes = {
+    /** Email/Phone login of the current user from their personal details */
+    login: PropTypes.string,
+
+    /** Display first name of the current user from their personal details */
+    firstName: PropTypes.string,
+
+    /** Display last name of the current user from their personal details */
+    lastName: PropTypes.string,
+
+    /** Avatar URL of the current user from their personal details */
+    avatar: PropTypes.string,
+
+    /** Pronouns of the current user from their personal details */
+    pronouns: PropTypes.string,
+
+    /** Timezone of the current user from their personal details */
+    timezone: PropTypes.shape({
+
+        /** Value of selected timezone */
+        selected: PropTypes.string,
+
+        /** Whether timezone is automatically set */
+        automatic: PropTypes.bool,
+    }),
+};
+
+export default currentUserPersonalDetailsPropsTypes;

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -919,7 +919,7 @@ const styles = {
     },
 
     chatItemCompose: {
-        minHeight: 65,
+        minHeight: 85,
         marginBottom: 5,
         paddingLeft: 20,
         paddingRight: 20,

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -919,11 +919,15 @@ const styles = {
     },
 
     chatItemCompose: {
-        minHeight: 85,
+        minHeight: 65,
         marginBottom: 5,
         paddingLeft: 20,
         paddingRight: 20,
         display: 'flex',
+    },
+
+    chatItemComposeWithFirstRow: {
+        minHeight: 85,
     },
 
     chatItemComposeBoxColor: {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ Fixes #3819

### Tests | QA Steps
1. Open Any conversation on E.cash.
2. Other user's Local Time should be visible over the composer.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web | Desktop
<!-- Insert screenshots of your changes on the web platform-->
![image](https://user-images.githubusercontent.com/24370807/124668057-f2e9c280-decd-11eb-8a4f-c940c1a0cbfd.png)

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
![time-m](https://user-images.githubusercontent.com/24370807/124669828-ac499780-ded0-11eb-8015-4c7e00b904db.png)

#### 
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
![time-a](https://user-images.githubusercontent.com/24370807/124669841-b10e4b80-ded0-11eb-8aa5-a1866b8730fd.png)
