### PR TITLE
Perf: remove Onyx usage from `withLocalize`

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import {SafeAreaProvider} from 'react-native-safe-area-context';
 import CustomStatusBar from './components/CustomStatusBar';
 import ErrorBoundary from './components/ErrorBoundary';
 import Expensify from './Expensify';
+import {LocaleContextProvider} from './components/withLocalize';
 
 LogBox.ignoreLogs([
     // Basically it means that if the app goes in the background and back to foreground on Android,
@@ -17,10 +18,12 @@ LogBox.ignoreLogs([
 
 const App = () => (
     <SafeAreaProvider>
-        <CustomStatusBar />
-        <ErrorBoundary errorMessage="E.cash crash caught by error boundary">
-            <Expensify />
-        </ErrorBoundary>
+        <LocaleContextProvider>
+            <CustomStatusBar />
+            <ErrorBoundary errorMessage="E.cash crash caught by error boundary">
+                <Expensify />
+            </ErrorBoundary>
+        </LocaleContextProvider>
     </SafeAreaProvider>
 );
 

--- a/src/components/withLocalize.js
+++ b/src/components/withLocalize.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {createContext, forwardRef} from 'react';
 import PropTypes from 'prop-types';
 import {withOnyx} from 'react-native-onyx';
 import getComponentDisplayName from '../libs/getComponentDisplayName';
@@ -8,6 +8,8 @@ import DateUtils from '../libs/DateUtils';
 import {toLocalPhone, fromLocalPhone} from '../libs/LocalePhoneNumber';
 import numberFormat from '../libs/numberFormat';
 import CONST from '../CONST';
+
+const LocaleContext = createContext(null);
 
 const withLocalizePropTypes = {
     /** Returns translated string for given locale and phrase */
@@ -29,124 +31,122 @@ const withLocalizePropTypes = {
     fromLocalPhone: PropTypes.func.isRequired,
 };
 
-export default (WrappedComponent) => {
-    const propTypes = {
-        /** The user's preferred locale e.g. 'en', 'es-ES' */
-        preferredLocale: PropTypes.string,
+const localeProviderPropTypes = {
+    /** The user's preferred locale e.g. 'en', 'es-ES' */
+    preferredLocale: PropTypes.string,
 
-        /** Passed ref from whatever component is wrapped in the HOC */
-        forwardedRef: PropTypes.oneOfType([
-            PropTypes.func,
-            PropTypes.shape({current: PropTypes.instanceOf(React.Component)}),
-        ]),
-    };
+    /* Actual content wrapped by this component */
+    children: PropTypes.node.isRequired,
+};
 
-    const defaultProps = {
-        preferredLocale: CONST.DEFAULT_LOCALE,
-        forwardedRef: undefined,
-    };
+const localeProviderDefaultProps = {
+    preferredLocale: CONST.DEFAULT_LOCALE,
+};
 
-    class WithLocalize extends React.Component {
-        constructor(props) {
-            super(props);
+class LocaleContextProvider extends React.Component {
+    constructor(props) {
+        super(props);
 
-            this.translate = this.translate.bind(this);
-            this.numberFormat = this.numberFormat.bind(this);
-            this.timestampToRelative = this.timestampToRelative.bind(this);
-            this.timestampToDateTime = this.timestampToDateTime.bind(this);
-            this.fromLocalPhone = this.fromLocalPhone.bind(this);
-            this.toLocalPhone = this.toLocalPhone.bind(this);
-        }
-
-        /**
-         * @param {String} phrase
-         * @param {Object} [variables]
-         * @returns {String}
-         */
-        translate(phrase, variables) {
-            return translate(this.props.preferredLocale, phrase, variables);
-        }
-
-        /**
-         * @param {Number} number
-         * @param {Intl.NumberFormatOptions} options
-         * @returns {String}
-         */
-        numberFormat(number, options) {
-            return numberFormat(this.props.preferredLocale, number, options);
-        }
-
-        /**
-         * @param {Number} timestamp
-         * @returns {String}
-         */
-        timestampToRelative(timestamp) {
-            return DateUtils.timestampToRelative(this.props.preferredLocale, timestamp);
-        }
-
-        /**
-         * @param {Number} timestamp
-         * @param {Boolean} [includeTimezone]
-         * @returns {String}
-         */
-        timestampToDateTime(timestamp, includeTimezone) {
-            return DateUtils.timestampToDateTime(
-                this.props.preferredLocale,
-                timestamp,
-                includeTimezone,
-            );
-        }
-
-        /**
-         * @param {Number} number
-         * @returns {String}
-         */
-        toLocalPhone(number) {
-            return toLocalPhone(this.props.preferredLocale, number);
-        }
-
-        /**
-         * @param {Number} number
-         * @returns {String}
-         */
-        fromLocalPhone(number) {
-            return fromLocalPhone(this.props.preferredLocale, number);
-        }
-
-        render() {
-            return (
-                <WrappedComponent
-                    // eslint-disable-next-line react/jsx-props-no-spreading
-                    {...this.props}
-                    ref={this.props.forwardedRef}
-                    translate={this.translate}
-                    numberFormat={this.numberFormat}
-                    timestampToRelative={this.timestampToRelative}
-                    timestampToDateTime={this.timestampToDateTime}
-                    toLocalPhone={this.toLocalPhone}
-                    fromLocalPhone={this.fromLocalPhone}
-                />
-            );
-        }
+        /* The context this component exposes to consumers */
+        this.translateUtils = {
+            translate: this.translate.bind(this),
+            numberFormat: this.numberFormat.bind(this),
+            timestampToRelative: this.timestampToRelative.bind(this),
+            timestampToDateTime: this.timestampToDateTime.bind(this),
+            fromLocalPhone: this.fromLocalPhone.bind(this),
+            toLocalPhone: this.toLocalPhone.bind(this),
+        };
     }
 
-    WithLocalize.propTypes = propTypes;
-    WithLocalize.defaultProps = defaultProps;
+    /**
+     * @param {String} phrase
+     * @param {Object} [variables]
+     * @returns {String}
+     */
+    translate(phrase, variables) {
+        return translate(this.props.preferredLocale, phrase, variables);
+    }
 
-    const withForwardedRef = React.forwardRef((props, ref) => (
-        // eslint-disable-next-line react/jsx-props-no-spreading
-        <WithLocalize {...props} forwardedRef={ref} />
+    /**
+     * @param {Number} number
+     * @param {Intl.NumberFormatOptions} options
+     * @returns {String}
+     */
+    numberFormat(number, options) {
+        return numberFormat(this.props.preferredLocale, number, options);
+    }
+
+    /**
+     * @param {Number} timestamp
+     * @returns {String}
+     */
+    timestampToRelative(timestamp) {
+        return DateUtils.timestampToRelative(this.props.preferredLocale, timestamp);
+    }
+
+    /**
+     * @param {Number} timestamp
+     * @param {Boolean} [includeTimezone]
+     * @returns {String}
+     */
+    timestampToDateTime(timestamp, includeTimezone) {
+        return DateUtils.timestampToDateTime(
+            this.props.preferredLocale,
+            timestamp,
+            includeTimezone,
+        );
+    }
+
+    /**
+     * @param {Number} number
+     * @returns {String}
+     */
+    toLocalPhone(number) {
+        return toLocalPhone(this.props.preferredLocale, number);
+    }
+
+    /**
+     * @param {Number} number
+     * @returns {String}
+     */
+    fromLocalPhone(number) {
+        return fromLocalPhone(this.props.preferredLocale, number);
+    }
+
+    render() {
+        return (
+            <LocaleContext.Provider value={this.translateUtils}>
+                {this.props.children}
+            </LocaleContext.Provider>
+        );
+    }
+}
+
+LocaleContextProvider.propTypes = localeProviderPropTypes;
+LocaleContextProvider.defaultProps = localeProviderDefaultProps;
+
+const Provider = withOnyx({
+    preferredLocale: {
+        key: ONYXKEYS.NVP_PREFERRED_LOCALE,
+    },
+})(LocaleContextProvider);
+
+Provider.displayName = 'withOnyx(LocaleContextProvider)';
+
+export default function withLocalize(WrappedComponent) {
+    const WithLocalize = forwardRef((props, ref) => (
+        <LocaleContext.Consumer>
+            {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+            { translateUtils => <WrappedComponent {...translateUtils} {...props} ref={ref} />}
+        </LocaleContext.Consumer>
     ));
 
-    withForwardedRef.displayName = `withLocalize(${getComponentDisplayName(WrappedComponent)})`;
+    WithLocalize.displayName = `withLocalize(${getComponentDisplayName(WrappedComponent)})`;
 
-    return withOnyx({
-        preferredLocale: {
-            key: ONYXKEYS.NVP_PREFERRED_LOCALE,
-        },
-    })(withForwardedRef);
-};
+    return WithLocalize;
+}
 
 export {
     withLocalizePropTypes,
+    Provider as LocaleContextProvider,
 };


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
@marcaaron 

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This component is one of the most used components and has more than 310 instances depending on chat size
Instead of creating a new connection for each `withLocalize` usage - use the already cached value in `translate`
This significantly reduces the `Onyx.get` load that is caused by all the connections

### Fixed Issues (Related To)
Fixes #4268

### Tests
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->
1. Measure performance (init time) before this change
2. Measure performance (init time) with the change in this PR

I'm using `Onyx.printMetrics()` to monitor the `Onyx.get` calls that happen during init: https://github.com/Expensify/react-native-onyx#benchmarks

#### My Benchmarks

##### Before
Total: | 123.80sec |   |   | Last | 17.49sec |   |   | ReportID | 71955477
-- | -- | -- | -- | -- | -- | -- | -- | -- | --

method | total time spent | max | min | avg | time last call completed | calls made
-- | -- | -- | -- | -- | -- | --
Onyx:get | 96.85sec | 2.92sec | 0.10ms | 144.77ms | 17.48sec | 669
- see the individual Onyx.get calls here: https://docs.google.com/spreadsheets/d/1wGrVXsad6ayQZVqvyUmTuTb1cmeegdE0y-IFzhLiPKU/edit?usp=sharing
  - search for `preferredLocale` 

##### After
Total: | 62.62sec |   |   | Last | 12.27sec |   |   | ReportID | 71955477
-- | -- | -- | -- | -- | -- | -- | -- | -- | --

method | total time spent | max | min | avg | time last call completed | calls made
-- | -- | -- | -- | -- | -- | --
Onyx:get | 40.44sec | 1.79sec | 0.08ms | 139.94ms | 12.27sec | 289
- excel data: https://docs.google.com/spreadsheets/d/1cVe3eEnwYgwbH4DRV__g9_W8kQFpVhvTjDu3Igr6Ds0/edit?usp=sharing

### QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
![image](https://user-images.githubusercontent.com/12156624/127711858-844f638d-6950-4402-ad4f-49770a807923.png)

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
