### PR TITLE
Update Bank Account RequestorStep UI

### DIFF
--- a/src/pages/ReimbursementAccount/RequestorStep.js
+++ b/src/pages/ReimbursementAccount/RequestorStep.js
@@ -83,7 +83,7 @@ class RequestorStep extends React.Component {
                 <HeaderWithCloseButton
                     title={this.props.translate('requestorStep.headerTitle')}
                     shouldShowBackButton
-                    onBackButtonPress={() => goToWithdrawalAccountSetupStep(CONST.BANK_ACCOUNT.STEP.COMPANY_STEP)}
+                    onBackButtonPress={() => goToWithdrawalAccountSetupStep(CONST.BANK_ACCOUNT.STEP.COMPANY)}
                     onCloseButtonPress={Navigation.dismissModal}
                 />
                 {this.props.achData.useOnfido && this.props.achData.sdkToken ? (
@@ -110,7 +110,7 @@ class RequestorStep extends React.Component {
                                         lastName: this.state.lastName,
                                         street: this.state.requestorAddressStreet,
                                         city: this.state.requestorAddressCity,
-                                        state: this.state.requestorAddressCity,
+                                        state: this.state.requestorAddressState,
                                         zipCode: this.state.requestorAddressZipCode,
                                         dob: this.state.dob,
                                         ssnLast4: this.state.ssnLast4,


### PR DESCRIPTION
### Details
- Fixes the back button on the requestor step so that it takes you to the Bank Account step 
- Ensures that we're maintaining the requestorAddressState instead of accidentally resetting it 

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ N/A Found while doing some manual testing

### Tests/QA
1. Log into E.cash with an account that does not have a bank account set up 
1. Navigate to /bank-account/new
2. Following these steps, input the information to add a `PENDING` bank account 
    - ![image](https://user-images.githubusercontent.com/16747822/125339332-0d74cf00-e306-11eb-8ad7-93a353e52d4b.png)
3. When you get to the `Requestor Step` confirm that checking and unchecking the `I am authorized to use my company bank account for business spend` checkbox does **not** reset the value in the `State` dropdown 
4. Click on the `<` button in the top left of the view and confirm you're taken back to the `Company Step`. 


### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web

https://user-images.githubusercontent.com/16747822/125339683-67759480-e306-11eb-9d37-ec8a98c78e49.mov

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
