### PR TITLE
Remove `gradle` mention from ReadMe to improve clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You can use any IDE or code editing tool for developing on any platform. Use you
 * Changes applied to Javascript will be applied automatically, any changes to native code will require a recompile
 
 ## Running the Android app 🤖
-* To install the Android dependencies, run: `npm install`, then `gradle` will install all linked dependencies
+* To install the Android dependencies, run: `npm install`
 * Make sure you have Java installed `java -version`. If not, install it by running `npm install -g openjdk8`.
 * To run a on a **Development Emulator**: `npm run android`
 * Changes applied to Javascript will be applied automatically, any changes to native code will require a recompile


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Makes the Android setup a bit more clear that you do not need to run anything related to `gradle` to install dependencies. 

### Fixed Issues
N/A


### Tests
N/A