### PR TITLE
[HOLD https://github.com/Expensify/App/pull/5014/files] Fix wallet balances

### DIFF
--- a/src/components/CurrentWalletBalance.js
+++ b/src/components/CurrentWalletBalance.js
@@ -13,7 +13,7 @@ const propTypes = {
     /** The user's wallet account */
     userWallet: PropTypes.shape({
         /** The user's current wallet balance */
-        availableBalance: PropTypes.number,
+        currentBalance: PropTypes.number,
     }),
 
     ...withLocalizePropTypes,
@@ -35,7 +35,7 @@ const CurrentWalletBalance = (props) => {
     }
 
     const formattedBalance = props.numberFormat(
-        props.userWallet.availableBalance,
+        (props.userWallet.currentBalance / 100),
         {style: 'currency', currency: 'USD'},
     );
     return (

--- a/src/pages/settings/InitialPage.js
+++ b/src/pages/settings/InitialPage.js
@@ -71,7 +71,7 @@ const propTypes = {
     /** The user's wallet account */
     userWallet: PropTypes.shape({
         /** The user's current wallet balance */
-        availableBalance: PropTypes.number,
+        currentBalance: PropTypes.number,
     }),
 
     ...withLocalizePropTypes,
@@ -83,7 +83,7 @@ const defaultProps = {
     session: {},
     policies: {},
     userWallet: {
-        availableBalance: 0,
+        currentBalance: 0,
     },
 };
 
@@ -133,7 +133,7 @@ const InitialSettingsPage = ({
     userWallet,
 }) => {
     const walletBalance = numberFormat(
-        userWallet.availableBalance,
+        (userWallet.currentBalance / 100),
         {style: 'currency', currency: 'USD'},
     );
 


### PR DESCRIPTION
### Details
We store wallet balances as cents, so when we format for display we need to divide by 100 to get dollars and cents. This is common practice across oldDot.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/173151

### Tests
1. Add a balance to your wallet with a query like this:
```SQL
insert into reimbursements values (<next incremental value>, '2021-02-05 19:08:49', 827633, <Your wallet bank account>, -12345, NULL, NULL, NULL, 9, 8, NULL, NULL, NULL);
```
2. Go to the settings page and make sure your balance is $123.45 (not $12345.00)
3. Go to the payments page and make sure your balance is $123.45 (not $12345.00)

### QA Steps
1. Ping @kevinksullivan to test this

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
![2021-09-02_15-39-50](https://user-images.githubusercontent.com/42391420/131919893-e6829394-ea11-4910-ac23-49bc5f5144f9.png)
![2021-09-02_15-39-58](https://user-images.githubusercontent.com/42391420/131919899-82aa01ee-e0b3-4f3e-9808-fc7575fd1451.png)

