### PR TITLE
Grab iOS version from release event

### DIFF
--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -223,11 +223,15 @@ jobs:
           APPLE_DEMO_EMAIL: ${{ secrets.APPLE_DEMO_EMAIL }}
           APPLE_DEMO_PASSWORD: ${{ secrets.APPLE_DEMO_PASSWORD }}
 
+      - name: Set iOS version in ENV
+        if: ${{ env.SHOULD_DEPLOY_PRODUCTION == 'true' }}
+        run: echo "IOS_VERSION=$(echo '${{ github.event.release.tag_name }}' | tr '-' '.')" >> $GITHUB_ENV
+
       - name: Run Fastlane for App Store release
         if: ${{ env.SHOULD_DEPLOY_PRODUCTION == 'true' }}
         run: bundle exec fastlane ios production
         env:
-          VERSION: ${{ env.NEW_IOS_VERSION }}
+          VERSION: ${{ env.IOS_VERSION }}
 
   web:
     name: Build and deploy Web

--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -225,7 +225,9 @@ jobs:
 
       - name: Set iOS version in ENV
         if: ${{ fromJSON(env.SHOULD_DEPLOY_PRODUCTION) }}
-        run: echo "IOS_VERSION=$(echo '${{ github.event.release.tag_name }}' | tr '-' '.')" >> $GITHUB_ENV
+        run: |
+          echo "IOS_VERSION=$(echo '${{ github.event.release.tag_name }}' | tr '-' '.')" >> $GITHUB_ENV
+          echo "iOS version is: ${{ env.IOS_VERSION }}"
 
       - name: Run Fastlane for App Store release
         if: ${{ env.SHOULD_DEPLOY_PRODUCTION == 'true' }}

--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -224,7 +224,7 @@ jobs:
           APPLE_DEMO_PASSWORD: ${{ secrets.APPLE_DEMO_PASSWORD }}
 
       - name: Set iOS version in ENV
-        if: ${{ env.SHOULD_DEPLOY_PRODUCTION == 'true' }}
+        if: ${{ fromJSON(env.SHOULD_DEPLOY_PRODUCTION) }}
         run: echo "IOS_VERSION=$(echo '${{ github.event.release.tag_name }}' | tr '-' '.')" >> $GITHUB_ENV
 
       - name: Run Fastlane for App Store release

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -149,7 +149,7 @@ platform :ios do
       api_key_path: "./ios/ios-fastlane-json-key.json",
       build_number: ENV["VERSION"],
       submit_for_review: true,
-      automatic_release: false,
+      automatic_release: true,
       skip_metadata: true,
       skip_screenshots: true,
       skip_binary_upload: true,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Uses the release event's tag to send to fastlane, to determine which version to promote to iOS production. It looks like the old ios.yml used to rely on `bumpVersion.js` to set this in the `env` which we cannot rely on anymore

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/4723
--->
$ https://github.com/Expensify/Expensify/issues/175849

### Tests
1. I tested this syntax here: https://github.com/Andrew-Test-Org/Public-Test-Repo/runs/3476298417?check_suite_focus=true
2. In order to fully test this, we will need to merge this and wait until we fully deploy a checklist
