### PR TITLE
Fix ExpensiInput autoFocus & tab Focus

### DIFF
--- a/src/components/ExpensiTextInput/BaseExpensiTextInput.js
+++ b/src/components/ExpensiTextInput/BaseExpensiTextInput.js
@@ -35,6 +35,7 @@ class BaseExpensiTextInput extends Component {
     }
 
     componentDidMount() {
+        // We are manually managing focus to prevent this issue: https://github.com/Expensify/App/issues/4514
         if (this.props.autoFocus && this.input) {
             this.input.focus();
         }

--- a/src/components/ExpensiTextInput/BaseExpensiTextInput.js
+++ b/src/components/ExpensiTextInput/BaseExpensiTextInput.js
@@ -34,6 +34,12 @@ class BaseExpensiTextInput extends Component {
         this.onBlur = this.onBlur.bind(this);
     }
 
+    componentDidMount() {
+        if (this.props.autoFocus && this.input) {
+            this.input.focus();
+        }
+    }
+
     onFocus() {
         if (this.props.onFocus) { this.props.onFocus(); }
         this.setState({isFocused: true});
@@ -84,13 +90,14 @@ class BaseExpensiTextInput extends Component {
             inputStyle,
             ignoreLabelTranslateX,
             innerRef,
+            autoFocus,
             ...inputProps
         } = this.props;
 
         const hasLabel = Boolean(label.length);
         return (
             <View style={[styles.componentHeightLarge, ...containerStyles]}>
-                <TouchableWithoutFeedback onPress={() => this.input.focus()}>
+                <TouchableWithoutFeedback onPress={() => this.input.focus()} focusable={false}>
                     <View
                         style={[
                             styles.expensiTextInputContainer,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ Fixes #4514

### Tests | QA Steps
1. Open the Login page on the Web.
2. Observe the email input. It should be autofocused correctly.
3. Go to the password page, observe the password input. If it is auto-filled, input should be focused correctly.
4. Now try to navigate using the Tab key. Ony single tab pres, the focus should be set on the Input.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
https://user-images.githubusercontent.com/24370807/128928131-a9ad7ac5-1e05-48eb-8241-71b4293baec6.mp4

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
![foucs-fix-m](https://user-images.githubusercontent.com/24370807/129108803-c4b87625-a269-4cfc-b4e2-6664caae87ff.png)

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
![fcous-fix-a](https://user-images.githubusercontent.com/24370807/129110505-c6b88382-043f-45a7-ab86-2e1b621a8a77.png)
