### PR TITLE
Wallet balance translation fix in Payments Page

### DIFF
--- a/src/components/CurrentWalletBalance.js
+++ b/src/components/CurrentWalletBalance.js
@@ -34,13 +34,15 @@ const CurrentWalletBalance = (props) => {
         );
     }
 
-    const formattedBalance = Number(props.userWallet.availableBalance).toFixed(2);
-
+    const formattedBalance = props.numberFormat(
+        props.userWallet.availableBalance,
+        {style: 'currency', currency: 'USD'},
+    );
     return (
         <Text
             style={[styles.textXXXLarge, styles.pv5, styles.alignSelfCenter]}
         >
-            {`$${formattedBalance}`}
+            {`${formattedBalance}`}
         </Text>
     );
 };

--- a/src/libs/numberFormat/index.native.js
+++ b/src/libs/numberFormat/index.native.js
@@ -4,8 +4,9 @@ import '@formatjs/intl-locale/polyfill';
 import '@formatjs/intl-pluralrules/polyfill';
 import '@formatjs/intl-numberformat/polyfill';
 
-// Load en Locale data
+// Load en & es Locale data
 import '@formatjs/intl-numberformat/locale-data/en';
+import '@formatjs/intl-numberformat/locale-data/es';
 
 function numberFormat(locale, number, options) {
     return new Intl.NumberFormat(locale, options).format(number);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
@marklouisdeshaun 

### Fixed Issues
#4448 

### Tests & QA Steps
1. Select preferred language to Español in Settings -> preferences.
2. Settings Page Near the payments option, we show a balance as `$0.00` for English. In Spanish, we show
`0,00 US$.`
3. In Mobile both pages will show `$0.00` for Spanish.

4. Fix - On the Payments page also, we will show translation for wallet balance.
Included English translations also.
5. Fix - For Mobile both settings & payments page we will show translation for wallet balance.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android 

### Screenshots

#### Web
<img width="1438" alt="Screenshot 2021-08-06 at 10 21 51 PM" src="https://user-images.githubusercontent.com/85645967/128548066-7b38021e-c7ff-4728-a64d-f7c40e5e5743.png">

<img width="1427" alt="Screenshot 2021-08-06 at 10 21 14 PM" src="https://user-images.githubusercontent.com/85645967/128548051-a10ca9d8-fe7a-44f2-a08d-ec09a55ef992.png">

#### Mobile Web
<img width="434" alt="Screenshot 2021-08-06 at 10 49 16 PM" src="https://user-images.githubusercontent.com/85645967/128548465-c4b893d7-4ed7-4fcc-839f-cf4939a622db.png">
<img width="463" alt="Screenshot 2021-08-06 at 10 49 38 PM" src="https://user-images.githubusercontent.com/85645967/128548484-4b38facb-d0c9-47f1-8fbf-2571b91ff802.png">

#### Desktop
<img width="1192" alt="Screenshot 2021-08-06 at 10 53 53 PM" src="https://user-images.githubusercontent.com/85645967/128549429-3491554a-f03e-4f7c-a6b1-a9ef311e1ac2.png">
<img width="1199" alt="Screenshot 2021-08-06 at 10 54 13 PM" src="https://user-images.githubusercontent.com/85645967/128549444-8f48c9da-159b-4965-810a-6709b2925a66.png">

#### iOS
![Simulator Screen Shot - iPhone 11 Pro Max - 2021-08-09 at 22 17 39](https://user-images.githubusercontent.com/85645967/128743835-a15d27a9-0540-42ba-a94a-255c8d00d2e9.png)
![Simulator Screen Shot - iPhone 11 Pro Max - 2021-08-09 at 22 25 34](https://user-images.githubusercontent.com/85645967/128744922-a5ddf11c-e7d9-47e5-875f-58782d0f9d8f.png)
![Simulator Screen Shot - iPhone 11 Pro Max - 2021-08-09 at 22 24 54](https://user-images.githubusercontent.com/85645967/128744939-8f37a910-2fed-450a-991b-bb9c0fd1a485.png)
![Simulator Screen Shot - iPhone 11 Pro Max - 2021-08-09 at 22 24 35](https://user-images.githubusercontent.com/85645967/128744946-813fa15d-c828-4d09-a341-6a1fb7cc356f.png)


#### Android
![Screenshot_1628528779](https://user-images.githubusercontent.com/85645967/128747474-74b4476c-9ca5-46f3-8bc3-935c81392545.png)
![Screenshot_1628528761](https://user-images.githubusercontent.com/85645967/128747481-29eeea61-4792-42db-918d-34f0c10184c8.png)
![Screenshot_1628528757](https://user-images.githubusercontent.com/85645967/128747485-8707092c-bd59-4579-afb5-425b7a792511.png)
![Screenshot_1628528772](https://user-images.githubusercontent.com/85645967/128747489-61ee325c-6be8-4867-82c5-92bae00c1e6c.png)
