### PR TITLE
Add profile details to avatar and names

### DIFF
--- a/src/pages/home/report/ReportActionItemSingle.js
+++ b/src/pages/home/report/ReportActionItemSingle.js
@@ -38,6 +38,10 @@ const defaultProps = {
     wrapperStyles: [styles.chatItem],
 };
 
+const showUserDetails = (email) => {
+    Navigation.navigate(`${ROUTES.DETAILS}/${email}`);
+};
+
 const ReportActionItemSingle = ({
     action,
     personalDetails,
@@ -58,10 +62,6 @@ const ReportActionItemSingle = ({
     const personArray = displayName
         ? [{type: 'TEXT', text: Str.isSMSLogin(login) ? toLocalPhone(displayName) : displayName}]
         : action.person;
-
-    const showUserDetails = (email) => {
-        Navigation.navigate(`${ROUTES.DETAILS}/${email}`);
-    };
 
     return (
         <View style={wrapperStyles}>

--- a/src/pages/home/report/ReportActionItemSingle.js
+++ b/src/pages/home/report/ReportActionItemSingle.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View} from 'react-native';
+import {View, Pressable} from 'react-native';
 import {withOnyx} from 'react-native-onyx';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
@@ -14,6 +14,8 @@ import ONYXKEYS from '../../../ONYXKEYS';
 import personalDetailsPropType from '../../personalDetailsPropType';
 import compose from '../../../libs/compose';
 import withLocalize, {withLocalizePropTypes} from '../../../components/withLocalize';
+import Navigation from '../../../libs/Navigation/Navigation';
+import ROUTES from '../../../ROUTES';
 
 const propTypes = {
     /** All the data of the action */
@@ -56,24 +58,33 @@ const ReportActionItemSingle = ({
     const personArray = displayName
         ? [{type: 'TEXT', text: Str.isSMSLogin(login) ? toLocalPhone(displayName) : displayName}]
         : action.person;
+
+    const showUserDetails = (email) => {
+        Navigation.navigate(`${ROUTES.DETAILS}/${email}`);
+    };
+
     return (
         <View style={wrapperStyles}>
-            <Avatar
-                imageStyles={[styles.actionAvatar]}
-                source={avatarUrl}
-            />
+            <Pressable onPress={() => showUserDetails(action.actorEmail)}>
+                <Avatar
+                    imageStyles={[styles.actionAvatar]}
+                    source={avatarUrl}
+                />
+            </Pressable>
             <View style={[styles.chatItemRight]}>
                 <View style={[styles.chatItemMessageHeader]}>
-                    {_.map(personArray, (fragment, index) => (
-                        <ReportActionItemFragment
-                            key={`person-${action.sequenceNumber}-${index}`}
-                            fragment={fragment}
-                            tooltipText={action.actorEmail}
-                            isAttachment={action.isAttachment}
-                            isLoading={action.loading}
-                            isSingleLine
-                        />
-                    ))}
+                    <Pressable onPress={() => showUserDetails(action.actorEmail)}>
+                        {_.map(personArray, (fragment, index) => (
+                            <ReportActionItemFragment
+                                key={`person-${action.sequenceNumber}-${index}`}
+                                fragment={fragment}
+                                tooltipText={action.actorEmail}
+                                isAttachment={action.isAttachment}
+                                isLoading={action.loading}
+                                isSingleLine
+                            />
+                        ))}
+                    </Pressable>
                     <ReportActionItemDate timestamp={action.timestamp} />
                 </View>
                 {children}


### PR DESCRIPTION
### Fixed Issues
$ https://github.com/Expensify/Expensify.cash/issues/3784

### Tests
1. Open a chat
2. Click a user's avatar and verify that the detail page opens
3. Repeat step 2 for a user's name

### QA Steps
Same as above,

### Tested On

- [X] Web
- [X] Mobile Web
- [X] Desktop
- [X] iOS
- [X] Android

### Screenshots

#### Web

https://user-images.githubusercontent.com/22219519/124969250-b3ad9580-dfe3-11eb-8c73-f2659d54297c.mov

#### Mobile Web

https://user-images.githubusercontent.com/22219519/124969259-b8724980-dfe3-11eb-8771-2fe50f31ca15.mov

#### Desktop

https://user-images.githubusercontent.com/22219519/124969710-464e3480-dfe4-11eb-9bdd-3672e72bdd72.mov

#### iOS

https://user-images.githubusercontent.com/22219519/124969296-c2944800-dfe3-11eb-910e-ef1a547f5918.mov

#### Android

https://user-images.githubusercontent.com/22219519/124969731-4d754280-dfe4-11eb-9a6b-1d92238d4bb8.mov
