### PR TITLE
Fix: incorrect prop name passed for locale

### DIFF
--- a/src/components/withLocalize.js
+++ b/src/components/withLocalize.js
@@ -56,7 +56,7 @@ class LocaleContextProvider extends React.Component {
             timestampToDateTime: this.timestampToDateTime.bind(this),
             fromLocalPhone: this.fromLocalPhone.bind(this),
             toLocalPhone: this.toLocalPhone.bind(this),
-            locale: this.props.preferredLocale,
+            preferredLocale: this.props.preferredLocale,
         };
     }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Update to pass `preferredLocale` down to children as we did before
@aman-atg thanks for the investigation: https://github.com/Expensify/App/issues/4404#issuecomment-892506251

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ #4404 

### Tests
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->
1. open any chat
2. refresh the page
3. the timestring should not flash and should remain in the same locale

### QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->
Same as above

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
https://user-images.githubusercontent.com/12156624/128333197-841c910d-058a-4861-ae64-61a73a7e70ae.mov

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
https://user-images.githubusercontent.com/12156624/128333513-75e30249-1ae1-4e83-bd99-b4fee7ad99c6.mov

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
https://user-images.githubusercontent.com/12156624/128332837-ea40a5c1-6132-4a38-94e8-bc83dc8606ba.mov

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
![image](https://user-images.githubusercontent.com/12156624/128366462-8cd367ca-83d1-4ade-bc8d-c1199befce6c.png)

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
![image](https://user-images.githubusercontent.com/12156624/128366577-141e1036-48f8-4641-99f2-b0d44672663e.png)
