### PR TITLE
Add missing period to preferences page

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -283,7 +283,7 @@ export default {
     },
     preferencesPage: {
         mostRecent: 'Most Recent',
-        mostRecentModeDescription: 'This will display all chats by default, sorted by most recent, with pinned items at the top',
+        mostRecentModeDescription: 'This will display all chats by default, sorted by most recent, with pinned items at the top.',
         focus: '#focus',
         focusModeDescription: '#focus – This will only display unread and pinned chats, all sorted alphabetically.',
         receiveRelevantFeatureUpdatesAndExpensifyNews: 'Receive relevant feature updates and Expensify news',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -283,7 +283,7 @@ export default {
     },
     preferencesPage: {
         mostRecent: 'Más Recientes',
-        mostRecentModeDescription: 'Esta opción muestra por defecto todos los chats, ordenados a partir del más reciente, con los chats destacados arriba de todo',
+        mostRecentModeDescription: 'Esta opción muestra por defecto todos los chats, ordenados a partir del más reciente, con los chats destacados arriba de todo.',
         focus: '#concentración',
         focusModeDescription: '#concentración – Muestra sólo los chats no leídos y destacados ordenados alfabéticamente.',
         receiveRelevantFeatureUpdatesAndExpensifyNews: 'Recibir noticias sobre Expensify y actualizaciones del producto',


### PR DESCRIPTION
### Details
Adds a missing period

### Fixed Issues
$ https://github.com/Expensify/App/issues/4772

### Tests
1. Open Preference page
2. Set your notification mode to `Most Recent`
3. _Verify_ there is a period at the end of the sentence


### QA Steps
1. Open Preference page
2. Set your notification mode to `Most Recent`
3. _Verify_ there is a period at the end of the sentence

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web
![image](https://user-images.githubusercontent.com/22447860/130670574-2a26def4-b42a-496f-bec8-5c9c1ddd1ca4.png)

Also tested Spanish translation
![image](https://user-images.githubusercontent.com/22447860/130670669-202e1d23-d752-4f96-9889-c10c92a47014.png)

#### Mobile Web
![image](https://user-images.githubusercontent.com/22447860/130670706-4fba25a1-4f77-4315-8ced-faafc7e50fef.png)

#### Desktop
![image](https://user-images.githubusercontent.com/22447860/130671185-ed5e9b9e-e83b-443c-92a0-fdb3664f3c7c.png)

#### iOS
![image](https://user-images.githubusercontent.com/22447860/130672052-aaaa4bee-cf7c-4b5a-9b2d-9e7b5e7eb665.png)

#### Android
![image](https://user-images.githubusercontent.com/22447860/130673363-4e4821ce-eaae-437f-8d74-83980284a372.png)