### PR TITLE
Remove unnecessary password field from add account via plaid step

### DIFF
--- a/src/components/AddPlaidBankAccount.js
+++ b/src/components/AddPlaidBankAccount.js
@@ -15,7 +15,6 @@ import {
 } from '../libs/actions/BankAccounts';
 import ONYXKEYS from '../ONYXKEYS';
 import styles from '../styles/styles';
-import canFocusInputOnScreenFocus from '../libs/canFocusInputOnScreenFocus';
 import compose from '../libs/compose';
 import withLocalize, {withLocalizePropTypes} from './withLocalize';
 import Button from './Button';
@@ -93,7 +92,6 @@ class AddPlaidBankAccount extends React.Component {
 
         this.state = {
             selectedIndex: undefined,
-            password: '',
             isCreatingAccount: false,
             institution: {},
         };
@@ -174,16 +172,6 @@ class AddPlaidBankAccount extends React.Component {
                                     value={this.state.selectedIndex}
                                 />
                             </View>
-                            {/* {!_.isUndefined(this.state.selectedIndex) && (
-                                <View style={[styles.mb5]}>
-                                    <ExpensiTextInput
-                                        label={'DELET THIS'}
-                                        value={this.state.password} // delete
-                                        autoFocus={canFocusInputOnScreenFocus()} // delete
-                                        onChangeText={text => this.setState({password: text})} // delete
-                                    />
-                                </View>
-                            )} */}
                         </View>
                         <View style={[styles.m5]}>
                             <Button

--- a/src/components/AddPlaidBankAccount.js
+++ b/src/components/AddPlaidBankAccount.js
@@ -20,7 +20,6 @@ import withLocalize, {withLocalizePropTypes} from './withLocalize';
 import Button from './Button';
 import ExpensiPicker from './ExpensiPicker';
 import Text from './Text';
-import ExpensiTextInput from './ExpensiTextInput';
 
 const propTypes = {
     ...withLocalizePropTypes,

--- a/src/components/AddPlaidBankAccount.js
+++ b/src/components/AddPlaidBankAccount.js
@@ -174,20 +174,16 @@ class AddPlaidBankAccount extends React.Component {
                                     value={this.state.selectedIndex}
                                 />
                             </View>
-                            {!_.isUndefined(this.state.selectedIndex) && (
+                            {/* {!_.isUndefined(this.state.selectedIndex) && (
                                 <View style={[styles.mb5]}>
                                     <ExpensiTextInput
-                                        label={this.props.translate('addPersonalBankAccountPage.enterPassword')}
-                                        secureTextEntry
-                                        value={this.state.password}
-                                        autoCompleteType="password"
-                                        textContentType="password"
-                                        autoCapitalize="none"
-                                        autoFocus={canFocusInputOnScreenFocus()}
-                                        onChangeText={text => this.setState({password: text})}
+                                        label={'DELET THIS'}
+                                        value={this.state.password} // delete
+                                        autoFocus={canFocusInputOnScreenFocus()} // delete
+                                        onChangeText={text => this.setState({password: text})} // delete
                                     />
                                 </View>
-                            )}
+                            )} */}
                         </View>
                         <View style={[styles.m5]}>
                             <Button
@@ -195,7 +191,7 @@ class AddPlaidBankAccount extends React.Component {
                                 text={this.props.translate('common.saveAndContinue')}
                                 isLoading={this.state.isCreatingAccount}
                                 onPress={this.selectAccount}
-                                isDisabled={_.isUndefined(this.state.selectedIndex) || !this.state.password}
+                                isDisabled={_.isUndefined(this.state.selectedIndex)}
                             />
                         </View>
                     </>

--- a/src/components/AddPlaidBankAccount.js
+++ b/src/components/AddPlaidBankAccount.js
@@ -113,7 +113,7 @@ class AddPlaidBankAccount extends React.Component {
     selectAccount() {
         const account = this.getAccounts()[this.state.selectedIndex];
         this.props.onSubmit({
-            account, password: this.state.password, plaidLinkToken: this.props.plaidLinkToken,
+            account, plaidLinkToken: this.props.plaidLinkToken,
         });
         this.setState({isCreatingAccount: true});
     }

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -404,7 +404,6 @@ export default {
         },
     },
     addPersonalBankAccountPage: {
-        enterPassword: 'Enter Expensify password',
         alreadyAdded: 'This account has already been added.',
         chooseAccountLabel: 'Account',
     },

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -404,7 +404,6 @@ export default {
         },
     },
     addPersonalBankAccountPage: {
-        enterPassword: 'Escribe tu contraseña de Expensify',
         alreadyAdded: 'Esta cuenta ya ha sido agregada.',
         chooseAccountLabel: 'Cuenta',
     },

--- a/src/pages/ReimbursementAccount/BankAccountStep.js
+++ b/src/pages/ReimbursementAccount/BankAccountStep.js
@@ -92,7 +92,6 @@ class BankAccountStep extends React.Component {
 
     /**
      * @param {Object} params
-     * @param {String} params.password
      * @param {Object} params.account
      * @param {String} params.account.bankName
      * @param {Boolean} params.account.isSavings
@@ -108,7 +107,6 @@ class BankAccountStep extends React.Component {
             setupType: CONST.BANK_ACCOUNT.SETUP_TYPE.PLAID,
 
             // Params passed via the Plaid callback when an account is selected
-            password: params.password,
             plaidAccessToken: params.plaidLinkToken,
             accountNumber: params.account.accountNumber,
             routingNumber: params.account.routingNumber,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Removes an unnecessary password field from the 'Add Bank Account' via Plaid step.

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/4723
--->
$ https://github.com/Expensify/Expensify/issues/175424

### Tests
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

**A) Confirm that the password step is no longer seen**
- Create a New Workspace via the global menu, or navigate to an existing workspace
- Tap 'Get Started' to launch the add bank account flow
- Tap 'Log in to your bank' which launches the Plaid modal
- Enter 'user_good' & 'pass_good'
- You **should NOT** see a password input field
- The button should be enabled after selecting an account from the dropdown

**B) Confirm that removing the password does not block the flow**
- _Continue from test **A**_
- You should be able to progress through the remaining modal steps (use [these details](https://stackoverflow.com/c/expensify/questions/342/525#525) if on dev env)


### QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

Run above test

### Tested On

- [x] Web
- [ ] Mobile Web
- [x] Desktop
- [x] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->


@trjExpensify 
#### Web
<!-- Insert screenshots of your changes on the web platform-->
<img width="967" alt="Screenshot 2021-08-31 at 12 44 25" src="https://user-images.githubusercontent.com/10736861/131496754-228185c4-1d12-4d6a-b011-8b23cf936abd.png">

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

I have been unable to verify this due to a [possible SSL issue](https://expensify.slack.com/archives/C03TQ48KC/p1630082007038700)

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
<img width="919" alt="Screenshot 2021-08-31 at 12 48 59" src="https://user-images.githubusercontent.com/10736861/131497324-ef85f18c-331b-4540-9136-9ff5149e580e.png">


#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
![Simulator Screen Shot - iPhone 8 - 2021-08-31 at 15 51 38](https://user-images.githubusercontent.com/10736861/131525172-e2ccbba5-6b3d-4a2f-b0cc-874117401bb0.png)
![Simulator Screen Shot - iPhone 8 - 2021-09-01 at 16 24 57](https://user-images.githubusercontent.com/10736861/131699238-42041dd5-0bb5-47ea-ac5f-7c8828a1b52c.png)



#### Android
<!-- Insert screenshots of your changes on the Android platform-->

Note: Android is blocked by this issue, we should retest Android after [this issue](https://github.com/Expensify/App/issues/4959) is resolved.

