### PR TITLE
Remember preferred locale on signup/login

### DIFF
--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -67,6 +67,8 @@ import WorkspaceSettingsDrawerNavigator from './WorkspaceSettingsDrawerNavigator
 import spacing from '../../../styles/utilities/spacing';
 import CardOverlay from '../../../components/CardOverlay';
 import defaultScreenOptions from './defaultScreenOptions';
+import * as API from '../../API';
+import {setLocale} from '../../actions/App';
 
 Onyx.connect({
     key: ONYXKEYS.MY_PERSONAL_DETAILS,
@@ -85,6 +87,12 @@ Onyx.connect({
             PersonalDetails.setPersonalDetails({timezone});
         }
     },
+});
+
+let currentPreferredLocale;
+Onyx.connect({
+    key: ONYXKEYS.NVP_PREFERRED_LOCALE,
+    callback: val => currentPreferredLocale = val || CONST.DEFAULT_LOCALE,
 });
 
 const RootStack = createCustomModalStackNavigator();
@@ -158,7 +166,19 @@ class AuthScreens extends React.Component {
 
         // Fetch some data we need on initialization
         NameValuePair.get(CONST.NVP.PRIORITY_MODE, ONYXKEYS.NVP_PRIORITY_MODE, 'default');
-        NameValuePair.get(CONST.NVP.PREFERRED_LOCALE, ONYXKEYS.NVP_PREFERRED_LOCALE, 'en');
+
+        API.Get({
+            returnValueList: 'nameValuePairs',
+            nvpNames: ONYXKEYS.NVP_PREFERRED_LOCALE,
+        }).then((response) => {
+            const preferredLocale = response.nameValuePairs.preferredLocale || CONST.DEFAULT_LOCALE;
+            if (currentPreferredLocale !== CONST.DEFAULT_LOCALE && preferredLocale !== currentPreferredLocale) {
+                setLocale(currentPreferredLocale);
+            } else {
+                Onyx.set(ONYXKEYS.NVP_PREFERRED_LOCALE, preferredLocale);
+            }
+        });
+
         PersonalDetails.fetchPersonalDetails();
         User.getUserDetails();
         User.getBetas();

--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -172,7 +172,7 @@ class AuthScreens extends React.Component {
             nvpNames: ONYXKEYS.NVP_PREFERRED_LOCALE,
         }).then((response) => {
             const preferredLocale = response.nameValuePairs.preferredLocale || CONST.DEFAULT_LOCALE;
-            if (currentPreferredLocale !== CONST.DEFAULT_LOCALE && preferredLocale !== currentPreferredLocale) {
+            if ((currentPreferredLocale !== CONST.DEFAULT_LOCALE) && (preferredLocale !== currentPreferredLocale)) {
                 setLocale(currentPreferredLocale);
             } else {
                 Onyx.set(ONYXKEYS.NVP_PREFERRED_LOCALE, preferredLocale);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
Upon login or Signup, get the `NVP_PREFERRED_LOCALE`. If it's not default(en) and changed, update the NVP and set that in Onyx, else set previously selected locale fetched from NVP in Onyx

### Details
<!-- Explanation of the change or anything fishy that is going on -->

$ https://github.com/Expensify/App/issues/4999

### Tests/QA Steps

1. From the login page select Espanyol and login
2. Make sure language is changed inside the app
3. From a new device or incognito window login into the app without changing anything(the login page by default will be in English)
4. Verify language inside the app is still Espanyol.

### Tested On

- [x] Web
- [ ] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->


https://user-images.githubusercontent.com/32012005/131890508-f00d6a55-6d35-4c9c-aec6-97ef07e0b30b.mov



#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop

https://user-images.githubusercontent.com/32012005/131897469-0eaa6591-6645-451b-99a6-20353f17393a.mov



#### iOS

https://user-images.githubusercontent.com/32012005/131893107-33ebe664-a3e7-4fa3-a187-4633473f98c1.mp4



#### Android


https://user-images.githubusercontent.com/32012005/131896389-9e167899-5d8f-429a-8a27-9876ba124c62.mov



