### PR TITLE
Fix: marker is not clickable on android

### DIFF
--- a/src/pages/home/report/MarkerBadge/MarkerBadgeContainer/MarkerBadgeContainerPropTypes.js
+++ b/src/pages/home/report/MarkerBadge/MarkerBadgeContainer/MarkerBadgeContainerPropTypes.js
@@ -1,10 +1,10 @@
 import PropTypes from 'prop-types';
 
 const propTypes = {
-    /** Container Styles */
+    /** Styles to be assigned to Container */
     containerStyles: PropTypes.arrayOf(PropTypes.object).isRequired,
 
-    /** Children of the MakerBadgeContainer */
+    /** Rendered child component */
     children: PropTypes.element.isRequired,
 };
 

--- a/src/pages/home/report/MarkerBadge/MarkerBadgeContainer/MarkerBadgeContainerPropTypes.js
+++ b/src/pages/home/report/MarkerBadge/MarkerBadgeContainer/MarkerBadgeContainerPropTypes.js
@@ -1,0 +1,11 @@
+import PropTypes from 'prop-types';
+
+const propTypes = {
+    /** Container Styles */
+    containerStyles: PropTypes.arrayOf(PropTypes.object).isRequired,
+
+    /** Children of the MakerBadgeContainer */
+    children: PropTypes.element.isRequired,
+};
+
+export default propTypes;

--- a/src/pages/home/report/MarkerBadge/MarkerBadgeContainer/index.android.js
+++ b/src/pages/home/report/MarkerBadge/MarkerBadgeContainer/index.android.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import {View, Animated} from 'react-native';
+import styles from '../../../../../styles/styles';
+import propTypes from './MarkerBadgeContainerPropTypes';
+
+const MarkerBadgeContainer = props => (
+    <Animated.View style={[styles.reportMarkerBadgeWrapperAndroid, ...props.containerStyles]}>
+        <View style={styles.reportMarkerBadgeSubWrapperAndroid}>
+            {props.children}
+        </View>
+    </Animated.View>
+);
+
+MarkerBadgeContainer.propTypes = propTypes;
+MarkerBadgeContainer.displayName = 'MarkerBadgeContainer';
+
+export default MarkerBadgeContainer;

--- a/src/pages/home/report/MarkerBadge/MarkerBadgeContainer/index.js
+++ b/src/pages/home/report/MarkerBadge/MarkerBadgeContainer/index.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import {Animated} from 'react-native';
+import styles from '../../../../../styles/styles';
+import propTypes from './MarkerBadgeContainerPropTypes';
+
+const MarkerBadgeContainer = props => (
+    <Animated.View style={[styles.reportMarkerBadgeWrapper, ...props.containerStyles]}>
+        {props.children}
+    </Animated.View>
+);
+
+MarkerBadgeContainer.propTypes = propTypes;
+MarkerBadgeContainer.displayName = 'MarkerBadgeContainer';
+
+export default MarkerBadgeContainer;

--- a/src/pages/home/report/MarkerBadge/index.js
+++ b/src/pages/home/report/MarkerBadge/index.js
@@ -35,7 +35,7 @@ const defaultProps = {
 const MARKER_NOT_ACTIVE_TRANSLATE_Y = -30;
 const MARKER_ACTIVE_TRANSLATE_Y = 10;
 
-class BaseMarkerBadge extends PureComponent {
+class MarkerBadge extends PureComponent {
     constructor(props) {
         super(props);
         this.translateY = new Animated.Value(MARKER_NOT_ACTIVE_TRANSLATE_Y);
@@ -118,8 +118,8 @@ class BaseMarkerBadge extends PureComponent {
     }
 }
 
-BaseMarkerBadge.propTypes = propTypes;
-BaseMarkerBadge.defaultProps = defaultProps;
-BaseMarkerBadge.displayName = 'BaseMarkerBadge';
+MarkerBadge.propTypes = propTypes;
+MarkerBadge.defaultProps = defaultProps;
+MarkerBadge.displayName = 'MarkerBadge';
 
-export default withLocalize(BaseMarkerBadge);
+export default withLocalize(MarkerBadge);

--- a/src/pages/home/report/MarkerBadge/index.js
+++ b/src/pages/home/report/MarkerBadge/index.js
@@ -1,15 +1,14 @@
 import React, {PureComponent} from 'react';
 import {Animated, Text, View} from 'react-native';
 import PropTypes from 'prop-types';
-import styles from '../../../styles/styles';
-import Button from '../../../components/Button';
-import Icon from '../../../components/Icon';
-import {Close, DownArrow} from '../../../components/Icon/Expensicons';
-import themeColors from '../../../styles/themes/default';
-import withLocalize, {withLocalizePropTypes} from '../../../components/withLocalize';
+import styles from '../../../../styles/styles';
+import Button from '../../../../components/Button';
+import Icon from '../../../../components/Icon';
+import {Close, DownArrow} from '../../../../components/Icon/Expensicons';
+import themeColors from '../../../../styles/themes/default';
+import withLocalize, {withLocalizePropTypes} from '../../../../components/withLocalize';
+import MarkerBadgeContainer from './MarkerBadgeContainer';
 
-const MARKER_NOT_ACTIVE_TRANSLATE_Y = -30;
-const MARKER_ACTIVE_TRANSLATE_Y = 10;
 const propTypes = {
     /** Count of new messages to show in the badge */
     count: PropTypes.number,
@@ -25,13 +24,18 @@ const propTypes = {
 
     ...withLocalizePropTypes,
 };
+
 const defaultProps = {
     count: 0,
     active: false,
     onClose: () => {},
     onClick: () => {},
 };
-class MarkerBadge extends PureComponent {
+
+const MARKER_NOT_ACTIVE_TRANSLATE_Y = -30;
+const MARKER_ACTIVE_TRANSLATE_Y = 10;
+
+class BaseMarkerBadge extends PureComponent {
     constructor(props) {
         super(props);
         this.translateY = new Animated.Value(MARKER_NOT_ACTIVE_TRANSLATE_Y);
@@ -65,12 +69,8 @@ class MarkerBadge extends PureComponent {
 
     render() {
         return (
-            <View style={styles.reportMarkerBadgeWrapper}>
-                <Animated.View style={[
-                    styles.reportMarkerBadge,
-                    styles.reportMarkerBadgeTransformation(this.translateY),
-                ]}
-                >
+            <MarkerBadgeContainer containerStyles={[styles.reportMarkerBadgeTransformation(this.translateY)]}>
+                <View style={styles.reportMarkerBadge}>
                     <View style={[
                         styles.flexRow,
                         styles.justifyContentBetween,
@@ -112,14 +112,14 @@ class MarkerBadge extends PureComponent {
                             )}
                         />
                     </View>
-                </Animated.View>
-            </View>
+                </View>
+            </MarkerBadgeContainer>
         );
     }
 }
 
-MarkerBadge.propTypes = propTypes;
-MarkerBadge.defaultProps = defaultProps;
-MarkerBadge.displayName = 'MarkerBadge';
+BaseMarkerBadge.propTypes = propTypes;
+BaseMarkerBadge.defaultProps = defaultProps;
+BaseMarkerBadge.displayName = 'BaseMarkerBadge';
 
-export default withLocalize(MarkerBadge);
+export default withLocalize(BaseMarkerBadge);

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -2002,6 +2002,21 @@ const styles = {
         ...visibility('hidden'),
     },
 
+    reportMarkerBadgeWrapperAndroid: {
+        left: 0,
+        width: '100%',
+        alignItems: 'center',
+        position: 'absolute',
+        top: 0,
+        zIndex: 100,
+        ...visibility('hidden'),
+    },
+
+    reportMarkerBadgeSubWrapperAndroid: {
+        left: '50%',
+        width: 'auto',
+    },
+
     reportMarkerBadge: {
         left: '-50%',
         ...visibility('visible'),


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Changed the design for MarkerBadge as touches are not propagated in Android outside the parent which was blocking the click on the half of the Badge.

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ #4716 

### Tests | QA Steps
1. Navigate to a conversation with user A
2. Scroll up the conversation
3. As user, A send some messages
4. Tap on the left area of the new message badge

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->

https://user-images.githubusercontent.com/24370807/130304051-582ef154-82bc-4598-adf9-fc764bdfddf1.mp4

