### PR TITLE
Added translation for edit button text

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -14,6 +14,7 @@ export default {
         add: 'Add',
         resend: 'Resend',
         save: 'Save',
+        saveChanges: 'Save Changes',
         password: 'Password',
         profile: 'Profile',
         payments: 'Payments',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -14,6 +14,7 @@ export default {
         add: 'Agregar',
         resend: 'Reenviar',
         save: 'Guardar',
+        saveChanges: 'Guardar cambios',
         password: 'Contraseña',
         profile: 'Perfil',
         payments: 'Pagos',

--- a/src/pages/home/report/ReportActionItemMessageEdit.js
+++ b/src/pages/home/report/ReportActionItemMessageEdit.js
@@ -10,8 +10,10 @@ import {editReportComment, saveReportActionDraft} from '../../../libs/actions/Re
 import {scrollToIndex} from '../../../libs/ReportScrollManager';
 import toggleReportActionComposeView from '../../../libs/toggleReportActionComposeView';
 import withWindowDimensions, {windowDimensionsPropTypes} from '../../../components/withWindowDimensions';
+import withLocalize, {withLocalizePropTypes} from '../../../components/withLocalize';
 import Button from '../../../components/Button';
 import ReportActionComposeFocusManager from '../../../libs/ReportActionComposeFocusManager';
+import compose from '../../../libs/compose';
 
 const propTypes = {
     /** All the data of the action */
@@ -28,6 +30,9 @@ const propTypes = {
 
     /** Window Dimensions Props */
     ...windowDimensionsPropTypes,
+
+    /** Localization props */
+    ...withLocalizePropTypes,
 };
 
 class ReportActionItemMessageEdit extends React.Component {
@@ -139,13 +144,13 @@ class ReportActionItemMessageEdit extends React.Component {
                     <Button
                         style={[styles.mr2]}
                         onPress={this.deleteDraft}
-                        text="Cancel"
+                        text={this.props.translate('common.cancel')}
                     />
                     <Button
                         success
                         style={[styles.mr2]}
                         onPress={this.publishDraft}
-                        text="Save Changes"
+                        text={this.props.translate('common.saveChanges')}
                     />
                 </View>
             </View>
@@ -154,4 +159,7 @@ class ReportActionItemMessageEdit extends React.Component {
 }
 
 ReportActionItemMessageEdit.propTypes = propTypes;
-export default withWindowDimensions(ReportActionItemMessageEdit);
+export default compose(
+    withLocalize,
+    withWindowDimensions,
+)(ReportActionItemMessageEdit);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
- Added translations for edit button text 

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ #4494 

### Tests
1. Tested texts in both the languages - English and Spanish
2. Verified the button texts, on language change


<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
![edit-button-text-eng-web](https://user-images.githubusercontent.com/3069065/128804822-86b3c100-ab6e-4129-ad2e-1a87f2267cda.png)
![edit-button-text-esp-web](https://user-images.githubusercontent.com/3069065/128804829-19859abf-a80b-4c77-81a0-811c2002156c.png)

#### Mobile Web
![edit-button-text-eng-mweb](https://user-images.githubusercontent.com/3069065/128805004-03b6916a-19c1-489e-be1b-58d937c581e1.png)
![edit-button-text-esp-mweb](https://user-images.githubusercontent.com/3069065/128805009-2ad05c09-b5a0-4f16-adbf-e5cd07b941d1.png)

#### Desktop
![edit-button-text-eng-desktop](https://user-images.githubusercontent.com/3069065/128805039-0d12b8da-edf9-4885-a8b4-ffc186d121c8.png)
![edit-button-text-esp-desktop](https://user-images.githubusercontent.com/3069065/128805053-766cdf5a-5684-4f47-a886-c6c34b918647.png)

#### iOS
<img width="356" alt="edit-button-text-esp-ios" src="https://user-images.githubusercontent.com/3069065/128805184-17c2a157-ed27-4217-9c02-0aef2ca0ad79.png">
<img width="354" alt="edit-button-text-eng-ios" src="https://user-images.githubusercontent.com/3069065/128805188-b25324c7-d8c8-4afc-bea4-989e2b8d8266.png">


#### Android
<img width="325" alt="edit-button-text-eng-android" src="https://user-images.githubusercontent.com/3069065/128806186-7ff901c8-3043-43d3-bbaf-ff1fed8325aa.png">
<img width="319" alt="edit-button-text-esp-android" src="https://user-images.githubusercontent.com/3069065/128806193-4cbcf10d-3ac7-41e5-8a5e-645e9959a251.png">

<!-- Insert screenshots of your changes on the Android platform-->
