### PR TITLE
Revert add payment button changes

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -240,6 +240,7 @@ export default {
         payPalMe: 'PayPal.me/',
         yourPayPalUsername: 'Your PayPal username',
         addPayPalAccount: 'Add PayPal Account',
+        editPayPalAccount: 'Update PayPal Account',
         growlMessageOnSave: 'Your PayPal username was successfully added',
     },
     paymentsPage: {

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -231,7 +231,8 @@ export default {
         enterYourUsernameToGetPaidViaPayPal: 'Escribe tu nombre de usuario para que otros puedan pagarte a través de PayPal.',
         payPalMe: 'PayPal.me/',
         yourPayPalUsername: 'Tu usuario de PayPal',
-        addPayPalAccount: 'Agregar Cuenta de Paypal',
+        addPayPalAccount: 'Agregar Cuenta de PayPal',
+        editPayPalAccount: 'Actualizar Cuenta de PayPal',
     },
     paymentsPage: {
         paymentMethodsTitle: 'Métodos de pago',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -231,8 +231,8 @@ export default {
         enterYourUsernameToGetPaidViaPayPal: 'Escribe tu nombre de usuario para que otros puedan pagarte a través de PayPal.',
         payPalMe: 'PayPal.me/',
         yourPayPalUsername: 'Tu usuario de PayPal',
-        addPayPalAccount: 'Agregar Cuenta de PayPal',
-        editPayPalAccount: 'Actualizar Cuenta de PayPal',
+        addPayPalAccount: 'Agregar cuenta de PayPal',
+        editPayPalAccount: 'Actualizar cuenta de PayPal',
     },
     paymentsPage: {
         paymentMethodsTitle: 'Métodos de pago',

--- a/src/libs/actions/User.js
+++ b/src/libs/actions/User.js
@@ -69,7 +69,7 @@ function getBetas() {
 function getUserDetails() {
     API.Get({
         returnValueList: 'account, loginList, nameValuePairs',
-        nvpNames: [CONST.NVP.BLOCKED_FROM_CONCIERGE, CONST.NVP.PAYPAL_ME_ADDRESS].join(','),
+        nvpNames: CONST.NVP.PAYPAL_ME_ADDRESS,
     })
         .then((response) => {
             // Update the User onyx key

--- a/src/pages/settings/Payments/AddPayPalMePage.js
+++ b/src/pages/settings/Payments/AddPayPalMePage.js
@@ -103,7 +103,9 @@ class AddPayPalMePage extends React.Component {
                             onPress={this.setPayPalMeUsername}
                             pressOnEnter
                             style={[styles.mt3]}
-                            text={this.props.translate('addPayPalMePage.addPayPalAccount')}
+                            text={this.props.payPalMeUsername
+                                ? this.props.translate('addPayPalMePage.editPayPalAccount')
+                                : this.props.translate('addPayPalMePage.addPayPalAccount')}
                         />
                     </FixedFooter>
                 </KeyboardAvoidingView>

--- a/src/pages/settings/Payments/AddPayPalMePage.js
+++ b/src/pages/settings/Payments/AddPayPalMePage.js
@@ -9,7 +9,7 @@ import HeaderWithCloseButton from '../../../components/HeaderWithCloseButton';
 import Text from '../../../components/Text';
 import ScreenWrapper from '../../../components/ScreenWrapper';
 import NameValuePair from '../../../libs/actions/NameValuePair';
-import {getUserDetails} from '../../../libs/actions/User';
+import getPaymentMethods from '../../../libs/actions/PaymentMethods';
 import Navigation from '../../../libs/Navigation/Navigation';
 import styles from '../../../styles/styles';
 import withLocalize, {withLocalizePropTypes} from '../../../components/withLocalize';
@@ -42,7 +42,7 @@ class AddPayPalMePage extends React.Component {
     }
 
     componentDidMount() {
-        getUserDetails();
+        getPaymentMethods();
     }
 
     componentDidUpdate(prevProps) {
@@ -59,6 +59,7 @@ class AddPayPalMePage extends React.Component {
     setPayPalMeUsername() {
         NameValuePair.set(CONST.NVP.PAYPAL_ME_ADDRESS, this.state.payPalMeUsername, ONYXKEYS.NVP_PAYPAL_ME_ADDRESS);
         Growl.show(this.props.translate('addPayPalMePage.growlMessageOnSave'), CONST.GROWL.SUCCESS, 3000);
+        Navigation.navigate(ROUTES.SETTINGS_PAYMENTS);
     }
 
     render() {

--- a/src/pages/settings/Payments/PaymentMethodList.js
+++ b/src/pages/settings/Payments/PaymentMethodList.js
@@ -130,19 +130,14 @@ class PaymentMethodList extends Component {
             });
         }
 
-        // Don't show Add Payment Method button if user provided details for all possible payment methods.
-        // Right now only available method is Paypal.me
-        // When there is a new payment method, it needs to be added to following if condition.
-        if (!this.props.payPalMeUsername) {
-            combinedPaymentMethods.push({
-                type: MENU_ITEM,
-                title: this.props.translate('paymentMethodList.addPaymentMethod'),
-                icon: Plus,
-                onPress: e => this.props.onPress(e),
-                key: 'addPaymentMethodButton',
-                disabled: this.props.isLoadingPayments,
-            });
-        }
+        combinedPaymentMethods.push({
+            type: MENU_ITEM,
+            title: this.props.translate('paymentMethodList.addPaymentMethod'),
+            icon: Plus,
+            onPress: e => this.props.onPress(e),
+            key: 'addPaymentMethodButton',
+            disabled: this.props.isLoadingPayments,
+        });
 
         return combinedPaymentMethods;
     }

--- a/src/pages/settings/Payments/PaymentsPage.js
+++ b/src/pages/settings/Payments/PaymentsPage.js
@@ -1,8 +1,5 @@
 import React from 'react';
 import {View} from 'react-native';
-import PropTypes from 'prop-types';
-import {withOnyx} from 'react-native-onyx';
-import ONYXKEYS from '../../../ONYXKEYS';
 import PaymentMethodList from './PaymentMethodList';
 import ROUTES from '../../../ROUTES';
 import HeaderWithCloseButton from '../../../components/HeaderWithCloseButton';
@@ -23,9 +20,6 @@ import CurrentWalletBalance from '../../../components/CurrentWalletBalance';
 const PAYPAL = 'payPalMe';
 
 const propTypes = {
-    /** User's paypal.me username if they have one */
-    payPalMeUsername: PropTypes.string,
-
     ...withLocalizePropTypes,
 };
 
@@ -129,13 +123,11 @@ class PaymentsPage extends React.Component {
                             left: this.state.anchorPositionLeft,
                         }}
                     >
-                        {!this.props.payPalMeUsername && (
-                            <MenuItem
-                                title="PayPal.me"
-                                icon={PayPal}
-                                onPress={() => this.addPaymentMethodTypePressed(PAYPAL)}
-                            />
-                        )}
+                        <MenuItem
+                            title="PayPal.me"
+                            icon={PayPal}
+                            onPress={() => this.addPaymentMethodTypePressed(PAYPAL)}
+                        />
                     </Popover>
                 </KeyboardAvoidingView>
             </ScreenWrapper>
@@ -149,9 +141,4 @@ PaymentsPage.displayName = 'PaymentsPage';
 
 export default compose(
     withLocalize,
-    withOnyx({
-        payPalMeUsername: {
-            key: ONYXKEYS.NVP_PAYPAL_ME_ADDRESS,
-        },
-    }),
 )(PaymentsPage);


### PR DESCRIPTION
### Details
We accidentally mislead a contributor to add some changes we don't actually want.

This PR:
1. Removes the hiding of the "add payment method" button (you can always add accounts)
2. Properly fixes a UI bug that would show multiple paypal accounts in your payment methods
3. Navigates back to the payments page after you add a paypal account

### Fixed Issues
$ https://github.com/Expensify/App/issues/4238

### Tests/QA
1. Create a new account
1. Go to the payments page in settings
2. Click the "Add Payment Method" button
3. Click the paypal.me button
4. Enter a paypal.me username
5. Make sure the button says "Add paypal account" and click it
5. Make sure you are brought back to the payments page
5. Make sure you see a new payment method
2. Click the "Add Payment Method" button again
3. Click the paypal.me button again
4. Enter a different paypal.me username
5. Make sure the button says "Update paypal account" and click it
5. Make sure the paypal changes

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots

#### Web

https://user-images.githubusercontent.com/42391420/127081043-28d686d0-7f6f-4915-9635-d13f4e7a7057.mp4


