### PR TITLE
Fixes styling for hidden element

### DIFF
--- a/src/components/TextInputAutoWidth.js
+++ b/src/components/TextInputAutoWidth.js
@@ -42,13 +42,15 @@ class TextInputAutoWidth extends React.Component {
     render() {
         const propsWithoutStyles = _.omit(this.props, ['inputStyle', 'textStyle']);
         return (
-            <View>
-                <TextInputFocusable
-                    style={[this.props.inputStyle, getAutoGrowTextInputStyle(this.state.textInputWidth)]}
-                    ref={this.props.forwardedRef}
-                    /* eslint-disable-next-line react/jsx-props-no-spreading */
-                    {...propsWithoutStyles}
-                />
+            <>
+                <View>
+                    <TextInputFocusable
+                        style={[this.props.inputStyle, getAutoGrowTextInputStyle(this.state.textInputWidth)]}
+                        ref={this.props.forwardedRef}
+                        /* eslint-disable-next-line react/jsx-props-no-spreading */
+                        {...propsWithoutStyles}
+                    />
+                </View>
                 {/*
                 Text input component doesn't support auto grow by default.
                 We're using a hidden text input to achieve that.
@@ -61,7 +63,7 @@ class TextInputAutoWidth extends React.Component {
                 >
                     {this.props.value || this.props.placeholder}
                 </Text>
-            </View>
+            </>
         );
     }
 }

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1641,11 +1641,10 @@ const styles = {
     },
 
     hiddenElementOutsideOfWindow: {
-        position: 'fixed',
+        position: 'absolute',
         top: 0,
         left: 0,
         opacity: 0,
-        transform: 'translateX(-100%)',
     },
 
     growlNotificationWrapper: {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
1. Changes the styling of our `hiddenElementOutsideOfWindow` to be cross-platform. 
2. Takes our hidden `Text` out of the `View` that wraps `TextInputAutoWidth` so that our `position: absolute` is in relation to the parent component.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ https://github.com/Expensify/App/issues/3296
$ https://github.com/Expensify/App/issues/3355

### Tests
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->
1. Open the app on an iPad Pro in Landscape mode
2. Start the IOU flow (request money or split bill)
3. You should be able to type an amount


### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

https://user-images.githubusercontent.com/53711423/126665931-25ae1a1e-c313-4292-b449-67ad215d8e4f.mov




#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

https://user-images.githubusercontent.com/53711423/126665360-05a5206b-4b83-468a-9b78-05570f669b0d.mp4



#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

https://user-images.githubusercontent.com/53711423/126665365-39076dba-babf-46b8-82ac-e5111180d58f.mov



#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

https://user-images.githubusercontent.com/53711423/126665381-bfa51028-bb50-4728-9d83-92324ee8ab67.mp4



https://user-images.githubusercontent.com/53711423/126414756-709f1b04-3322-48fb-a6d2-19e9d0e68261.mov



#### Android
<!-- Insert screenshots of your changes on the Android platform-->

https://user-images.githubusercontent.com/53711423/126665391-acb23069-c45f-464c-a058-1ed3acd3b9ff.mp4


