### PR TITLE
Make button visible in WorkspaceInvitePage

### DIFF
--- a/src/pages/workspace/WorkspaceInvitePage.js
+++ b/src/pages/workspace/WorkspaceInvitePage.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {TextInput, View} from 'react-native';
+import {ScrollView, TextInput, View} from 'react-native';
 import {withOnyx} from 'react-native-onyx';
 import Str from 'expensify-common/lib/str';
 import withLocalize, {withLocalizePropTypes} from '../../components/withLocalize';
@@ -17,6 +17,8 @@ import TextLink from '../../components/TextLink';
 import getEmailKeyboardType from '../../libs/getEmailKeyboardType';
 import themeColors from '../../styles/themes/default';
 import Growl from '../../libs/Growl';
+import KeyboardAvoidingView from '../../components/KeyboardAvoidingView';
+import FixedFooter from '../../components/FixedFooter';
 
 const propTypes = {
     ...withLocalizePropTypes,
@@ -83,51 +85,53 @@ class WorkspaceInvitePage extends React.Component {
     render() {
         return (
             <ScreenWrapper>
-                <HeaderWithCloseButton
-                    title={this.props.translate('workspace.invite.invitePeople')}
-                    onCloseButtonPress={Navigation.dismissModal}
-                />
-                <View style={[styles.p5, styles.flex1, styles.overflowAuto]}>
-                    <View style={styles.flexGrow1}>
-                        <Text style={[styles.mb6]}>
-                            {this.props.translate('workspace.invite.invitePeoplePrompt')}
-                        </Text>
-                        <View style={styles.mb6}>
-                            <Text style={[styles.mb2]}>
-                                {this.props.translate('workspace.invite.enterEmailOrPhone')}
+                <KeyboardAvoidingView>
+                    <HeaderWithCloseButton
+                        title={this.props.translate('workspace.invite.invitePeople')}
+                        onCloseButtonPress={Navigation.dismissModal}
+                    />
+                    <ScrollView style={[styles.p5, styles.flex1, styles.overflowAuto]}>
+                        <View style={styles.flexGrow1}>
+                            <Text style={[styles.mb6]}>
+                                {this.props.translate('workspace.invite.invitePeoplePrompt')}
                             </Text>
-                            <TextInput
-                                autoCompleteType="email"
-                                autoCorrect={false}
-                                autoCapitalize="none"
-                                style={[styles.textInput]}
-                                value={this.state.emailOrPhone}
-                                keyboardType={getEmailKeyboardType()}
-                                onChangeText={text => this.setState({emailOrPhone: text})}
-                            />
+                            <View style={styles.mb6}>
+                                <Text style={[styles.mb2]}>
+                                    {this.props.translate('workspace.invite.enterEmailOrPhone')}
+                                </Text>
+                                <TextInput
+                                    autoCompleteType="email"
+                                    autoCorrect={false}
+                                    autoCapitalize="none"
+                                    style={[styles.textInput]}
+                                    value={this.state.emailOrPhone}
+                                    keyboardType={getEmailKeyboardType()}
+                                    onChangeText={text => this.setState({emailOrPhone: text})}
+                                />
+                            </View>
+                            <View style={styles.mb6}>
+                                <Text style={[styles.mb2]}>
+                                    {this.props.translate('workspace.invite.personalMessagePrompt')}
+                                </Text>
+                                <TextInput
+                                    autoCompleteType="off"
+                                    autoCorrect={false}
+                                    style={[styles.textInput, styles.workspaceInviteWelcome, styles.mb6]}
+                                    numberOfLines={10}
+                                    textAlignVertical="top"
+                                    multiline
+                                    value={this.state.welcomeNote}
+                                    placeholder={this.getWelcomeNotePlaceholder()}
+                                    placeholderTextColor={themeColors.placeholderText}
+                                    onChangeText={text => this.setState({welcomeNote: text})}
+                                />
+                                <TextLink href="https://use.expensify.com/privacy">
+                                    {this.props.translate('common.privacy')}
+                                </TextLink>
+                            </View>
                         </View>
-                        <View style={styles.mb6}>
-                            <Text style={[styles.mb2]}>
-                                {this.props.translate('workspace.invite.personalMessagePrompt')}
-                            </Text>
-                            <TextInput
-                                autoCompleteType="off"
-                                autoCorrect={false}
-                                style={[styles.textInput, styles.workspaceInviteWelcome, styles.mb6]}
-                                numberOfLines={10}
-                                textAlignVertical="top"
-                                multiline
-                                value={this.state.welcomeNote}
-                                placeholder={this.getWelcomeNotePlaceholder()}
-                                placeholderTextColor={themeColors.placeholderText}
-                                onChangeText={text => this.setState({welcomeNote: text})}
-                            />
-                            <TextLink href="https://use.expensify.com/privacy">
-                                {this.props.translate('common.privacy')}
-                            </TextLink>
-                        </View>
-                    </View>
-                    <View style={styles.flexGrow0}>
+                    </ScrollView>
+                    <FixedFooter style={[styles.flexGrow0]}>
                         <Button
                             success
                             style={[styles.mb2]}
@@ -135,8 +139,8 @@ class WorkspaceInvitePage extends React.Component {
                             text={this.props.translate('common.invite')}
                             onPress={this.inviteUser}
                         />
-                    </View>
-                </View>
+                    </FixedFooter>
+                </KeyboardAvoidingView>
             </ScreenWrapper>
         );
     }


### PR DESCRIPTION
### Details
Use a `KeyboardAvoidingView`, `FixedFooter`, and `ScrollView` to responsively ensure that the button will always be visible on the workspace invite page.

### Fixed Issues
$ https://github.com/Expensify/Expensify.cash/issues/3974

### Tests / QA Steps
1. Create a new workspace if you don't already have one.
1. Go to `Settings` -> `Workspace` -> `People` -> `Invite`
1. Fill out the invite form, and ensure that the button is always visible (not hidden behind keyboard).

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
#### Web
![image](https://user-images.githubusercontent.com/47436092/125357185-1ffa0300-e31c-11eb-8fb6-45ca45969ebc.png)

#### Mobile Web
![image](https://user-images.githubusercontent.com/47436092/125363017-b7fbea80-e324-11eb-95b1-0432c6523ee6.png)

#### Desktop
![image](https://user-images.githubusercontent.com/47436092/125361832-be896280-e322-11eb-8219-4549e58b67c5.png)

#### iOS
<img src="https://user-images.githubusercontent.com/47436092/125356914-bd086c00-e31b-11eb-8c5a-87de39ee0832.png" alt="" width="300px" />

<img src="https://user-images.githubusercontent.com/47436092/125356951-c8f42e00-e31b-11eb-8d3c-37f6cb1b60bb.png" alt="" width="300px" />

#### Android
![image](https://user-images.githubusercontent.com/47436092/125362667-242a1e80-e324-11eb-91a1-61b24b7e252c.png)
