### PR TITLE
Prevent infinite loading in validateBankAccount

### DIFF
--- a/src/libs/actions/BankAccounts.js
+++ b/src/libs/actions/BankAccounts.js
@@ -553,7 +553,6 @@ function validateBankAccount(bankAccountID, validateCode) {
             if (response.jsonCode === 200) {
                 Growl.show('Bank Account successfully validated!', CONST.GROWL.SUCCESS, 3000);
                 Navigation.dismissModal();
-                return;
             }
 
             Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {loading: false, error: response.message});

--- a/src/libs/actions/BankAccounts.js
+++ b/src/libs/actions/BankAccounts.js
@@ -553,6 +553,8 @@ function validateBankAccount(bankAccountID, validateCode) {
             if (response.jsonCode === 200) {
                 Growl.show('Bank Account successfully validated!', CONST.GROWL.SUCCESS, 3000);
                 Navigation.dismissModal();
+                Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {loading: false, error: ''});
+                return;
             }
 
             Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {loading: false, error: response.message});


### PR DESCRIPTION
cc @chiragsalian 
### Details
Removes `return` statement that kept API calls in an infinite loading state.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/171371

### Tests
1. Create a new Workspace
2. Follow [these steps](https://stackoverflow.com/c/expensify/questions/342/525#525) to add a `PENDING` account.
3. When prompted for the 3 codes, follow [these steps](https://stackoverflow.com/c/expensify/questions/8323).
4. Verify that the button text reappears.

### QA Steps
Internal QA.

### Tested On

- [X] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web

https://user-images.githubusercontent.com/22219519/126534777-41718933-61e7-4faa-9053-6896b1ea6cc5.mov

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
