### PR TITLE
Set proper reportID for chatReport after creating IOU

### DIFF
--- a/src/libs/actions/IOU.js
+++ b/src/libs/actions/IOU.js
@@ -32,7 +32,8 @@ function getIOUReportsForNewTransaction(requestParams) {
                 // First, the existing chat report needs updated with the details about the new IOU
                 const paramsForIOUReport = _.findWhere(requestParams, {reportID: reportData.reportID});
                 if (paramsForIOUReport && paramsForIOUReport.chatReportID) {
-                    const chatReportKey = `${ONYXKEYS.COLLECTION.REPORT}${paramsForIOUReport.chatReportID}`;
+                    const chatReportID = paramsForIOUReport.chatReportID;
+                    const chatReportKey = `${ONYXKEYS.COLLECTION.REPORT}${chatReportID}`;
                     chatReportsToUpdate[chatReportKey] = {
                         iouReportID: reportData.reportID,
                         total: reportData.total,
@@ -42,7 +43,7 @@ function getIOUReportsForNewTransaction(requestParams) {
 
                     // Second, the IOU report needs updated with the new IOU details too
                     const iouReportKey = `${ONYXKEYS.COLLECTION.REPORT_IOUS}${reportData.reportID}`;
-                    iouReportsToUpdate[iouReportKey] = getSimplifiedIOUReport(reportData, paramsForIOUReport.chatReportID);
+                    iouReportsToUpdate[iouReportKey] = getSimplifiedIOUReport(reportData, chatReportID);
                 }
             });
 

--- a/src/libs/actions/IOU.js
+++ b/src/libs/actions/IOU.js
@@ -42,7 +42,7 @@ function getIOUReportsForNewTransaction(requestParams) {
 
                     // Second, the IOU report needs updated with the new IOU details too
                     const iouReportKey = `${ONYXKEYS.COLLECTION.REPORT_IOUS}${reportData.reportID}`;
-                    iouReportsToUpdate[iouReportKey] = getSimplifiedIOUReport(reportData, reportData.reportID);
+                    iouReportsToUpdate[iouReportKey] = getSimplifiedIOUReport(reportData, paramsForIOUReport.chatReportID);
                 }
             });
 

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -567,8 +567,8 @@ function updateReportWithNewAction(reportID, reportAction, notificationPreferenc
 
     Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`, reportActionsToMerge);
 
-    // If chat report receives an action with IOU, update IOU object
-    if (reportAction.actionName === CONST.REPORT.ACTIONS.TYPE.IOU) {
+    // If chat report receives an action with IOU and we have an IOUReportID, update IOU object
+    if (reportAction.actionName === CONST.REPORT.ACTIONS.TYPE.IOU && reportAction.originalMessage.IOUReportID) {
         const iouReportID = reportAction.originalMessage.IOUReportID;
 
         // We know this iouReport is open because reportActions of type CONST.REPORT.ACTIONS.TYPE.IOU can only be


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This fixes an issue where the chatReportID for an IOUReport was being set incorrectly after creating a new IOU transaction.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ https://github.com/Expensify/Expensify.cash/issues/3940

### Tests/QA
1. Log in with any account
2. Click on Green button and click on Split
3. Put amount and click next
4. Select couple users and click next
5. After Split Request is done select user which you requested money.
6. Click on Badge in the header
7. Confirm payment details are shown
8. Click on a single user's chat and request money from them via the `+` button in the compose box
9. Request money and then click on the badge, confirm the payment details are shown


### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
| Single Request | Split Bill |
|---|---|
| <img src='http://g.recordit.co/gdZe8Kt1Dg.gif' width='400'/> | <img src='http://g.recordit.co/vIlYO9qe4V.gif' width='400'/> |
