### PR TITLE
Stop automatically creating a workspace when landing on an invalid url

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -618,7 +618,7 @@ export default {
             avatarUploadFailureMessage: 'An error occurred uploading the avatar, please try again.',
         },
         error: {
-            growlMessageInvalidPolicy: 'Invalid workspace! A new workspace has been created.',
+            growlMessageInvalidPolicy: 'Invalid workspace!',
         },
     },
     requestCallPage: {

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -620,7 +620,7 @@ export default {
             avatarUploadFailureMessage: 'No se pudo subir el avatar. Por favor, inténtalo de nuevo.',
         },
         error: {
-            growlMessageInvalidPolicy: '¡Espacio de trabajo no válido! Un nuevo espacio de trabajo ha sido creado.',
+            growlMessageInvalidPolicy: '¡Espacio de trabajo no válido!',
         },
     },
     requestCallPage: {

--- a/src/pages/workspace/WorkspaceSidebar.js
+++ b/src/pages/workspace/WorkspaceSidebar.js
@@ -25,7 +25,6 @@ import Growl from '../../libs/Growl';
 import ONYXKEYS from '../../ONYXKEYS';
 import Avatar from '../../components/Avatar';
 import CONST from '../../CONST';
-import {create} from '../../libs/actions/Policy';
 
 const propTypes = {
     /** Policy for the current route */

--- a/src/pages/workspace/WorkspaceSidebar.js
+++ b/src/pages/workspace/WorkspaceSidebar.js
@@ -80,7 +80,6 @@ const WorkspaceSidebar = ({
     if (allPolicies !== null && _.isEmpty(policy)) {
         Growl.error(translate('workspace.error.growlMessageInvalidPolicy'), CONST.GROWL.DURATION_LONG);
         Navigation.dismissModal();
-        create();
         return null;
     }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
We will stop creating a workspace when a user lands tries to access the workspace modal with an invalid policyID. Before when we had the `Create Workspace` modal, this was useful since the user could actively choose to create a workspace if the one they're accessing does not exist. Now, we are  

### Fixed Issues
https://github.com/Expensify/Expensify/issues/174834

### Tests
Same as QA, done locally

### QA Steps
1. Go to staging.new.expensify.com/workspace/whatever/card
2. Verify you see this error message in the screenshot and the workspace modal simply disappears.

### Tested On
Only relevant on Web at the moment.

- [x] Web
- [x] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
![image](https://user-images.githubusercontent.com/19364431/130987374-29d6c6cb-4800-4fef-8a32-e939ebc5aca8.png)


