### PR TITLE
Properly JSON-decode outputs

### DIFF
--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -15,7 +15,7 @@ jobs:
   validateActor:
     runs-on: ubuntu-latest
     outputs:
-      IS_DEPLOYER: ${{ steps.isUserDeployer.outputs.isTeamMember || github.actor == 'OSBotify' }}
+      IS_DEPLOYER: ${{ fromJSON(steps.isUserDeployer.outputs.isTeamMember) || github.actor == 'OSBotify' }}
     steps:
       - id: isUserDeployer
         uses: tspascoal/get-user-teams-membership@baf2e6adf4c3b897bd65a7e3184305c165aec872

--- a/.github/workflows/finishReleaseCycle.yml
+++ b/.github/workflows/finishReleaseCycle.yml
@@ -11,7 +11,7 @@ jobs:
     if: contains(github.event.issue.labels.*.name, 'StagingDeployCash')
 
     outputs:
-      isValid: ${{ steps.validateActor.outputs.isTeamMember && steps.checkDeployBlockers.outputs.HAS_DEPLOY_BLOCKERS == 'false' }}
+      isValid: ${{ fromJSON(steps.validateActor.outputs.isTeamMember) && !fromJSON(steps.checkDeployBlockers.outputs.HAS_DEPLOY_BLOCKERS) }}
 
     steps:
       - name: Validate actor is deployer


### PR DESCRIPTION

### Details
After a fair deal of discussion and experimentation in `Public-Test-Repo`, I learned that, even after [this PR](https://github.com/Expensify/App/pull/4915/files), not all json values were being properly decoded.

Going forward, I think we should establish the explicit use of `fromJSON` as a best-practice over doing string comparisons as we have in the past. Using `fromJSON` is a more explicit way of handling this data, and using it demonstrates a better understanding of the problem, and might be easier to remember to look for when writing GH Workflows and reviewing PRs.

Going forward, we should all recognize that _any output_ in a GitHub workflow is a JSON string, and must be treated as such.

### Fixed Issues
$ n/a

### Tests
Same as https://github.com/Expensify/App/pull/4796

### QA Steps
None.