### PR TITLE
Get&returnValueList=reportSummaryList

### DIFF
--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -992,6 +992,12 @@ function Inbox_CallUser(parameters) {
     return Network.post(commandName, parameters);
 }
 
+function GetReportSummaryList(parameters) {
+    const commandName = 'Get';
+    requireParameters(['reportIDList'], parameters, commandName);
+    return Network.post(commandName, {...parameters, returnValueList: 'reportSummaryList'});
+}
+
 export {
     Authenticate,
     BankAccount_Create,
@@ -1007,6 +1013,7 @@ export {
     GetIOUReport,
     GetPolicyList,
     GetPolicySummaryList,
+    GetReportSummaryList,
     GetRequestCountryCode,
     Graphite_Timer,
     Inbox_CallUser,

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -178,7 +178,7 @@ function getSimplifiedReportObject(report) {
         reportID: report.reportID,
         reportName,
         chatType,
-        ownerEmail: lodashGet(report, ['accountEmail'], ''),
+        ownerEmail: lodashGet(report, ['ownerEmail'], ''),
         policyID: lodashGet(report, ['reportNameValuePairs', 'expensify_policyID'], ''),
         unreadActionCount: getUnreadActionCount(report),
         maxSequenceNumber: report.reportActionListLength,

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -154,22 +154,22 @@ function getChatReportName(fullReport, chatType) {
  * @returns {Object}
  */
 function getSimplifiedReportObject(report) {
-    const lastReportAction = !_.isEmpty(report.mostRecentReportAction) ? report.mostRecentReportAction : null;
-    const createTimestamp = lastReportAction ? lastReportAction.created : 0;
+    const createTimestamp = lodashGet(report, 'lastActionCreated', 0);
     const lastMessageTimestamp = moment.utc(createTimestamp).unix();
-    const isLastMessageAttachment = /<img([^>]+)\/>/gi.test(lodashGet(lastReportAction, ['message', 'html'], ''));
+    const lastActionMessage = lodashGet(report, ['lastActionMessage', 'html'], '');
+    const isLastMessageAttachment = /<img([^>]+)\/>/gi.test(lastActionMessage);
     const chatType = lodashGet(report, ['reportNameValuePairs', 'chatType'], '');
 
     // We are removing any html tags from the message html since we cannot access the text version of any comments as
     // the report only has the raw reportActionList and not the processed version returned by Report_GetHistory
     // We convert the line-breaks in html to space ' ' before striping the tags
-    const lastMessageText = lodashGet(lastReportAction, ['message', 'html'], '')
+    const lastMessageText = lastActionMessage
         .replace(/((<br[^>]*>)+)/gi, ' ')
         .replace(/(<([^>]+)>)/gi, '');
     const reportName = lodashGet(report, ['reportNameValuePairs', 'type']) === 'chat'
         ? getChatReportName(report, chatType)
         : report.reportName;
-    const lastActorEmail = lodashGet(lastReportAction, 'accountEmail', '');
+    const lastActorEmail = lodashGet(report, 'lastActionActorEmail', '');
     const notificationPreference = isDefaultRoom({chatType})
         ? lodashGet(report, ['reportNameValuePairs', 'notificationPreferences', currentUserAccountID], 'daily')
         : '';
@@ -181,7 +181,7 @@ function getSimplifiedReportObject(report) {
         ownerEmail: lodashGet(report, ['ownerEmail'], ''),
         policyID: lodashGet(report, ['reportNameValuePairs', 'expensify_policyID'], ''),
         unreadActionCount: getUnreadActionCount(report),
-        maxSequenceNumber: report.reportActionListLength,
+        maxSequenceNumber: lodashGet(report, 'reportActionCount', 0),
         participants: getParticipantEmailsFromReport(report),
         isPinned: report.isPinned,
         lastVisitedTimestamp: lodashGet(report, [


### PR DESCRIPTION
### Details

Replaces `Get&returnValueList=reportStuff` with `reportSummaryList`.

This cuts initial fetching and re-fetching of reports from ~ 7 seconds to 1.5 seconds on a test account with many large chats and should speed things up for users.

### Fixed Issues
$ https://github.com/Expensify/Expensify.cash/issues/3875

### Tests
**Note: Pull Auth main branch and re-build before testing!**

1. Create an account with several hundred reports each having 1000+ comments (clitools can help with this)
2. Sign in and verify that you are able to do so and the LHN populates in a reasonable amount of time less than a couple of seconds and not 5-7 seconds. 
3. We are looking for the response time of the command `Get&returnValueList=reportSummaryList` which can be analyzed in the network tab

### QA Steps
For QA we'll do the same steps but ask @JmillsExpensify or someone with a large number of chats to test this out for us on staging.

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
