### PR TITLE
Don't show loading state in workspace setup button

### DIFF
--- a/src/pages/workspace/WorkspaceCardPage.js
+++ b/src/pages/workspace/WorkspaceCardPage.js
@@ -179,7 +179,6 @@ const WorkspaceCardPage = ({
                                     success
                                     large
                                     text={buttonText}
-                                    isLoading={reimbursementAccount.loading}
                                 />
                             </View>
                         </View>


### PR DESCRIPTION
### Details
We were getting double spinners when setting up workspaces. We only want the sidebar loading icon, not the button.
![image](https://user-images.githubusercontent.com/22508290/127926698-ad86d04b-e835-49bd-97a9-07b1f9f2f35d.png)

### Fixed Issues
$ https://github.com/Expensify/App/issues/4384

### Tests
1. Open a workspace
2. Set up a bank account
3. Between steps make sure the button does not have a loading state

### QA Steps
n/a

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
![2021-08-03_17-02-07](https://user-images.githubusercontent.com/42391420/128097135-aad37262-300d-4f70-bbf4-bb930147aee6.png)

