### PR TITLE
[No QA] Ping deployers when mobile prod deploys fail

### DIFF
--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -100,7 +100,7 @@ jobs:
               attachments: [{
                 color: "#DB4545",
                 pretext: `<!subteam^S4TJJ3PSL>`,
-                text: `💥 Android production deploy failed. Please manually submit ${{ github.event.release.tag_name }} in the Google Play Store. 💥`,
+                text: `💥 Android production deploy failed. Please manually submit ${{ github.event.release.tag_name }} in the <https://play.google.com/console/u/0/developers/8765590895836334604/app/4973041797096886180/releases/overview|Google Play Store>. 💥`,
               }]
             }
         env:
@@ -264,7 +264,7 @@ jobs:
               attachments: [{
                 color: "#DB4545",
                 pretext: `<!subteam^S4TJJ3PSL>`,
-                text: `💥 iOS production deploy failed. Please manually submit ${{ env.IOS_VERSION }} in the App Store. 💥`,
+                text: `💥 iOS production deploy failed. Please manually submit ${{ env.IOS_VERSION }} in the <https://appstoreconnect.apple.com/apps/1530278510/appstore|App Store>. 💥`,
               }]
             }
         env:

--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -89,6 +89,24 @@ jobs:
         env:
           VERSION: ${{ env.VERSION_CODE }}
 
+      - name: Warn deployers if Android production deploy failed
+        if: ${{ failure() && fromJSON(env.SHOULD_DEPLOY_PRODUCTION) }}
+        uses: 8398a7/action-slack@v3
+        with:
+          status: custom
+          custom_payload: |
+            {
+              channel: '#deployer',
+              attachments: [{
+                color: "#DB4545",
+                pretext: `<!subteam^S4TJJ3PSL>`,
+                text: `💥 Android production deploy failed. Please manually submit ${{ github.event.release.tag_name }} in the Google Play Store. 💥`,
+              }]
+            }
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+
   desktop:
     name: Build and deploy Desktop
     needs: validateActor
@@ -234,6 +252,24 @@ jobs:
         run: bundle exec fastlane ios production
         env:
           VERSION: ${{ env.IOS_VERSION }}
+
+      - name: Warn deployers if iOS production deploy failed
+        if: ${{ failure() && fromJSON(env.SHOULD_DEPLOY_PRODUCTION) }}
+        uses: 8398a7/action-slack@v3
+        with:
+          status: custom
+          custom_payload: |
+            {
+              channel: '#deployer',
+              attachments: [{
+                color: "#DB4545",
+                pretext: `<!subteam^S4TJJ3PSL>`,
+                text: `💥 iOS production deploy failed. Please manually submit ${{ env.IOS_VERSION }} in the App Store. 💥`,
+              }]
+            }
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
 
   web:
     name: Build and deploy Web


### PR DESCRIPTION
### Details
Ping mobile-deployers in #deployer when mobile prod deploys fail.

### Fixed Issues
$ https://github.com/Expensify/App/issues/4955

### Tests
Not 100% sure how to test this. Maybe the following:

1. Merge this PR
1. Retry [this production deploy](https://github.com/Expensify/App/runs/3479417738)
1. When iOS prod deploy fails, verify that we post in slack with the given message.

Two potential issues with this testing plan I see:

1. In step `2`, I think it might use the previous version of the GH workflow code and not the code including this PR.
1. It doesn't test Android (although that might be fine)

### QA Steps
None.