### PR TITLE
Fix copy to clipboard in long emails

### DIFF
--- a/src/components/CommunicationsLink.js
+++ b/src/components/CommunicationsLink.js
@@ -44,16 +44,15 @@ const CommunicationsLink = props => (
                 >
                     {props.children}
                 </Pressable>
-            )
-            : props.children}
-        {!props.isSmallScreenWidth
-            && (
+            ) : (
                 <View style={[
-                    styles.pAbsolute,
+                    styles.flexRow,
                     styles.alignItemsCenter,
-                    styles.justifyContentCenter,
-                    styles.communicationsLinkIcon]}
+                    styles.w100,
+                    styles.communicationsLinkHeight,
+                ]}
                 >
+                    {props.children}
                     <ContextMenuItem
                         icon={ClipboardIcon}
                         text={props.translate('contextMenuItem.copyToClipboard')}

--- a/src/pages/DetailsPage.js
+++ b/src/pages/DetailsPage.js
@@ -98,7 +98,7 @@ const DetailsPage = ({
                                 </Text>
                             )}
                             {details.login ? (
-                                <View style={[styles.mb6, styles.detailsPageSectionContainer]}>
+                                <View style={[styles.mb6, styles.detailsPageSectionContainer, styles.w100]}>
                                     <Text style={[styles.formLabel, styles.mb2]} numberOfLines={1}>
                                         {translate(isSMSLogin
                                             ? 'common.phoneNumber'

--- a/src/pages/DetailsPage.js
+++ b/src/pages/DetailsPage.js
@@ -94,7 +94,7 @@ const DetailsPage = ({
                             />
                             {details.displayName && (
                                 <Text style={[styles.displayName, styles.mb6]} numberOfLines={1}>
-                                    {isSMSLogin ? toLocalPhone(details.displayName) : details.displayName || null}
+                                    {isSMSLogin ? toLocalPhone(details.displayName) : details.displayName}
                                 </Text>
                             )}
                             {details.login ? (

--- a/src/pages/DetailsPage.js
+++ b/src/pages/DetailsPage.js
@@ -92,22 +92,11 @@ const DetailsPage = ({
                                 imageStyles={[styles.avatarLarge]}
                                 source={details.avatar}
                             />
-                            {details.displayName && isSMSLogin
-                                ? (
-                                    <CommunicationsLink
-                                        style={[styles.mt1, styles.mb6]}
-                                        type={CONST.LOGIN_TYPE.PHONE}
-                                        value={getPhoneNumber(details)}
-                                    >
-                                        <Text style={[styles.displayName]} numberOfLines={1}>
-                                            {toLocalPhone(details.displayName)}
-                                        </Text>
-                                    </CommunicationsLink>
-                                ) : (
-                                    <Text style={[styles.displayName]} numberOfLines={1}>
-                                        {details.displayName || null}
-                                    </Text>
-                                )}
+                            {details.displayName && (
+                                <Text style={[styles.displayName, styles.mb6]} numberOfLines={1}>
+                                    {isSMSLogin ? toLocalPhone(details.displayName) : details.displayName || null}
+                                </Text>
+                            )}
                             {details.login ? (
                                 <View style={[styles.mb6, styles.detailsPageSectionContainer]}>
                                     <Text style={[styles.formLabel, styles.mb2]} numberOfLines={1}>

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1793,10 +1793,8 @@ const styles = {
         ...whiteSpace.noWrap,
     },
 
-    communicationsLinkIcon: {
-        right: -36,
-        top: 0,
-        bottom: 0,
+    communicationsLinkHeight: {
+        height: 20,
     },
 };
 


### PR DESCRIPTION
cc @chiragsalian 

### Details
Also fixed an issue with the space below display name and `Email` or `Phone`, as well as copy to clipboard being shown on user's display name. See screenshot below:

![Screen Shot 2021-07-20 at 10 40 50 AM](https://user-images.githubusercontent.com/22219519/126381030-d7bb7a85-1589-4a52-acdc-912bd43855ec.png)


### Fixed Issues
$ https://github.com/Expensify/App/issues/4076

### Tests
1. Open a chat with a user that has a long email address, e.g. applausetester+0118mn@applause.expensifail.com
2. Tap on user's avatar to open their details page
3. Verify that the copy to clipboard icon is visible

### QA Steps
Steps above.

### Tested On

- [X] Web
- [X] Mobile Web
- [X] Desktop
- [X] iOS
- [X] Android

### Screenshots

#### Web

https://user-images.githubusercontent.com/22219519/126380578-f7c8d96a-634a-42c3-b98c-c7ae9631a8d0.mov

#### Mobile Web

https://user-images.githubusercontent.com/22219519/126380595-22ab60b6-9847-47bd-89c7-8ec4e11eecda.mov

#### Desktop

https://user-images.githubusercontent.com/22219519/126380612-ad8aebce-d93e-4e92-a1e4-875da69b8bf8.mov

#### iOS

https://user-images.githubusercontent.com/22219519/126380626-3c94d409-93ed-4699-a0a4-1376e2d16d7f.mov

#### Android

https://user-images.githubusercontent.com/22219519/126380646-094217c2-9bdf-481f-8f49-9a608c91decb.mov
