### PR TITLE
[No QA] Implement Why Did You Render

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,4 @@ SECURE_NGROK_URL=https://secure-expensify-user.ngrok.io/
 NGROK_URL=https://expensify-user.ngrok.io/
 USE_NGROK=false
 USE_WEB_PROXY=false
+USE_WDYR=false

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -25,11 +25,11 @@
 **Suggested:** [Deep Dive with the React DevTools creator](https://www.youtube.com/watch?v=nySib7ipZdk)
 
 ### Why Did You Render?
-- Why Did You Render (WDYR) sends notifications about potentially avoidable component re-renders.
+- Why Did You Render (WDYR) sends console notifications about potentially avoidable component re-renders.
 - It can also help to simply track when and why a certain component re-renders.
 - To enable it, set `USE_WDYR=true` in your `.env` file. 
 - You can add or exclude tracked components by their `displayName` in `wdyr.js`.
-- Open the Chrome Dev Tools console to see WDYR notifications.
+- Open the browser console to see WDYR notifications.
 
 **Suggested** [Why Did You Render docs](https://github.com/welldone-software/why-did-you-render)
 

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -24,6 +24,15 @@
 
 **Suggested:** [Deep Dive with the React DevTools creator](https://www.youtube.com/watch?v=nySib7ipZdk)
 
+### Why Did You Render?
+- Why Did You Render (WDYR) sends notifications about potentially avoidable component re-renders.
+- It can also help to simply track when and why a certain component re-renders.
+- To enable it, set `USE_WDYR=true` in your `.env` file. 
+- You can add or exclude tracked components by their `displayName` in `wdyr.js`.
+- Open the Chrome Dev Tools console to see WDYR notifications.
+
+**Suggested** [Why Did You Render docs](https://github.com/welldone-software/why-did-you-render)
+
 ## Reconciliation
 
 React is pretty smart and in many cases is able to tell if something needs to update. The process by which React goes about updating the "tree" or view heirarchy is called reconciliation. If React thinks something needs to update it will render it again. React also assumes that if a parent component rendered then it's child should also re-render.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15678,6 +15678,15 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@welldone-software/why-did-you-render": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@welldone-software/why-did-you-render/-/why-did-you-render-6.2.0.tgz",
+      "integrity": "sha512-ViwaE09Vgb0yXzyZuGTWCmWy/nBRAEGyztMdFYuxIgmL8yoXX5TVMCfieiJGdRQQPiDUznlYmcu0lu8kN1lwtQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4"
+      }
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "@testing-library/jest-native": "^3.4.2",
     "@testing-library/react-native": "^7.0.2",
     "@vercel/ncc": "^0.27.0",
+    "@welldone-software/why-did-you-render": "^6.2.0",
     "ajv-cli": "^5.0.0",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^26.2.2",

--- a/src/App.js
+++ b/src/App.js
@@ -1,3 +1,4 @@
+import '../wdyr';
 import React from 'react';
 import {LogBox} from 'react-native';
 import {SafeAreaProvider} from 'react-native-safe-area-context';

--- a/wdyr.js
+++ b/wdyr.js
@@ -12,6 +12,7 @@ if (useWDYR && process.env.NODE_ENV === 'development') {
         // Include and exclude components to be tracked by their displayName here
         include: [
             /^Avatar/,
+            /^ReportActionItem/,
             /^ReportActionItemSingle/,
         ],
         exclude: [],

--- a/wdyr.js
+++ b/wdyr.js
@@ -9,15 +9,22 @@ const useWDYR = lodashGet(Config, 'USE_WDYR') === 'true';
 if (useWDYR) {
     const whyDidYouRender = require('@welldone-software/why-did-you-render');
     whyDidYouRender(React, {
-        // Tracks all components by default
+        // Enable tracking in all pure components by default
         trackAllPureComponents: true,
 
-        // Uncomment below to include/exclude components to be tracked by their displayName
-        // include: [
-        //     /^Avatar/,
-        //     /^ReportActionItem/,
-        //     /^ReportActionItemSingle/,
-        // ],
-        // exclude: [],
+        include: [
+            // Uncomment to enable tracking in all components. Must also uncomment /^Screen/ in exclude.
+            // /.*/,
+
+            // Uncomment to enable tracking by displayName, e.g.:
+            // /^Avatar/,
+            // /^ReportActionItem/,
+            // /^ReportActionItemSingle/,
+        ],
+
+        exclude: [
+            // Uncomment to enable tracking in all components
+            // /^Screen/
+        ],
     });
 }

--- a/wdyr.js
+++ b/wdyr.js
@@ -9,12 +9,15 @@ const useWDYR = lodashGet(Config, 'USE_WDYR') === 'true';
 if (useWDYR) {
     const whyDidYouRender = require('@welldone-software/why-did-you-render');
     whyDidYouRender(React, {
-        // Include and exclude components to be tracked by their displayName here
-        include: [
-            /^Avatar/,
-            /^ReportActionItem/,
-            /^ReportActionItemSingle/,
-        ],
-        exclude: [],
+        // Tracks all components by default
+        trackAllPureComponents: true,
+
+        // Uncomment below to include/exclude components to be tracked by their displayName
+        // include: [
+        //     /^Avatar/,
+        //     /^ReportActionItem/,
+        //     /^ReportActionItemSingle/,
+        // ],
+        // exclude: [],
     });
 }

--- a/wdyr.js
+++ b/wdyr.js
@@ -1,0 +1,19 @@
+// Implements Why Did You Render (WDYR) in Dev
+
+import React from 'react';
+import Config from 'react-native-config';
+import lodashGet from 'lodash/get';
+
+const useWDYR = lodashGet(Config, 'USE_WDYR', 'false') === 'true';
+
+if (useWDYR && process.env.NODE_ENV === 'development') {
+    const whyDidYouRender = require('@welldone-software/why-did-you-render');
+    whyDidYouRender(React, {
+        // Include and exclude components to be tracked by their displayName here
+        include: [
+            /^Avatar/,
+            /^ReportActionItemSingle/,
+        ],
+        exclude: [],
+    });
+}

--- a/wdyr.js
+++ b/wdyr.js
@@ -4,9 +4,9 @@ import React from 'react';
 import Config from 'react-native-config';
 import lodashGet from 'lodash/get';
 
-const useWDYR = lodashGet(Config, 'USE_WDYR', 'false') === 'true';
+const useWDYR = lodashGet(Config, 'USE_WDYR') === 'true';
 
-if (useWDYR && process.env.NODE_ENV === 'development') {
+if (useWDYR) {
     const whyDidYouRender = require('@welldone-software/why-did-you-render');
     whyDidYouRender(React, {
         // Include and exclude components to be tracked by their displayName here


### PR DESCRIPTION
cc @marcaaron @chiragsalian 

### Details
Implements Why Did You Render to help track and avoid unnecessary re-renders. Once enabled, it will track re-renders of `Avatar`, `ReportActionItem` and `ReportActionItemSingle`. More components can be added in `wdyr.js`.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/165181

### Tests
1. Set `USE_WDYR=true` in your `.env` file.
2.  Run `npm run web`
3. Open the browser console and see notifications from Why Did You Render.
4. Profit!

### QA Steps
Internal QA

### Tested On

- [X] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots

#### Web
![Screen Shot 2021-07-27 at 4 02 31 PM](https://user-images.githubusercontent.com/22219519/127234810-7b3ff2eb-14cb-44e2-b044-ac59f43d48dd.png)

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
