### PR TITLE
Remove (NEW!) message after logout and update it to be unread count

### DIFF
--- a/src/libs/UnreadIndicatorUpdater/updateUnread/index.website.js
+++ b/src/libs/UnreadIndicatorUpdater/updateUnread/index.website.js
@@ -10,7 +10,7 @@ import CONFIG from '../../../CONFIG';
  */
 function updateUnread(totalCount) {
     const hasUnread = totalCount !== 0;
-    document.title = hasUnread ? `(NEW!) ${CONFIG.SITE_TITLE}` : CONFIG.SITE_TITLE;
+    document.title = hasUnread ? `(${totalCount}) ${CONFIG.SITE_TITLE}` : CONFIG.SITE_TITLE;
     document.getElementById('favicon').href = hasUnread ? CONFIG.FAVICON.UNREAD : CONFIG.FAVICON.DEFAULT;
 }
 

--- a/src/pages/signin/SignInPage.js
+++ b/src/pages/signin/SignInPage.js
@@ -53,7 +53,8 @@ const defaultProps = {
 class SignInPage extends Component {
     componentDidMount() {
         // Always reset the unread counter to zero on this page
-        updateUnread(0);
+        // NOTE: We need to wait for the next tick to ensure that the unread indicator is updated
+        setTimeout(() => updateUnread(0), 0);
     }
 
     render() {


### PR DESCRIPTION
### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ https://github.com/Expensify/App/issues/3971

### Tests/QA Steps

1. Open two Expensify accounts. Let's call them (a) and (b).
2. Make (a) focus a conversation with an account that is not (b).
3. From (b), send a message to (a).
4. From (a), make sure the title is updated and is set to `(1) Expensify.cash`, and the favicon has the red dot.
5. From (a), log out and once you're in the Sign In screen, make sure the title and the favicon have been set to their default values, no dot in the favicon, and the `Expensify.cash` title.

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web

https://user-images.githubusercontent.com/6759612/127127716-8fd5da6f-f292-443b-a3be-428b7e97f0a3.mov




