### PR TITLE
Fix Line-break parsing issue in E.cash.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23054,8 +23054,8 @@
       }
     },
     "expensify-common": {
-      "version": "git://github.com/Expensify/expensify-common.git#77b43a207e36a3aae646e38a16ef468ac488bbab",
-      "from": "git://github.com/Expensify/expensify-common.git#77b43a207e36a3aae646e38a16ef468ac488bbab",
+      "version": "git://github.com/Expensify/expensify-common.git#cf78cdc764ac17fb2aaa8b73626cca64c3aa565f",
+      "from": "git://github.com/Expensify/expensify-common.git#cf78cdc764ac17fb2aaa8b73626cca64c3aa565f",
       "requires": {
         "classnames": "2.3.1",
         "clipboard": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "electron-log": "^4.3.5",
     "electron-serve": "^1.0.0",
     "electron-updater": "^4.3.4",
-    "expensify-common": "git://github.com/Expensify/expensify-common.git#77b43a207e36a3aae646e38a16ef468ac488bbab",
+    "expensify-common": "git://github.com/Expensify/expensify-common.git#cf78cdc764ac17fb2aaa8b73626cca64c3aa565f",
     "expo-haptics": "^10.0.0",
     "file-loader": "^6.0.0",
     "html-entities": "^1.3.1",


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ #4052

### Tests | QA Steps
1. Open any chat in e.cash
2. Copy the following text:

**Bold text**
_italic text_
~Strikethrough text~

3. Paste the text in e.cash composer
4. Line breaks should be shown correctly.


### Tested On

- [x] Web
- [ ] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android

### Screenshots

Can't capture this effect as I don't have any example of copied content where <br> contains style but unit test are in place to verify it.

<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
