### PR TITLE
fix unread marking logic for mobile on visibility change

### DIFF
--- a/src/libs/Visibility/index.native.js
+++ b/src/libs/Visibility/index.native.js
@@ -1,10 +1,12 @@
 // Mobile apps do not require this check for visibility as
 // they do not use the Notification lib.
 
+import {AppState} from 'react-native';
+
 /**
  * @return {Boolean}
  */
-const isVisible = () => true;
+const isVisible = () => AppState.currentState === 'active';
 
 export default {
     isVisible,

--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -129,7 +129,12 @@ class ReportActionsView extends React.Component {
                 this.scrollToListBottom();
             }
         });
-        updateLastReadActionID(this.props.reportID);
+
+        // Only mark as read if the report is open
+        if (!this.props.isDrawerOpen) {
+            updateLastReadActionID(this.props.reportID);
+        }
+
         this.updateUnreadIndicatorPosition(this.props.report.unreadActionCount);
         fetchActions(this.props.reportID);
     }
@@ -229,7 +234,8 @@ class ReportActionsView extends React.Component {
      * Records the max action on app visibility change event.
      */
     onVisibilityChange() {
-        if (Visibility.isVisible()) {
+        // only mark as read if visible AND report is open.
+        if (Visibility.isVisible() && !this.props.isDrawerOpen) {
             updateLastReadActionID(this.props.reportID);
         }
     }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
1. Fix the `isVisible` native implementation by using the [`AppState.currentState`](https://reactnative.dev/docs/0.64/appstate#currentstate) to determine the state app is in.
2. Only mark as read when the report is actually open by checking `this.props.isDrawerOpen`.


### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/4855
--->
$ https://github.com/Expensify/App/issues/4855

### Tests
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

1. Open any report.
2. Mark any message as unread.
3. Background or quit the app
4. Reopen the app and report
5. Verify the message remains unread
6. Repeat the steps for web, desktop and mobile web to see this does not break any current mark-read functionality on these platforms.

### QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

1. Open any report.
2. Mark any message as unread.
3. Background or quit the app
4. Reopen the app and report
5. Verify the message remains unread
6. Repeat the steps for web, desktop and mobile web to see this does not break any current mark-read functionality on these platforms.
### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [x] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web


https://user-images.githubusercontent.com/7620533/133232750-917db0d6-5f62-44ba-9c1f-fc4b6914baaf.mov


https://user-images.githubusercontent.com/7620533/133232784-cf97a0b8-8b9e-41eb-9b18-3428e8af331a.mov



#### Mobile Web

Not needed, native mobile bug only.

#### Desktop

Not needed, native mobile bug only.

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

https://user-images.githubusercontent.com/7620533/132639399-24605ef9-32ea-4b39-8acd-5d8243fb0c5c.mp4


#### Android

Would need help testing this.
