### PR TITLE
Clear storage immediately on sign out

### DIFF
--- a/src/libs/actions/SignInRedirect.js
+++ b/src/libs/actions/SignInRedirect.js
@@ -45,21 +45,18 @@ function redirectToSignIn(errorMessage) {
     const activeClients = currentActiveClients;
     const preferredLocale = currentPreferredLocale;
 
-    // We must set the authToken to null so we can navigate to "signin" it's not possible to navigate to the route as
-    // it only exists when the authToken is null.
-    Onyx.set(ONYXKEYS.SESSION, {authToken: null})
+    // Clearing storage discards the authToken. This causes a redirect to the SignIn screen
+    Onyx.clear()
         .then(() => {
-            Onyx.clear().then(() => {
-                if (preferredLocale) {
-                    Onyx.set(ONYXKEYS.NVP_PREFERRED_LOCALE, preferredLocale);
-                }
-                if (errorMessage) {
-                    Onyx.set(ONYXKEYS.SESSION, {error: errorMessage});
-                }
-                if (activeClients && activeClients.length > 0) {
-                    Onyx.set(ONYXKEYS.ACTIVE_CLIENTS, activeClients);
-                }
-            });
+            if (preferredLocale) {
+                Onyx.set(ONYXKEYS.NVP_PREFERRED_LOCALE, preferredLocale);
+            }
+            if (errorMessage) {
+                Onyx.set(ONYXKEYS.SESSION, {error: errorMessage});
+            }
+            if (activeClients && activeClients.length > 0) {
+                Onyx.set(ONYXKEYS.ACTIVE_CLIENTS, activeClients);
+            }
         });
 }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
cc @iwiznia @francoisl 

### Details
Waiting for `set` to complete gives enough time for other connections (triggered by `authToken` change) to be initiated with cached data
This causes a bug where the SignIn component does not have correct state
More details are available in the linked issue

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ #4595

### Tests
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->
1. Launch the mobile app
2. Switch a few chats
3. Log out

You should be on the initial Login screen, where you need to input your email

### QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->
Same as above

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
https://user-images.githubusercontent.com/12156624/129252213-9554755a-7232-4cdc-ac2d-0fee29ff7424.mp4

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
https://user-images.githubusercontent.com/12156624/129252335-b318a949-9cdc-440e-9546-8e9422428bc7.mp4

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
![image](https://user-images.githubusercontent.com/12156624/129252396-604a9a3e-1ec9-49ec-946b-0ad6baacf3b0.png)

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
https://user-images.githubusercontent.com/12156624/129253278-cee25cac-1326-4294-8064-a21181969bc7.mov

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
https://user-images.githubusercontent.com/12156624/129247928-86ea75a1-5ec7-4ecb-b711-9491f02a124b.mp4