### PR TITLE
Update height of default buttons to to match the text inputs

### DIFF
--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -183,7 +183,7 @@ const styles = {
     buttonText: {
         color: themeColors.heading,
         fontFamily: fontFamily.GTA_BOLD,
-        fontSize: variables.fontSizeLabel,
+        fontSize: variables.fontSizeNormal,
         fontWeight: fontWeightBold,
         textAlign: 'center',
     },

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -175,7 +175,7 @@ const styles = {
     button: {
         backgroundColor: themeColors.buttonDefaultBG,
         borderRadius: variables.componentBorderRadiusNormal,
-        height: variables.componentSizeNormal,
+        height: variables.componentSizeLarge,
         justifyContent: 'center',
         ...spacing.ph3,
     },


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Update height of default buttons to to match the text inputs

### Fixed Issues
Fixes: #4762

### Tests
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
![Screen Shot 2021-08-24 at 1 26 59 AM](https://user-images.githubusercontent.com/11542415/130516719-6fc059be-df6f-4985-a9b2-52d0f61cb871.png)

#### Mobile Web
![Screen Shot 2021-08-24 at 1 27 34 AM](https://user-images.githubusercontent.com/11542415/130516846-5770ef28-8267-4b20-bfdd-7e4d0328fc90.png)

#### Desktop
![Screen Shot 2021-08-24 at 1 40 02 AM](https://user-images.githubusercontent.com/11542415/130517051-b013eb4c-d2e7-4ddc-8c80-2e3955ab2dbf.png)

#### iOS
![Screen Shot 2021-08-24 at 1 37 56 AM](https://user-images.githubusercontent.com/11542415/130517379-ffeecbf5-2162-4508-b701-dd488d0e297c.png)

#### Android
![Screenshot_20210824-014719_New Expensify](https://user-images.githubusercontent.com/11542415/130517533-b00695be-38f0-4ecd-9924-a9d67240f14f.png)
