### PR TITLE
 Change the `View open jobs` URL to click through to E/App open issues instead of Upwork jobs

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -122,7 +122,7 @@ const CONST = {
     NEW_GOOGLE_MEET_MEETING_URL: 'https://meet.google.com/new',
     PDF_VIEWER_URL: '/pdf/web/viewer.html',
     EXPENSIFY_ICON_URL: `${CLOUDFRONT_URL}/images/favicon-2019.png`,
-    UPWORK_URL: 'https://www.upwork.com/ab/jobs/search/?q=Expensify%20React%20Native&user_location_match=2',
+    UPWORK_URL: 'https://github.com/Expensify/App/issues?q=is%3Aopen+is%3Aissue+label%3A%22Help+Wanted%22',
     GITHUB_URL: 'https://github.com/Expensify/Expensify.cash',
     TERMS_URL: 'https://use.expensify.com/terms',
     PRIVACY_URL: 'https://use.expensify.com/privacy',


### PR DESCRIPTION
CC: @parasharrajat @mallenexpensify 

### Details
We used to link out to open jobs in Upwork here: https://www.upwork.com/ab/jobs/search/?q=Expensify%20React%20Native&user_location_match=2&sort=recency

.. but we're changing that to link to a filtered view of open issues in the E/App repo instead here: https://github.com/Expensify/App/issues?q=is%3Aopen+is%3Aissue+label%3A%22Help+Wanted%22

### Fixed Issues

$https://github.com/Expensify/App/issues/4470

### Tests

1. Click Avatar > `About`
2. Click on `View open Jobs`
3. Ensure you're navigated to open issues in GH [here](https://github.com/Expensify/App/issues?q=is%3Aopen+is%3Aissue+label%3A%22Help+Wanted%22) and not the old Upwork URL [here](https://www.upwork.com/ab/jobs/search/?q=Expensify%20React%20Native&user_location_match=2&sort=recency)

### QA Steps

1. Tap Avatar > `About`
2. Click on `View open Jobs`
3. Ensure you're navigated to here: https://github.com/Expensify/App/issues?q=is%3Aopen+is%3Aissue+label%3A%22Help+Wanted%22

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
None

#### Web
None

#### Mobile Web
None

#### Desktop
None

#### iOS
None

#### Android
None
