### PR TITLE
Hide Password mismatch incase both the passwords are empty

### DIFF
--- a/src/pages/settings/PasswordPage.js
+++ b/src/pages/settings/PasswordPage.js
@@ -71,6 +71,8 @@ class PasswordPage extends Component {
 
         if (this.state.newPassword && this.state.confirmNewPassword && !this.doPasswordsMatch()) {
             stateToUpdate.shouldShowPasswordConfirmError = true;
+        } else {
+            stateToUpdate.shouldShowPasswordConfirmError = false;
         }
 
         if (!isEmpty(stateToUpdate)) {

--- a/src/pages/settings/PasswordPage.js
+++ b/src/pages/settings/PasswordPage.js
@@ -75,9 +75,7 @@ class PasswordPage extends Component {
             stateToUpdate.shouldShowPasswordConfirmError = false;
         }
 
-        if (!isEmpty(stateToUpdate)) {
-            this.setState(stateToUpdate);
-        }
+        this.setState(stateToUpdate);
     }
 
     onBlurConfirmPassword() {

--- a/src/pages/settings/PasswordPage.js
+++ b/src/pages/settings/PasswordPage.js
@@ -79,7 +79,7 @@ class PasswordPage extends Component {
     }
 
     onBlurConfirmPassword() {
-        if (!this.state.confirmNewPassword || !this.doPasswordsMatch()) {
+        if ((this.state.newPassword && !this.state.confirmNewPassword) || !this.doPasswordsMatch()) {
             this.setState({shouldShowPasswordConfirmError: true});
         } else {
             this.setState({shouldShowPasswordConfirmError: false});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

@alex-mechler Can you please help review this?

### Details
Show Password mismatch error only if New Password is entered.

Regression from #4367 

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ #4606 
$ https://github.com/Expensify/App/issues/4665

### Tests
Apart from the test cases mentioned here #4409 
1. Tested by keeping New Password and Confirm Password blank onBlur.
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
https://user-images.githubusercontent.com/3069065/129234939-5848e435-5263-4524-91f6-170f3fc7810c.mp4

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
https://user-images.githubusercontent.com/3069065/129235065-483dc148-cc64-43fe-826b-334771a95604.mp4

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
https://user-images.githubusercontent.com/3069065/129235081-9b4dadd4-1632-4af8-ad70-a13ac33f3d7b.mp4

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
https://user-images.githubusercontent.com/3069065/129235210-eb744c66-c388-4c9b-9e2c-79ebba0d6bfa.mp4


#### Android
<!-- Insert screenshots of your changes on the Android platform-->
https://user-images.githubusercontent.com/3069065/129235156-46f18b9f-2f1e-4e4f-a5c6-9457e5edc03c.mp4

