### PR TITLE
Styles h3/h4 missing bold fixed for web, desktop, iOS

### DIFF
--- a/src/pages/signin/PasswordForm.js
+++ b/src/pages/signin/PasswordForm.js
@@ -90,7 +90,7 @@ class PasswordForm extends React.Component {
                         onPress={resetPassword}
                         underlayColor={themeColors.componentBG}
                     >
-                        <Text style={[styles.link, styles.h4]}>
+                        <Text style={[styles.link]}>
                             {this.props.translate('passwordForm.forgot')}
                         </Text>
                     </TouchableOpacity>

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -60,11 +60,13 @@ const styles = {
     h3: {
         fontFamily: fontFamily.GTA_BOLD,
         fontSize: variables.fontSizeNormal,
+        fontWeight: fontWeightBold,
     },
 
     h4: {
         fontFamily: fontFamily.GTA_BOLD,
         fontSize: variables.fontSizeLabel,
+        fontWeight: fontWeightBold,
     },
 
     textAlignCenter: {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
@roryabraham 

### Details
Bold style missed out for welcome text

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/4723
--->
$ #4729 

### Tests & QA Steps
1. Go to the new Expensify app. Log out if already logged in.
2. Login page welcome text should be bolded on all platforms
3. Enter email click continue
4. `Forgot?` should also be not be bolded.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<img width="1440" alt="Screenshot 2021-08-26 at 12 46 29 AM" src="https://user-images.githubusercontent.com/85645967/130864758-de0f1854-7cb0-417e-9613-03a33cfb8852.png">


<img width="1440" alt="Screenshot 2021-08-26 at 2 22 03 AM" src="https://user-images.githubusercontent.com/85645967/130863351-49d1812e-8766-4c65-8005-8f18c39b89aa.png">


#### Mobile Web
<img width="484" alt="Screenshot 2021-08-26 at 12 46 43 AM" src="https://user-images.githubusercontent.com/85645967/130854519-44d01e42-b758-4e7d-b1ea-0c9dc1896f15.png">
<img width="491" alt="Screenshot 2021-08-26 at 2 22 16 AM" src="https://user-images.githubusercontent.com/85645967/130863331-f64d4603-6e33-4c5e-a949-797c7689037b.png">


#### Desktop
<img width="1200" alt="Screenshot 2021-08-26 at 1 01 05 AM" src="https://user-images.githubusercontent.com/85645967/130854435-f44d0269-e0f6-4c8c-800e-0e1b1e049d7b.png">
<img width="1199" alt="Screenshot 2021-08-26 at 2 34 40 AM" src="https://user-images.githubusercontent.com/85645967/130864534-491eb139-eefd-43f7-bf52-cd6e9b2add9f.png">


#### iOS
![Simulator Screen Shot - iPhone 12 - 2021-08-26 at 00 52 22](https://user-images.githubusercontent.com/85645967/130854415-f9d5da9d-f049-4e9d-9280-e1cdd8a71757.png)
![Simulator Screen Shot - iPhone 12 - 2021-08-26 at 02 21 28](https://user-images.githubusercontent.com/85645967/130863231-30f20fa3-ee12-4d09-8433-cafd1a5deaff.png)


#### Android
![Screenshot_1629924608](https://user-images.githubusercontent.com/85645967/130863178-c735a119-a91e-436d-8747-276a71704116.png)
![Screenshot_1629924632](https://user-images.githubusercontent.com/85645967/130863166-1797dcd4-754f-4db1-baec-9aebab91b07e.png)



