### PR TITLE
Allow users to decline/cancel when IOU total balance is 0

### DIFF
--- a/src/pages/iou/IOUDetailsModal.js
+++ b/src/pages/iou/IOUDetailsModal.js
@@ -238,7 +238,7 @@ class IOUDetailsModal extends Component {
                             <IOUTransactions
                                 chatReportID={Number(this.props.route.params.chatReportID)}
                                 iouReportID={Number(this.props.route.params.iouReportID)}
-                                hasOutstandingIOU={this.props.iouReport.hasOutstandingIOU}
+                                isIOUSettled={this.props.iouReport.stateNum === CONST.REPORT.STATE_NUM.SUBMITTED}
                                 userEmail={sessionEmail}
                             />
                         </ScrollView>

--- a/src/pages/iou/IOUTransactions.js
+++ b/src/pages/iou/IOUTransactions.js
@@ -24,15 +24,15 @@ const propTypes = {
     /** Email for the authenticated user */
     userEmail: PropTypes.string.isRequired,
 
-    /** Does the associaed have an outstanding IOU? */
-    hasOutstandingIOU: PropTypes.bool,
+    /** Is the associated IOU settled? */
+    isIOUSettled: PropTypes.bool,
 
     ...withLocalizePropTypes,
 };
 
 const defaultProps = {
     reportActions: {},
-    hasOutstandingIOU: false,
+    isIOUSettled: false,
 };
 
 class IOUTransactions extends Component {
@@ -50,7 +50,7 @@ class IOUTransactions extends Component {
      * @returns {Array}
      */
     getRejectableTransactions() {
-        if (!this.props.hasOutstandingIOU) {
+        if (this.props.isIOUSettled) {
             return [];
         }
 


### PR DESCRIPTION
@Julesssss 

### Details
Allow users to cancel/decline IOU requests until transactions are settled.

### Fixed Issues
$ #4998 

### Tests & QA Steps
1. Open New Expensify on two separate devices and login with two different accounts. (Accounts User A & User B)
2. Settle up if there are any pending IOU transactions between two accounts.
3. From `User A` request $100 to `User B`.
4. From `User B` request $100 to `User A`.
5. In both devices click view details on the IOU Request

### Fix:
Now IOU Details Page will open, Relevant transactions should be able to cancel or decline.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<img width="1439" alt="Screenshot 2021-09-02 at 10 10 30 PM" src="https://user-images.githubusercontent.com/85645967/131886261-9b6b895d-29c5-40b9-b82e-056f74c75ac4.png">

#### Mobile Web
![Simulator Screen Shot - iPhone 11 - 2021-09-02 at 21 52 57](https://user-images.githubusercontent.com/85645967/131886295-9583f533-845d-45d0-af62-d2c4a3d78b24.png)

#### Desktop
<img width="1195" alt="Screenshot 2021-09-02 at 9 48 54 PM" src="https://user-images.githubusercontent.com/85645967/131886323-9cf78242-5925-4cdf-927b-2cdab17218cf.png">

#### iOS
![Simulator Screen Shot - iPhone 12 - 2021-09-02 at 21 46 17](https://user-images.githubusercontent.com/85645967/131886606-f3a17780-6eac-4448-9fd0-e148e7cd6866.png)

#### Android
![Screenshot_1630599380](https://user-images.githubusercontent.com/85645967/131886637-36cb6319-70e6-42f7-a9fa-6fb4914b1207.png)
