### PR TITLE
[InternalQA] Update Onyx after validating bank account

### DIFF
--- a/src/libs/actions/BankAccounts.js
+++ b/src/libs/actions/BankAccounts.js
@@ -554,20 +554,20 @@ function validateBankAccount(bankAccountID, validateCode) {
                 Growl.show('Bank Account successfully validated!', CONST.GROWL.SUCCESS, 3000);
                 API.User_IsUsingExpensifyCard()
                     .then(({isUsingExpensifyCard}) => {
-                        Onyx.merge(ONYXKEYS.USER, {isUsingExpensifyCard});
-                        Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {
+                        const reimbursementAccount = {
                             loading: false,
                             error: '',
                             achData: {state: BankAccount.STATE.OPEN},
-                        });
+                        };
 
                         if (isUsingExpensifyCard) {
                             Navigation.dismissModal();
                         } else {
-                            Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {
-                                achData: {currentStep: CONST.BANK_ACCOUNT.STEP.ENABLE},
-                            });
+                            reimbursementAccount.achData.currentStep = CONST.BANK_ACCOUNT.STEP.ENABLE;
                         }
+
+                        Onyx.merge(ONYXKEYS.USER, {isUsingExpensifyCard});
+                        Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, reimbursementAccount);
                     });
                 return;
             }

--- a/src/libs/actions/BankAccounts.js
+++ b/src/libs/actions/BankAccounts.js
@@ -10,6 +10,7 @@ import BankAccount from '../models/BankAccount';
 import promiseAllSettled from '../promiseAllSettled';
 import Growl from '../Growl';
 import {translateLocal} from '../translate';
+import Navigation from '../Navigation/Navigation';
 
 /**
  * List of bank accounts. This data should not be stored in Onyx since it contains unmasked PANs.
@@ -554,7 +555,12 @@ function validateBankAccount(bankAccountID, validateCode) {
                 API.User_IsUsingExpensifyCard()
                     .then(({isUsingExpensifyCard}) => {
                         Onyx.merge(ONYXKEYS.USER, {isUsingExpensifyCard});
-                        Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {loading: false, error: ''});
+                        if (isUsingExpensifyCard) {
+                            Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {loading: false, error: '', achData: {state: BankAccount.STATE.OPEN}});
+                            Navigation.dismissModal();
+                        } else {
+                            Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {loading: false, error: '', achData: {state: BankAccount.STATE.OPEN, currentStep: CONST.BANK_ACCOUNT.STEP.ENABLE}});
+                        }
                     });
                 return;
             }

--- a/src/libs/actions/BankAccounts.js
+++ b/src/libs/actions/BankAccounts.js
@@ -555,12 +555,18 @@ function validateBankAccount(bankAccountID, validateCode) {
                 API.User_IsUsingExpensifyCard()
                     .then(({isUsingExpensifyCard}) => {
                         Onyx.merge(ONYXKEYS.USER, {isUsingExpensifyCard});
-                        Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {loading: false, error: '', achData: {state: BankAccount.STATE.OPEN}});
+                        Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {
+                            loading: false,
+                            error: '',
+                            achData: {state: BankAccount.STATE.OPEN},
+                        });
 
                         if (isUsingExpensifyCard) {
                             Navigation.dismissModal();
                         } else {
-                            Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {achData: {currentStep: CONST.BANK_ACCOUNT.STEP.ENABLE}});
+                            Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {
+                                achData: {currentStep: CONST.BANK_ACCOUNT.STEP.ENABLE},
+                            });
                         }
                     });
                 return;

--- a/src/libs/actions/BankAccounts.js
+++ b/src/libs/actions/BankAccounts.js
@@ -555,11 +555,12 @@ function validateBankAccount(bankAccountID, validateCode) {
                 API.User_IsUsingExpensifyCard()
                     .then(({isUsingExpensifyCard}) => {
                         Onyx.merge(ONYXKEYS.USER, {isUsingExpensifyCard});
+                        Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {loading: false, error: '', achData: {state: BankAccount.STATE.OPEN}});
+
                         if (isUsingExpensifyCard) {
-                            Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {loading: false, error: '', achData: {state: BankAccount.STATE.OPEN}});
                             Navigation.dismissModal();
                         } else {
-                            Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {loading: false, error: '', achData: {state: BankAccount.STATE.OPEN, currentStep: CONST.BANK_ACCOUNT.STEP.ENABLE}});
+                            Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {achData: {currentStep: CONST.BANK_ACCOUNT.STEP.ENABLE}});
                         }
                     });
                 return;


### PR DESCRIPTION
### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ https://github.com/Expensify/Expensify/issues/173086
$ https://github.com/Expensify/App/issues/4466

### Tests
1. Login into an account without the Expensify Card or Withdrawal Bank account setup.
2. Create a New Workspace
3. Click on `Get Started`
4. Follow this [SO](https://stackoverflow.com/c/expensify/questions/342/525#525) to setup an account in the `PENDING` state.
5. Follow this [SO](https://stackoverflow.com/c/expensify/questions/8323) to grab the validating codes.
6. Verify that the account is validated but now you see this step:

![Screen Shot 2021-08-06 at 3 03 46 PM](https://user-images.githubusercontent.com/22219519/128572992-96a4caa8-d297-4b28-9e9e-48665a35ecfa.png)

7. Repeat steps 1-6 but applying `isUsingExpensifyCard:true` [here](https://github.com/Expensify/App/blob/c778197d2f01e8b7074fd0e84d841b56b83d0d2b/src/libs/actions/BankAccounts.js#L557) so we can simulate auto provisioning of the card.
8. Verify that the modal closes and the button changes to `Manage Card`.


### QA Steps
Internal QA. Steps above.

### Tested On

- [X] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web

https://user-images.githubusercontent.com/22219519/128573630-be7d7cad-5efa-4ea8-92ed-22950fa4b484.mov

https://user-images.githubusercontent.com/22219519/128573637-d5c07d00-67bf-4fbc-93a8-f654dfff762c.mov



#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
