### PR TITLE
Ensure Requestor Info validation shows error growl

### DIFF
--- a/src/libs/ValidationUtils.js
+++ b/src/libs/ValidationUtils.js
@@ -74,27 +74,27 @@ function isValidSSNLastFour(ssnLast4) {
  */
 function isValidIdentity(identity) {
     if (!isValidAddress(identity.street)) {
-        showBankAccountFormValidationError(translateLocal('bankAccount.error.address'));
+        showBankAccountFormValidationError(translateLocal('bankAccount.error.address'), true);
         return false;
     }
 
     if (identity.state === '') {
-        showBankAccountFormValidationError(translateLocal('bankAccount.error.addressState'));
+        showBankAccountFormValidationError(translateLocal('bankAccount.error.addressState'), true);
         return false;
     }
 
     if (!isValidZipCode(identity.zipCode)) {
-        showBankAccountFormValidationError(translateLocal('bankAccount.error.zipCode'));
+        showBankAccountFormValidationError(translateLocal('bankAccount.error.zipCode'), true);
         return false;
     }
 
     if (!isValidDate(identity.dob)) {
-        showBankAccountFormValidationError(translateLocal('bankAccount.error.dob'));
+        showBankAccountFormValidationError(translateLocal('bankAccount.error.dob'), true);
         return false;
     }
 
     if (!isValidSSNLastFour(identity.ssnLast4)) {
-        showBankAccountFormValidationError(translateLocal('bankAccount.error.ssnLast4'));
+        showBankAccountFormValidationError(translateLocal('bankAccount.error.ssnLast4'), true);
         return false;
     }
 

--- a/src/libs/actions/BankAccounts.js
+++ b/src/libs/actions/BankAccounts.js
@@ -606,14 +606,13 @@ function validateBankAccount(bankAccountID, validateCode) {
  * Set the current error message. Show Growl for errors which are not yet handled by the error Modal.
  *
  * @param {String} error
- * @param {Boolean} isUnhandledError
+ * @param {Boolean} shouldGrowl
  */
-function showBankAccountFormValidationError(error, isUnhandledError) {
-    Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {error}).then(() => {
-        if (isUnhandledError) {
-            Growl.error(error);
-        }
-    });
+function showBankAccountFormValidationError(error, shouldGrowl) {
+    Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {error});
+    if (shouldGrowl) {
+        Growl.error(error);
+    }
 }
 
 /**

--- a/src/libs/actions/BankAccounts.js
+++ b/src/libs/actions/BankAccounts.js
@@ -603,14 +603,14 @@ function validateBankAccount(bankAccountID, validateCode) {
 }
 
 /**
- * Set the current error message. Show Growl for server errors as they are not yet handled by the error Modal.
+ * Set the current error message. Show Growl for errors which are not yet handled by the error Modal.
  *
  * @param {String} error
- * @param {Boolean} isServerError
+ * @param {Boolean} isUnhandledError
  */
-function showBankAccountFormValidationError(error, isServerError) {
+function showBankAccountFormValidationError(error, isUnhandledError) {
     Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {error}).then(() => {
-        if (isServerError) {
+        if (isUnhandledError) {
             Growl.error(error);
         }
     });


### PR DESCRIPTION
### Details
Follow up to [this PR](https://github.com/Expensify/App/pull/4875), which was accidentally merged early. 

Adds the Growl for non-server errors on the Requestor Info VBA step. These errors are not yet displayed in the error Modal, so we need to continue to show with the Growl.

### Fixed Issues

$ https://github.com/Expensify/Expensify/issues/175331

### Tests

**0) Test Setup**
- Create a new user
- From the global create menu, tap 'New Workspace', then the 'Get Started' button
- Tap 'Connect Manually' and use the data from [this StackOverflow post ](https://stackoverflow.com/c/expensify/questions/342/525#525)to fill the Routing and Account number 

**1) Verify that Modal validation errors DO NOT show as a Growl**
- Using the [stack overflow post](https://stackoverflow.com/c/expensify/questions/342/525#525), fill each field except 'Company Website', leave that as `https://`
- Hit 'Save & Continue'
- You **should** see the Company Website field highlighted red with an error message
- You **should** see a Modal popup with an error message
- You **should NOT** see a Growl with the same message

**2) Verify that server errors DO show as a Growl**
- _Continue from the end of test 1_
- Enter a valid website
- Set the 'Phone Number' field to  `12345678` 
- Hit 'Save & Continue'
- You **should** see a Growl with an error message 
- You **should NOT** see the field highlighted red
- You **should NOT** see a Modal popup 

**2) Verify that unhandled validation errors DO show as a Growl**
- _Continue from the end of test 2_
- Enter valid information in every field
- Hit 'Save & Continue'
- At the 'Requestor Information' step, enter first and second name only
- Hit 'Save & Continue'
- Fix each error one by one, ensure a Growl message shows for each
- _These will be changed to Modal validation in a separate issue_

### QA Steps

Run above tests

### Tested On

- [x] Web
- [ ] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web

![Screenshot 2021-08-27 at 14 33 51](https://user-images.githubusercontent.com/10736861/131135562-d9503507-d36c-4346-b20d-42e279b525cb.png)


#### Mobile Web


#### Desktop
<img width="1063" alt="Screenshot 2021-08-27 at 17 04 51" src="https://user-images.githubusercontent.com/10736861/131156420-8b275158-b628-45ff-aadd-994a87f8cdce.png">


#### iOS
![Simulator Screen Shot - iPhone 8 - 2021-08-27 at 17 07 29](https://user-images.githubusercontent.com/10736861/131156656-94089dbf-0ae4-46fb-922a-1d1a6581ceb9.png)


#### Android
![Screenshot_1630080877](https://user-images.githubusercontent.com/10736861/131157603-7be51e45-c6a3-4e50-a5b5-6231697d4c96.png)


