### PR TITLE
[NO QA] Clarify risk of submitting early proposals

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,7 @@ In this scenario, it’s possible that you found a bug or enhancement that we ha
 
 #### Propose a solution for the job
 4. After you reproduce the issue, make a proposal for your solution and post it as a comment in the corresponding GitHub issue (linked in the Upwork job). Your solution proposal should include a brief technical explanation of the changes you will make.
+    - Note: If you post a proposed solution in an issue that has not been marked as `External`, Expensify has the right to use your proposal to fix said issue, without providing compensation for your solution.
 5. Pause at this step until Expensify provides feedback on your proposal (do not begin coding or creating a pull request yet).
 6. If your solution proposal is accepted, Expensify will hire you on Upwork and assign the GitHub issue to you.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ In this scenario, it’s possible that you found a bug or enhancement that we ha
 
 #### Propose a solution for the job
 4. After you reproduce the issue, make a proposal for your solution and post it as a comment in the corresponding GitHub issue (linked in the Upwork job). Your solution proposal should include a brief technical explanation of the changes you will make.
-    - Note: If you post a proposed solution in an issue that has not been marked as `External`, Expensify has the right to use your proposal to fix said issue, without providing compensation for your solution.
+    - Note: If you post a proposed solution in an issue that has not been tagged with the `External` label, Expensify has the right to use your proposal to fix said issue, without providing compensation for your solution.
 5. Pause at this step until Expensify provides feedback on your proposal (do not begin coding or creating a pull request yet).
 6. If your solution proposal is accepted, Expensify will hire you on Upwork and assign the GitHub issue to you.
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Purpose: Update phrasing in `CONTRIBUTING.md` to encourage people not to post solutions before an issue is marked `External`.

Discussion in Slack [here](https://expensify.slack.com/archives/C01SKUP7QR0/p1627895303016900).

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
N/A

### Tests
N/A

### QA Steps
N/A