### PR TITLE
Update StagingDeployCash for manual cherry-picks

### DIFF
--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -179,3 +179,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
           PULL_REQUEST: ${{ steps.createPullRequest.outputs.pr_number }}
+
+      # Note: we only run this action if the PR was manually CP'd. Otherwise, the deploy checklist is updated from preDeploy.yml
+      - name: Update StagingDeployCash
+        if: ${{ github.actor != 'OSBotify' }}
+        uses: Expensify/App/.github/actions/createOrUpdateStagingDeploy@main
+        with:
+          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+          NPM_VERSION: ${{ env.NEW_VERSION }}


### PR DESCRIPTION

### Details
If the `cherryPick.yml` workflow was run manually (i.e: by a user other than `OSBotify`), then we need to update the deploy checklist to include the newly deployed PR.

### Fixed Issues
$ https://github.com/Expensify/App/issues/4379

### Tests
1. Merge this PR with the deploy checklist locked.
1. Manually CP this PR.
1. Verify that, once the CP workflow completes, the checklist is updated to include this PR.

### QA Steps
None.