### PR TITLE
Add incorporationState as required field in Bank Account flow

### DIFF
--- a/src/pages/ReimbursementAccount/CompanyStep.js
+++ b/src/pages/ReimbursementAccount/CompanyStep.js
@@ -56,6 +56,7 @@ class CompanyStep extends React.Component {
             'website',
             'companyTaxID',
             'incorporationDate',
+            'incorporationState',
             'industryCode',
             'password',
         ];


### PR DESCRIPTION
@jasperhuangg will you please review this

### Details
This PR adds a missing required field on the CompanyStep in the Bank Account flow

### Fixed Issues
Follow-up to https://github.com/Expensify/App/pull/4272/files coming from [slack convo](https://expensify.slack.com/archives/C020EPP9B9A/p1628278038384200)

### Tests/QA
1. Navigate to the company step in the VBA flow: `<baseURL>/bank-account/company`.
2. These are the fields that need to be filled out in order for the "Save & Continue" button to be enabled. Verify that the button is disabled if any of these fields aren't filled out. You don't need to input a valid value, any value will suffice as long as it isn't empty:
    - Legal Business Name
    - Company Address
    - City (for company address)
    - State (for company address)
    - Zip Code (for company address)
    - Company Website
    - Tax ID Number
    - Incorporation Date
    - Incorporation State
    - Industry Classification Code
    - Expensify Password

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<img src='http://g.recordit.co/UdaY9UDlhb.gif' width='400'/>