### PR TITLE
Trim long workspace name

### DIFF
--- a/src/components/MenuItem.js
+++ b/src/components/MenuItem.js
@@ -151,11 +151,13 @@ const MenuItem = ({
                         </View>
                     )}
                     <View style={[styles.justifyContentCenter, styles.menuItemTextContainer]}>
-                        <Text style={[
-                            styles.popoverMenuText,
-                            styles.ml3,
-                            (disabled ? styles.disabledText : undefined),
-                        ]}
+                        <Text
+                            style={[
+                                styles.popoverMenuText,
+                                styles.ml3,
+                                (disabled ? styles.disabledText : undefined),
+                            ]}
+                            numberOfLines={1}
                         >
                             {title}
                         </Text>

--- a/src/pages/workspace/WorkspaceSidebar.js
+++ b/src/pages/workspace/WorkspaceSidebar.js
@@ -26,6 +26,7 @@ import ONYXKEYS from '../../ONYXKEYS';
 import Avatar from '../../components/Avatar';
 import CONST from '../../CONST';
 import {create} from '../../libs/actions/Policy';
+import Tooltip from '../../components/Tooltip';
 
 const propTypes = {
     /** Policy for the current route */
@@ -134,17 +135,20 @@ const WorkspaceSidebar = ({
                                     styles.alignSelfCenter,
                                     styles.mt4,
                                     styles.mb6,
+                                    styles.w100,
                                 ]}
                                 onPress={openEditor}
                             >
-                                <Text
-                                    numberOfLines={1}
-                                    style={[
-                                        styles.displayName,
-                                    ]}
-                                >
-                                    {policy.name}
-                                </Text>
+                                <Tooltip text={policy.name}>
+                                    <Text
+                                        numberOfLines={1}
+                                        style={[
+                                            styles.displayName,
+                                        ]}
+                                    >
+                                        {policy.name}
+                                    </Text>
+                                </Tooltip>
                             </Pressable>
                         </View>
                     </View>

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -895,6 +895,7 @@ const styles = {
         fontSize: variables.fontSizeNormal,
         fontWeight: fontWeightBold,
         color: themeColors.heading,
+        maxWidth: 240,
     },
 
     menuItemTextContainer: {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
@Julesssss Can you please review this?

### Details
- Trimmed workspace name when its too long

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/4723
--->
$ #4747 

### Tests
1. Test on WorkspaceSidebar
2. Tested on Home Sidebar

<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### QA Steps
1. Create an account with a very long email
2. Create a new workspace
3. Then visit the workspace and verify that it doesn't get trimmed outside the container.

<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<img width="532" alt="Screenshot 2021-08-25 at 11 17 34 PM" src="https://user-images.githubusercontent.com/57435789/130843464-b8ab8cd5-834c-422e-a824-2884f7e73ca6.png">
<img width="941" alt="Screenshot 2021-08-25 at 11 01 01 PM" src="https://user-images.githubusercontent.com/57435789/130843479-ee17b362-ce10-4bb3-a8d4-38342fe3848c.png">


#### Mobile Web
<img width="379" alt="Screenshot 2021-08-25 at 11 36 02 PM" src="https://user-images.githubusercontent.com/57435789/130843497-1dfdf1d2-f5e6-4151-937a-3f448afea231.png">
<img width="352" alt="Screenshot 2021-08-25 at 11 35 55 PM" src="https://user-images.githubusercontent.com/57435789/130843508-240c7e10-8be9-4d05-a818-4cbe79a924de.png">


#### Desktop
<img width="600" alt="Screenshot 2021-08-25 at 11 38 02 PM" src="https://user-images.githubusercontent.com/57435789/130843531-bc9f3a2a-532d-42ef-8fdb-8276916896c5.png">
<img width="917" alt="Screenshot 2021-08-25 at 11 37 48 PM" src="https://user-images.githubusercontent.com/57435789/130843536-ad7a5a43-11f4-4ba8-91e8-28bcbd354430.png">


#### iOS
<img width="348" alt="Screenshot 2021-08-25 at 11 46 04 PM" src="https://user-images.githubusercontent.com/57435789/130844048-234239d6-468c-466b-b08e-53f4dff28fd7.png">
<img width="339" alt="Screenshot 2021-08-25 at 11 46 17 PM" src="https://user-images.githubusercontent.com/57435789/130844090-ef84d7e2-cdc1-4009-a199-5debf8d5ad5a.png">


#### Android
<img width="325" alt="Screenshot 2021-08-26 at 12 05 52 AM" src="https://user-images.githubusercontent.com/57435789/130846440-4aebde9a-3998-4ee7-99db-ddb8e944df69.png">
<img width="319" alt="Screenshot 2021-08-26 at 12 05 26 AM" src="https://user-images.githubusercontent.com/57435789/130846448-63c721f0-45b9-4c19-a91c-693559439efe.png">

