### PR TITLE
Password Error message Translation on Language change

### DIFF
--- a/src/pages/signin/LoginForm.js
+++ b/src/pages/signin/LoginForm.js
@@ -45,6 +45,7 @@ class LoginForm extends React.Component {
         super(props);
 
         this.validateAndSubmitForm = this.validateAndSubmitForm.bind(this);
+        this.isFormValid = this.isFormValid.bind(this);
 
         this.state = {
             formError: false,
@@ -53,20 +54,33 @@ class LoginForm extends React.Component {
     }
 
     /**
-     * Check that all the form fields are valid, then trigger the submit callback
+     * Check that all the form fields are valid
+     * @returns {Boolean}
      */
-    validateAndSubmitForm() {
+    isFormValid() {
         if (!this.state.login.trim()) {
-            this.setState({formError: this.props.translate('loginForm.pleaseEnterEmailOrPhoneNumber')});
-            return;
+            this.setState({formError: 'loginForm.pleaseEnterEmailOrPhoneNumber'});
+            return false;
         }
 
         this.setState({
             formError: null,
         });
 
-        // Check if this login has an account associated with it or not
-        fetchAccountDetails(this.state.login);
+        return true;
+    }
+
+
+    /**
+     * Check if form is valid, then trigger the submit callback
+     */
+    validateAndSubmitForm() {
+        const isValid = this.isFormValid();
+
+        if (isValid) {
+            // Check if this login has an account associated with it or not
+            fetchAccountDetails(this.state.login);
+        }
     }
 
     render() {
@@ -87,15 +101,16 @@ class LoginForm extends React.Component {
                         placeholderTextColor={themeColors.placeholderText}
                         autoFocus={canFocusInputOnScreenFocus()}
                         translateX={-18}
+                        onBlur={this.isFormValid}
                     />
                 </View>
                 {this.state.formError && (
                     <Text style={[styles.formError]}>
-                        {this.state.formError}
+                        {this.props.translate(this.state.formError)}
                     </Text>
                 )}
 
-                {!_.isEmpty(this.props.account.error) && (
+                {!this.state.formError && !_.isEmpty(this.props.account.error) && (
                     <Text style={[styles.formError]}>
                         {this.props.account.error}
                     </Text>

--- a/src/pages/signin/LoginForm.js
+++ b/src/pages/signin/LoginForm.js
@@ -45,7 +45,6 @@ class LoginForm extends React.Component {
         super(props);
 
         this.validateAndSubmitForm = this.validateAndSubmitForm.bind(this);
-        this.isFormValid = this.isFormValid.bind(this);
 
         this.state = {
             formError: false,
@@ -54,33 +53,20 @@ class LoginForm extends React.Component {
     }
 
     /**
-     * Check that all the form fields are valid
-     * @returns {Boolean}
+     * Check that all the form fields are valid, then trigger the submit callback
      */
-    isFormValid() {
+    validateAndSubmitForm() {
         if (!this.state.login.trim()) {
             this.setState({formError: 'loginForm.pleaseEnterEmailOrPhoneNumber'});
-            return false;
+            return;
         }
 
         this.setState({
             formError: null,
         });
 
-        return true;
-    }
-
-
-    /**
-     * Check if form is valid, then trigger the submit callback
-     */
-    validateAndSubmitForm() {
-        const isValid = this.isFormValid();
-
-        if (isValid) {
-            // Check if this login has an account associated with it or not
-            fetchAccountDetails(this.state.login);
-        }
+        // Check if this login has an account associated with it or not
+        fetchAccountDetails(this.state.login);
     }
 
     render() {
@@ -101,7 +87,6 @@ class LoginForm extends React.Component {
                         placeholderTextColor={themeColors.placeholderText}
                         autoFocus={canFocusInputOnScreenFocus()}
                         translateX={-18}
-                        onBlur={this.isFormValid}
                     />
                 </View>
                 {this.state.formError && (

--- a/src/pages/signin/PasswordForm.js
+++ b/src/pages/signin/PasswordForm.js
@@ -123,7 +123,7 @@ class PasswordForm extends React.Component {
                     </View>
                 )}
 
-                {this.props.account && !_.isEmpty(this.props.account.error) && (
+                {!this.state.formError && this.props.account && !_.isEmpty(this.props.account.error) && (
                     <Text style={[styles.formError]}>
                         {this.props.account.error}
                     </Text>

--- a/src/pages/signin/PasswordForm.js
+++ b/src/pages/signin/PasswordForm.js
@@ -44,6 +44,7 @@ class PasswordForm extends React.Component {
         super(props);
 
         this.validateAndSubmitForm = this.validateAndSubmitForm.bind(this);
+        this.isFormValid = this.isFormValid.bind(this);
 
         this.state = {
             formError: false,
@@ -53,9 +54,11 @@ class PasswordForm extends React.Component {
     }
 
     /**
-     * Check that all the form fields are valid, then trigger the submit callback
+     * Check that all the form fields are valid
+     * @returns {Boolean}
      */
-    validateAndSubmitForm() {
+
+    isFormValid() {
         if (!this.state.password.trim()
             || (this.props.account.requiresTwoFactorAuth && !this.state.twoFactorAuthCode.trim())
         ) {
@@ -66,8 +69,16 @@ class PasswordForm extends React.Component {
         this.setState({
             formError: null,
         });
+    }
 
-        signIn(this.state.password, this.state.twoFactorAuthCode);
+    /**
+     * Check if form is valid, then trigger the submit callback
+     */
+    validateAndSubmitForm() {
+        const isValid = this.isFormValid();
+        if (isValid) {
+            signIn(this.state.password, this.state.twoFactorAuthCode);
+        }
     }
 
     render() {
@@ -84,6 +95,7 @@ class PasswordForm extends React.Component {
                         onSubmitEditing={this.validateAndSubmitForm}
                         autoFocus
                         translateX={-18}
+                        onBlur={this.isFormValid}
                     />
                     <TouchableOpacity
                         style={[styles.mt2]}

--- a/src/pages/signin/PasswordForm.js
+++ b/src/pages/signin/PasswordForm.js
@@ -44,7 +44,6 @@ class PasswordForm extends React.Component {
         super(props);
 
         this.validateAndSubmitForm = this.validateAndSubmitForm.bind(this);
-        this.isFormValid = this.isFormValid.bind(this);
 
         this.state = {
             formError: false,
@@ -54,32 +53,21 @@ class PasswordForm extends React.Component {
     }
 
     /**
-     * Check that all the form fields are valid
-     * @returns {Boolean}
+     * Check that all the form fields are valid, then trigger the submit callback
      */
-
-    isFormValid() {
+    validateAndSubmitForm() {
         if (!this.state.password.trim()
             || (this.props.account.requiresTwoFactorAuth && !this.state.twoFactorAuthCode.trim())
         ) {
             this.setState({formError: 'passwordForm.pleaseFillOutAllFields'});
-            return false;
+            return;
         }
 
         this.setState({
             formError: null,
         });
-        return true;
-    }
 
-    /**
-     * Check if form is valid, then trigger the submit callback
-     */
-    validateAndSubmitForm() {
-        const isValid = this.isFormValid();
-        if (isValid) {
-            signIn(this.state.password, this.state.twoFactorAuthCode);
-        }
+        signIn(this.state.password, this.state.twoFactorAuthCode);
     }
 
     render() {
@@ -96,7 +84,6 @@ class PasswordForm extends React.Component {
                         onSubmitEditing={this.validateAndSubmitForm}
                         autoFocus
                         translateX={-18}
-                        onBlur={this.isFormValid}
                     />
                     <TouchableOpacity
                         style={[styles.mt2]}

--- a/src/pages/signin/PasswordForm.js
+++ b/src/pages/signin/PasswordForm.js
@@ -63,12 +63,13 @@ class PasswordForm extends React.Component {
             || (this.props.account.requiresTwoFactorAuth && !this.state.twoFactorAuthCode.trim())
         ) {
             this.setState({formError: 'passwordForm.pleaseFillOutAllFields'});
-            return;
+            return false;
         }
 
         this.setState({
             formError: null,
         });
+        return true;
     }
 
     /**

--- a/src/pages/signin/PasswordForm.js
+++ b/src/pages/signin/PasswordForm.js
@@ -59,7 +59,7 @@ class PasswordForm extends React.Component {
         if (!this.state.password.trim()
             || (this.props.account.requiresTwoFactorAuth && !this.state.twoFactorAuthCode.trim())
         ) {
-            this.setState({formError: this.props.translate('passwordForm.pleaseFillOutAllFields')});
+            this.setState({formError: 'passwordForm.pleaseFillOutAllFields'});
             return;
         }
 
@@ -119,7 +119,7 @@ class PasswordForm extends React.Component {
 
                 {this.state.formError && (
                     <Text style={[styles.formError]}>
-                        {this.state.formError}
+                        {this.props.translate(this.state.formError)}
                     </Text>
                 )}
                 <View>

--- a/src/pages/signin/TermsAndLicenses/TermsWithLicenses/index.ios.js
+++ b/src/pages/signin/TermsAndLicenses/TermsWithLicenses/index.ios.js
@@ -20,7 +20,7 @@ const TermsWithLicenses = ({translate}) => (
                 styles.justifyContentCenter,
             ]}
         >
-            <View style={[styles.dFlex, styles.flexRow, styles.alignItemsCenter]}>
+            <View style={[styles.dFlex, styles.flexRow, styles.flexWrap, styles.alignItemsCenter]}>
                 <Text style={[styles.textAlignCenter, styles.loginTermsText]}>
                     {translate('termsOfUse.phrase1')}
                 </Text>


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

@Jag96  Can you please review this?

### Details
- Changed error translation on language change
- Also added `onBlur` to the forms
- Hide API error if formError exists

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/4723
--->
$ #4663 

### Tests
1. Checked error messages translation on changing the language after the error is shown
2. Ensure that error hides if the value is entered and textinput is blurred

<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### QA Steps
1. Go to the Login Form, press the button and the error is shown
2. After that if the language is changed, then the translation for the password should also be changed

This has to be tested for LoginForm as well as PasswordForm


<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
https://user-images.githubusercontent.com/3069065/131161002-8b8e6295-d164-4eab-8443-66e11dcc25a3.mp4
https://user-images.githubusercontent.com/3069065/131161028-b7838053-9e1a-49b6-a92b-39931c55c6c4.mp4


#### Mobile Web
https://user-images.githubusercontent.com/3069065/131161480-d7740257-a2ec-474a-a1c6-7ecfdbb11d8d.mp4
https://user-images.githubusercontent.com/3069065/131161519-9d5d35e6-d41b-436e-ae2b-e62ce202c3c7.mp4

#### Desktop
https://user-images.githubusercontent.com/3069065/131161556-e09b9c9f-dc50-45f6-a86b-3d27dc478a38.mp4
https://user-images.githubusercontent.com/3069065/131161563-5c2a0277-714c-473c-985d-9ff8de724ef3.mp4

#### iOS
https://user-images.githubusercontent.com/3069065/131163340-d6da9bef-def5-4005-bb06-313ac3f9ab6d.mp4
https://user-images.githubusercontent.com/3069065/131163367-6ceffb31-f3d5-46d6-a693-e1192693ee53.mp4

#### Android
https://user-images.githubusercontent.com/3069065/131163437-40bfd47e-5b54-4a79-9d94-0f6a47c44719.mp4
https://user-images.githubusercontent.com/3069065/131163469-a44dbf84-1a5f-4abb-832b-15ae0b5abebc.mp4



