### PR TITLE
Refactor withLocalize + fix displayName

### DIFF
--- a/src/components/InvertedFlatList/BaseInvertedFlatList.js
+++ b/src/components/InvertedFlatList/BaseInvertedFlatList.js
@@ -150,7 +150,10 @@ class BaseInvertedFlatList extends Component {
                 // Web requires that items be measured or else crazy things happen when scrolling.
                 getItemLayout={this.props.shouldMeasureItems ? this.getItemLayout : undefined}
                 bounces={false}
-                windowSize={5}
+
+                // We keep this property very low so that chat switching remains fast
+                maxToRenderPerBatch={1}
+                windowSize={15}
                 removeClippedSubviews={this.props.shouldRemoveClippedSubviews}
             />
         );

--- a/src/components/InvertedFlatList/BaseInvertedFlatList.js
+++ b/src/components/InvertedFlatList/BaseInvertedFlatList.js
@@ -150,10 +150,7 @@ class BaseInvertedFlatList extends Component {
                 // Web requires that items be measured or else crazy things happen when scrolling.
                 getItemLayout={this.props.shouldMeasureItems ? this.getItemLayout : undefined}
                 bounces={false}
-
-                // We keep this property very low so that chat switching remains fast
-                maxToRenderPerBatch={1}
-                windowSize={15}
+                windowSize={5}
                 removeClippedSubviews={this.props.shouldRemoveClippedSubviews}
             />
         );

--- a/src/components/withLocalize.js
+++ b/src/components/withLocalize.js
@@ -31,7 +31,7 @@ const withLocalizePropTypes = {
 
 export default (WrappedComponent) => {
     const propTypes = {
-        /** The user's preferred locale e.g. en or es */
+        /** The user's preferred locale e.g. 'en', 'es-ES' */
         preferredLocale: PropTypes.string,
 
         /** Passed ref from whatever component is wrapped in the HOC */

--- a/src/components/withLocalize.js
+++ b/src/components/withLocalize.js
@@ -55,18 +55,37 @@ export default (WrappedComponent) => {
             this.toLocalPhone = this.toLocalPhone.bind(this);
         }
 
+        /**
+         * @param {String} phrase
+         * @param {Object} [variables]
+         * @returns {String}
+         */
         translate(phrase, variables) {
             return translate(this.props.preferredLocale, phrase, variables);
         }
 
+        /**
+         * @param {Number} number
+         * @param {Intl.NumberFormatOptions} options
+         * @returns {String}
+         */
         numberFormat(number, options) {
             return numberFormat(this.props.preferredLocale, number, options);
         }
 
+        /**
+         * @param {Number} timestamp
+         * @returns {String}
+         */
         timestampToRelative(timestamp) {
             return DateUtils.timestampToRelative(this.props.preferredLocale, timestamp);
         }
 
+        /**
+         * @param {Number} timestamp
+         * @param {Boolean} [includeTimezone]
+         * @returns {String}
+         */
         timestampToDateTime(timestamp, includeTimezone) {
             return DateUtils.timestampToDateTime(
                 this.props.preferredLocale,
@@ -75,10 +94,18 @@ export default (WrappedComponent) => {
             );
         }
 
+        /**
+         * @param {Number} number
+         * @returns {String}
+         */
         toLocalPhone(number) {
             return toLocalPhone(this.props.preferredLocale, number);
         }
 
+        /**
+         * @param {Number} number
+         * @returns {String}
+         */
         fromLocalPhone(number) {
             return fromLocalPhone(this.props.preferredLocale, number);
         }
@@ -101,7 +128,6 @@ export default (WrappedComponent) => {
     }
 
     WithLocalize.propTypes = propTypes;
-
     WithLocalize.defaultProps = defaultProps;
 
     const withForwardedRef = React.forwardRef((props, ref) => (

--- a/src/components/withLocalize.js
+++ b/src/components/withLocalize.js
@@ -29,7 +29,20 @@ const withLocalizePropTypes = {
     fromLocalPhone: PropTypes.func.isRequired,
 };
 
-const withLocalizeHOC = (WrappedComponent) => {
+export default (WrappedComponent) => {
+    const propTypes = {
+        preferredLocale: PropTypes.string,
+        forwardedRef: PropTypes.oneOfType([
+            PropTypes.func,
+            PropTypes.shape({current: PropTypes.instanceOf(React.Component)}),
+        ]),
+    };
+
+    const defaultProps = {
+        preferredLocale: CONST.DEFAULT_LOCALE,
+        forwardedRef: undefined,
+    };
+
     class WithLocalize extends React.Component {
         constructor(props) {
             super(props);
@@ -40,35 +53,34 @@ const withLocalizeHOC = (WrappedComponent) => {
             this.timestampToDateTime = this.timestampToDateTime.bind(this);
             this.fromLocalPhone = this.fromLocalPhone.bind(this);
             this.toLocalPhone = this.toLocalPhone.bind(this);
-            this.preferredLocale = 'en';
         }
 
         translate(phrase, variables) {
-            return translate(this.preferredLocale, phrase, variables);
+            return translate(this.props.preferredLocale, phrase, variables);
         }
 
         numberFormat(number, options) {
-            return numberFormat(this.preferredLocale, number, options);
+            return numberFormat(this.props.preferredLocale, number, options);
         }
 
         timestampToRelative(timestamp) {
-            return DateUtils.timestampToRelative(this.preferredLocale, timestamp);
+            return DateUtils.timestampToRelative(this.props.preferredLocale, timestamp);
         }
 
         timestampToDateTime(timestamp, includeTimezone) {
             return DateUtils.timestampToDateTime(
-                this.preferredLocale,
+                this.props.preferredLocale,
                 timestamp,
                 includeTimezone,
             );
         }
 
         toLocalPhone(number) {
-            return toLocalPhone(this.preferredLocale, number);
+            return toLocalPhone(this.props.preferredLocale, number);
         }
 
         fromLocalPhone(number) {
-            return fromLocalPhone(this.preferredLocale, number);
+            return fromLocalPhone(this.props.preferredLocale, number);
         }
 
         render() {
@@ -88,28 +100,23 @@ const withLocalizeHOC = (WrappedComponent) => {
         }
     }
 
-    WithLocalize.propTypes = {
-        preferredLocale: PropTypes.string,
-        forwardedRef: PropTypes.oneOfType([
-            PropTypes.func,
-            PropTypes.shape({current: PropTypes.instanceOf(React.Component)}),
-        ]),
-    };
-    WithLocalize.defaultProps = {
-        preferredLocale: CONST.DEFAULT_LOCALE,
-        forwardedRef: undefined,
-    };
+    WithLocalize.propTypes = propTypes;
+
+    WithLocalize.defaultProps = defaultProps;
 
     const withForwardedRef = React.forwardRef((props, ref) => (
         // eslint-disable-next-line react/jsx-props-no-spreading
         <WithLocalize {...props} forwardedRef={ref} />
     ));
 
-    withForwardedRef.displayName = `WithLocalize(${getComponentDisplayName(WrappedComponent)})`;
-    return withForwardedRef;
-};
+    withForwardedRef.displayName = `withLocalize(${getComponentDisplayName(WrappedComponent)})`;
 
-export default withLocalizeHOC;
+    return withOnyx({
+        preferredLocale: {
+            key: ONYXKEYS.PREFERRED_LOCALE,
+        },
+    })(withForwardedRef);
+};
 
 export {
     withLocalizePropTypes,

--- a/src/components/withLocalize.js
+++ b/src/components/withLocalize.js
@@ -31,7 +31,10 @@ const withLocalizePropTypes = {
 
 export default (WrappedComponent) => {
     const propTypes = {
+        /** The user's preferred locale e.g. en or es */
         preferredLocale: PropTypes.string,
+
+        /** Passed ref from whatever component is wrapped in the HOC */
         forwardedRef: PropTypes.oneOfType([
             PropTypes.func,
             PropTypes.shape({current: PropTypes.instanceOf(React.Component)}),

--- a/src/libs/LocalePhoneNumber.js
+++ b/src/libs/LocalePhoneNumber.js
@@ -10,7 +10,7 @@ import translations from '../languages/translations';
  *
  * @param {String} locale eg 'en', 'es-ES'
  * @param {String} number
- * @returns {string}
+ * @returns {String}
  */
 function toLocalPhone(locale, number) {
     const numString = lodashTrim(number);
@@ -31,7 +31,7 @@ function toLocalPhone(locale, number) {
  *
  * @param {String} locale eg 'en', 'es-ES'
  * @param {String} number
- * @returns {string}
+ * @returns {String}
  */
 function fromLocalPhone(locale, number) {
     const numString = lodashTrim(number);

--- a/src/pages/home/report/ReportActionContextMenu.js
+++ b/src/pages/home/report/ReportActionContextMenu.js
@@ -14,7 +14,6 @@ import {
 import ContextMenuItem from '../../../components/ContextMenuItem';
 import ReportActionPropTypes from './ReportActionPropTypes';
 import Clipboard from '../../../libs/Clipboard';
-import compose from '../../../libs/compose';
 import {isReportMessageAttachment, canEditReportAction, canDeleteReportAction} from '../../../libs/reportUtils';
 import withLocalize, {withLocalizePropTypes} from '../../../components/withLocalize';
 import ReportActionComposeFocusManager from '../../../libs/ReportActionComposeFocusManager';

--- a/src/pages/home/report/ReportActionContextMenu.js
+++ b/src/pages/home/report/ReportActionContextMenu.js
@@ -197,6 +197,4 @@ class ReportActionContextMenu extends React.Component {
 ReportActionContextMenu.propTypes = propTypes;
 ReportActionContextMenu.defaultProps = defaultProps;
 
-export default compose(
-    withLocalize,
-)(ReportActionContextMenu);
+export default withLocalize(ReportActionContextMenu);

--- a/src/pages/home/report/ReportActionItemSingle.js
+++ b/src/pages/home/report/ReportActionItemSingle.js
@@ -95,6 +95,8 @@ const ReportActionItemSingle = ({
 
 ReportActionItemSingle.propTypes = propTypes;
 ReportActionItemSingle.defaultProps = defaultProps;
+ReportActionItemSingle.displayName = 'ReportActionItemSingle';
+
 export default compose(
     withLocalize,
     withOnyx({

--- a/src/pages/home/report/ReportView.js
+++ b/src/pages/home/report/ReportView.js
@@ -47,6 +47,7 @@ const ReportView = ({reportID, session}) => (
 
 ReportView.propTypes = propTypes;
 ReportView.defaultProps = defaultProps;
+ReportView.displayName = 'ReportView';
 
 export default withOnyx({
     session: {


### PR DESCRIPTION
### Details

- The previous implementation caused any wrapped components to recreate the methods passed on render.
- This binds the methods so they are not created on re-renders.
- The `displayName` feature of `withLocalize` was also not working correctly when wrapped `withOnyx` so that is also fixed now
- Adds missing `displayName` to some components

### Fixed Issues
$ https://github.com/Expensify/App/issues/4109

### Tests
### QA Steps
There are no particular tests as the behavior of the app should largely remain the same after these changes.

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
