### PR TITLE
Prepend website form with https://

### DIFF
--- a/src/pages/ReimbursementAccount/CompanyStep.js
+++ b/src/pages/ReimbursementAccount/CompanyStep.js
@@ -36,7 +36,7 @@ class CompanyStep extends React.Component {
             addressState: lodashGet(props, ['achData', 'addressState']) || 'AK',
             addressZipCode: lodashGet(props, ['achData', 'addressZipCode'], ''),
             companyPhone: lodashGet(props, ['achData', 'companyPhone'], ''),
-            website: lodashGet(props, ['achData', 'website'], ''),
+            website: lodashGet(props, ['achData', 'website'], 'https://'),
             companyTaxID: lodashGet(props, ['achData', 'companyTaxID'], ''),
             incorporationType: lodashGet(props, ['achData', 'incorporationType'], ''),
             incorporationDate: lodashGet(props, ['achData', 'incorporationDate'], ''),


### PR DESCRIPTION

### Details
Prepends the website form input on the VBA company step with `https://`

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/170004

### Tests / QA Steps (Web only)
1. Go to `/bank-account/company`
1. Verify that the text input for the company website is pre-populated with `https://`
1. Verify that when you select the input and start typing, that `https://` isn't automatically overwritten.

### Tests / QA Steps (other platforms)
On other platforms, the VBA flow is not yet readily accessible.

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
#### Web
![image](https://user-images.githubusercontent.com/47436092/125004453-6561bc00-e00e-11eb-8d76-780f75f763ca.png)

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
