### PR TITLE
Treat IOU debts as pinned reports in the LHN

### DIFF
--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -317,9 +317,11 @@ function getOptions(reports, personalDetails, draftComments, activeReportID, {
         const reportDraftComment = report
             && draftComments
             && lodashGet(draftComments, `${ONYXKEYS.COLLECTION.REPORT_DRAFT_COMMENT}${report.reportID}`, '');
-        const reportContainsUserOwedIOU = lodashGet(report, 'hasOutstandingIOU', false)
-            && lodashGet(iouReports, [`${ONYXKEYS.COLLECTION.REPORT_IOUS}${report.iouReportID}`, 'ownerEmail'], '') !== currentUserLogin;
+        const iouReportOwner = lodashGet(report, 'hasOutstandingIOU', false)
+            ? lodashGet(iouReports, [`${ONYXKEYS.COLLECTION.REPORT_IOUS}${report.iouReportID}`, 'ownerEmail'], '')
+            : '';
 
+        const reportContainsUserOwedIOU = iouReportOwner && iouReportOwner !== currentUserLogin;
         const shouldFilterReportIfEmpty = !showReportsWithNoComments && report.lastMessageTimestamp === 0;
         const shouldFilterReportIfRead = hideReadReports && report.unreadActionCount === 0;
         const shouldShowReportIfHasDraft = showReportsWithDrafts && reportDraftComment && reportDraftComment.length > 0;

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -45,6 +45,16 @@ Onyx.connect({
     },
 });
 
+const iouReports = {};
+Onyx.connect({
+    key: ONYXKEYS.COLLECTION.REPORT_IOUS,
+    callback: (iouReport, key) => {
+        if (iouReport && key && iouReport.ownerEmail) {
+            iouReports[key] = iouReport;
+        }
+    },
+});
+
 /**
  * Helper method to return a default avatar
  *
@@ -307,6 +317,8 @@ function getOptions(reports, personalDetails, draftComments, activeReportID, {
         const reportDraftComment = report
             && draftComments
             && lodashGet(draftComments, `${ONYXKEYS.COLLECTION.REPORT_DRAFT_COMMENT}${report.reportID}`, '');
+        const reportContainsUserOwedIOU = lodashGet(report, 'hasOutstandingIOU', false)
+            && lodashGet(iouReports, [`${ONYXKEYS.COLLECTION.REPORT_IOUS}${report.iouReportID}`, 'ownerEmail'], '') !== currentUserLogin;
 
         const shouldFilterReportIfEmpty = !showReportsWithNoComments && report.lastMessageTimestamp === 0;
         const shouldFilterReportIfRead = hideReadReports && report.unreadActionCount === 0;
@@ -315,7 +327,8 @@ function getOptions(reports, personalDetails, draftComments, activeReportID, {
         if (report.reportID !== activeReportID
             && !report.isPinned
             && !shouldShowReportIfHasDraft
-            && shouldFilterReport) {
+            && shouldFilterReport
+            && !reportContainsUserOwedIOU) {
             return;
         }
 

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -628,8 +628,6 @@ function getSidebarOptions(
             hideReadReports: true,
             sortByAlphaAsc: true,
             showReportsWithDrafts: true,
-            prioritizePinnedReports: true,
-            prioritizeIOUDebts: true,
         };
     }
 

--- a/tests/unit/OptionsListUtilsTest.js
+++ b/tests/unit/OptionsListUtilsTest.js
@@ -86,6 +86,19 @@ describe('OptionsListUtils', () => {
             reportName: 'Silver Surfer',
             unreadActionCount: 0,
         },
+
+        // Note: This report has an IOU
+        9: {
+            lastVisitedTimestamp: 1610666739302,
+            lastMessageTimestamp: 1611282168,
+            isPinned: false,
+            reportID: 9,
+            participants: ['mistersinister@marauders.com'],
+            reportName: 'Mister Sinister',
+            unreadActionCount: 0,
+            iouReportID: 100,
+            hasOutstandingIOU: true,
+        },
     };
 
     // And a set of personalDetails some with existing reports and some without
@@ -119,6 +132,10 @@ describe('OptionsListUtils', () => {
             displayName: 'Captain America',
             login: 'steverogers@expensify.com',
         },
+        'mistersinister@marauders.com': {
+            displayName: 'Mr Sinister',
+            login: 'mistersinister@marauders.com',
+        },
 
         // These do not exist in reports at all
         'natasharomanoff@expensify.com': {
@@ -134,11 +151,11 @@ describe('OptionsListUtils', () => {
     const REPORTS_WITH_CONCIERGE = {
         ...REPORTS,
 
-        9: {
+        10: {
             lastVisitedTimestamp: 1610666739302,
             lastMessageTimestamp: 1,
             isPinned: false,
-            reportID: 9,
+            reportID: 10,
             participants: ['concierge@expensify.com'],
             reportName: 'Concierge',
             unreadActionCount: 1,
@@ -160,6 +177,10 @@ describe('OptionsListUtils', () => {
             keys: ONYXKEYS,
             initialKeyStates: {
                 [ONYXKEYS.SESSION]: {email: 'tonystark@expensify.com'},
+                [`${ONYXKEYS.COLLECTION.REPORT_IOUS}100`]: {
+                    ownerEmail: 'mistersinister@marauders.com',
+                    total: '1000',
+                },
             },
             registerStorageEventListener: () => {},
         });
@@ -404,11 +425,11 @@ describe('OptionsListUtils', () => {
             ...REPORTS,
 
             // Note: This report has no lastMessageTimestamp but is also pinned
-            9: {
+            10: {
                 lastVisitedTimestamp: 1610666739300,
                 lastMessageTimestamp: 0,
                 isPinned: true,
-                reportID: 9,
+                reportID: 10,
                 participants: ['captain_britain@expensify.com'],
                 reportName: 'Captain Britain',
             },
@@ -436,8 +457,11 @@ describe('OptionsListUtils', () => {
         // And the most recent pinned report is first in the list of reports
         expect(results.recentReports[0].login).toBe('captain_britain@expensify.com');
 
-        // And the third report is the report with a lastMessageTimestamp
-        expect(results.recentReports[2].login).toBe('steverogers@expensify.com');
+        // And the third report is the report with an IOU debt
+        expect(results.recentReports[2].login).toBe('mistersinister@marauders.com');
+
+        // And the fourth report is the report with the lastMessage timestamp
+        expect(results.recentReports[3].login).toBe('steverogers@expensify.com');
     });
 
     it('getSidebarOptions() with GSD priority mode', () => {
@@ -457,5 +481,8 @@ describe('OptionsListUtils', () => {
 
         // And Black Panther is alphabetically the first report and has an unread message
         expect(results.recentReports[0].login).toBe('tchalla@expensify.com');
+
+        // And Mister Sinister is alphabetically the fifth report and has an IOU debt despite not being pinned
+        expect(results.recentReports[5].login).toBe('mistersinister@marauders.com');
     });
 });


### PR DESCRIPTION
### Details
This PR updates the LHN to show IOUs the user owes at the top of the LHN with pinned reports.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ https://github.com/Expensify/Expensify.cash/issues/3389

### Tests/QA
1. Sign into account A and send some requests to other users for different amounts
2. Sign into account B and send a request to account A so that account A owes account B
3. Sign into account C and send a request to account A *larger than the amount in step 2* so that account A owes account C
4. In account A, change the Priority Mode (click user profile image -> preferences -> priority mode) to #focus, confirm that after navigating back to the LHN all reports are shown in alphabetical order, and unpinned IOU debt reports are still shown in the LHN
5. Change the Priority Mode back to Recent Mode, confirm that after navigating back to the LHN the pinned reports are at the top, followed by the debts in order from highest to lowest amount owed, followed by other chats
6. Hit the search icon, confirm that the results are still shown in recent order, and not in order of pinned reports or debts.
7. Hit the green plus button and select a new chat, confirm that the results still show the recent chats in order of recently viewed, ~and the contacts below are listed in alphabetical order.~

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web/Desktop/Mobile Web
| #focus | Recent |
|---|---|
| ![image](https://user-images.githubusercontent.com/3981102/125012409-fe003800-e01e-11eb-988b-4c1babc50314.png) | ![image](https://user-images.githubusercontent.com/3981102/125012426-05bfdc80-e01f-11eb-9284-9a7ddaffb773.png) |

#### iOS/Android
| #focus | Recent |
|---|---|
| ![image](https://user-images.githubusercontent.com/3981102/125012646-67804680-e01f-11eb-93f6-c9bc853de022.png) | ![image](https://user-images.githubusercontent.com/3981102/125012655-6b13cd80-e01f-11eb-9114-39efa9a9db31.png) |