### PR TITLE
Make sure we get state/status from the right variable name when we get chat report name

### DIFF
--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -140,8 +140,8 @@ function getChatReportName(fullReport, chatType) {
     if (isDefaultRoom({chatType})) {
         return `#${fullReport.reportName}${(isArchivedRoom({
             chatType,
-            stateNum: fullReport.stateNum,
-            statusNum: fullReport.reportStatus,
+            stateNum: fullReport.state,
+            statusNum: fullReport.status,
         })
             ? ` (${translateLocal('common.deleted')})`
             : '')}`;


### PR DESCRIPTION
@TomatoToaster please review

### Details
I messed up here and was pulling the `state`/`status` from `stateNum`/`statusNum` rather than `state`/`status`

### Fixed Issues
$ https://github.com/Expensify/App/pull/4023

### Tests/QA
See: https://github.com/Expensify/App/pull/4023#issuecomment-886278869

Made sure `(deleted)` was showing in the report name:
<img width="290" alt="Screen Shot 2021-07-26 at 3 47 11 PM" src="https://user-images.githubusercontent.com/4741899/127068835-043a29f4-b472-4d20-b86a-c5d64878cee1.png">
