### PR TITLE
Fix: autofill on the BaseExpensiInput

### DIFF
--- a/src/components/ExpensiTextInput/BaseExpensiTextInput.js
+++ b/src/components/ExpensiTextInput/BaseExpensiTextInput.js
@@ -57,9 +57,15 @@ class BaseExpensiTextInput extends Component {
         this.deactivateLabel();
     }
 
-    setValue(v) {
-        this.value = v;
-        Str.result(this.props.onChangeText, v);
+    /**
+     * Set Value & activateLabel
+     *
+     * @param {String} value
+     * @memberof BaseExpensiTextInput
+     */
+    setValue(value) {
+        this.value = value;
+        Str.result(this.props.onChangeText, value);
         this.activateLabel();
     }
 

--- a/src/components/ExpensiTextInput/BaseExpensiTextInput.js
+++ b/src/components/ExpensiTextInput/BaseExpensiTextInput.js
@@ -48,6 +48,22 @@ class BaseExpensiTextInput extends Component {
     onFocus() {
         if (this.props.onFocus) { this.props.onFocus(); }
         this.setState({isFocused: true});
+        this.activateLabel();
+    }
+
+    onBlur() {
+        if (this.props.onBlur) { this.props.onBlur(); }
+        this.setState({isFocused: false});
+        this.deactivateLabel();
+    }
+
+    setValue(v) {
+        this.value = v;
+        Str.result(this.props.onChangeText, v);
+        this.activateLabel();
+    }
+
+    activateLabel() {
         if (this.value.length >= 0 && !this.isLabelActive) {
             this.animateLabel(
                 ACTIVE_LABEL_TRANSLATE_Y,
@@ -58,18 +74,11 @@ class BaseExpensiTextInput extends Component {
         }
     }
 
-    onBlur() {
-        if (this.props.onBlur) { this.props.onBlur(); }
-        this.setState({isFocused: false});
+    deactivateLabel() {
         if (this.value.length === 0) {
             this.animateLabel(INACTIVE_LABEL_TRANSLATE_Y, INACTIVE_LABEL_TRANSLATE_X, INACTIVE_LABEL_SCALE);
             this.isLabelActive = false;
         }
-    }
-
-    setValue(v) {
-        this.value = v;
-        Str.result(this.props.onChangeText, v);
     }
 
     animateLabel(translateY, translateX, scale) {

--- a/src/components/ExpensiTextInput/BaseExpensiTextInput.js
+++ b/src/components/ExpensiTextInput/BaseExpensiTextInput.js
@@ -2,6 +2,7 @@ import React, {Component} from 'react';
 import {
     Animated, TextInput, View, TouchableWithoutFeedback,
 } from 'react-native';
+import Str from 'expensify-common/lib/str';
 import ExpensiTextInputLabel from './ExpensiTextInputLabel';
 import {propTypes, defaultProps} from './propTypes';
 import themeColors from '../../styles/themes/default';
@@ -30,8 +31,11 @@ class BaseExpensiTextInput extends Component {
         };
 
         this.input = null;
+        this.value = hasValue ? props.value : '';
+        this.isLabelActive = false;
         this.onFocus = this.onFocus.bind(this);
         this.onBlur = this.onBlur.bind(this);
+        this.setValue = this.setValue.bind(this);
     }
 
     componentDidMount() {
@@ -44,21 +48,28 @@ class BaseExpensiTextInput extends Component {
     onFocus() {
         if (this.props.onFocus) { this.props.onFocus(); }
         this.setState({isFocused: true});
-        if (this.props.value.length === 0) {
+        if (this.value.length >= 0 && !this.isLabelActive) {
             this.animateLabel(
                 ACTIVE_LABEL_TRANSLATE_Y,
                 ACTIVE_LABEL_TRANSLATE_X(this.props.translateX),
                 ACTIVE_LABEL_SCALE,
             );
+            this.isLabelActive = true;
         }
     }
 
     onBlur() {
         if (this.props.onBlur) { this.props.onBlur(); }
         this.setState({isFocused: false});
-        if (this.props.value.length === 0) {
+        if (this.value.length === 0) {
             this.animateLabel(INACTIVE_LABEL_TRANSLATE_Y, INACTIVE_LABEL_TRANSLATE_X, INACTIVE_LABEL_SCALE);
+            this.isLabelActive = false;
         }
+    }
+
+    setValue(v) {
+        this.value = v;
+        Str.result(this.props.onChangeText, v);
     }
 
     animateLabel(translateY, translateX, scale) {
@@ -133,6 +144,7 @@ class BaseExpensiTextInput extends Component {
                             style={inputStyle}
                             onFocus={this.onFocus}
                             onBlur={this.onBlur}
+                            onChangeText={this.setValue}
                         />
                     </View>
                 </TouchableWithoutFeedback>


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ Fixes #4597

### Tests | QA Steps
1. Open any form on NewDot where data is auto-filled for you on the Web Platform.
2. Label should be correctly placed.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop


### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web | Mobile Web | Desktop
<!-- Insert screenshots of your changes on the web platform-->
![image](https://user-images.githubusercontent.com/24370807/129276378-9c04eea0-44d8-45b2-b0fe-8d32199b6f50.png)
