### PR TITLE
Remove unnecessary withOnyx from chat messages

### DIFF
--- a/src/components/OnyxProvider.js
+++ b/src/components/OnyxProvider.js
@@ -39,6 +39,7 @@ Onyx.registerLogger(({level, message}) => {
 // the same key (e.g. FlatList renderItem components)
 const [withNetwork, NetworkProvider] = createOnyxContext(ONYXKEYS.NETWORK);
 const [withPersonalDetails, PersonalDetailsProvider] = createOnyxContext(ONYXKEYS.PERSONAL_DETAILS);
+const [withCurrentDate, CurrentDateProvider] = createOnyxContext(ONYXKEYS.CURRENT_DATE);
 const [
     withReportActionsDrafts,
     ReportActionsDraftsProvider,
@@ -55,6 +56,7 @@ const OnyxProvider = props => (
             NetworkProvider,
             PersonalDetailsProvider,
             ReportActionsDraftsProvider,
+            CurrentDateProvider,
         ]}
     >
         {props.children}
@@ -70,4 +72,5 @@ export {
     withNetwork,
     withPersonalDetails,
     withReportActionsDrafts,
+    withCurrentDate,
 };

--- a/src/pages/home/report/ReportActionItemDate.js
+++ b/src/pages/home/report/ReportActionItemDate.js
@@ -1,11 +1,10 @@
 import React, {memo} from 'react';
 import PropTypes from 'prop-types';
-import {withOnyx} from 'react-native-onyx';
 import styles from '../../../styles/styles';
 import withLocalize, {withLocalizePropTypes} from '../../../components/withLocalize';
 import compose from '../../../libs/compose';
-import ONYXKEYS from '../../../ONYXKEYS';
 import Text from '../../../components/Text';
+import {withCurrentDate} from '../../../components/OnyxProvider';
 
 const propTypes = {
     /** UTC timestamp for when the action was created */
@@ -24,10 +23,6 @@ ReportActionItemDate.displayName = 'ReportActionItemDate';
 
 export default compose(
     withLocalize,
-    withOnyx({
-        currentDate: {
-            key: ONYXKEYS.CURRENT_DATE,
-        },
-    }),
+    withCurrentDate(),
     memo,
 )(ReportActionItemDate);


### PR DESCRIPTION
### Details
Missed this when creating the context provider - there is an additional `withOnyx()` getting connected to each chat message slowing down chat rendering. There is more context about this in the original PR that added the `OnyxProvider` here -> https://github.com/Expensify/App/pull/4348

cc @kidroca 

### Fixed Issues (Related To)
https://github.com/Expensify/App/issues/4022

### Tests
### QA Steps
1. No specific tests. Make sure chats load normally.

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
