### PR TITLE
[NO QA] Document why we pass the `currentDate` but we don't use it

### DIFF
--- a/src/pages/home/report/ReportActionItemDate.js
+++ b/src/pages/home/report/ReportActionItemDate.js
@@ -23,6 +23,9 @@ ReportActionItemDate.displayName = 'ReportActionItemDate';
 
 export default compose(
     withLocalize,
+
+    /** This component is hooked to the current date so that relative times can update when necessary
+     * e.g. past midnight */
     withCurrentDate(),
     memo,
 )(ReportActionItemDate);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
The `ReportActionItemDate` component receives a `currentDate` prop that is not used inside
The prop's purpose is to cause a re-render when it change, but that's not very obvious
Related to https://github.com/Expensify/App/pull/3573

### Fixed Issues
N/A Documentation change only

### Tests
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->
N/A Documentation change only

### QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->
N/A Documentation change only

### Tested On

N/A Documentation change only
