### PR TITLE
Change "Requestor Information" to "Personal Information" and make requirements clearer in VBA flow

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -532,7 +532,8 @@ export default {
         companyPhonePlaceholder: '10 digits, no hyphens',
     },
     requestorStep: {
-        headerTitle: 'Requestor information',
+        headerTitle: 'Personal information',
+        subtitle: 'Please provide your personal information.',
         financialRegulations: 'Financial regulation and bank rules require us to validate the identity of any individual setting up bank accounts on behalf of a company. ',
         learnMore: 'Learn more',
         isMyDataSafe: 'Is my data safe?',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -534,7 +534,8 @@ export default {
         companyPhonePlaceholder: '10 dígitos, sin guiones',
     },
     requestorStep: {
-        headerTitle: 'Información del solicitante',
+        headerTitle: 'Información personal',
+        subtitle: 'Dé más información sobre tí.',
         financialRegulations: 'Las leyes fiscales y el reglamento bancario nos obliga a verificar la identidad de todo individuo que desee añadir una cuenta bancaria representando a una compañía. ',
         learnMore: 'Más información',
         isMyDataSafe: '¿Están seguros mis datos?',

--- a/src/pages/ReimbursementAccount/ReimbursementAccountPage.js
+++ b/src/pages/ReimbursementAccount/ReimbursementAccountPage.js
@@ -144,7 +144,7 @@ class ReimbursementAccountPage extends React.Component {
             case CONST.BANK_ACCOUNT.STEP.COMPANY:
                 return 'company';
             case CONST.BANK_ACCOUNT.STEP.REQUESTOR:
-                return 'requestor';
+                return 'personal-information';
             case CONST.BANK_ACCOUNT.STEP.ACH_CONTRACT:
                 return 'contract';
             case CONST.BANK_ACCOUNT.STEP.VALIDATION:

--- a/src/pages/ReimbursementAccount/RequestorStep.js
+++ b/src/pages/ReimbursementAccount/RequestorStep.js
@@ -136,7 +136,7 @@ class RequestorStep extends React.Component {
                         <ScrollView style={[styles.flex1, styles.w100]}>
                             <View style={[styles.p4]}>
                                 <Text>{this.props.translate('requestorStep.subtitle')}</Text>
-                                <View style={[styles.mb5, styles.dFlex, styles.flexRow]}>
+                                <View style={[styles.mb5, styles.mt1, styles.dFlex, styles.flexRow]}>
                                     <TextLink
                                         style={[styles.textMicro]}
                                         // eslint-disable-next-line max-len

--- a/src/pages/ReimbursementAccount/RequestorStep.js
+++ b/src/pages/ReimbursementAccount/RequestorStep.js
@@ -135,6 +135,24 @@ class RequestorStep extends React.Component {
                     <>
                         <ScrollView style={[styles.flex1, styles.w100]}>
                             <View style={[styles.p4]}>
+                                <Text>{this.props.translate('requestorStep.subtitle')}</Text>
+                                <View style={[styles.mb5, styles.dFlex, styles.flexRow]}>
+                                    <TextLink
+                                        style={[styles.textMicro]}
+                                        // eslint-disable-next-line max-len
+                                        href="https://community.expensify.com/discussion/6983/faq-why-do-i-need-to-provide-personal-documentation-when-setting-up-updating-my-bank-account"
+                                    >
+                                        {`${this.props.translate('requestorStep.learnMore')}`}
+                                    </TextLink>
+                                    <Text style={[styles.textMicroSupporting]}>{' | '}</Text>
+                                    <TextLink
+                                        style={[styles.textMicro, styles.textLink]}
+                                        // eslint-disable-next-line max-len
+                                        href="https://community.expensify.com/discussion/5677/deep-dive-security-how-expensify-protects-your-information"
+                                    >
+                                        {`${this.props.translate('requestorStep.isMyDataSafe')}`}
+                                    </TextLink>
+                                </View>
                                 <IdentityForm
                                     onFieldChange={(field, value) => this.onFieldChange(field, value)}
                                     values={{
@@ -165,21 +183,6 @@ class RequestorStep extends React.Component {
                                 />
                                 <Text style={[styles.textMicroSupporting, styles.mt5]}>
                                     {this.props.translate('requestorStep.financialRegulations')}
-                                    <TextLink
-                                        style={styles.textMicro}
-                                        // eslint-disable-next-line max-len
-                                        href="https://community.expensify.com/discussion/6983/faq-why-do-i-need-to-provide-personal-documentation-when-setting-up-updating-my-bank-account"
-                                    >
-                                        {`${this.props.translate('requestorStep.learnMore')}`}
-                                    </TextLink>
-                                    {' | '}
-                                    <TextLink
-                                        style={styles.textMicro}
-                                        // eslint-disable-next-line max-len
-                                        href="https://community.expensify.com/discussion/5677/deep-dive-security-how-expensify-protects-your-information"
-                                    >
-                                        {`${this.props.translate('requestorStep.isMyDataSafe')}`}
-                                    </TextLink>
                                 </Text>
                                 <Text style={[styles.mt3, styles.textMicroSupporting]}>
                                     {this.props.translate('requestorStep.onFidoConditions')}


### PR DESCRIPTION
### Details
This PR changes `Requestor information` to `Personal information`, as well as updates the URL to the step and adds a clarifying line below the header text.

### Fixed Issues
$ https://github.com/Expensify/App/issues/5081

### Tests
1. Login to an account with a Workspace, but without a bank account setup.
2. Open the VBA flow by clicking on `Settings > Select Workspace > Get Started`
3. Fill the form until you get to the `Personal information` step. You can add [these credentials](https://stackoverflow.com/c/expensify/questions/342/525#525) if needed.
4. Verify that it looks like the screenshots below.

### QA Steps
Steps above.

### Tested On

- [X] Web
- [X] Mobile Web
- [X] Desktop
- [X] iOS
- [X] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
![web](https://user-images.githubusercontent.com/22219519/132602172-128ef5bd-6669-4d35-828c-f377677b38ac.png)

#### Mobile Web
![mWeb](https://user-images.githubusercontent.com/22219519/132602177-34499ff4-51d5-4060-8538-93ddfb19c6f7.png)

#### Desktop
<img width="1204" alt="desktop" src="https://user-images.githubusercontent.com/22219519/132602184-1fe1c8eb-2284-4fec-bbba-ca8d66855b64.png">

#### iOS
![ios](https://user-images.githubusercontent.com/22219519/132602192-369c8023-0574-4793-bf79-c025040837ec.png)

#### Android
![android](https://user-images.githubusercontent.com/22219519/132602275-fe65f7b9-746e-42de-ae8f-6f9bf2a62ac1.png)


