### PR TITLE
Fix: Using trim() for better UX

### DIFF
--- a/src/pages/SearchPage.js
+++ b/src/pages/SearchPage.js
@@ -128,7 +128,7 @@ class SearchPage extends Component {
         } = getSearchOptions(
             this.props.reports,
             this.props.personalDetails,
-            this.state.searchValue,
+            this.state.searchValue.trim(),
             this.props.betas,
         );
         this.setState({

--- a/src/pages/home/report/EmojiPickerMenu/index.js
+++ b/src/pages/home/report/EmojiPickerMenu/index.js
@@ -274,7 +274,7 @@ class EmojiPickerMenu extends Component {
      * @param {String} searchTerm
      */
     filterEmojis(searchTerm) {
-        const normalizedSearchTerm = searchTerm.toLowerCase();
+        const normalizedSearchTerm = searchTerm.toLowerCase().trim();
         if (normalizedSearchTerm === '') {
             // There are no headers when searching, so we need to re-make them sticky when there is no search term
             this.setState({

--- a/src/pages/settings/Profile/ProfilePage.js
+++ b/src/pages/settings/Profile/ProfilePage.js
@@ -193,8 +193,8 @@ class ProfilePage extends Component {
                 && this.props.myPersonalDetails.pronouns === this.state.selfSelectedPronouns);
 
         // Disables button if none of the form values have changed
-        const isButtonDisabled = (this.props.myPersonalDetails.firstName === this.state.firstName)
-            && (this.props.myPersonalDetails.lastName === this.state.lastName)
+        const isButtonDisabled = (this.props.myPersonalDetails.firstName === this.state.firstName.trim())
+            && (this.props.myPersonalDetails.lastName === this.state.lastName.trim())
             && (this.props.myPersonalDetails.timezone.selected === this.state.selectedTimezone)
             && (this.props.myPersonalDetails.timezone.automatic === this.state.isAutomaticTimezone)
             && arePronounsUnchanged;


### PR DESCRIPTION
 <!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
[Comment](https://github.com/Expensify/App/issues/4155#issuecomment-884008083)

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
#4155 and #4156

### Tests || QA Steps

## Search Page
1. Search for an email
2. Add extra space
3. Search result should not disppear
 
## Profile
1. Add extra whitespace anywhere in either names
2. Save button will not be activated

## Emoji picker Menu
1. Go to any chat
2. Open emoji picker 
3. Search for an emoji
4. Adding extra whitespace won't make the result(s) disappear 


### Tested On

- [ :heavy_check_mark: ] Web
- [ :heavy_check_mark: ] Mobile Web
- [ :x: ] Desktop
- [ :x: ] iOS
- [ :heavy_check_mark: ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
#### Search
![web](https://user-images.githubusercontent.com/28243942/126782755-f4804e65-e05a-42cc-985b-6852a97c522d.png)
#### Profile
![web2](https://user-images.githubusercontent.com/28243942/126782761-a4feb9d0-f429-40c5-8ccb-4d41e999cb91.png)
#### Emoji Picker
![web3](https://user-images.githubusercontent.com/28243942/126782771-9df0d7db-a8f6-42c2-8b31-3c0426f62ff5.png)


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
#### Profile
![mWeb](https://user-images.githubusercontent.com/28243942/126783366-2a291f8f-d2cf-4fce-9ab1-b71459c29981.jpeg)

#### Search
![mWeb2](https://user-images.githubusercontent.com/28243942/126783377-61b93485-725e-4024-a83d-965e511a0412.jpeg)

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->

#### Profile
![mobile](https://user-images.githubusercontent.com/28243942/126783409-19076f1c-8959-44e5-87f6-6932575aacf0.jpeg)

#### Search 
![mobile2](https://user-images.githubusercontent.com/28243942/126783445-0c60c6da-987c-4e77-9e43-6a40505f99ea.jpeg)


