### PR TITLE
Update getPullRequestsMergedBetween to run pre-set string command

### DIFF
--- a/.github/actions/createOrUpdateStagingDeploy/index.js
+++ b/.github/actions/createOrUpdateStagingDeploy/index.js
@@ -195,6 +195,7 @@ const {execSync} = __nccwpck_require__(3129);
 function getPullRequestsMergedBetween(fromRef, toRef) {
     const command = `git log --format="%s" ${fromRef}...${toRef}`;
     console.log('Getting pull requests merged between the following refs:', fromRef, toRef);
+    console.log('Running command: ', command);
     const localGitLogs = execSync(command).toString();
     return _.map(
         [...localGitLogs.matchAll(/Merge pull request #(\d{1,6}) from (?!Expensify\/(?:master|main|version-))/g)],

--- a/.github/actions/createOrUpdateStagingDeploy/index.js
+++ b/.github/actions/createOrUpdateStagingDeploy/index.js
@@ -193,8 +193,9 @@ const {execSync} = __nccwpck_require__(3129);
  * @returns {Array}
  */
 function getPullRequestsMergedBetween(fromRef, toRef) {
+    const command = `git log --format="%s" ${fromRef}...${toRef}`;
     console.log('Getting pull requests merged between the following refs:', fromRef, toRef);
-    const localGitLogs = execSync(`git log --format="%s" ${fromRef}...${toRef}`).toString();
+    const localGitLogs = execSync(command).toString();
     return _.map(
         [...localGitLogs.matchAll(/Merge pull request #(\d{1,6}) from (?!Expensify\/(?:master|main|version-))/g)],
         match => match[1],

--- a/.github/actions/getDeployPullRequestList/index.js
+++ b/.github/actions/getDeployPullRequestList/index.js
@@ -119,6 +119,7 @@ const {execSync} = __nccwpck_require__(3129);
 function getPullRequestsMergedBetween(fromRef, toRef) {
     const command = `git log --format="%s" ${fromRef}...${toRef}`;
     console.log('Getting pull requests merged between the following refs:', fromRef, toRef);
+    console.log('Running command: ', command);
     const localGitLogs = execSync(command).toString();
     return _.map(
         [...localGitLogs.matchAll(/Merge pull request #(\d{1,6}) from (?!Expensify\/(?:master|main|version-))/g)],

--- a/.github/actions/getDeployPullRequestList/index.js
+++ b/.github/actions/getDeployPullRequestList/index.js
@@ -117,8 +117,9 @@ const {execSync} = __nccwpck_require__(3129);
  * @returns {Array}
  */
 function getPullRequestsMergedBetween(fromRef, toRef) {
+    const command = `git log --format="%s" ${fromRef}...${toRef}`;
     console.log('Getting pull requests merged between the following refs:', fromRef, toRef);
-    const localGitLogs = execSync(`git log --format="%s" ${fromRef}...${toRef}`).toString();
+    const localGitLogs = execSync(command).toString();
     return _.map(
         [...localGitLogs.matchAll(/Merge pull request #(\d{1,6}) from (?!Expensify\/(?:master|main|version-))/g)],
         match => match[1],

--- a/.github/libs/GitUtils.js
+++ b/.github/libs/GitUtils.js
@@ -11,6 +11,7 @@ const {execSync} = require('child_process');
 function getPullRequestsMergedBetween(fromRef, toRef) {
     const command = `git log --format="%s" ${fromRef}...${toRef}`;
     console.log('Getting pull requests merged between the following refs:', fromRef, toRef);
+    console.log('Running command: ', command);
     const localGitLogs = execSync(command).toString();
     return _.map(
         [...localGitLogs.matchAll(/Merge pull request #(\d{1,6}) from (?!Expensify\/(?:master|main|version-))/g)],

--- a/.github/libs/GitUtils.js
+++ b/.github/libs/GitUtils.js
@@ -9,8 +9,9 @@ const {execSync} = require('child_process');
  * @returns {Array}
  */
 function getPullRequestsMergedBetween(fromRef, toRef) {
+    const command = `git log --format="%s" ${fromRef}...${toRef}`;
     console.log('Getting pull requests merged between the following refs:', fromRef, toRef);
-    const localGitLogs = execSync(`git log --format="%s" ${fromRef}...${toRef}`).toString();
+    const localGitLogs = execSync(command).toString();
     return _.map(
         [...localGitLogs.matchAll(/Merge pull request #(\d{1,6}) from (?!Expensify\/(?:master|main|version-))/g)],
         match => match[1],


### PR DESCRIPTION
@roryabraham will you please review this
cc @AndrewGable 

### Details
This PR attempts to fix an issue where when a CP happens, the `toRef` is set to an empty string, even though it is being logged out properly beforehand. Came up with this approach after looking at [this SO](https://stackoverflow.com/questions/37331797/can-i-pass-a-variable-in-javascript-to-a-child-process-exec-command) and seeing that our other usages of `execSync` only set variables that are separated by spaces, so perhaps there is an issue in this case. I also added a log line that will spit out the command to ensure that the string is what we expect it to be.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Related to https://github.com/Expensify/Expensify/issues/168349, possibly a fix 🤞 

### Tests
1. Merge this PR
2. With a staging deploy checklist open, CP a new PR
3. Confirm that the deploy checklist issue description isn't updated with PRs that aren't on staging

I ran tests locally to confirm that the function still works as expected:

![image](https://user-images.githubusercontent.com/3981102/127708641-e86486ac-3870-4408-af53-56844c968525.png)


### QA Steps
None

### Screenshots
N/A
