### PR TITLE
Fix MarkerBadge Count

### DIFF
--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -99,7 +99,7 @@ class ReportActionsView extends React.Component {
         this.state = {
             isLoadingMoreChats: false,
             isMarkerActive: false,
-            unreadActionCount: this.props.report.unreadActionCount,
+            localUnreadActionCount: this.props.report.unreadActionCount,
         };
 
         this.currentScrollOffset = 0;
@@ -110,7 +110,7 @@ class ReportActionsView extends React.Component {
         this.showMarker = this.showMarker.bind(this);
         this.hideMarker = this.hideMarker.bind(this);
         this.toggleMarker = this.toggleMarker.bind(this);
-        this.updateUnreadMessageCount = this.updateUnreadMessageCount.bind(this);
+        this.updateLocalUnreadActionCount = this.updateLocalUnreadActionCount.bind(this);
     }
 
     componentDidMount() {
@@ -163,7 +163,7 @@ class ReportActionsView extends React.Component {
             return true;
         }
 
-        if (nextState.unreadActionCount !== this.state.unreadActionCount) {
+        if (nextState.localUnreadActionCount !== this.state.localUnreadActionCount) {
             return true;
         }
 
@@ -205,11 +205,11 @@ class ReportActionsView extends React.Component {
                 updateLastReadActionID(this.props.reportID);
             }
 
-            if (lastAction && (lastAction.actorEmail !== this.props.session.email)) {
+            if (lodashGet(lastAction, 'actorEmail', '') !== lodashGet(this.props.session, 'email', '')) {
                 // Only update the unread count when MarkerBadge is visible
                 // Otherwise marker will be shown on scrolling up from the bottom even if user have read those messages
                 if (this.state.isMarkerActive) {
-                    this.updateUnreadMessageCount();
+                    this.updateLocalUnreadActionCount();
                 }
 
                 // show new MarkerBadge when there is a new message
@@ -378,7 +378,7 @@ class ReportActionsView extends React.Component {
     toggleMarker() {
         // Update the unread message count before MarkerBadge is about to show
         if (this.currentScrollOffset < -200 && !this.state.isMarkerActive) {
-            this.updateUnreadMessageCount();
+            this.updateLocalUnreadActionCount();
             this.showMarker();
         }
 
@@ -390,8 +390,8 @@ class ReportActionsView extends React.Component {
     /**
      * Update the unread messages count to show in the MarkerBadge
      */
-    updateUnreadMessageCount() {
-        this.setState(prevState => ({unreadActionCount: prevState.unreadActionCount + this.props.report.unreadActionCount}));
+    updateLocalUnreadActionCount() {
+        this.setState(prevState => ({localUnreadActionCount: prevState.localUnreadActionCount + this.props.report.unreadActionCount}));
     }
 
     /**
@@ -406,7 +406,7 @@ class ReportActionsView extends React.Component {
      */
     hideMarker() {
         this.setState({isMarkerActive: false}, () => {
-            this.setState({unreadActionCount: 0});
+            this.setState({localUnreadActionCount: 0});
         });
     }
 
@@ -503,7 +503,7 @@ class ReportActionsView extends React.Component {
             <>
                 <MarkerBadge
                     active={this.state.isMarkerActive}
-                    count={this.state.unreadActionCount}
+                    count={this.state.localUnreadActionCount}
                     onClick={scrollToBottom}
                     onClose={this.hideMarker}
                 />

--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -206,13 +206,13 @@ class ReportActionsView extends React.Component {
             }
 
             if (lastAction && (lastAction.actorEmail !== this.props.session.email)) {
-                // Only update the UnreadCount when Marker is visible
-                // Otheriwise marker will be shown when scroll up from the bottom even if we read those messages
+                // Only update the unread count when MarkerBadge is visible
+                // Otherwise marker will be shown on scrolling up from the bottom even if user have read those messages
                 if (this.state.isMarkerActive) {
                     this.updateUnreadMessageCount();
                 }
 
-                // show new MarkerBadge when there is a new Message
+                // show new MarkerBadge when there is a new message
                 this.toggleMarker();
             }
         }
@@ -376,7 +376,7 @@ class ReportActionsView extends React.Component {
      * Show/hide the new MarkerBadge when user is scrolling back/forth in the history of messages.
      */
     toggleMarker() {
-        // Update the unread message count while the
+        // Update the unread message count before MarkerBadge is about to show
         if (this.currentScrollOffset < -200 && !this.state.isMarkerActive) {
             this.updateUnreadMessageCount();
             this.showMarker();

--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -205,14 +205,16 @@ class ReportActionsView extends React.Component {
                 updateLastReadActionID(this.props.reportID);
             }
 
-            // Only update the UnreadCount when Marker is visible
-            // Otheriwise marker will be shown when scroll up from the bottom even if we read those messages
-            if (this.state.isMarkerActive) {
-                this.updateUnreadMessageCount();
-            }
+            if (lastAction && (lastAction.actorEmail !== this.props.session.email)) {
+                // Only update the UnreadCount when Marker is visible
+                // Otheriwise marker will be shown when scroll up from the bottom even if we read those messages
+                if (this.state.isMarkerActive) {
+                    this.updateUnreadMessageCount();
+                }
 
-            // show new MarkerBadge when there is a new Message
-            this.toggleMarker();
+                // show new MarkerBadge when there is a new Message
+                this.toggleMarker();
+            }
         }
 
         // We want to mark the unread comments when user resize the screen to desktop
@@ -496,9 +498,6 @@ class ReportActionsView extends React.Component {
                 </View>
             );
         }
-
-        console.debug('unread messages', this.state.unreadActionCount);
-        console.debug('marker shows', this.state.isMarkerActive);
 
         return (
             <>


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
1. Fixed count issue
2. Fixes another issue where the marker was setting visible for user's own messages on different devices.


### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ #4669 

### Tests QA Steps

1. Open any conversation in newDot.
2. Scroll back in the history to see the new Markerbadge when new messages are received.
3. Send a new message from another device to the correct chat from the other user.
4. See that the new Marker badge is shown.
5. Now don't yet interact with the app or marker yet.
6. Send another message from the other device.
7. Observe that count.


### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web | Desktop | Mobile Web
<!-- Insert screenshots of your changes on the web platform-->

https://user-images.githubusercontent.com/24370807/130302691-6a252ee1-5a08-4a43-bb82-3af9e0f1ec03.mp4

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
![Screenshot 2021-08-21 05:06:58](https://user-images.githubusercontent.com/24370807/130302800-8c1b33ee-7c5c-4d68-bf85-6e32142e8fce.png)
