### PR TITLE
Login phone number validation message

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -371,6 +371,7 @@ const CONST = {
     REGEX: {
         US_PHONE: /^\+1\d{10}$/,
         DIGITS_AND_PLUS: /^\+?[0-9]*$/,
+        DIGITS_START_WITH_PLUS: /^\+(?:[0-9]*)$/, // Number should start with plus eg: +443433
         PHONE_E164_PLUS: /^\+?[1-9]\d{1,14}$/,
         NON_ALPHA_NUMERIC: /[^A-Za-z0-9+]/g,
         PO_BOX: /\b[P|p]?(OST|ost)?\.?\s*[O|o|0]?(ffice|FFICE)?\.?\s*[B|b][O|o|0]?[X|x]?\.?\s+[#]?(\d+)\b/,

--- a/src/pages/signin/LoginForm.js
+++ b/src/pages/signin/LoginForm.js
@@ -15,6 +15,7 @@ import canFocusInputOnScreenFocus from '../../libs/canFocusInputOnScreenFocus';
 import withLocalize, {withLocalizePropTypes} from '../../components/withLocalize';
 import getEmailKeyboardType from '../../libs/getEmailKeyboardType';
 import ExpensiTextInput from '../../components/ExpensiTextInput';
+import CONST from '../../CONST';
 
 const propTypes = {
     /* Onyx Props */
@@ -89,6 +90,13 @@ class LoginForm extends React.Component {
                         translateX={-18}
                     />
                 </View>
+
+                {this.state.login && CONST.REGEX.NUMBER.test(this.state.login) && !CONST.REGEX.DIGITS_START_WITH_PLUS.test(this.state.login) && (
+                    <Text style={[styles.formError]}>
+                        {this.props.translate('messages.noPhoneNumber')}
+                    </Text>
+                )}
+
                 {this.state.formError && (
                     <Text style={[styles.formError]}>
                         {this.state.formError}

--- a/src/pages/signin/LoginForm.js
+++ b/src/pages/signin/LoginForm.js
@@ -73,7 +73,7 @@ class LoginForm extends React.Component {
 
     render() {
         // Check if phone number is valid and ensure it has country code with prefix +
-        const isInvalidPhone = this.state.login && Str.isValidPhone(this.state.login) && !CONST.REGEX.DIGITS_START_WITH_PLUS.test(this.state.login);
+        const isInvalidPhone = this.state.login.trim() !== '' && Str.isValidPhone(this.state.login) && !CONST.REGEX.DIGITS_START_WITH_PLUS.test(this.state.login);
 
         return (
             <>

--- a/src/pages/signin/LoginForm.js
+++ b/src/pages/signin/LoginForm.js
@@ -3,6 +3,7 @@ import {View} from 'react-native';
 import {withOnyx} from 'react-native-onyx';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
+import Str from 'expensify-common/lib/str';
 import styles from '../../styles/styles';
 import themeColors from '../../styles/themes/default';
 import Button from '../../components/Button';
@@ -71,6 +72,9 @@ class LoginForm extends React.Component {
     }
 
     render() {
+        // Check if phone number is valid and ensure it has country code with prefix +
+        const isInvalidPhone = this.state.login && Str.isValidPhone(this.state.login) && !CONST.REGEX.DIGITS_START_WITH_PLUS.test(this.state.login);
+
         return (
             <>
                 <View style={[styles.mt3]}>
@@ -91,7 +95,7 @@ class LoginForm extends React.Component {
                     />
                 </View>
 
-                {this.state.login && CONST.REGEX.NUMBER.test(this.state.login) && !CONST.REGEX.DIGITS_START_WITH_PLUS.test(this.state.login) && (
+                {isInvalidPhone && (
                     <Text style={[styles.formError]}>
                         {this.props.translate('messages.noPhoneNumber')}
                     </Text>
@@ -119,9 +123,9 @@ class LoginForm extends React.Component {
                         text={this.props.translate('common.continue')}
                         isLoading={this.props.account.loading}
                         onPress={this.validateAndSubmitForm}
+                        isDisabled={isInvalidPhone}
                     />
                 </View>
-
             </>
         );
     }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
@deetergp 
### Details
Just added validation for an invalid phone number on the login page, while entering input itself.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ #4415 

### Tests & QA Steps
1. Open new Expensify.
2. Log out if already logged in
3. Login using a phone number, enter the phone number without country code

Fixes: 
1. Will show error message `Please enter a phone number including the country code e.g +447814266907`
2. If an invalid number is entered `Continue` button is disabled.


### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<img width="695" alt="Screenshot 2021-08-18 at 9 09 27 PM" src="https://user-images.githubusercontent.com/85645967/129929464-1d595a8c-d9a8-46e6-ae93-7fa10d7fb71c.png">

#### Mobile Web
![Simulator Screen Shot - iPhone 12 - 2021-08-18 at 21 11 16](https://user-images.githubusercontent.com/85645967/129929382-f24f6c09-ff27-4acb-b29e-b35c305f1650.png)

#### Desktop
<img width="1195" alt="Screenshot 2021-08-18 at 9 08 27 PM" src="https://user-images.githubusercontent.com/85645967/129929424-838dd1f4-e603-41dc-982e-1b1cc067a607.png">

#### iOS
![Simulator Screen Shot - iPhone 12 - 2021-08-18 at 21 12 24](https://user-images.githubusercontent.com/85645967/129929533-8b08fa22-c578-4ed0-8eb6-0e445b25fc82.png)

#### Android
![Screenshot_1629301486](https://user-images.githubusercontent.com/85645967/129929567-90cbe2c2-1f39-4aea-88b4-02e6ba8a4f89.png)

