### PR TITLE
Add beta for NL8 and hide display of wallet balance

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -87,6 +87,7 @@ const CONST = {
         PAY_WITH_EXPENSIFY: 'payWithExpensify',
         FREE_PLAN: 'freePlan',
         DEFAULT_ROOMS: 'defaultRooms',
+        BETA_EXPENSIFY_WALLET: 'expensifyWallet',
     },
     BUTTON_STATES: {
         DEFAULT: 'default',

--- a/src/libs/Permissions.js
+++ b/src/libs/Permissions.js
@@ -51,10 +51,19 @@ function canUseDefaultRooms(betas) {
     return _.contains(betas, CONST.BETAS.DEFAULT_ROOMS) || canUseAllBetas(betas);
 }
 
+/**
+ * @param {Array<String>} betas
+ * @returns {Boolean}
+ */
+function canUseWallet(betas) {
+    return _.contains(betas, CONST.BETAS.BETA_EXPENSIFY_WALLET || canUseAllBetas(betas));
+}
+
 export default {
     canUseChronos,
     canUseIOU,
     canUsePayWithExpensify,
     canUseFreePlan,
     canUseDefaultRooms,
+    canUseWallet,
 };

--- a/src/pages/settings/InitialPage.js
+++ b/src/pages/settings/InitialPage.js
@@ -28,6 +28,7 @@ import withLocalize, {withLocalizePropTypes} from '../../components/withLocalize
 import compose from '../../libs/compose';
 import CONST from '../../CONST';
 import DateUtils from '../../libs/DateUtils';
+import Permissions from '../../libs/Permissions';
 
 const propTypes = {
     /* Onyx Props */
@@ -74,6 +75,9 @@ const propTypes = {
         availableBalance: PropTypes.number,
     }),
 
+    /** List of betas available to current user */
+    betas: PropTypes.arrayOf(PropTypes.string),
+
     ...withLocalizePropTypes,
 };
 
@@ -85,6 +89,7 @@ const defaultProps = {
     userWallet: {
         availableBalance: 0,
     },
+    betas: [],
 };
 
 const defaultMenuItems = [
@@ -131,6 +136,7 @@ const InitialSettingsPage = ({
     policies,
     translate,
     userWallet,
+    betas
 }) => {
     const walletBalance = numberFormat(
         userWallet.availableBalance,
@@ -207,7 +213,7 @@ const InitialSettingsPage = ({
                                 iconStyles={item.iconStyles}
                                 iconFill={item.iconFill}
                                 shouldShowRightIcon
-                                badgeText={isPaymentItem ? walletBalance : undefined}
+                                badgeText={(isPaymentItem && Permissions.canUseWallet(betas)) ? walletBalance : undefined}
                             />
                         );
                     })}
@@ -238,6 +244,9 @@ export default compose(
         },
         userWallet: {
             key: ONYXKEYS.USER_WALLET,
+        },
+        betas: {
+            key: ONYXKEYS.BETAS,
         },
     }),
 )(InitialSettingsPage);

--- a/src/pages/settings/InitialPage.js
+++ b/src/pages/settings/InitialPage.js
@@ -136,7 +136,7 @@ const InitialSettingsPage = ({
     policies,
     translate,
     userWallet,
-    betas
+    betas,
 }) => {
     const walletBalance = numberFormat(
         userWallet.availableBalance,

--- a/src/pages/settings/Payments/PaymentsPage.js
+++ b/src/pages/settings/Payments/PaymentsPage.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import {View} from 'react-native';
+import {withOnyx} from 'react-native-onyx';
+import PropTypes from 'prop-types';
 import PaymentMethodList from './PaymentMethodList';
 import ROUTES from '../../../ROUTES';
 import HeaderWithCloseButton from '../../../components/HeaderWithCloseButton';
@@ -16,9 +18,7 @@ import {PayPal} from '../../../components/Icon/Expensicons';
 import MenuItem from '../../../components/MenuItem';
 import getClickedElementLocation from '../../../libs/getClickedElementLocation';
 import CurrentWalletBalance from '../../../components/CurrentWalletBalance';
-import {withOnyx} from 'react-native-onyx';
 import ONYXKEYS from '../../../ONYXKEYS';
-import PropTypes from 'prop-types';
 import Permissions from '../../../libs/Permissions';
 
 const PAYPAL = 'payPalMe';

--- a/src/pages/settings/Payments/PaymentsPage.js
+++ b/src/pages/settings/Payments/PaymentsPage.js
@@ -16,15 +16,22 @@ import {PayPal} from '../../../components/Icon/Expensicons';
 import MenuItem from '../../../components/MenuItem';
 import getClickedElementLocation from '../../../libs/getClickedElementLocation';
 import CurrentWalletBalance from '../../../components/CurrentWalletBalance';
+import {withOnyx} from 'react-native-onyx';
+import ONYXKEYS from '../../../ONYXKEYS';
+import PropTypes from 'prop-types';
+import Permissions from '../../../libs/Permissions';
 
 const PAYPAL = 'payPalMe';
 
 const propTypes = {
     ...withLocalizePropTypes,
+
+    /** List of betas available to current user */
+    betas: PropTypes.arrayOf(PropTypes.string),
 };
 
 const defaultProps = {
-    payPalMeUsername: '',
+    betas: [],
 };
 
 class PaymentsPage extends React.Component {
@@ -103,7 +110,9 @@ class PaymentsPage extends React.Component {
                         onCloseButtonPress={() => Navigation.dismissModal(true)}
                     />
                     <View>
-                        <CurrentWalletBalance />
+                        {
+                            Permissions.canUseWallet(this.props.betas) && <CurrentWalletBalance />
+                        }
                         <Text
                             style={[styles.ph5, styles.formLabel]}
                         >
@@ -141,4 +150,9 @@ PaymentsPage.displayName = 'PaymentsPage';
 
 export default compose(
     withLocalize,
+    withOnyx({
+        betas: {
+            key: ONYXKEYS.BETAS,
+        },
+    }),
 )(PaymentsPage);


### PR DESCRIPTION
### Details
Just adding a beta and hiding some features that can't currently be used

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/176415

### Tests
1. Change [this line](https://github.com/Expensify/App/blob/38d6caf7f4178d474bbf6c59279d433f59c13261/src/libs/Permissions.js#L11) to always return false
1. Open settings and make sure your wallet balance is not next to the "payments" button
2. Go to the payments page and make sure you can't see your wallet balance
3. 
### QA Steps
1. Open settings and make sure your wallet balance is not next to the "payments" button
2. Go to the payments page and make sure you can't see your wallet balance

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
![2021-09-03_17-23-04](https://user-images.githubusercontent.com/42391420/132074101-0107cc4d-e6de-4510-b216-5fcdfb361935.png)
-
![2021-09-03_17-23-15](https://user-images.githubusercontent.com/42391420/132074107-a4684589-0f38-43b4-9345-60db20b23ba3.png)
