### PR TITLE
Fix autocomplete issue in VBA flow

### DIFF
--- a/src/components/ExpensiTextInput/index.android.js
+++ b/src/components/ExpensiTextInput/index.android.js
@@ -7,6 +7,7 @@ const ExpensiTextInput = forwardRef((props, ref) => (
     <BaseExpensiTextInput
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...props}
+        autoCompleteType={props.autoCompleteType === 'new-password' ? 'password' : props.autoCompleteType}
         innerRef={ref}
         inputStyle={[
             styles.expensiTextInput,

--- a/src/components/ExpensiTextInput/index.android.js
+++ b/src/components/ExpensiTextInput/index.android.js
@@ -7,6 +7,9 @@ const ExpensiTextInput = forwardRef((props, ref) => (
     <BaseExpensiTextInput
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...props}
+
+        // Setting autoCompleteType to new-password throws an error on Android, so fall back to password in that case
+        // eslint-disable-next-line react/jsx-props-no-multi-spaces
         autoCompleteType={props.autoCompleteType === 'new-password' ? 'password' : props.autoCompleteType}
         innerRef={ref}
         inputStyle={[

--- a/src/components/ExpensiTextInput/index.ios.js
+++ b/src/components/ExpensiTextInput/index.ios.js
@@ -8,7 +8,7 @@ const ExpensiTextInput = forwardRef((props, ref) => (
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...props}
 
-        // Setting autoCompleteType to new-password throws an error on Android, so fall back to password in that case
+        // Setting autoCompleteType to new-password throws an error on iOS, so fall back to password in that case
         // eslint-disable-next-line react/jsx-props-no-multi-spaces
         autoCompleteType={props.autoCompleteType === 'new-password' ? 'password' : props.autoCompleteType}
         innerRef={ref}

--- a/src/components/ExpensiTextInput/index.ios.js
+++ b/src/components/ExpensiTextInput/index.ios.js
@@ -7,6 +7,10 @@ const ExpensiTextInput = forwardRef((props, ref) => (
     <BaseExpensiTextInput
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...props}
+
+        // Setting autoCompleteType to new-password throws an error on Android, so fall back to password in that case
+        // eslint-disable-next-line react/jsx-props-no-multi-spaces
+        autoCompleteType={props.autoCompleteType === 'new-password' ? 'password' : props.autoCompleteType}
         innerRef={ref}
         inputStyle={[styles.expensiTextInput]}
     />

--- a/src/pages/ReimbursementAccount/CompanyStep.js
+++ b/src/pages/ReimbursementAccount/CompanyStep.js
@@ -303,7 +303,6 @@ class CompanyStep extends React.Component {
                                 : ''}
                         />
                         <ExpensiTextInput
-                            autoCompleteType="new-password"
                             label={`Expensify ${this.props.translate('common.password')}`}
                             containerStyles={[styles.mt4]}
                             secureTextEntry
@@ -319,6 +318,10 @@ class CompanyStep extends React.Component {
                             errorText={error === this.props.translate('common.passwordCannotBeBlank')
                                 ? this.props.translate('common.passwordCannotBeBlank')
                                 : ''}
+
+                            // Use new-password to prevent an autoComplete bug https://github.com/Expensify/Expensify/issues/173177
+                            // eslint-disable-next-line react/jsx-props-no-multi-spaces
+                            autoCompleteType="new-password"
                         />
                         <CheckboxWithLabel
                             isChecked={this.state.hasNoConnectionToCannabis}

--- a/src/pages/ReimbursementAccount/CompanyStep.js
+++ b/src/pages/ReimbursementAccount/CompanyStep.js
@@ -303,7 +303,7 @@ class CompanyStep extends React.Component {
                                 : ''}
                         />
                         <ExpensiTextInput
-                            autoCompleteType="password"
+                            autoCompleteType="new-password"
                             label={`Expensify ${this.props.translate('common.password')}`}
                             containerStyles={[styles.mt4]}
                             secureTextEntry


### PR DESCRIPTION
cc @kevinksullivan @iwiznia 

### Details
This PR fixes a regression from https://github.com/Expensify/App/pull/4471 that caused an issue that was undone in https://github.com/Expensify/App/pull/4765. Original issue is https://github.com/Expensify/Expensify/issues/173177.

### Tests/QA
1. Sign into an account on chrome and save the password in chrome when prompted
1. Sign into an account, tap on the profile icon to go to settings, and then click on a workspace
2. Click on `Get Started` for the Expensify Card
3. Select `Connect Manually` and enter `123123123` for both fields
4. On the autoComplete section, confirm no values are pre-filled for `Industry Classification Code`
5. Confirm the same happens on all platforms (you won't be able to save password on the others)
6. Confirm that on Android, you can view the `Company Information` page without the app throwing an error
7. Confirm that on iOS, you can view the `Company Information` page without the app throwing an error

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

<img src='https://user-images.githubusercontent.com/3981102/131009305-e043272c-bdfe-47fe-91ba-fbdd6a665c75.png' witdh='400'/>
<img src='https://user-images.githubusercontent.com/3981102/131009338-ff856fc5-c02a-48f8-b33c-2d35ff0ccbb6.png' witdh='400'/>
<img src='https://user-images.githubusercontent.com/3981102/131012943-b125005d-3b18-4485-914d-dae0a7659130.png' width='400'/>
