### PR TITLE
[No QA] Add logs directly inside GetPRsMergedBetween

### DIFF
--- a/.github/actions/createOrUpdateStagingDeploy/index.js
+++ b/.github/actions/createOrUpdateStagingDeploy/index.js
@@ -193,9 +193,10 @@ const {execSync} = __nccwpck_require__(3129);
  * @returns {Array}
  */
 function getPullRequestsMergedBetween(fromRef, toRef) {
+    console.log('Getting pull requests merged between the following refs:', fromRef, toRef);
     const localGitLogs = execSync(`git log --format="%s" ${fromRef}...${toRef}`).toString();
     return _.map(
-        [...localGitLogs.matchAll(/Merge pull request #(\d{1,6}) from (?!Expensify\/(?:master|main|version-))/g)],
+        [...localGitLogs.matchAll(/Merge pull request #(\d{1,6}) from (?!Expensify\/main)/g)],
         match => match[1],
     );
 }

--- a/.github/actions/createOrUpdateStagingDeploy/index.js
+++ b/.github/actions/createOrUpdateStagingDeploy/index.js
@@ -196,7 +196,7 @@ function getPullRequestsMergedBetween(fromRef, toRef) {
     console.log('Getting pull requests merged between the following refs:', fromRef, toRef);
     const localGitLogs = execSync(`git log --format="%s" ${fromRef}...${toRef}`).toString();
     return _.map(
-        [...localGitLogs.matchAll(/Merge pull request #(\d{1,6}) from (?!Expensify\/main)/g)],
+        [...localGitLogs.matchAll(/Merge pull request #(\d{1,6}) from (?!Expensify\/(?:master|main|version-))/g)],
         match => match[1],
     );
 }

--- a/.github/actions/getDeployPullRequestList/index.js
+++ b/.github/actions/getDeployPullRequestList/index.js
@@ -120,7 +120,7 @@ function getPullRequestsMergedBetween(fromRef, toRef) {
     console.log('Getting pull requests merged between the following refs:', fromRef, toRef);
     const localGitLogs = execSync(`git log --format="%s" ${fromRef}...${toRef}`).toString();
     return _.map(
-        [...localGitLogs.matchAll(/Merge pull request #(\d{1,6}) from (?!Expensify\/main)/g)],
+        [...localGitLogs.matchAll(/Merge pull request #(\d{1,6}) from (?!Expensify\/(?:master|main|version-))/g)],
         match => match[1],
     );
 }

--- a/.github/actions/getDeployPullRequestList/index.js
+++ b/.github/actions/getDeployPullRequestList/index.js
@@ -117,9 +117,10 @@ const {execSync} = __nccwpck_require__(3129);
  * @returns {Array}
  */
 function getPullRequestsMergedBetween(fromRef, toRef) {
+    console.log('Getting pull requests merged between the following refs:', fromRef, toRef);
     const localGitLogs = execSync(`git log --format="%s" ${fromRef}...${toRef}`).toString();
     return _.map(
-        [...localGitLogs.matchAll(/Merge pull request #(\d{1,6}) from (?!Expensify\/(?:master|main|version-))/g)],
+        [...localGitLogs.matchAll(/Merge pull request #(\d{1,6}) from (?!Expensify\/main)/g)],
         match => match[1],
     );
 }

--- a/.github/libs/GitUtils.js
+++ b/.github/libs/GitUtils.js
@@ -12,7 +12,7 @@ function getPullRequestsMergedBetween(fromRef, toRef) {
     console.log('Getting pull requests merged between the following refs:', fromRef, toRef);
     const localGitLogs = execSync(`git log --format="%s" ${fromRef}...${toRef}`).toString();
     return _.map(
-        [...localGitLogs.matchAll(/Merge pull request #(\d{1,6}) from (?!Expensify\/main)/g)],
+        [...localGitLogs.matchAll(/Merge pull request #(\d{1,6}) from (?!Expensify\/(?:master|main|version-))/g)],
         match => match[1],
     );
 }

--- a/.github/libs/GitUtils.js
+++ b/.github/libs/GitUtils.js
@@ -9,9 +9,10 @@ const {execSync} = require('child_process');
  * @returns {Array}
  */
 function getPullRequestsMergedBetween(fromRef, toRef) {
+    console.log('Getting pull requests merged between the following refs:', fromRef, toRef);
     const localGitLogs = execSync(`git log --format="%s" ${fromRef}...${toRef}`).toString();
     return _.map(
-        [...localGitLogs.matchAll(/Merge pull request #(\d{1,6}) from (?!Expensify\/(?:master|main|version-))/g)],
+        [...localGitLogs.matchAll(/Merge pull request #(\d{1,6}) from (?!Expensify\/main)/g)],
         match => match[1],
     );
 }


### PR DESCRIPTION

### Details
Still trying to figure out how `createOrUpdateStagingDeploy` is broken. It seems as though the correct inputs are being passed to `GitUtils.getPullRequestsMergedBetween`, but it's producing the wrong outputs. So the only next step for now is to log what's happening within that function.

### Fixed Issues
$ n/a

### Tests
Merge this PR and see what happens.

### Platforms

GitHub only.