### PR TITLE
Remove auto-complete for Industry Classification Code

### DIFF
--- a/src/pages/ReimbursementAccount/CompanyStep.js
+++ b/src/pages/ReimbursementAccount/CompanyStep.js
@@ -234,7 +234,7 @@ class CompanyStep extends React.Component {
                             value={this.state.industryCode}
                         />
                         <TextInputWithLabel
-                            autoCompleteType='new-password'
+                            autoCompleteType="new-password"
                             label={`Expensify ${this.props.translate('common.password')}`}
                             containerStyles={[styles.mt4]}
                             secureTextEntry

--- a/src/pages/ReimbursementAccount/CompanyStep.js
+++ b/src/pages/ReimbursementAccount/CompanyStep.js
@@ -226,7 +226,6 @@ class CompanyStep extends React.Component {
                         </View>
                         {/* TODO: Replace with NAICS picker */}
                         <TextInputWithLabel
-                            autoCompleteType="new-password"
                             label={this.props.translate('companyStep.industryClassificationCode')}
                             helpLinkText={this.props.translate('common.whatThis')}
                             helpLinkURL="https://www.naics.com/search/"
@@ -235,7 +234,7 @@ class CompanyStep extends React.Component {
                             value={this.state.industryCode}
                         />
                         <TextInputWithLabel
-                            autoCompleteType="new-password"
+                            autoCompleteType='new-password'
                             label={`Expensify ${this.props.translate('common.password')}`}
                             containerStyles={[styles.mt4]}
                             secureTextEntry

--- a/src/pages/ReimbursementAccount/CompanyStep.js
+++ b/src/pages/ReimbursementAccount/CompanyStep.js
@@ -226,6 +226,7 @@ class CompanyStep extends React.Component {
                         </View>
                         {/* TODO: Replace with NAICS picker */}
                         <TextInputWithLabel
+                            autoCompleteType="new-password"
                             label={this.props.translate('companyStep.industryClassificationCode')}
                             helpLinkText={this.props.translate('common.whatThis')}
                             helpLinkURL="https://www.naics.com/search/"
@@ -234,10 +235,10 @@ class CompanyStep extends React.Component {
                             value={this.state.industryCode}
                         />
                         <TextInputWithLabel
+                            autoCompleteType="new-password"
                             label={`Expensify ${this.props.translate('common.password')}`}
                             containerStyles={[styles.mt4]}
                             secureTextEntry
-                            autoCompleteType="password"
                             textContentType="password"
                             onChangeText={password => this.setState({password})}
                             value={this.state.password}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This fixes an issue where chrome will auto-complete for Industry Classification Code. This is the workaround that we follow in [Web](https://github.com/Expensify/Expensify/issues/71427) because Chrome will auto-populate the autoComplete data even if the autoComplete field is set to `off`. As an additional side-effect of this, we need to also remove the autoComplete for the ExpensifyPassword field.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ https://github.com/Expensify/Expensify/issues/173177

### Tests/QA
1. Sign into an account on chrome and save the password in chrome when prompted
1. Sign into an account, tap on the profile icon to go to settings, and then click on a workspace
2. Click on `Get Started` for the Expensify Card
3. Select `Connect Manually` and enter `123123123` for both fields
4. On the autoComplete section, confirm no values are pre-filled for `Industry Classification Code`
5. Confirm the same happens on all platforms (you won't be able to save password on the others)

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web/Desktop
<img src='http://g.recordit.co/sq3fpR4KM6.gif' width='400'/>