### PR TITLE
[No QA] fix: suppress distracting log box warnings

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,19 @@
 import React from 'react';
+import {LogBox} from 'react-native';
 import {SafeAreaProvider} from 'react-native-safe-area-context';
 import CustomStatusBar from './components/CustomStatusBar';
 import ErrorBoundary from './components/ErrorBoundary';
 import Expensify from './Expensify';
+
+LogBox.ignoreLogs([
+    // Basically it means that if the app goes in the background and back to foreground on Android,
+    // the timer is lost. Currently Expensify is using a 30 minutes interval to refresh personal details.
+    // More details here: https://git.io/JJYeb
+    'Setting a timer for a long period of time',
+
+    // Caused by rn-fetch-blob. Can safely ignore as it has no impact on features.
+    'Require cycle: node_modules/rn-fetch-blob',
+]);
 
 const App = () => (
     <SafeAreaProvider>


### PR DESCRIPTION
@marcaaron 

### Details

Suppress warnings which cause are well understood and can be safely ignored, as discussed in #4014 

### Fixed Issues

https://github.com/Expensify/Expensify.cash/issues/4014

### Tests

Launch the app in dev mode and make sure the suppressed warnings are not shown anymore.

### Tested On

- [X] Web
- [X] Mobile Web
- [X] Desktop
- [X] iOS
- [X] Android

### Screenshots

I don't think it's relevant to provide screenshots here, but if you really require it I will.