### PR TITLE
[No QA] Make Firebase traces an opt-in feature of global Timing class

### DIFF
--- a/src/libs/actions/App.js
+++ b/src/libs/actions/App.js
@@ -6,10 +6,10 @@ import * as API from '../API';
 import CONST from '../../CONST';
 import Log from '../Log';
 import CONFIG from '../../CONFIG';
-import Firebase from '../Firebase';
 import ROUTES from '../../ROUTES';
 import {printPerformanceMetrics} from '../Performance';
 import canCapturePerformanceMetrics from '../canCapturePerformanceMetrics';
+import Timing from './Timing';
 
 let currentUserAccountID;
 Onyx.connect({
@@ -60,7 +60,7 @@ function setSidebarLoaded() {
     }
 
     Onyx.set(ONYXKEYS.IS_SIDEBAR_LOADED, true);
-    Firebase.stopTrace(CONST.TIMING.SIDEBAR_LOADED);
+    Timing.end(CONST.TIMING.SIDEBAR_LOADED);
 
     if (!canCapturePerformanceMetrics()) {
         return;

--- a/src/pages/home/sidebar/SidebarScreen.js
+++ b/src/pages/home/sidebar/SidebarScreen.js
@@ -49,7 +49,7 @@ class SidebarScreen extends Component {
     }
 
     componentDidMount() {
-        Timing.start(CONST.TIMING.SIDEBAR_LOADED);
+        Timing.start(CONST.TIMING.SIDEBAR_LOADED, true);
     }
 
     /**

--- a/src/pages/home/sidebar/SidebarScreen.js
+++ b/src/pages/home/sidebar/SidebarScreen.js
@@ -23,7 +23,6 @@ import {
 } from '../../../components/Icon/Expensicons';
 import Permissions from '../../../libs/Permissions';
 import ONYXKEYS from '../../../ONYXKEYS';
-import Firebase from '../../../libs/Firebase';
 import {create} from '../../../libs/actions/Policy';
 
 const propTypes = {
@@ -50,7 +49,7 @@ class SidebarScreen extends Component {
     }
 
     componentDidMount() {
-        Firebase.startTrace(CONST.TIMING.SIDEBAR_LOADED);
+        Timing.start(CONST.TIMING.SIDEBAR_LOADED);
     }
 
     /**


### PR DESCRIPTION
### Details

We are using the sidebar loaded event as an indicator of Time to Interactive as it roughly measures how much time it takes for the app to become usable once the JS bundle is parsed. This metric was previously only sent to Firebase - but it's more useful to have this in Grafana as well.

I'm still evaluating whether or not it's worth keeping this in Firebase so this _might_ be removed in the future.

### Fixed Issues
No Issue

### Tests
1. Make sure the existing timing logs are not breaking
2. Look for the new log in console for event `sidebar_loaded` e.g. `Timing:expensify.cash.sidebar_loaded 551`

### QA Steps

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
