### PR TITLE
Fix User is able to upload a file larger than 50mb

### DIFF
--- a/src/components/AttachmentPicker/index.native.js
+++ b/src/components/AttachmentPicker/index.native.js
@@ -50,6 +50,7 @@ function getDataForUpload(fileData) {
         name: fileData.fileName || fileData.name || 'chat_attachment',
         type: fileData.type,
         uri: fileData.uri,
+        size: fileData.size,
     };
 }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Fixing regression caused by [this PR](https://github.com/Expensify/App/pull/4269).
### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ #4356 

### Tests / QA
1. Login to New Expensify.
2. Navigate to a conversation.
3. Click on add attachment.
4. Select a file larger than 50mb.
5. Verify that there is a message saying that the file must be under 50mb.

### Tested On

- [x] iOS
- [x] Android

Web, mobile web, desktop aren't applicable.
### Screenshots

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

https://user-images.githubusercontent.com/29673073/127785555-8bc327ea-cbda-4bae-a066-d2bff8a968fa.mov


#### Android
<!-- Insert screenshots of your changes on the Android platform-->
<img src="https://user-images.githubusercontent.com/29673073/127784801-aff5c33f-7387-4243-9f1b-f4a4b774a104.jpeg" height="500">
