### PR TITLE
Treat Default Chat Rooms like Multiple Participant Rooms when it comes to their OptionRow->login property

### DIFF
--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -191,7 +191,8 @@ function getSearchText(report, personalDetailList, isDefaultChatRoom) {
 function createOption(personalDetailList, report, draftComments, {
     showChatPreviewLine = false, forcePolicyNamePreview = false,
 }) {
-    const hasMultipleParticipants = personalDetailList.length > 1;
+    const isDefaultChatRoom = isDefaultRoom(report);
+    const hasMultipleParticipants = personalDetailList.length > 1 || isDefaultChatRoom;
     const personalDetail = personalDetailList[0];
     const reportDraftComment = report
         && draftComments
@@ -210,7 +211,6 @@ function createOption(personalDetailList, report, draftComments, {
         + _.unescape(report.lastMessageText)
         : '';
 
-    const isDefaultChatRoom = isDefaultRoom(report);
     const tooltipText = getReportParticipantsTitle(lodashGet(report, ['participants'], []));
 
     let text;


### PR DESCRIPTION
@TomatoToaster please review

### Details
Weird edge case where we treated Default Chat Rooms like DMs for the `login` property in `OptionsListUtils` when there was only one other participant in it. I think essentially we should just treat Default Chat Rooms like Multiple Participant Rooms in this case.

### Fixed Issues
$ https://github.com/Expensify/App/issues/4376

### Tests/QA
1. Login with Account A (Be sure it's new with no Workspaces) 
2. Create a Workspace and invite user B 
3. Navigate to the conversation with user B and send some messages 
4. Navigate to #Announce room and send some messages
5. Make sure both the #Announce room and the DM show up in the LHN
6. Send messages in each, make sure neither ends up disappearing from the LHN and that they re-organize in order of most recent:
![Kapture 2021-08-03 at 13 12 01](https://user-images.githubusercontent.com/4741899/128058411-aaeee8e3-54ef-4fcc-8d30-15f3ee0db2dc.gif)
7. Search for each room, make sure the search functionality works as expected:
![Kapture 2021-08-03 at 13 17 49](https://user-images.githubusercontent.com/4741899/128058462-e49aab23-a9ac-4977-a0e5-ea6961139f11.gif)

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android
