### PR TITLE
Adjust outline for focused elments

### DIFF
--- a/src/styles/addOutlineWidth/index.js
+++ b/src/styles/addOutlineWidth/index.js
@@ -3,6 +3,8 @@
  * can be added to the object
  */
 
+import themeDefault from '../themes/default';
+
 /**
  * Adds the addOutlineWidth property to an object to be used when styling
  *
@@ -14,6 +16,7 @@ function withOutlineWidth(obj, val) {
     return {
         ...obj,
         outlineWidth: val,
+        boxShadow: `0px 0px 0px ${val}px ${themeDefault.borderFocus}`,
     };
 }
 

--- a/web/index.html
+++ b/web/index.html
@@ -32,8 +32,13 @@
             -webkit-user-select: none !important;
             -webkit-touch-callout: none !important;
         }
-        *:focus, *:focus-visible, [data-focusvisible-polyfill] {
-            outline: 1px solid #0185ff;
+        :focus-visible {
+            outline: 0;
+            box-shadow: 0px 0px 0px 1px #0185ff;
+        }
+        :focus[data-focusvisible-polyfill] {
+            outline: 0;
+            box-shadow: 0px 0px 0px 1px #0185ff;
         }
     </style>
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1">

--- a/web/index.html
+++ b/web/index.html
@@ -32,6 +32,9 @@
             -webkit-user-select: none !important;
             -webkit-touch-callout: none !important;
         }
+        *:focus, *:focus-visible, [data-focusvisible-polyfill] {
+            outline: 1px solid #0185ff;
+        }
     </style>
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1">
     <link rel="shortcut icon" id="favicon" href="/favicon.png">


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ Fixes https://github.com/Expensify/App/issues/3959

### Tests | QA Steps
1. Open any convo on E.cash on the web.
2. Try to use the tab for navigation.
3. See multiple elements get focus with an outline that is different across the platforms. (please look at the original issue for Image Samples).

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Chrome
![out-w-chrome](https://user-images.githubusercontent.com/24370807/127307845-e8aac075-cffe-4502-bb96-7cd2260ece8f.png)

#### Firefox
![out-w-firefox](https://user-images.githubusercontent.com/24370807/127307880-6b2caa1f-8bce-4238-92bd-56ef03a8e92d.png)


#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
#### Linux desktop
![out-d](https://user-images.githubusercontent.com/24370807/127307913-98c323e1-5e1d-407a-9159-a135fa0ba1f5.png)

#### MAC
![out-d-mac](https://user-images.githubusercontent.com/24370807/127308532-7e1f3de5-945c-4b0f-b8fb-8ff17031a1a5.png)
