### PR TITLE
Allow builds to distribute to external testers

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -113,15 +113,8 @@ platform :ios do
 
     upload_to_testflight(
         api_key_path: "./ios/ios-fastlane-json-key.json",
-        # TODO: Remove skip_waiting_for_build_processing when https://github.com/fastlane/fastlane/issues/18408 is resolved
-        # See: https://github.com/Expensify/App/pull/1984 for more information
-        skip_waiting_for_build_processing: true,
-        # TODO: Set distribute_external back to true when https://github.com/fastlane/fastlane/issues/18408 is resolved
-        # See: https://github.com/Expensify/App/pull/1984 for more information
-        distribute_external: false,
-        # TODO: Set reject_build_waiting_for_review back to true when https://github.com/fastlane/fastlane/issues/18408 is resolved
-        # See: https://github.com/Expensify/App/pull/1984 for more information
-        reject_build_waiting_for_review: false,
+        distribute_external: true,
+        notify_external_testers: true,
         changelog: "Thank you for beta testing New Expensify, this version includes bug fixes and improvements.",
         groups: ["Beta"],
         demo_account_required: true,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
I am curious to see what happens when we have `distribute_external` set to true and `reject_build_waiting_for_review` set to false (the default) and we have a build in review. I think it might fail in these instances, but I want to make sure this throws an error only in that case, then in all other cases it does distribute the build to testers.

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/4723
--->
$ https://github.com/Expensify/App/issues/2748

### Tests
1. Merge this PR
2. Let's see if the build is available for testers to use immediately (it should be)
3. When a new version is submitted, let's make sure it's put into review (it should be)
4. Let's watch and see what happens when another build is submitted when 3 is in review (it might error, but let's see)