### PR TITLE
Send emailList as string when removing from workspace

### DIFF
--- a/src/libs/actions/Policy.js
+++ b/src/libs/actions/Policy.js
@@ -116,7 +116,7 @@ function removeMembers(members, policyID) {
 
     // Make the API call to merge the login into the policy
     API.Policy_Employees_Remove({
-        emailList: members,
+        emailList: members.join(','),
         policyID,
     })
         .then((data) => {

--- a/src/libs/actions/Policy.js
+++ b/src/libs/actions/Policy.js
@@ -114,7 +114,7 @@ function removeMembers(members, policyID) {
     // Optimistically remove the members from the policy
     Onyx.set(key, policy);
 
-    // Make the API call to merge the login into the policy
+    // Make the API call to remove a login from the policy
     API.Policy_Employees_Remove({
         emailList: members.join(','),
         policyID,


### PR DESCRIPTION
### Details
We're currently sending an array of strings to the API when removing a user from a workspace which isn't working on iOS (the API receives nothing). In the Web repo for the same command we send a comma-separated list of emails, and the API expects a comma-separated list as well, so this PR updates the usage here to be in line with our other usages.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ https://github.com/Expensify/App/issues/4299

### Tests/QA
1. Launch the app
2. Click on FAB menu
3. New Workspace
4. Click on Get Started!
5. Select People
6. Invite 3 users to your workspace
7. Select one of the users/ user and Click Remove
8. Click Remove button on the Remove Members popup, confirm user is removed successfully

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
Mobile
<img src='http://g.recordit.co/fJUlIu6wY8.gif' width='400'/>

Web

<img src='http://g.recordit.co/xIq76dtDmR.gif' width='700'/>