### PR TITLE
Added Balance badge to the Settings page

### DIFF
--- a/src/components/Badge.js
+++ b/src/components/Badge.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import {Pressable, View} from 'react-native';
+import PropTypes from 'prop-types';
+import styles, {getBadgeColorStyle} from '../styles/styles';
+import Text from './Text';
+
+const propTypes = {
+    /** Is success type */
+    success: PropTypes.bool,
+
+    /** Is success type */
+    error: PropTypes.bool,
+
+    /** Whether badge is clickable */
+    pressable: PropTypes.bool,
+
+    /** Text to display in the Badge */
+    text: PropTypes.string.isRequired,
+
+    /** Styles for Badge */
+    badgeStyles: PropTypes.arrayOf(PropTypes.object),
+
+    /** Callback to be called on onPress */
+    onPress: PropTypes.func,
+};
+
+const defaultProps = {
+    success: false,
+    error: false,
+    pressable: false,
+    badgeStyles: [],
+    onPress: undefined,
+};
+
+const Badge = (props) => {
+    const textStyles = props.success || props.error ? styles.textWhite : undefined;
+    const Wrapper = props.pressable ? Pressable : View;
+    const wrapperStyles = ({pressed}) => ([
+        styles.badge,
+        styles.ml2,
+        getBadgeColorStyle(props.success, props.error, pressed),
+        ...props.badgeStyles,
+    ]);
+
+    return (
+        <Wrapper
+            style={props.pressable ? wrapperStyles : wrapperStyles(false)}
+            onPress={props.onPress}
+        >
+            <Text
+                style={[styles.badgeText, textStyles]}
+                numberOfLines={1}
+            >
+                {props.text}
+            </Text>
+        </Wrapper>
+    );
+};
+
+Badge.displayName = 'EnvironmentBadge';
+Badge.propTypes = propTypes;
+Badge.defaultProps = defaultProps;
+export default Badge;

--- a/src/components/Badge.js
+++ b/src/components/Badge.js
@@ -5,10 +5,10 @@ import styles, {getBadgeColorStyle} from '../styles/styles';
 import Text from './Text';
 
 const propTypes = {
-    /** Is success type */
+    /** Is Success type */
     success: PropTypes.bool,
 
-    /** Is success type */
+    /** Is Error type */
     error: PropTypes.bool,
 
     /** Whether badge is clickable */

--- a/src/components/Badge.js
+++ b/src/components/Badge.js
@@ -57,7 +57,7 @@ const Badge = (props) => {
     );
 };
 
-Badge.displayName = 'EnvironmentBadge';
+Badge.displayName = 'Badge';
 Badge.propTypes = propTypes;
 Badge.defaultProps = defaultProps;
 export default Badge;

--- a/src/components/EnvironmentBadge.js
+++ b/src/components/EnvironmentBadge.js
@@ -1,9 +1,7 @@
 import React from 'react';
-import {View} from 'react-native';
-import styles from '../styles/styles';
 import CONST from '../CONST';
-import Text from './Text';
 import withEnvironment, {environmentPropTypes} from './withEnvironment';
+import Badge from './Badge';
 
 const EnvironmentBadge = (props) => {
     // If we are on production, don't show any badge
@@ -11,16 +9,12 @@ const EnvironmentBadge = (props) => {
         return null;
     }
 
-    const backgroundColorStyle = props.environment === CONST.ENVIRONMENT.STAGING
-        ? styles.badgeSuccess
-        : styles.badgeDanger;
-
     return (
-        <View style={[styles.badge, backgroundColorStyle, styles.ml2]}>
-            <Text style={styles.badgeText}>
-                {props.environment}
-            </Text>
-        </View>
+        <Badge
+            success={props.environment === CONST.ENVIRONMENT.STAGING}
+            error={props.environment !== CONST.ENVIRONMENT.STAGING}
+            text={props.environment}
+        />
     );
 };
 

--- a/src/components/IOUBadge.js
+++ b/src/components/IOUBadge.js
@@ -1,15 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {Pressable} from 'react-native';
 import {withOnyx} from 'react-native-onyx';
 import ONYXKEYS from '../ONYXKEYS';
-import styles, {getBadgeColorStyle} from '../styles/styles';
 import Navigation from '../libs/Navigation/Navigation';
 import ROUTES from '../ROUTES';
 import compose from '../libs/compose';
 import withLocalize, {withLocalizePropTypes} from './withLocalize';
 import CONST from '../CONST';
-import Text from './Text';
+import Badge from './Badge';
 
 const propTypes = {
     /** IOU Report data object */
@@ -53,24 +51,16 @@ const IOUBadge = (props) => {
         Navigation.navigate(ROUTES.getIouDetailsRoute(props.iouReport.chatReportID, props.iouReport.reportID));
     };
     return (
-        <Pressable
-            style={({pressed}) => ([
-                styles.badge,
-                styles.ml2,
-                getBadgeColorStyle(props.session.email === props.iouReport.ownerEmail, pressed),
-            ])}
-        >
-            <Text
-                style={styles.badgeText}
-                numberOfLines={1}
-                onPress={launchIOUDetailsModal}
-            >
-                {props.numberFormat(
-                    props.iouReport.total / 100,
-                    {style: 'currency', currency: props.iouReport.currency},
-                )}
-            </Text>
-        </Pressable>
+        <Badge
+            pressable
+            onPress={launchIOUDetailsModal}
+            success={props.session.email === props.iouReport.ownerEmail}
+            error={props.session.email !== props.iouReport.ownerEmail}
+            text={props.numberFormat(
+                props.iouReport.total / 100,
+                {style: 'currency', currency: props.iouReport.currency},
+            )}
+        />
     );
 };
 

--- a/src/components/MenuItem.js
+++ b/src/components/MenuItem.js
@@ -8,8 +8,12 @@ import styles, {getButtonBackgroundColorStyle, getIconFillColor} from '../styles
 import Icon from './Icon';
 import {ArrowRight} from './Icon/Expensicons';
 import getButtonState from '../libs/getButtonState';
+import Badge from './Badge';
 
 const propTypes = {
+    // Text to be shown as badge near the right end.
+    badgeText: PropTypes.string,
+
     /** Any additional styles to apply */
     // eslint-disable-next-line react/forbid-prop-types
     wrapperStyle: PropTypes.object,
@@ -58,6 +62,7 @@ const propTypes = {
 };
 
 const defaultProps = {
+    badgeText: undefined,
     shouldShowRightIcon: false,
     wrapperStyle: {},
     success: false,
@@ -74,6 +79,7 @@ const defaultProps = {
 };
 
 const MenuItem = ({
+    badgeText,
     onPress,
     icon,
     iconRight,
@@ -141,6 +147,7 @@ const MenuItem = ({
                     </View>
                 </View>
                 <View style={[styles.flexRow, styles.menuItemTextContainer]}>
+                    {badgeText && <Badge text={badgeText} badgeStyles={[styles.alignSelfCenter]} />}
                     {subtitle && (
                         <View style={[styles.justifyContentCenter, styles.mr1]}>
                             <Text

--- a/src/components/MenuItem.js
+++ b/src/components/MenuItem.js
@@ -11,7 +11,7 @@ import getButtonState from '../libs/getButtonState';
 import Badge from './Badge';
 
 const propTypes = {
-    // Text to be shown as badge near the right end.
+    /** Text to be shown as badge near the right end. */
     badgeText: PropTypes.string,
 
     /** Any additional styles to apply */

--- a/src/pages/settings/InitialPage.js
+++ b/src/pages/settings/InitialPage.js
@@ -67,6 +67,12 @@ const propTypes = {
         role: PropTypes.string,
     })),
 
+    /** The user's wallet account */
+    userWallet: PropTypes.shape({
+        /** The user's current wallet balance */
+        availableBalance: PropTypes.number,
+    }),
+
     ...withLocalizePropTypes,
 };
 
@@ -75,6 +81,7 @@ const defaultProps = {
     network: {},
     session: {},
     policies: {},
+    userWallet: {},
 };
 
 const defaultMenuItems = [
@@ -113,10 +120,17 @@ const defaultMenuItems = [
 const InitialSettingsPage = ({
     myPersonalDetails,
     network,
+    numberFormat,
     session,
     policies,
     translate,
+    userWallet,
 }) => {
+    const walletBalance = numberFormat(
+        userWallet.availableBalance,
+        {style: 'currency', currency: 'USD'},
+    );
+
     // On the very first sign in or after clearing storage these
     // details will not be present on the first render so we'll just
     // return nothing for now.
@@ -169,6 +183,7 @@ const InitialSettingsPage = ({
                     </View>
                     {_.map(menuItems, (item, index) => {
                         const keyTitle = item.translationKey ? translate(item.translationKey) : item.title;
+                        const isPaymentItem = item.translationKey === 'common.payments';
                         return (
                             <MenuItem
                                 key={`${keyTitle}_${index}`}
@@ -178,6 +193,7 @@ const InitialSettingsPage = ({
                                 iconStyles={item.iconStyles}
                                 iconFill={item.iconFill}
                                 shouldShowRightIcon
+                                badgeText={isPaymentItem ? walletBalance : undefined}
                             />
                         );
                     })}
@@ -205,6 +221,9 @@ export default compose(
         },
         policies: {
             key: ONYXKEYS.COLLECTION.POLICY,
+        },
+        userWallet: {
+            key: ONYXKEYS.USER_WALLET,
         },
     }),
 )(InitialSettingsPage);

--- a/src/pages/settings/InitialPage.js
+++ b/src/pages/settings/InitialPage.js
@@ -81,7 +81,9 @@ const defaultProps = {
     network: {},
     session: {},
     policies: {},
-    userWallet: {},
+    userWallet: {
+        availableBalance: 0,
+    },
 };
 
 const defaultMenuItems = [

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -2014,8 +2014,8 @@ function getBackgroundColorStyle(backgroundColor) {
 /**
  * Generate a style for the background color of the Badge
  *
- * @param {*} success
- * @param {*} error
+ * @param {Boolean} success
+ * @param {Boolean} error
  * @param {boolean} [isPressed=false]
  * @return {Object}
  */

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -366,7 +366,7 @@ const styles = {
     },
 
     badgeText: {
-        color: themeColors.textReversed,
+        color: themeColors.text,
         fontSize: variables.fontSizeSmall,
         lineHeight: 16,
         ...whiteSpace.noWrap,
@@ -2012,17 +2012,21 @@ function getBackgroundColorStyle(backgroundColor) {
 }
 
 /**
- * Generate a style for the background color of the IOU badge
+ * Generate a style for the background color of the Badge
  *
- * @param {Boolean} isOwner
- * @param {Boolean} [isPressed]
- * @returns {Object}
+ * @param {*} success
+ * @param {*} error
+ * @param {boolean} [isPressed=false]
+ * @return {Object}
  */
-function getBadgeColorStyle(isOwner, isPressed = false) {
-    if (isOwner) {
+function getBadgeColorStyle(success, error, isPressed = false) {
+    if (success) {
         return isPressed ? styles.badgeSuccessPressed : styles.badgeSuccess;
     }
-    return isPressed ? styles.badgeDangerPressed : styles.badgeDanger;
+    if (error) {
+        return isPressed ? styles.badgeDangerPressed : styles.badgeDanger;
+    }
+    return {};
 }
 
 /**


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

cc @stitesExpensify 

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ #4171

### Tests | QA Steps
1. Open E.cash.
2. Open Settings page.
3. See the payments Link, it should have the wallet balance badge.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
![image](https://user-images.githubusercontent.com/24370807/126900594-806abae0-3b22-4239-a402-33736eecfd95.png)

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
![badge-m](https://user-images.githubusercontent.com/24370807/126900701-5e76fa02-c976-44a8-a95b-e635c48e2c56.png)

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
![badge-i](https://user-images.githubusercontent.com/24370807/126910493-4cf3bb5a-2d83-49ce-8650-196c36c1c53f.png)

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
![badge-a](https://user-images.githubusercontent.com/24370807/126901815-751af380-c85f-438e-b672-1eb1417ef1a8.png)
