### PR TITLE
Fix: blue screen issue on Safari Web

### DIFF
--- a/src/components/PressableWithSecondaryInteraction/index.js
+++ b/src/components/PressableWithSecondaryInteraction/index.js
@@ -1,11 +1,7 @@
 import _ from 'underscore';
 import React, {Component} from 'react';
 import {Pressable} from 'react-native';
-import pressableWithSecondaryInteractionPropTypes from './pressableWithSecondaryInteractionPropTypes';
-
-const defaultProps = {
-    forwardedRef: () => {},
-};
+import {propTypes, defaultProps} from './pressableWithSecondaryInteractionPropTypes';
 
 /**
  * This is a special Pressable that calls onSecondaryInteraction when LongPressed, or right-clicked.
@@ -42,7 +38,9 @@ class PressableWithSecondaryInteraction extends Component {
         const defaultPressableProps = _.omit(this.props, ['onSecondaryInteraction', 'children', 'onLongPress']);
         return (
             <Pressable
+                onPressIn={this.props.onPressIn}
                 onLongPress={e => this.props.onSecondaryInteraction(e)}
+                onPressOut={this.props.onPressOut}
                 ref={el => this.pressableRef = el}
                 // eslint-disable-next-line react/jsx-props-no-spreading
                 {...defaultPressableProps}
@@ -53,7 +51,7 @@ class PressableWithSecondaryInteraction extends Component {
     }
 }
 
-PressableWithSecondaryInteraction.propTypes = pressableWithSecondaryInteractionPropTypes;
+PressableWithSecondaryInteraction.propTypes = propTypes;
 PressableWithSecondaryInteraction.defaultProps = defaultProps;
 export default React.forwardRef((props, ref) => (
     // eslint-disable-next-line react/jsx-props-no-spreading

--- a/src/components/PressableWithSecondaryInteraction/index.native.js
+++ b/src/components/PressableWithSecondaryInteraction/index.native.js
@@ -1,11 +1,7 @@
 import _ from 'underscore';
 import React, {forwardRef} from 'react';
 import {Pressable} from 'react-native';
-import pressableWithSecondaryInteractionPropTypes from './pressableWithSecondaryInteractionPropTypes';
-
-const defaultProps = {
-    forwardedRef: () => {},
-};
+import {propTypes, defaultProps} from './pressableWithSecondaryInteractionPropTypes';
 
 /**
  * This is a special Pressable that calls onSecondaryInteraction when LongPressed.
@@ -16,10 +12,12 @@ const defaultProps = {
 const PressableWithSecondaryInteraction = props => (
     <Pressable
         ref={props.forwardedRef}
+        onPressIn={props.onPressIn}
         onLongPress={(e) => {
             e.preventDefault();
             props.onSecondaryInteraction(e);
         }}
+        onPressOut={props.onPressOut}
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...(_.omit(props, 'onLongPress'))}
     >
@@ -27,7 +25,7 @@ const PressableWithSecondaryInteraction = props => (
     </Pressable>
 );
 
-PressableWithSecondaryInteraction.propTypes = pressableWithSecondaryInteractionPropTypes;
+PressableWithSecondaryInteraction.propTypes = propTypes;
 PressableWithSecondaryInteraction.defaultProps = defaultProps;
 PressableWithSecondaryInteraction.displayName = 'PressableWithSecondaryInteraction';
 

--- a/src/components/PressableWithSecondaryInteraction/pressableWithSecondaryInteractionPropTypes.js
+++ b/src/components/PressableWithSecondaryInteraction/pressableWithSecondaryInteractionPropTypes.js
@@ -1,6 +1,12 @@
 import PropTypes from 'prop-types';
 
-export default {
+const propTypes = {
+    /** The function that should be called when this pressable is pressedIn */
+    onPressIn: PropTypes.func,
+
+    /** The function that should be called when this pressable is pressedOut */
+    onPressOut: PropTypes.func,
+
     /** The function that should be called when this pressable is LongPressed or right-clicked. */
     onSecondaryInteraction: PropTypes.func.isRequired,
 
@@ -10,3 +16,11 @@ export default {
     /** The ref to the search input (may be null on small screen widths) */
     forwardedRef: PropTypes.func,
 };
+
+const defaultProps = {
+    forwardedRef: () => {},
+    onPressIn: () => {},
+    onPressOut: () => {},
+};
+
+export {propTypes, defaultProps};

--- a/src/libs/ControlSelection/index.js
+++ b/src/libs/ControlSelection/index.js
@@ -1,0 +1,20 @@
+/**
+ * Block selection on the whole app
+ *
+ */
+function block() {
+    document.body.classList.add('disable-select');
+}
+
+/**
+ * Unblock selection on the whole app
+ *
+ */
+function unblock() {
+    document.body.classList.remove('disable-select');
+}
+
+export default {
+    block,
+    unblock,
+};

--- a/src/libs/ControlSelection/index.native.js
+++ b/src/libs/ControlSelection/index.native.js
@@ -1,0 +1,7 @@
+function block() {}
+function unblock() {}
+
+export default {
+    block,
+    unblock,
+};

--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -24,6 +24,8 @@ import ConfirmModal from '../../../components/ConfirmModal';
 import compose from '../../../libs/compose';
 import withLocalize, {withLocalizePropTypes} from '../../../components/withLocalize';
 import {deleteReportComment} from '../../../libs/actions/Report';
+import withWindowDimensions, {windowDimensionsPropTypes} from '../../../components/withWindowDimensions';
+import ControlSelection from '../../../libs/ControlSelection';
 
 const propTypes = {
     /** The ID of the report this action is on. */
@@ -56,6 +58,7 @@ const propTypes = {
     onLayout: PropTypes.func.isRequired,
 
     ...withLocalizePropTypes,
+    ...windowDimensionsPropTypes,
 };
 
 const defaultProps = {
@@ -269,6 +272,8 @@ class ReportActionItem extends Component {
             <>
                 <PressableWithSecondaryInteraction
                     ref={el => this.popoverAnchor = el}
+                    onPressIn={() => this.props.isSmallScreenWidth && ControlSelection.block()}
+                    onPressOut={() => ControlSelection.unblock()}
                     onSecondaryInteraction={this.showPopover}
                 >
                     <Hoverable resetsOnClickOutside={false}>
@@ -354,6 +359,7 @@ ReportActionItem.propTypes = propTypes;
 ReportActionItem.defaultProps = defaultProps;
 
 export default compose(
+    withWindowDimensions,
     withLocalize,
     withOnyx({
         draftMessage: {

--- a/web/index.html
+++ b/web/index.html
@@ -28,6 +28,10 @@
         input[type=text] {
             -webkit-user-select: text !important;
         }
+        .disable-select * {
+            -webkit-user-select: none !important;
+            -webkit-touch-callout: none !important;
+        }
     </style>
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1">
     <link rel="shortcut icon" id="favicon" href="/favicon.png">


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ Fixes #2705

### Tests | QA Steps
1. Open Any conversation on E.cash in safari Mobile web.
2. Long press any message to open the context menu.
3. You should not see any blue screen. (See the linked issue for example).

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

https://user-images.githubusercontent.com/24370807/124889537-d09e9480-dff4-11eb-9560-edda29080a7f.mp4


#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
