### PR TITLE
Race fix attempt 2

### DIFF
--- a/src/pages/home/HeaderView.js
+++ b/src/pages/home/HeaderView.js
@@ -54,17 +54,23 @@ const propTypes = {
     }).isRequired,
 
     /** Personal details of all the users */
-    personalDetails: PropTypes.objectOf(participantPropTypes).isRequired,
+    personalDetails: PropTypes.objectOf(participantPropTypes),
 
     ...windowDimensionsPropTypes,
     ...withLocalizePropTypes,
 };
 
 const defaultProps = {
+    personalDetails: {},
     report: null,
 };
 
 const HeaderView = (props) => {
+    // Waiting until ONYX variables are loaded before displaying the component
+    if (_.isEmpty(props.personalDetails)) {
+        return null;
+    }
+
     const participants = lodashGet(props.report, 'participants', []);
     const isMultipleParticipant = participants.length > 1;
     const displayNamesWithTooltips = _.map(

--- a/src/pages/home/report/ParticipantLocalTime.js
+++ b/src/pages/home/report/ParticipantLocalTime.js
@@ -10,6 +10,7 @@ import withLocalize, {withLocalizePropTypes} from '../../../components/withLocal
 import {participantPropTypes} from '../sidebar/optionPropTypes';
 import ExpensiText from '../../../components/Text';
 import Timers from '../../../libs/Timers';
+import CONST from '../../../CONST';
 
 const propTypes = {
     /** Personal details of the participant */
@@ -40,7 +41,7 @@ class ParticipantLocalTime extends PureComponent {
     }
 
     getParticipantLocalTime() {
-        const reportRecipientTimezone = lodashGet(this.props.participant, 'timezone', {});
+        const reportRecipientTimezone = lodashGet(this.props.participant, 'timezone', CONST.DEFAULT_TIME_ZONE);
         moment.locale(this.props.preferredLocale);
         const reportRecipientDay = moment().tz(reportRecipientTimezone.selected).format('dddd');
         const currentUserDay = moment().tz(this.props.currentUserTimezone.selected).format('dddd');

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -77,10 +77,10 @@ const propTypes = {
     }),
 
     /** The personal details of the person who is logged in */
-    myPersonalDetails: PropTypes.shape(currentUserPersonalDetailsPropsTypes).isRequired,
+    myPersonalDetails: PropTypes.shape(currentUserPersonalDetailsPropsTypes),
 
     /** Personal details of all the users */
-    personalDetails: PropTypes.objectOf(participantPropTypes).isRequired,
+    personalDetails: PropTypes.objectOf(participantPropTypes),
 
     /** The report currently being looked at */
     report: PropTypes.shape({
@@ -123,6 +123,8 @@ const defaultProps = {
     reportActions: {},
     network: {isOffline: false},
     blockedFromConcierge: {},
+    personalDetails: {},
+    myPersonalDetails: {},
 };
 
 class ReportActionCompose extends React.Component {
@@ -421,14 +423,19 @@ class ReportActionCompose extends React.Component {
     }
 
     render() {
+        // Waiting until ONYX variables are loaded before displaying the component
+        if (_.isEmpty(this.props.personalDetails) || _.isEmpty(this.props.myPersonalDetails)) {
+            return null;
+        }
+
         // eslint-disable-next-line no-unused-vars
         const reportParticipants = lodashGet(this.props.report, 'participants', []);
         const hasMultipleParticipants = reportParticipants.length > 1;
         const hasChronosParticipant = _.contains(reportParticipants, CONST.EMAIL.CHRONOS);
         const hasConciergeParticipant = _.contains(reportParticipants, CONST.EMAIL.CONCIERGE);
         const reportRecipient = this.props.personalDetails[reportParticipants[0]];
-        const currentUserTimezone = lodashGet(this.props.myPersonalDetails, 'timezone', {});
-        const reportRecipientTimezone = lodashGet(reportRecipient, 'timezone', {});
+        const currentUserTimezone = lodashGet(this.props.myPersonalDetails, 'timezone', CONST.DEFAULT_TIME_ZONE);
+        const reportRecipientTimezone = lodashGet(reportRecipient, 'timezone', CONST.DEFAULT_TIME_ZONE);
         const shouldShowReportRecipientLocalTime = !hasConciergeParticipant
             && !hasChronosParticipant
             && !hasMultipleParticipants

--- a/src/pages/home/sidebar/SidebarLinks.js
+++ b/src/pages/home/sidebar/SidebarLinks.js
@@ -99,8 +99,8 @@ class SidebarLinks extends React.Component {
     }
 
     render() {
-        // Wait until the reports are actually loaded before displaying the LHN
-        if (!this.props.initialReportDataLoaded) {
+        // Wait until the reports and personalDetails are actually loaded before displaying the LHN
+        if (!this.props.initialReportDataLoaded || _.isEmpty(this.props.personalDetails)) {
             return null;
         }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ https://github.com/Expensify/App/issues/4388

### Tests
1. Add `sleep(10);` after this [line](https://github.com/Expensify/Web-Expensify/blob/3f9fa3b9641a643df68e5273637066116357e743/lib/GetAPI.php#L165)
2. Logout and login on ecash and confirm everything works fine and that there are no errors related to personalDetails for HeaderView, ReportActionCompose and SidebarLinks as the personalDetails take 10 seconds to load.

### QA Steps
Same as the [issue](https://github.com/Expensify/App/issues/4388#issue-958601614)

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
