### PR TITLE
Add beta check to Workspaces page

### DIFF
--- a/src/pages/workspace/WorkspaceCardPage.js
+++ b/src/pages/workspace/WorkspaceCardPage.js
@@ -20,11 +20,15 @@ import themeDefault from '../../styles/themes/default';
 import ROUTES from '../../ROUTES';
 import CONFIG from '../../CONFIG';
 import CONST from '../../CONST';
+import Permissions from '../../libs/Permissions';
 import HeroCardWebImage from '../../../assets/images/cascading-cards-web.svg';
 import HeroCardMobileImage from '../../../assets/images/cascading-cards-mobile.svg';
 
 const propTypes = {
     /* Onyx Props */
+
+    /** Beta features list */
+    betas: PropTypes.arrayOf(PropTypes.string).isRequired,
 
     /** The details about the user that is signed in */
     user: PropTypes.shape({
@@ -65,6 +69,7 @@ const publicLink = CONFIG.EXPENSIFY.URL_EXPENSIFY_COM + CONST.ADD_SECONDARY_LOGI
 const manageCardLink = CONFIG.EXPENSIFY.URL_EXPENSIFY_COM + CONST.MANAGE_CARDS_URL;
 
 const WorkspaceCardPage = ({
+    betas,
     user,
     translate,
     isSmallScreenWidth,
@@ -91,6 +96,11 @@ const WorkspaceCardPage = ({
             Navigation.navigate(ROUTES.getBankAccountRoute());
         }
     };
+
+    if (!Permissions.canUseFreePlan(betas)) {
+        console.debug('Not showing workspace card page because user is not on free plan beta');
+        return <Navigation.DismissModal />;
+    }
 
     return (
         <ScreenWrapper style={[styles.defaultModalContainer]}>
@@ -192,6 +202,9 @@ export default compose(
         },
         reimbursementAccount: {
             key: ONYXKEYS.REIMBURSEMENT_ACCOUNT,
+        },
+        betas: {
+            key: ONYXKEYS.BETAS,
         },
     }),
 )(WorkspaceCardPage);

--- a/src/pages/workspace/WorkspacePeoplePage.js
+++ b/src/pages/workspace/WorkspacePeoplePage.js
@@ -21,6 +21,7 @@ import Text from '../../components/Text';
 import ROUTES from '../../ROUTES';
 import ConfirmModal from '../../components/ConfirmModal';
 import personalDetailsPropType from '../personalDetailsPropType';
+import Permissions from '../../libs/Permissions';
 import withWindowDimensions, {windowDimensionsPropTypes} from '../../components/withWindowDimensions';
 import OptionRow from '../home/sidebar/OptionRow';
 
@@ -28,6 +29,9 @@ const propTypes = {
     ...withLocalizePropTypes,
 
     ...windowDimensionsPropTypes,
+
+    /** List of betas */
+    betas: PropTypes.arrayOf(PropTypes.string),
 
     /** The personal details of the person who is logged in */
     personalDetails: personalDetailsPropType.isRequired,
@@ -204,6 +208,10 @@ class WorkspacePeoplePage extends React.Component {
     }
 
     render() {
+        if (!Permissions.canUseFreePlan(this.props.betas)) {
+            console.debug('Not showing workspace people page because user is not on free plan beta');
+            return <Navigation.DismissModal />;
+        }
         const policyEmployeeList = lodashGet(this.props, 'policy.employeeList', []);
         const data = _.chain(policyEmployeeList)
             .map(email => this.props.personalDetails[email])
@@ -284,6 +292,9 @@ export default compose(
         },
         session: {
             key: ONYXKEYS.SESSION,
+        },
+        betas : {
+            key: ONYXKEYS.BETAS,
         },
     }),
 )(WorkspacePeoplePage);

--- a/src/pages/workspace/WorkspacePeoplePage.js
+++ b/src/pages/workspace/WorkspacePeoplePage.js
@@ -31,7 +31,7 @@ const propTypes = {
     ...windowDimensionsPropTypes,
 
     /** List of betas */
-    betas: PropTypes.arrayOf(PropTypes.string),
+    betas: PropTypes.arrayOf(PropTypes.string).isRequired,
 
     /** The personal details of the person who is logged in */
     personalDetails: personalDetailsPropType.isRequired,
@@ -293,7 +293,7 @@ export default compose(
         session: {
             key: ONYXKEYS.SESSION,
         },
-        betas : {
+        betas: {
             key: ONYXKEYS.BETAS,
         },
     }),


### PR DESCRIPTION
@johnmlee101, please review when you get the chance.

### Details
Add Beta Check to workspaces page. These changes don't to be CP'ed because these pages aren't functional if you aren't in the beta and also if you haven't already created a workspace. However you can still access `new.expensify.com/workspace` and if you somehow knew the URL you shouldn't see that page. It'll look unfunctional since there's no **sidebar:**
![image](https://user-images.githubusercontent.com/19364431/127241439-381e9047-aa07-429c-ab00-ebea1d2e849c.png)

This is valuable for us because switching between accounts that are in beta and outside of beta (if you were on the workspace settings page last) won't redirect you to the regular chat page, but show you this weird unfunctional modal instead modal instead.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/172009

### Tests
Locally all betas should be active, so these steps were used to verify this works
1. Change [this line](https://github.com/Expensify/App/blob/1275f58c4a171c03cbe01e7fa14cebcfdb280f85/src/libs/Permissions.js#L43) to get rid of the ` || canUseAllBetas(betas)` so that your local dev account doesn't have access to the beta.
2. Go to `localhost:8080/workspace` and `localhost:8080/workspace/undefined/people` and `localhost:8080/workspace/undefined/card`
3. Verify all 3 of those links bring you back to a regular chat page and does not open a blank modal like in the screenshots below.

### QA Steps
Don't need to test the people page portion of this because you can't really be in a workspace
1. Log in with an account that is NOT in the freePlan beta
2. Go to staging.new.expensify.com/workspace and make sure you can't see a modal like this (you should get redirected to chat like you just logged in):
![image](https://user-images.githubusercontent.com/19364431/127241439-381e9047-aa07-429c-ab00-ebea1d2e849c.png)
3. Go to `staging.new.expensify.com/workspace/undefined/card` and verify you do not see a modal like above
4. Go to `staging.new.expensify.com/workspace/undefined/people` and verify you do NOT see a modal like this:
![image](https://user-images.githubusercontent.com/19364431/127242082-b26cb622-fec9-455e-8982-9b8196e091cd.png)


### Tested On
Only affects web.

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
Included in QA steps. 