### PR TITLE
Fix: inline messages

### DIFF
--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1901,6 +1901,10 @@ const webViewStyles = {
     // styles from the renderer, just pass the "style" prop to the underlying
     // component.
     tagStyles: {
+        body: {
+            flexDirection: 'row',
+        },
+
         em: {
             fontFamily: fontFamily.GTA_ITALIC,
             fontStyle: 'italic',
@@ -1966,6 +1970,7 @@ const webViewStyles = {
         lineHeight: variables.fontSizeNormalHeight,
         fontFamily: fontFamily.GTA,
         flex: 1,
+        alignSelf: 'flex-start',
     },
 };
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Due to a recent upgrade to v6 of React-native-render-html. block styling change for the container element body which broke the inline messages. 

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ Fixes https://github.com/Expensify/App/issues/4377

### Tests | QA Steps
1. Open any conversation on NewDot.
2. Send any message that contains inline formatted or unformatted text which should be a few words.
3. If this case. This inline message should not extend to the full width of the viewport.
e.g. Send this message.
```
`text`
```

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web | Desktop
<!-- Insert screenshots of your changes on the web platform-->
![image](https://user-images.githubusercontent.com/24370807/128093855-dcc032b2-b6d6-44c5-8575-531e0af728ab.png)

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
![issue-code-fix-m](https://user-images.githubusercontent.com/24370807/128094846-bbb31b64-bb81-4036-9f41-7387853c7223.png)

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
| BEFORE | AFTER |
|--------| -------| 
|![issue-code](https://user-images.githubusercontent.com/24370807/128094635-bbdc9bb7-6999-47e7-baf8-5314b9572729.png)|![issue-code-fix](https://user-images.githubusercontent.com/24370807/128094645-2c9a1d36-db60-4954-8381-e9beb0fd29a5.png)|

Note: Code formatting issue is https://github.com/Expensify/App/issues/4005.
