### PR TITLE
Fix link to AsyncStorage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ This application is built with the following principles.
     1. UI inputs push data to the server (React component -> Action -> XHR to server).
     1. Go to 1
 1. **Offline first**
-    - All data that is brought into the app and is necessary to display the app when offline should be stored on disk in persistent storage (eg. localStorage on browser platforms). [AsyncStorage](https://react-native-community.github.io/async-storage/) is a cross-platform abstraction layer that is used to access persistent storage.
+    - All data that is brought into the app and is necessary to display the app when offline should be stored on disk in persistent storage (eg. localStorage on browser platforms). [AsyncStorage](https://reactnative.dev/docs/asyncstorage) is a cross-platform abstraction layer that is used to access persistent storage.
     - All data that is displayed, comes from persistent storage.
 1. **UI Binds to data on disk**
     - Onyx is a Pub/Sub library to connect the application to the data stored on disk.


### PR DESCRIPTION
### Details
The existing link to AsyncStorage documentation (https://react-native-community.github.io/async-storage/) leads to a 404 error page. 

This seems to be a link that works: https://reactnative.dev/docs/asyncstorage

### Fixed Issues

No issue created

### Tests
Check the link in the README.md for AsyncStorage.

