### PR TITLE
Add icons to buttons, fix inboxcallbutton text size

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -1,16 +1,20 @@
 import _ from 'underscore';
 import React, {Component} from 'react';
-import {Pressable, ActivityIndicator} from 'react-native';
+import {Pressable, ActivityIndicator, View} from 'react-native';
 import PropTypes from 'prop-types';
 import styles from '../styles/styles';
 import themeColors from '../styles/themes/default';
 import OpacityView from './OpacityView';
 import Text from './Text';
 import KeyboardShortcut from '../libs/KeyboardShortcut';
+import Icon from './Icon';
 
 const propTypes = {
     /** The text for the button label */
     text: PropTypes.string,
+
+    /** The icon asset to display to the left of the text */
+    icon: PropTypes.func,
 
     /** Small sized button */
     small: PropTypes.bool,
@@ -57,6 +61,7 @@ const propTypes = {
 
 const defaultProps = {
     text: '',
+    icon: null,
     isLoading: false,
     isDisabled: false,
     small: false,
@@ -107,24 +112,42 @@ class Button extends Component {
             return <ContentComponent />;
         }
 
-        return this.props.isLoading
-            ? (
-                <ActivityIndicator color={themeColors.textReversed} />
-            ) : (
-                <Text
-                    selectable={false}
-                    style={[
-                        styles.buttonText,
-                        this.props.small && styles.buttonSmallText,
-                        this.props.large && styles.buttonLargeText,
-                        this.props.success && styles.buttonSuccessText,
-                        this.props.danger && styles.buttonDangerText,
-                        ...this.props.textStyles,
-                    ]}
-                >
-                    {this.props.text}
-                </Text>
+        if (this.props.isLoading) {
+            return <ActivityIndicator color={themeColors.textReversed} />;
+        }
+
+        const textComponent = (
+            <Text
+                selectable={false}
+                style={[
+                    styles.buttonText,
+                    this.props.small && styles.buttonSmallText,
+                    this.props.large && styles.buttonLargeText,
+                    this.props.success && styles.buttonSuccessText,
+                    this.props.danger && styles.buttonDangerText,
+                    ...this.props.textStyles,
+                ]}
+            >
+                {this.props.text}
+            </Text>
+        );
+
+        if (this.props.icon) {
+            return (
+                <View style={[styles.flexRow, styles.alignItemsCenter]}>
+                    <View style={styles.mr1}>
+                        <Icon
+                            src={this.props.icon}
+                            fill={themeColors.heading}
+                            small={this.props.small}
+                        />
+                    </View>
+                    {textComponent}
+                </View>
             );
+        }
+
+        return textComponent;
     }
 
     render() {

--- a/src/components/InboxCallButton.js
+++ b/src/components/InboxCallButton.js
@@ -1,18 +1,13 @@
 import React from 'react';
-import {
-    View, Pressable,
-} from 'react-native';
 import PropTypes from 'prop-types';
-import Icon from './Icon';
-import {Phone} from './Icon/Expensicons';
 import styles from '../styles/styles';
-import themeColors from '../styles/themes/default';
 import withLocalize, {withLocalizePropTypes} from './withLocalize';
 import compose from '../libs/compose';
 import Navigation from '../libs/Navigation/Navigation';
 import ROUTES from '../ROUTES';
-import Text from './Text';
 import Tooltip from './Tooltip';
+import Button from './Button';
+import {Phone} from './Icon/Expensicons';
 
 const propTypes = {
     ...withLocalizePropTypes,
@@ -30,27 +25,14 @@ const InboxCallButton = props => (
         text={props.translate('requestCallPage.needHelpTooltip')}
         containerStyles={[styles.justifyContentCenter, styles.alignItemsCenter]}
     >
-        <Pressable
+        <Button
             onPress={() => {
                 Navigation.navigate(ROUTES.getRequestCallRoute(props.taskID));
             }}
-            style={[styles.button, styles.buttonSmall]}
-        >
-            <View style={styles.flexRow}>
-                <View style={styles.mr1}>
-                    <Icon
-                        src={Phone}
-                        fill={themeColors.heading}
-                        small
-                    />
-                </View>
-                <View>
-                    <Text style={styles.buttonText}>
-                        {props.translate('requestCallPage.needHelp')}
-                    </Text>
-                </View>
-            </View>
-        </Pressable>
+            text={props.translate('requestCallPage.needHelp')}
+            small
+            icon={Phone}
+        />
     </Tooltip>
 );
 
@@ -58,3 +40,19 @@ InboxCallButton.propTypes = propTypes;
 InboxCallButton.defaultProps = defaultProps;
 InboxCallButton.displayName = 'InboxCallButton';
 export default compose(withLocalize)(InboxCallButton);
+
+// <View style={[styles.flexRow, styles.alignItemsCenter]}>
+//                 <View style={styles.mr1}>
+//                     <Icon
+//                         src={Phone}
+//                         fill={themeColors.heading}
+//                         width={12}
+//                         height={12}
+//                     />
+//                 </View>
+//                 <View>
+//                     <Text style={styles.buttonSmallText}>
+//                         {props.translate('requestCallPage.needHelp')}
+//                     </Text>
+//                 </View>
+//             </View>

--- a/src/components/InboxCallButton.js
+++ b/src/components/InboxCallButton.js
@@ -40,19 +40,3 @@ InboxCallButton.propTypes = propTypes;
 InboxCallButton.defaultProps = defaultProps;
 InboxCallButton.displayName = 'InboxCallButton';
 export default compose(withLocalize)(InboxCallButton);
-
-// <View style={[styles.flexRow, styles.alignItemsCenter]}>
-//                 <View style={styles.mr1}>
-//                     <Icon
-//                         src={Phone}
-//                         fill={themeColors.heading}
-//                         width={12}
-//                         height={12}
-//                     />
-//                 </View>
-//                 <View>
-//                     <Text style={styles.buttonSmallText}>
-//                         {props.translate('requestCallPage.needHelp')}
-//                     </Text>
-//                 </View>
-//             </View>


### PR DESCRIPTION
@shawnborton can you review the screenshots to make sure everything looks good?

### Details
This fixes the cutoff `p` and otherwise misplaced font in the `Help` button. This also refactors `Button` to support icons, and `InboxCallButton` to use a button

### Fixed Issues
$ https://github.com/Expensify/App/issues/4866

### Tests
1. From the FAB, click the `New Workspace` button
1. [mobile only] Click the `Company Cards` button
1. _Verify_ you see the call button and that the `Help` is not cut off
1. [Web & Desktop only] Hover the call button, verify you see the tooltip
1. Click the call button
1. _Verify_ it opens the inbox call dialog
1. Fill out the form and submit it
1. _Verify_ you have a new `Expensiworks/InboxCallUser` job with the taskID `WorkspaceCompanyCards` in your jobs table 

### QA Steps
1. From the FAB, click the `New Workspace` button
1. [mobile only] Click the `Company Cards` button
1. _Verify_ you see the call button and the `Help` is not cut off
1. [Web & Desktop only] Hover the call button, verify you see the tooltip
1. Click the call button
1. _Verify_ it opens the inbox call dialog

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
![image](https://user-images.githubusercontent.com/22447860/131379655-40d4178d-e109-4e4b-bae9-42af368b8470.png)

Also tested the translations
![image](https://user-images.githubusercontent.com/22447860/131380214-d8687752-e58d-402a-90d5-cf3049f6dd88.png)

#### Mobile Web
![image](https://user-images.githubusercontent.com/22447860/131380271-e1edd8c5-7f8b-4d34-973d-7bd48695acd4.png)

#### Desktop
![image](https://user-images.githubusercontent.com/22447860/131380792-810f6e09-bbe0-4b7e-b858-a3bb080e5aa2.png)

#### iOS
![image](https://user-images.githubusercontent.com/22447860/131383615-d667a51a-2039-4faf-87a4-c23ddf6b6ea8.png)

#### Android
(headline is the wrong font, [known issue](https://expensify.slack.com/archives/C01GTK53T8Q/p1630044269055500))
![image](https://user-images.githubusercontent.com/22447860/131383074-3300e0d3-9ece-4801-85b4-f116a8c00c4f.png)