### PR TITLE
Require restricted business checkbox on CompanyStep

### DIFF
--- a/src/pages/ReimbursementAccount/CompanyStep.js
+++ b/src/pages/ReimbursementAccount/CompanyStep.js
@@ -119,8 +119,8 @@ class CompanyStep extends React.Component {
     render() {
         const shouldDisableCompanyName = Boolean(this.props.achData.bankAccountID && this.props.achData.companyName);
         const shouldDisableCompanyTaxID = Boolean(this.props.achData.bankAccountID && this.props.achData.companyTaxID);
-        const shouldDisableSubmitButton = this.requiredFields
-            .reduce((acc, curr) => acc || !this.state[curr].trim(), false);
+        const missingRequiredFields = this.requiredFields.reduce((acc, curr) => acc || !this.state[curr].trim(), false);
+        const shouldDisableSubmitButton = !this.state.hasNoConnectionToCannabis || missingRequiredFields;
 
         return (
             <>


### PR DESCRIPTION
### Details
This PR adds a check to ensure the user can't continue on the Company Step of the VBA flow if the checkbox isn't checked.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
Follow up PR to the issue found here: https://github.com/Expensify/App/pull/4479#issuecomment-896160707
cc @kevinksullivan 

### Tests/QA
1. Navigate to the company step in the VBA flow: `<baseURL>/bank-account/company`.
2. These are the fields that need to be filled out in order for the "Save & Continue" button to be enabled. Verify that the button is disabled if any of these fields aren't filled out. You don't need to input a valid value, any value will suffice as long as it isn't empty:
    - Legal Business Name
    - Company Address
    - City (for company address)
    - State (for company address)
    - Zip Code (for company address)
    - Company Website
    - Tax ID Number
    - Incorporation Date
    - Incorporation State
    - Industry Classification Code
    - Expensify Password
    - Checkbox at the bottom

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<img src='http://g.recordit.co/13tiIwTFDf.gif' width='400'/>