### PR TITLE
Fix bad apple app site association

### DIFF
--- a/apple-app-site-association
+++ b/apple-app-site-association
@@ -10,9 +10,9 @@
                     "/setpassword/*",
                     "/details/*",
                     "/v/*",
-                    "/add-bank-account/*",
+                    "/bank-account/*",
                     "/iou/*",
-                    "/enable-payments/*",
+                    "/enable-payments/*"
                 ]
             }
         ]


### PR DESCRIPTION
### Details
Fixes deep links and unblocks testing via deep links on iOS. Seems this has been broken for a minute. But we need QA to test this flow in the latest staging build so I'm asking for a CP.

### Fixed Issues (Comment)
$ https://github.com/Expensify/App/pull/5029#issuecomment-912829890

### Tests

Can't really test this on dev because the universal link needs to be tested on staging after staging web deploys. It uses the JSON file that we are modifying here.

### QA Steps
1. Navigate to `https://staging.new.expensify.com/bank-account`
2. Verify the deep link works

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
