### PR TITLE
Show day of the week when other user is in a different date

### DIFF
--- a/src/pages/home/report/ParticipantLocalTime.js
+++ b/src/pages/home/report/ParticipantLocalTime.js
@@ -42,9 +42,14 @@ class ParticipantLocalTime extends React.Component {
 
     getParticipantLocalTime() {
         const reportRecipientTimezone = lodashGet(this.props.participant, 'timezone', {});
-        return moment().tz(reportRecipientTimezone.selected).format('LT');
-    }
+        const reportRecipientDay = moment().tz(reportRecipientTimezone.selected).format('dddd');
+        const currentUserDay = moment().tz(this.props.currentUserTimezone.selected).format('dddd');
 
+        if (reportRecipientDay !== currentUserDay) {
+            return `${moment().tz(reportRecipientTimezone.selected).format('LT')} ${reportRecipientDay}`;
+        }
+        return `${moment().tz(reportRecipientTimezone.selected).format('LT')}`;
+    }
 
     render() {
         // Moment.format does not return AM or PM values immediately.

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -452,7 +452,7 @@ class ReportActionCompose extends React.Component {
             ]}
             >
                 {shouldShowReportRecipientLocalTime
-                    && <ParticipantLocalTime participant={reportRecipient} />}
+                    && <ParticipantLocalTime participant={reportRecipient} currentUserTimezone={currentUserTimezone} />}
                 <View style={[
                     (this.state.isFocused || this.state.isDraggingOver)
                         ? styles.chatItemComposeBoxFocusedColor


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Modifies our `ParticipantLocalTime` to also show the day of the week when the other user is in a different day.


### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ https://github.com/Expensify/App/issues/4118

### Tests
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->
1. Open any chat
2. Change your timezone so that you're one day ahead or one day behind the other user
3. Above the composer you should see the day of the week that the other user is in
### QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

https://user-images.githubusercontent.com/53711423/127076626-13b16006-37c7-40ab-8ba3-c441d47fb9a2.mov


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
![mWeb](https://user-images.githubusercontent.com/53711423/127076947-4337adc1-0f48-4e32-acc1-2ff5a3fba6c9.png)

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

https://user-images.githubusercontent.com/53711423/127076633-98b4ab0a-2782-42eb-94f9-013d5d6c6784.mov


#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

https://user-images.githubusercontent.com/53711423/127076637-e79249e9-170d-4cf3-9ddf-9d29f1a328ec.mp4


#### Android
<!-- Insert screenshots of your changes on the Android platform-->
![android](https://user-images.githubusercontent.com/53711423/127077348-ad7e1d4e-74b1-408e-8e2c-7713ced1b293.png)
