### PR TITLE
Use currentBalance instead of availableBalance

### DIFF
--- a/src/components/CurrentWalletBalance.js
+++ b/src/components/CurrentWalletBalance.js
@@ -13,7 +13,7 @@ const propTypes = {
     /** The user's wallet account */
     userWallet: PropTypes.shape({
         /** The user's current wallet balance */
-        availableBalance: PropTypes.number,
+        currentBalance: PropTypes.number,
     }),
 
     ...withLocalizePropTypes,
@@ -35,7 +35,7 @@ const CurrentWalletBalance = (props) => {
     }
 
     const formattedBalance = props.numberFormat(
-        props.userWallet.availableBalance,
+        props.userWallet.currentBalance,
         {style: 'currency', currency: 'USD'},
     );
     return (

--- a/src/components/CurrentWalletBalance.js
+++ b/src/components/CurrentWalletBalance.js
@@ -35,7 +35,7 @@ const CurrentWalletBalance = (props) => {
     }
 
     const formattedBalance = props.numberFormat(
-        props.userWallet.currentBalance,
+        props.userWallet.currentBalance / 100, // Divide by 100 because balance is in cents
         {style: 'currency', currency: 'USD'},
     );
     return (

--- a/src/pages/settings/InitialPage.js
+++ b/src/pages/settings/InitialPage.js
@@ -71,7 +71,7 @@ const propTypes = {
     /** The user's wallet account */
     userWallet: PropTypes.shape({
         /** The user's current wallet balance */
-        availableBalance: PropTypes.number,
+        currentBalance: PropTypes.number,
     }),
 
     ...withLocalizePropTypes,
@@ -83,7 +83,7 @@ const defaultProps = {
     session: {},
     policies: {},
     userWallet: {
-        availableBalance: 0,
+        currentBalance: 0,
     },
 };
 
@@ -133,7 +133,7 @@ const InitialSettingsPage = ({
     userWallet,
 }) => {
     const walletBalance = numberFormat(
-        userWallet.availableBalance,
+        userWallet.currentBalance,
         {style: 'currency', currency: 'USD'},
     );
 

--- a/src/pages/settings/InitialPage.js
+++ b/src/pages/settings/InitialPage.js
@@ -133,7 +133,7 @@ const InitialSettingsPage = ({
     userWallet,
 }) => {
     const walletBalance = numberFormat(
-        userWallet.currentBalance,
+        userWallet.currentBalance / 100, // Divide by 100 because balance is in cents
         {style: 'currency', currency: 'USD'},
     );
 


### PR DESCRIPTION
### Details
<!-- Explanation of the change or anything fishy that is going on -->

We're showing the wrong balance to the user. The `currentBalance` is the one we want the user to see. `availableBalance` is used on the backend to decide wether or not to authorize transactions.

cc @parasharrajat 

### Fixed Issues

$ https://github.com/Expensify/Expensify/issues/173152
$ https://github.com/Expensify/Expensify/issues/173151

### Tests

- Log into an account with a wallet
- Insert a queued reimbursement with the creditBankAccountID the wallet of the account you are logged in with
- Make sure that you see the balance updated. 
- Check that available balance is 0 by running this snippet:
```
API.get({returnValueList: 'userWallet'}).done(({userWallet}) => {
            console.log(userWallet);
        }).fail((e) => {
            console.log(e);
        });
```

### QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

- Request money from someone
- Have them pay the IOU via bank account, not debit card
- Make sure you see your balance change right after they paid the IOU

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

<img width="378" alt="Screen Shot 2021-09-06 at 10 04 48 PM" src="https://user-images.githubusercontent.com/7016692/132257837-3340d101-5fc8-4fc7-9f12-e7e4035c08bf.png">
<img width="378" alt="Screen Shot 2021-09-06 at 10 04 53 PM" src="https://user-images.githubusercontent.com/7016692/132257841-d607d20e-59f5-4ed0-895e-00685c36e463.png">
<img width="773" alt="Screen Shot 2021-09-06 at 10 05 22 PM" src="https://user-images.githubusercontent.com/7016692/132257852-e9567fa6-0c05-4bb1-b7a4-b5f7570975e6.png">


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
