### PR TITLE
Fixed icon alignment on ReportComposeAction

### DIFF
--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -493,19 +493,22 @@ class ReportActionCompose extends React.Component {
                                 <AttachmentPicker>
                                     {({openPicker}) => (
                                         <>
-                                            <Tooltip text={this.props.translate('reportActionCompose.addAction')}>
-                                                <TouchableOpacity
-                                                    onPress={(e) => {
-                                                        e.preventDefault();
-                                                        this.setMenuVisibility(true);
-                                                    }}
-                                                    style={styles.chatItemAttachButton}
-                                                    underlayColor={themeColors.componentBG}
-                                                    disabled={isBlockedFromConcierge || isArchivedChatRoom}
-                                                >
-                                                    <Icon src={Plus} />
-                                                </TouchableOpacity>
-                                            </Tooltip>
+                                            <View style={[styles.justifyContentEnd]}>
+                                                <Tooltip text={this.props.translate('reportActionCompose.addAction')}>
+                                                    <TouchableOpacity
+                                                        onPress={(e) => {
+                                                            e.preventDefault();
+                                                            this.setMenuVisibility(true);
+                                                        }}
+                                                        style={styles.chatItemAttachButton}
+                                                        underlayColor={themeColors.componentBG}
+                                                        disabled={isBlockedFromConcierge || isArchivedChatRoom}
+                                                    >
+
+                                                        <Icon src={Plus} />
+                                                    </TouchableOpacity>
+                                                </Tooltip>
+                                            </View>
                                             <PopoverMenu
                                                 isVisible={this.state.isMenuVisible}
                                                 onClose={() => this.setMenuVisibility(false)}
@@ -645,18 +648,24 @@ class ReportActionCompose extends React.Component {
                             </Tooltip>
                         )}
                     </Pressable>
-                    <Tooltip text={this.props.translate('common.send')}>
-                        <TouchableOpacity
-                            style={[styles.chatItemSubmitButton,
-                                this.state.isCommentEmpty
-                                    ? styles.buttonDisable : styles.buttonSuccess]}
-                            onPress={this.submitForm}
-                            underlayColor={themeColors.componentBG}
-                            disabled={this.state.isCommentEmpty || isBlockedFromConcierge || isArchivedChatRoom}
-                        >
-                            <Icon src={Send} fill={themeColors.componentBG} />
-                        </TouchableOpacity>
-                    </Tooltip>
+                    <View style={[styles.justifyContentEnd]}>
+                        <Tooltip text={this.props.translate('common.send')}>
+                            <TouchableOpacity
+                                style={[styles.chatItemSubmitButton,
+                                    this.state.isCommentEmpty
+                                        ? styles.buttonDisable : styles.buttonSuccess]}
+                                onPress={this.submitForm}
+                                underlayColor={themeColors.componentBG}
+                                disabled={this.state.isCommentEmpty || isBlockedFromConcierge || isArchivedChatRoom}
+                            >
+
+                                <Icon src={Send} fill={themeColors.componentBG} />
+
+                            </TouchableOpacity>
+                        </Tooltip>
+                    </View>
+
+
                 </View>
                 {this.props.network.isOffline ? (
                     <View style={[styles.chatItemComposeSecondaryRow]}>

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -504,7 +504,6 @@ class ReportActionCompose extends React.Component {
                                                         underlayColor={themeColors.componentBG}
                                                         disabled={isBlockedFromConcierge || isArchivedChatRoom}
                                                     >
-
                                                         <Icon src={Plus} />
                                                     </TouchableOpacity>
                                                 </Tooltip>
@@ -658,14 +657,10 @@ class ReportActionCompose extends React.Component {
                                 underlayColor={themeColors.componentBG}
                                 disabled={this.state.isCommentEmpty || isBlockedFromConcierge || isArchivedChatRoom}
                             >
-
                                 <Icon src={Send} fill={themeColors.componentBG} />
-
                             </TouchableOpacity>
                         </Tooltip>
                     </View>
-
-
                 </View>
                 {this.props.network.isOffline ? (
                     <View style={[styles.chatItemComposeSecondaryRow]}>


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

@iwiznia  Can you please review this for regression in https://github.com/Expensify/App/issues/4499#issuecomment-906269846
### Details
- Fixed `flexEnd` alignment issue due to Tooltip.

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/4723
--->
$ https://github.com/Expensify/App/issues/4499

### Tests
1. Tested the Web View ReportActionCompose button alignments with multiline input.
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### QA Steps
1. Go to chat
2. Enter multiline content
3. Icon buttons should be retained at the bottom.
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<img width="846" alt="Screenshot 2021-08-26 at 3 48 12 PM" src="https://user-images.githubusercontent.com/3069065/130947656-b2cffa4b-08da-4b5d-92ae-0243635e0790.png">
<img width="1103" alt="Screenshot 2021-08-26 at 4 02 01 PM" src="https://user-images.githubusercontent.com/3069065/130947774-f4767ba2-c038-49ab-8324-9c56fb1b90c9.png">


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<img width="830" alt="Screenshot 2021-08-26 at 3 58 30 PM" src="https://user-images.githubusercontent.com/3069065/130947666-f39bf475-fdee-4d88-8fbc-52dc993081ec.png">


#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
