### PR TITLE
Undo conversion of errorAttemptsCount to object

### DIFF
--- a/src/libs/actions/BankAccounts.js
+++ b/src/libs/actions/BankAccounts.js
@@ -643,9 +643,6 @@ function setupWithdrawalAccount(data) {
             : CONST.BANK_ACCOUNT.SETUP_TYPE.MANUAL;
     }
 
-    // Convert the errorAttemptsCount to an object to prevent it from being wiped out by JSON.stringify
-    newACHData.errorAttemptsCount = {...newACHData.errorAttemptsCount};
-
     nextStep = newACHData.currentStep;
 
     // If we are setting up a Plaid account replace the accountNumber with the unmasked number


### PR DESCRIPTION
cc: @marcaaron 

### Details
Follow up PR to https://github.com/Expensify/Web-Secure/pull/2022 to clean out some old, no longer needed logic. 

### Fixed Issues

$ https://github.com/Expensify/App/pull/4889#issuecomment-907460540

### Tests
1. Set `isPlaidTestAccountNumbers()` and `isPlaidTestRequestor()` and ` in `lib/ACHData.php` to return `false` so that we run the some necessary checks
2. Run through the QA steps 

### QA
1. Log into an account on new.expensify.com without a bank account set up
1. Navigate to `/bank-account`
1. Click on `Connect Manually` and enter the credentials for a `PENDING` bank account from this [SO post](https://stackoverflow.com/c/expensify/questions/342/525#525)
    - ![image](https://user-images.githubusercontent.com/16747822/125864039-d67264bd-d9e9-4659-8524-8583ab928cd3.png)
1. Once you get to the `Requestor` step confirm that you get the `Please verify your name and date of birth. If the information is correct, click "Save & Continue` error once 
1. Resubmit your information and confirm you're routed to the next view and not looped back to the requestor step again 

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web

https://user-images.githubusercontent.com/16747822/131423739-606f0f69-617b-4e8a-ba76-fc6c411e5402.mov


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
