### PR TITLE
Fix keyboard shortcut

### DIFF
--- a/src/components/ScreenWrapper.js
+++ b/src/components/ScreenWrapper.js
@@ -8,6 +8,7 @@ import styles, {getSafeAreaPadding} from '../styles/styles';
 import HeaderGap from './HeaderGap';
 import KeyboardShortcut from '../libs/KeyboardShortcut';
 import onScreenTransitionEnd from '../libs/onScreenTransitionEnd';
+import Navigation from '../libs/Navigation/Navigation';
 
 const propTypes = {
     /** Array of additional styles to add */
@@ -32,9 +33,6 @@ const propTypes = {
     navigation: PropTypes.shape({
         // Method to attach listener to Navigation state.
         addListener: PropTypes.func.isRequired,
-
-        // Returns to the previous navigation state e.g. if this is inside a Modal we will dismiss it
-        goBack: PropTypes.func,
     }),
 };
 
@@ -45,7 +43,6 @@ const defaultProps = {
     onTransitionEnd: () => {},
     navigation: {
         addListener: () => {},
-        goBack: () => {},
     },
 };
 
@@ -59,7 +56,7 @@ class ScreenWrapper extends React.Component {
 
     componentDidMount() {
         this.unsubscribeEscapeKey = KeyboardShortcut.subscribe('Escape', () => {
-            this.props.navigation.goBack();
+            Navigation.dismissModal();
         }, [], true);
 
         this.unsubscribeTransitionEnd = onScreenTransitionEnd(this.props.navigation, () => {

--- a/src/libs/KeyboardShortcut/index.js
+++ b/src/libs/KeyboardShortcut/index.js
@@ -126,7 +126,7 @@ const KeyboardShortcut = {
      */
     unsubscribe(key) {
         const keyCode = this.getKeyCode(key);
-        delete events[keyCode];
+        events[keyCode].pop();
     },
 };
 

--- a/src/libs/KeyboardShortcut/index.js
+++ b/src/libs/KeyboardShortcut/index.js
@@ -12,9 +12,10 @@ function bindHandlerToKeyupEvent(event) {
     }
 
     const eventCallbacks = events[event.keyCode];
+    const reversedEventCallbacks = [...eventCallbacks].reverse();
 
     // Loop over all the callbacks
-    eventCallbacks.forEach((callback) => {
+    _.every(reversedEventCallbacks, (callback) => {
         const pressedModifiers = _.all(callback.modifiers, (modifier) => {
             if (modifier === 'shift' && !event.shiftKey) {
                 return false;
@@ -50,7 +51,7 @@ function bindHandlerToKeyupEvent(event) {
             return false;
         });
         if (!pressedModifiers || pressedExtraModifiers) {
-            return;
+            return true;
         }
 
         // If configured to do so, prevent input text control to trigger this event
@@ -59,13 +60,16 @@ function bindHandlerToKeyupEvent(event) {
             || event.target.nodeName === 'TEXTAREA'
             || event.target.contentEditable === 'true'
         )) {
-            return;
+            return true;
         }
 
         if (_.isFunction(callback.callback)) {
             callback.callback(event);
         }
         event.preventDefault();
+
+        // Short circuit the loop because the event is triggered
+        return false;
     });
 }
 

--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -174,24 +174,23 @@ class AuthScreens extends React.Component {
 
         Timing.end(CONST.TIMING.HOMEPAGE_INITIAL_RENDER);
 
+        let searchShortcutModifiers = ['control'];
+        let groupShortcutModifiers = ['control', 'shift'];
+
+        if (getOperatingSystem() === CONST.OS.MAC_OS) {
+            searchShortcutModifiers = ['meta'];
+            groupShortcutModifiers = ['meta', 'shift'];
+        }
+
         // Listen for the key K being pressed so that focus can be given to
         // the chat switcher, or new group chat
         // based on the key modifiers pressed and the operating system
-        if (getOperatingSystem() === CONST.OS.MAC_OS) {
-            KeyboardShortcut.subscribe('K', () => {
-                Navigation.navigate(ROUTES.SEARCH);
-            }, ['meta'], true);
-            KeyboardShortcut.subscribe('K', () => {
-                Navigation.navigate(ROUTES.NEW_GROUP);
-            }, ['meta', 'shift'], true);
-        } else {
-            KeyboardShortcut.subscribe('K', () => {
-                Navigation.navigate(ROUTES.SEARCH);
-            }, ['control'], true);
-            KeyboardShortcut.subscribe('K', () => {
-                Navigation.navigate(ROUTES.NEW_GROUP);
-            }, ['control', 'shift'], true);
-        }
+        this.unsubscribeSearchShortcut = KeyboardShortcut.subscribe('K', () => {
+            Navigation.navigate(ROUTES.SEARCH);
+        }, searchShortcutModifiers, true);
+        this.unsubscribeGroupShortcut = KeyboardShortcut.subscribe('K', () => {
+            Navigation.navigate(ROUTES.NEW_GROUP);
+        }, groupShortcutModifiers, true);
     }
 
     shouldComponentUpdate(nextProps) {
@@ -211,7 +210,12 @@ class AuthScreens extends React.Component {
     }
 
     componentWillUnmount() {
-        KeyboardShortcut.unsubscribe('K');
+        if (this.unsubscribeSearchShortcut) {
+            this.unsubscribeSearchShortcut();
+        }
+        if (this.unsubscribeGroupShortcut) {
+            this.unsubscribeGroupShortcut();
+        }
         NetworkConnection.stopListeningForReconnect();
         clearInterval(this.interval);
         this.interval = null;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
cc @tgolen 
### Details
<!-- Explanation of the change or anything fishy that is going on -->
[Comment](https://github.com/Expensify/App/issues/4028#issuecomment-879530439)
### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ #4028 

### Tests
Test 1
1. Open Search with `Cmd + K`
2. Open New Group with `Cmd + Shift + K`
3. Click outside New Group popup to close it.
4. Verify that pressing `Escape` key closes Search.

Test 2
1. Open Search with `Cmd + K`
2. Open New Group with `Cmd + Shift + K`
3. Verify that pressing `Escape` closes New Group.
4. Verify that pressing `Escape` closes Search.

### QA
Make sure that keyboard shortcuts work, and `Escape` closes modals on Web and Desktop.

### Tested On

- [x] Web
- [x] Desktop
- Not Applicable. Just verify that there are no errors.
    - [x] Mobile Web
    - [x] iOS
    - [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
https://user-images.githubusercontent.com/29673073/125552185-4e046b9d-3bd2-4e7a-9ccf-309413191742.mp4

#### Desktop

