### PR TITLE
 Updated Add Phone/Email Style in Profile Page

### DIFF
--- a/src/pages/settings/Profile/LoginField.js
+++ b/src/pages/settings/Profile/LoginField.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import {View, Pressable} from 'react-native';
+import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import Text from '../../../components/Text';
 import styles from '../../../styles/styles';
@@ -12,6 +12,7 @@ import Navigation from '../../../libs/Navigation/Navigation';
 import {resendValidateCode} from '../../../libs/actions/User';
 import withLocalize, {withLocalizePropTypes} from '../../../components/withLocalize';
 import Button from '../../../components/Button';
+import MenuItem from '../../../components/MenuItem';
 
 const propTypes = {
     /** Label to display on login form */
@@ -85,21 +86,14 @@ class LoginField extends Component {
             <View style={styles.mb6}>
                 <Text style={styles.formLabel}>{this.props.label}</Text>
                 {!this.props.login.partnerUserID ? (
-                    <Pressable
-                        style={[styles.createMenuItem, styles.ph0]}
-                        onPress={() => Navigation.navigate(ROUTES.getSettingsAddLoginRoute(this.props.type))}
-                    >
-                        <View style={styles.flexRow}>
-                            <View style={styles.createMenuIcon}>
-                                <Icon src={Plus} />
-                            </View>
-                            <View style={styles.justifyContentCenter}>
-                                <Text style={[styles.createMenuText, styles.ml3]}>
-                                    {`${this.props.translate('common.add')} ${this.props.label}`}
-                                </Text>
-                            </View>
-                        </View>
-                    </Pressable>
+                    <View style={[styles.mln5, styles.mrn5]}>
+                        <MenuItem
+                            key={`common.add.${this.props.type}`}
+                            title={`${this.props.translate('common.add')} ${this.props.label}`}
+                            icon={Plus}
+                            onPress={() => Navigation.navigate(ROUTES.getSettingsAddLoginRoute(this.props.type))}
+                        />
+                    </View>
                 ) : (
                     <View style={[styles.flexRow, styles.justifyContentBetween, styles.alignItemsCenter]}>
                         <Text numberOfLines={1}>

--- a/src/styles/utilities/spacing.js
+++ b/src/styles/utilities/spacing.js
@@ -73,6 +73,10 @@ export default {
         marginRight: 20,
     },
 
+    mrn5: {
+        marginRight: -20,
+    },
+
     ml1: {
         marginLeft: 4,
     },
@@ -91,6 +95,10 @@ export default {
 
     ml5: {
         marginLeft: 20,
+    },
+
+    mln5: {
+        marginLeft: -20,
     },
 
     mt1: {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

@dylanexpensify 

### Fixed Issues
$ #4528 

### Tests & QA Steps
1. Open profile page in settings. 
2. See` + Add Phone number` has incorrect styling. It should be like about's page options

3. Fix - provided to update the style, kindly verify.
### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->
Note: In Web & Desktop - Hovered over the option before taking the screenshot.

#### Web
<img width="1440" alt="Screenshot 2021-08-11 at 6 03 59 PM" src="https://user-images.githubusercontent.com/85645967/129029384-cb37fd4d-9c70-488a-a8a9-b7692e8e91cc.png">

#### Mobile Web
![localhost_8080_](https://user-images.githubusercontent.com/85645967/128922908-58bdbffe-43c3-468d-b835-7db9a737f0b3.png)

#### Desktop
<img width="1202" alt="Screenshot 2021-08-11 at 6 01 09 PM" src="https://user-images.githubusercontent.com/85645967/129028976-3f2f98c9-98a0-4cd7-9af8-d417e9a9cc4e.png">

#### iOS
![Simulator Screen Shot - iPhone 12 - 2021-08-11 at 17 56 06](https://user-images.githubusercontent.com/85645967/129028390-1eb57889-455a-4655-a363-77830d5ac4f6.png)

#### Android
![Screenshot_1628684703](https://user-images.githubusercontent.com/85645967/129028415-03074a91-cdac-4ac4-9f82-d80db645bbf7.png)

