### PR TITLE
Move deploy blocker notification to open source channel

### DIFF
--- a/.github/workflows/deployBlocker.yml
+++ b/.github/workflows/deployBlocker.yml
@@ -44,17 +44,17 @@ jobs:
           add-labels: 'Hourly, Engineering'
           remove-labels: 'Daily, Weekly, Monthly'
 
-      - name: 'Post the issue in the #deployer slack room'
+      - name: 'Post the issue in the #expensify-open-source slack room'
         if: ${{ success() }}
         uses: 8398a7/action-slack@v3
         with:
           status: custom
           custom_payload: |
             {
-              channel: '#deployer',
+              channel: '#expensify-open-source',
               attachments: [{
                 color: "#DB4545",
-                text: '💥 New E.cash Deploy Blocker: <${{ env.DEPLOY_BLOCKER_URL }}|'+ `${{ env.DEPLOY_BLOCKER_TITLE }}`.replace(/(^'|'$)/gi, '').replace(/'\''/gi,'\'') + '>',
+                text: '💥 We have found a new E.cash Deploy Blocker, if you have any idea which PR could be causing this, please comment in the issue: <${{ env.DEPLOY_BLOCKER_URL }}|'+ `${{ env.DEPLOY_BLOCKER_TITLE }}`.replace(/(^'|'$)/gi, '').replace(/'\''/gi,'\'') + '>',
               }]
             }
         env:

--- a/.github/workflows/deployBlocker.yml
+++ b/.github/workflows/deployBlocker.yml
@@ -54,7 +54,7 @@ jobs:
               channel: '#expensify-open-source',
               attachments: [{
                 color: "#DB4545",
-                text: '💥 We have found a new E.cash Deploy Blocker, if you have any idea which PR could be causing this, please comment in the issue: <${{ env.DEPLOY_BLOCKER_URL }}|'+ `${{ env.DEPLOY_BLOCKER_TITLE }}`.replace(/(^'|'$)/gi, '').replace(/'\''/gi,'\'') + '>',
+                text: '💥 We have found a New Expensify Deploy Blocker, if you have any idea which PR could be causing this, please comment in the issue: <${{ env.DEPLOY_BLOCKER_URL }}|'+ `${{ env.DEPLOY_BLOCKER_TITLE }}`.replace(/(^'|'$)/gi, '').replace(/'\''/gi,'\'') + '>',
               }]
             }
         env:


### PR DESCRIPTION
We are posting it in the #deployers room now, I am just moving it to the open source channel to involve contributors and changing the copy, since I don't think posting it twice is useful.


### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ https://github.com/Expensify/Expensify/issues/173930

### Tests
None, is there a way to test this before merging?

### QA Steps
- Create a deploy blocker issue
- Check it was posted in #expensify-open-soruce slack channel
