### PR TITLE
password match error fixed

### DIFF
--- a/src/pages/settings/NewPasswordForm.js
+++ b/src/pages/settings/NewPasswordForm.js
@@ -76,7 +76,7 @@ class NewPasswordForm extends React.Component {
         return Boolean(
             !this.doPasswordsMatch()
             && this.state.shouldShowPasswordConfirmError
-            && this.state.confirmNewPassword
+            && this.state.confirmNewPassword,
         );
     }
 

--- a/src/pages/settings/NewPasswordForm.js
+++ b/src/pages/settings/NewPasswordForm.js
@@ -73,7 +73,7 @@ class NewPasswordForm extends React.Component {
     }
 
     showPasswordMatchError() {
-        return (
+        return Boolean(
             !this.doPasswordsMatch()
             && this.state.shouldShowPasswordConfirmError
             && this.state.confirmNewPassword


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Check out the comments in this issue for more detail: #3976 
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->

$ #3976 

### Tests

1. Enter email on the first screen after you have downloaded the app.
2. The magic link is sent to your email.
3. Tap on the magic link to open it in Expensify.cash app.
4. Tap on confirm password field.
5. Type anything and tap on enter your new password field.
6. Type password as directed as at least 8 characters, 1 capital letter, 1 lowercase letter, 1 number.
7. Tap on confirm the password field and clear all the text on the "Confirm Password" field then the screen will not become blank again.

### QA Steps
Same as tests

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [x] Android

### Screenshots

#### Android


https://user-images.githubusercontent.com/42933600/126526497-37f88a40-eeef-448c-a95c-8c8a3e7797a1.mp4


