### PR TITLE
Exclude cards that are not activated

### DIFF
--- a/src/libs/actions/PaymentMethods.js
+++ b/src/libs/actions/PaymentMethods.js
@@ -15,6 +15,7 @@ function getPaymentMethods() {
         name: 'paypalMeAddress',
         includeDeleted: false,
         includeNotIssued: false,
+        excludeNotActivated: true,
     })
         .then((response) => {
             Onyx.multiSet({


### PR DESCRIPTION
### Details
Add a new param to prevent the inclusion of non-activated cards

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/172363#

### Tests
1. Assign a user a new expensify card
2. Have the user enter their shipping details
3. Go to localhost:8080/settings/payments and make sure you only see the virtual card, not the pending expensify card

### QA Steps
Ping Mitch Ward on slack to check if it worked

### Tested On

- [x] Web
