### PR TITLE
Remove deleted workspaces from list

### DIFF
--- a/src/libs/actions/Policy.js
+++ b/src/libs/actions/Policy.js
@@ -1,6 +1,8 @@
 import _ from 'underscore';
 import Onyx from 'react-native-onyx';
 import lodashGet from 'lodash/get';
+import cache from 'react-native-onyx/lib/OnyxCache';
+import Str from 'expensify-common/lib/str';
 import * as API from '../API';
 import ONYXKEYS from '../../ONYXKEYS';
 import {formatPersonalDetails} from './PersonalDetails';
@@ -10,8 +12,6 @@ import {translateLocal} from '../translate';
 import Navigation from '../Navigation/Navigation';
 import ROUTES from '../../ROUTES';
 import {addSMSDomainIfPhoneNumber} from '../OptionsListUtils';
-import cache from "react-native-onyx/lib/OnyxCache";
-import Str from "expensify-common/lib/str";
 
 const allPolicies = {};
 Onyx.connect({

--- a/src/libs/actions/Policy.js
+++ b/src/libs/actions/Policy.js
@@ -93,7 +93,7 @@ function getPolicyList() {
                     ...(_.reduce(_.keys(allPolicies), (memo, key) => ({...memo, [key]: null}), {})),
 
                     // And overwrite them with only the ones returned by the API call
-                    ...policyDataToStore
+                    ...policyDataToStore,
                 });
             }
         });

--- a/src/libs/actions/Policy.js
+++ b/src/libs/actions/Policy.js
@@ -93,7 +93,8 @@ function getPolicyList() {
                     ...(_.reduce(_.keys(allPolicies), (memo, key) => ({...memo, [key]: null}), {})),
 
                     // And overwrite them with only the ones returned by the API call
-                    ...policyDataToStore});
+                    ...policyDataToStore
+                });
             }
         });
 }

--- a/src/libs/actions/Policy.js
+++ b/src/libs/actions/Policy.js
@@ -87,7 +87,7 @@ function getPolicyList() {
                         avatarURL: lodashGet(policy, 'value.avatarURL', ''),
                     },
                 }), {});
-                Onyx.mergeCollection(ONYXKEYS.COLLECTION.POLICY, policyDataToStore);
+                Onyx.mergeCollection(ONYXKEYS.COLLECTION.POLICY, policyDataToStore, true);
             }
         });
 }

--- a/src/libs/actions/Policy.js
+++ b/src/libs/actions/Policy.js
@@ -90,18 +90,15 @@ function getPolicyList() {
                     },
                 }), {});
                 Onyx.mergeCollection(ONYXKEYS.COLLECTION.POLICY, policyDataToStore);
-                Onyx.getAllKeys()
-                    .then((keys) => {
-                        const keysToClear = _.filter(keys, key => Str.startsWith(key, ONYXKEYS.COLLECTION.POLICY)
-                            && !_.keys(policyDataToStore).includes(key));
-                        const keyValuePairsForClearing = _.map(keysToClear, key => [key, 'null']);
-                        if (keyValuePairsForClearing.length > 0) {
-                            Onyx.multiSet(keyValuePairsForClearing);
+                const keysToClear = _.filter(_.keys(allPolicies), key => Str.startsWith(key, ONYXKEYS.COLLECTION.POLICY)
+                    && !_.keys(policyDataToStore).includes(key));
+                const keyValuePairsForClearing = _.map(keysToClear, key => [key, 'null']);
+                if (keyValuePairsForClearing.length > 0) {
+                    Onyx.multiSet(keyValuePairsForClearing);
 
-                            // Clear them in cache
-                            _.each(keysToClear, key => cache.set(key, null));
-                        }
-                    });
+                    // Clear them in cache
+                    _.each(keysToClear, key => cache.set(key, null));
+                }
             }
         });
 }

--- a/src/libs/actions/Policy.js
+++ b/src/libs/actions/Policy.js
@@ -1,8 +1,6 @@
 import _ from 'underscore';
 import Onyx from 'react-native-onyx';
 import lodashGet from 'lodash/get';
-import cache from 'react-native-onyx/lib/OnyxCache';
-import Str from 'expensify-common/lib/str';
 import * as API from '../API';
 import ONYXKEYS from '../../ONYXKEYS';
 import {formatPersonalDetails} from './PersonalDetails';
@@ -89,16 +87,13 @@ function getPolicyList() {
                         avatarURL: lodashGet(policy, 'value.avatarURL', ''),
                     },
                 }), {});
-                Onyx.mergeCollection(ONYXKEYS.COLLECTION.POLICY, policyDataToStore);
-                const keysToClear = _.filter(_.keys(allPolicies), key => Str.startsWith(key, ONYXKEYS.COLLECTION.POLICY)
-                    && !_.keys(policyDataToStore).includes(key));
-                const keyValuePairsForClearing = _.map(keysToClear, key => [key, 'null']);
-                if (keyValuePairsForClearing.length > 0) {
-                    Onyx.multiSet(keyValuePairsForClearing);
 
-                    // Clear them in cache
-                    _.each(keysToClear, key => cache.set(key, null));
-                }
+                Onyx.mergeCollection(ONYXKEYS.COLLECTION.POLICY, {
+                    // Erase all policies in Onyx
+                    ...(_.reduce(_.keys(allPolicies), (memo, key) => ({...memo, [key]: null}), {})),
+
+                    // And overwrite them with only the ones returned by the API call
+                    ...policyDataToStore});
             }
         });
 }


### PR DESCRIPTION
### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ https://github.com/Expensify/Expensify/issues/173112

### Tests/ QA Steps
- Log into Newdot and add a new workspace:
<img width="353" alt="Screen Shot 2021-08-06 at 3 29 43 PM" src="https://user-images.githubusercontent.com/19366280/128517716-68768245-1e76-426f-be59-0be11383b6d1.png">

- The workspace should now display on the Settings page:
<img width="382" alt="Screen Shot 2021-08-06 at 3 30 57 PM" src="https://user-images.githubusercontent.com/19366280/128517913-0e6bf637-9d2b-4adf-96d8-7e6f598ce558.png">

- Close the settings page.

- Log into oldDot (DO NOT log out of NewDot) and go to Policies-> group. You should see the new workspace you just created. Delete it.

- Go back to NewDot and refresh. The workspace should be gone from the Settings page.

### Tested On

- [X] Web
- [ ] Mobile Web
- [X] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
Not really a very screenshoty change