### PR TITLE
Fetch reimbursementAccount data on Login

### DIFF
--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -32,6 +32,7 @@ import modalCardStyleInterpolator from './modalCardStyleInterpolator';
 import createCustomModalStackNavigator from './createCustomModalStackNavigator';
 import Permissions from '../../Permissions';
 import getOperatingSystem from '../../getOperatingSystem';
+import {fetchFreePlanVerifiedBankAccount} from '../../actions/BankAccounts';
 
 // Main drawer navigator
 import MainDrawerNavigator from './MainDrawerNavigator';
@@ -167,6 +168,7 @@ class AuthScreens extends React.Component {
         fetchAllReports(true, true);
         fetchCountryCodeByRequestIP();
         UnreadIndicatorUpdater.listenForReportChanges();
+        fetchFreePlanVerifiedBankAccount();
 
         loadPoliciesBehindBeta(this.props.betas);
 


### PR DESCRIPTION
### Details
Investigating https://github.com/Expensify/Expensify/issues/176091, we found that the problem occurs when users are jumping in and out of accounts. We wipe Onyx data when the user signs out, and those particular keys are only fetched once we click Get Started again, thus updating the text. This PR fetches the data when the user logs in.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/176091

### Tests
1. Login in to New Expensify - make sure your account does not have a Business Account setup yet.
2. Click `Settings > Select a Workspace (or create a new one) > Get Started`.
2. Follow the steps in [this SO](https://stackoverflow.com/c/expensify/questions/342) to add a `Pending Account`. Stop when you see the `Get Started` button change to `Finish Setup`.
3. Log out and log back in.
4.  Navigate back to `Settings > Select the previous Workspace`.
5. Verify that the button still says `Finish Setup`.

### QA Steps
Steps above.

### Tested On

- [X] Web
- [X] Mobile Web
- [X] Desktop
- [X] iOS
- [X] Android

### Screenshots

#### Web
https://user-images.githubusercontent.com/22219519/131885504-ee1c7441-eee1-4412-973c-f93cc9d3adf1.mov

#### Mobile Web
https://user-images.githubusercontent.com/22219519/131885518-8c222081-392b-4124-a9e4-fb926432331f.mov

#### Desktop
https://user-images.githubusercontent.com/22219519/131885547-90d63d67-763a-43a8-8b43-9ac64f772a64.mov

#### iOS
https://user-images.githubusercontent.com/22219519/131885570-a9b1ac4d-c588-43cf-a68a-ed4b57bb9a96.mov

#### Android
https://user-images.githubusercontent.com/22219519/131885889-140b7a3b-78e8-42c2-90a7-9c4f9e92e788.mov
