### PR TITLE
#4375 fix ios user redirect to set up password + update staging url for app association on native platforms

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -55,7 +55,7 @@
             <action android:name="android.intent.action.VIEW"/>
             <category android:name="android.intent.category.DEFAULT"/>
             <category android:name="android.intent.category.BROWSABLE"/>
-            <data android:scheme="https" android:host="staging.expensify.cash" />
+            <data android:scheme="https" android:host="staging.new.expensify.com" />
         </intent-filter>
       </activity>
       <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />

--- a/ios/ExpensifyCash/Chat.entitlements
+++ b/ios/ExpensifyCash/Chat.entitlements
@@ -6,7 +6,7 @@
 	<string>development</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:staging.expensify.cash</string>
+		<string>applinks:staging.new.expensify.com</string>
 		<string>applinks:new.expensify.com</string>
 	</array>
 </dict>

--- a/ios/ExpensifyCash/Chat.entitlements
+++ b/ios/ExpensifyCash/Chat.entitlements
@@ -6,9 +6,8 @@
 	<string>development</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:www.expensify.cash</string>
 		<string>applinks:staging.expensify.cash</string>
-		<string>applinks:expensify.cash</string>
+		<string>applinks:new.expensify.com</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

This PR updates the list of associated domains with iOS app to make it identical with the one in AndroidManifest.xml
Also updates the staging url used for app association on both iOS and android.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ #4375 

### Tests / QA Steps
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->
prod url test for iOS only:
1. Logout
2. Input an email address for new account
3. Check the inbox, tap the link in the email
4. If the "Choose app to open with" modal appears, select "Expensify"
5. An app should open 
6. Input the password
7. You should be automatically logged in

staging url test (ios and android):
1. Logout
2. Input an email address for new account
3. Check the inbox, long tap the link in the email. Tap "Copy" button.
4. Paste the link into any app that renders hyperlinks as clickable objects(I used calendar on ios and messages on android). Add `staging` to the URL, so it says `staging.new.expenisify.com...`.
5. Tap the link.
6. If the "Choose app to open with" modal appears, select "Expensify"
7. An app should open 
8. Input the password
9. You should be automatically logged in

### Tested On
- [x] iOS
- [x] andorid

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

prod url:

https://user-images.githubusercontent.com/64093836/128330262-7441caa8-ea29-48ee-86a6-abf4a360a2b9.mp4

staging url:

https://user-images.githubusercontent.com/64093836/128626813-fd3a4f38-e8b8-41e0-b4f2-fe53fc14f768.mp4

#### Android

https://user-images.githubusercontent.com/64093836/128628128-9313e05f-b63f-4845-81cc-334bfecf9723.mp4
