### PR TITLE
Corrected Placeholders not vertically centered in text inputs issue #4675

### DIFF
--- a/src/components/ExpensiTextInput/BaseExpensiTextInput.js
+++ b/src/components/ExpensiTextInput/BaseExpensiTextInput.js
@@ -9,7 +9,7 @@ import {propTypes, defaultProps} from './propTypes';
 import themeColors from '../../styles/themes/default';
 import styles from '../../styles/styles';
 
-const ACTIVE_LABEL_TRANSLATE_Y = -10;
+const ACTIVE_LABEL_TRANSLATE_Y = -12;
 const ACTIVE_LABEL_TRANSLATE_X = (translateX = -22) => translateX;
 const ACTIVE_LABEL_SCALE = 0.8668;
 

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -523,7 +523,7 @@ const styles = {
     expensiTextInputLabel: {
         position: 'absolute',
         left: 12,
-        top: 14,
+        top: 16,
         fontSize: variables.fontSizeNormal,
         color: themeColors.textSupporting,
         fontFamily: fontFamily.GTA,


### PR DESCRIPTION
Corrected Placeholders not vertically centered in text inputs.  @marklouisdeshaun  kindly review pull request, please message me if any information missing from my side.

### Details
Basically when there is no focus it shows ExpensiTextInputLabel.js component. We need to update top value for expensiTextInputLabel style within src/styles/styles.js file. i.e. change top: 14 to top: 16 as under:

    expensiTextInputLabel: {
	...
        top: 16,
	...
    },

So now we moved inactive label default position 2 pt down, So to keep the active label (i.e. when focused) at the same position we have to set ACTIVE_LABEL_TRANSLATE_Y = -12 (at present it is -10) within src/components/ExpensiTextInput/BaseExpensiTextInput.js  (line 12)

### Fixed Issues
https://github.com/Expensify/App/issues/4675

### Tests
1. Run app on any platform
2. Check  text input placeholder on Login screen.
3. Check  text input placeholder on any after login screen where text input used.

### QA Steps
1. Login screen text input. When there is no focus on text input, placeholder shows vertically centered now. (previously it was vertically off centered)
2. After login any text input.  When there is no focus on text input, placeholder shows vertically centered now. (previously it was vertically off centered)

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web
<img width="1328" alt="4675-Web" src="https://user-images.githubusercontent.com/7823358/130825259-922aea0c-3253-4f4b-9017-eb998b342e40.png">

#### Mobile Web
<img width="600" alt="4675-mobileWeb" src="https://user-images.githubusercontent.com/7823358/130825054-9877dab8-5c15-4770-9f2c-4c9cbd907b02.png">

#### Desktop
<img width="1312" alt="macOsDesktop" src="https://user-images.githubusercontent.com/7823358/130824449-8299d586-7c83-4b1b-abff-a4c6feacb245.png">

#### iOS
<img width="600" alt="4675-iOS" src="https://user-images.githubusercontent.com/7823358/130825357-a989cc21-cd5d-4fb1-9483-64c2ae1346f5.png">

#### Android
<img width="600" alt="4675-Android7" src="https://user-images.githubusercontent.com/7823358/130825523-02000150-637d-4ac3-8931-890fe8eb78f8.jpg">
