### PR TITLE
Fix bolded text for Existing Owners Error

### DIFF
--- a/src/libs/actions/BankAccounts.js
+++ b/src/libs/actions/BankAccounts.js
@@ -618,18 +618,12 @@ function setupWithdrawalAccount(data) {
                 // Show warning if another account already set up this bank account and promote share
                 if (response.existingOwners) {
                     console.error('Cannot set up withdrawal account due to existing owners', response);
-                    const existingOwnersList = response.existingOwners.reduce((ownersStr, owner, i, ownersArr) => {
-                        let separator = ',\n';
-                        if (i === 0) {
-                            separator = '\n';
-                        } else if (i === ownersArr.length - 1) {
-                            separator = ' and\n';
-                        }
-                        return `${ownersStr}${separator}${owner}`;
-                    }, '');
                     Onyx.merge(
                         ONYXKEYS.REIMBURSEMENT_ACCOUNT,
-                        {existingOwnersList, error: CONST.BANK_ACCOUNT.ERROR.EXISTING_OWNERS},
+                        {
+                            existingOwners: response.existingOwners,
+                            error: CONST.BANK_ACCOUNT.ERROR.EXISTING_OWNERS,
+                        },
                     );
                     return;
                 }

--- a/src/pages/ReimbursementAccount/BankAccountStep.js
+++ b/src/pages/ReimbursementAccount/BankAccountStep.js
@@ -253,7 +253,7 @@ class BankAccountStep extends React.Component {
                     onConfirm={hideExistingOwnersError}
                     shouldShowCancelButton={false}
                     prompt={(
-                        <View style={[styles.flex1]}>
+                        <View>
                             <Text style={[styles.mb4]}>
                                 <Text>
                                     {this.props.translate('bankAccount.error.existingOwners.alreadyInUse')}

--- a/src/pages/ReimbursementAccount/BankAccountStep.js
+++ b/src/pages/ReimbursementAccount/BankAccountStep.js
@@ -36,8 +36,8 @@ const propTypes = {
         /** Error set when handling the API response */
         error: PropTypes.string,
 
-        /** A list of existing owners, set if the bank account being added is already owned */
-        existingOwnersList: PropTypes.string,
+        /** The existing owners for if the bank account is already owned */
+        existingOwners: PropTypes.arrayOf(PropTypes.string),
     }).isRequired,
 
     ...withLocalizePropTypes,
@@ -129,8 +129,9 @@ class BankAccountStep extends React.Component {
         // Disable bank account fields once they've been added in db so they can't be changed
         const isFromPlaid = this.props.achData.setupType === CONST.BANK_ACCOUNT.SETUP_TYPE.PLAID;
         const shouldDisableInputs = Boolean(this.props.achData.bankAccountID) || isFromPlaid;
+        const existingOwners = this.props.reimbursementAccount.existingOwners;
         const isExistingOwnersErrorVisible = Boolean(this.props.reimbursementAccount.error
-            && this.props.reimbursementAccount.existingOwnersList);
+            && existingOwners);
         return (
             <View style={[styles.flex1, styles.justifyContentBetween]}>
                 <HeaderWithCloseButton
@@ -257,9 +258,21 @@ class BankAccountStep extends React.Component {
                                 <Text>
                                     {this.props.translate('bankAccount.error.existingOwners.alreadyInUse')}
                                 </Text>
-                                <Text style={styles.textStrong}>
-                                    {this.props.reimbursementAccount.existingOwnersList}
-                                </Text>
+                                {existingOwners && existingOwners.map((existingOwner, i) => {
+                                    let separator = ', ';
+                                    if (i === 0) {
+                                        separator = '';
+                                    } else if (i === existingOwners.length - 1) {
+                                        separator = ` ${this.props.translate('common.and')} `;
+                                    }
+                                    return (
+                                        <>
+                                            <Text>{separator}</Text>
+                                            <Text style={styles.textStrong}>{existingOwner}</Text>
+                                            {i === existingOwners.length - 1 && <Text>.</Text>}
+                                        </>
+                                    );
+                                })}
                             </Text>
                             <Text style={[styles.mb4]}>
                                 {this.props.translate('bankAccount.error.existingOwners.pleaseAskThemToShare')}


### PR DESCRIPTION
### Details
This PR fixes the text in the error message to prevent any separators (e.g. `, `, `, and`, etc.) from being bolded. It also ensures we use the localization for the word `and`.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/169896#issuecomment-884327715

### Tests
1. Paste this code block [here](https://github.com/Expensify/App/blob/3ea4b275d6fa885e631a69d6335bc80a46e4f955/src/libs/actions/BankAccounts.js#L600). This'll simulate the server returning with an existingOwners error:
    ```js
    return new Promise(resolve => resolve({existingOwners: ['patrick@expensify.com', 'spongebob@expensify.com', 'sandy@expensify.com']})).then((response) => {
        const existingOwnersList = response.existingOwners.reduce((ownersStr, owner, i, ownersArr) => {
            let separator = ',\n';
            if (i === 0) {
                separator = '\n';
            } else if (i === ownersArr.length - 1) {
                separator = ' and\n';
            }
            return `${ownersStr}${separator}${owner}`;
        }, '');
        Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {loading: false, error: CONST.BANK_ACCOUNT.ERROR.EXISTING_OWNERS, existingOwnersList});
    });
    ```
2. Navigate to the add bank account flow for a workspace. 
3. Verify that you're unable to add the account since the bank account already has an existing owner, and verify that the error step displays (see screenshots).

### QA
1. Create a new workspace and click "Get Started".
2. Add a bank account manually following the steps [here](https://stackoverflow.com/c/expensify/questions/342).
3. In a different account, follow steps 1 and 2.
4. Verify that you're unable to add the account since the bank account already has an existing owner, and verify that the error step displays (see screenshots).

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<img width="1209" alt="Screen Shot 2021-07-27 at 3 45 11 PM" src="https://user-images.githubusercontent.com/31285285/127237280-b1d0695c-9bcd-4094-be56-53cb14e07541.png">

#### Mobile Web
<img width="408" alt="Screen Shot 2021-07-27 at 3 45 25 PM" src="https://user-images.githubusercontent.com/31285285/127237294-7c45605c-34a3-4827-88fe-663a05c977e0.png">

#### Desktop
<img width="1195" alt="Screen Shot 2021-07-27 at 3 47 18 PM" src="https://user-images.githubusercontent.com/31285285/127237304-272ce0d3-5f5c-45ba-9063-3e4233aa9300.png">

#### iOS
<img width="375" alt="Screen Shot 2021-07-27 at 3 45 34 PM" src="https://user-images.githubusercontent.com/31285285/127237313-43cc3c7a-c7df-4bca-b1c9-55c8ac410287.png">

#### Android
<img width="386" alt="Screen Shot 2021-07-28 at 11 39 34 AM" src="https://user-images.githubusercontent.com/31285285/127377951-5e5797e1-3fef-42e2-aac8-29b070e935f6.png">


cc @michelle-thompson 