### PR TITLE
Prevent large attachment

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -1,6 +1,8 @@
 const CLOUDFRONT_URL = 'https://d2k5nsl2zxldvw.cloudfront.net';
 
 const CONST = {
+    // 50 MB in bytes
+    API_MAX_ATTACHMENT_SIZE: 52428800,
     APP_DOWNLOAD_LINKS: {
         ANDROID: 'https://play.google.com/store/apps/details?id=com.expensify.chat',
         IOS: 'https://apps.apple.com/us/app/expensify-cash/id1530278510',

--- a/src/CONST.js
+++ b/src/CONST.js
@@ -1,7 +1,7 @@
 const CLOUDFRONT_URL = 'https://d2k5nsl2zxldvw.cloudfront.net';
 
 const CONST = {
-    // 50 MB in bytes
+    // 50 megabytes in bytes
     API_MAX_ATTACHMENT_SIZE: 52428800,
     APP_DOWNLOAD_LINKS: {
         ANDROID: 'https://play.google.com/store/apps/details?id=com.expensify.chat',

--- a/src/components/AttachmentModal.js
+++ b/src/components/AttachmentModal.js
@@ -2,6 +2,7 @@ import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {View} from 'react-native';
 import Str from 'expensify-common/lib/str';
+import lodashGet from 'lodash/get';
 import CONST from '../CONST';
 import Modal from './Modal';
 import AttachmentView from './AttachmentView';
@@ -98,7 +99,7 @@ class AttachmentModal extends PureComponent {
      * @returns {Boolean}
      */
     isValidSize(file) {
-        return !file || parseInt(file.size, 10) < CONST.API_MAX_ATTACHMENT_SIZE;
+        return !file || lodashGet(file, 'size', 0) < CONST.API_MAX_ATTACHMENT_SIZE;
     }
 
     render() {

--- a/src/components/AttachmentModal.js
+++ b/src/components/AttachmentModal.js
@@ -98,10 +98,7 @@ class AttachmentModal extends PureComponent {
      * @returns {Boolean}
      */
     isValidSize(file) {
-        if (!file) {
-            return true;
-        }
-        return parseInt(file.size, 10) < CONST.API_MAX_ATTACHMENT_SIZE;
+        return !file || parseInt(file.size, 10) < CONST.API_MAX_ATTACHMENT_SIZE;
     }
 
     render() {

--- a/src/components/AttachmentModal.js
+++ b/src/components/AttachmentModal.js
@@ -14,6 +14,7 @@ import Button from './Button';
 import HeaderWithCloseButton from './HeaderWithCloseButton';
 import fileDownload from '../libs/fileDownload';
 import withLocalize, {withLocalizePropTypes} from './withLocalize';
+import ConfirmModal from './ConfirmModal';
 
 /**
  * Modal render prop component that exposes modal launching triggers that can be used
@@ -58,11 +59,13 @@ class AttachmentModal extends PureComponent {
 
         this.state = {
             isModalOpen: false,
+            isConfirmModalOpen: false,
             file: null,
             sourceURL: props.sourceURL,
         };
 
         this.submitAndClose = this.submitAndClose.bind(this);
+        this.closeConfirmModal = this.closeConfirmModal.bind(this);
         this.isValidSize = this.isValidSize.bind(this);
     }
 
@@ -83,8 +86,15 @@ class AttachmentModal extends PureComponent {
     }
 
     /**
-     * Check if the attachment file is less than the API size limit.
-     * @param {Object} file 
+     * Close the confirm modal.
+     */
+    closeConfirmModal() {
+        this.setState({isConfirmModalOpen: false});
+    }
+
+    /**
+     * Check if the attachment size is less than the API size limit.
+     * @param {Object} file
      * @returns {Boolean}
      */
     isValidSize(file) {
@@ -147,8 +157,20 @@ class AttachmentModal extends PureComponent {
                         />
                     )}
                 </Modal>
+                <ConfirmModal
+                    title={this.props.translate('attachmentPicker.attachmentTooLarge')}
+                    onConfirm={this.closeConfirmModal}
+                    isVisible={this.state.isConfirmModalOpen}
+                    prompt={this.props.translate('attachmentPicker.sizeExceeded')}
+                    confirmText={this.props.translate('common.close')}
+                    shouldShowCancelButton={false}
+                />
                 {this.props.children({
                     displayFileInModal: ({file}) => {
+                        if (!this.isValidSize(file)) {
+                            this.setState({isConfirmModalOpen: true});
+                            return;
+                        }
                         if (file instanceof File) {
                             const source = URL.createObjectURL(file);
                             this.setState({isModalOpen: true, sourceURL: source, file});

--- a/src/components/AttachmentModal.js
+++ b/src/components/AttachmentModal.js
@@ -63,6 +63,7 @@ class AttachmentModal extends PureComponent {
         };
 
         this.submitAndClose = this.submitAndClose.bind(this);
+        this.isValidSize = this.isValidSize.bind(this);
     }
 
     /**
@@ -79,6 +80,18 @@ class AttachmentModal extends PureComponent {
         }
 
         this.setState({isModalOpen: false});
+    }
+
+    /**
+     * Check if the attachment file is less than the API size limit.
+     * @param {Object} file 
+     * @returns {Boolean}
+     */
+    isValidSize(file) {
+        if (!file) {
+            return true;
+        }
+        return parseInt(file.size, 10) < CONST.API_MAX_ATTACHMENT_SIZE;
     }
 
     render() {

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -70,6 +70,7 @@ export default {
         takePhoto: 'Take Photo',
         chooseFromGallery: 'Choose from Gallery',
         chooseDocument: 'Choose Document',
+        sizeExceeded: 'Attachment size is larger than 50 MB limit',
     },
     textInputFocusable: {
         noExtentionFoundForMimeType: 'No extension found for mime type',

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -71,7 +71,7 @@ export default {
         chooseFromGallery: 'Choose from Gallery',
         chooseDocument: 'Choose Document',
         attachmentTooLarge: 'Attachment too large',
-        sizeExceeded: 'Attachment size is larger than 50 MB limit',
+        sizeExceeded: 'Attachment size is larger than 50 MB limit.',
     },
     textInputFocusable: {
         noExtentionFoundForMimeType: 'No extension found for mime type',

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -70,6 +70,7 @@ export default {
         takePhoto: 'Take Photo',
         chooseFromGallery: 'Choose from Gallery',
         chooseDocument: 'Choose Document',
+        attachmentTooLarge: 'Attachment too large',
         sizeExceeded: 'Attachment size is larger than 50 MB limit',
     },
     textInputFocusable: {

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -65,6 +65,7 @@ export default {
         takePhoto: 'Hacer una Foto',
         chooseFromGallery: 'Elegir de la galería',
         chooseDocument: 'Elegir Documento',
+        sizeExceeded: 'El archivo adjunto supera el límite de 50 MB',
     },
     textInputFocusable: {
         noExtentionFoundForMimeType: 'No se encontró una extension para este tipo de contenido',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -66,7 +66,7 @@ export default {
         chooseFromGallery: 'Elegir de la galería',
         chooseDocument: 'Elegir Documento',
         attachmentTooLarge: 'Archivo adjunto demasiado grandes',
-        sizeExceeded: 'El archivo adjunto supera el límite de 50 MB',
+        sizeExceeded: 'El archivo adjunto supera el límite de 50 MB.',
     },
     textInputFocusable: {
         noExtentionFoundForMimeType: 'No se encontró una extension para este tipo de contenido',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -65,6 +65,7 @@ export default {
         takePhoto: 'Hacer una Foto',
         chooseFromGallery: 'Elegir de la galería',
         chooseDocument: 'Elegir Documento',
+        attachmentTooLarge: 'Archivo adjunto demasiado grandes',
         sizeExceeded: 'El archivo adjunto supera el límite de 50 MB',
     },
     textInputFocusable: {

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -65,7 +65,7 @@ export default {
         takePhoto: 'Hacer una Foto',
         chooseFromGallery: 'Elegir de la galería',
         chooseDocument: 'Elegir Documento',
-        attachmentTooLarge: 'Archivo adjunto demasiado grandes',
+        attachmentTooLarge: 'Archivo adjunto demasiado grande',
         sizeExceeded: 'El archivo adjunto supera el límite de 50 MB.',
     },
     textInputFocusable: {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Acceptable API attachment size: Less than 50 MB (52428800 bytes). [Source](https://github.com/Expensify/App/issues/3926#issuecomment-887720880)

`ConfirmModal` is used to display a message when a larger file is uploaded.

The following language is added.
#### English
 Attachment too large
Attachment size is larger than 50 MB limit.
#### Spanish ([Source](https://github.com/Expensify/App/issues/3926#issuecomment-887715529) & [verification](https://expensify.slack.com/archives/C01GTK53T8Q/p1627470098380100))
Archivo adjunto demasiado grande
El archivo adjunto supera el límite de 50 MB.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ #3926 

### Tests / QA
1. Create a dummy file of size at least 50 MB (52428800 bytes).
- Windows: `fsutil file createnew test50 52428800`
- MacOS: `mkfile -n test50 50m`
2. Login to New Expensify.
3. Navigate to any user.
4.  Press `+` in chat, then press Add Attachment. 
5. Select the dummy file.
6. Verify that Attachment too large message is shown.
7. Similarly, verify that you can upload a file smaller than 50 MB.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
##### English 
<img width="1440" alt="Screen Shot 2021-07-28 at 12 25 32 PM" src="https://user-images.githubusercontent.com/29673073/127305698-c0378e42-2594-4860-8d89-42545f65ee72.png">

##### Spanish
<img width="1440" alt="Screen Shot 2021-07-28 at 12 39 48 PM" src="https://user-images.githubusercontent.com/29673073/127309673-5c57df29-1587-4bcf-ac7f-afc8717edcc5.png">

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
<img src="https://user-images.githubusercontent.com/29673073/127305733-b52e06ea-249b-4a30-98c5-fe0ab9aafa78.jpeg" height="500">

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
<img width="1312" alt="Screen Shot 2021-07-28 at 12 55 50 PM" src="https://user-images.githubusercontent.com/29673073/127305788-6ad76214-b704-4ec5-840d-d5db89fe2e4b.png">

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
<img width="478" alt="Screen Shot 2021-07-28 at 12 54 16 PM" src="https://user-images.githubusercontent.com/29673073/127305804-cbf68b45-4b6f-43df-8369-f95410ed43e7.png">

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
<img src="https://user-images.githubusercontent.com/29673073/127305751-ec1af31b-d7e1-433a-bb35-b2b30fb795da.jpeg" height="500">
