### PR TITLE
Only provide a default lineHeight when the fontSize is default

### DIFF
--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -59,7 +59,7 @@ const Text = React.forwardRef(({
         ...mergedStyles,
     };
 
-    if (fontSize === variables.fontSizeNormal) {
+    if (componentStyle.fontSize === variables.fontSizeNormal) {
         componentStyle.lineHeight = 20;
     }
 

--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -54,11 +54,14 @@ const Text = React.forwardRef(({
     const componentStyle = {
         color,
         fontSize,
-        lineHeight: 20,
         textAlign,
         fontFamily: fontFamily[family],
         ...mergedStyles,
     };
+
+    if (fontSize === variables.fontSizeNormal) {
+        componentStyle.lineHeight = 20;
+    }
 
     return (
         // eslint-disable-next-line react/jsx-props-no-spreading


### PR DESCRIPTION
### Details
Our custom `Text` component provided a default line height. However, for larger fonts, that caused the text to appear cut off. To fix, we only provide a default line height when the font size is the default.

### Fixed Issues
$ https://github.com/Expensify/Expensify.cash/issues/3964

### Tests / QA Steps
1. Open the app
1. Create a new bill split
1. Verify that the currency/amount is fully visible.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
#### Web
![image](https://user-images.githubusercontent.com/47436092/125145733-5bf05680-e0d7-11eb-87f0-49386af1f387.png)

#### Mobile Web
![image](https://user-images.githubusercontent.com/47436092/125145793-a1ad1f00-e0d7-11eb-9c98-8ecc7c277d34.png)

#### Desktop
![image](https://user-images.githubusercontent.com/47436092/125145938-68c17a00-e0d8-11eb-90ec-dc02678d0736.png)

#### iOS
![image](https://user-images.githubusercontent.com/47436092/125146694-11250d80-e0dc-11eb-9a72-42e2fb343210.png)

#### Android
![image](https://user-images.githubusercontent.com/47436092/125337576-077dee80-e304-11eb-84d7-a1352c05978f.png)
