### PR TITLE
Update NewDot deploy permissions.

### DIFF
--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -15,7 +15,7 @@ jobs:
   validateActor:
     runs-on: ubuntu-latest
     outputs:
-      IS_DEPLOYER: ${{ steps.isUserDeployer.outputs.isTeamMember }}
+      IS_DEPLOYER: ${{ steps.isUserDeployer.outputs.isTeamMember || github.actor == 'OSBotify' }}
     steps:
       - id: isUserDeployer
         uses: tspascoal/get-user-teams-membership@baf2e6adf4c3b897bd65a7e3184305c165aec872

--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
           username: ${{ github.actor }}
-          team: expensify-cash-deployers
+          team: mobile-deployers
 
   createNewVersion:
     needs: validateActor

--- a/.github/workflows/finishReleaseCycle.yml
+++ b/.github/workflows/finishReleaseCycle.yml
@@ -6,14 +6,22 @@ on:
 
 # The updateProduction and createNewStagingDeployCash jobs are executed when a StagingDeployCash is closed.
 jobs:
-  checkDeployBlockers:
+  validate:
     runs-on: ubuntu-latest
     if: contains(github.event.issue.labels.*.name, 'StagingDeployCash')
 
     outputs:
-      hasDeployBlockers: ${{ steps.checkDeployBlockers.outputs.HAS_DEPLOY_BLOCKERS }}
+      isValid: ${{ steps.validateActor.outputs.isTeamMember && steps.checkDeployBlockers.outputs.HAS_DEPLOY_BLOCKERS == 'false' }}
 
     steps:
+      - name: Validate actor is deployer
+        id: validateActor
+        uses: tspascoal/get-user-teams-membership@baf2e6adf4c3b897bd65a7e3184305c165aec872
+        with:
+          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+          username: ${{ github.actor }}
+          team: mobile-deployers
+
       - name: Check for any deploy blockers
         id: checkDeployBlockers
         uses: Expensify/App/.github/actions/checkDeployBlockers@main
@@ -28,7 +36,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           COMMENT: |
-            This issue either has unchecked QA steps or has not yet been marked with the `:shipit:` emoji of approval.
+            Oops, something went wrong! This issue must:
+                1. Have unchecked QA steps, or
+                2. Not have been marked with the `:shipit:` emoji of approval, or
+                3. Have been closed by someone who is not a member of @Expensify/Mobile-Deployers.
             Reopening!
 
   # Update the production branch to trigger the production deploy.
@@ -36,8 +47,8 @@ jobs:
     runs-on: ubuntu-latest
 
     # Note: Anyone with Triage access to the New Expensify repo can trigger a production deploy
-    needs: checkDeployBlockers
-    if: ${{ needs.checkDeployBlockers.outputs.hasDeployBlockers == 'false' }}
+    needs: validate
+    if: ${{ needs.validate.outputs.isValid }}
     steps:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
@@ -54,8 +65,8 @@ jobs:
   # Deploy deferred PRs to staging and create a new StagingDeployCash for the next release cycle.
   createNewStagingDeployCash:
     runs-on: macos-11
-    needs: checkDeployBlockers
-    if: ${{ needs.checkDeployBlockers.outputs.hasDeployBlockers == 'false' }}
+    needs: validate
+    if: ${{ needs.validate.outputs.isValid }}
     steps:
       # Version: 2.3.4
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f

--- a/.github/workflows/finishReleaseCycle.yml
+++ b/.github/workflows/finishReleaseCycle.yml
@@ -22,7 +22,18 @@ jobs:
           username: ${{ github.actor }}
           team: mobile-deployers
 
+      - name: Reopen and comment on issue
+        if: ${{ !steps.validateActor.outputs.isTeamMember }}
+        uses: Expensify/App/.github/actions/reopenIssueWithComment@main
+        with:
+          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          COMMENT: |
+            Sorry, only members of @Expensify/Mobile-Deployers can close deploy checklists.
+            Reopening!
+
       - name: Check for any deploy blockers
+        if: ${{ steps.validateActor.outputs.isTeamMember }}
         id: checkDeployBlockers
         uses: Expensify/App/.github/actions/checkDeployBlockers@main
         with:
@@ -30,16 +41,13 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
 
       - name: Reopen and comment on issue
-        if: ${{ steps.checkDeployBlockers.outputs.HAS_DEPLOY_BLOCKERS == 'true' }}
+        if: ${{ steps.validateActor.outputs.isTeamMember && steps.checkDeployBlockers.outputs.HAS_DEPLOY_BLOCKERS == 'true' }}
         uses: Expensify/App/.github/actions/reopenIssueWithComment@main
         with:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           COMMENT: |
-            Oops, something went wrong! This issue must:
-                1. Have unchecked QA steps, or
-                2. Not have been marked with the `:shipit:` emoji of approval, or
-                3. Have been closed by someone who is not a member of @Expensify/Mobile-Deployers.
+            This issue either has unchecked QA steps or has not yet been marked with the `:shipit:` emoji of approval.
             Reopening!
 
   # Update the production branch to trigger the production deploy.

--- a/.github/workflows/finishReleaseCycle.yml
+++ b/.github/workflows/finishReleaseCycle.yml
@@ -45,8 +45,6 @@ jobs:
   # Update the production branch to trigger the production deploy.
   updateProduction:
     runs-on: ubuntu-latest
-
-    # Note: Anyone with Triage access to the New Expensify repo can trigger a production deploy
     needs: validate
     if: ${{ needs.validate.outputs.isValid }}
     steps:

--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -13,9 +13,22 @@ env:
   DEVELOPER_DIR: /Applications/Xcode_12.5.app/Contents/Developer
 
 jobs:
+  validateActor:
+    runs-on: ubuntu-latest
+    outputs:
+      IS_DEPLOYER: ${{ steps.isUserDeployer.outputs.isTeamMember || github.actor == 'OSBotify' }}
+    steps:
+      - id: isUserDeployer
+        uses: tspascoal/get-user-teams-membership@baf2e6adf4c3b897bd65a7e3184305c165aec872
+        with:
+          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+          username: ${{ github.actor }}
+          team: mobile-deployers
+
   android:
     name: Build and deploy Android
-    if: github.actor == 'OSBotify'
+    needs: validateActor
+    if: ${{ needs.validateActor.outputs.IS_DEPLOYER }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -78,7 +91,8 @@ jobs:
 
   desktop:
     name: Build and deploy Desktop
-    if: github.actor == 'OSBotify'
+    needs: validateActor
+    if: ${{ needs.validateActor.outputs.IS_DEPLOYER }}
     runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
@@ -133,7 +147,8 @@ jobs:
 
   iOS:
     name: Build and deploy iOS
-    if: github.actor == 'OSBotify'
+    needs: validateActor
+    if: ${{ needs.validateActor.outputs.IS_DEPLOYER }}
     runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
@@ -216,7 +231,8 @@ jobs:
 
   web:
     name: Build and deploy Web
-    if: github.actor == 'OSBotify'
+    needs: validateActor
+    if: ${{ needs.validateActor.outputs.IS_DEPLOYER }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -368,7 +384,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
-      
+
       - name: 'Announces a production deploy in the #expensify-open-source Slack room'
         uses: 8398a7/action-slack@v3
         if: ${{ env.SHOULD_DEPLOY_PRODUCTION == 'true' }}


### PR DESCRIPTION
### Details
1. Opens up manual CP privileges to the @Expensify/mobile-deployers group
1. Restricts production deploy abilities to the @Expensify/mobile-deployers group
1. Allows @Expensify/mobile-deployers to run the `platformDeploy.yml` workflow. This means we can now retry failed deploy workflows. But be warned! With great power comes great responsibility. You must understand that if you push a tag or create a GH release, you will trigger a staging/production deploy.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/171977
$ https://github.com/Expensify/Expensify/issues/173687

### Tests
This must be live-tested. Testing steps can happen out-of-order, but the complete list of things we need to verify is:

- [ ] Merge a PR when the deploy checklist is unlocked. Verify that a staging deploy occurs as expected.
- [ ] Have a mobile-deployer restart an active `platformDeploy.yml` workflow. Verify that it restarts and works as expected.
- [ ] Have a non-mobile deployer restart a `platformDeploy.yml` workflow. Verify that it does not restart.
- [ ] With the deploy checklist locked, merge a PR with the `CP Staging` label. It should be CP'd to staging.
- [ ] Have a mobile-deployer (not a member of the deprecated expensify-cash-deployers team) attempt to manually trigger a CP. It should work as expected.
- [ ] Have a non-mobile-deployer attempt to manually trigger a CP. It should not work.
- [ ] Have a non-mobile deployer attempt to close out a `StagingDeployCash` where there are unchecked boxes in the description. It should not work.
- [ ] Have a mobile-deployer attempt to close out a `StagingDeployCash` where there are unchecked boxes in the description. It should not work.
- [ ] Have a non-mobile-deployer attempt to close out a `StagingDeployCash` with all the boxes checked and with the :shipit: comment. It should not work.
- [ ] Have a mobile-deployer attempt to close out a `StagingDeployCash` with all the boxes checked and with the :shipit: comment. It should work and trigger the prod deploy.