### PR TITLE
Update Onyx version to improve handling of defaultKeyStates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36080,8 +36080,8 @@
       }
     },
     "react-native-onyx": {
-      "version": "git+https://github.com/Expensify/react-native-onyx.git#61e688873dd582af22d6461c416d9967304e67a8",
-      "from": "git+https://github.com/Expensify/react-native-onyx.git#61e688873dd582af22d6461c416d9967304e67a8",
+      "version": "git+https://github.com/Expensify/react-native-onyx.git#d73900b7cb7bf82bed77cb6b6baabf8fe2eb3a0e",
+      "from": "git+https://github.com/Expensify/react-native-onyx.git#d73900b7cb7bf82bed77cb6b6baabf8fe2eb3a0e",
       "requires": {
         "ascii-table": "0.0.9",
         "expensify-common": "git+https://github.com/Expensify/expensify-common.git#2e5cff552cf132da90a3fb9756e6b4fb6ae7b40c",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16350,6 +16350,11 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
+    "ascii-table": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/ascii-table/-/ascii-table-0.0.9.tgz",
+      "integrity": "sha1-BqZgTWpV1L9BqaR9mHLXp42jHnM="
+    },
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -36075,12 +36080,12 @@
       }
     },
     "react-native-onyx": {
-      "version": "git+https://github.com/Expensify/react-native-onyx.git#84a27cdd03a39baa167058efc3379d9a477849dd",
-      "from": "git+https://github.com/Expensify/react-native-onyx.git#84a27cdd03a39baa167058efc3379d9a477849dd",
+      "version": "git+https://github.com/Expensify/react-native-onyx.git#61e688873dd582af22d6461c416d9967304e67a8",
+      "from": "git+https://github.com/Expensify/react-native-onyx.git#61e688873dd582af22d6461c416d9967304e67a8",
       "requires": {
+        "ascii-table": "0.0.9",
         "expensify-common": "git+https://github.com/Expensify/expensify-common.git#2e5cff552cf132da90a3fb9756e6b4fb6ae7b40c",
         "lodash": "4.17.21",
-        "react": "^16.13.1",
         "underscore": "^1.13.1"
       },
       "dependencies": {
@@ -36101,16 +36106,6 @@
             "underscore": "1.9.1"
           },
           "dependencies": {
-            "react": {
-              "version": "16.12.0",
-              "resolved": "https://registry.npmjs.org/react/-/react-16.12.0.tgz",
-              "integrity": "sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==",
-              "requires": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2"
-              }
-            },
             "underscore": {
               "version": "1.9.1",
               "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
@@ -36119,9 +36114,9 @@
           }
         },
         "react": {
-          "version": "16.14.0",
-          "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-          "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+          "version": "16.12.0",
+          "resolved": "https://registry.npmjs.org/react/-/react-16.12.0.tgz",
+          "integrity": "sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==",
           "requires": {
             "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "react-native-image-picker": "^4.0.3",
     "react-native-keyboard-spacer": "^0.4.1",
     "react-native-modal": "^11.10.0",
-    "react-native-onyx": "git+https://github.com/Expensify/react-native-onyx.git#61e688873dd582af22d6461c416d9967304e67a8",
+    "react-native-onyx": "git+https://github.com/Expensify/react-native-onyx.git#d73900b7cb7bf82bed77cb6b6baabf8fe2eb3a0e",
     "react-native-pdf": "^6.2.2",
     "react-native-permissions": "^3.0.1",
     "react-native-picker-select": "8.0.4",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "react-native-image-picker": "^4.0.3",
     "react-native-keyboard-spacer": "^0.4.1",
     "react-native-modal": "^11.10.0",
-    "react-native-onyx": "git+https://github.com/Expensify/react-native-onyx.git#84a27cdd03a39baa167058efc3379d9a477849dd",
+    "react-native-onyx": "git+https://github.com/Expensify/react-native-onyx.git#61e688873dd582af22d6461c416d9967304e67a8",
     "react-native-pdf": "^6.2.2",
     "react-native-permissions": "^3.0.1",
     "react-native-picker-select": "8.0.4",

--- a/tests/unit/NetworkTest.js
+++ b/tests/unit/NetworkTest.js
@@ -15,6 +15,13 @@ jest.mock('../../src/libs/Notification/PushNotification', () => ({
 
 jest.useFakeTimers();
 
+Onyx.init({
+    keys: ONYXKEYS,
+    registerStorageEventListener: () => {},
+});
+
+beforeEach(() => Onyx.clear().then(waitForPromisesToResolve));
+
 test('failing to reauthenticate while offline should not log out user', () => {
     // Given a test user login and account ID
     const TEST_USER_LOGIN = 'test@testguy.com';


### PR DESCRIPTION
### Details

cc @kidroca updating the Onyx version to incorporate the latest changes regarding `defaultKeyStates`

**Notes:** 

There are two changes included in this PR under one sha

- `defaultKeyStates` PR - I ran some basic user timing tests around boot time and when the side bar first loads, but didn't notice anything worthy of reporting as far as performance improvements. We are viewing this as a pre-requisite to future improvements that should have a greater impact.
- The second PR for preventing unnecessary writes adds about 250ms to chat switching on Android release builds 🎉 

### Fixed Issues (Related)
https://github.com/Expensify/App/issues/2667

### Tests
### QA Steps
- Make sure the app initialize and runs OK
- No specific test steps other than basic regressions and look out for errors when the app boots

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
