### PR TITLE
Fix notification preference selector label

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -189,7 +189,7 @@ export default {
         },
     },
     reportDetailsPage: {
-        notificationPreferencesDescription: 'How often should we notify you when there are new messages to catch up on in this room?',
+        notificationPreferencesDescription: 'Notify me about new messages',
         always: 'Always',
         daily: 'Daily',
         mute: 'Mute',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -189,7 +189,7 @@ export default {
         },
     },
     reportDetailsPage: {
-        notificationPreferencesDescription: 'Cada cuanto tiempo quieres que te avisemos que hay nuevos mensajes en este canal?',
+        notificationPreferencesDescription: 'Avisar sobre nuevos mensajes',
         always: 'Siempre',
         daily: 'Cada día',
         mute: 'Nunca',


### PR DESCRIPTION
### Fixed Issues
$ https://github.com/Expensify/App/issues/4849

### Tests
Went to the announce room and made sure that the notifications selector looked good with the new copies.

### QA Steps
None, it's just a copy change

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots

#### Web
In english
![image](https://user-images.githubusercontent.com/2463975/131102549-fe7a8a29-58df-420d-b2f1-b7bf2d7afa89.png)

In spanish
![image](https://user-images.githubusercontent.com/2463975/131102485-abeb81c3-750d-439a-81f0-6038689689f3.png)

