### PR TITLE
Remove unnecessary calls to updateLastRead

### DIFF
--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -1132,6 +1132,11 @@ function updateLastReadActionID(reportID, sequenceNumber) {
     // action). If 1 isn't subtracted then the "New" marker appears one row below the action (the first unread action)
     const lastReadSequenceNumber = (sequenceNumber - 1) || reportMaxSequenceNumbers[reportID];
 
+    // We call this method in many cases where there's nothing to update because we already updated it, so we avoid
+    // doing an unnecessary server call if the last read is the same one we had already
+    if (lastReadSequenceNumbers[reportID] === lastReadSequenceNumber) {
+        return;
+    }
     setLocalLastRead(reportID, lastReadSequenceNumber);
 
     // Mark the report as not having any unread items


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ https://github.com/Expensify/Expensify.cash/issues/4077

### Tests
On web:
- Open a chat
- Open the JS console and go to network
- Send a message
- Check only one call to Report_UpdateLastRead API command is done
- Switch to a chat with no unread messages
- Check no calls to Report_UpdateLastRead were done

### QA Steps
Same as tests

### Tested On

- [X] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

