### PR TITLE
[CP Staging] Use props not state in NewPasswordForm

### DIFF
--- a/src/pages/settings/NewPasswordForm.js
+++ b/src/pages/settings/NewPasswordForm.js
@@ -98,7 +98,7 @@ class NewPasswordForm extends React.Component {
                         secureTextEntry
                         autoCompleteType="password"
                         textContentType="password"
-                        value={this.state.password}
+                        value={this.props.password}
                         onChangeText={password => this.props.updatePassword(password)}
                         onBlur={() => this.onBlurNewPassword()}
                     />


### PR DESCRIPTION
### Details
cc @stitesExpensify 

### Fixed Issues
$ https://github.com/Expensify/App/issues/4599

### Tests
### QA Steps
1. Create a new account in NewDot
2. Check the email for the set password link
3. Tap and try set the password
4. Verify you are logged in

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [x] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
