### PR TITLE
When navigating to the same report, don't reset the navigation state

### DIFF
--- a/src/libs/Navigation/CustomActions.js
+++ b/src/libs/Navigation/CustomActions.js
@@ -11,17 +11,16 @@ import lodashGet from 'lodash/get';
  *
  * @param {String} screenName
  * @param {Object} params
+ * @param {Object} navigationRef
  * @returns {Function}
  */
 function pushDrawerRoute(screenName, params, navigationRef) {
     return (state) => {
-
-
         // Avoid the navigation and refocus the report if we're trying to navigate to our active report
         // We use our RootState as the dispatch's state is relative to the active navigator and might
         // not contain our active report.
         const rootState = navigationRef.current.getRootState();
-        const activeReportID = lodashGet(rootState, 'routes[0].state.routes[0].params.reportID', '')
+        const activeReportID = lodashGet(rootState, 'routes[0].state.routes[0].params.reportID', '');
 
         if (activeReportID === params.reportID) {
             if (state.type !== 'drawer') {

--- a/src/libs/Navigation/CustomActions.js
+++ b/src/libs/Navigation/CustomActions.js
@@ -1,4 +1,4 @@
-import {CommonActions} from '@react-navigation/native';
+import {CommonActions, StackActions, DrawerActions} from '@react-navigation/native';
 
 /**
  * In order to create the desired browser navigation behavior on web and mobile web we need to replace any
@@ -12,8 +12,23 @@ import {CommonActions} from '@react-navigation/native';
  * @param {Object} params
  * @returns {Function}
  */
-function pushDrawerRoute(screenName, params) {
+function pushDrawerRoute(screenName, params, navigationRef) {
     return (state) => {
+
+
+        // Avoid the navigation and refocus the report if we're trying to navigate to our active report
+        const rootState = navigationRef.current.getRootState();
+        const activeReportID = rootState.routes[0].state.routes[0].params.reportID;
+
+        console.log(`activeReportID: ${activeReportID}, params.reportID: ${params.reportID}`)
+        console.log(params);
+        if (activeReportID === params.reportID) {
+            if (state.type != 'drawer') {
+                navigationRef.current.dispatch(StackActions.pop());
+            }
+            return DrawerActions.closeDrawer();
+        }
+
         // Non Drawer navigators have routes and not history so we'll fallback to navigate() in the case where we are
         // unable to push a new screen onto the history stack e.g. navigating to a ReportScreen via a modal screen.
         // Note: One downside of this is that the history will be reset.

--- a/src/libs/Navigation/CustomActions.js
+++ b/src/libs/Navigation/CustomActions.js
@@ -1,4 +1,5 @@
 import {CommonActions, StackActions, DrawerActions} from '@react-navigation/native';
+import lodashGet from 'lodash/get';
 
 /**
  * In order to create the desired browser navigation behavior on web and mobile web we need to replace any
@@ -17,13 +18,13 @@ function pushDrawerRoute(screenName, params, navigationRef) {
 
 
         // Avoid the navigation and refocus the report if we're trying to navigate to our active report
+        // We use our RootState as the dispatch's state is relative to the active navigator and might
+        // not contain our active report.
         const rootState = navigationRef.current.getRootState();
-        const activeReportID = rootState.routes[0].state.routes[0].params.reportID;
+        const activeReportID = lodashGet(rootState, 'routes[0].state.routes[0].params.reportID', '')
 
-        console.log(`activeReportID: ${activeReportID}, params.reportID: ${params.reportID}`)
-        console.log(params);
         if (activeReportID === params.reportID) {
-            if (state.type != 'drawer') {
+            if (state.type !== 'drawer') {
                 navigationRef.current.dispatch(StackActions.pop());
             }
             return DrawerActions.closeDrawer();

--- a/src/libs/Navigation/Navigation.js
+++ b/src/libs/Navigation/Navigation.js
@@ -62,7 +62,7 @@ function navigate(route = ROUTES.HOME) {
     // have a participants route since those should go through linkTo() as they open a different screen.
     const {reportID, isParticipantsRoute} = ROUTES.parseReportRouteParams(route);
     if (reportID && !isParticipantsRoute) {
-        navigationRef.current.dispatch(CustomActions.pushDrawerRoute(SCREENS.REPORT, {reportID}));
+        navigationRef.current.dispatch(CustomActions.pushDrawerRoute(SCREENS.REPORT, {reportID}, navigationRef));
         return;
     }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Check if we're attempting to navigate to the active report. If we are, reveals the report and do not reset the navigation state.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ https://github.com/Expensify/Expensify.cash/issues/3893

### Tests
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->
1. Opened a chat on the app
2. Attempted to navigate to that chat again (via a notification or directly)
3. The chat was revealed and the navigation state wasn't reseted 

### QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->
1. Open any chat on the app
2. Attempt to navigate to that chat again (via a notification or directly)
3. The chat should be revealed and the navigation state shouldn't be reseted (the component isn't being remounted and the Pusher isn't being reconnected)
### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

https://user-images.githubusercontent.com/53711423/125021850-cfe81b80-e051-11eb-9723-a8cf8a4de270.mov


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

https://user-images.githubusercontent.com/53711423/125021854-d2e30c00-e051-11eb-81d3-41fc45b72821.mov


#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->

I'm having a hard time adding videos for mobile as it isn't receiving the notifications. I tested on mobile by emulating the behavior of a notification click somewhere in a modal.