### PR TITLE
Remove onSubmitEditing if submit button disabled

### DIFF
--- a/src/pages/ReimbursementAccount/CompanyStep.js
+++ b/src/pages/ReimbursementAccount/CompanyStep.js
@@ -315,7 +315,7 @@ class CompanyStep extends React.Component {
                                 this.setState({password});
                             }}
                             value={this.state.password}
-                            onSubmitEditing={this.submit}
+                            onSubmitEditing={shouldDisableSubmitButton ? undefined : this.submit}
                             errorText={error === this.props.translate('common.passwordCannotBeBlank')
                                 ? this.props.translate('common.passwordCannotBeBlank')
                                 : ''}


### PR DESCRIPTION

### Details
Don't pass this.submit callback as a prop if the form submit button is disabled


### Fixed Issues

$ https://github.com/Expensify/App/issues/4748

### Tests

- Navigate to /bank-account/company. (Web)
- The submit button at the end of the form should be disabled
- Click the Password field at the end to bring it into focus
- Press Enter key (Web) / Press the submit check in the virtual keyboard (Android, IOS?)

Android:
<img src="https://user-images.githubusercontent.com/87341702/131008559-ab3be046-cf99-4e08-b7ec-1cdcb869bad2.png" width="200">


### QA Steps

1. Navigate to /bank-account/company. (Web)
2. The submit button at the end of the form should be disabled
2. Click the Password field at the end to bring it into focus
3. Press Enter key (Web) / Press the submit check in the virtual keyboard (Android, not sure how it looks in IOS)

Nothing should happen, no form submitted because the submit form button 'Save & Continue' is disabled

### Tested On

- [x] Web
- [x] Mobile Web
- [ ] Desktop
- [ ] iOS
- [x] Android

