### PR TITLE
Prevent accounts without account numbers from breaking the payments page

### DIFF
--- a/src/libs/actions/PaymentMethods.js
+++ b/src/libs/actions/PaymentMethods.js
@@ -13,6 +13,8 @@ function getPaymentMethods() {
     return API.Get({
         returnValueList: 'bankAccountList, cardList, userWallet, nameValuePairs',
         name: 'paypalMeAddress',
+        includeDeleted: false,
+        includeNotIssued: false,
     })
         .then((response) => {
             Onyx.multiSet({

--- a/src/pages/settings/Payments/PaymentMethodList.js
+++ b/src/pages/settings/Payments/PaymentMethodList.js
@@ -83,12 +83,15 @@ class PaymentMethodList extends Component {
         _.each(this.props.bankAccountList, (bankAccount) => {
             // Add all bank accounts besides the wallet
             if (bankAccount.type !== CONST.BANK_ACCOUNT_TYPES.WALLET) {
+                const formattedBankAccountNumber = bankAccount.accountNumber
+                    ? `${this.props.translate('paymentMethodList.accountLastFour')} ${bankAccount.accountNumber.slice(-4)}`
+                    : null;
                 combinedPaymentMethods.push({
                     type: MENU_ITEM,
                     title: bankAccount.addressName,
 
                     // eslint-disable-next-line
-                    description: `${this.props.translate('paymentMethodList.accountLastFour')} ${bankAccount.accountNumber.slice(-4)}`,
+                    description: formattedBankAccountNumber,
                     icon: Bank,
                     onPress: e => this.props.onPress(e, bankAccount.bankAccountID),
                     key: `bankAccount-${bankAccount.bankAccountID}`,
@@ -99,12 +102,15 @@ class PaymentMethodList extends Component {
         _.each(this.props.cardList, (card) => {
             // Add all cards besides the "cash" card
             if (card.cardName !== CONST.CARD_TYPES.DEFAULT_CASH) {
+                const formattedCardNumber = card.cardNumber
+                    ? `${this.props.translate('paymentMethodList.cardLastFour')} ${card.cardNumber.slice(-4)}`
+                    : null;
                 combinedPaymentMethods.push({
                     type: MENU_ITEM,
                     title: card.cardName,
 
                     // eslint-disable-next-line
-                    description: `${this.props.translate('paymentMethodList.cardLastFour')} ${card.cardNumber.slice(-4)}`,
+                    description: formattedCardNumber,
                     icon: CreditCard,
                     onPress: e => this.props.onPress(e, card.cardID),
                     key: `card-${card.cardID}`,

--- a/src/pages/settings/Payments/PaymentMethodList.js
+++ b/src/pages/settings/Payments/PaymentMethodList.js
@@ -84,7 +84,9 @@ class PaymentMethodList extends Component {
             // Add all bank accounts besides the wallet
             if (bankAccount.type !== CONST.BANK_ACCOUNT_TYPES.WALLET) {
                 const formattedBankAccountNumber = bankAccount.accountNumber
-                    ? `${this.props.translate('paymentMethodList.accountLastFour')} ${bankAccount.accountNumber.slice(-4)}`
+                    ? `${this.props.translate('paymentMethodList.accountLastFour')} ${
+                        bankAccount.accountNumber.slice(-4)
+                    }`
                     : null;
                 combinedPaymentMethods.push({
                     type: MENU_ITEM,


### PR DESCRIPTION
### Details
1. Do not return un-issued or deleted cards
2. If we get an account without an account number just don't display the description.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/171546

### Tests
1. Log into e.cash with an account that has both a bank account and credit card
2. Make sure there are descriptions under each with the last 4 of the account numbers

### QA Steps
1. Ping @joekaufmanexpensify and ask him to go to the payments page
2. His page should not crash

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android
![2021-07-28_11-22-20](https://user-images.githubusercontent.com/42391420/127368150-61e3251d-eae9-4b6f-9e13-17095d9a26d0.png)
