### PR TITLE
Fix IOU currency routes

### DIFF
--- a/src/ROUTES.js
+++ b/src/ROUTES.js
@@ -10,9 +10,9 @@ const IOU_REQUEST = 'iou/request';
 const IOU_BILL = 'iou/split';
 const IOU_SEND = 'iou/send';
 const IOU_DETAILS = 'iou/details';
-const IOU_REQUEST_CURRENCY = `${IOU_REQUEST}/:reportID/currency`;
-const IOU_BILL_CURRENCY = `${IOU_BILL}/:reportID/currency`;
-const IOU_SEND_CURRENCY = `${IOU_SEND}/:reportID/currency`;
+const IOU_REQUEST_CURRENCY = `${IOU_REQUEST}/currency`;
+const IOU_BILL_CURRENCY = `${IOU_BILL}/currency`;
+const IOU_SEND_CURRENCY = `${IOU_SEND}/currency`;
 
 export default {
     BANK_ACCOUNT: 'bank-account/:stepToOpen?',
@@ -40,15 +40,15 @@ export default {
     IOU_REQUEST_WITH_REPORT_ID: `${IOU_REQUEST}/:reportID?`,
     IOU_BILL_WITH_REPORT_ID: `${IOU_BILL}/:reportID?`,
     IOU_SEND_WITH_REPORT_ID: `${IOU_SEND}/:reportID?`,
-    getIouRequestRoute: reportID => (reportID ? `${IOU_REQUEST}/${reportID}` : IOU_REQUEST),
-    getIouSplitRoute: reportID => (reportID ? `${IOU_BILL}/${reportID}` : IOU_BILL),
-    getIOUSendRoute: reportID => (reportID ? `${IOU_SEND}/${reportID}` : IOU_SEND),
-    IOU_BILL_CURRENCY,
-    IOU_REQUEST_CURRENCY,
-    IOU_SEND_CURRENCY,
-    getIouRequestCurrencyRoute: reportID => (reportID ? `${IOU_REQUEST}/${reportID}/currency` : IOU_REQUEST_CURRENCY),
-    getIouBillCurrencyRoute: reportID => (reportID ? `${IOU_BILL}/${reportID}/currency` : IOU_BILL_CURRENCY),
-    getIouSendCurrencyRoute: reportID => (reportID ? `${IOU_SEND}/${reportID}/currency` : IOU_SEND_CURRENCY),
+    getIouRequestRoute: reportID => `${IOU_REQUEST}/${reportID}`,
+    getIouSplitRoute: reportID => `${IOU_BILL}/${reportID}`,
+    getIOUSendRoute: reportID => `${IOU_SEND}/${reportID}`,
+    IOU_BILL_CURRENCY: `${IOU_BILL_CURRENCY}/:reportID?`,
+    IOU_REQUEST_CURRENCY: `${IOU_REQUEST_CURRENCY}/:reportID?`,
+    IOU_SEND_CURRENCY: `${IOU_SEND_CURRENCY}/:reportID?`,
+    getIouRequestCurrencyRoute: reportID => `${IOU_REQUEST_CURRENCY}/${reportID}`,
+    getIouBillCurrencyRoute: reportID => `${IOU_BILL_CURRENCY}/${reportID}`,
+    getIouSendCurrencyRoute: reportID => `${IOU_SEND_CURRENCY}/${reportID}`,
     IOU_DETAILS,
     IOU_DETAILS_WITH_IOU_REPORT_ID: `${IOU_DETAILS}/:chatReportID/:iouReportID/`,
     getIouDetailsRoute: (chatReportID, iouReportID) => `iou/details/${chatReportID}/${iouReportID}`,

--- a/src/ROUTES.js
+++ b/src/ROUTES.js
@@ -10,6 +10,9 @@ const IOU_REQUEST = 'iou/request';
 const IOU_BILL = 'iou/split';
 const IOU_SEND = 'iou/send';
 const IOU_DETAILS = 'iou/details';
+const IOU_REQUEST_CURRENCY = `${IOU_REQUEST}/:reportID/currency`;
+const IOU_BILL_CURRENCY = `${IOU_BILL}/:reportID/currency`;
+const IOU_SEND_CURRENCY = `${IOU_SEND}/:reportID/currency`;
 
 export default {
     BANK_ACCOUNT: 'bank-account/:stepToOpen?',
@@ -35,17 +38,17 @@ export default {
     IOU_BILL,
     IOU_SEND,
     IOU_REQUEST_WITH_REPORT_ID: `${IOU_REQUEST}/:reportID?`,
-    IOU_BILL_WITH_REPORTID: `${IOU_BILL}/:reportID?`,
-    IOU_SEND_WITH_REPORTID: `${IOU_SEND}/:reportID?`,
-    getIouRequestRoute: reportID => `${IOU_REQUEST}/${reportID}`,
-    getIouSplitRoute: reportID => `${IOU_BILL}/${reportID}`,
-    getIOUSendRoute: reportID => `${IOU_SEND}/${reportID}`,
-    IOU_BILL_CURRENCY: `${IOU_BILL}/:reportID/currency`,
-    IOU_REQUEST_CURRENCY: `${IOU_REQUEST}/:reportID/currency`,
-    IOU_SEND_CURRENCY: `${IOU_SEND}/:reportID/currency`,
-    getIouRequestCurrencyRoute: reportID => `${IOU_REQUEST}/${reportID}/currency`,
-    getIouBillCurrencyRoute: reportID => `${IOU_BILL}/${reportID}/currency`,
-    getIouSendCurrencyRoute: reportID => `${IOU_SEND}/${reportID}/currency`,
+    IOU_BILL_WITH_REPORT_ID: `${IOU_BILL}/:reportID?`,
+    IOU_SEND_WITH_REPORT_ID: `${IOU_SEND}/:reportID?`,
+    getIouRequestRoute: reportID => (reportID ? `${IOU_REQUEST}/${reportID}` : IOU_REQUEST),
+    getIouSplitRoute: reportID => (reportID ? `${IOU_BILL}/${reportID}` : IOU_BILL),
+    getIOUSendRoute: reportID => (reportID ? `${IOU_SEND}/${reportID}` : IOU_SEND),
+    IOU_BILL_CURRENCY,
+    IOU_REQUEST_CURRENCY,
+    IOU_SEND_CURRENCY,
+    getIouRequestCurrencyRoute: reportID => (reportID ? `${IOU_REQUEST}/${reportID}/currency` : IOU_REQUEST_CURRENCY),
+    getIouBillCurrencyRoute: reportID => (reportID ? `${IOU_BILL}/${reportID}/currency` : IOU_BILL_CURRENCY),
+    getIouSendCurrencyRoute: reportID => (reportID ? `${IOU_SEND}/${reportID}/currency` : IOU_SEND_CURRENCY),
     IOU_DETAILS,
     IOU_DETAILS_WITH_IOU_REPORT_ID: `${IOU_DETAILS}/:chatReportID/:iouReportID/`,
     getIouDetailsRoute: (chatReportID, iouReportID) => `iou/details/${chatReportID}/${iouReportID}`,

--- a/src/libs/Navigation/linkingConfig.js
+++ b/src/libs/Navigation/linkingConfig.js
@@ -106,13 +106,13 @@ export default {
             },
             IOU_Bill: {
                 screens: {
-                    IOU_Bill_Root: ROUTES.IOU_BILL_WITH_REPORTID,
+                    IOU_Bill_Root: ROUTES.IOU_BILL_WITH_REPORT_ID,
                     IOU_Bill_Currency: ROUTES.IOU_BILL_CURRENCY,
                 },
             },
             IOU_Send: {
                 screens: {
-                    IOU_Send_Root: ROUTES.IOU_SEND_WITH_REPORTID,
+                    IOU_Send_Root: ROUTES.IOU_SEND_WITH_REPORT_ID,
                     IOU_Send_Currency: ROUTES.IOU_SEND_CURRENCY,
                 },
             },


### PR DESCRIPTION
### Details
Just some broken routes – we were trying to go to `/iou/split//currency`, where the missing section is meant to be a `reportID`. However, in this case it's perfectly legitimate to not have a `reportID`, because we're creating a new bill split. So instead, we can fix this by going to `/iou/split/:reportID/currency`. It actually doesn't matter what's between `split/` and `/currency`, as long as it's not empty. Just `x` seems to work as well.

### Fixed Issues
$ https://github.com/Expensify/Expensify.cash/issues/3920

### Tests / QA Steps
1. Click on the big green FAB.
1. Select `Split Bill`
1. Click on the currency symbol in the "Split Bill" modal.
1. Verify that the currency selection page opens up.
1. Close the modal.
1. Click on the big green FAB.
1. Select `Request Money`
1. Click on the currency symbol in the "Request Money" modal.
1. Verify that the currency selection page opens up.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [ ] Android

### Screenshots
#### Web
https://user-images.githubusercontent.com/47436092/124957769-4b07ee00-dfce-11eb-9875-804887b5774c.mov

#### Mobile Web
https://user-images.githubusercontent.com/47436092/124960764-81933800-dfd1-11eb-9c94-9f2660e08cfc.mov

#### Desktop
https://user-images.githubusercontent.com/47436092/124958130-aa65fe00-dfce-11eb-9ff1-501874aa84c7.mov

#### iOS
https://user-images.githubusercontent.com/47436092/124960346-15183900-dfd1-11eb-95fc-de637ca13e6a.mov

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
