### PR TITLE
Remove redundant placeholder for login form

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -336,7 +336,6 @@ export default {
     loginForm: {
         pleaseEnterEmailOrPhoneNumber: 'Please enter an email or phone number',
         phoneOrEmail: 'Phone or email',
-        enterYourPhoneOrEmail: 'Enter your phone or email:',
     },
     resendValidationForm: {
         linkHasBeenResent: 'Link has been re-sent',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -336,7 +336,6 @@ export default {
     loginForm: {
         pleaseEnterEmailOrPhoneNumber: 'Por favor escribe un email o número de teléfono',
         phoneOrEmail: 'Número de teléfono o email',
-        enterYourPhoneOrEmail: 'Escribe tu número de teléfono o email:',
     },
     resendValidationForm: {
         linkHasBeenResent: 'El enlace se ha reenviado',

--- a/src/pages/signin/LoginForm.js
+++ b/src/pages/signin/LoginForm.js
@@ -4,7 +4,6 @@ import {withOnyx} from 'react-native-onyx';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
 import styles from '../../styles/styles';
-import themeColors from '../../styles/themes/default';
 import Button from '../../components/Button';
 import Text from '../../components/Text';
 import {fetchAccountDetails} from '../../libs/actions/Session';

--- a/src/pages/signin/LoginForm.js
+++ b/src/pages/signin/LoginForm.js
@@ -83,8 +83,6 @@ class LoginForm extends React.Component {
                         autoCapitalize="none"
                         autoCorrect={false}
                         keyboardType={getEmailKeyboardType()}
-                        placeholder={this.props.translate('loginForm.enterYourPhoneOrEmail')}
-                        placeholderTextColor={themeColors.placeholderText}
                         autoFocus={canFocusInputOnScreenFocus()}
                         translateX={-18}
                     />


### PR DESCRIPTION
@Expensify/pullerbear 

### Details
We have a redundant placeholder. Just removing it.

### Fixed Issues
$ https://github.com/Expensify/App/issues/4738

### Tests
Start up a local env of the app. Sign out if necessary. Verify that the login screen no longer has the label as well as the placeholder asking for the email.
![image](https://user-images.githubusercontent.com/12980144/131384199-62e968ed-c42a-4172-81c6-a29e3d9d4a59.png)


### QA Steps
1. Go to the app
2. Log out if necessary or if you don't see the login screen. Navigate to where you have to input your phone or email
3. Verify that we only ask for your "Phone or email" once, instead of it being doubled up like the image below:
    ![image](https://user-images.githubusercontent.com/12980144/131384317-8da35527-e2e6-4c9d-b70a-70edbc4cae28.png)
4. 

### Tested On

- [x] Web
- [ ] Mobile Web
- [x] Desktop
- [x] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
