### PR TITLE
[InternalQA] Update Workspace button text during pending account validation

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -69,6 +69,7 @@ const CONST = {
         VERIFICATION_MAX_ATTEMPTS: 7,
         STATE: {
             VERIFYING: 'VERIFYING',
+            PENDING: 'PENDING',
         },
     },
     INCORPORATION_TYPES: {

--- a/src/pages/workspace/WorkspaceCardPage.js
+++ b/src/pages/workspace/WorkspaceCardPage.js
@@ -74,6 +74,7 @@ const WorkspaceCardPage = ({
     reimbursementAccount,
 }) => {
     const isVerifying = lodashGet(reimbursementAccount, 'achData.state', '') === BankAccount.STATE.VERIFYING;
+    const isPending = lodashGet(reimbursementAccount, 'achData.state', '') === BankAccount.STATE.PENDING;
     const isNotAutoProvisioned = !user.isUsingExpensifyCard
         && lodashGet(reimbursementAccount, 'achData.state', '') === BankAccount.STATE.OPEN;
     let buttonText;
@@ -81,7 +82,7 @@ const WorkspaceCardPage = ({
         buttonText = translate('workspace.card.addEmail');
     } else if (user.isUsingExpensifyCard) {
         buttonText = translate('workspace.card.manageCards');
-    } else if (isVerifying || isNotAutoProvisioned) {
+    } else if (isVerifying || isPending || isNotAutoProvisioned) {
         buttonText = translate('workspace.card.finishSetup');
     } else {
         buttonText = translate('workspace.card.getStarted');


### PR DESCRIPTION
### Details

cc @chiragsalian 
cc @MitchExpensify 

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ https://github.com/Expensify/App/issues/4236

### Tests
1. Create a new Workspace.
2. Follow [these steps](https://stackoverflow.com/c/expensify/questions/342/525#525) to add a PENDING account.
3. When you get to the Validate step, verify that the button text changes to `Finish Setup`.
3. When prompted for the 3 codes, follow [these steps](https://stackoverflow.com/c/expensify/questions/10445).
4. Verify that the button text is set to `Manage Cards` and clicking it directs the user to `expensify.com`.

### QA Steps
Internal QA.

### Tested On

- [X] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web

https://user-images.githubusercontent.com/22219519/127061316-639624be-db2d-4aff-b980-2785b6bfeaa9.mov

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
