### PR TITLE
Make staging secure endpoint toggle on staging

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -132,6 +132,7 @@ const CONST = {
     MANAGE_CARDS_URL: '/domain_companycards',
     FEES_URL: 'https://use.expensify.com/fees',
     CFPB_PREPAID_URL: 'https://cfpb.gov/prepaid',
+    STAGING_SECURE_URL: 'https://staging-secure.expensify.com/',
     NEWDOT: 'new.expensify.com',
     OPTION_TYPE: {
         REPORT: 'report',

--- a/src/libs/actions/User.js
+++ b/src/libs/actions/User.js
@@ -268,6 +268,13 @@ function subscribeToUserEvents() {
         });
 }
 
+/**
+ * @param {Boolean} shouldUseSecureStaging
+ */
+function setShouldUseSecureStaging(shouldUseSecureStaging) {
+    Onyx.merge(ONYXKEYS.USER, {shouldUseSecureStaging});
+}
+
 export {
     changePassword,
     getBetas,
@@ -279,4 +286,5 @@ export {
     isBlockedFromConcierge,
     getDomainInfo,
     subscribeToUserEvents,
+    setShouldUseSecureStaging,
 };

--- a/src/pages/settings/PreferencesPage.js
+++ b/src/pages/settings/PreferencesPage.js
@@ -12,12 +12,13 @@ import styles from '../../styles/styles';
 import Text from '../../components/Text';
 import NameValuePair from '../../libs/actions/NameValuePair';
 import CONST from '../../CONST';
-import {setExpensifyNewsStatus} from '../../libs/actions/User';
+import {setExpensifyNewsStatus, setShouldUseSecureStaging} from '../../libs/actions/User';
 import ScreenWrapper from '../../components/ScreenWrapper';
 import Switch from '../../components/Switch';
 import withLocalize, {withLocalizePropTypes} from '../../components/withLocalize';
 import compose from '../../libs/compose';
 import ExpensiPicker from '../../components/ExpensiPicker';
+import withEnvironment, {environmentPropTypes} from '../../components/withEnvironment';
 
 const propTypes = {
     /** The chat priority mode */
@@ -27,9 +28,11 @@ const propTypes = {
     user: PropTypes.shape({
         /** Whether or not the user is subscribed to news updates */
         expensifyNewsStatus: PropTypes.bool,
+        shouldUseSecureStaging: PropTypes.bool,
     }),
 
     ...withLocalizePropTypes,
+    ...environmentPropTypes,
 };
 
 const defaultProps = {
@@ -38,7 +41,7 @@ const defaultProps = {
 };
 
 const PreferencesPage = ({
-    priorityMode, user, translate,
+    priorityMode, user, translate, environment,
 }) => {
     const priorityModes = {
         default: {
@@ -95,6 +98,29 @@ const PreferencesPage = ({
                     <View style={[styles.mb2]}>
                         <LocalePicker />
                     </View>
+
+                    {/* If we are in the staging environment then we have the option to switch from using the staging secure endpoint or the production secure endpoint. This enables QA */}
+                    {/* and internal testers to take advantage of sandbox environments for 3rd party services like Plaid and Onfido */}
+                    {environment === CONST.ENVIRONMENT.STAGING && (
+                        <>
+                            <Text style={[styles.formLabel]} numberOfLines={1}>
+                                Test Preferences
+                            </Text>
+                            <View style={[styles.flexRow, styles.mb6, styles.justifyContentBetween]}>
+                                <View style={styles.flex4}>
+                                    <Text>
+                                        Use Secure Staging Server
+                                    </Text>
+                                </View>
+                                <View style={[styles.flex1, styles.alignItemsEnd]}>
+                                    <Switch
+                                        isOn={user.shouldUseSecureStaging || false}
+                                        onToggle={setShouldUseSecureStaging}
+                                    />
+                                </View>
+                            </View>
+                        </>
+                    )}
                 </View>
             </View>
         </ScreenWrapper>
@@ -106,6 +132,7 @@ PreferencesPage.defaultProps = defaultProps;
 PreferencesPage.displayName = 'PreferencesPage';
 
 export default compose(
+    withEnvironment,
     withLocalize,
     withOnyx({
         priorityMode: {


### PR DESCRIPTION
### Details
Staging versions of the apps are not able to connect with Plaid test credentials in the native apps because we always use the `.env.production` credentials there. This change is necessary so that we can ask QA (and internal testers) to test the VBA flow in TestFlight and Google Play store versions of the app.

### Fixed Issues
$ https://github.com/Expensify/App/issues/5075

### Tests

Tested that the app continued to work normally on dev builds + web. The specific change here is not easy to test locally since the app needs to be a "beta" version. But we can force it by applying this diff:

```diff
diff --git a/src/pages/settings/PreferencesPage.js b/src/pages/settings/PreferencesPage.js
index 2a659c3f2..93b36c317 100755
--- a/src/pages/settings/PreferencesPage.js
+++ b/src/pages/settings/PreferencesPage.js
@@ -101,26 +101,26 @@ const PreferencesPage = ({

                     {/* If we are in the staging environment then we have the option to switch from using the staging secure endpoint or the production secure endpoint. This enables QA */}
                     {/* and internal testers to take advantage of sandbox environments for 3rd party services like Plaid and Onfido */}
-                    {environment === CONST.ENVIRONMENT.STAGING && (
-                        <>
-                            <Text style={[styles.formLabel]} numberOfLines={1}>
-                                Test Preferences
-                            </Text>
-                            <View style={[styles.flexRow, styles.mb6, styles.justifyContentBetween]}>
-                                <View style={styles.flex4}>
-                                    <Text>
-                                        Use Secure Staging Server
-                                    </Text>
-                                </View>
-                                <View style={[styles.flex1, styles.alignItemsEnd]}>
-                                    <Switch
-                                        isOn={user.shouldUseSecureStaging || false}
-                                        onToggle={setShouldUseSecureStaging}
-                                    />
-                                </View>
+                    {/* {environment === CONST.ENVIRONMENT.STAGING && ( */}
+                    <>
+                        <Text style={[styles.formLabel]} numberOfLines={1}>
+                            Test Preferences
+                        </Text>
+                        <View style={[styles.flexRow, styles.mb6, styles.justifyContentBetween]}>
+                            <View style={styles.flex4}>
+                                <Text>
+                                    Use Secure Staging Server
+                                </Text>
+                            </View>
+                            <View style={[styles.flex1, styles.alignItemsEnd]}>
+                                <Switch
+                                    isOn={user.shouldUseSecureStaging || false}
+                                    onToggle={setShouldUseSecureStaging}
+                                />
                             </View>
-                        </>
-                    )}
+                        </View>
+                    </>
+                    {/* )} */}
                 </View>
             </View>
         </ScreenWrapper>
```
Keep in mind that if you do this then you will effectively be pointing the built app at the staging server and you won't be authenticated. So in order to test this you should also edit your `.env` to use the production credentials and then verify that the staging secure server is getting hit instead of production when following the rest of QA steps.

### QA Steps
1. With the app installed on the device navigate to settings
2. Tap "Preferences"
3. Verify that a new section called "Test Preferences" appears
4. Tap the "Use Secure Staging Server" toggle and verify it changes
5. Navigate back to Settings and then back to preferences and verify the change sticks
5. Navigate to [staging.new.expensify.com/bank-account](https://staging.new.expensify.com/bank-account/new)
1. Select the option to log in to bank account
1. Enter the test credentials (bank: `Chase` user: `user_good` pass: `pass_good`)
2. Verify there are no errors and you are able to continue to the next screen with these credentials

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
![2021-09-07_13-01-18](https://user-images.githubusercontent.com/32969087/132421026-e408cc50-8f29-473b-b754-969810d93589.png)
![2021-09-07_13-01-29](https://user-images.githubusercontent.com/32969087/132421042-0ff7c6d3-eb60-4437-b4ab-8ef794195bd1.png)
![2021-09-07_13-01-38](https://user-images.githubusercontent.com/32969087/132421053-f449f833-18cf-4b37-beb2-2bf3207ebed8.png)
