### PR TITLE
call debounce only when it's required

### DIFF
--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -316,7 +316,9 @@ class ReportActionCompose extends React.Component {
         });
         this.comment = newComment;
         this.debouncedSaveReportComment(newComment);
-        this.debouncedBroadcastUserIsTyping();
+        if (newComment) {
+            this.debouncedBroadcastUserIsTyping();
+        }
     }
 
     /**


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->


### Details
<!-- Explanation of the change or anything fishy that is going on -->
https://github.com/Expensify/App/issues/4267#issuecomment-888058630

### Fixed Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing -->
$ #4267

### Tests || QA Steps
1. Login with two devices
2. Open chat room for both of them
 #### *Use one of the account*
3. Type your message
4. Submit/Send the message.
5. It will **NOT** show `*User* is typing` after the message is sent.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

https://user-images.githubusercontent.com/28243942/130318604-6d9a91fc-d00f-4360-9339-e6fa2cb3e495.mov


#### Mobile Web

https://user-images.githubusercontent.com/28243942/130318612-a92f5860-c5cd-4f53-9a8b-7f4b97c4aef7.mov


<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

https://user-images.githubusercontent.com/28243942/130318615-b0d93b7b-1719-4503-b900-b96120a778ca.mov


#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

https://user-images.githubusercontent.com/28243942/130318619-b0ffbf3d-04ab-4067-bf07-3c3141248155.mov


#### Android
<!-- Insert screenshots of your changes on the Android platform-->

https://user-images.githubusercontent.com/28243942/130318621-55538396-dcb1-4cde-a074-b5f958d68743.mov

