### PR TITLE
Fix rendering of timezone info inside chats when the selected language is Spanish

### DIFF
--- a/src/pages/home/report/ParticipantLocalTime.js
+++ b/src/pages/home/report/ParticipantLocalTime.js
@@ -35,6 +35,10 @@ class ParticipantLocalTime extends React.Component {
         }, 1000));
     }
 
+    shouldComponentUpdate(nextProps, nextState) {
+        return nextState.localTime !== this.state.localTime;
+    }
+
     componentWillUnmount() {
         clearInterval(this.timer);
         clearInterval(this.readyTimer);
@@ -42,6 +46,7 @@ class ParticipantLocalTime extends React.Component {
 
     getParticipantLocalTime() {
         const reportRecipientTimezone = lodashGet(this.props.participant, 'timezone', {});
+        moment.locale(this.props.preferredLocale);
         const reportRecipientDay = moment().tz(reportRecipientTimezone.selected).format('dddd');
         const currentUserDay = moment().tz(this.props.currentUserTimezone.selected).format('dddd');
 
@@ -52,38 +57,32 @@ class ParticipantLocalTime extends React.Component {
     }
 
     render() {
-        // Moment.format does not return AM or PM values immediately.
-        // So we have to wait until we are ready before showing the time to the user
-        const isReportRecipientLocalTimeReady = this.state.localTime.toString().match(/(A|P)M/ig);
         const reportRecipientDisplayName = this.props.participant.firstName
             || (Str.isSMSLogin(this.props.participant.login)
                 ? this.props.toLocalPhone(this.props.participant.displayName)
                 : this.props.participant.displayName);
 
         return (
-            isReportRecipientLocalTimeReady ? (
-                <View style={[styles.chatItemComposeSecondaryRow]}>
-                    <View style={[
-                        styles.chatItemComposeSecondaryRowOffset,
-                        styles.flexRow,
-                        styles.alignItemsCenter]}
-                    >
-                        <ExpensiText style={[styles.chatItemComposeSecondaryRowSubText, styles.mr1]}>
-                            {this.props.translate('common.timePrefix')}
-                        </ExpensiText>
-                        <ExpensiText style={[styles.textMicroSupportingBold, styles.mr1]}>
-                            {this.state.localTime}
-                        </ExpensiText>
-                        <ExpensiText style={[styles.chatItemComposeSecondaryRowSubText, styles.mr1]}>
-                            {this.props.translate('common.conjunctionFor')}
-                        </ExpensiText>
-                        <ExpensiText style={[styles.textMicroSupportingBold]}>
-                            {reportRecipientDisplayName}
-                        </ExpensiText>
-                    </View>
+            <View style={[styles.chatItemComposeSecondaryRow]}>
+                <View style={[
+                    styles.chatItemComposeSecondaryRowOffset,
+                    styles.flexRow,
+                    styles.alignItemsCenter]}
+                >
+                    <ExpensiText style={[styles.chatItemComposeSecondaryRowSubText, styles.mr1]}>
+                        {this.props.translate('common.timePrefix')}
+                    </ExpensiText>
+                    <ExpensiText style={[styles.textMicroSupportingBold, styles.mr1]}>
+                        {this.state.localTime}
+                    </ExpensiText>
+                    <ExpensiText style={[styles.chatItemComposeSecondaryRowSubText, styles.mr1]}>
+                        {this.props.translate('common.conjunctionFor')}
+                    </ExpensiText>
+                    <ExpensiText style={[styles.textMicroSupportingBold]}>
+                        {reportRecipientDisplayName}
+                    </ExpensiText>
                 </View>
-            )
-                : <View style={[styles.chatItemComposeSecondaryRow]} />
+            </View>
         );
     }
 }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
([Comment](https://github.com/expensify/app/issues/4218#issuecomment-886613169))

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ #4218 

### Tests || ### QA Steps
1. Login to the app
2. Change your language to Spanish
3. Open any chat
4. Timezone information in the chat will be shown


--->

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Android
- Can't test on these two 
- [ ] Desktop
- [ ] iOS

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
https://user-images.githubusercontent.com/28243942/127539644-393480b3-c50b-4b6e-ad81-eff74f89ff5d.mp4



#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
https://user-images.githubusercontent.com/28243942/127539503-34cdb044-3233-46ad-9fe2-5d37404ee340.mp4



#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->

https://user-images.githubusercontent.com/28243942/127539844-d976f094-6a21-40bf-a0a9-b89dca761999.mp4

