### PR TITLE
Added spacing between Routing & Account Number

### DIFF
--- a/src/pages/ReimbursementAccount/BankAccountStep.js
+++ b/src/pages/ReimbursementAccount/BankAccountStep.js
@@ -222,7 +222,7 @@ class BankAccountStep extends React.Component {
                                     ? error : ''}
                             />
                             <ExpensiTextInput
-                                containerStyles={[styles.mt4]} 
+                                containerStyles={[styles.mt4]}
                                 placeholder={this.props.translate('bankAccount.accountNumber')}
                                 keyboardType="number-pad"
                                 value={this.state.accountNumber}

--- a/src/pages/ReimbursementAccount/BankAccountStep.js
+++ b/src/pages/ReimbursementAccount/BankAccountStep.js
@@ -222,6 +222,7 @@ class BankAccountStep extends React.Component {
                                     ? error : ''}
                             />
                             <ExpensiTextInput
+                                containerStyles={[styles.mt4]} 
                                 placeholder={this.props.translate('bankAccount.accountNumber')}
                                 keyboardType="number-pad"
                                 value={this.state.accountNumber}


### PR DESCRIPTION
@puneetlath 

### Details
Just added a space between the` Routing Number` & `Account Number` input in Add Bank Account Step.

### Fixed Issues
$ #4834 

### Tests & QA Steps
1. Add account to free plan beta
2. Go to new.expensify.com
3. Create a workspace
4. Select Get Started in Expensify Card tab of the workspace
5. Choose the "Connect Manually" option

Fix:
Ensure space is added between `Routing Number` & `Account Number` input.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<img width="1440" alt="Screenshot 2021-09-01 at 10 54 30 PM" src="https://user-images.githubusercontent.com/85645967/131718696-b27c6bde-b3f3-4d45-9974-5afaecb41c8c.png">

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
![Simulator Screen Shot - iPhone 12 - 2021-09-01 at 22 55 59](https://user-images.githubusercontent.com/85645967/131718694-c74066e0-8ddb-4fde-a1e1-f17582adac79.png)

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
<img width="1216" alt="Screenshot 2021-09-01 at 10 54 05 PM" src="https://user-images.githubusercontent.com/85645967/131718675-c3286bdb-575b-4f94-af6e-6ffb8d779daa.png">

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
![Simulator Screen Shot - iPhone 12 - 2021-09-01 at 22 57 16](https://user-images.githubusercontent.com/85645967/131718691-a5b79f65-5fe7-4720-9581-1d04848a075f.png)

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
![Screenshot_1630517457](https://user-images.githubusercontent.com/85645967/131718686-d9f97ca8-111e-4654-a8bc-d52593b8f385.png)