### PR TITLE
fix: message alignment

### DIFF
--- a/src/components/InlineCodeBlock/index.native.js
+++ b/src/components/InlineCodeBlock/index.native.js
@@ -4,21 +4,25 @@ import WrappedText from './WrappedText';
 import inlineCodeBlockPropTypes from './inlineCodeBlockPropTypes';
 
 const InlineCodeBlock = ({
+    TDefaultRenderer,
     defaultRendererProps,
     boxModelStyle,
     textStyle,
 }) => (
-    <WrappedText
-        textStyles={[textStyle]}
-        wordStyles={[
-            boxModelStyle,
-            styles.codeWordStyle,
-        ]}
-        // eslint-disable-next-line react/jsx-props-no-spreading
+    <TDefaultRenderer
+    // eslint-disable-next-line react/jsx-props-no-spreading
         {...defaultRendererProps}
     >
-        {defaultRendererProps.tnode.data}
-    </WrappedText>
+        <WrappedText
+            textStyles={[textStyle]}
+            wordStyles={[
+                boxModelStyle,
+                styles.codeWordStyle,
+            ]}
+        >
+            {defaultRendererProps.tnode.data}
+        </WrappedText>
+    </TDefaultRenderer>
 );
 
 InlineCodeBlock.propTypes = inlineCodeBlockPropTypes;

--- a/src/components/RenderHTML/BaseRenderHTML.js
+++ b/src/components/RenderHTML/BaseRenderHTML.js
@@ -227,6 +227,7 @@ const BaseRenderHTML = ({html, debug, textSelectable}) => {
     return (
         <HTML
             defaultTextProps={{selectable: textSelectable}}
+            defaultViewProps={{style: {alignItems: 'flex-start'}}}
             customHTMLElementModels={customHTMLElementModels}
             renderers={renderers}
             renderersProps={renderersProps}

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1965,7 +1965,6 @@ const webViewStyles = {
         lineHeight: variables.fontSizeNormalHeight,
         fontFamily: fontFamily.GTA,
         flex: 1,
-        alignSelf: 'flex-start',
     },
 };
 

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1900,10 +1900,6 @@ const webViewStyles = {
     // styles from the renderer, just pass the "style" prop to the underlying
     // component.
     tagStyles: {
-        body: {
-            flexDirection: 'row',
-        },
-
         em: {
             fontFamily: fontFamily.GTA_ITALIC,
             fontStyle: 'italic',


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR only touches base for inline code block and trimming behavior is being fixed in other PR. I have raised the [issue](https://github.com/meliorence/react-native-render-html/issues/514#issue-962991420) with `react-native-render-html` and this issue is caused by the recent upgrade of this lib to v6 and As soon as the library fix this issue, I will send another PR to merge that fix.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ Fixes #4488

### Tests | QA Steps
1. Send a multiple-line message and observe the behavior. all lines should be in their own line.
2. Send two single-line messages and observe the behavior. They should lie in their own lines.
```
text - first line
text - second line
```

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web | Desktop
<!-- Insert screenshots of your changes on the web platform-->
![image](https://user-images.githubusercontent.com/24370807/128749435-bd556fb2-b045-44fe-bbbf-401393e5a9ac.png)

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
![Screenshot 2021-08-09 23:10:32](https://user-images.githubusercontent.com/24370807/128749666-c3e39cda-74e4-46d1-9dd9-1d0fd0faa2bd.png)

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
![Screenshot 2021-08-09 23:09:22](https://user-images.githubusercontent.com/24370807/128749552-1c294397-7915-4487-b903-e7a7f9347bba.png)
