### PR TITLE
Link Workspace ID to reimbursement account setup so it is accessible during validation step

### DIFF
--- a/src/ONYXKEYS.js
+++ b/src/ONYXKEYS.js
@@ -120,6 +120,6 @@ export default {
     // Stores information about the active reimbursement account being set up
     REIMBURSEMENT_ACCOUNT: 'reimbursementAccount',
 
-    // Stores workspace id that will be tied to reimbursement account during setup
+    // Stores Workspace ID that will be tied to reimbursement account during setup
     REIMBURSEMENT_ACCOUNT_WORKSPACE_ID: 'reimbursementAccountWorkspaceID',
 };

--- a/src/ONYXKEYS.js
+++ b/src/ONYXKEYS.js
@@ -119,4 +119,7 @@ export default {
 
     // Stores information about the active reimbursement account being set up
     REIMBURSEMENT_ACCOUNT: 'reimbursementAccount',
+
+    // Stores workspace id that will be tied to reimbursement account during setup
+    REIMBURSEMENT_ACCOUNT_WORKSPACE_ID: 'reimbursementAccountWorkspaceID',
 };

--- a/src/libs/actions/BankAccounts.js
+++ b/src/libs/actions/BankAccounts.js
@@ -30,6 +30,14 @@ Onyx.connect({
     },
 });
 
+let reimbursementAccountWorkspaceID = null;
+Onyx.connect({
+    key: ONYXKEYS.REIMBURSEMENT_ACCOUNT_WORKSPACE_ID,
+    callback: (val) => {
+        reimbursementAccountWorkspaceID = val;
+    },
+});
+
 /**
  * Gets the Plaid Link token used to initialize the Plaid SDK
  */
@@ -409,7 +417,7 @@ function fetchFreePlanVerifiedBankAccount(stepToOpen) {
                     let currentStep = reimbursementAccountInSetup.currentStep;
                     const achData = bankAccount ? bankAccount.toACHData() : {};
                     achData.useOnfido = true;
-                    achData.policyID = '';
+                    achData.policyID = reimbursementAccountWorkspaceID || '';
                     achData.isInSetup = !bankAccount || bankAccount.isInSetup();
                     achData.bankAccountInReview = bankAccount && bankAccount.isVerifying();
                     achData.domainLimit = 0;
@@ -803,6 +811,10 @@ function hideBankAccountErrors() {
     Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {error: '', existingOwnersList: ''});
 }
 
+function setWorkspaceIDForReimbursementAccount(workspaceID) {
+    Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT_WORKSPACE_ID, workspaceID);
+}
+
 export {
     activateWallet,
     addPersonalBankAccount,
@@ -817,4 +829,5 @@ export {
     validateBankAccount,
     hideBankAccountErrors,
     showBankAccountFormValidationError,
+    setWorkspaceIDForReimbursementAccount,
 };

--- a/src/pages/workspace/WorkspaceCardPage.js
+++ b/src/pages/workspace/WorkspaceCardPage.js
@@ -24,6 +24,7 @@ import HeroCardWebImage from '../../../assets/images/cascading-cards-web.svg';
 import HeroCardMobileImage from '../../../assets/images/cascading-cards-mobile.svg';
 import BankAccount from '../../libs/models/BankAccount';
 import {openSignedInLink} from '../../libs/actions/App';
+import {setWorkspaceIDForReimbursementAccount} from '../../libs/actions/BankAccounts';
 
 const propTypes = {
     /* Onyx Props */
@@ -39,6 +40,15 @@ const propTypes = {
         /** Whether the user is using Expensify Card */
         isUsingExpensifyCard: PropTypes.bool,
     }),
+
+    /** URL Route params */
+    route: PropTypes.shape({
+        /** Params from the URL path */
+        params: PropTypes.shape({
+            /** policyID passed via route: /workspace/:policyID/people */
+            policyID: PropTypes.string,
+        }),
+    }).isRequired,
 
     /** Bank account currently in setup */
     reimbursementAccount: PropTypes.shape({
@@ -70,6 +80,7 @@ const WorkspaceCardPage = ({
     betas,
     user,
     translate,
+    route,
     isSmallScreenWidth,
     isMediumScreenWidth,
     reimbursementAccount,
@@ -95,6 +106,7 @@ const WorkspaceCardPage = ({
         } else if (user.isUsingExpensifyCard) {
             openSignedInLink(CONST.MANAGE_CARDS_URL);
         } else {
+            setWorkspaceIDForReimbursementAccount(route.params.policyID);
             Navigation.navigate(ROUTES.getBankAccountRoute());
         }
     };


### PR DESCRIPTION
@robertjchen , please review when you get the chance

### Details
We are currently not linking workspaces to the reimbursement accounts when we create them in NewDot.

This is a problem since when it comes to the validation step (enter 3 amounts) in bank setup, the user is routed to `your workspace` and it points to no actual workspace. It'll be `new.expensify.com/workspace//card` instead of something like 'new.exepsnify.com/workspace/153B54BA57F38FA7/card`. This PR fixes that issue by making sure we link the reimbursement bank account to a workspace id. Specifically it takes the workspace id from the one that most recently clicked `Get Started`/`Finish Setup` on the workspace page.

You can see where the `your workspace` message is generated here in Web-Secure: https://github.com/Expensify/Web-Secure/blob/master/lib/BankAccount/VerificationUtils.php#L320

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/173546

### Tests
Same as QA, done locally.

### QA Steps
1. Create a new account on NewDot that has access to the freePlan beta (or do this in an account on the beta, that does not already have a verified bank account tied to a workspace).
2. Create a workspace from clicking the plus on the bottom right:
![image](https://user-images.githubusercontent.com/19364431/131395552-c72c5b53-3d0d-4f36-b49b-c3c86c1bb322.png)

3. Click on `Get Started` and follow the steps in this S/O for `To create a PENDING bank account`: https://stackoverflow.com/c/expensify/questions/342

4. Eventually you should get to this step: 
![image](https://user-images.githubusercontent.com/19364431/131395888-2adc054f-7aee-42d5-bb01-fc3f8c36e999.png)

5. You can close the modal here and go to the chat with concierge. You should see a message like this:
![image](https://user-images.githubusercontent.com/19364431/131395843-2e96fad5-eceb-483d-9a00-9c3710075993.png)

6. Click on `your workspace` and verify that it actually opens you up to the workspace:
![image](https://user-images.githubusercontent.com/19364431/131395941-f1631512-e634-4421-8a6d-4216ea4d4239.png)


### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
Only affects web and screenshots included in QA Steps
