### PR TITLE
[No QA] Tag staging instead of main before updating checklist

### DIFF
--- a/.github/workflows/finishReleaseCycle.yml
+++ b/.github/workflows/finishReleaseCycle.yml
@@ -108,7 +108,10 @@ jobs:
           echo "NEW_VERSION=$(npm run print-version --silent)" >> $GITHUB_ENV
           echo "New version is ${{ env.NEW_VERSION }}"
 
-      # Note: we need to create this tag but not push it, because of how GitUtils.getPullRequestsMergedBetween works
+        # Create a local git tag so that GitUtils.getPullRequestsMergedBetween can use `git log` to generate a
+        # list of pull requests that were merged between this version tag and another.
+        # NOTE: It's important to not push this tag now, because that would cause a staging deploy,
+        # which is handled separately in the deploy.yml workflow.
       - name: Tag version
         run: git tag ${{ env.NEW_VERSION }}
 

--- a/.github/workflows/finishReleaseCycle.yml
+++ b/.github/workflows/finishReleaseCycle.yml
@@ -110,8 +110,8 @@ jobs:
 
         # Create a local git tag so that GitUtils.getPullRequestsMergedBetween can use `git log` to generate a
         # list of pull requests that were merged between this version tag and another.
-        # NOTE: It's important to not push this tag now, because that would cause a staging deploy,
-        # which is handled separately in the deploy.yml workflow.
+        # NOTE: This tag is only used locally and shouldn't be pushed to the remote.
+        # If it was pushed, that would trigger the staging deploy which is handled in a separate workflow (deploy.yml)
       - name: Tag version
         run: git tag ${{ env.NEW_VERSION }}
 

--- a/.github/workflows/lockDeploys.yml
+++ b/.github/workflows/lockDeploys.yml
@@ -38,11 +38,15 @@ jobs:
 
       - name: Pull staging to get the new version
         run: |
+          git checkout staging
           git pull origin staging
           echo "NEW_VERSION=$(npm run print-version --silent)" >> $GITHUB_ENV
           echo "New version is ${{ env.NEW_VERSION }}"
 
-      # Note: we need to create this tag but not push it, because of how GitUtils.getPullRequestsMergedBetween works
+        # Create a local git tag on staging so that GitUtils.getPullRequestsMergedBetween can use `git log` to generate a
+        # list of pull requests that were merged between this version tag and another.
+        # NOTE: It's important to not push this tag now, because that would cause a staging deploy,
+        # which is handled separately in the deploy.yml workflow.
       - name: Tag version
         run: git tag ${{ env.NEW_VERSION }}
 

--- a/.github/workflows/lockDeploys.yml
+++ b/.github/workflows/lockDeploys.yml
@@ -45,8 +45,8 @@ jobs:
 
         # Create a local git tag on staging so that GitUtils.getPullRequestsMergedBetween can use `git log` to generate a
         # list of pull requests that were merged between this version tag and another.
-        # NOTE: It's important to not push this tag now, because that would cause a staging deploy,
-        # which is handled separately in the deploy.yml workflow.
+        # NOTE: This tag is only used locally and shouldn't be pushed to the remote.
+        # If it was pushed, that would trigger the staging deploy which is handled in a separate workflow (deploy.yml)
       - name: Tag version
         run: git tag ${{ env.NEW_VERSION }}
 

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -79,6 +79,12 @@ jobs:
           WORKFLOW: createNewVersion.yml
           INPUTS: '{ "SEMVER_LEVEL": "BUILD" }'
 
+      - name: Pull main to get the new version
+        run: |
+          git pull origin main
+          echo "NEW_VERSION=$(npm run print-version --silent)" >> $GITHUB_ENV
+          echo "New version is ${{ env.NEW_VERSION }}"
+
       - name: Update staging branch from main
         if: ${{ needs.chooseDeployActions.outputs.isStagingDeployLocked == 'false' }}
         uses: Expensify/App/.github/actions/triggerWorkflowAndWait@main
@@ -87,23 +93,20 @@ jobs:
           WORKFLOW: updateProtectedBranch.yml
           INPUTS: '{ "TARGET_BRANCH": "staging" }'
 
-      - name: Pull main to get the new version
-        run: |
-          git pull origin main
-          echo "NEW_VERSION=$(npm run print-version --silent)" >> $GITHUB_ENV
-          echo "New version is ${{ env.NEW_VERSION }}"
-
-      # Note: we need to create this tag but not push it, because of how GitUtils.getPullRequestsMergedBetween works
-      - name: Tag version
-        run: git tag ${{ env.NEW_VERSION }}
-
       - name: Cherry pick to staging
         if: ${{ needs.chooseDeployActions.outputs.isStagingDeployLocked == 'true' && needs.chooseDeployActions.outputs.shouldCherryPick == 'true' }}
         uses: Expensify/App/.github/actions/triggerWorkflowAndWait@main
         with:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
           WORKFLOW: cherryPick.yml
-          INPUTS: '{ "PULL_REQUEST_NUMBER": "${{ needs.chooseDeployActions.outputs.mergedPullRequest }}", "NEW_VERSION": "${{ env.NEW_VERSION }}" }'
+          INPUTS: '{ "PULL_REQUEST_NUMBER": "${{ needs.chooseDeployActions.outputs.mergedPullRequest }}", "NEW_VERSION": "${{ env.MAIN_VERSION }}" }'
+
+      # Note: we need to create this tag but not push it, because GitUtils.getPullRequestsMergedBetween uses tags to generate a list of merged pull requests
+      - name: Tag staging
+        run: |
+          git checkout staging
+          git pull origin staging
+          git tag ${{ env.NEW_VERSION }}
 
       - name: Update StagingDeployCash
         uses: Expensify/App/.github/actions/createOrUpdateStagingDeploy@main

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -103,8 +103,8 @@ jobs:
 
       # Create a local git tag on staging so that GitUtils.getPullRequestsMergedBetween can use `git log` to generate a
       # list of pull requests that were merged between this version tag and another.
-      # NOTE: It's important to not push this tag now, because that would cause a staging deploy,
-      # which is handled separately in the deploy.yml workflow.
+      # NOTE: This tag is only used locally and shouldn't be pushed to the remote.
+      # If it was pushed, that would trigger the staging deploy which is handled in a separate workflow (deploy.yml)
       - name: Tag staging
         run: |
           git checkout staging

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -99,7 +99,7 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
           WORKFLOW: cherryPick.yml
-          INPUTS: '{ "PULL_REQUEST_NUMBER": "${{ needs.chooseDeployActions.outputs.mergedPullRequest }}", "NEW_VERSION": "${{ env.MAIN_VERSION }}" }'
+          INPUTS: '{ "PULL_REQUEST_NUMBER": "${{ needs.chooseDeployActions.outputs.mergedPullRequest }}", "NEW_VERSION": "${{ env.NEW_VERSION }}" }'
 
       # Note: we need to create this tag but not push it, because GitUtils.getPullRequestsMergedBetween uses tags to generate a list of merged pull requests
       - name: Tag staging

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -101,7 +101,10 @@ jobs:
           WORKFLOW: cherryPick.yml
           INPUTS: '{ "PULL_REQUEST_NUMBER": "${{ needs.chooseDeployActions.outputs.mergedPullRequest }}", "NEW_VERSION": "${{ env.NEW_VERSION }}" }'
 
-      # Note: we need to create this tag but not push it, because GitUtils.getPullRequestsMergedBetween uses tags to generate a list of merged pull requests
+      # Create a local git tag on staging so that GitUtils.getPullRequestsMergedBetween can use `git log` to generate a
+      # list of pull requests that were merged between this version tag and another.
+      # NOTE: It's important to not push this tag now, because that would cause a staging deploy,
+      # which is handled separately in the deploy.yml workflow.
       - name: Tag staging
         run: |
           git checkout staging


### PR DESCRIPTION

### Details
[Right here](https://github.com/Expensify/App/blob/35fd9a1b6834e30a880dc9f35b3def11228348c1/.github/workflows/preDeploy.yml#L90-L98) we're pulling `main` and creating a tag with the new version. Then in the next two steps we:

1. maybe CP the PR, and
2. always update the checklist using that tag as a reference to figure out what PRs were merged.

However, the tag created from `main` might include PRs that were merged but not deployed to staging. For example:

1. PR 1 is merged.
1. Tag A is created that includes PR 1.
1. Staging deploy is locked. Other stuff happens that doesn't matter in this example.
1. PR 2 is merged. No deploy happens and no tag is created.
1. PR 3 is merged + CP'd.
1. Tag B is created off `main`, and includes PR 2 in its history. _But PR 2 was not deployed to staging_ ❌ 

This PR _should_ fix this issue by tagging `staging` instead of `main` before updating the checklist.

### Fixed Issues
Hopefully might (at least partially) fix https://github.com/Expensify/Expensify/issues/168349

### Tests
1. With the deploy checklist locked, merge a PR (A).
1. Merge + CP another PR (B).
1. The checklist should be updated to include B but not A.

### QA Steps
None.