### PR TITLE
Remove Bintray repository to speed up Android builds

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,8 +28,6 @@ buildscript {
 
 allprojects {
     repositories {
-        maven { url "https://dl.bintray.com/onfido/maven" }
-
         mavenLocal()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm


### PR DESCRIPTION
### Details
I ran into long build times when developing some changes for the Android native part of the app (+30 minutes long builds!) and thought this made no sense. 

I found out that the culprit was the Bintray repository, and removing it from the list of repositories is what solved the issue.

Why is the Bintray repository the cause? [JFrog closed it!](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/), and they wanted to close JCenter too. However, they say they'll keep that one as a read-only repository indefinitely.

I tried replacing `jcenter` with `mavenCentral`, but there are still some packages that we use and haven't migrated (for example, Flipper or some internal dependencies of react-native). We'll need to keep an eye on that in the future.

### Tests/QA Steps
Run the following commands and make sure the app gets built in a reasonable amount of time:

```bash
cd android
./gradlew clean
cd ..
npx react-native run-android
```

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [x] Android

### Screenshots
N/A
