### PR TITLE
Change to use _.isObject, also stop the loading state

### DIFF
--- a/src/pages/RequestCallPage.js
+++ b/src/pages/RequestCallPage.js
@@ -78,8 +78,10 @@ class RequestCallPage extends Component {
         }
 
         const personalPolicy = _.find(this.props.policies, policy => policy.type === CONST.POLICY.TYPE.PERSONAL);
-        if (!personalPolicy) {
-            Growl.error(this.props.translate('requestCallPage.growlMessageNoPersonalPolicy'), 3000);
+        if (!_.isObject(personalPolicy)) {
+            this.setState({isLoading: false}, () => {
+                Growl.error(this.props.translate('requestCallPage.growlMessageNoPersonalPolicy'), 3000);
+            });
             return;
         }
         requestConciergeDMCall(personalPolicy.id, this.state.firstName, this.state.lastName, this.state.phoneNumber)


### PR DESCRIPTION
### Details
There was a bizarre staging QA bug where using the logical NOT operator on an object that had values would return true. We found that using `_.isObject` fixes things (see all messages after [this](https://expensify.slack.com/archives/C07J32337/p1626312238196800?thread_ts=1626299785.184500&cid=C07J32337) in the thread for more context).

### Fixed Issues
https://expensify.slack.com/archives/C07J32337/p1626299785184500

### Tests/QA
1. Navigate to your chat with Concierge, and click the call button.
2. Enter a valid first name, last name, and phone number.
3. Verify that you're able to request a call, and a growl message appears saying 'Call Requested'.

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android