### PR TITLE
Download button removed from upload attachment preview modal

### DIFF
--- a/src/components/AttachmentModal.js
+++ b/src/components/AttachmentModal.js
@@ -133,7 +133,7 @@ class AttachmentModal extends PureComponent {
                             ? this.props.translate('reportActionCompose.sendAttachment')
                             : this.props.translate('common.attachment')}
                         shouldShowBorderBottom
-                        shouldShowDownloadButton
+                        shouldShowDownloadButton={!this.props.isUploadingAttachment}
                         onDownloadButtonPress={() => fileDownload(sourceURL)}
                         onCloseButtonPress={() => this.setState({isModalOpen: false})}
                     />


### PR DESCRIPTION
### Details
Download button removed from upload attachment preview modal.

### Fixed Issues
$ https://github.com/Expensify/App/issues/5066

### Tests and QA Steps
1. Run Web, Mobile Web, Desktop, iOS, or Android version.
2. Open any Chat
3. Click + (Actions) button, Click Add Attachment
4. Choose Image or any document to upload.
5. Once image/document selected it shows Send attachment preview modal. We removed download button, so now download button will not show within Upload attachment preview modal. 

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web
<img width="1101" alt="Web1" src="https://user-images.githubusercontent.com/7823358/132236662-e3ca0196-0ceb-48e3-803d-234b5d32c5fb.png">

#### Mobile Web
<img width="431" alt="MobileWeb" src="https://user-images.githubusercontent.com/7823358/132236705-eeede3d2-c088-46d7-b8c1-a1651db0c916.png">

#### Desktop
<img width="1275" alt="Desktop" src="https://user-images.githubusercontent.com/7823358/132236768-989eca16-796a-4e63-979e-59ede7e02d95.png">

#### iOS
<img width="475" alt="iOS1" src="https://user-images.githubusercontent.com/7823358/132236815-bf47e5b6-374a-4d8e-a96e-be05ad940b80.png">

#### Android
<img width="600" alt="Android" src="https://user-images.githubusercontent.com/7823358/132236865-3ea28001-1f8f-416a-a50c-4ade5d5a1374.jpg">

