### PR TITLE
Handle errorText in TextInputWithLabel

### DIFF
--- a/src/components/ExpensiTextInput/BaseExpensiTextInput.js
+++ b/src/components/ExpensiTextInput/BaseExpensiTextInput.js
@@ -113,13 +113,13 @@ class BaseExpensiTextInput extends Component {
             label,
             value,
             placeholder,
+            errorText,
             hasError,
             containerStyles,
             inputStyle,
             ignoreLabelTranslateX,
             innerRef,
             autoFocus,
-            errorText,
             ...inputProps
         } = this.props;
 

--- a/src/components/ExpensiTextInput/BaseExpensiTextInput.js
+++ b/src/components/ExpensiTextInput/BaseExpensiTextInput.js
@@ -167,8 +167,8 @@ class BaseExpensiTextInput extends Component {
                         </View>
                     </TouchableWithoutFeedback>
                 </View>
-                {errorText !== '' && (
-                    <Text style={[styles.formError]}>{errorText}</Text>
+                {Boolean(errorText) && (
+                    <Text style={[styles.formError, styles.mt1]}>{errorText}</Text>
                 )}
             </View>
         );

--- a/src/components/ExpensiTextInput/BaseExpensiTextInput.js
+++ b/src/components/ExpensiTextInput/BaseExpensiTextInput.js
@@ -177,5 +177,6 @@ class BaseExpensiTextInput extends Component {
 
 BaseExpensiTextInput.propTypes = propTypes;
 BaseExpensiTextInput.defaultProps = defaultProps;
+BaseExpensiTextInput.displayName = 'BaseExpensiTextInput';
 
 export default BaseExpensiTextInput;

--- a/src/components/ExpensiTextInput/BaseExpensiTextInput.js
+++ b/src/components/ExpensiTextInput/BaseExpensiTextInput.js
@@ -4,6 +4,7 @@ import {
 } from 'react-native';
 import Str from 'expensify-common/lib/str';
 import ExpensiTextInputLabel from './ExpensiTextInputLabel';
+import Text from '../Text';
 import {propTypes, defaultProps} from './propTypes';
 import themeColors from '../../styles/themes/default';
 import styles from '../../styles/styles';
@@ -118,51 +119,57 @@ class BaseExpensiTextInput extends Component {
             ignoreLabelTranslateX,
             innerRef,
             autoFocus,
+            errorText,
             ...inputProps
         } = this.props;
 
         const hasLabel = Boolean(label.length);
         return (
-            <View style={[styles.componentHeightLarge, ...containerStyles]}>
-                <TouchableWithoutFeedback onPress={() => this.input.focus()} focusable={false}>
-                    <View
-                        style={[
-                            styles.expensiTextInputContainer,
-                            !hasLabel && styles.pv0,
-                            this.state.isFocused && styles.borderColorFocus,
-                            hasError && styles.borderColorDanger,
-                        ]}
-                    >
-                        {hasLabel ? (
-                            <ExpensiTextInputLabel
-                                label={label}
-                                labelTranslateX={
-                                    ignoreLabelTranslateX
-                                        ? new Animated.Value(0)
-                                        : this.state.labelTranslateX
-                                }
-                                labelTranslateY={this.state.labelTranslateY}
-                                labelScale={this.state.labelScale}
+            <View>
+                <View style={[styles.componentHeightLarge, ...containerStyles]}>
+                    <TouchableWithoutFeedback onPress={() => this.input.focus()} focusable={false}>
+                        <View
+                            style={[
+                                styles.expensiTextInputContainer,
+                                !hasLabel && styles.pv0,
+                                this.state.isFocused && styles.borderColorFocus,
+                                (hasError || errorText) && styles.borderColorDanger,
+                            ]}
+                        >
+                            {hasLabel ? (
+                                <ExpensiTextInputLabel
+                                    label={label}
+                                    labelTranslateX={
+                                        ignoreLabelTranslateX
+                                            ? new Animated.Value(0)
+                                            : this.state.labelTranslateX
+                                    }
+                                    labelTranslateY={this.state.labelTranslateY}
+                                    labelScale={this.state.labelScale}
+                                />
+                            ) : null}
+                            <TextInput
+                                ref={(ref) => {
+                                    if (typeof innerRef === 'function') { innerRef(ref); }
+                                    this.input = ref;
+                                }}
+                                // eslint-disable-next-line
+                                {...inputProps}
+                                value={value}
+                                placeholder={(this.state.isFocused || !label) ? placeholder : null}
+                                placeholderTextColor={themeColors.placeholderText}
+                                underlineColorAndroid="transparent"
+                                style={[...inputStyle, errorText ? styles.errorOutline : undefined]}
+                                onFocus={this.onFocus}
+                                onBlur={this.onBlur}
+                                onChangeText={this.setValue}
                             />
-                        ) : null}
-                        <TextInput
-                            ref={(ref) => {
-                                if (typeof innerRef === 'function') { innerRef(ref); }
-                                this.input = ref;
-                            }}
-                            // eslint-disable-next-line
-                            {...inputProps}
-                            value={value}
-                            placeholder={(this.state.isFocused || !label) ? placeholder : null}
-                            placeholderTextColor={themeColors.placeholderText}
-                            underlineColorAndroid="transparent"
-                            style={inputStyle}
-                            onFocus={this.onFocus}
-                            onBlur={this.onBlur}
-                            onChangeText={this.setValue}
-                        />
-                    </View>
-                </TouchableWithoutFeedback>
+                        </View>
+                    </TouchableWithoutFeedback>
+                </View>
+                {errorText !== '' && (
+                    <Text style={[styles.formError]}>{errorText}</Text>
+                )}
             </View>
         );
     }

--- a/src/components/ExpensiTextInput/BaseExpensiTextInput.js
+++ b/src/components/ExpensiTextInput/BaseExpensiTextInput.js
@@ -177,6 +177,5 @@ class BaseExpensiTextInput extends Component {
 
 BaseExpensiTextInput.propTypes = propTypes;
 BaseExpensiTextInput.defaultProps = defaultProps;
-BaseExpensiTextInput.displayName = 'BaseExpensiTextInput';
 
 export default BaseExpensiTextInput;

--- a/src/components/ExpensiTextInput/propTypes.js
+++ b/src/components/ExpensiTextInput/propTypes.js
@@ -4,14 +4,14 @@ const propTypes = {
     /** Input label */
     label: PropTypes.string,
 
-    /** Text to show if there is an error */
-    errorText: PropTypes.string,
-
     /** Input value */
     value: PropTypes.string.isRequired,
 
     /** Input value placeholder */
     placeholder: PropTypes.string,
+
+    /** Error text to display */
+    errorText: PropTypes.string,
 
     /** Should the input be styled for errors  */
     hasError: PropTypes.bool,

--- a/src/components/ExpensiTextInput/propTypes.js
+++ b/src/components/ExpensiTextInput/propTypes.js
@@ -4,6 +4,9 @@ const propTypes = {
     /** Input label */
     label: PropTypes.string,
 
+    /** Text to show if there is an error */
+    errorText: PropTypes.string,
+
     /** Input value */
     value: PropTypes.string.isRequired,
 
@@ -28,6 +31,7 @@ const propTypes = {
 
 const defaultProps = {
     label: '',
+    errorText: '',
     placeholder: '',
     error: false,
     containerStyles: [],


### PR DESCRIPTION
@pecanoro @jasperhuangg 

### Details
Add support for `errorText` prop in `TextInputWithLabel` component.

Currently the error is showing like this:

![Screen Shot 2021-08-19 at 9 50 20 AM](https://user-images.githubusercontent.com/87341702/130110355-af27e93a-938c-495e-ae5c-2713da42c52a.png)


Is the styling correct?

### Fixed Issues
$ https://github.com/Expensify/App/issues/4730

### Tests/QA
1. Navigate to `<baseURL>/bank-account/company`.
2. Input invalid data for the following fields and try to submit the form. Verify that red outlines AND growl messages occur.
    - Empty password
    - Invalid address street
    - Invalid address zip code
    - Invalid website URL
    - Invalid company tax ID
    - Invalid industry code
    - Invalid incorporation date



### Tested On

- [x] Web
- [ ] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
