### PR TITLE
Fix circle mobile icons for default room in focus mode

### DIFF
--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1197,7 +1197,6 @@ const styles = {
     avatarSmall: {
         height: variables.avatarSizeSmall,
         width: variables.avatarSizeSmall,
-        backgroundColor: themeColors.icon,
         borderRadius: variables.avatarSizeSmall,
     },
 


### PR DESCRIPTION
@yuwenmemon, please review

### Details
My B, when reviewing/testing [this one](https://github.com/Expensify/App/pull/4144) I thought I had tested `avatarSmall` on iOS/android but forgot that those are focus icons. This one also needs to get rid of the backgroundColor rule since it'll make focus icons square:
Bad:
![image](https://user-images.githubusercontent.com/19364431/126372799-8b3d3dfc-f247-4861-b29b-a4650a6efc53.png)


Good:
![image](https://user-images.githubusercontent.com/19364431/126372838-91f90caf-c777-41a7-9619-24953456be0b.png)


### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Follow up for: https://github.com/Expensify/App/pull/4144


### Tests
QA done locally

### QA Steps
This is for defaultRooms, should require an internal test.
1. Go to Preferences and set Priority Mode to `#focus`
2. Verify the icons for default rooms are circular like in the screenshot above.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
![image](https://user-images.githubusercontent.com/19364431/126374718-d7d657ea-cc7a-4014-95ad-db70b9644284.png)

#### iOS
![image](https://user-images.githubusercontent.com/19364431/126372838-91f90caf-c777-41a7-9619-24953456be0b.png)

#### Android
![image](https://user-images.githubusercontent.com/19364431/126374138-a5954365-eeb5-4987-b8f8-d1cc0bb8dc90.png)