### PR TITLE
[No QA] Catch http errors that don't trigger `.then()`

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -65,6 +65,7 @@ export default {
         tomorrowAt: 'Tomorrow at',
         yesterdayAt: 'Yesterday at',
         conjunctionAt: 'at',
+        genericErrorMessage: 'Oops... something went wrong and your request could not be completed. Please try again later.',
     },
     attachmentPicker: {
         cameraPermissionRequired: 'Camera Permission Required',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -65,6 +65,7 @@ export default {
         tomorrowAt: 'Mañana a las',
         yesterdayAt: 'Ayer a las',
         conjunctionAt: 'a',
+        genericErrorMessage: 'Ups... algo no ha ido bien y la acción no se ha podido completar. Por favor inténtalo más tarde.',
     },
     attachmentPicker: {
         cameraPermissionRequired: 'Se necesita permiso para usar la cámara',

--- a/src/libs/actions/BankAccounts.js
+++ b/src/libs/actions/BankAccounts.js
@@ -727,6 +727,11 @@ function setupWithdrawalAccount(data) {
             if (error) {
                 Growl.error(error, 5000);
             }
+        })
+        .catch((response) => {
+            Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {loading: false, achData: {...newACHData}});
+            console.error(response.stack);
+            Growl.error(translateLocal('common.genericErrorMessage'), 5000);
         });
 }
 


### PR DESCRIPTION
### Details
We were not catching errors that hit `.catch()` as opposed to `.then` when adding user's bank accounts. This led to endless spinners which is a bad user experience. This adds `.catch` and throws an error when this happens.

### Fixed Issues
$ https://github.com/Expensify/App/issues/4321

### Tests
1. Update your .env file to cause 404s on secure calls e.g. `EXPENSIFY_URL_SECURE=https://secuasdfre.expensify.com.dev/`
1. Go to http://localhost:8080/bank-account
2. Click "Manual"
2. Disconnect from wifi
3. Fill out the forms and click continue
4. Make sure you see an error and are sent back to the main page

### QA Steps
Ping me to test this as you need a special account set up

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web

https://user-images.githubusercontent.com/42391420/128096270-8c0d5977-41f4-44c7-a9fc-ae38115a7752.mp4


