### PR TITLE
Add offline message to IOU and Split bill and allow currency selection while offline

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -197,7 +197,7 @@ const CONST = {
         DEFAULT: 'default',
     },
     ERROR: {
-        API_OFFLINE: 'session.offlineMessage',
+        API_OFFLINE: 'session.offlineMessageRetry',
     },
     NETWORK: {
         METHOD: {

--- a/src/components/IOUConfirmationList.js
+++ b/src/components/IOUConfirmationList.js
@@ -88,12 +88,19 @@ const propTypes = {
         /** Whether or not the IOU step is loading (creating the IOU Report) */
         loading: PropTypes.bool,
     }),
+
+    /** Information about the network */
+    network: PropTypes.shape({
+        /** Is the network currently offline or not */
+        isOffline: PropTypes.bool,
+    }),
 };
 
 const defaultProps = {
     iou: {},
     onUpdateComment: null,
     comment: '',
+    network: {},
 };
 
 // Gives minimum height to offset the height of
@@ -274,8 +281,14 @@ class IOUConfirmationList extends Component {
                     </View>
                 </ScrollView>
                 <FixedFooter>
+                    {this.props.network.isOffline && (
+                        <Text style={[styles.formError, styles.pb2]}>
+                            {this.props.translate('session.offlineMessage')}
+                        </Text>
+                    )}
                     <Button
                         success
+                        isDisabled={this.props.network.isOffline}
                         style={[styles.w100]}
                         isLoading={this.props.iou.loading}
                         text={buttonText}
@@ -300,6 +313,9 @@ export default compose(
         iou: {key: ONYXKEYS.IOU},
         myPersonalDetails: {
             key: ONYXKEYS.MY_PERSONAL_DETAILS,
+        },
+        network: {
+            key: ONYXKEYS.NETWORK,
         },
     }),
 )(IOUConfirmationList);

--- a/src/components/IOUConfirmationList.js
+++ b/src/components/IOUConfirmationList.js
@@ -19,19 +19,11 @@ import SafeAreaInsetPropTypes from '../pages/SafeAreaInsetPropTypes';
 import withWindowDimensions, {windowDimensionsPropTypes} from './withWindowDimensions';
 import compose from '../libs/compose';
 import FixedFooter from './FixedFooter';
+import CONST from '../CONST';
 
 const propTypes = {
     /** Callback to inform parent modal of success */
     onConfirm: PropTypes.func.isRequired,
-
-    // User's currency preference
-    selectedCurrency: PropTypes.shape({
-        // Currency code for the selected currency
-        currencyCode: PropTypes.string,
-
-        // Currency symbol for the selected currency
-        currencySymbol: PropTypes.string,
-    }).isRequired,
 
     // Callback to update comment from IOUModal
     onUpdateComment: PropTypes.func,
@@ -80,7 +72,13 @@ const propTypes = {
 
         /** Primary login of the user */
         login: PropTypes.string,
-    }).isRequired,
+
+        // Selected Currency Code of the current IOU
+        selectedCurrencyCode: PropTypes.string,
+
+        // Currency Symbol of the Selected Currency
+        selectedCurrencySymbol: PropTypes.string,
+    }),
 
     /** Holds data related to IOU view state, rather than the underlying IOU data. */
     iou: PropTypes.shape({
@@ -101,6 +99,10 @@ const defaultProps = {
     onUpdateComment: null,
     comment: '',
     network: {},
+    myPersonalDetails: {
+        selectedCurrencyCode: CONST.CURRENCY.USD,
+        selectedCurrencySymbol: '$',
+    },
 };
 
 // Gives minimum height to offset the height of
@@ -122,14 +124,14 @@ class IOUConfirmationList extends Component {
                 this.props.myPersonalDetails,
                 this.props.numberFormat(this.calculateAmount() / 100, {
                     style: 'currency',
-                    currency: this.props.selectedCurrency.currencyCode,
+                    currency: this.props.myPersonalDetails.selectedCurrencyCode,
                 }),
             );
 
             const formattedParticipants = getIOUConfirmationOptionsFromParticipants(this.props.participants,
                 this.props.numberFormat(this.calculateAmount() / 100, {
                     style: 'currency',
-                    currency: this.props.selectedCurrency.currencyCode,
+                    currency: this.props.myPersonalDetails.selectedCurrencyCode,
                 }));
 
             sections.push({
@@ -148,7 +150,7 @@ class IOUConfirmationList extends Component {
             const formattedParticipants = getIOUConfirmationOptionsFromParticipants(this.props.participants,
                 this.props.numberFormat(this.props.iouAmount, {
                     style: 'currency',
-                    currency: this.props.selectedCurrency.currencyCode,
+                    currency: this.props.myPersonalDetails.selectedCurrencyCode,
                 }));
 
             sections.push({
@@ -244,7 +246,7 @@ class IOUConfirmationList extends Component {
             this.props.hasMultipleParticipants ? 'iou.split' : 'iou.request', {
                 amount: this.props.numberFormat(
                     this.props.iouAmount,
-                    {style: 'currency', currency: this.props.selectedCurrency.currencyCode},
+                    {style: 'currency', currency: this.props.myPersonalDetails.selectedCurrencyCode},
                 ),
             },
         );

--- a/src/components/IOUConfirmationList.js
+++ b/src/components/IOUConfirmationList.js
@@ -75,9 +75,6 @@ const propTypes = {
 
         // Selected Currency Code of the current IOU
         selectedCurrencyCode: PropTypes.string,
-
-        // Currency Symbol of the Selected Currency
-        selectedCurrencySymbol: PropTypes.string,
     }),
 
     /** Holds data related to IOU view state, rather than the underlying IOU data. */
@@ -101,7 +98,6 @@ const defaultProps = {
     network: {},
     myPersonalDetails: {
         selectedCurrencyCode: CONST.CURRENCY.USD,
-        selectedCurrencySymbol: '$',
     },
 };
 

--- a/src/components/IOUConfirmationList.js
+++ b/src/components/IOUConfirmationList.js
@@ -72,9 +72,6 @@ const propTypes = {
 
         /** Primary login of the user */
         login: PropTypes.string,
-
-        // Selected Currency Code of the current IOU
-        selectedCurrencyCode: PropTypes.string,
     }),
 
     /** Holds data related to IOU view state, rather than the underlying IOU data. */
@@ -82,6 +79,9 @@ const propTypes = {
 
         /** Whether or not the IOU step is loading (creating the IOU Report) */
         loading: PropTypes.bool,
+
+        // Selected Currency Code of the current IOU
+        selectedCurrencyCode: PropTypes.string,
     }),
 
     /** Information about the network */
@@ -92,13 +92,13 @@ const propTypes = {
 };
 
 const defaultProps = {
-    iou: {},
+    iou: {
+        selectedCurrencyCode: CONST.CURRENCY.USD,
+    },
     onUpdateComment: null,
     comment: '',
     network: {},
-    myPersonalDetails: {
-        selectedCurrencyCode: CONST.CURRENCY.USD,
-    },
+    myPersonalDetails: {},
 };
 
 // Gives minimum height to offset the height of
@@ -120,14 +120,14 @@ class IOUConfirmationList extends Component {
                 this.props.myPersonalDetails,
                 this.props.numberFormat(this.calculateAmount() / 100, {
                     style: 'currency',
-                    currency: this.props.myPersonalDetails.selectedCurrencyCode,
+                    currency: this.props.iou.selectedCurrencyCode,
                 }),
             );
 
             const formattedParticipants = getIOUConfirmationOptionsFromParticipants(this.props.participants,
                 this.props.numberFormat(this.calculateAmount() / 100, {
                     style: 'currency',
-                    currency: this.props.myPersonalDetails.selectedCurrencyCode,
+                    currency: this.props.iou.selectedCurrencyCode,
                 }));
 
             sections.push({
@@ -146,7 +146,7 @@ class IOUConfirmationList extends Component {
             const formattedParticipants = getIOUConfirmationOptionsFromParticipants(this.props.participants,
                 this.props.numberFormat(this.props.iouAmount, {
                     style: 'currency',
-                    currency: this.props.myPersonalDetails.selectedCurrencyCode,
+                    currency: this.props.iou.selectedCurrencyCode,
                 }));
 
             sections.push({
@@ -242,7 +242,7 @@ class IOUConfirmationList extends Component {
             this.props.hasMultipleParticipants ? 'iou.split' : 'iou.request', {
                 amount: this.props.numberFormat(
                     this.props.iouAmount,
-                    {style: 'currency', currency: this.props.myPersonalDetails.selectedCurrencyCode},
+                    {style: 'currency', currency: this.props.iou.selectedCurrencyCode},
                 ),
             },
         );

--- a/src/components/IOUConfirmationList.js
+++ b/src/components/IOUConfirmationList.js
@@ -288,7 +288,7 @@ class IOUConfirmationList extends Component {
                         success
                         isDisabled={this.props.network.isOffline}
                         style={[styles.w100]}
-                        isLoading={this.props.iou.loading}
+                        isLoading={this.props.iou.loading && !this.props.network.isOffline}
                         text={buttonText}
                         onPress={() => this.props.onConfirm(this.getSplits())}
                         pressOnEnter

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -456,7 +456,8 @@ export default {
         },
     },
     session: {
-        offlineMessage: 'Looks like you\'re offline. Please check your connection and try again.',
+        offlineMessageRetry: 'Looks like you\'re offline. Please check your connection and try again.',
+        offlineMessage: 'Looks like you\'re offline.',
     },
     workspace: {
         common: {

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -373,7 +373,8 @@ export default {
         },
     },
     session: {
-        offlineMessage: 'Parece que estás desconectado. Por favor chequea tu conexión e inténtalo otra vez',
+        offlineMessageRetry: 'Parece que estás desconectado. Por favor chequea tu conexión e inténtalo otra vez',
+        offlineMessage: 'Parece que estás desconectado.',
     },
     workspace: {
         common: {

--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -961,8 +961,8 @@ function Mobile_GetConstants(parameters) {
  * @param {Number} [parameters.longitude]
  * @returns {Promise}
  */
-function GetPreferredCurrency(parameters) {
-    const commandName = 'GetPreferredCurrency';
+function GetLocalCurrency(parameters) {
+    const commandName = 'GetLocalCurrency';
     return Network.post(commandName, parameters);
 }
 
@@ -1095,7 +1095,7 @@ export {
     ValidateEmail,
     Wallet_Activate,
     Wallet_GetOnfidoSDKToken,
-    GetPreferredCurrency,
+    GetLocalCurrency,
     GetCurrencyList,
     Policy_Create,
     Policy_Employees_Remove,

--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -153,7 +153,7 @@ class AuthScreens extends React.Component {
         User.getUserDetails();
         User.getBetas();
         User.getDomainInfo();
-        PersonalDetails.fetchCurrencyPreferences();
+        PersonalDetails.fetchLocalCurrency();
         fetchAllReports(true, true);
         fetchCountryCodeByRequestIP();
         UnreadIndicatorUpdater.listenForReportChanges();

--- a/src/libs/Network.js
+++ b/src/libs/Network.js
@@ -109,9 +109,13 @@ function processNetworkRequestQueue() {
         }
 
         // If we have a request then we need to check if it can be persisted in case we close the tab while offline
-        const retryableRequests = _.filter(networkRequestQueue, request => (
-            !request.data.doNotRetry && request.data.persist
-        ));
+        const retryableRequests = [];
+        _.each(networkRequestQueue, (request) => {
+            if ((request.data.doNotRetry || request.data.forceNetworkRequest) && !request.data.persist) {
+                return request.resolve();
+            }
+            retryableRequests.push(request);
+        });
         Onyx.set(ONYXKEYS.NETWORK_REQUEST_QUEUE, retryableRequests);
         return;
     }

--- a/src/libs/Network.js
+++ b/src/libs/Network.js
@@ -109,13 +109,9 @@ function processNetworkRequestQueue() {
         }
 
         // If we have a request then we need to check if it can be persisted in case we close the tab while offline
-        const retryableRequests = [];
-        _.each(networkRequestQueue, (request) => {
-            if ((request.data.doNotRetry || request.data.forceNetworkRequest) && !request.data.persist) {
-                return request.resolve();
-            }
-            retryableRequests.push(request);
-        });
+        const retryableRequests = _.filter(networkRequestQueue, request => (
+            !request.data.doNotRetry && request.data.persist
+        ));
         Onyx.set(ONYXKEYS.NETWORK_REQUEST_QUEUE, retryableRequests);
         return;
     }

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -679,7 +679,6 @@ function getHeaderMessage(hasSelectableOptions, hasUserToInvite, searchValue, ma
  *
  * @param {Object} currencyOptions
  * @param {String} searchValue
- * @param {Object} selectedCurrency
  * @returns {Array}
  */
 function getCurrencyListForSections(currencyOptions, searchValue) {

--- a/src/libs/actions/IOU.js
+++ b/src/libs/actions/IOU.js
@@ -156,13 +156,9 @@ function rejectTransaction({
  * Sets IOU'S selected currency
  *
  * @param {Object} params.selectedCurrencyCode
- * @param {Object} params.selectedCurrencySymbol
  */
-function setSelectedCurrency({selectedCurrencyCode, selectedCurrencySymbol}) {
-    Onyx.merge(ONYXKEYS.MY_PERSONAL_DETAILS, {
-        selectedCurrencyCode,
-        selectedCurrencySymbol,
-    });
+function setSelectedCurrency({selectedCurrencyCode}) {
+    Onyx.merge(ONYXKEYS.MY_PERSONAL_DETAILS, {selectedCurrencyCode});
 }
 
 /**

--- a/src/libs/actions/IOU.js
+++ b/src/libs/actions/IOU.js
@@ -158,7 +158,7 @@ function rejectTransaction({
  * @param {Object} params.selectedCurrencyCode
  */
 function setSelectedCurrency({selectedCurrencyCode}) {
-    Onyx.merge(ONYXKEYS.MY_PERSONAL_DETAILS, {selectedCurrencyCode});
+    Onyx.merge(ONYXKEYS.IOU, {selectedCurrencyCode});
 }
 
 /**

--- a/src/libs/actions/IOU.js
+++ b/src/libs/actions/IOU.js
@@ -153,25 +153,12 @@ function rejectTransaction({
 }
 
 /**
- * Resets IOU currency to preferredCurrency
+ * Sets IOU'S selected currency
  *
  * @param {Object} params.selectedCurrencyCode
  * @param {Object} params.selectedCurrencySymbol
  */
 function setSelectedCurrency({selectedCurrencyCode, selectedCurrencySymbol}) {
-    Onyx.merge(ONYXKEYS.MY_PERSONAL_DETAILS, {
-        selectedCurrencyCode,
-        selectedCurrencySymbol,
-    });
-}
-
-/**
- * Resets IOU currency to preferredCurrency
- *
- * @param {Object} params.selectedCurrencyCode
- * @param {Object} params.selectedCurrencySymbol
- */
-function resetSelectedCurrency({selectedCurrencyCode, selectedCurrencySymbol}) {
     Onyx.merge(ONYXKEYS.MY_PERSONAL_DETAILS, {
         selectedCurrencyCode,
         selectedCurrencySymbol,
@@ -265,6 +252,5 @@ export {
     createIOUSplit,
     rejectTransaction,
     payIOUReport,
-    resetSelectedCurrency,
     setSelectedCurrency,
 };

--- a/src/libs/actions/IOU.js
+++ b/src/libs/actions/IOU.js
@@ -155,9 +155,9 @@ function rejectTransaction({
 /**
  * Sets IOU'S selected currency
  *
- * @param {Object} params.selectedCurrencyCode
+ * @param {String} selectedCurrencyCode
  */
-function setIOUSelectedCurrency({selectedCurrencyCode}) {
+function setIOUSelectedCurrency(selectedCurrencyCode) {
     Onyx.merge(ONYXKEYS.IOU, {selectedCurrencyCode});
 }
 

--- a/src/libs/actions/IOU.js
+++ b/src/libs/actions/IOU.js
@@ -153,6 +153,32 @@ function rejectTransaction({
 }
 
 /**
+ * Resets IOU currency to preferredCurrency
+ *
+ * @param {Object} params.selectedCurrencyCode
+ * @param {Object} params.selectedCurrencySymbol
+ */
+function setSelectedCurrency({selectedCurrencyCode, selectedCurrencySymbol}) {
+    Onyx.merge(ONYXKEYS.MY_PERSONAL_DETAILS, {
+        selectedCurrencyCode,
+        selectedCurrencySymbol,
+    });
+}
+
+/**
+ * Resets IOU currency to preferredCurrency
+ *
+ * @param {Object} params.selectedCurrencyCode
+ * @param {Object} params.selectedCurrencySymbol
+ */
+function resetSelectedCurrency({selectedCurrencyCode, selectedCurrencySymbol}) {
+    Onyx.merge(ONYXKEYS.MY_PERSONAL_DETAILS, {
+        selectedCurrencyCode,
+        selectedCurrencySymbol,
+    });
+}
+
+/**
  * @private
  *
  * @param {Number} amount
@@ -239,4 +265,6 @@ export {
     createIOUSplit,
     rejectTransaction,
     payIOUReport,
+    resetSelectedCurrency,
+    setSelectedCurrency,
 };

--- a/src/libs/actions/IOU.js
+++ b/src/libs/actions/IOU.js
@@ -157,7 +157,7 @@ function rejectTransaction({
  *
  * @param {Object} params.selectedCurrencyCode
  */
-function setSelectedCurrency({selectedCurrencyCode}) {
+function setIOUSelectedCurrency({selectedCurrencyCode}) {
     Onyx.merge(ONYXKEYS.IOU, {selectedCurrencyCode});
 }
 
@@ -248,5 +248,5 @@ export {
     createIOUSplit,
     rejectTransaction,
     payIOUReport,
-    setSelectedCurrency,
+    setIOUSelectedCurrency,
 };

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -243,7 +243,7 @@ function fetchCurrencyPreferences() {
         isRetrievingCurrency: true,
     });
 
-    API.GetPreferredCurrency({...coords, doNotRetry: true})
+    API.GetPreferredCurrency({...coords})
         .then((data) => {
             currency = data.currency;
         })

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -243,7 +243,7 @@ function fetchCurrencyPreferences() {
         isRetrievingCurrency: true,
     });
 
-    API.GetPreferredCurrency({...coords})
+    API.GetPreferredCurrency({...coords, doNotRetry: true})
         .then((data) => {
             currency = data.currency;
         })

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -247,7 +247,6 @@ function fetchLocalCurrency() {
         .then((data) => {
             currency = data.currency;
         })
-        .then(API.GetCurrencyList)
         .then(getCurrencyList)
         .then(() => {
             Onyx.merge(ONYXKEYS.MY_PERSONAL_DETAILS, {localCurrencyCode: currency});

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -249,12 +249,8 @@ function fetchLocalCurrency() {
         })
         .then(API.GetCurrencyList)
         .then(getCurrencyList)
-        .then((currencyList) => {
-            Onyx.merge(ONYXKEYS.MY_PERSONAL_DETAILS,
-                {
-                    localCurrencyCode: currency,
-                    localCurrencySymbol: currencyList[currency].symbol,
-                });
+        .then(() => {
+            Onyx.merge(ONYXKEYS.MY_PERSONAL_DETAILS, {localCurrencyCode: currency});
         })
         .catch(error => console.debug(`Error fetching currency preference: , ${error}`))
         .finally(() => {

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -233,9 +233,9 @@ function getCurrencyList() {
 }
 
 /**
- * Fetches the Currency preferences based on location and sets currency code/symbol to local storage
+ * Fetches the local currency based on location and sets currency code/symbol to local storage
  */
-function fetchCurrencyPreferences() {
+function fetchLocalCurrency() {
     const coords = {};
     let currency = '';
 
@@ -243,7 +243,7 @@ function fetchCurrencyPreferences() {
         isRetrievingCurrency: true,
     });
 
-    API.GetPreferredCurrency({...coords})
+    API.GetLocalCurrency({...coords})
         .then((data) => {
             currency = data.currency;
         })
@@ -252,8 +252,8 @@ function fetchCurrencyPreferences() {
         .then((currencyList) => {
             Onyx.merge(ONYXKEYS.MY_PERSONAL_DETAILS,
                 {
-                    preferredCurrencyCode: currency,
-                    preferredCurrencySymbol: currencyList[currency].symbol,
+                    localCurrencyCode: currency,
+                    localCurrencySymbol: currencyList[currency].symbol,
                 });
         })
         .catch(error => console.debug(`Error fetching currency preference: , ${error}`))
@@ -302,6 +302,6 @@ export {
     setPersonalDetails,
     setAvatar,
     deleteAvatar,
-    fetchCurrencyPreferences,
+    fetchLocalCurrency,
     getCurrencyList,
 };

--- a/src/libs/actions/Session.js
+++ b/src/libs/actions/Session.js
@@ -135,7 +135,7 @@ function fetchAccountDetails(login) {
             Onyx.merge(ONYXKEYS.ACCOUNT, {error: response.message});
         })
         .catch(() => {
-            Onyx.merge(ONYXKEYS.ACCOUNT, {error: translateLocal('session.offlineMessage')});
+            Onyx.merge(ONYXKEYS.ACCOUNT, {error: translateLocal('session.offlineMessageRetry')});
         })
         .finally(() => {
             Onyx.merge(ONYXKEYS.ACCOUNT, {loading: false});

--- a/src/pages/iou/IOUCurrencySelection.js
+++ b/src/pages/iou/IOUCurrencySelection.js
@@ -75,6 +75,7 @@ class IOUCurrencySelection extends Component {
         this.state = {
             searchValue: '',
             currencyData: currencyOptions,
+            toggledCurrencyCode: '',
         };
         this.getCurrencyOptions = this.getCurrencyOptions.bind(this);
         this.toggleOption = this.toggleOption.bind(this);
@@ -121,13 +122,13 @@ class IOUCurrencySelection extends Component {
     }
 
     /**
-     * Function which renders a row in the list
+     * Function which toggles a currency in the list
      *
-     * @param {String} selectedCurrencyCode
+     * @param {String} toggledCurrencyCode
      *
      */
-    toggleOption(selectedCurrencyCode) {
-        setIOUSelectedCurrency({selectedCurrencyCode});
+    toggleOption(toggledCurrencyCode) {
+        this.setState({toggledCurrencyCode});
     }
 
     /**
@@ -151,9 +152,7 @@ class IOUCurrencySelection extends Component {
      * @return {void}
      */
     confirmCurrencySelection() {
-        setIOUSelectedCurrency({
-            selectedCurrencyCode: this.props.iou.selectedCurrencyCode,
-        });
+        setIOUSelectedCurrency(this.state.toggledCurrencyCode);
         Navigation.goBack();
     }
 
@@ -194,7 +193,7 @@ class IOUCurrencySelection extends Component {
                                             option={item}
                                             onSelectRow={() => this.toggleOption(item.currencyCode)}
                                             isSelected={
-                                                item.currencyCode === this.props.iou.selectedCurrencyCode
+                                                item.currencyCode === this.state.toggledCurrencyCode
                                             }
                                             showSelectedState
                                             hideAdditionalOptionStates

--- a/src/pages/iou/IOUCurrencySelection.js
+++ b/src/pages/iou/IOUCurrencySelection.js
@@ -34,6 +34,12 @@ const propTypes = {
 
         // Currency Symbol of the Preferred Currency
         preferredCurrencySymbol: PropTypes.string,
+
+        // Preferred Currency Code of the current user
+        selectedCurrencyCode: PropTypes.string,
+
+        // Currency Symbol of the Preferred Currency
+        selectedCurrencySymbol: PropTypes.string,
     }),
 
     // The currency list constant object from Onyx
@@ -51,7 +57,12 @@ const propTypes = {
 };
 
 const defaultProps = {
-    myPersonalDetails: {preferredCurrencyCode: CONST.CURRENCY.USD, preferredCurrencySymbol: '$'},
+    myPersonalDetails: {
+        preferredCurrencyCode: CONST.CURRENCY.USD,
+        preferredCurrencySymbol: '$',
+        selectedCurrencyCode: CONST.CURRENCY.USD,
+        selectedCurrencySymbol: '$',
+    },
     currencyList: {},
 };
 
@@ -151,8 +162,8 @@ class IOUCurrencySelection extends Component {
      */
     confirmCurrencySelection() {
         Onyx.merge(ONYXKEYS.MY_PERSONAL_DETAILS, {
-            preferredCurrencyCode: this.state.selectedCurrency.currencyCode,
-            preferredCurrencySymbol: this.state.selectedCurrency.currencySymbol,
+            selectedCurrencyCode: this.state.selectedCurrency.currencyCode,
+            selectedCurrencySymbol: this.state.selectedCurrency.currencySymbol,
         });
         Navigation.goBack();
     }

--- a/src/pages/iou/IOUCurrencySelection.js
+++ b/src/pages/iou/IOUCurrencySelection.js
@@ -1,7 +1,7 @@
 import React, {Component} from 'react';
 import {SectionList, View} from 'react-native';
 import PropTypes from 'prop-types';
-import Onyx, {withOnyx} from 'react-native-onyx';
+import {withOnyx} from 'react-native-onyx';
 import _ from 'underscore';
 import styles from '../../styles/styles';
 import {getCurrencyList} from '../../libs/actions/PersonalDetails';
@@ -20,6 +20,7 @@ import CONST from '../../CONST';
 import KeyboardAvoidingView from '../../components/KeyboardAvoidingView';
 import Button from '../../components/Button';
 import FixedFooter from '../../components/FixedFooter';
+import {setSelectedCurrency} from '../../libs/actions/IOU';
 
 /**
  * IOU Currency selection for selecting currency
@@ -76,10 +77,6 @@ class IOUCurrencySelection extends Component {
         this.state = {
             searchValue: '',
             currencyData: currencyOptions,
-            selectedCurrency: {
-                currencyCode: this.props.myPersonalDetails.preferredCurrencyCode,
-                currencySymbol: this.props.myPersonalDetails.preferredCurrencySymbol,
-            },
         };
         this.getCurrencyOptions = this.getCurrencyOptions.bind(this);
         this.toggleOption = this.toggleOption.bind(this);
@@ -128,15 +125,13 @@ class IOUCurrencySelection extends Component {
     /**
      * Function which renders a row in the list
      *
-     * @param {String} currencyCode
+     * @param {String} selectedCurrencyCode
      *
      */
-    toggleOption(currencyCode) {
-        this.setState({
-            selectedCurrency: {
-                currencyCode,
-                currencySymbol: this.props.currencyList[currencyCode].symbol,
-            },
+    toggleOption(selectedCurrencyCode) {
+        setSelectedCurrency({
+            selectedCurrencyCode,
+            selectedCurrencySymbol: this.props.currencyList[selectedCurrencyCode].symbol,
         });
     }
 
@@ -161,9 +156,9 @@ class IOUCurrencySelection extends Component {
      * @return {void}
      */
     confirmCurrencySelection() {
-        Onyx.merge(ONYXKEYS.MY_PERSONAL_DETAILS, {
-            selectedCurrencyCode: this.state.selectedCurrency.currencyCode,
-            selectedCurrencySymbol: this.state.selectedCurrency.currencySymbol,
+        setSelectedCurrency({
+            selectedCurrencyCode: this.props.myPersonalDetails.selectedCurrencyCode,
+            selectedCurrencySymbol: this.props.myPersonalDetails.selectedCurrencySymbol,
         });
         Navigation.goBack();
     }
@@ -204,7 +199,9 @@ class IOUCurrencySelection extends Component {
                                             mode="compact"
                                             option={item}
                                             onSelectRow={() => this.toggleOption(item.currencyCode)}
-                                            isSelected={item.currencyCode === this.state.selectedCurrency.currencyCode}
+                                            isSelected={
+                                                item.currencyCode === this.props.myPersonalDetails.selectedCurrencyCode
+                                            }
                                             showSelectedState
                                             hideAdditionalOptionStates
                                         />
@@ -223,7 +220,7 @@ class IOUCurrencySelection extends Component {
                     <FixedFooter>
                         <Button
                             success
-                            isDisabled={!this.state.selectedCurrency?.currencyCode}
+                            isDisabled={!this.props.myPersonalDetails.selectedCurrencyCode}
                             style={[styles.w100]}
                             text={this.props.translate('iou.confirm')}
                             onPress={this.confirmCurrencySelection}

--- a/src/pages/iou/IOUCurrencySelection.js
+++ b/src/pages/iou/IOUCurrencySelection.js
@@ -33,14 +33,8 @@ const propTypes = {
         // Local Currency Code of the current user
         localCurrencyCode: PropTypes.string,
 
-        // Currency Symbol of the Local Currency
-        localCurrencySymbol: PropTypes.string,
-
         // Selected Currency Code of the current user
         selectedCurrencyCode: PropTypes.string,
-
-        // Currency Symbol of the Selected Currency
-        selectedCurrencySymbol: PropTypes.string,
     }),
 
     // The currency list constant object from Onyx
@@ -60,9 +54,7 @@ const propTypes = {
 const defaultProps = {
     myPersonalDetails: {
         localCurrencyCode: CONST.CURRENCY.USD,
-        localCurrencySymbol: '$',
         selectedCurrencyCode: CONST.CURRENCY.USD,
-        selectedCurrencySymbol: '$',
     },
     currencyList: {},
 };
@@ -129,10 +121,7 @@ class IOUCurrencySelection extends Component {
      *
      */
     toggleOption(selectedCurrencyCode) {
-        setSelectedCurrency({
-            selectedCurrencyCode,
-            selectedCurrencySymbol: this.props.currencyList[selectedCurrencyCode].symbol,
-        });
+        setSelectedCurrency({selectedCurrencyCode});
     }
 
     /**
@@ -158,7 +147,6 @@ class IOUCurrencySelection extends Component {
     confirmCurrencySelection() {
         setSelectedCurrency({
             selectedCurrencyCode: this.props.myPersonalDetails.selectedCurrencyCode,
-            selectedCurrencySymbol: this.props.myPersonalDetails.selectedCurrencySymbol,
         });
         Navigation.goBack();
     }

--- a/src/pages/iou/IOUCurrencySelection.js
+++ b/src/pages/iou/IOUCurrencySelection.js
@@ -20,7 +20,7 @@ import CONST from '../../CONST';
 import KeyboardAvoidingView from '../../components/KeyboardAvoidingView';
 import Button from '../../components/Button';
 import FixedFooter from '../../components/FixedFooter';
-import {setSelectedCurrency} from '../../libs/actions/IOU';
+import {setIOUSelectedCurrency} from '../../libs/actions/IOU';
 
 /**
  * IOU Currency selection for selecting currency
@@ -59,7 +59,7 @@ const defaultProps = {
     myPersonalDetails: {
         localCurrencyCode: CONST.CURRENCY.USD,
     },
-    ios: {
+    iou: {
         selectedCurrencyCode: CONST.CURRENCY.USD,
     },
     currencyList: {},
@@ -127,7 +127,7 @@ class IOUCurrencySelection extends Component {
      *
      */
     toggleOption(selectedCurrencyCode) {
-        setSelectedCurrency({selectedCurrencyCode});
+        setIOUSelectedCurrency({selectedCurrencyCode});
     }
 
     /**
@@ -151,7 +151,7 @@ class IOUCurrencySelection extends Component {
      * @return {void}
      */
     confirmCurrencySelection() {
-        setSelectedCurrency({
+        setIOUSelectedCurrency({
             selectedCurrencyCode: this.props.iou.selectedCurrencyCode,
         });
         Navigation.goBack();

--- a/src/pages/iou/IOUCurrencySelection.js
+++ b/src/pages/iou/IOUCurrencySelection.js
@@ -36,10 +36,10 @@ const propTypes = {
         // Currency Symbol of the Preferred Currency
         preferredCurrencySymbol: PropTypes.string,
 
-        // Preferred Currency Code of the current user
+        // Selected Currency Code of the current user
         selectedCurrencyCode: PropTypes.string,
 
-        // Currency Symbol of the Preferred Currency
+        // Currency Symbol of the Selected Currency
         selectedCurrencySymbol: PropTypes.string,
     }),
 

--- a/src/pages/iou/IOUCurrencySelection.js
+++ b/src/pages/iou/IOUCurrencySelection.js
@@ -32,8 +32,12 @@ const propTypes = {
 
         // Local Currency Code of the current user
         localCurrencyCode: PropTypes.string,
+    }),
 
-        // Selected Currency Code of the current user
+    /** Holds data related to IOU */
+    iou: PropTypes.shape({
+
+        // Selected Currency Code of the current IOU
         selectedCurrencyCode: PropTypes.string,
     }),
 
@@ -54,6 +58,8 @@ const propTypes = {
 const defaultProps = {
     myPersonalDetails: {
         localCurrencyCode: CONST.CURRENCY.USD,
+    },
+    ios: {
         selectedCurrencyCode: CONST.CURRENCY.USD,
     },
     currencyList: {},
@@ -146,7 +152,7 @@ class IOUCurrencySelection extends Component {
      */
     confirmCurrencySelection() {
         setSelectedCurrency({
-            selectedCurrencyCode: this.props.myPersonalDetails.selectedCurrencyCode,
+            selectedCurrencyCode: this.props.iou.selectedCurrencyCode,
         });
         Navigation.goBack();
     }
@@ -188,7 +194,7 @@ class IOUCurrencySelection extends Component {
                                             option={item}
                                             onSelectRow={() => this.toggleOption(item.currencyCode)}
                                             isSelected={
-                                                item.currencyCode === this.props.myPersonalDetails.selectedCurrencyCode
+                                                item.currencyCode === this.props.iou.selectedCurrencyCode
                                             }
                                             showSelectedState
                                             hideAdditionalOptionStates
@@ -208,7 +214,7 @@ class IOUCurrencySelection extends Component {
                     <FixedFooter>
                         <Button
                             success
-                            isDisabled={!this.props.myPersonalDetails.selectedCurrencyCode}
+                            isDisabled={!this.props.iou.selectedCurrencyCode}
                             style={[styles.w100]}
                             text={this.props.translate('iou.confirm')}
                             onPress={this.confirmCurrencySelection}
@@ -229,5 +235,6 @@ export default compose(
     withOnyx({
         currencyList: {key: ONYXKEYS.CURRENCY_LIST},
         myPersonalDetails: {key: ONYXKEYS.MY_PERSONAL_DETAILS},
+        iou: {key: ONYXKEYS.IOU},
     }),
 )(IOUCurrencySelection);

--- a/src/pages/iou/IOUCurrencySelection.js
+++ b/src/pages/iou/IOUCurrencySelection.js
@@ -30,11 +30,11 @@ const propTypes = {
     // The personal details of the person who is logged in
     myPersonalDetails: PropTypes.shape({
 
-        // Preferred Currency Code of the current user
-        preferredCurrencyCode: PropTypes.string,
+        // Local Currency Code of the current user
+        localCurrencyCode: PropTypes.string,
 
-        // Currency Symbol of the Preferred Currency
-        preferredCurrencySymbol: PropTypes.string,
+        // Currency Symbol of the Local Currency
+        localCurrencySymbol: PropTypes.string,
 
         // Selected Currency Code of the current user
         selectedCurrencyCode: PropTypes.string,
@@ -59,8 +59,8 @@ const propTypes = {
 
 const defaultProps = {
     myPersonalDetails: {
-        preferredCurrencyCode: CONST.CURRENCY.USD,
-        preferredCurrencySymbol: '$',
+        localCurrencyCode: CONST.CURRENCY.USD,
+        localCurrencySymbol: '$',
         selectedCurrencyCode: CONST.CURRENCY.USD,
         selectedCurrencySymbol: '$',
     },

--- a/src/pages/iou/IOUModal.js
+++ b/src/pages/iou/IOUModal.js
@@ -42,9 +42,6 @@ const propTypes = {
 
         // Local Currency Code of the current user
         localCurrencyCode: PropTypes.string,
-
-        // Selected Currency Code of the current IOU
-        selectedCurrencyCode: PropTypes.string,
     }),
 
     // Holds data related to IOU view state, rather than the underlying IOU data.
@@ -57,6 +54,9 @@ const propTypes = {
 
         /** Flag to show a loading indicator and avoid showing a previously selected currency */
         isRetrievingCurrency: PropTypes.bool,
+
+        // Selected Currency Code of the current IOU
+        selectedCurrencyCode: PropTypes.string,
     }).isRequired,
 
     /** Personal details of all the users */
@@ -81,9 +81,11 @@ const defaultProps = {
     },
     myPersonalDetails: {
         localCurrencyCode: CONST.CURRENCY.USD,
-        selectedCurrencyCode: CONST.CURRENCY.USD,
     },
     iouType: '',
+    iou: {
+        selectedCurrencyCode: CONST.CURRENCY.USD,
+    }
 };
 
 // Determines type of step to display within Modal, value provides the title for that page.
@@ -141,10 +143,10 @@ class IOUModal extends Component {
             Navigation.dismissModal();
         }
 
-        if (prevProps.myPersonalDetails.selectedCurrencyCode
-            !== this.props.myPersonalDetails.selectedCurrencyCode) {
+        if (prevProps.iou.selectedCurrencyCode
+            !== this.props.iou.selectedCurrencyCode) {
             setSelectedCurrency({
-                selectedCurrencyCode: this.props.myPersonalDetails.selectedCurrencyCode,
+                selectedCurrencyCode: this.props.iou.selectedCurrencyCode,
             });
         }
     }
@@ -160,7 +162,7 @@ class IOUModal extends Component {
             const formattedAmount = this.props.numberFormat(
                 this.state.amount, {
                     style: 'currency',
-                    currency: this.props.myPersonalDetails.selectedCurrencyCode,
+                    currency: this.props.iou.selectedCurrencyCode,
                 },
             );
             if (this.props.iouType === 'send') {
@@ -235,7 +237,7 @@ class IOUModal extends Component {
 
                 // should send in cents to API
                 amount: Math.round(this.state.amount * 100),
-                currency: this.props.myPersonalDetails.selectedCurrencyCode,
+                currency: this.props.iou.selectedCurrencyCode,
                 splits,
             });
             return;
@@ -246,7 +248,7 @@ class IOUModal extends Component {
 
             // should send in cents to API
             amount: Math.round(this.state.amount * 100),
-            currency: this.props.myPersonalDetails.selectedCurrencyCode,
+            currency: this.props.iou.selectedCurrencyCode,
             debtorEmail: this.state.participants[0].login,
         });
     }

--- a/src/pages/iou/IOUModal.js
+++ b/src/pages/iou/IOUModal.js
@@ -9,7 +9,7 @@ import IOUConfirmPage from './steps/IOUConfirmPage';
 import Header from '../../components/Header';
 import styles from '../../styles/styles';
 import Icon from '../../components/Icon';
-import {createIOUSplit, createIOUTransaction, resetSelectedCurrency} from '../../libs/actions/IOU';
+import {createIOUSplit, createIOUTransaction, setSelectedCurrency} from '../../libs/actions/IOU';
 import {Close, BackArrow} from '../../components/Icon/Expensicons';
 import Navigation from '../../libs/Navigation/Navigation';
 import ONYXKEYS from '../../ONYXKEYS';
@@ -106,7 +106,6 @@ class IOUModal extends Component {
         super(props);
         this.navigateToPreviousStep = this.navigateToPreviousStep.bind(this);
         this.navigateToNextStep = this.navigateToNextStep.bind(this);
-        this.currencySelected = this.currencySelected.bind(this);
         this.addParticipants = this.addParticipants.bind(this);
         this.createTransaction = this.createTransaction.bind(this);
         this.updateComment = this.updateComment.bind(this);
@@ -138,6 +137,13 @@ class IOUModal extends Component {
         }
     }
 
+    componentDidMount() {
+        setSelectedCurrency({
+            selectedCurrencyCode: this.props.myPersonalDetails.preferredCurrencyCode,
+            selectedCurrencySymbol: this.props.myPersonalDetails.preferredCurrencySymbol,
+        });
+    }
+
     componentDidUpdate(prevProps) {
         // Successfully close the modal if transaction creation has ended and there is no error
         if (prevProps.iou.creatingIOUTransaction && !this.props.iou.creatingIOUTransaction && !this.props.iou.error) {
@@ -146,18 +152,11 @@ class IOUModal extends Component {
 
         if (prevProps.myPersonalDetails.selectedCurrencyCode
             !== this.props.myPersonalDetails.selectedCurrencyCode) {
-            this.updateSelectedCurrency({
-                currencyCode: this.props.myPersonalDetails.selectedCurrencyCode,
-                currencySymbol: this.props.myPersonalDetails.selectedCurrencySymbol,
+            setSelectedCurrency({
+                selectedCurrencyCode: this.props.myPersonalDetails.selectedCurrencyCode,
+                selectedCurrencySymbol: this.props.myPersonalDetails.selectedCurrencySymbol,
             });
         }
-    }
-
-    componentWillUnmount() {
-        resetSelectedCurrency({
-            selectedCurrencyCode: this.props.myPersonalDetails.preferredCurrencyCode,
-            selectedCurrencySymbol: this.props.myPersonalDetails.preferredCurrencySymbol,
-        });
     }
 
     /**
@@ -202,16 +201,6 @@ class IOUModal extends Component {
     }
 
     /**
-     * Update the selected currency
-     * @param {Object} selectedCurrency
-     */
-    updateSelectedCurrency(selectedCurrency) {
-        this.setState({
-            selectedCurrency,
-        });
-    }
-
-    /**
      * Navigate to the next IOU step if possible
      */
     navigateToPreviousStep() {
@@ -244,15 +233,6 @@ class IOUModal extends Component {
         this.setState({
             comment,
         });
-    }
-
-    /**
-     * Update the currency state
-     *
-     * @param {String} selectedCurrency
-     */
-    currencySelected(selectedCurrency) {
-        this.setState({selectedCurrency});
     }
 
     /**
@@ -332,9 +312,7 @@ class IOUModal extends Component {
                                                 this.setState({amount});
                                                 this.navigateToNextStep();
                                             }}
-                                            currencySelected={this.currencySelected}
                                             reportID={reportID}
-                                            selectedCurrencySymbol={this.props.myPersonalDetails.selectedCurrencySymbol}
                                             hasMultipleParticipants={this.props.hasMultipleParticipants}
                                             selectedAmount={this.state.amount}
                                             navigation={this.props.navigation}
@@ -355,7 +333,6 @@ class IOUModal extends Component {
                                             participants={this.state.participants}
                                             iouAmount={this.state.amount}
                                             comment={this.state.comment}
-                                            selectedCurrency={this.state.selectedCurrency}
                                             onUpdateComment={this.updateComment}
                                         />
                                     )}

--- a/src/pages/iou/IOUModal.js
+++ b/src/pages/iou/IOUModal.js
@@ -2,14 +2,14 @@ import React, {Component} from 'react';
 import {View, TouchableOpacity} from 'react-native';
 import PropTypes from 'prop-types';
 import lodashGet from 'lodash/get';
-import Onyx, {withOnyx} from 'react-native-onyx';
+import {withOnyx} from 'react-native-onyx';
 import IOUAmountPage from './steps/IOUAmountPage';
 import IOUParticipantsPage from './steps/IOUParticipantsPage';
 import IOUConfirmPage from './steps/IOUConfirmPage';
 import Header from '../../components/Header';
 import styles from '../../styles/styles';
 import Icon from '../../components/Icon';
-import {createIOUSplit, createIOUTransaction} from '../../libs/actions/IOU';
+import {createIOUSplit, createIOUTransaction, resetSelectedCurrency} from '../../libs/actions/IOU';
 import {Close, BackArrow} from '../../components/Icon/Expensicons';
 import Navigation from '../../libs/Navigation/Navigation';
 import ONYXKEYS from '../../ONYXKEYS';
@@ -126,10 +126,6 @@ class IOUModal extends Component {
 
             // amount is currency in decimal format
             amount: '',
-            selectedCurrency: {
-                currencyCode: props.myPersonalDetails.preferredCurrencyCode,
-                currencySymbol: props.myPersonalDetails.preferredCurrencySymbol,
-            },
             comment: '',
         };
 
@@ -158,7 +154,7 @@ class IOUModal extends Component {
     }
 
     componentWillUnmount() {
-        Onyx.merge(ONYXKEYS.MY_PERSONAL_DETAILS, {
+        resetSelectedCurrency({
             selectedCurrencyCode: this.props.myPersonalDetails.preferredCurrencyCode,
             selectedCurrencySymbol: this.props.myPersonalDetails.preferredCurrencySymbol,
         });
@@ -175,7 +171,7 @@ class IOUModal extends Component {
             const formattedAmount = this.props.numberFormat(
                 this.state.amount, {
                     style: 'currency',
-                    currency: this.state.selectedCurrency.currencyCode,
+                    currency: this.props.myPersonalDetails.selectedCurrencyCode,
                 },
             );
             if (this.props.iouType === 'send') {
@@ -269,7 +265,7 @@ class IOUModal extends Component {
 
                 // should send in cents to API
                 amount: Math.round(this.state.amount * 100),
-                currency: this.state.selectedCurrency.currencyCode,
+                currency: this.props.myPersonalDetails.selectedCurrencyCode,
                 splits,
             });
             return;
@@ -280,7 +276,7 @@ class IOUModal extends Component {
 
             // should send in cents to API
             amount: Math.round(this.state.amount * 100),
-            currency: this.state.selectedCurrency.currencyCode,
+            currency: this.props.myPersonalDetails.selectedCurrencyCode,
             debtorEmail: this.state.participants[0].login,
         });
     }
@@ -338,7 +334,7 @@ class IOUModal extends Component {
                                             }}
                                             currencySelected={this.currencySelected}
                                             reportID={reportID}
-                                            selectedCurrency={this.state.selectedCurrency}
+                                            selectedCurrencySymbol={this.props.myPersonalDetails.selectedCurrencySymbol}
                                             hasMultipleParticipants={this.props.hasMultipleParticipants}
                                             selectedAmount={this.state.amount}
                                             navigation={this.props.navigation}

--- a/src/pages/iou/IOUModal.js
+++ b/src/pages/iou/IOUModal.js
@@ -9,7 +9,7 @@ import IOUConfirmPage from './steps/IOUConfirmPage';
 import Header from '../../components/Header';
 import styles from '../../styles/styles';
 import Icon from '../../components/Icon';
-import {createIOUSplit, createIOUTransaction, setSelectedCurrency} from '../../libs/actions/IOU';
+import {createIOUSplit, createIOUTransaction, setIOUSelectedCurrency} from '../../libs/actions/IOU';
 import {Close, BackArrow} from '../../components/Icon/Expensicons';
 import Navigation from '../../libs/Navigation/Navigation';
 import ONYXKEYS from '../../ONYXKEYS';
@@ -83,9 +83,6 @@ const defaultProps = {
         localCurrencyCode: CONST.CURRENCY.USD,
     },
     iouType: '',
-    iou: {
-        selectedCurrencyCode: CONST.CURRENCY.USD,
-    }
 };
 
 // Determines type of step to display within Modal, value provides the title for that page.
@@ -132,7 +129,7 @@ class IOUModal extends Component {
     }
 
     componentDidMount() {
-        setSelectedCurrency({
+        setIOUSelectedCurrency({
             selectedCurrencyCode: this.props.myPersonalDetails.localCurrencyCode,
         });
     }
@@ -145,7 +142,7 @@ class IOUModal extends Component {
 
         if (prevProps.iou.selectedCurrencyCode
             !== this.props.iou.selectedCurrencyCode) {
-            setSelectedCurrency({
+            setIOUSelectedCurrency({
                 selectedCurrencyCode: this.props.iou.selectedCurrencyCode,
             });
         }

--- a/src/pages/iou/IOUModal.js
+++ b/src/pages/iou/IOUModal.js
@@ -43,14 +43,8 @@ const propTypes = {
         // Local Currency Code of the current user
         localCurrencyCode: PropTypes.string,
 
-        // Currency Symbol of the Local Currency
-        localCurrencySymbol: PropTypes.string,
-
         // Selected Currency Code of the current IOU
         selectedCurrencyCode: PropTypes.string,
-
-        // Currency Symbol of the Selected Currency
-        selectedCurrencySymbol: PropTypes.string,
     }),
 
     // Holds data related to IOU view state, rather than the underlying IOU data.
@@ -87,9 +81,7 @@ const defaultProps = {
     },
     myPersonalDetails: {
         localCurrencyCode: CONST.CURRENCY.USD,
-        localCurrencySymbol: '$',
         selectedCurrencyCode: CONST.CURRENCY.USD,
-        selectedCurrencySymbol: '$',
     },
     iouType: '',
 };
@@ -140,7 +132,6 @@ class IOUModal extends Component {
     componentDidMount() {
         setSelectedCurrency({
             selectedCurrencyCode: this.props.myPersonalDetails.localCurrencyCode,
-            selectedCurrencySymbol: this.props.myPersonalDetails.localCurrencySymbol,
         });
     }
 
@@ -154,7 +145,6 @@ class IOUModal extends Component {
             !== this.props.myPersonalDetails.selectedCurrencyCode) {
             setSelectedCurrency({
                 selectedCurrencyCode: this.props.myPersonalDetails.selectedCurrencyCode,
-                selectedCurrencySymbol: this.props.myPersonalDetails.selectedCurrencySymbol,
             });
         }
     }

--- a/src/pages/iou/IOUModal.js
+++ b/src/pages/iou/IOUModal.js
@@ -40,11 +40,11 @@ const propTypes = {
     // The personal details of the person who is logged in
     myPersonalDetails: PropTypes.shape({
 
-        // Preferred Currency Code of the current user
-        preferredCurrencyCode: PropTypes.string,
+        // Local Currency Code of the current user
+        localCurrencyCode: PropTypes.string,
 
-        // Currency Symbol of the Preferred Currency
-        preferredCurrencySymbol: PropTypes.string,
+        // Currency Symbol of the Local Currency
+        localCurrencySymbol: PropTypes.string,
 
         // Selected Currency Code of the current IOU
         selectedCurrencyCode: PropTypes.string,
@@ -86,8 +86,8 @@ const defaultProps = {
         participants: [],
     },
     myPersonalDetails: {
-        preferredCurrencyCode: CONST.CURRENCY.USD,
-        preferredCurrencySymbol: '$',
+        localCurrencyCode: CONST.CURRENCY.USD,
+        localCurrencySymbol: '$',
         selectedCurrencyCode: CONST.CURRENCY.USD,
         selectedCurrencySymbol: '$',
     },
@@ -139,8 +139,8 @@ class IOUModal extends Component {
 
     componentDidMount() {
         setSelectedCurrency({
-            selectedCurrencyCode: this.props.myPersonalDetails.preferredCurrencyCode,
-            selectedCurrencySymbol: this.props.myPersonalDetails.preferredCurrencySymbol,
+            selectedCurrencyCode: this.props.myPersonalDetails.localCurrencyCode,
+            selectedCurrencySymbol: this.props.myPersonalDetails.localCurrencySymbol,
         });
     }
 

--- a/src/pages/iou/IOUModal.js
+++ b/src/pages/iou/IOUModal.js
@@ -129,9 +129,7 @@ class IOUModal extends Component {
     }
 
     componentDidMount() {
-        setIOUSelectedCurrency({
-            selectedCurrencyCode: this.props.myPersonalDetails.localCurrencyCode,
-        });
+        setIOUSelectedCurrency(this.props.myPersonalDetails.localCurrencyCode);
     }
 
     componentDidUpdate(prevProps) {
@@ -142,9 +140,7 @@ class IOUModal extends Component {
 
         if (prevProps.iou.selectedCurrencyCode
             !== this.props.iou.selectedCurrencyCode) {
-            setIOUSelectedCurrency({
-                selectedCurrencyCode: this.props.iou.selectedCurrencyCode,
-            });
+            setIOUSelectedCurrency(this.props.iou.selectedCurrencyCode);
         }
     }
 
@@ -291,9 +287,9 @@ class IOUModal extends Component {
                         </View>
                         <View style={[styles.pRelative, styles.flex1]}>
                             <FullScreenLoadingIndicator
-                                visible={!didScreenTransitionEnd}
+                                visible={!didScreenTransitionEnd || this.props.iou.isRetrievingCurrency}
                             />
-                            {didScreenTransitionEnd && (
+                            {didScreenTransitionEnd && !this.props.iou.isRetrievingCurrency && (
                                 <>
                                     {currentStep === Steps.IOUAmount && (
                                         <IOUAmountPage

--- a/src/pages/iou/steps/IOUAmountPage.js
+++ b/src/pages/iou/steps/IOUAmountPage.js
@@ -34,10 +34,19 @@ const propTypes = {
 
         // Selected Currency Code of the current IOU
         selectedCurrencyCode: PropTypes.string,
-
-        // Currency Symbol of the Selected Currency
-        selectedCurrencySymbol: PropTypes.string,
     }),
+
+    // The currency list constant object from Onyx
+    currencyList: PropTypes.objectOf(PropTypes.shape({
+        // Symbol for the currency
+        symbol: PropTypes.string,
+
+        // Name of the currency
+        name: PropTypes.string,
+
+        // ISO4217 Code for the currency
+        ISO4217: PropTypes.string,
+    })),
 
     /** Previously selected amount to show if the user comes back to this screen */
     selectedAmount: PropTypes.string.isRequired,
@@ -61,8 +70,8 @@ const defaultProps = {
     iou: {},
     myPersonalDetails: {
         selectedCurrencyCode: CONST.CURRENCY.USD,
-        selectedCurrencySymbol: '$',
     },
+    currencyList: {},
 };
 
 class IOUAmountPage extends React.Component {
@@ -149,7 +158,7 @@ class IOUAmountPage extends React.Component {
                         : ROUTES.getIouRequestCurrencyRoute(this.props.reportID))}
                     >
                         <Text style={styles.iouAmountText}>
-                            {this.props.myPersonalDetails.selectedCurrencySymbol}
+                            {this.props.currencyList[this.props.myPersonalDetails.selectedCurrencyCode].symbol}
                         </Text>
                     </TouchableOpacity>
                     {this.props.isSmallScreenWidth
@@ -200,6 +209,7 @@ export default compose(
     withWindowDimensions,
     withLocalize,
     withOnyx({
+        currencyList: {key: ONYXKEYS.CURRENCY_LIST},
         myPersonalDetails: {
             key: ONYXKEYS.MY_PERSONAL_DETAILS,
         },

--- a/src/pages/iou/steps/IOUAmountPage.js
+++ b/src/pages/iou/steps/IOUAmountPage.js
@@ -39,7 +39,7 @@ const propTypes = {
 
         // ISO4217 Code for the currency
         ISO4217: PropTypes.string,
-    })),
+    })).isRequired,
 
     /** Previously selected amount to show if the user comes back to this screen */
     selectedAmount: PropTypes.string.isRequired,

--- a/src/pages/iou/steps/IOUAmountPage.js
+++ b/src/pages/iou/steps/IOUAmountPage.js
@@ -27,18 +27,18 @@ const propTypes = {
     /** The ID of the report this screen should display */
     reportID: PropTypes.string.isRequired,
 
-    /** Callback to inform parent modal of success */ 
+    /** Callback to inform parent modal of success */
     onStepComplete: PropTypes.func.isRequired,
 
-    /** The currency list constant object from Onyx */ 
+    /** The currency list constant object from Onyx */
     currencyList: PropTypes.objectOf(PropTypes.shape({
-        /** Symbol for the currency */ 
+        /** Symbol for the currency */
         symbol: PropTypes.string,
 
-        /** Name of the currency */ 
+        /** Name of the currency */
         name: PropTypes.string,
 
-        /** ISO4217 Code for the currency */ 
+        /** ISO4217 Code for the currency */
         ISO4217: PropTypes.string,
     })).isRequired,
 

--- a/src/pages/iou/steps/IOUAmountPage.js
+++ b/src/pages/iou/steps/IOUAmountPage.js
@@ -6,6 +6,7 @@ import {
 } from 'react-native';
 import PropTypes from 'prop-types';
 import {withOnyx} from 'react-native-onyx';
+import lodashGet from 'lodash/get';
 import ONYXKEYS from '../../../ONYXKEYS';
 import styles from '../../../styles/styles';
 import BigNumberPad from '../../../components/BigNumberPad';
@@ -20,24 +21,24 @@ import Text from '../../../components/Text';
 import CONST from '../../../CONST';
 
 const propTypes = {
-    // Whether or not this IOU has multiple participants
+    /** Whether or not this IOU has multiple participants */
     hasMultipleParticipants: PropTypes.bool.isRequired,
 
-    /* The ID of the report this screen should display */
+    /** The ID of the report this screen should display */
     reportID: PropTypes.string.isRequired,
 
-    // Callback to inform parent modal of success
+    /** Callback to inform parent modal of success */ 
     onStepComplete: PropTypes.func.isRequired,
 
-    // The currency list constant object from Onyx
+    /** The currency list constant object from Onyx */ 
     currencyList: PropTypes.objectOf(PropTypes.shape({
-        // Symbol for the currency
+        /** Symbol for the currency */ 
         symbol: PropTypes.string,
 
-        // Name of the currency
+        /** Name of the currency */ 
         name: PropTypes.string,
 
-        // ISO4217 Code for the currency
+        /** ISO4217 Code for the currency */ 
         ISO4217: PropTypes.string,
     })).isRequired,
 
@@ -55,7 +56,7 @@ const propTypes = {
         /** Whether or not the IOU step is loading (retrieving users preferred currency) */
         loading: PropTypes.bool,
 
-        // Selected Currency Code of the current IOU
+        /** Selected Currency Code of the current IOU */
         selectedCurrencyCode: PropTypes.string,
     }),
 
@@ -152,7 +153,7 @@ class IOUAmountPage extends React.Component {
                         : ROUTES.getIouRequestCurrencyRoute(this.props.reportID))}
                     >
                         <Text style={styles.iouAmountText}>
-                            {this.props.currencyList[this.props.iou.selectedCurrencyCode].symbol}
+                            {lodashGet(this.props.currencyList, [this.props.iou.selectedCurrencyCode, 'symbol'])}
                         </Text>
                     </TouchableOpacity>
                     {this.props.isSmallScreenWidth

--- a/src/pages/iou/steps/IOUAmountPage.js
+++ b/src/pages/iou/steps/IOUAmountPage.js
@@ -29,13 +29,6 @@ const propTypes = {
     // Callback to inform parent modal of success
     onStepComplete: PropTypes.func.isRequired,
 
-    // The personal details of the person who is logged in
-    myPersonalDetails: PropTypes.shape({
-
-        // Selected Currency Code of the current IOU
-        selectedCurrencyCode: PropTypes.string,
-    }),
-
     // The currency list constant object from Onyx
     currencyList: PropTypes.objectOf(PropTypes.shape({
         // Symbol for the currency
@@ -61,14 +54,16 @@ const propTypes = {
 
         /** Whether or not the IOU step is loading (retrieving users preferred currency) */
         loading: PropTypes.bool,
+
+        // Selected Currency Code of the current IOU
+        selectedCurrencyCode: PropTypes.string,
     }),
 
     ...withLocalizePropTypes,
 };
 
 const defaultProps = {
-    iou: {},
-    myPersonalDetails: {
+    iou: {
         selectedCurrencyCode: CONST.CURRENCY.USD,
     },
     currencyList: {},
@@ -158,7 +153,7 @@ class IOUAmountPage extends React.Component {
                         : ROUTES.getIouRequestCurrencyRoute(this.props.reportID))}
                     >
                         <Text style={styles.iouAmountText}>
-                            {this.props.currencyList[this.props.myPersonalDetails.selectedCurrencyCode].symbol}
+                            {this.props.currencyList[this.props.iou.selectedCurrencyCode].symbol}
                         </Text>
                     </TouchableOpacity>
                     {this.props.isSmallScreenWidth
@@ -210,9 +205,6 @@ export default compose(
     withLocalize,
     withOnyx({
         currencyList: {key: ONYXKEYS.CURRENCY_LIST},
-        myPersonalDetails: {
-            key: ONYXKEYS.MY_PERSONAL_DETAILS,
-        },
         iou: {key: ONYXKEYS.IOU},
     }),
 )(IOUAmountPage);

--- a/src/pages/iou/steps/IOUAmountPage.js
+++ b/src/pages/iou/steps/IOUAmountPage.js
@@ -17,6 +17,7 @@ import withLocalize, {withLocalizePropTypes} from '../../../components/withLocal
 import compose from '../../../libs/compose';
 import Button from '../../../components/Button';
 import Text from '../../../components/Text';
+import CONST from '../../../CONST';
 
 const propTypes = {
     // Whether or not this IOU has multiple participants
@@ -32,14 +33,15 @@ const propTypes = {
     // eslint-disable-next-line react/no-unused-prop-types
     currencySelected: PropTypes.func.isRequired,
 
-    // User's currency preference
-    selectedCurrency: PropTypes.shape({
-        // Currency code for the selected currency
-        currencyCode: PropTypes.string,
+    // The personal details of the person who is logged in
+    myPersonalDetails: PropTypes.shape({
 
-        // Currency symbol for the selected currency
-        currencySymbol: PropTypes.string,
-    }).isRequired,
+        // Selected Currency Code of the current IOU
+        selectedCurrencyCode: PropTypes.string,
+
+        // Currency Symbol of the Selected Currency
+        selectedCurrencySymbol: PropTypes.string,
+    }),
 
     /** Previously selected amount to show if the user comes back to this screen */
     selectedAmount: PropTypes.string.isRequired,
@@ -61,6 +63,10 @@ const propTypes = {
 
 const defaultProps = {
     iou: {},
+    myPersonalDetails: {
+        selectedCurrencyCode: CONST.CURRENCY.USD,
+        selectedCurrencySymbol: '$',
+    },
 };
 
 class IOUAmountPage extends React.Component {
@@ -147,7 +153,7 @@ class IOUAmountPage extends React.Component {
                         : ROUTES.getIouRequestCurrencyRoute(this.props.reportID))}
                     >
                         <Text style={styles.iouAmountText}>
-                            {this.props.selectedCurrency.currencySymbol}
+                            {this.props.myPersonalDetails.selectedCurrencySymbol}
                         </Text>
                     </TouchableOpacity>
                     {this.props.isSmallScreenWidth
@@ -198,6 +204,9 @@ export default compose(
     withWindowDimensions,
     withLocalize,
     withOnyx({
+        myPersonalDetails: {
+            key: ONYXKEYS.MY_PERSONAL_DETAILS,
+        },
         iou: {key: ONYXKEYS.IOU},
     }),
 )(IOUAmountPage);

--- a/src/pages/iou/steps/IOUAmountPage.js
+++ b/src/pages/iou/steps/IOUAmountPage.js
@@ -29,10 +29,6 @@ const propTypes = {
     // Callback to inform parent modal of success
     onStepComplete: PropTypes.func.isRequired,
 
-    /** Currency selection will be implemented later */
-    // eslint-disable-next-line react/no-unused-prop-types
-    currencySelected: PropTypes.func.isRequired,
-
     // The personal details of the person who is logged in
     myPersonalDetails: PropTypes.shape({
 

--- a/src/pages/iou/steps/IOUAmountPage.js
+++ b/src/pages/iou/steps/IOUAmountPage.js
@@ -66,7 +66,6 @@ const defaultProps = {
     iou: {
         selectedCurrencyCode: CONST.CURRENCY.USD,
     },
-    currencyList: {},
 };
 
 class IOUAmountPage extends React.Component {

--- a/src/pages/iou/steps/IOUConfirmPage.js
+++ b/src/pages/iou/steps/IOUConfirmPage.js
@@ -18,15 +18,6 @@ const propTypes = {
     /** IOU amount */
     iouAmount: PropTypes.string.isRequired,
 
-    // User's currency preference
-    selectedCurrency: PropTypes.shape({
-        // Currency code for the selected currency
-        currencyCode: PropTypes.string,
-
-        // Currency symbol for the selected currency
-        currencySymbol: PropTypes.string,
-    }).isRequired,
-
     /** Selected participants from IOUMOdal with login */
     participants: PropTypes.arrayOf(PropTypes.shape({
         login: PropTypes.string.isRequired,
@@ -55,7 +46,6 @@ const IOUConfirmPage = props => (
         participants={props.participants}
         comment={props.comment}
         onUpdateComment={props.onUpdateComment}
-        selectedCurrency={props.selectedCurrency}
         iouAmount={props.iouAmount}
         onConfirm={props.onConfirm}
     />


### PR DESCRIPTION
cc @chiragsalian
cc @tgolen and @marcaaron because of changes to `processNetworkRequestQueue`

Currently, requests that are sent offline and should not be retried are hanging since the promises never resolve. This PR should solve that and allow users to go through the currency selection, as well as see an offline error message on the confirmation page.

### Fixed Issues
$ https://github.com/Expensify/Expensify.cash/issues/3792

### Tests
1. Login to app
2. Kill internet connection
3. Click '+' and select `Request Money`
4. Verify that you can go through the flow and see `Looks like you're offline. Please check your connection and try again.` error message on the request confirmation page.
5. Dismiss the modal
6. Click '+' and select `Split Bill`
7. Verify that you can go through the flow and see `Looks like you're offline. Please check your connection and try again.` error message on the request confirmation page.

### QA Steps
Steps above.

### Tested On

- [X] Web
- [X] Mobile Web
- [X] Desktop
- [X] iOS
- [X] Android

### Screenshots

#### Web

https://user-images.githubusercontent.com/22219519/125698474-cdbb7dd4-26e5-4a2f-a311-c5005358bb25.mov

#### Mobile Web

https://user-images.githubusercontent.com/22219519/125698483-0daa548d-2b9d-413a-bd8b-4c6fa9fd274b.mov

#### Desktop

https://user-images.githubusercontent.com/22219519/125698493-a27cf75d-fee3-420c-9776-542ceb26c5b5.mov

#### iOS

https://user-images.githubusercontent.com/22219519/125698503-6c4f36db-da76-4585-8311-f6e2eafc24f8.mov

#### Android

https://user-images.githubusercontent.com/22219519/125698527-636603c9-8e5d-47f9-bfd2-2685010499bc.mov