### PR TITLE
Added validation for age in Bank Requestor Form

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -396,6 +396,7 @@ export default {
             tooManyAttempts: 'Due to a high number of login attempts, this option has been temporarily disabled for 24 hours. Please try again later or manually enter details instead.',
             address: 'Please enter a valid address',
             dob: 'Please enter a valid date of birth',
+            age: 'Requestors must be over 18 years old',
             ssnLast4: 'Please enter valid last 4 digits of SSN',
             noDefaultDepositAccountOrDebitCardAvailable: 'Please add a default deposit bank account or debit card',
             existingOwners: {

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -396,6 +396,7 @@ export default {
             tooManyAttempts: 'Debido a la gran cantidad de intentos de inicio de sesión, esta opción se ha desactivado temporalmente durante 24 horas. Vuelva a intentarlo más tarde o introduzca los detalles manualmente.',
             address: 'Ingrese una dirección válida',
             dob: 'Ingrese una fecha de nacimiento válida',
+            age: 'Los solicitantes deben ser mayores de 18 años',
             ssnLast4: 'Ingrese los últimos 4 dígitos del número de seguro social',
             noDefaultDepositAccountOrDebitCardAvailable: 'Por favor agregue una cuenta bancaria para depósitos o una tarjeta de débito',
             existingOwners: {

--- a/src/libs/ValidationUtils.js
+++ b/src/libs/ValidationUtils.js
@@ -69,6 +69,15 @@ function isValidSSNLastFour(ssnLast4) {
 }
 
 /**
+ *
+ * @param {String} date
+ * @returns {Boolean}
+ */
+function isValidAge(date) {
+    return moment().diff(moment(date), 'years') >= 18;
+}
+
+/**
  * @param {Object} identity
  * @returns {Boolean}
  */
@@ -93,6 +102,12 @@ function isValidIdentity(identity) {
 
     if (!isValidDate(identity.dob)) {
         showBankAccountFormValidationError(translateLocal('bankAccount.error.dob'));
+        showBankAccountErrorModal();
+        return false;
+    }
+
+    if (!isValidAge(identity.dob)) {
+        showBankAccountFormValidationError(translateLocal('bankAccount.error.age'));
         showBankAccountErrorModal();
         return false;
     }

--- a/src/pages/ReimbursementAccount/IdentityForm.js
+++ b/src/pages/ReimbursementAccount/IdentityForm.js
@@ -94,12 +94,12 @@ const IdentityForm = ({
                 placeholder={translate('common.dateFormat')}
                 value={dob}
                 onChangeText={(val) => {
-                    if (error === translateLocal('bankAccount.error.dob')) {
+                    if (error === translateLocal('bankAccount.error.dob') || error === translateLocal('bankAccount.error.age')) {
                         hideBankAccountErrors();
                     }
                     onFieldChange('dob', val);
                 }}
-                errorText={error === translateLocal('bankAccount.error.dob') ? error : ''}
+                errorText={error === translateLocal('bankAccount.error.dob') || error === translateLocal('bankAccount.error.age') ? error : ''}
             />
             <ExpensiTextInput
                 label={`${translate('common.ssnLast4')}`}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

@pecanoro Can you please review this PR?

### Details
- Added age validation to the date field of Bank Account Requestor 

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/4723
--->
$ https://github.com/Expensify/App/issues/5030

### Tests
1. Tested by entering date > 18 years
2. Tested by entering date < 18 years
3. 
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### QA Steps
1. Go to `bank-account/requestor` step
2. Fill in date that is lesser than 18 years
3. It should show a validation message of age for the given date.
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<img width="421" alt="web-date-valid" src="https://user-images.githubusercontent.com/57435789/132599230-694d5035-c51a-499e-82d7-27d0d6cc3372.png">
<img width="564" alt="web-date-error" src="https://user-images.githubusercontent.com/57435789/132599234-fc37d153-502d-4403-9a2e-a6cb885abf39.png">

#### Mobile Web
<img width="345" alt="mweb-date-valid" src="https://user-images.githubusercontent.com/57435789/132599311-6a5bece1-dc20-4244-a14d-1e1f088c2779.png">
<img width="350" alt="mweb-date-error" src="https://user-images.githubusercontent.com/57435789/132599314-cc8b7bfa-0433-489f-b35a-f21c6c2b31f3.png">

#### Desktop
<img width="390" alt="desktop-date-valid" src="https://user-images.githubusercontent.com/57435789/132599337-713e6951-e72d-43f0-ac57-8ca01289d125.png">
<img width="478" alt="desktop-date-error" src="https://user-images.githubusercontent.com/57435789/132599342-0593c393-5c7a-4fe0-a797-866bdf949af1.png">


#### iOS
<img width="347" alt="ios-date-valid" src="https://user-images.githubusercontent.com/57435789/132599401-dfb816ca-ebe7-44b4-854b-2c29844d6b60.png">
<img width="330" alt="ios-date-error" src="https://user-images.githubusercontent.com/57435789/132599406-32620c56-1c3f-4bdc-b94e-dfdb005361a8.png">


#### Android
<img width="331" alt="android-date-valid" src="https://user-images.githubusercontent.com/57435789/132600046-6711a86c-4d09-41d7-9ffc-10b90fd2daaa.png">
<img width="323" alt="android-date-error" src="https://user-images.githubusercontent.com/57435789/132600053-fcd61310-7119-4f01-95ac-fe194f1b85c3.png">

