### PR TITLE
[HOLD] Fix translation for (edited) label in chat

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -132,6 +132,9 @@ export default {
         deleteComment: 'Delete Comment',
         deleteConfirmation: 'Are you sure you want to delete this comment?',
     },
+    reportActionItemFragment: {
+        edited: '(edited)',
+    },
     reportActionsView: {
         beFirstPersonToComment: 'Be the first person to comment',
     },

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -132,6 +132,9 @@ export default {
         deleteComment: 'Eliminar Comentario',
         deleteConfirmation: '¿Estás seguro de que quieres eliminar este comentario?',
     },
+    reportActionItemFragment: {
+        edited: '(editado)',
+    },
     reportActionsView: {
         beFirstPersonToComment: 'Sé el primero en comentar',
     },

--- a/src/pages/home/report/ReportActionItemFragment.js
+++ b/src/pages/home/report/ReportActionItemFragment.js
@@ -12,6 +12,8 @@ import Tooltip from '../../../components/Tooltip';
 import {isSingleEmoji} from '../../../libs/ValidationUtils';
 import withWindowDimensions, {windowDimensionsPropTypes} from '../../../components/withWindowDimensions';
 import canUseTouchScreen from '../../../libs/canUseTouchscreen';
+import withLocalize, {withLocalizePropTypes} from '../../../components/withLocalize';
+import compose from '../../../libs/compose';
 
 const propTypes = {
     /** The message fragment needing to be displayed */
@@ -30,6 +32,7 @@ const propTypes = {
     isSingleLine: PropTypes.bool,
 
     ...windowDimensionsPropTypes,
+    ...withLocalizePropTypes,
 };
 
 const defaultProps = {
@@ -76,7 +79,7 @@ class ReportActionItemFragment extends React.PureComponent {
                             >
                                 {/* Native devices do not support margin between nested text */}
                                 <Text style={styles.w1}>{' '}</Text>
-                                (edited)
+                                {this.props.translate('reportActionItemFragment.edited')}
                             </Text>
                             )}
                         </Text>
@@ -117,4 +120,7 @@ ReportActionItemFragment.propTypes = propTypes;
 ReportActionItemFragment.defaultProps = defaultProps;
 ReportActionItemFragment.displayName = 'ReportActionItemFragment';
 
-export default withWindowDimensions(ReportActionItemFragment);
+export default compose(
+    withLocalize,
+    withWindowDimensions,
+)(ReportActionItemFragment);

--- a/src/pages/home/report/ReportActionItemFragment.js
+++ b/src/pages/home/report/ReportActionItemFragment.js
@@ -32,6 +32,7 @@ const propTypes = {
     isSingleLine: PropTypes.bool,
 
     ...windowDimensionsPropTypes,
+
     ...withLocalizePropTypes,
 };
 


### PR DESCRIPTION
@pecanoro 

### Details
Fix translation for (edited) label in chat when a user edit a message they already sent

### Fixed Issues
$ https://github.com/Expensify/App/issues/4518

### Tests

1. Send a message in chat
2. Edit the message
3. A label with grey font should display `(edited)`  if the user configured the app language to 'English'. If the user configured the app language to Spanish, it should display `(editado)`


### QA Steps

### Tested On

- [x] Web
- [ ] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web

<img width="410" alt="Screen Shot 2021-08-16 at 11 34 27 AM" src="https://user-images.githubusercontent.com/87341702/129612828-685ee233-6215-4eb8-93a2-831f77e04a35.png">

<img width="410" alt="Screen Shot 2021-08-16 at 11 36 33 AM" src="https://user-images.githubusercontent.com/87341702/129613067-66f07a89-f0db-45e0-9449-9c3e678c05d8.png">


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

<img width="410" alt="Screen Shot 2021-08-16 at 11 48 25 AM" src="https://user-images.githubusercontent.com/87341702/129614466-22b251a7-abfb-4cd3-a779-3fd219b0e185.png">

<img width="410" alt="Screen Shot 2021-08-16 at 11 48 40 AM" src="https://user-images.githubusercontent.com/87341702/129614497-13bce48f-5324-4609-98e0-e027016f4641.png">

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
