### PR TITLE
[No QA] Announce CP failures in the #announce Slack channel

### DIFF
--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -180,14 +180,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
           PULL_REQUEST: ${{ steps.createPullRequest.outputs.pr_number }}
 
-      # Note: we only run this action if the PR was manually CP'd. Otherwise, the deploy checklist is updated from preDeploy.yml
-      - name: Update StagingDeployCash
-        if: ${{ github.actor != 'OSBotify' }}
-        uses: Expensify/App/.github/actions/createOrUpdateStagingDeploy@main
-        with:
-          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
-          NPM_VERSION: ${{ env.NEW_VERSION }}
-
       - name: 'Announces a CP failure in the #announce Slack room'
         uses: 8398a7/action-slack@v3
         if: ${{ failure() }}

--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -179,8 +179,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
           PULL_REQUEST: ${{ steps.createPullRequest.outputs.pr_number }}
-<<<<<<< HEAD
-=======
 
       # Note: we only run this action if the PR was manually CP'd. Otherwise, the deploy checklist is updated from preDeploy.yml
       - name: Update StagingDeployCash
@@ -207,4 +205,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
->>>>>>> 2cd86b9fc (announce CP failures in slack)

--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -200,7 +200,8 @@ jobs:
               channel: '#announce',
               attachments: [{
                 color: "#DB4545",
-                text: `🔥️ Failed to CP https://github.com/Expensify/App/pull/${{ github.event.inputs.PULL_REQUEST_NUMBER }} to staging 🔥️`,
+                pretext: `<!subteam^S4TJJ3PSL>`,
+                text: `💥 Failed to CP https://github.com/Expensify/App/pull/${{ github.event.inputs.PULL_REQUEST_NUMBER }} to staging 💥`,
               }]
             }
         env:

--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -190,8 +190,7 @@ jobs:
               channel: '#announce',
               attachments: [{
                 color: "#DB4545",
-                pretext: `<!subteam^S4TJJ3PSL>`,
-                text: `💥 Failed to CP https://github.com/Expensify/App/pull/${{ github.event.inputs.PULL_REQUEST_NUMBER }} to staging 💥`,
+                text: `@mobile-deployers 💥 Failed to CP https://github.com/Expensify/App/pull/${{ github.event.inputs.PULL_REQUEST_NUMBER }} to staging 💥`,
               }]
             }
         env:

--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -179,3 +179,31 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
           PULL_REQUEST: ${{ steps.createPullRequest.outputs.pr_number }}
+<<<<<<< HEAD
+=======
+
+      # Note: we only run this action if the PR was manually CP'd. Otherwise, the deploy checklist is updated from preDeploy.yml
+      - name: Update StagingDeployCash
+        if: ${{ github.actor != 'OSBotify' }}
+        uses: Expensify/App/.github/actions/createOrUpdateStagingDeploy@main
+        with:
+          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+          NPM_VERSION: ${{ env.NEW_VERSION }}
+
+      - name: 'Announces a CP failure in the #announce Slack room'
+        uses: 8398a7/action-slack@v3
+        if: ${{ failure() }}
+        with:
+          status: custom
+          custom_payload: |
+            {
+              channel: '#announce',
+              attachments: [{
+                color: "#DB4545",
+                text: `🔥️ Failed to CP https://github.com/Expensify/App/pull/${{ github.event.inputs.PULL_REQUEST_NUMBER }} to staging 🔥️`,
+              }]
+            }
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+>>>>>>> 2cd86b9fc (announce CP failures in slack)


### PR DESCRIPTION
cc @roryabraham 

### Details
CP failures should be announced in the #announce channel in Slack.

### Fixed Issues
$ https://github.com/Expensify/App/issues/4788

### Tests
1. Once deployed, attempt to CP an issue instead of a PR 🤯 
2. When the CP fails, verify that it was announced in the `#announce` Slack channel🤞 

### QA Steps
None.

### Tested On
N/A GitHub only!