### PR TITLE
[No QA] Switch warnCPLabel trigger from pull_request to pull_request_target

### DIFF
--- a/.github/workflows/warnCPLabel.yml
+++ b/.github/workflows/warnCPLabel.yml
@@ -1,7 +1,7 @@
 name: Explain Cherry-Pick label via OSBotify comment
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - labeled
 

--- a/.github/workflows/warnCPLabel.yml
+++ b/.github/workflows/warnCPLabel.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Comment on PR to explain the CP Staging label
         uses: actions-ecosystem/action-create-comment@cd098164398331c50e7dfdd0dfa1b564a1873fac
         with:
-          github_token: ${{ secrets.OS_BOTIFY_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           body: |
             :warning: :warning: **Heads up! This pull request has the `CP Staging` label.** :warning: :warning:
             Merging it will cause it to be immediately deployed to staging, _even if the [open `StagingDeployCash` deploy checklist](https://github.com/Expensify/Expensify.cash/issues?q=is%3Aopen+is%3Aissue+label%3AStagingDeployCash) is locked._


### PR DESCRIPTION

### Details
The `warnCPLabel.yml` workflow has been [failing on any PR from a fork](https://github.com/Expensify/App/actions/workflows/warnCPLabel.yml). This PR should fix that.

More discussion [here](https://expensify.slack.com/archives/C03TQ48KC/p1627924973092300).

### Fixed Issues
$ n/a

### Tests
1. Merge this PR.
1. Create a PR and give it the `CP Staging` label. `OSBotify` should comment on the PR explaining the implications of the `CP Staging Label`.
1. Create a PR from a fork of Expensify/App and give it the `CP Staging` label. `OSBotify` should comment on the PR explaining the implications of the `CP Staging Label`.

### Tested On

n/a – Live testing in GH only.