### PR TITLE
Automatically open bank setup modal if user has incomplete bank setup

### DIFF
--- a/src/pages/workspace/WorkspaceCardPage.js
+++ b/src/pages/workspace/WorkspaceCardPage.js
@@ -90,12 +90,19 @@ const WorkspaceCardPage = ({
     const isNotAutoProvisioned = !user.isUsingExpensifyCard
         && lodashGet(reimbursementAccount, 'achData.state', '') === BankAccount.STATE.OPEN;
     let buttonText;
+
+    const openBankSetupModal = () => {
+        setWorkspaceIDForReimbursementAccount(route.params.policyID);
+        Navigation.navigate(ROUTES.getBankAccountRoute());
+    };
+
     if (user.isFromPublicDomain) {
         buttonText = translate('workspace.card.addEmail');
     } else if (user.isUsingExpensifyCard) {
         buttonText = translate('workspace.card.manageCards');
     } else if (isVerifying || isPending || isNotAutoProvisioned) {
         buttonText = translate('workspace.card.finishSetup');
+        openBankSetupModal();
     } else {
         buttonText = translate('workspace.card.getStarted');
     }
@@ -106,8 +113,7 @@ const WorkspaceCardPage = ({
         } else if (user.isUsingExpensifyCard) {
             openSignedInLink(CONST.MANAGE_CARDS_URL);
         } else {
-            setWorkspaceIDForReimbursementAccount(route.params.policyID);
-            Navigation.navigate(ROUTES.getBankAccountRoute());
+            openBankSetupModal();
         }
     };
 


### PR DESCRIPTION
@ctkochan22, please review when you get the chance


### Details
Now makes it so that the `Finish Setup` modal automatically opens when landing on the `Workspace/Card` settings if the user started working on a bank account.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/176437

### Tests
Same as Web QA, but done locally (easier since you can make up domains that don't have the expensify card yet).

### QA Steps
Reach out to Amal (@TomatoToaster) to help test this. The first condition is tough since most domains we control already have the Expensify Card in the domain. 

1. Create a new account on NewDot that has access to the freePlan beta who's domain d
2. Create a workspace from clicking the plus on the bottom right:
![image](https://user-images.githubusercontent.com/19364431/131395552-c72c5b53-3d0d-4f36-b49b-c3c86c1bb322.png)

3. Click on `Get Started` and follow the steps in this S/O for `To create a PENDING bank account`: https://stackoverflow.com/c/expensify/questions/342. HOWEVER, in between the steps. Close the bank setup modal and the Workspace/Card modal and reopen the workspace  modal.

![image](https://user-images.githubusercontent.com/19364431/132579939-483995fa-84d9-4996-814d-a4e79cdbb75e.png)


4. Verify that when you reopen the modal `Workspace/Card` modal it also opens the 

5. Delete the bank account in OldDot and verify when you go back to the workspace settings in NewDot, the bank account modal does not automatiaclly open (it should also not say `finish setup`).

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
Screenshots included in QA steps
