### PR TITLE
Revert regex changes for :shipit: comment

### DIFF
--- a/.github/actions/checkDeployBlockers/checkDeployBlockers.js
+++ b/.github/actions/checkDeployBlockers/checkDeployBlockers.js
@@ -49,7 +49,7 @@ const run = function () {
 
             console.log('Verifying that the last comment is the :shipit: seal of approval');
             const lastComment = comments.data.pop();
-            const shipItRegex = /:shipit:/g;
+            const shipItRegex = /^:shipit:/g;
             if (_.isNull(shipItRegex.exec(lastComment.body))) {
                 console.log('The last comment on the issue was not :shipit');
                 core.setOutput('HAS_DEPLOY_BLOCKERS', true);

--- a/.github/actions/checkDeployBlockers/index.js
+++ b/.github/actions/checkDeployBlockers/index.js
@@ -59,7 +59,7 @@ const run = function () {
 
             console.log('Verifying that the last comment is the :shipit: seal of approval');
             const lastComment = comments.data.pop();
-            const shipItRegex = /:shipit:/g;
+            const shipItRegex = /^:shipit:/g;
             if (_.isNull(shipItRegex.exec(lastComment.body))) {
                 console.log('The last comment on the issue was not :shipit');
                 core.setOutput('HAS_DEPLOY_BLOCKERS', true);

--- a/tests/unit/checkDeployBlockersTest.js
+++ b/tests/unit/checkDeployBlockersTest.js
@@ -96,7 +96,6 @@ describe('checkDeployBlockers', () => {
             mockGetIssue.mockResolvedValue(checkedBoxesNoShipitIssue);
             // eslint-disable-next-line max-len
             baseComments.data.push({body: 'This issue either has unchecked QA steps or has not yet been stamped with a :shipit: comment. Reopening!'});
-            baseComments.data.push({body: 'This is another comment!'});
             mockListComments.mockResolvedValue(baseComments);
             return run().then(() => {
                 expect(mockSetOutput).toHaveBeenCalledWith('HAS_DEPLOY_BLOCKERS', true);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Reverts two lines of a PR that is causing issues with the deploy:
1. https://github.com/Expensify/App/pull/4824/files#diff-3e6c7483e879c6b2a3a2c952cfe3e6ff3b764fc9b72648fb83aba55feee1371cR52
2. https://github.com/Expensify/App/pull/4824/files#diff-08433ea1c181ba5c44014a8e3a1f2dd845ae64b10fba816543dc3393277500f7R99

### Tests
1. Comment something that is not :shipit: on a deploy checklist
2. Make sure the deploy is not kicked off
3. Comment :shipit: and verify the deploy is kicked off