### PR TITLE
Update state picker component in VBA flow

### DIFF
--- a/src/components/StatePicker.js
+++ b/src/components/StatePicker.js
@@ -2,19 +2,13 @@ import _ from 'underscore';
 import React from 'react';
 import PropTypes from 'prop-types';
 import {CONST} from 'expensify-common/lib/CONST';
-import Picker from './Picker';
+import ExpensiPicker from './ExpensiPicker';
+import withLocalize, {withLocalizePropTypes} from './withLocalize';
 
 const STATES = _.map(CONST.STATES, ({stateISO}) => ({
     value: stateISO,
     label: stateISO,
 }));
-
-
-// Add a blank state so users are sure to actively choose a state instead accidentally going with the default choice
-STATES.unshift({
-    value: '',
-    label: '-',
-});
 
 const propTypes = {
     /** A callback method that is called when the value changes and it received the selected value as an argument */
@@ -22,16 +16,26 @@ const propTypes = {
 
     /** The value that needs to be selected */
     value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+    ...withLocalizePropTypes,
 };
 
 const defaultProps = {
     value: '',
 };
 
-const StatePicker = props => <Picker items={STATES} onChange={props.onChange} value={props.value} />;
+const StatePicker = props => (
+    <ExpensiPicker
+        placeholder={{value: '', label: '-'}}
+        items={STATES}
+        onChange={props.onChange}
+        value={props.value}
+        label={props.translate('common.state')}
+    />
+);
 
 StatePicker.propTypes = propTypes;
 StatePicker.defaultProps = defaultProps;
 StatePicker.displayName = 'StatePicker';
 
-export default StatePicker;
+export default withLocalize(StatePicker);

--- a/src/pages/ReimbursementAccount/CompanyStep.js
+++ b/src/pages/ReimbursementAccount/CompanyStep.js
@@ -76,6 +76,7 @@ class CompanyStep extends React.Component {
             'companyTaxID',
             'incorporationDate',
             'incorporationState',
+            'incorporationType',
             'industryCode',
             'password',
         ];
@@ -255,6 +256,7 @@ class CompanyStep extends React.Component {
                                 items={_.map(CONST.INCORPORATION_TYPES, (label, value) => ({value, label}))}
                                 onChange={incorporationType => this.setState({incorporationType})}
                                 value={this.state.incorporationType}
+                                placeholder={{value: '', label: '-'}}
                             />
                         </View>
                         <View style={[styles.flexRow, styles.mt4]}>

--- a/src/pages/ReimbursementAccount/CompanyStep.js
+++ b/src/pages/ReimbursementAccount/CompanyStep.js
@@ -255,7 +255,6 @@ class CompanyStep extends React.Component {
                                 items={_.map(CONST.INCORPORATION_TYPES, (label, value) => ({value, label}))}
                                 onChange={incorporationType => this.setState({incorporationType})}
                                 value={this.state.incorporationType}
-                                placeholder={{value: '', label: 'Type'}}
                             />
                         </View>
                         <View style={[styles.flexRow, styles.mt4]}>

--- a/src/pages/ReimbursementAccount/CompanyStep.js
+++ b/src/pages/ReimbursementAccount/CompanyStep.js
@@ -191,7 +191,6 @@ class CompanyStep extends React.Component {
                                 />
                             </View>
                             <View style={[styles.flex1]}>
-                                <Text style={[styles.formLabel]}>{this.props.translate('common.state')}</Text>
                                 <StatePicker
                                     onChange={addressState => this.setState({addressState})}
                                     value={this.state.addressState}
@@ -278,7 +277,6 @@ class CompanyStep extends React.Component {
                                 />
                             </View>
                             <View style={[styles.flex1]}>
-                                <Text style={[styles.formLabel]}>{this.props.translate('common.state')}</Text>
                                 <StatePicker
                                     onChange={incorporationState => this.setState({incorporationState})}
                                     value={this.state.incorporationState}

--- a/src/pages/ReimbursementAccount/IdentityForm.js
+++ b/src/pages/ReimbursementAccount/IdentityForm.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import {View} from 'react-native';
 import PropTypes from 'prop-types';
-import StatePicker from '../../component/StatePicker';
+import StatePicker from '../../components/StatePicker';
 import ExpensiTextInput from '../../components/ExpensiTextInput';
 import styles from '../../styles/styles';
 import withLocalize, {withLocalizePropTypes} from '../../components/withLocalize';

--- a/src/pages/ReimbursementAccount/IdentityForm.js
+++ b/src/pages/ReimbursementAccount/IdentityForm.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import {View} from 'react-native';
 import PropTypes from 'prop-types';
-import Text from '../../components/Text';
-import StatePicker from '../../components/StatePicker';
+import StatePicker from '../../component/StatePicker';
 import ExpensiTextInput from '../../components/ExpensiTextInput';
 import styles from '../../styles/styles';
 import withLocalize, {withLocalizePropTypes} from '../../components/withLocalize';
@@ -134,7 +133,6 @@ const IdentityForm = ({
                     />
                 </View>
                 <View style={[styles.flex1]}>
-                    <Text style={[styles.formLabel]}>{translate('common.state')}</Text>
                     <StatePicker
                         value={state}
                         onChange={val => onFieldChange('state', val)}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This PR updates the other usages of StatePicker, which was using the old Picker component instead of the new Expensipicker.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ https://github.com/Expensify/App/issues/4630

### Tests
1. Navigate to Profile->Workspace->Expensify Card->Get Started and fill out any values for the first form
2. On the 2nd form, confirm the State dropdowns show properly

### QA Steps
1. Navigate to https://staging.new.expensify.com/bank-account/new and fill out the first form w/ any info
2. On the 2nd form, confirm the State dropdowns show properly

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

| Web | Mobile | Desktop |
|---|---|---|
| ![image](https://user-images.githubusercontent.com/3981102/129282091-41a0b118-e232-498b-a2a5-e64d7f71364f.png) | ![image](https://user-images.githubusercontent.com/3981102/129282107-eb70bda3-31c2-4cd8-8297-0c3c0adaf571.png) | ![image](https://user-images.githubusercontent.com/3981102/129282119-147d985c-83e6-49f2-b655-34f3232481a9.png) |
