### PR TITLE
Different throw for Missing partnerUserSecret

### DIFF
--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -223,7 +223,7 @@ function Authenticate(parameters) {
                     case 402:
                         // If too few characters are passed as the password, the WAF will pass it to the API as an empty
                         // string, which results in a 402 error from Auth.
-                        if (response.message === "402 Missing partnerUserSecret") {
+                        if (response.message === '402 Missing partnerUserSecret') {
                             throw new Error('passwordForm.error.incorrectLoginOrPassword');
                         }
                         throw new Error('passwordForm.error.twoFactorAuthenticationEnabled');

--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -221,6 +221,11 @@ function Authenticate(parameters) {
                     case 401:
                         throw new Error('passwordForm.error.incorrectLoginOrPassword');
                     case 402:
+                        // If too few characters are passed as the password, the WAF will pass it to the API as an empty
+                        // string, which results in a 402 error from Auth.
+                        if (response.message === "402 Missing partnerUserSecret") {
+                            throw new Error('passwordForm.error.incorrectLoginOrPassword');
+                        }
                         throw new Error('passwordForm.error.twoFactorAuthenticationEnabled');
                     case 403:
                         throw new Error('passwordForm.error.invalidLoginOrPassword');


### PR DESCRIPTION
@Expensify/pullerbear will you please review?

### Details
This PR allows us to display the correct error message when a password of less than 4 characters is entered.

### Fixed Issues
$ https://github.com/Expensify/App/issues/4292

### Tests
1. Entered a password that was less than 4 characters long and confirmed I got the correct error message:
![image](https://user-images.githubusercontent.com/13264774/127565402-f2cf5dec-28ca-4fb1-9327-d7e799dd964e.png)

### QA
1. Repeat the steps from the above test on Web, iOS and Android