### PR TITLE
Hide add payment button

### DIFF
--- a/src/libs/actions/User.js
+++ b/src/libs/actions/User.js
@@ -64,7 +64,7 @@ function getBetas() {
 function getUserDetails() {
     API.Get({
         returnValueList: 'account, loginList, nameValuePairs',
-        nvpNames: CONST.NVP.BLOCKED_FROM_CONCIERGE,
+        nvpNames: [CONST.NVP.BLOCKED_FROM_CONCIERGE, CONST.NVP.PAYPAL_ME_ADDRESS].join(','),
     })
         .then((response) => {
             // Update the User onyx key

--- a/src/pages/settings/Payments/AddPayPalMePage.js
+++ b/src/pages/settings/Payments/AddPayPalMePage.js
@@ -92,7 +92,6 @@ class AddPayPalMePage extends React.Component {
                                 value={this.state.payPalMeUsername}
                                 placeholder={this.props.translate('addPayPalMePage.yourPayPalUsername')}
                                 onChangeText={text => this.setState({payPalMeUsername: text})}
-                                editable={!this.props.payPalMeUsername}
                                 returnKeyType="done"
                             />
                         </View>
@@ -100,7 +99,6 @@ class AddPayPalMePage extends React.Component {
                     <FixedFooter>
                         <Button
                             success
-                            isDisabled={Boolean(this.props.payPalMeUsername)}
                             onPress={this.setPayPalMeUsername}
                             style={[styles.mt3]}
                             text={this.props.translate('addPayPalMePage.addPayPalAccount')}

--- a/src/pages/settings/Payments/PaymentMethodList.js
+++ b/src/pages/settings/Payments/PaymentMethodList.js
@@ -110,12 +110,17 @@ class PaymentMethodList extends Component {
             });
         }
 
-        combinedPaymentMethods.push({
-            title: this.props.translate('paymentMethodList.addPaymentMethod'),
-            icon: Plus,
-            onPress: e => this.props.onPress(e),
-            key: 'addPaymentMethodButton',
-        });
+        // Don't show Add Payment Method button if user provided details for all possible payment methods.
+        // Right now only available method is Paypal.me
+        // When there is a new payment method, it needs to be added to following if condition.
+        if (!this.props.payPalMeUsername) {
+            combinedPaymentMethods.push({
+                title: this.props.translate('paymentMethodList.addPaymentMethod'),
+                icon: Plus,
+                onPress: e => this.props.onPress(e),
+                key: 'addPaymentMethodButton',
+            });
+        }
 
         return combinedPaymentMethods;
     }

--- a/src/pages/settings/Payments/PaymentsPage.js
+++ b/src/pages/settings/Payments/PaymentsPage.js
@@ -1,5 +1,8 @@
 import React from 'react';
 import {View} from 'react-native';
+import PropTypes from 'prop-types';
+import {withOnyx} from 'react-native-onyx';
+import ONYXKEYS from '../../../ONYXKEYS';
 import PaymentMethodList from './PaymentMethodList';
 import ROUTES from '../../../ROUTES';
 import HeaderWithCloseButton from '../../../components/HeaderWithCloseButton';
@@ -18,7 +21,14 @@ import getClickedElementLocation from '../../../libs/getClickedElementLocation';
 const PAYPAL = 'payPalMe';
 
 const propTypes = {
+    /** User's paypal.me username if they have one */
+    payPalMeUsername: PropTypes.string,
+
     ...withLocalizePropTypes,
+};
+
+const defaultProps = {
+    payPalMeUsername: '',
 };
 
 class PaymentsPage extends React.Component {
@@ -104,11 +114,13 @@ class PaymentsPage extends React.Component {
                             left: this.state.anchorPositionLeft,
                         }}
                     >
-                        <MenuItem
-                            title="PayPal.me"
-                            icon={PayPal}
-                            onPress={() => this.addPaymentMethodTypePressed(PAYPAL)}
-                        />
+                        {!this.props.payPalMeUsername && (
+                            <MenuItem
+                                title="PayPal.me"
+                                icon={PayPal}
+                                onPress={() => this.addPaymentMethodTypePressed(PAYPAL)}
+                            />
+                        )}
                     </Popover>
                 </KeyboardAvoidingView>
             </ScreenWrapper>
@@ -117,8 +129,14 @@ class PaymentsPage extends React.Component {
 }
 
 PaymentsPage.propTypes = propTypes;
+PaymentsPage.defaultProps = defaultProps;
 PaymentsPage.displayName = 'PaymentsPage';
 
 export default compose(
     withLocalize,
+    withOnyx({
+        payPalMeUsername: {
+            key: ONYXKEYS.NVP_PAYPAL_ME_ADDRESS,
+        },
+    }),
 )(PaymentsPage);

--- a/src/pages/settings/Payments/PaymentsPage.js
+++ b/src/pages/settings/Payments/PaymentsPage.js
@@ -58,7 +58,9 @@ class PaymentsPage extends React.Component {
      */
     paymentMethodPressed(nativeEvent, account) {
         if (account) {
-            // TODO: Show the make default/delete popover
+            if (account === PAYPAL) {
+                Navigation.navigate(ROUTES.SETTINGS_ADD_PAYPAL_ME);
+            }
         } else {
             const position = getClickedElementLocation(nativeEvent);
             this.setState({


### PR DESCRIPTION
cc @roryabraham @kevinksullivan 

### Details
`Add Payment Method` no longer shows paypal.me option if there's an existing Paypal.me username and `Add Payment Method` button is hidden completely if there is no available payment method to add.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify.cash/issues/3960

### Tests
Tested by adding and updating Paypal.me username on different platforms.

### QA Steps

- Navigate to settings/payments
- Click on "Add new payment method"
- Click on PayPal.me
- Add a Paypal.me account and save
- Go back to Payment Method List
- Make sure "Add new payment method" button is hidden
- Click and edit existing Paypal.me username

### Tested On

- [X] Web
- [X] Mobile Web
- [X] Desktop
- [X] iOS
- [X] Android

### Screenshots

#### Web

https://user-images.githubusercontent.com/3853003/125638660-ecba2340-b29d-479e-ba9d-91ce172323ea.mov

#### Mobile Web

https://user-images.githubusercontent.com/3853003/125638979-3e18c8f7-b919-47e3-9794-ee90fbb71e74.mov

#### Desktop

https://user-images.githubusercontent.com/3853003/125638883-6057096a-faac-4366-baea-92669ea80047.mov

#### iOS

https://user-images.githubusercontent.com/3853003/125639402-8eaa8f96-773d-4b86-9a40-8ad4ec1e2bfd.mov

#### Android

https://user-images.githubusercontent.com/3853003/125639043-bf63feb7-ed2a-43e7-8848-41185e7e1ae1.mov

