### PR TITLE
Hide localtime for Expensify Emails (Automated Accounts)

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -261,6 +261,13 @@ const CONST = {
         CHRONOS: 'chronos@expensify.com',
         CONCIERGE: 'concierge@expensify.com',
         RECEIPTS: 'receipts@expensify.com',
+        HELP: 'help@expensify.com',
+        QA: 'qa@expensify.com',
+        CONTRIBUTORS: 'contributors@expensify.com',
+        FIRST_RESPONDER: 'firstresponders@expensify.com',
+        QA_TRAVIS: 'qa+travisreceipts@expensify.com',
+        BILLS: 'bills@expensify.com',
+        STUDENT_AMBASSADOR: 'studentambassadors@expensify.com',
     },
 
     ENVIRONMENT: {
@@ -385,4 +392,13 @@ const CONST = {
     },
 };
 
+const EXPENSIFY_EMAILS = [
+    CONST.EMAIL.CONCIERGE, CONST.EMAIL.CONTRIBUTORS, CONST.EMAIL.FIRST_RESPONDER,
+    CONST.EMAIL.HELP, CONST.EMAIL.QA, CONST.EMAIL.CHRONOS, CONST.EMAIL.RECEIPTS,
+    CONST.EMAIL.BILLS, CONST.EMAIL.STUDENT_AMBASSADOR, CONST.EMAIL.QA_TRAVIS,
+];
+
+export {
+    EXPENSIFY_EMAILS,
+};
 export default CONST;

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -434,6 +434,7 @@ class ReportActionCompose extends React.Component {
         const reportParticipants = lodashGet(this.props.report, 'participants', []);
         const hasMultipleParticipants = reportParticipants.length > 1;
         const hasExpensifyEmails = lodashIntersection(reportParticipants, EXPENSIFY_EMAILS).length > 0;
+        const hasConciergeParticipant = _.contains(reportParticipants, CONST.EMAIL.CONCIERGE);
         const reportRecipient = this.props.personalDetails[reportParticipants[0]];
         const currentUserTimezone = lodashGet(this.props.myPersonalDetails, 'timezone', CONST.DEFAULT_TIME_ZONE);
         const reportRecipientTimezone = lodashGet(reportRecipient, 'timezone', CONST.DEFAULT_TIME_ZONE);

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -11,6 +11,7 @@ import {withNavigationFocus} from '@react-navigation/compat';
 import _ from 'underscore';
 import lodashGet from 'lodash/get';
 import {withOnyx} from 'react-native-onyx';
+import lodashIntersection from 'lodash/intersection';
 import styles, {getButtonBackgroundColorStyle, getIconFillColor} from '../../../styles/styles';
 import themeColors from '../../../styles/themes/default';
 import TextInputFocusable from '../../../components/TextInputFocusable';
@@ -41,7 +42,7 @@ import EmojiPickerMenu from './EmojiPickerMenu';
 import withWindowDimensions, {windowDimensionsPropTypes} from '../../../components/withWindowDimensions';
 import withDrawerState from '../../../components/withDrawerState';
 import getButtonState from '../../../libs/getButtonState';
-import CONST from '../../../CONST';
+import CONST, {EXPENSIFY_EMAILS} from '../../../CONST';
 import canFocusInputOnScreenFocus from '../../../libs/canFocusInputOnScreenFocus';
 import variables from '../../../styles/variables';
 import withLocalize, {withLocalizePropTypes} from '../../../components/withLocalize';
@@ -432,13 +433,11 @@ class ReportActionCompose extends React.Component {
         // eslint-disable-next-line no-unused-vars
         const reportParticipants = lodashGet(this.props.report, 'participants', []);
         const hasMultipleParticipants = reportParticipants.length > 1;
-        const hasChronosParticipant = _.contains(reportParticipants, CONST.EMAIL.CHRONOS);
-        const hasConciergeParticipant = _.contains(reportParticipants, CONST.EMAIL.CONCIERGE);
+        const hasExpensifyEmails = lodashIntersection(reportParticipants, EXPENSIFY_EMAILS).length > 0;
         const reportRecipient = this.props.personalDetails[reportParticipants[0]];
         const currentUserTimezone = lodashGet(this.props.myPersonalDetails, 'timezone', CONST.DEFAULT_TIME_ZONE);
         const reportRecipientTimezone = lodashGet(reportRecipient, 'timezone', CONST.DEFAULT_TIME_ZONE);
-        const shouldShowReportRecipientLocalTime = !hasConciergeParticipant
-            && !hasChronosParticipant
+        const shouldShowReportRecipientLocalTime = !hasExpensifyEmails
             && !hasMultipleParticipants
             && reportRecipient
             && reportRecipientTimezone


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

@pecanoro Can you please review?

### Details
Added the expensify emails block from expensify-common and hid the localtime when participants are automated accounts.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ #4664 

### Tests
1. Tested the chats with regular users to confirm localtime shows
2. Tested the chats with automated accounts to confirm localtime doesn't show
3. Tested group participants with 0 or more Expensify email accounts.

<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### QA Steps
1. Go to chat with any system accounts - concierge, chronos, receipts, qa, bills, etc.
2. It shouldn't show localtime for the system accounts

<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<img width="935" alt="localtime-hidden-web" src="https://user-images.githubusercontent.com/3069065/130083419-11662d38-b491-49f9-8084-d8610f3d6344.png">
<img width="679" alt="localtime-shown-for-regular-user" src="https://user-images.githubusercontent.com/3069065/130083426-5cd10be8-6117-4052-80be-f16d60b34e4d.png">


#### Mobile Web
<img width="332" alt="Screenshot 2021-08-19 at 7 35 32 PM" src="https://user-images.githubusercontent.com/3069065/130083563-5f9e6630-514d-4a7c-8996-baa16b2cf34d.png">

#### Desktop
<img width="809" alt="Screenshot 2021-08-19 at 7 39 52 PM" src="https://user-images.githubusercontent.com/3069065/130083586-cee793ca-08a7-4c23-8b5c-9e37be0b8264.png">


#### iOS
<img width="342" alt="Screenshot 2021-08-19 at 7 51 15 PM" src="https://user-images.githubusercontent.com/3069065/130085540-af03cc81-7b6e-4e42-876f-b3ecf642dd0d.png">

#### Android
<img width="325" alt="Screenshot 2021-08-19 at 7 56 23 PM" src="https://user-images.githubusercontent.com/3069065/130086559-e63990a3-26f2-478e-aa25-606f77b831bb.png">

