### PR TITLE
fix: Inline code block styling

### DIFF
--- a/src/components/InlineCodeBlock/index.js
+++ b/src/components/InlineCodeBlock/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import {Text} from 'react-native';
 import inlineCodeBlockPropTypes from './inlineCodeBlockPropTypes';
 
 const InlineCodeBlock = ({
@@ -8,10 +9,15 @@ const InlineCodeBlock = ({
     textStyle,
 }) => (
     <TDefaultRenderer
-        style={{...boxModelStyle, ...textStyle}}
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...defaultRendererProps}
-    />
+    >
+        <Text
+            style={{...boxModelStyle, ...textStyle}}
+        >
+            {defaultRendererProps.tnode.data}
+        </Text>
+    </TDefaultRenderer>
 );
 
 InlineCodeBlock.propTypes = inlineCodeBlockPropTypes;

--- a/src/styles/codeStyles/index.android.js
+++ b/src/styles/codeStyles/index.android.js
@@ -1,14 +1,14 @@
 const codeWordWrapper = {
-    height: 10,
+    height: 20,
 };
 
 const codeWordStyle = {
-    top: -1,
-    marginVertical: -2,
+    height: 18,
+    top: 4,
 };
 
 const codeTextStyle = {
-    lineHeight: 18,
+    lineHeight: 15,
 };
 
 export default {codeWordWrapper, codeWordStyle, codeTextStyle};


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ Fixes #4005 

### Tests | QA Steps
1. Open newDot.
2. Send some message that contains `inline code block`.
3. Observe the UI.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web | Desktop
<!-- Insert screenshots of your changes on the web platform-->
![image](https://user-images.githubusercontent.com/24370807/129262759-66cccda8-e724-4460-898c-f83546b8a57b.png)

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
![code-block-m](https://user-images.githubusercontent.com/24370807/129265726-57f959ae-3714-4b7a-b298-e9a6485ceee8.png)

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
![code-block-i](https://user-images.githubusercontent.com/24370807/129271845-e51439c8-a904-4b60-88a0-de5d13badafe.png)


#### Android
<!-- Insert screenshots of your changes on the Android platform-->
![code-block-a](https://user-images.githubusercontent.com/24370807/129262678-a30eea88-29fd-4ae9-817c-98742aebaeeb.png)
