### PR TITLE
Fix timerow should update on Language changes.

### DIFF
--- a/src/pages/home/report/ParticipantLocalTime.js
+++ b/src/pages/home/report/ParticipantLocalTime.js
@@ -1,5 +1,4 @@
-import React from 'react';
-import _ from 'underscore';
+import React, {PureComponent} from 'react';
 import {
     View,
 } from 'react-native';
@@ -19,7 +18,7 @@ const propTypes = {
     ...withLocalizePropTypes,
 };
 
-class ParticipantLocalTime extends React.Component {
+class ParticipantLocalTime extends PureComponent {
     constructor(props) {
         super(props);
         this.getParticipantLocalTime = this.getParticipantLocalTime.bind(this);
@@ -36,13 +35,8 @@ class ParticipantLocalTime extends React.Component {
         }, 1000));
     }
 
-    shouldComponentUpdate(nextProps, nextState) {
-        return !_.isEqual(nextProps, this.props) || nextState.localTime !== this.state.localTime;
-    }
-
     componentWillUnmount() {
         clearInterval(this.timer);
-        clearInterval(this.readyTimer);
     }
 
     getParticipantLocalTime() {

--- a/src/pages/home/report/ParticipantLocalTime.js
+++ b/src/pages/home/report/ParticipantLocalTime.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import _ from 'underscore';
 import {
     View,
 } from 'react-native';
@@ -36,7 +37,7 @@ class ParticipantLocalTime extends React.Component {
     }
 
     shouldComponentUpdate(nextProps, nextState) {
-        return nextState.localTime !== this.state.localTime;
+        return !_.isEqual(nextProps, this.props) || nextState.localTime !== this.state.localTime;
     }
 
     componentWillUnmount() {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Removed usages of `ShouldComponentUpdate` and used `PureComponent`. On change the Language the Callback passed as props from the WithLocalize HOC will not cause a render due to the current `ShouldComponentUpdate` only check for state changes. but this is a perfect example of using the Pure Component.

> :notebook: 
> There is another regression where WithLocalize is not causing the render of components which will be taken care of in separate PR. Only after, `withLocalize` is fixed, changes of this PR will fix the Original issue.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ #4352

### Tests | QA Steps
1. Change language from the Preference page.
2. see that TimeRow changes to a different language.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
