### PR TITLE
Update e-common & fix copy/paste the Text from MAC Note.app 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23082,8 +23082,8 @@
       }
     },
     "expensify-common": {
-      "version": "git://github.com/Expensify/expensify-common.git#e5a22b54cde72ff3b9b6b085ea4374144e8937b2",
-      "from": "git://github.com/Expensify/expensify-common.git#e5a22b54cde72ff3b9b6b085ea4374144e8937b2",
+      "version": "git://github.com/Expensify/expensify-common.git#a78cc23afe54d487ce2b7bafefa07e58d0280612",
+      "from": "git://github.com/Expensify/expensify-common.git#a78cc23afe54d487ce2b7bafefa07e58d0280612",
       "requires": {
         "classnames": "2.3.1",
         "clipboard": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "electron-log": "^4.3.5",
     "electron-serve": "^1.0.0",
     "electron-updater": "^4.3.4",
-    "expensify-common": "git://github.com/Expensify/expensify-common.git#e5a22b54cde72ff3b9b6b085ea4374144e8937b2",
+    "expensify-common": "git://github.com/Expensify/expensify-common.git#a78cc23afe54d487ce2b7bafefa07e58d0280612",
     "expo-haptics": "^10.0.0",
     "file-loader": "^6.0.0",
     "html-entities": "^1.3.1",


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
https://github.com/Expensify/App/issues/4484#issuecomment-903352516

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/4723
--->
$ https://github.com/Expensify/App/issues/4484

### Tests | QA Steps
1. Open newDot on chrome Web in MAC.
2. Navigate to a conversation that has some messages.
3. Paste the Text from MAC note.app to the composer.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
https://user-images.githubusercontent.com/24370807/132465072-ac738f80-d5fb-4ee0-b4d1-a05e801b5e25.mp4

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
