### PR TITLE
fixed text selection on resized web devices

### DIFF
--- a/src/components/RenderHTML/index.js
+++ b/src/components/RenderHTML/index.js
@@ -5,10 +5,11 @@ import {
     propTypes,
     defaultProps,
 } from './renderHTMLPropTypes';
+import canUseTouchScreen from '../../libs/canUseTouchscreen';
 
 const RenderHTML = ({html, debug, isSmallScreenWidth}) => (
     <BaseRenderHTML
-        textSelectable={!isSmallScreenWidth}
+        textSelectable={!canUseTouchScreen() || !isSmallScreenWidth}
         html={html}
         debug={debug}
     />

--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -26,6 +26,7 @@ import withLocalize, {withLocalizePropTypes} from '../../../components/withLocal
 import {deleteReportComment} from '../../../libs/actions/Report';
 import withWindowDimensions, {windowDimensionsPropTypes} from '../../../components/withWindowDimensions';
 import ControlSelection from '../../../libs/ControlSelection';
+import canUseTouchScreen from '../../../libs/canUseTouchscreen';
 
 const propTypes = {
     /** The ID of the report this action is on. */
@@ -272,7 +273,7 @@ class ReportActionItem extends Component {
             <>
                 <PressableWithSecondaryInteraction
                     ref={el => this.popoverAnchor = el}
-                    onPressIn={() => this.props.isSmallScreenWidth && ControlSelection.block()}
+                    onPressIn={() => this.props.isSmallScreenWidth && canUseTouchScreen() && ControlSelection.block()}
                     onPressOut={() => ControlSelection.unblock()}
                     onSecondaryInteraction={this.showPopover}
                 >

--- a/src/pages/home/report/ReportActionItemFragment.js
+++ b/src/pages/home/report/ReportActionItemFragment.js
@@ -11,6 +11,7 @@ import Text from '../../../components/Text';
 import Tooltip from '../../../components/Tooltip';
 import {isSingleEmoji} from '../../../libs/ValidationUtils';
 import withWindowDimensions, {windowDimensionsPropTypes} from '../../../components/withWindowDimensions';
+import canUseTouchScreen from '../../../libs/canUseTouchscreen';
 
 const propTypes = {
     /** The message fragment needing to be displayed */
@@ -65,7 +66,7 @@ class ReportActionItemFragment extends React.PureComponent {
                         />
                     ) : (
                         <Text
-                            selectable={!this.props.isSmallScreenWidth}
+                            selectable={!canUseTouchScreen() || !this.props.isSmallScreenWidth}
                             style={isSingleEmoji(fragment.text) ? styles.singleEmojiText : undefined}
                         >
                             {Str.htmlDecode(fragment.text)}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ #4012

### Tests | QA Steps
1. Open any chat on E.cash in a Web browser.
2. Resize the browser window until LHN is hidden.
3. Try to select text on the Chat messages.
4. You should be able to select the text.


### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

https://user-images.githubusercontent.com/24370807/125818782-45b77195-f822-45c4-ac18-69f0019a73de.mp4


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

https://user-images.githubusercontent.com/24370807/125821770-35a70512-5bdb-417e-8c16-c3b5de79ca2d.mp4


#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

https://user-images.githubusercontent.com/24370807/125820149-04a4c8b1-4d9f-4922-9753-67debc44ab23.mp4


#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
