### PR TITLE
fix count when LHN is open on mobile

### DIFF
--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -209,7 +209,7 @@ class ReportActionsView extends React.Component {
                 // Only update the unread count when MarkerBadge is visible
                 // Otherwise marker will be shown on scrolling up from the bottom even if user have read those messages
                 if (this.state.isMarkerActive) {
-                    this.updateLocalUnreadActionCount();
+                    this.updateLocalUnreadActionCount(shouldRecordMaxAction);
                 }
 
                 // show new MarkerBadge when there is a new message
@@ -389,9 +389,14 @@ class ReportActionsView extends React.Component {
 
     /**
      * Update the unread messages count to show in the MarkerBadge
+     * @param {Boolean} [incrementCount=true] Whether count should increment or reset
      */
-    updateLocalUnreadActionCount() {
-        this.setState(prevState => ({localUnreadActionCount: prevState.localUnreadActionCount + this.props.report.unreadActionCount}));
+    updateLocalUnreadActionCount(incrementCount = true) {
+        this.setState(prevState => ({
+            localUnreadActionCount: incrementCount
+                ? prevState.localUnreadActionCount + this.props.report.unreadActionCount
+                : this.props.report.unreadActionCount,
+        }));
     }
 
     /**

--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -209,7 +209,7 @@ class ReportActionsView extends React.Component {
                 // Only update the unread count when MarkerBadge is visible
                 // Otherwise marker will be shown on scrolling up from the bottom even if user have read those messages
                 if (this.state.isMarkerActive) {
-                    this.updateLocalUnreadActionCount(shouldRecordMaxAction);
+                    this.updateLocalUnreadActionCount(!shouldRecordMaxAction);
                 }
 
                 // show new MarkerBadge when there is a new message
@@ -389,13 +389,13 @@ class ReportActionsView extends React.Component {
 
     /**
      * Update the unread messages count to show in the MarkerBadge
-     * @param {Boolean} [incrementCount=true] Whether count should increment or reset
+     * @param {Boolean} [shouldResetLocalCount=false] Whether count should increment or reset
      */
-    updateLocalUnreadActionCount(incrementCount = true) {
+    updateLocalUnreadActionCount(shouldResetLocalCount = false) {
         this.setState(prevState => ({
-            localUnreadActionCount: incrementCount
-                ? prevState.localUnreadActionCount + this.props.report.unreadActionCount
-                : this.props.report.unreadActionCount,
+            localUnreadActionCount: shouldResetLocalCount
+                ? this.props.report.unreadActionCount
+                : prevState.localUnreadActionCount + this.props.report.unreadActionCount,
         }));
     }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
1. Only increment the counter when the report is visible and in other case, we should reset the counter.

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/4723
--->
$ https://github.com/Expensify/App/issues/4863

### Tests | QA Steps
1. Lunch the app
2. Log in with account A in device 1
3. Select user you will chat and scroll the chat to 10-30 messages to top
4. Back to LHN
5. Log in with account B in device 2
6. Send 13 messages to account A from device 2
7. Back to conversation from LHN in device 1 and check the green Marker Badge Coun

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->

https://user-images.githubusercontent.com/24370807/131048311-e46c43ad-8721-4104-8448-6382826bb4b8.mp4

