### PR TITLE
[No QA] Use pretext in chrerry pick workflow to tag mobile-deployers

### DIFF
--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -190,7 +190,8 @@ jobs:
               channel: '#announce',
               attachments: [{
                 color: "#DB4545",
-                text: `@mobile-deployers 💥 Failed to CP https://github.com/Expensify/App/pull/${{ github.event.inputs.PULL_REQUEST_NUMBER }} to staging 💥`,
+                pretext: `<!subteam^S4TJJ3PSL>`,
+                text: `💥 Failed to CP https://github.com/Expensify/App/pull/${{ github.event.inputs.PULL_REQUEST_NUMBER }} to staging 💥`,
               }]
             }
         env:


### PR DESCRIPTION
cc @roryabraham 

### Details
In https://github.com/Expensify/App/pull/4829 we added a message to tag mobile deployers when a CP fails, but slack doesn't tag properly when adding `@mobile-deployers` to the text value:
![image](https://user-images.githubusercontent.com/3981102/131404658-be309ccd-0e8e-4bf4-a067-19d6f2b9d7d6.png)

This PR adds the mobile-deployers tag via pretext like we did in https://github.com/Expensify/App/pull/4767

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/175742

### Tests
1. Once deployed, attempt to CP an issue instead of a PR 🤯
2. When the CP fails, verify that it was announced in the #announce Slack channel🤞

### QA Steps
None

