### PR TITLE
Fix display of report typing indicator and participant local time

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -57,6 +57,8 @@ export default {
         notifications: 'Notifications',
         noResultsFound: 'No results found',
         deletedCommentMessage: 'Comment deleted',
+        timePrefix: 'It\'s',
+        conjunctionFor: 'for',
     },
     attachmentPicker: {
         cameraPermissionRequired: 'Camera Permission Required',
@@ -106,7 +108,6 @@ export default {
         blockedFromConcierge: 'Communication is barred',
         youAppearToBeOffline: 'You appear to be offline.',
         fileUploadFailed: 'Upload Failed. File is not supported.',
-        localTime: ({user, time}) => `It's ${time} for ${user}`,
     },
     contextMenuItem: {
         copyToClipboard: 'Copy to Clipboard',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -53,6 +53,8 @@ export default {
         notifications: 'Notificaciones',
         noResultsFound: 'No se han encontrado resultados',
         deletedCommentMessage: 'Comentario borrado',
+        timePrefix: 'Son las',
+        conjunctionFor: 'para',
     },
     attachmentPicker: {
         cameraPermissionRequired: 'Se necesita permiso para usar la cámara',
@@ -101,7 +103,6 @@ export default {
         writeSomething: 'Escribe algo...',
         blockedFromConcierge: 'Comunicación no permitida',
         youAppearToBeOffline: 'Parece que estás desconectado.',
-        localTime: ({user, time}) => `Son las ${time} para ${user}`,
     },
     reportActionContextMenu: {
         copyToClipboard: 'Copiar al Portapapeles',

--- a/src/pages/home/report/ParticipantLocalTime.js
+++ b/src/pages/home/report/ParticipantLocalTime.js
@@ -58,21 +58,24 @@ class ParticipantLocalTime extends React.Component {
         return (
             isReportRecipientLocalTimeReady ? (
                 <View style={[styles.chatItemComposeSecondaryRow]}>
-                    <ExpensiText
-                        style={[
-                            styles.chatItemComposeSecondaryRowSubText,
-                            styles.chatItemComposeSecondaryRowOffset,
-                        ]}
-                        numberOfLines={1}
+                    <View style={[
+                        styles.chatItemComposeSecondaryRowOffset,
+                        styles.flexRow,
+                        styles.alignItemsCenter]}
                     >
-                        {this.props.translate(
-                            'reportActionCompose.localTime',
-                            {
-                                user: reportRecipientDisplayName,
-                                time: this.state.localTime,
-                            },
-                        )}
-                    </ExpensiText>
+                        <ExpensiText style={[styles.chatItemComposeSecondaryRowSubText, styles.mr1]}>
+                            {this.props.translate('common.timePrefix')}
+                        </ExpensiText>
+                        <ExpensiText style={[styles.textMicroSupportingBold, styles.mr1]}>
+                            {this.state.localTime}
+                        </ExpensiText>
+                        <ExpensiText style={[styles.chatItemComposeSecondaryRowSubText, styles.mr1]}>
+                            {this.props.translate('common.conjunctionFor')}
+                        </ExpensiText>
+                        <ExpensiText style={[styles.textMicroSupportingBold]}>
+                            {reportRecipientDisplayName}
+                        </ExpensiText>
+                    </View>
                 </View>
             )
                 : <View style={[styles.chatItemComposeSecondaryRow]} />

--- a/src/pages/home/report/ReportTypingIndicator.js
+++ b/src/pages/home/report/ReportTypingIndicator.js
@@ -59,7 +59,9 @@ class ReportTypingIndicator extends React.Component {
                             styles.chatItemComposeSecondaryRowOffset,
                         ]}
                         >
-                            <Text style={[styles.textStrong]}>{getDisplayName(this.state.usersTyping[0])}</Text>
+                            <Text style={[styles.textMicroSupportingBold]}>
+                                {getDisplayName(this.state.usersTyping[0])}
+                            </Text>
                             {` ${this.props.translate('reportTypingIndicator.isTyping')}`}
                         </Text>
                     </View>
@@ -72,9 +74,13 @@ class ReportTypingIndicator extends React.Component {
                             styles.chatItemComposeSecondaryRowOffset,
                         ]}
                         >
-                            <Text style={[styles.textStrong]}>{getDisplayName(this.state.usersTyping[0])}</Text>
+                            <Text style={[styles.textMicroSupportingBold]}>
+                                {getDisplayName(this.state.usersTyping[0])}
+                            </Text>
                             {` ${this.props.translate('common.and')} `}
-                            <Text style={[styles.textStrong]}>{getDisplayName(this.state.usersTyping[1])}</Text>
+                            <Text style={[styles.textMicroSupportingBold]}>
+                                {getDisplayName(this.state.usersTyping[1])}
+                            </Text>
                             {` ${this.props.translate('reportTypingIndicator.areTyping')}`}
                         </Text>
                     </View>
@@ -87,7 +93,7 @@ class ReportTypingIndicator extends React.Component {
                             styles.chatItemComposeSecondaryRowOffset,
                         ]}
                         >
-                            <Text style={[styles.textStrong]}>
+                            <Text style={[styles.textMicroSupportingBold]}>
                                 {this.props.translate('reportTypingIndicator.multipleUsers')}
                             </Text>
                             {` ${this.props.translate('reportTypingIndicator.areTyping')}`}

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -82,6 +82,14 @@ const styles = {
         lineHeight: 14,
     },
 
+    textMicroSupportingBold: {
+        color: themeColors.textSupporting,
+        fontFamily: fontFamily.GTA_BOLD,
+        fontWeight: fontWeightBold,
+        fontSize: variables.fontSizeSmall,
+        lineHeight: 14,
+    },
+
     textLarge: {
         fontSize: variables.fontSizeLarge,
     },


### PR DESCRIPTION
### Details
Fixes the style of the report typing indicator and participant local time. Context [here](https://expensify.slack.com/archives/C01GTK53T8Q/p1626211434198100)

### Fixed Issues
$ https://github.com/Expensify/Expensify.cash/issues/3965

### Tests / QA Steps
1. Log into E.cash on one device/window in one account, and another account in another device/window.
1. Open a chat report between the two accounts. Start typing in one, and verify that the report typing indicator appears for the other user. The username in the report typing indicator should be bold, grey, and the same size as the rest of the text. It should not be cut-off at all.
1. Go to `Settings` -> `Profile` and change the timezone of one of the users.
1. Open the chat report between the two accounts. The timezone of the other user should be shown above the main `ReportActionCompose` (you might have to refresh the page). The time and username should be bold, grey, and the same size as the rest of the text. The rest of the text should not be bold.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
#### Web
![image](https://user-images.githubusercontent.com/47436092/125535329-e864b454-5420-4f0a-80ce-4e9c0c3ca44f.png)

#### Mobile Web
![image](https://user-images.githubusercontent.com/47436092/125535712-a254c6b4-1a5b-4f0f-b293-4c5caa2b164e.png)

#### Desktop
![image](https://user-images.githubusercontent.com/47436092/125536599-4a144740-2d13-4398-918d-d6e5e5bb1132.png)

#### iOS
![image](https://user-images.githubusercontent.com/47436092/125536402-d56ca0d8-da52-4d25-a7b8-30deb65c8320.png)

#### Android
(sorry ignore this warning that pops up 100% of the time running the android app on dev)

![image](https://user-images.githubusercontent.com/47436092/125537491-4e59746e-33f2-4b90-8879-071c52291402.png)
