### PR TITLE
Add note about generating multiple test accounts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,9 @@ You can create as many accounts as needed in order to test your changes directly
 
 **Note**: When testing chat functionality in the app please do this between accounts you or your fellow contributors own - **do not test chatting with Concierge**, as this diverts to our customer support team. Thank you. 
 
+##### Generating Multiple Test Accounts
+You can generate multiple test accounts by using a `+` postfix, for example if your email is test@test.com, you can create multiple accounts by using test+123@test.com, test+456@test.com, etc.
+
 ## Code of Conduct
 This project and everyone participating in it is governed by the Expensify [Code of Conduct](https://github.com/Expensify/Expensify.cash/blob/main/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to [contributors@expensify.com](mailto:contributors@expensify.com).
 


### PR DESCRIPTION
### Details
Per [discussion in slack](https://expensify.slack.com/archives/C01GTK53T8Q/p1628155902016400), added a note about how to add multiple testing emails for easier testing.

### Tests
1. I verified this testing method still works via my personal email
<img width="341" alt="Screen Shot 2021-08-05 at 11 13 13 AM" src="https://user-images.githubusercontent.com/2838819/128393168-7527f64e-7b17-4c74-8748-0256b06d0020.png">

### QA Steps
N/A - Just documentation changes
