### PR TITLE
Load policies after we load betas as well

### DIFF
--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -98,6 +98,20 @@ const modalScreenListeners = {
 
 let hasLoadedPolicies = false;
 
+/**
+ * We want to only load policy info if you are in the freePlan beta.
+ * @param {Array} betas
+ */
+function loadPoliciesBehindBeta(betas) {
+    // When removing the freePlan beta, simply load the policyList and the policySummaries in componentDidMount().
+    // Policy info loading should not be blocked behind the defaultRooms beta alone.
+    if (!hasLoadedPolicies && (Permissions.canUseFreePlan(betas) || Permissions.canUseDefaultRooms(betas))) {
+        getPolicyList();
+        getPolicySummaries();
+        hasLoadedPolicies = true;
+    }
+}
+
 const propTypes = {
     /** Information about the network */
     network: PropTypes.shape({
@@ -144,12 +158,7 @@ class AuthScreens extends React.Component {
         fetchCountryCodeByRequestIP();
         UnreadIndicatorUpdater.listenForReportChanges();
 
-        // When removing the free plan beta, this whole check and the logic in componentDidUpdate can be removed
-        if (Permissions.canUseFreePlan(this.props.betas) || Permissions.canUseDefaultRooms(this.props.betas)) {
-            getPolicyList();
-            getPolicySummaries();
-            hasLoadedPolicies = true;
-        }
+        loadPoliciesBehindBeta(this.props.betas);
 
         // Refresh the personal details, timezone and betas every 30 minutes
         // There is no pusher event that sends updated personal details data yet
@@ -198,11 +207,7 @@ class AuthScreens extends React.Component {
     }
 
     componentDidUpdate() {
-        if (!hasLoadedPolicies && (Permissions.canUseFreePlan(this.props.betas) || Permissions.canUseDefaultRooms(this.props.betas))) {
-            getPolicyList();
-            getPolicySummaries();
-            hasLoadedPolicies = true;
-        }
+        loadPoliciesBehindBeta(this.props.betas);
     }
 
     componentWillUnmount() {

--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -96,6 +96,8 @@ const modalScreenListeners = {
     },
 };
 
+let hasLoadedPolicies = false;
+
 const propTypes = {
     /** Information about the network */
     network: PropTypes.shape({
@@ -142,9 +144,11 @@ class AuthScreens extends React.Component {
         fetchCountryCodeByRequestIP();
         UnreadIndicatorUpdater.listenForReportChanges();
 
+        // When removing the free plan beta, this whole check and the logic in componentDidUpdate can be removed
         if (Permissions.canUseFreePlan(this.props.betas) || Permissions.canUseDefaultRooms(this.props.betas)) {
             getPolicyList();
             getPolicySummaries();
+            hasLoadedPolicies = true;
         }
 
         // Refresh the personal details, timezone and betas every 30 minutes
@@ -186,7 +190,19 @@ class AuthScreens extends React.Component {
             return true;
         }
 
+        if (nextProps.betas !== this.props.betas) {
+            return true;
+        }
+
         return false;
+    }
+
+    componentDidUpdate() {
+        if (!hasLoadedPolicies && (Permissions.canUseFreePlan(this.props.betas) || Permissions.canUseDefaultRooms(this.props.betas))) {
+            getPolicyList();
+            getPolicySummaries();
+            hasLoadedPolicies = true;
+        }
     }
 
     componentWillUnmount() {


### PR DESCRIPTION
@Luke9389, please review
cc: @tgolen, because we discussed this solution

### Details
The first time a user logs in, we will load their betas and based on which betas they are in, we will load their policy infos. Currently, since this all happens in the `componentDidMount()` function, the betas aren't loaded for the beta check and so we don't load the policy info for the user. This will work after the user logs in and refreshes, since we store the betas locally.

This change will make it so we check for the betas again after we have loaded them in `componentDidUpdate`. 

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ https://github.com/Expensify/Expensify/issues/170607

### Tests
Web QA done locally, but to get the full effect of this you should change [this line](https://github.com/Expensify/Expensify.cash/blob/1275f58c4a171c03cbe01e7fa14cebcfdb280f85/src/libs/Permissions.js#L11) to remove the `isDevelopment()` otherwise you'll just always load every beta behavior on dev.

### QA Steps
Requires you  to be in the Free Plan beta (reach out to @TomatoToaster to test if you can't access it)
1. Create a Workspace
2. Log out of e.cash
3. Log back into e.cash
4. Go to settings and see no Workspaces exist.
5. Refresh and see the Workspace

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
![image](https://user-images.githubusercontent.com/19364431/125839194-7c1c09ec-aa72-4573-aa17-059961f309da.png)
