### PR TITLE
[No QA] Fix deploy comments for regular staging deploys

### DIFF
--- a/.github/actions/markPullRequestsAsDeployed/index.js
+++ b/.github/actions/markPullRequestsAsDeployed/index.js
@@ -129,7 +129,7 @@ const run = function () {
                     let deployer = lodashGet(response, 'data.merged_by.login', '');
                     const CPActorMatches = data.message
                         .match(/Merge pull request #\d+ from Expensify\/(.+)-cherry-pick-staging-\d+/);
-                    if (CPActorMatches.length === 2 && CPActorMatches[1] !== 'OSBotify') {
+                    if (_.isArray(CPActorMatches) && CPActorMatches.length === 2 && CPActorMatches[1] !== 'OSBotify') {
                         deployer = CPActorMatches[1];
                     }
 

--- a/.github/actions/markPullRequestsAsDeployed/markPullRequestsAsDeployed.js
+++ b/.github/actions/markPullRequestsAsDeployed/markPullRequestsAsDeployed.js
@@ -119,7 +119,7 @@ const run = function () {
                     let deployer = lodashGet(response, 'data.merged_by.login', '');
                     const CPActorMatches = data.message
                         .match(/Merge pull request #\d+ from Expensify\/(.+)-cherry-pick-staging-\d+/);
-                    if (CPActorMatches.length === 2 && CPActorMatches[1] !== 'OSBotify') {
+                    if (_.isArray(CPActorMatches) && CPActorMatches.length === 2 && CPActorMatches[1] !== 'OSBotify') {
                         deployer = CPActorMatches[1];
                     }
 

--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -354,7 +354,6 @@ jobs:
         with:
           PR_LIST: ${{ steps.getReleasePRList.outputs.PR_LIST }}
           IS_PRODUCTION_DEPLOY: ${{ env.SHOULD_DEPLOY_PRODUCTION == 'true' }}
-          STAGING_DEPLOY_NUMBER: ${{ steps.isStagingDeployLocked.outputs.NUMBER }}
           DEPLOY_VERSION: ${{ env.VERSION }}
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
           ANDROID: ${{ needs.android.result }}


### PR DESCRIPTION
### Details
This hopefully fixes a regression introduced in https://github.com/Expensify/App/pull/4274

### Fixed Issues
n/a

### Tests
1. Merge this PR.
1. Whenever a regular staging or production deploy completes, verify that the deployed PRs get a deploy comment including the actor who triggered that deploy.

### QA Steps
None.

### Tested On

GitHub only