### PR TITLE
Fix StagingDeployBlocker where chat draft message is kept in the test input while switching chats

### DIFF
--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -188,6 +188,12 @@ class ReportActionCompose extends React.Component {
             && prevProps.modal.isVisible && !this.props.modal.isVisible) {
             this.focus();
         }
+
+        // If we switch from a sidebar, the component does not mount again
+        // so we need to update the comment manually.
+        if (prevProps.comment !== this.props.comment && this.textInput) {
+            this.textInput.setNativeProps({text: this.props.comment});
+        }
     }
 
     componentWillUnmount() {

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -191,7 +191,7 @@ class ReportActionCompose extends React.Component {
 
         // If we switch from a sidebar, the component does not mount again
         // so we need to update the comment manually.
-        if (prevProps.comment !== this.props.comment && this.textInput) {
+        if (prevProps.comment !== this.props.comment) {
             this.textInput.setNativeProps({text: this.props.comment});
         }
     }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

cc @marcaaron @luacmartins 

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Testing on Staging has discovered a bug when using a Search sidebar modal to switch between chats does not update the composer box and draft from previous chat is shown in the new chat.

The issue was most likely introduced in this PR https://github.com/Expensify/App/pull/4538. As a result of the refactoring the `ReportActionCompose` does not mount when switching the chats using the search bar and hence the text input is to updated either.

As a probably temporary workaround, I have updated the `componentDidUpdate` function to check if the comment value has changed between `this.props` and `prevProps` and update it manually using ref.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ https://github.com/Expensify/App/issues/4756

### Tests
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->
Follow the steps described in the linked issue https://github.com/Expensify/App/issues/4756 and make sure that the bug does not prevail.

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->


https://user-images.githubusercontent.com/36083550/130245034-bcbe01a4-b85d-4fb7-82ed-31e69b96635a.mov

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->


