### PR TITLE
Disable the submit button if required form fields are not filled out

### DIFF
--- a/src/pages/ReimbursementAccount/CompanyStep.js
+++ b/src/pages/ReimbursementAccount/CompanyStep.js
@@ -65,18 +65,8 @@ class CompanyStep extends React.Component {
      * @returns {Boolean}
      */
     validate() {
-        if (!this.state.password.trim()) {
-            Growl.error(this.props.translate('common.passwordCannotBeBlank'));
-            return false;
-        }
-
         if (!isValidAddress(this.state.addressStreet)) {
             Growl.error(this.props.translate('bankAccount.error.addressStreet'));
-            return false;
-        }
-
-        if (this.state.addressState === '') {
-            Growl.error(this.props.translate('bankAccount.error.addressState'));
             return false;
         }
 

--- a/src/pages/ReimbursementAccount/CompanyStep.js
+++ b/src/pages/ReimbursementAccount/CompanyStep.js
@@ -65,8 +65,18 @@ class CompanyStep extends React.Component {
      * @returns {Boolean}
      */
     validate() {
+        if (!this.state.password.trim()) {
+            Growl.error(this.props.translate('common.passwordCannotBeBlank'));
+            return false;
+        }
+
         if (!isValidAddress(this.state.addressStreet)) {
             Growl.error(this.props.translate('bankAccount.error.addressStreet'));
+            return false;
+        }
+
+        if (this.state.addressState === '') {
+            Growl.error(this.props.translate('bankAccount.error.addressState'));
             return false;
         }
 

--- a/src/pages/ReimbursementAccount/CompanyStep.js
+++ b/src/pages/ReimbursementAccount/CompanyStep.js
@@ -45,6 +45,19 @@ class CompanyStep extends React.Component {
             hasNoConnectionToCannabis: lodashGet(props, ['achData', 'hasNoConnectionToCannabis'], false),
             password: '',
         };
+
+        // These fields need to be filled out in order to submit the form
+        this.requiredFields = [
+            'companyName',
+            'addressStreet',
+            'addressCity',
+            'addressState',
+            'addressZipCode',
+            'companyTaxID',
+            'incorporationDate',
+            'industryCode',
+            'password',
+        ];
     }
 
     /**
@@ -111,6 +124,8 @@ class CompanyStep extends React.Component {
     render() {
         const shouldDisableCompanyName = Boolean(this.props.achData.bankAccountID && this.props.achData.companyName);
         const shouldDisableCompanyTaxID = Boolean(this.props.achData.bankAccountID && this.props.achData.companyTaxID);
+        const shouldDisableSubmitButton = this.requiredFields
+            .reduce((acc, curr) => acc || !this.state[curr].trim(), false);
         return (
             <>
                 <HeaderWithCloseButton
@@ -253,6 +268,7 @@ class CompanyStep extends React.Component {
                         onPress={this.submit}
                         style={[styles.w100]}
                         text={this.props.translate('common.saveAndContinue')}
+                        isDisabled={shouldDisableSubmitButton}
                     />
                 </FixedFooter>
             </>

--- a/src/pages/ReimbursementAccount/CompanyStep.js
+++ b/src/pages/ReimbursementAccount/CompanyStep.js
@@ -53,6 +53,7 @@ class CompanyStep extends React.Component {
             'addressCity',
             'addressState',
             'addressZipCode',
+            'website',
             'companyTaxID',
             'incorporationDate',
             'industryCode',


### PR DESCRIPTION
### Details
See issue for more context.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/171673

### Tests/QA
1. Navigate to the company step in the VBA flow: `<baseURL>/bank-account/company`.
2. These are the fields that need to be filled out in order for the "Save & Continue" button to be enabled. Verify that the button is disabled if any of these fields aren't filled out. You don't need to input a valid value, any value will suffice as long as it isn't empty:
    - Legal Business Name
    - Company Address
    - City (for company address)
    - State (for company address)
    - Zip Code (for company address)
    - Company Website
    - Tax ID Number
    - Incorporation Date
    - Industry Classification Code
    - Expensify Password

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [ ] Android

### Screenshots
N/A