### PR TITLE
Remove workspace growl message that is no longer necessary

### DIFF
--- a/src/libs/actions/Policy.js
+++ b/src/libs/actions/Policy.js
@@ -203,7 +203,6 @@ function create(name = '') {
             });
             Navigation.dismissModal();
             Navigation.navigate(ROUTES.getWorkspaceCardRoute(response.policyID));
-            Growl.success(translateLocal('workspace.new.successMessage'));
         });
 }
 


### PR DESCRIPTION
@joelbettner, please review when you get the chance.

### Details
Removes this growl message since it's no longer needed. I couldn't find a translation for it which probably explains why it says `workspace.new.successMessage` instead of the actual thing.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ https://github.com/Expensify/Expensify/issues/173338

### Tests
Same as Web QA done locally

### QA Steps
1. Log into an account on the free plan beta
2. Go to the + on the bottom left and create a new workspace
![image](https://user-images.githubusercontent.com/19364431/128745588-df4e984d-08a2-48c8-8333-cc76ed0f883a.png)

3. Verify that when you are brought to this page, you do NOT see the success growl like this:
BAD:
![image](https://user-images.githubusercontent.com/19364431/128745509-258072ab-91d4-450d-b7ea-6d4a43ef50fc.png)


### Tested On

- [x] Web
- [x] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android


