### PR TITLE
Correct styling for timeRow for other user in 1:1 chat

### DIFF
--- a/src/pages/home/report/ParticipantLocalTime.js
+++ b/src/pages/home/report/ParticipantLocalTime.js
@@ -58,10 +58,12 @@ class ParticipantLocalTime extends React.Component {
         return (
             isReportRecipientLocalTimeReady ? (
                 <View style={[styles.chatItemComposeSecondaryRow]}>
-                    <ExpensiText style={[
-                        styles.chatItemComposeSecondaryRowSubText,
-                        styles.chatItemComposeSecondaryRowOffset,
-                    ]}
+                    <ExpensiText
+                        style={[
+                            styles.chatItemComposeSecondaryRowSubText,
+                            styles.chatItemComposeSecondaryRowOffset,
+                        ]}
+                        numberOfLines={1}
                     >
                         {this.props.translate(
                             'reportActionCompose.localTime',

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -385,6 +385,7 @@ const styles = {
         color: themeColors.textSupporting,
         fontFamily: fontFamily.GTA,
         fontSize: variables.fontSizeSmall,
+        lineHeight: 14,
     },
 
     chatItemComposeSecondaryRowOffset: {
@@ -927,7 +928,7 @@ const styles = {
     },
 
     chatItemComposeWithFirstRow: {
-        minHeight: 85,
+        minHeight: 90,
     },
 
     chatItemComposeBoxColor: {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Small change for https://github.com/Expensify/Expensify.cash/pull/3883#issuecomment-876831449.


### Tests |  QA Steps

  1. Open Any conversation on E.cash.
  2. Other user's Local Time should be visible over the composer.
  3. It should trim if the name of another user is bigger than the screen.


### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

![localhost_8080_r_68438375](https://user-images.githubusercontent.com/24370807/125011441-1a838b00-e086-11eb-9eaa-0b32b4d031e1.png)

