### PR TITLE
[No QA] Post deploy announcements in slack

### DIFF
--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -354,7 +354,6 @@ jobs:
           WEB: ${{ needs.web.result }}
 
       - name: 'Announces the deploy in the #announce Slack room'
-        if: ${{ success() }}
         uses: 8398a7/action-slack@v3
         with:
           status: custom

--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -352,3 +352,20 @@ jobs:
           DESKTOP: ${{ needs.desktop.result }}
           IOS: ${{ needs.iOS.result }}
           WEB: ${{ needs.web.result }}
+
+      - name: 'Announces the deploy in the #announce Slack room'
+        if: ${{ success() }}
+        uses: 8398a7/action-slack@v3
+        with:
+          status: custom
+          custom_payload: |
+            {
+              channel: '#announce',
+              attachments: [{
+                color: 'good',
+                text: `Successfully deployed ${process.env.AS_REPO} v${{ env.VERSION }} to ${{ env.SHOULD_DEPLOY_PRODUCTION == 'true' ? 'production' : 'staging' }}.`,
+              }]
+            }
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -368,3 +368,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+      
+      - name: 'Announces a production deploy in the #expensify-open-source Slack room'
+        uses: 8398a7/action-slack@v3
+        if: ${{ env.SHOULD_DEPLOY_PRODUCTION == 'true' }}
+        with:
+          status: custom
+          custom_payload: |
+            {
+              channel: '#expensify-open-source',
+              attachments: [{
+                color: 'good',
+                text: `Successfully deployed ${process.env.AS_REPO} v${{ env.VERSION }} to production.`,
+              }]
+            }
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -330,12 +330,6 @@ jobs:
         with:
           node-version: '14.x'
 
-      - name: Determine if this was a cherry-pick
-        id: isStagingDeployLocked
-        uses: Expensify/App/.github/actions/isStagingDeployLocked@main
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Set version
         run: echo "VERSION=$(npm run print-version --silent)" >> $GITHUB_ENV
 


### PR DESCRIPTION
cc @roryabraham will you please take a look?

### Details
Posts an announcement in the `#announce` Slack channel after app is deployed to staging and production.

### Fixed Issues
$ https://github.com/Expensify/App/issues/4727

### Tests
1. Make sure that the `StagingDeployCash` is not locked.
2. Lock the `StagingDeployCash`, then verify that the resulting staging deploy is announced in `#announce`.
3. Merge a PR with the `CP Staging` label, then verify that the resulting staging deploy is announced in `#announce`.
4. Once the deploy checklist is complete and we close it out, verify that the resulting prod deploy is announced in `#announce`.

### QA Steps
None.

### Tested On
N/A GitHub only!
