### PR TITLE
Ensure workspaces show after signing in

### DIFF
--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -228,6 +228,7 @@ class AuthScreens extends React.Component {
         NetworkConnection.stopListeningForReconnect();
         clearInterval(this.interval);
         this.interval = null;
+        hasLoadedPolicies = false;
     }
 
     render() {


### PR DESCRIPTION
### Details
We weren't resetting a variable after signing out, which caused policies to not load after signing out and signing back in. This PR fixes that.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ https://github.com/Expensify/Expensify/issues/173118#

### Tests/QA
1. Launch web in an incognito window and sign in, confirm that after signing in the user's workspaces show on the Settings page
2. Sign out and sign back in, confirm that the workspaces show on the Settings page

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web/Desktop
![image](https://user-images.githubusercontent.com/3981102/128446541-f48f789d-1315-4989-88ba-d8da08a6a897.png)

#### Mobile
![image](https://user-images.githubusercontent.com/3981102/128446549-af3cc790-b09f-46e3-a733-c657ed6476db.png)
