### PR TITLE
Fixed tooltip pointer in left/right-aligned tooltips

### DIFF
--- a/src/components/AvatarWithImagePicker.js
+++ b/src/components/AvatarWithImagePicker.js
@@ -11,7 +11,6 @@ import {
 import styles from '../styles/styles';
 import themeColors from '../styles/themes/default';
 import AttachmentPicker from './AttachmentPicker';
-import Tooltip from './Tooltip';
 import withLocalize, {withLocalizePropTypes} from './withLocalize';
 import variables from '../styles/variables';
 
@@ -100,47 +99,46 @@ class AvatarWithImagePicker extends React.Component {
         const additionalStyles = _.isArray(this.props.style) ? this.props.style : [this.props.style];
         return (
             <View style={[styles.alignItemsCenter, ...additionalStyles]}>
-                <Tooltip text={this.props.translate('avatarWithImagePicker.editImage')}>
-                    <View style={[styles.pRelative, styles.avatarLarge]}>
-                        {this.props.avatarURL
-                            ? (
-                                <Avatar
-                                    containerStyles={styles.avatarLarge}
-                                    imageStyles={[styles.avatarLarge, styles.alignSelfCenter]}
-                                    source={this.props.avatarURL}
-                                />
-                            )
-                            : (
-                                <DefaultAvatar />
-                            )}
-                        <AttachmentPicker>
-                            {({openPicker}) => (
-                                <>
-                                    <Pressable
-                                        style={[styles.smallEditIcon, styles.smallAvatarEditIcon]}
-                                        onPress={() => this.setState({isMenuVisible: true})}
-                                    >
-                                        <Icon
-                                            src={Pencil}
-                                            width={variables.iconSizeSmall}
-                                            height={variables.iconSizeSmall}
-                                            fill={themeColors.iconReversed}
-                                        />
-                                    </Pressable>
-                                    <PopoverMenu
-                                        isVisible={this.state.isMenuVisible}
-                                        onClose={() => this.setState({isMenuVisible: false})}
-                                        onItemSelected={() => this.setState({isMenuVisible: false})}
-                                        menuItems={this.createMenuItems(openPicker)}
-                                        anchorPosition={this.props.anchorPosition}
-                                        animationIn="fadeInDown"
-                                        animationOut="fadeOutUp"
+
+                <View style={[styles.pRelative, styles.avatarLarge]}>
+                    {this.props.avatarURL
+                        ? (
+                            <Avatar
+                                containerStyles={styles.avatarLarge}
+                                imageStyles={[styles.avatarLarge, styles.alignSelfCenter]}
+                                source={this.props.avatarURL}
+                            />
+                        )
+                        : (
+                            <DefaultAvatar />
+                        )}
+                    <AttachmentPicker>
+                        {({openPicker}) => (
+                            <>
+                                <Pressable
+                                    style={[styles.smallEditIcon, styles.smallAvatarEditIcon]}
+                                    onPress={() => this.setState({isMenuVisible: true})}
+                                >
+                                    <Icon
+                                        src={Pencil}
+                                        width={variables.iconSizeSmall}
+                                        height={variables.iconSizeSmall}
+                                        fill={themeColors.iconReversed}
                                     />
-                                </>
-                            )}
-                        </AttachmentPicker>
-                    </View>
-                </Tooltip>
+                                </Pressable>
+                                <PopoverMenu
+                                    isVisible={this.state.isMenuVisible}
+                                    onClose={() => this.setState({isMenuVisible: false})}
+                                    onItemSelected={() => this.setState({isMenuVisible: false})}
+                                    menuItems={this.createMenuItems(openPicker)}
+                                    anchorPosition={this.props.anchorPosition}
+                                    animationIn="fadeInDown"
+                                    animationOut="fadeOutUp"
+                                />
+                            </>
+                        )}
+                    </AttachmentPicker>
+                </View>
             </View>
         );
     }

--- a/src/components/HeaderWithCloseButton.js
+++ b/src/components/HeaderWithCloseButton.js
@@ -77,7 +77,7 @@ const HeaderWithCloseButton = props => (
                 </Tooltip>
             )}
             <Header title={props.title} />
-            <View style={[styles.reportOptions, styles.flexRow]}>
+            <View style={[styles.reportOptions, styles.flexRow, styles.pr5]}>
                 {
                     props.shouldShowDownloadButton && (
                     <Tooltip text={props.translate('common.download')}>
@@ -97,7 +97,7 @@ const HeaderWithCloseButton = props => (
                 <Tooltip text={props.translate('common.close')}>
                     <TouchableOpacity
                         onPress={props.onCloseButtonPress}
-                        style={[styles.touchableButtonImage]}
+                        style={[styles.touchableButtonImage, styles.mr0]}
                         accessibilityRole="button"
                         accessibilityLabel={props.translate('common.close')}
                     >

--- a/src/pages/iou/IOUModal.js
+++ b/src/pages/iou/IOUModal.js
@@ -303,11 +303,11 @@ class IOUModal extends Component {
                                         </Tooltip>
                                     )}
                                 <Header title={this.getTitleForStep()} />
-                                <View style={[styles.reportOptions, styles.flexRow]}>
+                                <View style={[styles.reportOptions, styles.flexRow, styles.pr5]}>
                                     <Tooltip text={this.props.translate('common.close')}>
                                         <TouchableOpacity
                                             onPress={() => Navigation.dismissModal()}
-                                            style={[styles.touchableButtonImage]}
+                                            style={[styles.touchableButtonImage, styles.mr0]}
                                             accessibilityRole="button"
                                             accessibilityLabel={this.props.translate('common.close')}
                                         >

--- a/src/styles/getTooltipStyles.js
+++ b/src/styles/getTooltipStyles.js
@@ -90,6 +90,13 @@ export default function getTooltipStyles(
     const tooltipVerticalPadding = spacing.pv1;
     const tooltipFontSize = variables.fontSizeSmall;
 
+    const topCornerBorderRadius = {};
+    if (horizontalShift < 0) {
+        topCornerBorderRadius.borderTopRightRadius = variables.componentBorderRadiusNone;
+    } else if (horizontalShift > 0) {
+        topCornerBorderRadius.borderTopLeftRadius = variables.componentBorderRadiusNone;
+    }
+
     return {
         animationStyle: {
             // remember Transform causes a new Local cordinate system
@@ -105,6 +112,7 @@ export default function getTooltipStyles(
             borderRadius: variables.componentBorderRadiusSmall,
             ...tooltipVerticalPadding,
             ...spacing.ph2,
+            ...topCornerBorderRadius,
             zIndex: variables.tooltipzIndex,
 
             // Because it uses fixed positioning, the top-left corner of the tooltip is aligned

--- a/src/styles/getTooltipStyles.js
+++ b/src/styles/getTooltipStyles.js
@@ -172,7 +172,7 @@ export default function getTooltipStyles(
             //      so the pointer's center lines up with the tooltipWidth's center.
             //   3) Due to the tip start from the left edge of wrapper Tooltip so we have to remove the
             //      horizontalShift which is added to adjust it into the Window
-            left: -horizontalShift + ((tooltipWidth / 2) - (POINTER_WIDTH / 2)),
+            left: -(horizontalShift + 4) + ((tooltipWidth / 2) - (POINTER_WIDTH / 2)),
         },
         pointerStyle: {
             width: 0,

--- a/src/styles/getTooltipStyles.js
+++ b/src/styles/getTooltipStyles.js
@@ -90,11 +90,6 @@ export default function getTooltipStyles(
     const tooltipVerticalPadding = spacing.pv1;
     const tooltipFontSize = variables.fontSizeSmall;
 
-    let pointerTopMargin = 0;
-    if (horizontalShift !== 0) {
-        pointerTopMargin = 2;
-    }
-
     return {
         animationStyle: {
             // remember Transform causes a new Local cordinate system
@@ -123,10 +118,10 @@ export default function getTooltipStyles(
             top: shouldShowBelow
 
                 // We need to shift the tooltip down below the component. So shift the tooltip down (+) by...
-                ? (yOffset + componentHeight + POINTER_HEIGHT + manualShiftVertical) - pointerTopMargin
+                ? (yOffset + componentHeight + POINTER_HEIGHT + manualShiftVertical)
 
                 // We need to shift the tooltip up above the component. So shift the tooltip up (-) by...
-                : ((yOffset - (tooltipHeight + POINTER_HEIGHT)) + manualShiftVertical) + pointerTopMargin,
+                : ((yOffset - (tooltipHeight + POINTER_HEIGHT)) + manualShiftVertical),
 
             // Next, we'll position it horizontally.
             // we will use xOffset to position the tooltip relative to the Wrapped Component
@@ -163,7 +158,7 @@ export default function getTooltipStyles(
             //      so that the top of the pointer aligns with the bottom of the component.
             //
             // Always add the manual vertical shift passed in as a parameter.
-            top: shouldShowBelow ? (manualShiftVertical - POINTER_HEIGHT) + pointerTopMargin : (tooltipHeight + manualShiftVertical) - pointerTopMargin,
+            top: shouldShowBelow ? (manualShiftVertical - POINTER_HEIGHT) : (tooltipHeight + manualShiftVertical),
 
             // To align it horizontally, we'll:
             //   1) Shift the pointer to the right (+) by the half the tooltipWidth's width,
@@ -172,7 +167,7 @@ export default function getTooltipStyles(
             //      so the pointer's center lines up with the tooltipWidth's center.
             //   3) Due to the tip start from the left edge of wrapper Tooltip so we have to remove the
             //      horizontalShift which is added to adjust it into the Window
-            left: -(horizontalShift + 4) + ((tooltipWidth / 2) - (POINTER_WIDTH / 2)),
+            left: -horizontalShift + ((tooltipWidth / 2) - (POINTER_WIDTH / 2)),
         },
         pointerStyle: {
             width: 0,

--- a/src/styles/getTooltipStyles.js
+++ b/src/styles/getTooltipStyles.js
@@ -90,11 +90,9 @@ export default function getTooltipStyles(
     const tooltipVerticalPadding = spacing.pv1;
     const tooltipFontSize = variables.fontSizeSmall;
 
-    const topCornerBorderRadius = {};
-    if (horizontalShift < 0) {
-        topCornerBorderRadius.borderTopRightRadius = variables.componentBorderRadiusNone;
-    } else if (horizontalShift > 0) {
-        topCornerBorderRadius.borderTopLeftRadius = variables.componentBorderRadiusNone;
+    let pointerTopMargin = 0;
+    if (horizontalShift !== 0) {
+        pointerTopMargin = 2;
     }
 
     return {
@@ -112,7 +110,6 @@ export default function getTooltipStyles(
             borderRadius: variables.componentBorderRadiusSmall,
             ...tooltipVerticalPadding,
             ...spacing.ph2,
-            ...topCornerBorderRadius,
             zIndex: variables.tooltipzIndex,
 
             // Because it uses fixed positioning, the top-left corner of the tooltip is aligned
@@ -126,10 +123,10 @@ export default function getTooltipStyles(
             top: shouldShowBelow
 
                 // We need to shift the tooltip down below the component. So shift the tooltip down (+) by...
-                ? yOffset + componentHeight + POINTER_HEIGHT + manualShiftVertical
+                ? (yOffset + componentHeight + POINTER_HEIGHT + manualShiftVertical) - pointerTopMargin
 
                 // We need to shift the tooltip up above the component. So shift the tooltip up (-) by...
-                : (yOffset - (tooltipHeight + POINTER_HEIGHT)) + manualShiftVertical,
+                : ((yOffset - (tooltipHeight + POINTER_HEIGHT)) + manualShiftVertical) + pointerTopMargin,
 
             // Next, we'll position it horizontally.
             // we will use xOffset to position the tooltip relative to the Wrapped Component
@@ -166,7 +163,7 @@ export default function getTooltipStyles(
             //      so that the top of the pointer aligns with the bottom of the component.
             //
             // Always add the manual vertical shift passed in as a parameter.
-            top: shouldShowBelow ? manualShiftVertical - POINTER_HEIGHT : tooltipHeight + manualShiftVertical,
+            top: shouldShowBelow ? (manualShiftVertical - POINTER_HEIGHT) + pointerTopMargin : (tooltipHeight + manualShiftVertical) - pointerTopMargin,
 
             // To align it horizontally, we'll:
             //   1) Shift the pointer to the right (+) by the half the tooltipWidth's width,

--- a/src/styles/variables.js
+++ b/src/styles/variables.js
@@ -4,6 +4,7 @@ export default {
     componentSizeNormal: 40,
     inputComponentSizeNormal: 42,
     componentSizeLarge: 52,
+    componentBorderRadiusNone: 0,
     componentBorderRadius: 8,
     componentBorderRadiusSmall: 4,
     componentBorderRadiusNormal: 8,

--- a/src/styles/variables.js
+++ b/src/styles/variables.js
@@ -4,7 +4,6 @@ export default {
     componentSizeNormal: 40,
     inputComponentSizeNormal: 42,
     componentSizeLarge: 52,
-    componentBorderRadiusNone: 0,
     componentBorderRadius: 8,
     componentBorderRadiusSmall: 4,
     componentBorderRadiusNormal: 8,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

@iwiznia  Can you please review this fix?

### Details
- Added fix to the broken pointer of the tooltip.

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/4723
--->
$ #4499 

### Tests
1. Tested the right aligned `tooltip`
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### QA Steps
1. Go to Homepage
2. Click on the Avatar to open Settings Screen
3. Check the Close(X) button  for its alignment and UI

<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### Tested On

- [x] Web
- [ ] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<img width="528" alt="web 2" src="https://user-images.githubusercontent.com/3069065/130825964-b7e5a70b-82b0-47ea-8a23-d8937537650f.png">
<img width="408" alt="web" src="https://user-images.githubusercontent.com/3069065/130825957-9efee705-bdb2-49bc-9240-7507154f1bda.png">

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<img width="1397" alt="desktop" src="https://user-images.githubusercontent.com/3069065/130825904-6c07da68-a2a2-4834-a237-dc084c877922.png">

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
