### PR TITLE
Fetch local currency on each IOU request, to ensure local currency is always up to date

### DIFF
--- a/src/pages/iou/IOUModal.js
+++ b/src/pages/iou/IOUModal.js
@@ -20,6 +20,7 @@ import FullScreenLoadingIndicator from '../../components/FullscreenLoadingIndica
 import ScreenWrapper from '../../components/ScreenWrapper';
 import CONST from '../../CONST';
 import KeyboardAvoidingView from '../../components/KeyboardAvoidingView';
+import * as PersonalDetails from '../../libs/actions/PersonalDetails';
 
 /**
  * IOU modal for requesting money and splitting bills.
@@ -129,6 +130,7 @@ class IOUModal extends Component {
     }
 
     componentDidMount() {
+        PersonalDetails.fetchLocalCurrency();
         setIOUSelectedCurrency(this.props.myPersonalDetails.localCurrencyCode);
     }
 

--- a/src/pages/iou/IOUModal.js
+++ b/src/pages/iou/IOUModal.js
@@ -289,9 +289,9 @@ class IOUModal extends Component {
                         </View>
                         <View style={[styles.pRelative, styles.flex1]}>
                             <FullScreenLoadingIndicator
-                                visible={!didScreenTransitionEnd || this.props.iou.isRetrievingCurrency}
+                                visible={!didScreenTransitionEnd}
                             />
-                            {didScreenTransitionEnd && !this.props.iou.isRetrievingCurrency && (
+                            {didScreenTransitionEnd && (
                                 <>
                                     {currentStep === Steps.IOUAmount && (
                                         <IOUAmountPage


### PR DESCRIPTION
### Details

In the original design for Request Money & Split Bills, we were to fetch the user's local currency each time the user started the flow to ensure their local currency was always set correctly. This was once the case, but is no longer occurring.

We also need to ensure the flow can be navigated when the user is offline. 

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/171917

### Tests

A) I ran the QA steps 

B) Check the flow is not blocked when the `GetLocalCurrency` request fails
- I broke the `GetLocalCurrency` command name in Web-e
- In E.cash, I opened the IOUModal to make a request
- Although the request failed, the loading spinner still disappeared, and the flow could be navigated

C) Check the flow is not blocked when offline
- I switched off WiFi
- Opened the Request Money flow via the global menu
- The spinner **did NOT** block progress, and the previously set currency was used

### QA Steps

- Open the app in Chrome
- Open developer tools via `View > Developer > Developer Tools` or `CMD + OPTION + i`
- Switch to the Network tab, clear the console
- From either the global nav, or DM menus, select `Split Bill` or `Request Money`
- You should see 2 Network requests in the Network tab (`GetLocalCurrency` & `Mobile_GetConstants`)


<img width="559" alt="Screenshot 2021-07-26 at 15 51 48" src="https://user-images.githubusercontent.com/10736861/127009959-b1b8b21d-5d0c-413b-b103-be32b56b3a1d.png">


### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web

![Screenshot 2021-07-26 at 15 08 21](https://user-images.githubusercontent.com/10736861/127002690-e7e653c1-8754-42bf-a039-560cefe22a0e.png)


#### Mobile Web

![Simulator Screen Shot - iPhone 12 - 2021-07-26 at 15 48 01](https://user-images.githubusercontent.com/10736861/127009467-470a0dc3-882e-421e-a963-8de30efae197.png)

#### Desktop

<img width="1625" alt="Screenshot 2021-07-26 at 15 07 09" src="https://user-images.githubusercontent.com/10736861/127002600-a14da9e9-5e12-47c0-b7ca-a62ea578448b.png">


#### iOS

![Simulator Screen Shot - iPhone 12 - 2021-07-26 at 15 48 39](https://user-images.githubusercontent.com/10736861/127009483-6e6a003b-8669-45ff-bd1a-afadd35cc132.png)


#### Android

![device-2021-07-26-152116](https://user-images.githubusercontent.com/10736861/127004782-4a3c6ab6-ed52-4996-a193-4c37d4f4aa4e.png)

