### PR TITLE
Modify line height so text does not get cut off in LHN

### DIFF
--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -60,7 +60,7 @@ const Text = React.forwardRef(({
     };
 
     if (componentStyle.fontSize === variables.fontSizeNormal) {
-        componentStyle.lineHeight = 18;
+        componentStyle.lineHeight = 20;
     }
 
     return (

--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -60,7 +60,7 @@ const Text = React.forwardRef(({
     };
 
     if (componentStyle.fontSize === variables.fontSizeNormal) {
-        componentStyle.lineHeight = 20;
+        componentStyle.lineHeight = 18;
     }
 
     return (

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -800,8 +800,8 @@ const styles = {
 
     optionDisplayName: {
         fontFamily: fontFamily.GTA,
-        height: 18,
-        lineHeight: 18,
+        height: 20,
+        lineHeight: 20,
         ...whiteSpace.noWrap,
     },
 


### PR DESCRIPTION
Pullerbearing (@Luke9389)
cc @roryabraham 

### Details
Fixes a line height so that text is not cut off in Android. h/t @parasharrajat for his comment here: https://github.com/Expensify/Expensify.cash/issues/4074#issuecomment-882880011

### Fixed Issues
$ https://github.com/Expensify/Expensify.cash/issues/4074
$ https://github.com/Expensify/App/pull/4143

### Tests/QA
1. Create a chat with multiple participants
2. Open up the LHN, make sure the commas and bottom ligatures of the text are not cut off.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<img width="396" alt="Screen Shot 2021-07-19 at 3 45 47 PM" src="https://user-images.githubusercontent.com/4741899/126237104-9507e5fa-535c-4a10-8007-f9751dd36090.png">

#### Mobile Web
![Screen Shot 2021-07-19 at 4 05 16 PM](https://user-images.githubusercontent.com/4741899/126238462-babb29e9-3d31-4336-af0d-20b452c0535d.png)

#### Desktop
<img width="382" alt="Screen Shot 2021-07-19 at 3 48 19 PM" src="https://user-images.githubusercontent.com/4741899/126237186-a97735cb-08cf-46df-819d-293875d91c91.png">cd i

#### iOS
![Screen Shot 2021-07-19 at 4 02 04 PM](https://user-images.githubusercontent.com/4741899/126238433-e1b85d5d-209a-48ed-9e82-5a79e4393506.png)

#### Android
![Screen Shot 2021-07-19 at 3 38 06 PM](https://user-images.githubusercontent.com/4741899/126236889-d5878dc7-0f47-4e5c-9891-68788f588dd6.png)
