### PR TITLE
Fix exitTo link by adding missing ?

### DIFF
--- a/src/libs/actions/App.js
+++ b/src/libs/actions/App.js
@@ -49,7 +49,7 @@ function setLocale(locale) {
  */
 function openSignedInLink(url = '') {
     API.GetAccountValidateCode().then((response) => {
-        const exitToURL = url ? `exitTo=${url}` : '';
+        const exitToURL = url ? `?exitTo=${url}` : '';
         const validateCodeUrl = `v/${currentUserAccountID}/${response.validateCode}${exitToURL}`;
         Linking.openURL(CONFIG.EXPENSIFY.URL_EXPENSIFY_COM + validateCodeUrl);
     });


### PR DESCRIPTION
@roryabraham or @tgolen 

Fix link by adding missing `?`

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/5105

Original PR: https://github.com/Expensify/App/pull/4789/files#diff-fed84caebc7e71b17fe9ac17cd04c5ec5aa8ce8a9f2ddc2ad33eb77253560a2eL91

### Tests
Strangely annoying. Need to setup a workspace where you have the cards enabled so that you can click "manage cards"

![image](https://user-images.githubusercontent.com/12980144/132553895-c13f85ae-188e-48a9-9539-57e606807891.png)


### QA Steps


### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
