### PR TITLE
New breakpoint for tablet size

### DIFF
--- a/src/components/withWindowDimensions.js
+++ b/src/components/withWindowDimensions.js
@@ -14,6 +14,9 @@ const windowDimensionsPropTypes = {
 
     // Is the window width narrow, like on a mobile device?
     isSmallScreenWidth: PropTypes.bool.isRequired,
+
+    // Is the window width narrow, like on a tablet device?
+    isMediumScreenWidth: PropTypes.bool.isRequired,
 };
 
 export default function (WrappedComponent) {
@@ -40,10 +43,14 @@ export default function (WrappedComponent) {
 
             const initialDimensions = Dimensions.get('window');
             const isSmallScreenWidth = initialDimensions.width <= variables.mobileResponsiveWidthBreakpoint;
+            const isMediumScreenWidth = initialDimensions.width > variables.mobileResponsiveWidthBreakpoint
+              && initialDimensions.width <= variables.tabletResponsiveWidthBreakpoint;
+
             this.state = {
                 windowHeight: initialDimensions.height,
                 windowWidth: initialDimensions.width,
                 isSmallScreenWidth,
+                isMediumScreenWidth,
             };
         }
 
@@ -81,6 +88,7 @@ export default function (WrappedComponent) {
                     windowHeight={this.state.windowHeight}
                     windowWidth={this.state.windowWidth}
                     isSmallScreenWidth={this.state.isSmallScreenWidth}
+                    isMediumScreenWidth={this.state.isMediumScreenWidth}
                 />
             );
         }

--- a/src/pages/workspace/WorkspaceCardPage.js
+++ b/src/pages/workspace/WorkspaceCardPage.js
@@ -121,7 +121,7 @@ const WorkspaceCardPage = ({
                         styles.flexRow,
                         styles.workspaceCard,
                         isSmallScreenWidth && styles.workspaceCardMobile,
-                        isMediumScreenWidth && styles.workspaceCardTablet,
+                        isMediumScreenWidth && styles.workspaceCardMediumScreen,
                     ]}
                     >
                         {isSmallScreenWidth || isMediumScreenWidth
@@ -130,7 +130,7 @@ const WorkspaceCardPage = ({
                                     style={StyleSheet.flatten([
                                         styles.fullscreenCard,
                                         isSmallScreenWidth && styles.fullscreenCardMobile,
-                                        isMediumScreenWidth && styles.fullscreenCardTablet,
+                                        isMediumScreenWidth && styles.fullscreenCardMediumScreen,
                                     ])}
                                 />
                             )
@@ -144,7 +144,7 @@ const WorkspaceCardPage = ({
                             styles.fullscreenCard,
                             styles.workspaceCardContent,
                             isSmallScreenWidth && styles.p5,
-                            isMediumScreenWidth && styles.workspaceCardContentTablet,
+                            isMediumScreenWidth && styles.workspaceCardContentMediumScreen,
                         ]}
                         >
                             <View

--- a/src/pages/workspace/WorkspaceCardPage.js
+++ b/src/pages/workspace/WorkspaceCardPage.js
@@ -71,6 +71,7 @@ const WorkspaceCardPage = ({
     user,
     translate,
     isSmallScreenWidth,
+    isMediumScreenWidth,
     reimbursementAccount,
 }) => {
     const isVerifying = lodashGet(reimbursementAccount, 'achData.state', '') === BankAccount.STATE.VERIFYING;
@@ -120,12 +121,17 @@ const WorkspaceCardPage = ({
                         styles.flexRow,
                         styles.workspaceCard,
                         isSmallScreenWidth && styles.workspaceCardMobile,
+                        isMediumScreenWidth && styles.workspaceCardTablet,
                     ]}
                     >
-                        {isSmallScreenWidth
+                        {isSmallScreenWidth || isMediumScreenWidth
                             ? (
                                 <HeroCardMobileImage
-                                    style={StyleSheet.flatten([styles.fullscreenCard, styles.fullscreenCardMobile])}
+                                    style={StyleSheet.flatten([
+                                        styles.fullscreenCard,
+                                        isSmallScreenWidth && styles.fullscreenCardMobile,
+                                        isMediumScreenWidth && styles.fullscreenCardTablet,
+                                    ])}
                                 />
                             )
                             : (
@@ -138,6 +144,7 @@ const WorkspaceCardPage = ({
                             styles.fullscreenCard,
                             styles.workspaceCardContent,
                             isSmallScreenWidth && styles.p5,
+                            isMediumScreenWidth && styles.workspaceCardContentTablet,
                         ]}
                         >
                             <View
@@ -146,6 +153,7 @@ const WorkspaceCardPage = ({
                                     styles.justifyContentEnd,
                                     styles.alignItemsStart,
                                     !isSmallScreenWidth && styles.w50,
+                                    isMediumScreenWidth && styles.w100,
                                 ]}
                             >
                                 <Text

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1880,6 +1880,12 @@ const styles = {
         width: '150%',
     },
 
+    fullscreenCardTablet: {
+        left: '-15%',
+        top: '-30%',
+        width: '145%',
+    },
+
     smallEditIcon: {
         alignItems: 'center',
         backgroundColor: themeColors.icon,
@@ -1910,6 +1916,10 @@ const styles = {
         height: 475,
     },
 
+    workspaceCardTablet: {
+        height: 540,
+    },
+
     workspaceCardMainText: {
         fontSize: variables.fontSizeXXXLarge,
         fontWeight: 'bold',
@@ -1919,6 +1929,10 @@ const styles = {
     workspaceCardContent: {
         zIndex: 1,
         padding: 50,
+    },
+
+    workspaceCardContentTablet: {
+        padding: 25,
     },
 
     workspaceCardCTA: {

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1880,7 +1880,7 @@ const styles = {
         width: '150%',
     },
 
-    fullscreenCardTablet: {
+    fullscreenCardMediumScreen: {
         left: '-15%',
         top: '-30%',
         width: '145%',
@@ -1916,7 +1916,7 @@ const styles = {
         height: 475,
     },
 
-    workspaceCardTablet: {
+    workspaceCardMediumScreen: {
         height: 540,
     },
 
@@ -1931,7 +1931,7 @@ const styles = {
         padding: 50,
     },
 
-    workspaceCardContentTablet: {
+    workspaceCardContentMediumScreen: {
         padding: 25,
     },
 

--- a/src/styles/variables.js
+++ b/src/styles/variables.js
@@ -29,6 +29,7 @@ export default {
     iconSizeLarge: 24,
     iouAmountTextSize: 40,
     mobileResponsiveWidthBreakpoint: 800,
+    tabletResponsiveWidthBreakpoint: 1024,
     safeInsertPercentage: 0.7,
     sideBarWidth: 375,
     pdfPageMaxWidth: 992,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

- Breakpoint added for tablet sizes (800px - 1024px)
- WorkspaceCardPage is responsive now

### Fixed Issues
Fixes #4659 

### Tests
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Tablet

### Tablet 801px
![Screen Shot 2021-08-24 at 2 31 15 AM](https://user-images.githubusercontent.com/11542415/130522643-75f17b0a-9cfc-4081-9d7e-acf7b7e88938.png)

### Tablet 1024px
![Screen Shot 2021-08-24 at 2 31 23 AM](https://user-images.githubusercontent.com/11542415/130522688-8f76aec3-f34f-4f26-952a-1162cd7007bd.png)
