### PR TITLE
Remove internationalization beta

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -87,7 +87,6 @@ const CONST = {
         PAY_WITH_EXPENSIFY: 'payWithExpensify',
         FREE_PLAN: 'freePlan',
         DEFAULT_ROOMS: 'defaultRooms',
-        INTERNATIONALIZATION: 'internationalization',
     },
     BUTTON_STATES: {
         DEFAULT: 'default',

--- a/src/components/LocalePicker.js
+++ b/src/components/LocalePicker.js
@@ -6,7 +6,6 @@ import {setLocale} from '../libs/actions/App';
 import withLocalize, {withLocalizePropTypes} from './withLocalize';
 import ONYXKEYS from '../ONYXKEYS';
 import CONST from '../CONST';
-import Permissions from '../libs/Permissions';
 import {translate} from '../libs/translate';
 import ExpensiPicker from './ExpensiPicker';
 
@@ -43,25 +42,19 @@ const localesToLanguages = {
 const LocalePicker = ({
     // eslint-disable-next-line no-shadow
     preferredLocale, translate, betas, size,
-}) => {
-    if (!Permissions.canUseInternationalization(betas)) {
-        return null;
-    }
-
-    return (
-        <ExpensiPicker
-            label={size === 'normal' ? translate('preferencesPage.language') : null}
-            onChange={(locale) => {
-                if (locale !== preferredLocale) {
-                    setLocale(locale);
-                }
-            }}
-            items={Object.values(localesToLanguages)}
-            size={size}
-            value={preferredLocale}
-        />
-    );
-};
+}) => (
+    <ExpensiPicker
+        label={size === 'normal' ? translate('preferencesPage.language') : null}
+        onChange={(locale) => {
+            if (locale !== preferredLocale) {
+                setLocale(locale);
+            }
+        }}
+        items={Object.values(localesToLanguages)}
+        size={size}
+        value={preferredLocale}
+    />
+);
 
 LocalePicker.defaultProps = defaultProps;
 LocalePicker.propTypes = propTypes;

--- a/src/components/LocalePicker.js
+++ b/src/components/LocalePicker.js
@@ -16,16 +16,12 @@ const propTypes = {
     /** Indicates size of a picker component and whether to render the label or not */
     size: PropTypes.oneOf(['normal', 'small']),
 
-    /** Beta features list */
-    betas: PropTypes.arrayOf(PropTypes.string),
-
     ...withLocalizePropTypes,
 };
 
 const defaultProps = {
     preferredLocale: CONST.DEFAULT_LOCALE,
     size: 'normal',
-    betas: [],
 };
 
 const localesToLanguages = {
@@ -41,7 +37,7 @@ const localesToLanguages = {
 
 const LocalePicker = ({
     // eslint-disable-next-line no-shadow
-    preferredLocale, translate, betas, size,
+    preferredLocale, translate, size,
 }) => (
     <ExpensiPicker
         label={size === 'normal' ? translate('preferencesPage.language') : null}
@@ -65,9 +61,6 @@ export default compose(
     withOnyx({
         preferredLocale: {
             key: ONYXKEYS.NVP_PREFERRED_LOCALE,
-        },
-        betas: {
-            key: ONYXKEYS.BETAS,
         },
     }),
 )(LocalePicker);

--- a/src/libs/Permissions.js
+++ b/src/libs/Permissions.js
@@ -51,19 +51,10 @@ function canUseDefaultRooms(betas) {
     return _.contains(betas, CONST.BETAS.DEFAULT_ROOMS) || canUseAllBetas(betas);
 }
 
-/**
- * @param {Array<String>} betas
- * @returns {Boolean}
- */
-function canUseInternationalization(betas) {
-    return _.contains(betas, CONST.BETAS.INTERNATIONALIZATION) || canUseAllBetas(betas);
-}
-
 export default {
     canUseChronos,
     canUseIOU,
     canUsePayWithExpensify,
     canUseFreePlan,
     canUseDefaultRooms,
-    canUseInternationalization,
 };


### PR DESCRIPTION
### Details
The locale picker cannot be used from the signup or login pages because betas are not yet available (because the user is not logged in). Dropped a message in Slack [here](https://expensify.slack.com/archives/C01GTK53T8Q/p1630450923241100), but I feel like at this point we can safely remove this beta entirely.

### Fixed Issues
$ https://github.com/Expensify/App/issues/4958

**Note:** The above issue is not reproducible on dev, because all betas are enabled by default.

### Tests / QA Steps
1. Go to signin page.
1. There should be a locale picker in the bottom of the signin page. Changing it should change the language.
1. Go to the password page.
1. There should be a locale picker in the bottom of the password page. Changing it should change the language.

### Screenshots
Not including screenshots because it looks the same on dev as it did before – this change will only be visible on staging.
