### PR TITLE
Fix profile menu position

### DIFF
--- a/src/components/AvatarWithImagePicker.js
+++ b/src/components/AvatarWithImagePicker.js
@@ -125,8 +125,8 @@ class AvatarWithImagePicker extends React.Component {
                                     onItemSelected={() => this.setState({isMenuVisible: false})}
                                     menuItems={this.createMenuItems(openPicker)}
                                     anchorPosition={this.props.anchorPosition}
-                                    animationIn="fadeInRight"
-                                    animationOut="fadeOutRight"
+                                    animationIn="fadeInDown"
+                                    animationOut="fadeOutUp"
                                 />
                             </>
                         )}

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -631,7 +631,7 @@ const styles = {
 
     createMenuPositionProfile: {
         right: 18,
-        top: 100,
+        top: 180,
     },
 
     createMenuPositionReportActionCompose: {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ Fixes #3895

### Tests |  QA Steps
1. Open ProfilePage on E.cash.
2. Click edit Image.
3. menu should open below the edit button and animating from top to bottom.

### Tested On

- [x] Web
- [ ] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web | Desktop
<!-- Insert screenshots of your changes on the web platform-->
![image](https://user-images.githubusercontent.com/24370807/125018878-91735080-e093-11eb-9e93-b97a3325c68c.png)

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
