### PR TITLE
[No QA] Update remaining e.cash usages w/ New Expensify

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -31,7 +31,7 @@ mc mb electron-builder/electron-builder
 6. Verify that the new bucket has been created by navigating to https://localhost:9000/minio/electron-builder in your browser and confriming you see an interface like this:
 ![electron-builder](https://user-images.githubusercontent.com/3981102/120376267-8842d700-c2d0-11eb-86cb-f595f27d535d.png)
 
-7. Set your testing bucket to be public, which will allow the e.cash dmg access the local latest-mac.yml file we'll be publishing
+7. Set your testing bucket to be public, which will allow the NewExpensify.dmg access the local latest-mac.yml file we'll be publishing
 ```
 mc policy set public electron-builder/electron-builder
 ```

--- a/src/App.js
+++ b/src/App.js
@@ -30,7 +30,7 @@ const App = () => (
         ]}
     >
         <CustomStatusBar />
-        <ErrorBoundary errorMessage="E.cash crash caught by error boundary">
+        <ErrorBoundary errorMessage="NewExpensify crash caught by error boundary">
             <Expensify />
         </ErrorBoundary>
     </ComposeProviders>

--- a/src/libs/actions/BankAccounts.js
+++ b/src/libs/actions/BankAccounts.js
@@ -463,7 +463,7 @@ function fetchFreePlanVerifiedBankAccount(stepToOpen) {
                             : CONST.BANK_ACCOUNT.STEP.BANK_ACCOUNT;
 
                         // @TODO Again, not sure how much of this logic is needed right now
-                        // as we shouldn't be handling any open accounts in E.cash yet that need to pass any more
+                        // as we shouldn't be handling any open accounts in New Expensify yet that need to pass any more
                         // checks or can be upgraded, but leaving in for possible future compatibility.
                         if (bankAccount.isOpen()) {
                             if (bankAccount.needsToPassLatestChecks()) {

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -750,7 +750,7 @@ function subscribeToUserEvents() {
 
 /**
  * There are 2 possibilities that we can receive via pusher for a user's typing status:
- * 1. The "new" way from e.cash is passed as {[login]: Boolean} (e.g. {yuwen@expensify.com: true}), where the value
+ * 1. The "new" way from New Expensify is passed as {[login]: Boolean} (e.g. {yuwen@expensify.com: true}), where the value
  * is whether the user with that login is typing on the report or not.
  * 2. The "old" way from e.com which is passed as {userLogin: login} (e.g. {userLogin: bstites@expensify.com})
  *

--- a/src/pages/signin/SignInPage.js
+++ b/src/pages/signin/SignInPage.js
@@ -72,7 +72,7 @@ class SignInPage extends Component {
 
         // Show the password form if
         // - A login has been entered
-        // - AND a GitHub username has been entered OR they already have access to expensify cash
+        // - AND a GitHub username has been entered OR they already have access to New Expensify
         // - AND an account exists and is validated for this login
         // - AND a password hasn't been entered yet
         const showPasswordForm = this.props.credentials.login


### PR DESCRIPTION
### Details
While investigating Firebase logs for another issue, I noticed that we're still using `e.cash` when logging for the ErrorBoundary component, so I went through and updated the remaining usages in the codebase. 

### Tests/QA
None, this just updates readme and comments