### PR TITLE
Deploy iOS to production when deploying other platforms

### DIFF
--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -208,7 +208,6 @@ jobs:
           APPLE_DEMO_EMAIL: ${{ secrets.APPLE_DEMO_EMAIL }}
           APPLE_DEMO_PASSWORD: ${{ secrets.APPLE_DEMO_PASSWORD }}
 
-
       - name: Run Fastlane for App Store release
         if: ${{ env.SHOULD_DEPLOY_PRODUCTION == 'true' }}
         run: bundle exec fastlane ios production

--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -208,10 +208,9 @@ jobs:
           APPLE_DEMO_EMAIL: ${{ secrets.APPLE_DEMO_EMAIL }}
           APPLE_DEMO_PASSWORD: ${{ secrets.APPLE_DEMO_PASSWORD }}
 
-      # TODO: uncomment when we want to release iOS to production
+
       - name: Run Fastlane for App Store release
-        #              if: ${{ env.SHOULD_DEPLOY_PRODUCTION == 'true' }}
-        if: ${{ env.SHOULD_DEPLOY_PRODUCTION == 'true' && 'false' == 'true' }}
+        if: ${{ env.SHOULD_DEPLOY_PRODUCTION == 'true' }}
         run: bundle exec fastlane ios production
         env:
           VERSION: ${{ env.NEW_IOS_VERSION }}


### PR DESCRIPTION
### Details
For some reason we cannot remember, we were not running iOS deploys when we were deploying every other platform to production. This code change will allow iOS to be deployed to production automatically.

### Tests
1. Merge this PR
2. Verify the correct iOS version is put into production review when we close a staging QA check list