### PR TITLE
[No QA] Add version to mergedPR logs

### DIFF
--- a/.github/actions/createOrUpdateStagingDeploy/createOrUpdateStagingDeploy.js
+++ b/.github/actions/createOrUpdateStagingDeploy/createOrUpdateStagingDeploy.js
@@ -61,10 +61,8 @@ const run = function () {
             if (shouldCreateNewStagingDeployCash) {
                 // Find the list of PRs merged between the last StagingDeployCash and the new version
                 const mergedPRs = GitUtils.getPullRequestsMergedBetween(previousStagingDeployCashData.tag, newVersion);
-                console.log(
-                    'The following PRs have been merged between the previous StagingDeployCash and new version:',
-                    mergedPRs,
-                );
+                // eslint-disable-next-line max-len
+                console.log(`The following PRs have been merged between the previous StagingDeployCash (${previousStagingDeployCashData.tag}) and new version (${newVersion}):`, mergedPRs);
 
                 // TODO: if there are open DeployBlockers and we are opening a new checklist,
                 //  then we should close / remove the DeployBlockerCash label from those
@@ -90,10 +88,8 @@ const run = function () {
 
             // Find the list of PRs merged between the last StagingDeployCash and the new version
             const mergedPRs = GitUtils.getPullRequestsMergedBetween(previousStagingDeployCashData.tag, tag);
-            console.log(
-                'The following PRs have been merged between the previous StagingDeployCash and new version:',
-                mergedPRs,
-            );
+            // eslint-disable-next-line max-len
+            console.log(`The following PRs have been merged between the previous StagingDeployCash (${previousStagingDeployCashData.tag}) and new version (${tag}):`, mergedPRs);
 
             // Generate the PR list, preserving the previous state of `isVerified` for existing PRs
             const PRList = _.sortBy(

--- a/.github/actions/createOrUpdateStagingDeploy/index.js
+++ b/.github/actions/createOrUpdateStagingDeploy/index.js
@@ -71,10 +71,8 @@ const run = function () {
             if (shouldCreateNewStagingDeployCash) {
                 // Find the list of PRs merged between the last StagingDeployCash and the new version
                 const mergedPRs = GitUtils.getPullRequestsMergedBetween(previousStagingDeployCashData.tag, newVersion);
-                console.log(
-                    'The following PRs have been merged between the previous StagingDeployCash and new version:',
-                    mergedPRs,
-                );
+                // eslint-disable-next-line max-len
+                console.log(`The following PRs have been merged between the previous StagingDeployCash (${previousStagingDeployCashData.tag}) and new version (${newVersion}):`, mergedPRs);
 
                 // TODO: if there are open DeployBlockers and we are opening a new checklist,
                 //  then we should close / remove the DeployBlockerCash label from those
@@ -100,10 +98,8 @@ const run = function () {
 
             // Find the list of PRs merged between the last StagingDeployCash and the new version
             const mergedPRs = GitUtils.getPullRequestsMergedBetween(previousStagingDeployCashData.tag, tag);
-            console.log(
-                'The following PRs have been merged between the previous StagingDeployCash and new version:',
-                mergedPRs,
-            );
+            // eslint-disable-next-line max-len
+            console.log(`The following PRs have been merged between the previous StagingDeployCash (${previousStagingDeployCashData.tag}) and new version (${tag}):`, mergedPRs);
 
             // Generate the PR list, preserving the previous state of `isVerified` for existing PRs
             const PRList = _.sortBy(


### PR DESCRIPTION

### Details
Still trying to diagnose what is going wrong with the `createOrUpdateStagingDeploy` action. I can see from the existing logs what is going wrong, but I have no idea why. For example, in [this action run](https://github.com/Expensify/Expensify.cash/runs/3013501677?check_suite_focus=true#step:9:7), we can see:

1. [That the `NPM_VERSION` input is being passed and parsed correctly](https://github.com/Expensify/Expensify.cash/runs/3013501677?check_suite_focus=true#step:9:7).
1. That the [tag of the previous `StagingDeployCash`](https://github.com/Expensify/Expensify.cash/issues/3802) is being [correctly parsed](https://github.com/Expensify/Expensify.cash/runs/3013501677?check_suite_focus=true#step:9:277).
1. That running `GitUtils.getPullRequestsMergedBetween` locally with the correct previous + new tag produces very different results than we're seeing [in the action](https://github.com/Expensify/Expensify.cash/runs/3013501677?check_suite_focus=true#step:9:473):

    ![image](https://user-images.githubusercontent.com/47436092/124836058-2dd41080-df37-11eb-8083-4f4322e6adcf.png)
    
1. That, when running this locally, switching the order of the tags doesn't even seem to matter:

    ![image](https://user-images.githubusercontent.com/47436092/124836191-670c8080-df37-11eb-9399-3228bed0f11d.png)

### Fixed Issues
$ n/a

### Tests
Merge this PR and look at the logs of the `createOrUpdateStagingDeploy` action that results.

### Platforms
GitHub only.