### PR TITLE
[InternalQA] Prevent UI change on VBA flow during data fetch

### DIFF
--- a/src/libs/actions/BankAccounts.js
+++ b/src/libs/actions/BankAccounts.js
@@ -406,6 +406,7 @@ function fetchFreePlanVerifiedBankAccount(stepToOpen) {
                     achData.isInSetup = !bankAccount || bankAccount.isInSetup();
                     achData.bankAccountInReview = bankAccount && bankAccount.isVerifying();
                     achData.domainLimit = 0;
+                    achData.state = lodashGet(achData, 'state', '');
 
                     // If the bank account has already been created in the db and is not yet open
                     // let's show the manual form with the previously added values

--- a/src/libs/actions/BankAccounts.js
+++ b/src/libs/actions/BankAccounts.js
@@ -330,7 +330,8 @@ function fetchUserWallet() {
 function fetchFreePlanVerifiedBankAccount(stepToOpen) {
     // We are using set here since we will rely on data from the server (not local data) to populate the VBA flow
     // and determine which step to navigate to.
-    Onyx.set(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {loading: true});
+    // We temporarily keep the achData state to prevent UI changes while fetching.
+    Onyx.set(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {loading: true, achData: {state: reimbursementAccountInSetup.state}});
     let bankAccountID;
 
     API.Get({

--- a/src/libs/actions/BankAccounts.js
+++ b/src/libs/actions/BankAccounts.js
@@ -330,9 +330,10 @@ function fetchUserWallet() {
 function fetchFreePlanVerifiedBankAccount(stepToOpen) {
     // We are using set here since we will rely on data from the server (not local data) to populate the VBA flow
     // and determine which step to navigate to.
-    // We temporarily keep the achData state to prevent UI changes while fetching.
     Onyx.set(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {
         loading: true,
+
+        // We temporarily keep the achData state to prevent UI changes while fetching.
         achData: {state: lodashGet(reimbursementAccountInSetup, 'state', '')},
     });
     let bankAccountID;

--- a/src/libs/actions/BankAccounts.js
+++ b/src/libs/actions/BankAccounts.js
@@ -331,7 +331,10 @@ function fetchFreePlanVerifiedBankAccount(stepToOpen) {
     // We are using set here since we will rely on data from the server (not local data) to populate the VBA flow
     // and determine which step to navigate to.
     // We temporarily keep the achData state to prevent UI changes while fetching.
-    Onyx.set(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {loading: true, achData: {state: reimbursementAccountInSetup.state}});
+    Onyx.set(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {
+        loading: true,
+        achData: {state: lodashGet(reimbursementAccountInSetup, 'state', '')},
+    });
     let bankAccountID;
 
     API.Get({

--- a/src/libs/actions/BankAccounts.js
+++ b/src/libs/actions/BankAccounts.js
@@ -407,6 +407,10 @@ function fetchFreePlanVerifiedBankAccount(stepToOpen) {
                     achData.isInSetup = !bankAccount || bankAccount.isInSetup();
                     achData.bankAccountInReview = bankAccount && bankAccount.isVerifying();
                     achData.domainLimit = 0;
+
+                    // Adding a default empty state to make sure we override the temporary one we are keeping
+                    // for UI purposes. This covers an edge case in which a user deleted their bank account,
+                    // but would still see Finish Setup in the UI, instead of Get Started.
                     achData.state = lodashGet(achData, 'state', '');
 
                     // If the bank account has already been created in the db and is not yet open


### PR DESCRIPTION
### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ https://github.com/Expensify/App/issues/4467

### Tests
1. Create a new Workspace and 
2. Add an account in `PENDING` state following this [SO](https://stackoverflow.com/c/expensify/questions/342/525#525).
3. When you get to the step where the button changes to `Finish Setup`, close the modal.
4. Click the button again and observe that it does not change back to `Get Started` while fetching.

### QA Steps
Internal QA

### Tested On

- [X] Web
- [ ] Mobile Web
- [X] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web

https://user-images.githubusercontent.com/22219519/128579477-e8a2fd6d-663f-473f-83e1-860620805084.mov

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop

https://user-images.githubusercontent.com/22219519/128579482-2c299014-85ca-4447-b6f2-6ff4ff0536bb.mov

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
