### PR TITLE
Clear push notifications when logging out

### DIFF
--- a/src/Expensify.js
+++ b/src/Expensify.js
@@ -101,6 +101,9 @@ class Expensify extends PureComponent {
                 // boot screen right away
                 if (!this.getAuthToken()) {
                     this.hideSplash();
+
+                    // In case of a crash that led to disconnection, we want to remove all the push notifications.
+                    PushNotification.clearNotifications();
                 }
 
                 this.setState({isOnyxMigrated: true});

--- a/src/libs/Notification/PushNotification/index.js
+++ b/src/libs/Notification/PushNotification/index.js
@@ -7,4 +7,5 @@ export default {
     onReceived: () => {},
     onSelected: () => {},
     TYPE: NotificationType,
+    clearNotifications: () => {},
 };

--- a/src/libs/Notification/PushNotification/index.native.js
+++ b/src/libs/Notification/PushNotification/index.native.js
@@ -141,10 +141,18 @@ function onSelected(notificationType, callback) {
     bind(notificationType, callback, EventType.NotificationResponse);
 }
 
+/**
+ * Clear all push notifications
+ */
+function clearNotifications() {
+    UrbanAirship.clearNotifications();
+}
+
 export default {
     register,
     deregister,
     onReceived,
     onSelected,
     TYPE: NotificationType,
+    clearNotifications,
 };

--- a/src/libs/actions/SignInRedirect.js
+++ b/src/libs/actions/SignInRedirect.js
@@ -28,6 +28,7 @@ Onyx.connect({
 function redirectToSignIn(errorMessage) {
     UnreadIndicatorUpdater.stopListeningForReportChanges();
     PushNotification.deregister();
+    PushNotification.clearNotifications();
     Pusher.disconnect();
     Timers.clearAll();
 


### PR DESCRIPTION
### Details
Check out the comments in this issue for more detail: https://github.com/Expensify/App/issues/4112

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ https://github.com/Expensify/App/issues/4112

### Tests
I couldn't test on dev because the emulator doesn't receive push notifications.

### QA Steps
1. Log in to e.cash on Android or iOS
2. Send a message from another account
3. Navigate to the home screen and verify you have the notification badge on the app icon
4. Navigate back to e.cash.
5. Log out and force close the app.
6. All push notifications should have been removed, and there should not be a notification badge indicator in the app's icon.

### Tested On
I couldn't test on dev because the emulator doesn't receive push notifications.

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
N/A
