### PR TITLE
Navigation.isActiveRoute function updated to handle currentRoute logic

### DIFF
--- a/src/libs/Navigation/Navigation.js
+++ b/src/libs/Navigation/Navigation.js
@@ -125,9 +125,7 @@ function dismissModal(shouldOpenDrawer = false) {
 /**
  * Check whether the passed route is currently Active or not.
  *
- * Previous implementation used navigationRef.current.getCurrentRoute().path, which was
- * undefined in the first navigation. Hence, in our current solution, we're rebuilding
- * the active route using the useLinkBuilder hook that takes routeName and params as the arguments.
+ * Building path with useLinkBuilder since navigationRef.current.getCurrentRoute().path is undefined in the first navigation.
  *
  * @param {String} routePath Path to check
  * @return {Boolean} is active

--- a/src/libs/Navigation/Navigation.js
+++ b/src/libs/Navigation/Navigation.js
@@ -125,7 +125,7 @@ function dismissModal(shouldOpenDrawer = false) {
 /**
  * Check whether the passed route is currently Active or not.
  *
- * Building path with useLinkBuilder since navigationRef.current.getCurrentRoute().path 
+ * Building path with useLinkBuilder since navigationRef.current.getCurrentRoute().path
  * is undefined in the first navigation.
  *
  * @param {String} routePath Path to check

--- a/src/libs/Navigation/Navigation.js
+++ b/src/libs/Navigation/Navigation.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 import React from 'react';
-import {StackActions, DrawerActions} from '@react-navigation/native';
+import {StackActions, DrawerActions, useLinkBuilder} from '@react-navigation/native';
 import PropTypes from 'prop-types';
 import Onyx from 'react-native-onyx';
 import linkTo from './linkTo';
@@ -125,13 +125,22 @@ function dismissModal(shouldOpenDrawer = false) {
 /**
  * Check whether the passed route is currently Active or not.
  *
+ * Previous implementation used navigationRef.current.getCurrentRoute().path, which was
+ * undefined in the first navigation. Hence, in our current solution, we're rebuilding
+ * the active route using the useLinkBuilder hook that takes routeName and params as the arguments.
+ *
  * @param {String} routePath Path to check
  * @return {Boolean} is active
  */
-function isActive(routePath) {
+function isActiveRoute(routePath) {
+    const buildLink = useLinkBuilder();
+
     // We remove First forward slash from the URL before matching
-    const path = navigationRef.current && navigationRef.current.getCurrentRoute().path
-        ? navigationRef.current.getCurrentRoute().path.substring(1)
+    const path = navigationRef.current && navigationRef.current.getCurrentRoute().name
+        ? buildLink(
+            navigationRef.current.getCurrentRoute().name,
+            navigationRef.current.getCurrentRoute().params,
+        ).substring(1)
         : '';
     return path === routePath;
 }
@@ -167,7 +176,7 @@ DismissModal.defaultProps = {
 export default {
     navigate,
     dismissModal,
-    isActive,
+    isActiveRoute,
     goBack,
     DismissModal,
     closeDrawer,

--- a/src/libs/Navigation/Navigation.js
+++ b/src/libs/Navigation/Navigation.js
@@ -125,7 +125,8 @@ function dismissModal(shouldOpenDrawer = false) {
 /**
  * Check whether the passed route is currently Active or not.
  *
- * Building path with useLinkBuilder since navigationRef.current.getCurrentRoute().path is undefined in the first navigation.
+ * Building path with useLinkBuilder since navigationRef.current.getCurrentRoute().path 
+ * is undefined in the first navigation.
  *
  * @param {String} routePath Path to check
  * @return {Boolean} is active

--- a/src/pages/workspace/WorkspaceSidebar.js
+++ b/src/pages/workspace/WorkspaceSidebar.js
@@ -50,7 +50,7 @@ const WorkspaceSidebar = ({translate, isSmallScreenWidth, policy}) => {
             action: () => {
                 Navigation.navigate(ROUTES.getWorkspaceCardRoute(policy.id));
             },
-            isActive: Navigation.isActive(ROUTES.getWorkspaceCardRoute(policy.id)),
+            isActive: Navigation.isActiveRoute(ROUTES.getWorkspaceCardRoute(policy.id)),
         },
         {
             translationKey: 'common.people',
@@ -58,7 +58,7 @@ const WorkspaceSidebar = ({translate, isSmallScreenWidth, policy}) => {
             action: () => {
                 Navigation.navigate(ROUTES.getWorkspacePeopleRoute(policy.id));
             },
-            isActive: Navigation.isActive(ROUTES.getWorkspacePeopleRoute(policy.id)),
+            isActive: Navigation.isActiveRoute(ROUTES.getWorkspacePeopleRoute(policy.id)),
         },
     ];
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

@iwiznia  Can you please review?

### Details
Fixed the current route logic with useLinkBuilder from 'react-navigation'

### Fixed Issues
$ Fixes [App/4280](https://github.com/Expensify/App/issues/4280)

### Tests
1. Visited routes from Create workspace and visit workspace links to see if the auto-select is visible
2. Reload. of the URLs done on the Web platform to see if the selection is retained
3. Switched menus to see if existing functionality is intact

### QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
https://user-images.githubusercontent.com/3069065/127917462-4238eb96-30ac-47f9-9fca-b2d32a5f488a.mp4


#### Mobile Web
https://user-images.githubusercontent.com/3069065/127917512-4197b413-caae-4bb0-8e35-fd94932d9556.mp4

#### Desktop
https://user-images.githubusercontent.com/3069065/127917822-4e409a8a-2844-4e59-838b-40e5502f3f2a.mp4

#### iOS
https://user-images.githubusercontent.com/3069065/127917609-f93ee798-4d77-4fe5-a04a-bb487eb542e7.mp4

#### Android
https://user-images.githubusercontent.com/3069065/127919222-5809a6be-f7ff-40a6-ac43-79aced28b872.mp4


