### PR TITLE
Autofill previously entered accounting and routing numbers

### DIFF
--- a/src/libs/actions/BankAccounts.js
+++ b/src/libs/actions/BankAccounts.js
@@ -619,8 +619,16 @@ function setupWithdrawalAccount(data) {
 
     API.BankAccount_SetupWithdrawal(newACHData)
         .then((response) => {
-            Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {loading: false, achData: {...newACHData}});
-
+            // Ensure that we don't continue until the merge is complete, this prevents the achData from getting
+            // overwritten later on in the flow before this merge happens
+            return Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {
+                loading: false,
+                achData: {...newACHData},
+            })
+                .then(() => {
+                    return Promise.resolve(response);
+                });
+        }).then((response) => {
             const currentStep = newACHData.currentStep;
             let achData = lodashGet(response, 'achData', {});
             let error = lodashGet(achData, CONST.BANK_ACCOUNT.VERIFICATIONS.ERROR_MESSAGE);

--- a/src/libs/actions/BankAccounts.js
+++ b/src/libs/actions/BankAccounts.js
@@ -328,6 +328,11 @@ function fetchUserWallet() {
  * @param {String} [stepToOpen]
  */
 function fetchFreePlanVerifiedBankAccount(stepToOpen) {
+    const oldACHData = {
+        accountNumber: reimbursementAccountInSetup.accountNumber || '',
+        routingNumber: reimbursementAccountInSetup.routingNumber || '',
+    };
+
     // We are using set here since we will rely on data from the server (not local data) to populate the VBA flow
     // and determine which step to navigate to.
     Onyx.set(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {loading: true});
@@ -478,7 +483,18 @@ function fetchFreePlanVerifiedBankAccount(stepToOpen) {
                     goToWithdrawalAccountSetupStep(currentStep, achData);
                 })
                 .finally(() => {
-                    Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {loading: false});
+                    const dataToMerge = {
+                        loading: false,
+                    };
+
+                    // If we didn't get a routingNumber and accountNumber from the response and we have previously saved
+                    // values, autofill them
+                    if (!reimbursementAccountInSetup.routingNumber && !reimbursementAccountInSetup.accountNumber
+                        && oldACHData.routingNumber && oldACHData.accountNumber) {
+                        dataToMerge.achData = oldACHData;
+                    }
+
+                    Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, dataToMerge);
                 });
         });
 }

--- a/src/pages/ReimbursementAccount/CompanyStep.js
+++ b/src/pages/ReimbursementAccount/CompanyStep.js
@@ -137,9 +137,7 @@ class CompanyStep extends React.Component {
                 />
                 <ScrollView style={[styles.flex1, styles.w100]}>
                     <View style={[styles.p4]}>
-                        <View style={[styles.alignItemsCenter]}>
-                            <Text>{this.props.translate('companyStep.subtitle')}</Text>
-                        </View>
+                        <Text>{this.props.translate('companyStep.subtitle')}</Text>
                         <TextInputWithLabel
                             label={this.props.translate('companyStep.legalBusinessName')}
                             containerStyles={[styles.mt4]}


### PR DESCRIPTION
@roryabraham will you please review this?

### Details
This PR updates the Add Bank Account flow to save the accountNumber and routingNumber if the user exits the flow after setting those values.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ https://github.com/Expensify/App/issues/4476

### Tests/QA
1. Log into an account w/ a workspace and go to Settings->Workspace->Expensify Card and hit `Get Started`
2. Fill out values for the accounting number and routing number and hit `Save & Continue`
3. Close the modal then hit `Get Started` again, confirm routing number and account number are saved
4. Change the routing and account numbers, then hit `Save & Continue`
5. Close the modal then hit `Get Started` again. Verify that the routing and account number have been updated.
6. Hit `Save & Continue` again.
7. Fill out the company information step and hit save and continue
8. Close the modal and hit `Get Started` again, confirm the values are pre-populated
9. Sign out of the account and sign back in, confirm that the values are pre-populated (this will only work if you save on the Company Information step)

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web/Desktop
| Starting Flow | Already saved at Company Info |
|---|---|
| <img src='http://g.recordit.co/NRcpQOmVsy.gif' width='400'/> | <img src='http://g.recordit.co/kH0aGFADUt.gif' width='400'/> |

#### Mobile
| Starting Flow | Already saved at Company Info |
|---|---|
| <img src='http://g.recordit.co/X8dAZMnmhV.gif' width='400'/> | <img src='http://g.recordit.co/sYD4u3eNTg.gif' width='400'/> |' width='400'/> |
