### PR TITLE
Fix broken two touch zoom for Attachment Images

### DIFF
--- a/src/components/ImageView/index.native.js
+++ b/src/components/ImageView/index.native.js
@@ -77,11 +77,10 @@ class ImageView extends PureComponent {
                     imageHeight={this.state.imageHeight}
                     onStartShouldSetPanResponder={() => {
                         const isDoubleClick = new Date().getTime() - this.lastClickTime <= this.doubleClickInterval;
-                        const touches = this.amountOfTouches;
                         this.lastClickTime = new Date().getTime();
 
                         // Let ImageZoom handle the event if the tap is more than one touchPoint or if we are zoomed in
-                        if (touches === 2 || this.imageZoomScale !== 1) {
+                        if (this.amountOfTouches === 2 || this.imageZoomScale !== 1) {
                             return true;
                         }
 

--- a/src/components/ImageView/index.native.js
+++ b/src/components/ImageView/index.native.js
@@ -36,18 +36,18 @@ class ImageView extends PureComponent {
 
         // PanResponder used to capture how many touches are active on the attachment image
         this.panResponder = PanResponder.create({
-            onStartShouldSetPanResponder: this.handleOnStartShouldSetPanResponder.bind(this),
+            onStartShouldSetPanResponder: this.updatePanResponderTouches.bind(this),
         });
     }
 
     /**
-     * Handler for the initial tap for the PanResponder on our ImageZoom overlay View
+     * Updates the amount of active touches on the PanResponder on our ImageZoom overlay View
      *
      * @param {Event} e
      * @param {GestureState} gestureState
      * @returns {Boolean}
      */
-    handleOnStartShouldSetPanResponder(e, gestureState) {
+    updatePanResponderTouches(e, gestureState) {
         if (_.isNumber(gestureState.numberActiveTouches)) {
             this.amountOfTouches = gestureState.numberActiveTouches;
         }

--- a/src/components/ImageView/index.native.js
+++ b/src/components/ImageView/index.native.js
@@ -75,7 +75,7 @@ class ImageView extends PureComponent {
                     cropHeight={windowHeight}
                     imageWidth={this.state.imageWidth}
                     imageHeight={this.state.imageHeight}
-                    onStartShouldSetPanResponder={(e) => {
+                    onStartShouldSetPanResponder={() => {
                         const isDoubleClick = new Date().getTime() - this.lastClickTime <= this.doubleClickInterval;
                         const touches = this.amountOfTouches;
                         this.lastClickTime = new Date().getTime();


### PR DESCRIPTION
@marcaaron will you please review this?

### Details
This PR fixes a regression where zooming with two fingers on an attachment was broken.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ https://github.com/Expensify/App/issues/2499

### Tests/QA
1. Sign into an account and send an image attachment
2. After the attachment uploads, tap on it, confirm an attachment modal shows
3. Double tap on the image, confirm it zooms
4. Double-tap again, confirm it zooms out
5. Use two fingers to zoom in, confirm the image zooms in
6. While zoomed in, swipe down and right and confirm the modal doesn't close, and that the viewport pans around the zoomed image
7. Double-tap again then swipe down or right, confirm the modal dismisses
8. Confirm that there are no regressions on web
    1. Confirm attachments still show up on web
    2. Confirm the modal attachment closes normally on web

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

<img src='http://g.recordit.co/6V36awfawm.gif' width='400'/>