### PR TITLE
Remove green color from new password form hint

### DIFF
--- a/src/pages/settings/NewPasswordForm.js
+++ b/src/pages/settings/NewPasswordForm.js
@@ -67,8 +67,8 @@ class NewPasswordForm extends React.Component {
 
     /**
      * checks if the password invalid
-     * @returns boolean
-     */
+     * @returns {Boolean}
+    */
     isInvalidPassword() {
         return this.state.passwordHintError && this.props.password && !this.isValidPassword();
     }
@@ -106,7 +106,7 @@ class NewPasswordForm extends React.Component {
                         style={[
                             styles.textLabelSupporting,
                             styles.mt1,
-                            this.isInvalidPassword() && styles.formError
+                            this.isInvalidPassword() && styles.formError,
                         ]}
                     >
                         {this.props.translate('setPasswordPage.newPasswordPrompt')}

--- a/src/pages/settings/NewPasswordForm.js
+++ b/src/pages/settings/NewPasswordForm.js
@@ -65,6 +65,14 @@ class NewPasswordForm extends React.Component {
         return this.props.password.match(CONST.PASSWORD_COMPLEXITY_REGEX_STRING);
     }
 
+    /**
+     * checks if the password invalid
+     * @returns boolean
+     */
+    isInvalidPassword() {
+        return this.state.passwordHintError && this.props.password && !this.isValidPassword();
+    }
+
     doPasswordsMatch() {
         return this.props.password === this.state.confirmNewPassword;
     }
@@ -82,14 +90,6 @@ class NewPasswordForm extends React.Component {
     }
 
     render() {
-        let passwordHintStyle;
-        if (this.state.passwordHintError && this.props.password && !this.isValidPassword()) {
-            passwordHintStyle = styles.formError;
-        }
-        if (this.isValidPassword()) {
-            passwordHintStyle = styles.formSuccess;
-        }
-
         return (
             <>
                 <View style={styles.mb6}>
@@ -102,7 +102,13 @@ class NewPasswordForm extends React.Component {
                         onChangeText={password => this.props.updatePassword(password)}
                         onBlur={() => this.onBlurNewPassword()}
                     />
-                    <Text style={[styles.textLabelSupporting, styles.mt1, passwordHintStyle]}>
+                    <Text
+                        style={[
+                            styles.textLabelSupporting,
+                            styles.mt1,
+                            this.isInvalidPassword() && styles.formError
+                        ]}
+                    >
                         {this.props.translate('setPasswordPage.newPasswordPrompt')}
                     </Text>
                 </View>


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Removes green hint color

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/4723
--->
$ https://github.com/Expensify/App/issues/4660

### Tests
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->
1. Create a new account
2. Click on the magic link
3. Validate there's no green color on new password hint

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
### Initial
<img width="375" alt="Screen Shot 2021-09-05 at 02 39 45" src="https://user-images.githubusercontent.com/11542415/132109230-37e2be7a-12fb-404e-9d54-9d469df2b2bb.png">

### With invalid password
<img width="374" alt="Screen Shot 2021-09-05 at 02 40 00" src="https://user-images.githubusercontent.com/11542415/132109245-e3533ce1-0cdb-4168-ae2f-139d66cc0686.png">

### With valid password
<img width="374" alt="Screen Shot 2021-09-05 at 02 40 16" src="https://user-images.githubusercontent.com/11542415/132109254-1c72985c-a363-4039-a933-cfe5a0d42f4a.png">
