### PR TITLE
Update Plaid Link for web / Fix logic breaking Plaid flow on web

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36611,12 +36611,12 @@
       }
     },
     "react-plaid-link": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/react-plaid-link/-/react-plaid-link-3.1.0.tgz",
-      "integrity": "sha512-jTbThGcka3YjpKntGquzmfMXpEhENdbpiGJ97W33McPcqAosdOUCdbBJmm2Ih6hE56exTrISxzpdhOpLD4/emA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/react-plaid-link/-/react-plaid-link-3.2.1.tgz",
+      "integrity": "sha512-GJoqnt28L+JD6Tc62e56Pyfy/RP4CF8b05blvZTFmBxqaPXMsP8a7S/J0wnGVSyN+gAeinSBUa5GPr/dgNHMyw==",
       "requires": {
         "prop-types": "^15.7.2",
-        "react-script-hook": "1.1.0"
+        "react-script-hook": "1.3.0"
       }
     },
     "react-popper": {
@@ -36657,9 +36657,9 @@
       "integrity": "sha512-Hwln1VNuGl/6bVwnd0Xdn1e84gT/8T9aYNL+HAKDArLCS7LWjwr7StE30IEYbIkx0Vi3vs+coQxe+SQDbGbbpA=="
     },
     "react-script-hook": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/react-script-hook/-/react-script-hook-1.1.0.tgz",
-      "integrity": "sha512-swEdGFIOgG4lfi1gdYzFNV28uKuowzbgEGb8Lwi/yp696BVa6RvvuW4a7FY9mic+SecojVlHMWcllygmAg6EJg=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-script-hook/-/react-script-hook-1.3.0.tgz",
+      "integrity": "sha512-VlAyqXywHJHpbJgWoWFWSavXumGAyfW2RD4Jd8DyV/G1n5ufngiaUlCHVvmglvJnysfAYzovcjjkEhSVzcVpuQ=="
     },
     "react-sizeme": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "react-native-unimodules": "^0.13.3",
     "react-native-web": "0.15.7",
     "react-pdf": "^5.2.0",
-    "react-plaid-link": "^3.1.0",
+    "react-plaid-link": "^3.2.0",
     "react-web-config": "^1.0.0",
     "rn-fetch-blob": "^0.12.0",
     "save": "^2.4.0",

--- a/src/components/AddPlaidBankAccount.js
+++ b/src/components/AddPlaidBankAccount.js
@@ -132,10 +132,11 @@ class AddPlaidBankAccount extends React.Component {
                             <ActivityIndicator color={themeColors.spinner} size="large" />
                         </View>
                     )}
-                {!_.isEmpty(this.props.plaidLinkToken) && _.isEmpty(this.state.institution) && (
+                {!_.isEmpty(this.props.plaidLinkToken) && (
                     <PlaidLink
                         token={this.props.plaidLinkToken}
                         onSuccess={({publicToken, metadata}) => {
+                            console.debug('[PlaidLink] Success: ', {publicToken, metadata});
                             getPlaidBankAccounts(publicToken, metadata.institution.name);
                             this.setState({institution: metadata.institution});
                         }}

--- a/src/components/PlaidLink/index.js
+++ b/src/components/PlaidLink/index.js
@@ -10,7 +10,13 @@ const PlaidLink = (props) => {
     const {open, ready, error} = usePlaidLink({
         token: props.token,
         onSuccess,
-        onExit: props.onExit,
+        onExit: (exitError, metadata) => {
+            console.debug('[PlaidLink] Exit: ', {exitError, metadata});
+            props.onExit();
+        },
+        onEvent: (event, metadata) => {
+            console.debug('[PlaidLink] Event: ', {event, metadata});
+        },
     });
 
     useEffect(() => {


### PR DESCRIPTION
cc @aldo-expensify this should fix the bug you ran into on `main`

### Details
We discovered while testing Plaid Link on the web side that the flow is broken after the changes [here](https://github.com/Expensify/App/pull/4962). Taking this opportunity to fix and update Plaid.

### Fixed Issues (Comment)
$ https://github.com/Expensify/App/issues/4785#issuecomment-911996962

### Tests AND QA Steps
1. Start with a non-public domain account that has not yet set up a workspace or bank account
2. Create a new workspace by tapping on the green FAB button
3. Navigate to `/bank-account` by selecting the workspace and tapping the "Get Started" button
4. Tap button to add account via Plaid (Note: This step may take time to complete)
5. Enter test credentials `user_good` `pass_good`
6. Press "Continue"
7. Verify that the account selection dropdown appears

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web
![2021-09-02_10-52-17](https://user-images.githubusercontent.com/32969087/131914537-ca4f2389-c416-4ea3-b8ba-2dd3bb2e245a.png)
![2021-09-02_10-52-27](https://user-images.githubusercontent.com/32969087/131914540-d99cd01c-be8c-496b-93c1-d464b0419151.png)

#### Mobile Web
Skip because they use the same code as web + there is no UI change.

#### Desktop
Skip because they use the same code as web + there is no UI change.

#### iOS
![2021-09-02_11-35-35](https://user-images.githubusercontent.com/32969087/131919438-2f9e3262-e93c-460e-8f3e-0fdac5f190c2.png)
![2021-09-02_11-35-42](https://user-images.githubusercontent.com/32969087/131919443-20809fb8-f0d2-4ed4-b2b1-326e776b2b66.png)

#### Android
![2021-09-02_11-09-44](https://user-images.githubusercontent.com/32969087/131916636-1ef573bc-383c-44b2-9da3-e5492f3f2b53.png)
![2021-09-02_11-09-37](https://user-images.githubusercontent.com/32969087/131916648-3cbc0eb9-dd31-481e-8438-0a56642b37bc.png)
