### PR TITLE
[CP Staging] Don't show all chats in LHN in #focus mode

### DIFF
--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -106,17 +106,17 @@ function getUnreadActionCount(report) {
     // Save the lastReadActionID locally so we can access this later
     lastReadSequenceNumbers[report.reportID] = lastReadSequenceNumber;
 
-    if (report.reportActionListLength === 0) {
+    if (report.reportActionCount === 0) {
         return 0;
     }
 
     if (!lastReadSequenceNumber) {
-        return report.reportActionListLength;
+        return report.reportActionCount;
     }
 
     // There are unread items if the last one the user has read is less
     // than the highest sequence number we have
-    const unreadActionCount = report.reportActionListLength - lastReadSequenceNumber;
+    const unreadActionCount = report.reportActionCount - lastReadSequenceNumber;
     return Math.max(0, unreadActionCount);
 }
 


### PR DESCRIPTION
@marcaaron will you please review this?

### Details
This fixes a bug introduced in https://github.com/Expensify/Expensify.cash/pull/3894 where all chats were showing in focus mode because the unreadActionCount was being set to a non-existent report property. This PR updates the property to match the one returned from the back end.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ https://github.com/Expensify/Expensify.cash/issues/4057

### Tests/QA
1. Login to an account and go to preferences, and change to `#focus` mode, confirm already-read chats only show up if they are pinned, if they are an IOU, or if they are the currently selected chat.
2. Change back to `Recent` mode, confirm all chats are shown

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
| Focus Mode | Recent Mode |
|---|---|
| ![image](https://user-images.githubusercontent.com/3981102/125712932-8012131a-983e-4fb1-8694-1d72481b6e50.png) | ![image](https://user-images.githubusercontent.com/3981102/125712973-530270cd-e749-4f54-8258-1dd4fd5beaca.png) |

