### PR TITLE
Don't check participants' whole names in default rooms

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -795,7 +795,7 @@ SPEC CHECKSUMS:
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   EXHaptics: 337c160c148baa6f0e7166249f368965906e346b
   FBLazyVector: 7b423f9e248eae65987838148c36eec1dbfe0b53
-  FBReactNativeSpec: e564123bce1111e84dc7aa0765fb1175f0c48aa0
+  FBReactNativeSpec: d65967936e86fe0fe6cca5c0125c237636868d4a
   Firebase: c23a36d9e4cdf7877dfcba8dd0c58add66358999
   FirebaseAnalytics: 3bb096873ee0d7fa4b6c70f5e9166b6da413cc7f
   FirebaseCore: d3a978a3cfa3240bf7e4ba7d137fdf5b22b628ec

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -259,9 +259,10 @@ function createOption(personalDetailList, report, draftComments, {
  * @param {String} searchValue
  * @param {String} searchText
  * @param {Set<String>} [participantNames]
+ * @param {Boolean} isDefaultChatRoom
  * @returns {Boolean}
  */
-function isSearchStringMatch(searchValue, searchText, participantNames = new Set()) {
+function isSearchStringMatch(searchValue, searchText, participantNames = new Set(), isDefaultChatRoom = false) {
     const searchWords = searchValue
         .replace(/,/g, ' ')
         .split(' ')
@@ -269,7 +270,7 @@ function isSearchStringMatch(searchValue, searchText, participantNames = new Set
     return _.every(searchWords, (word) => {
         const matchRegex = new RegExp(Str.escapeForRegExp(word), 'i');
         const valueToSearch = searchText && searchText.replace(new RegExp(/&nbsp;/g), '');
-        return matchRegex.test(valueToSearch) || participantNames.has(word);
+        return matchRegex.test(valueToSearch) || (!isDefaultChatRoom && participantNames.has(word));
     });
 }
 
@@ -400,9 +401,9 @@ function getOptions(reports, personalDetails, draftComments, activeReportID, {
             }
 
             // Finally check to see if this option is a match for the provided search string if we have one
-            const {searchText, participantsList} = reportOption;
+            const {searchText, participantsList, isDefaultChatRoom} = reportOption;
             const participantNames = getParticipantNames(participantsList);
-            if (searchValue && !isSearchStringMatch(searchValue, searchText, participantNames)) {
+            if (searchValue && !isSearchStringMatch(searchValue, searchText, participantNames, isDefaultChatRoom)) {
                 continue;
             }
 
@@ -449,9 +450,9 @@ function getOptions(reports, personalDetails, draftComments, activeReportID, {
             ))) {
                 return;
             }
-            const {searchText, participantsList} = personalDetailOption;
+            const {searchText, participantsList, isDefaultChatRoom} = personalDetailOption;
             const participantNames = getParticipantNames(participantsList);
-            if (searchValue && !isSearchStringMatch(searchValue, searchText, participantNames)) {
+            if (searchValue && !isSearchStringMatch(searchValue, searchText, participantNames, isDefaultChatRoom)) {
                 return;
             }
             personalDetailsOptions.push(personalDetailOption);


### PR DESCRIPTION
@thienlnam, please review

### Details
Now for sure, we won't be showing rooms that user's are in when you're searching their name (unless they share a name with a default room).

Also fixing a `Podfile.lock` spec checksum that's out of date.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/169139
specifically: https://github.com/Expensify/Expensify/issues/169139#issuecomment-882776491

### Tests
Do the Web QA locally.

### QA Steps
Since `defaultRooms` are only available to expensify employees rn, I can test this. Ping @TomatoToaster, if I haven't already checked this off for QA.
1. Search for a person's name and verify it only shows their dms and does not show rooms they are in. You'l have to type their full first name of full last name, to truly verify this works. If their name is a substring of room name, technically it should show that room name 😓  so try a name like `amal` or `shawn`.

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
Good:
![image](https://user-images.githubusercontent.com/19364431/126228927-0c27b115-f25d-45c0-acd8-8593768d75e8.png)
Bad:
![image](https://user-images.githubusercontent.com/19364431/126228864-54342b8c-19ae-444e-9cb7-4f835e067e37.png)


#### Web

