### PR TITLE
Fix Keyboard input for workspace invite page on mobile keyboards

### DIFF
--- a/src/pages/workspace/WorkspaceInvitePage.js
+++ b/src/pages/workspace/WorkspaceInvitePage.js
@@ -15,7 +15,6 @@ import compose from '../../libs/compose';
 import ONYXKEYS from '../../ONYXKEYS';
 import {invite} from '../../libs/actions/Policy';
 import TextLink from '../../components/TextLink';
-import getEmailKeyboardType from '../../libs/getEmailKeyboardType';
 import themeColors from '../../styles/themes/default';
 import Growl from '../../libs/Growl';
 import FixedFooter from '../../components/FixedFooter';
@@ -107,7 +106,6 @@ class WorkspaceInvitePage extends React.Component {
                                 autoCapitalize="none"
                                 style={[styles.textInput]}
                                 value={this.state.userLogins}
-                                keyboardType={getEmailKeyboardType()}
                                 onChangeText={text => this.setState({userLogins: text})}
                             />
                         </View>


### PR DESCRIPTION
@ctkochan22, please review
cc: @parasharrajat 

### Details
Now we are allowing users to invite multiple emails at once. On iOS, since we have made this an email specific keyboard, we can't use commas to invite multiple users. This PR turns this input into a regular keyboard so users can do that.

### Fixed Issues
resolves this regression identified: https://github.com/Expensify/App/pull/4068#issuecomment-886048003

### Tests
Web QA tested locally on iOS emulator

### QA Steps
Should be tested on iOS and android.
1. Launch the app and login with expensifail account
2. Tap + > New workspace
3. Enter name for workspace , tap Get started
4. Tap People > Invite
5. Enter email and verify that you can type a comma and enter various emails.
6. Try to invite multiple users and see if that works

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [x] iOS
- [] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
Now (good):
![image](https://user-images.githubusercontent.com/19364431/127041464-8e77ff78-0fe3-492b-a931-56d30d01a309.png)

Before (bad):
![image](https://user-images.githubusercontent.com/19364431/127041577-febbb227-0ccb-4efb-8778-9144d6e1be02.png)


#### Android
<!-- Insert screenshots of your changes on the Android platform-->
