### PR TITLE
Fix the text style for Payment Methods

### DIFF
--- a/src/pages/settings/Payments/PaymentsPage.js
+++ b/src/pages/settings/Payments/PaymentsPage.js
@@ -105,7 +105,7 @@ class PaymentsPage extends React.Component {
                     <View>
                         <CurrentWalletBalance />
                         <Text
-                            style={[styles.ph5, styles.textStrong]}
+                            style={[styles.ph5, styles.formLabel]}
                         >
                             {this.props.translate('paymentsPage.paymentMethodsTitle')}
                         </Text>


### PR DESCRIPTION
@shawnborton & @bondyaa

### Details
Fix the text style for Payment Methods

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ N/A

### QA Steps

1. Click on your user profile image to open the Settings menu
2. Go to "Payments"
3. Verify that the text is in a smaller font size

### Tested On

- [x] Web
- [x] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
![Screen Shot 2021-08-10 at 11 29 29](https://user-images.githubusercontent.com/1805746/128843871-e72c4e90-c6a7-4ebb-9ae7-42c6ceef516a.png)


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
![Screen Shot 2021-08-10 at 11 30 47](https://user-images.githubusercontent.com/1805746/128843889-dc9fd682-c410-44db-a8bb-2c3266ae818d.png)


#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
