### PR TITLE
Fix syntax error in GitHub action expression

### DIFF
--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -362,7 +362,7 @@ jobs:
               channel: '#announce',
               attachments: [{
                 color: 'good',
-                text: `Successfully deployed ${process.env.AS_REPO} v${{ env.VERSION }} to ${{ env.SHOULD_DEPLOY_PRODUCTION == 'true' && 'production' || 'staging' }}.`,
+                text: `🎉️ Successfully deployed ${process.env.AS_REPO} v${{ env.VERSION }} to ${{ env.SHOULD_DEPLOY_PRODUCTION == 'true' && 'production' || 'staging' }} 🎉️`,
               }]
             }
         env:
@@ -379,7 +379,7 @@ jobs:
               channel: '#expensify-open-source',
               attachments: [{
                 color: 'good',
-                text: `Successfully deployed ${process.env.AS_REPO} v${{ env.VERSION }} to production.`,
+                text: `🎉️ Successfully deployed ${process.env.AS_REPO} v${{ env.VERSION }} to production 🎉️`,
               }]
             }
         env:

--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -362,7 +362,7 @@ jobs:
               channel: '#announce',
               attachments: [{
                 color: 'good',
-                text: `Successfully deployed ${process.env.AS_REPO} v${{ env.VERSION }} to ${{ env.SHOULD_DEPLOY_PRODUCTION == 'true' ? 'production' : 'staging' }}.`,
+                text: `Successfully deployed ${process.env.AS_REPO} v${{ env.VERSION }} to ${{ env.SHOULD_DEPLOY_PRODUCTION == 'true' && 'production' || 'staging' }}.`,
               }]
             }
         env:


### PR DESCRIPTION
### Details
Coming from here https://expensify.slack.com/archives/C07J32337/p1629913059428800?thread_ts=1629910896.422200&cid=C07J32337

### Fixed Issues
$ https://github.com/Expensify/App/issues/4832

### Tests
I tested the new syntax [here](https://github.com/Andrew-Test-Org/Public-Test-Repo/runs/3427218646?check_suite_focus=true). While that test failed because we don't have the Slack secret in that repo, it did not complain about the syntax and correctly echoed `staging` since the conditional resolved to false. That seems to have solved the syntax issue [here](https://github.com/Expensify/App/pull/4757)!

1. During the next deploy, verify that successful deploy messages are posted in the `#announce` Slack channel for staging deploys and `#announce` and `#expensify-open-source` channels for production deploys.

### QA Steps
None.

### Tested On
N/A GitHub only