### PR TITLE
Show IOU preview component persistently

### DIFF
--- a/src/components/ReportActionItem/IOUAction.js
+++ b/src/components/ReportActionItem/IOUAction.js
@@ -47,13 +47,14 @@ const IOUAction = ({
                 shouldShowViewDetailsLink={Boolean(action.originalMessage.IOUReportID)}
                 onViewDetailsPressed={launchDetailsModal}
             />
-            {isMostRecentIOUReportAction && Boolean(action.originalMessage.IOUReportID) && (
-                <IOUPreview
-                    iouReportID={action.originalMessage.IOUReportID}
-                    chatReportID={chatReportID}
-                    onPayButtonPressed={launchDetailsModal}
-                    onPreviewPressed={launchDetailsModal}
-                />
+            {((isMostRecentIOUReportAction && Boolean(action.originalMessage.IOUReportID))
+                || (action.originalMessage.type === 'pay')) && (
+                    <IOUPreview
+                        iouReportID={action.originalMessage.IOUReportID}
+                        chatReportID={chatReportID}
+                        onPayButtonPressed={launchDetailsModal}
+                        onPreviewPressed={launchDetailsModal}
+                    />
             )}
         </>
     );


### PR DESCRIPTION
cc @Julesssss 

### Details
Added condition to display previously settled IOU reports.

### Fixed Issues
$ https://github.com/Expensify/App/issues/4135

### Tests
Created and settled 2 IOU reports and confirmed that it works.

### QA Steps

- Click the green + icon and select Request Money
- Enter an amount and click next
- Select an attendee and then Request $x to confirm
- Log-in as the other user that received the request, click pay and I'll settle up elsewhere
- Observe that there is a preview component on the settled IOU
- Send another request
- Observe that the preview components are displayed for all previously settled IOU reports and most recent IOU report.

### Tested On

- [X] Web
- [X] Mobile Web
- [X] Desktop
- [ ] iOS
- [ ] Android

### Screenshots

#### Web
<img width="1440" alt="Screenshot 2021-07-21 at 13 19 59" src="https://user-images.githubusercontent.com/3853003/126500541-19e470e3-50ec-40da-8c3b-41f274c7d61e.png">


#### Mobile Web
<img width="306" alt="Screenshot 2021-07-21 at 13 20 56" src="https://user-images.githubusercontent.com/3853003/126500570-8be47a00-3f45-46eb-a96f-f9f5dcc038c1.png">


#### Desktop
<img width="1196" alt="Screenshot 2021-07-21 at 13 23 32" src="https://user-images.githubusercontent.com/3853003/126500597-d05dc0f1-2f4b-41b1-beaa-64fb40b3d834.png">


#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
