### PR TITLE
Check for value before checking length

### DIFF
--- a/src/components/ExpensiTextInput/BaseExpensiTextInput.js
+++ b/src/components/ExpensiTextInput/BaseExpensiTextInput.js
@@ -19,7 +19,7 @@ class BaseExpensiTextInput extends Component {
     constructor(props) {
         super(props);
 
-        const hasValue = props.value.length > 0;
+        const hasValue = props.value && props.value.length > 0;
 
         this.state = {
             isFocused: false,


### PR DESCRIPTION
### Details
Regression due to [this refactor](https://github.com/Expensify/App/pull/3414). We just need to check if the value exists before we try to check the length.

### Fixed Issues
$ https://github.com/Expensify/App/issues/4599

### Tests
1. Enter the email for a new account on newDot
2. Go to localhost:8080/setpassword/<AccountID>/12345
3. Make sure you don't get a white screen

### QA Steps
1. Input an email address for new account
2. Check the inbox, long tap the link in the email. Tap "Copy" button.
3. Paste the link into any app that renders hyperlinks as clickable objects.
4. Add staging to the URL, so it says staging.new.expenisify.com....
5. Tap the link.
6. If the "Choose app to open with" modal appears, select "Expensify"
7. Make sure you don't get a white screen or error

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android