### PR TITLE
[No QA] Update package.json name to fix conflict issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "expensify.cash",
+  "name": "new.expensify",
   "version": "1.0.84-1",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "expensify.cash",
+  "name": "new.expensify",
   "version": "1.0.84-1",
   "author": "Expensify, Inc.",
   "homepage": "https://new.expensify.com",


### PR DESCRIPTION
cc @parasharrajat @Julesssss 

### Details
This PR updates the package.json/package-lock.json to include a change from https://github.com/Expensify/App/pull/4408 in an attempt to fix the conflicts that come up when any other PR is merged. Since that PR base branch is not internal, it isn't easy for any internal engineer to update it to resolve the conflicts, resulting in a lot of back and forth. 

When resolving the conflicts locally, it looks like the only two affected files are package.json/package-lock.json, which is why these are the only files updated here.

### Fixed Issues
Related to https://github.com/Expensify/App/pull/4408

### Tests
Confirm you can run the app on all platforms

### QA Steps
None

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android