### PR TITLE
Fix a typo in a translation

### DIFF
--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -338,7 +338,7 @@ export default {
             ssnLast4: 'Ingrese los últimos 4 dígitos del número de seguro social',
             noDefaultDepositAccountOrDebitCardAvailable: 'Por favor agregue una cuenta bancaria para depósitos o una tarjeta de débito',
             existingOwners: {
-                unableToAddBankAccount: 'No hay sido posible añadir la cuenta bancaria',
+                unableToAddBankAccount: 'No ha sido posible añadir la cuenta bancaria',
                 alreadyInUse: 'La cuenta bancaria ya se encuentra en uso por ',
                 pleaseAskThemToShare: 'Por favor, solicita que la compartan contigo.',
                 alternatively: 'En su defecto, puedes ',


### PR DESCRIPTION
### Details
Fixes a typo in a translation that was noticed [here](https://expensify.slack.com/archives/C21FRDWCV/p1626863639120800?thread_ts=1626828855.120100&cid=C21FRDWCV) after a PR was merged.

### Fixed Issues
N/A

### Tests
N/A