### PR TITLE
Prevent errorAttemptsCount from being wiped out by JSON.stringify

### DIFF
--- a/src/libs/actions/BankAccounts.js
+++ b/src/libs/actions/BankAccounts.js
@@ -644,6 +644,9 @@ function setupWithdrawalAccount(data) {
             : CONST.BANK_ACCOUNT.SETUP_TYPE.MANUAL;
     }
 
+    // Convert the errorAttemptsCount to an object to prevent it from being wiped out by JSON.stringify
+    newACHData.errorAttemptsCount = {...newACHData.errorAttemptsCount};
+
     nextStep = newACHData.currentStep;
 
     // If we are setting up a Plaid account replace the accountNumber with the unmasked number


### PR DESCRIPTION

### Details

Fixes a bug that keeps the user stuck at the Requestor Step of the bank account setup process. 

This was originally fixed by [this PR](https://github.com/Expensify/Web-Secure/pull/1995) but, for some reason, that fix (which worked for a solid month without issue) stopped working.  .

Instead of rewriting how we save errorAttemptsCount in Web-Secure and potentially causing issues with E.com bank account setups, let's just convert this to an object that JSON.stringify can handle before calling `API.BankAccount_SetupWithdrawal`.  We call JSON.stringify [here](https://github.com/Expensify/App/blob/c219c9e2abe96fe210e9800de361c6777a8eea24/src/libs/API.js#L851) We can also revert the changes made to Web-Secure the the afore mentioned PR since they're no longer necessary.

For reference as to why this is happening... JSON.stringify ignores any keys that aren't numeric.
<img width="444" alt="Screen Shot 2021-08-27 at 12 01 03 PM" src="https://user-images.githubusercontent.com/16747822/131177776-8873d768-3c9c-4963-8618-2cb4e23b5db9.png">


### Fixed Issues 

$ https://github.com/Expensify/Expensify/issues/169717#issuecomment-907336665

### Tests
1. Set `isPlaidTestRequestor()` in `lib/ACHData.php` to return `false` so that we run the ownerIdentity checks
2. Run through the testing steps 

### QA

1. Log into an account on new.expensify.com that doesn't have a bank account and navigate to `/bank-account`
2. Navigate to Settings > Account > Payments and click `Add Verified Bank Account` 
3. Click on `Log Into Your Bank` and then exist out of the Plaid modal that pops up 
4. Click on `Connect Manually` and enter the credentials for a `PENDING` bank account from this [SO post](https://stackoverflow.com/c/expensify/questions/342/525#525)
    - ![image](https://user-images.githubusercontent.com/16747822/125864039-d67264bd-d9e9-4659-8524-8583ab928cd3.png)
6. Once you get to the `Requestor` step confirm that you get the `Please verify your name and date of birth. If the information is correct, click "Save & Continue` error once 
7. Resubmit your information and confirm you're routed on the OnFido verification screen 
8. Exit the modal, refresh the page, and delete the verified bank account 

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
#### Web

https://user-images.githubusercontent.com/16747822/131179012-02174de2-0369-4e8a-9fa4-5bc646e093e9.mov


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
