### PR TITLE
Handle all relative links internally

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -1,6 +1,5 @@
 const CLOUDFRONT_URL = 'https://d2k5nsl2zxldvw.cloudfront.net';
 const NEW_EXPENSIFY_URL = 'https://new.expensify.com';
-const NEW_EXPENSIFY_STAGING_URL = 'https://staging.new.expensify.com';
 
 const CONST = {
     // 50 megabytes in bytes
@@ -137,7 +136,6 @@ const CONST = {
     STAGING_SECURE_URL: 'https://staging-secure.expensify.com/',
     NEWDOT: 'new.expensify.com',
     NEW_EXPENSIFY_URL,
-    NEW_EXPENSIFY_STAGING_URL,
     OPTION_TYPE: {
         REPORT: 'report',
         PERSONAL_DETAIL: 'personalDetail',

--- a/src/CONST.js
+++ b/src/CONST.js
@@ -1,4 +1,6 @@
 const CLOUDFRONT_URL = 'https://d2k5nsl2zxldvw.cloudfront.net';
+const NEW_EXPENSIFY_URL = 'https://new.expensify.com';
+const NEW_EXPENSIFY_STAGING_URL = 'https://staging.new.expensify.com';
 
 const CONST = {
     // 50 megabytes in bytes
@@ -6,7 +8,7 @@ const CONST = {
     APP_DOWNLOAD_LINKS: {
         ANDROID: 'https://play.google.com/store/apps/details?id=com.expensify.chat',
         IOS: 'https://apps.apple.com/us/app/expensify-cash/id1530278510',
-        DESKTOP: 'https://new.expensify.com/NewExpensify.dmg',
+        DESKTOP: `${NEW_EXPENSIFY_URL}/NewExpensify.dmg`,
     },
     DATE: {
         MOMENT_FORMAT_STRING: 'YYYY-MM-DD',
@@ -134,6 +136,8 @@ const CONST = {
     CFPB_PREPAID_URL: 'https://cfpb.gov/prepaid',
     STAGING_SECURE_URL: 'https://staging-secure.expensify.com/',
     NEWDOT: 'new.expensify.com',
+    NEW_EXPENSIFY_URL,
+    NEW_EXPENSIFY_STAGING_URL,
     OPTION_TYPE: {
         REPORT: 'report',
         PERSONAL_DETAIL: 'personalDetail',

--- a/src/components/HTMLEngineProvider/BaseHTMLEngineProvider.js
+++ b/src/components/HTMLEngineProvider/BaseHTMLEngineProvider.js
@@ -22,6 +22,7 @@ import variables from '../../styles/variables';
 import themeColors from '../../styles/themes/default';
 import Text from '../Text';
 import withLocalize from '../withLocalize';
+import Navigation from '../../libs/Navigation/Navigation';
 
 const propTypes = {
     /** Whether text elements should be selectable */
@@ -70,6 +71,20 @@ function AnchorRenderer({tnode, key, style}) {
     // An auth token is needed to download Expensify chat attachments
     const isAttachment = Boolean(htmlAttribs['data-expensify-source']);
     const fileName = lodashGet(tnode, 'domNode.children[0].data', '');
+
+    // If we are handling a relative link then we will assume this should be opened by the app internally
+    if (htmlAttribs.href.startsWith('/')) {
+        return (
+            <Text
+                style={styles.link}
+                onPress={() => {
+                    Navigation.navigate(htmlAttribs.href);
+                }}
+            >
+                <TNodeChildrenRenderer tnode={tnode} />
+            </Text>
+        );
+    }
 
     return (
         <AnchorForCommentsOnly

--- a/src/components/HTMLEngineProvider/BaseHTMLEngineProvider.js
+++ b/src/components/HTMLEngineProvider/BaseHTMLEngineProvider.js
@@ -72,15 +72,15 @@ function AnchorRenderer({tnode, key, style}) {
     // An auth token is needed to download Expensify chat attachments
     const isAttachment = Boolean(htmlAttribs['data-expensify-source']);
     const fileName = lodashGet(tnode, 'domNode.children[0].data', '');
-    const hrefURL = new URL(htmlAttribs.href);
+    const internalExpensifyPath = lodashGet(htmlAttribs.href.split(CONST.NEW_EXPENSIFY_URL), 1, '');
 
     // If we are handling a New Expensify link then we will assume this should be opened by the app internally. This ensures that the links are opened internally via react-navigation
     // instead of in a new tab or with a page refresh (which is the default behavior of an anchor tag)
-    if (hrefURL.origin === CONST.NEW_EXPENSIFY_URL) {
+    if (internalExpensifyPath) {
         return (
             <Text
                 style={styles.link}
-                onPress={() => Navigation.navigate(hrefURL.pathname)}
+                onPress={() => Navigation.navigate(internalExpensifyPath)}
             >
                 <TNodeChildrenRenderer tnode={tnode} />
             </Text>

--- a/src/components/HTMLEngineProvider/BaseHTMLEngineProvider.js
+++ b/src/components/HTMLEngineProvider/BaseHTMLEngineProvider.js
@@ -79,9 +79,7 @@ function AnchorRenderer({tnode, key, style}) {
         return (
             <Text
                 style={styles.link}
-                onPress={() => {
-                    Navigation.navigate(hrefURL.pathname);
-                }}
+                onPress={() => Navigation.navigate(hrefURL.pathname)}
             >
                 <TNodeChildrenRenderer tnode={tnode} />
             </Text>

--- a/src/components/HTMLEngineProvider/BaseHTMLEngineProvider.js
+++ b/src/components/HTMLEngineProvider/BaseHTMLEngineProvider.js
@@ -74,7 +74,8 @@ function AnchorRenderer({tnode, key, style}) {
     const fileName = lodashGet(tnode, 'domNode.children[0].data', '');
     const hrefURL = new URL(htmlAttribs.href);
 
-    // If we are handling a relative link then we will assume this should be opened by the app internally
+    // If we are handling a New Expensify link then we will assume this should be opened by the app internally. This ensures that the links are opened internally via react-navigation
+    // instead of in a new tab or with a page refresh (which is the default behavior of an anchor tag)
     if (hrefURL.origin === CONST.NEW_EXPENSIFY_URL || hrefURL.origin === CONST.NEW_EXPENSIFY_STAGING_URL) {
         return (
             <Text

--- a/src/components/HTMLEngineProvider/BaseHTMLEngineProvider.js
+++ b/src/components/HTMLEngineProvider/BaseHTMLEngineProvider.js
@@ -23,6 +23,7 @@ import themeColors from '../../styles/themes/default';
 import Text from '../Text';
 import withLocalize from '../withLocalize';
 import Navigation from '../../libs/Navigation/Navigation';
+import CONST from '../../CONST';
 
 const propTypes = {
     /** Whether text elements should be selectable */
@@ -71,14 +72,15 @@ function AnchorRenderer({tnode, key, style}) {
     // An auth token is needed to download Expensify chat attachments
     const isAttachment = Boolean(htmlAttribs['data-expensify-source']);
     const fileName = lodashGet(tnode, 'domNode.children[0].data', '');
+    const hrefURL = new URL(htmlAttribs.href);
 
     // If we are handling a relative link then we will assume this should be opened by the app internally
-    if (htmlAttribs.href.startsWith('/')) {
+    if (hrefURL.origin === CONST.NEW_EXPENSIFY_URL || hrefURL.origin === CONST.NEW_EXPENSIFY_STAGING_URL) {
         return (
             <Text
                 style={styles.link}
                 onPress={() => {
-                    Navigation.navigate(htmlAttribs.href);
+                    Navigation.navigate(hrefURL.pathname);
                 }}
             >
                 <TNodeChildrenRenderer tnode={tnode} />

--- a/src/components/HTMLEngineProvider/BaseHTMLEngineProvider.js
+++ b/src/components/HTMLEngineProvider/BaseHTMLEngineProvider.js
@@ -76,7 +76,7 @@ function AnchorRenderer({tnode, key, style}) {
 
     // If we are handling a New Expensify link then we will assume this should be opened by the app internally. This ensures that the links are opened internally via react-navigation
     // instead of in a new tab or with a page refresh (which is the default behavior of an anchor tag)
-    if (hrefURL.origin === CONST.NEW_EXPENSIFY_URL || hrefURL.origin === CONST.NEW_EXPENSIFY_STAGING_URL) {
+    if (hrefURL.origin === CONST.NEW_EXPENSIFY_URL) {
         return (
             <Text
                 style={styles.link}

--- a/src/components/HTMLEngineProvider/BaseHTMLEngineProvider.js
+++ b/src/components/HTMLEngineProvider/BaseHTMLEngineProvider.js
@@ -72,7 +72,7 @@ function AnchorRenderer({tnode, key, style}) {
     // An auth token is needed to download Expensify chat attachments
     const isAttachment = Boolean(htmlAttribs['data-expensify-source']);
     const fileName = lodashGet(tnode, 'domNode.children[0].data', '');
-    const internalExpensifyPath = lodashGet(htmlAttribs.href.split(CONST.NEW_EXPENSIFY_URL), 1, '');
+    const internalExpensifyPath = htmlAttribs.href.startsWith(CONST.NEW_EXPENSIFY_URL) && htmlAttribs.href.replace(CONST.NEW_EXPENSIFY_URL, '');
 
     // If we are handling a New Expensify link then we will assume this should be opened by the app internally. This ensures that the links are opened internally via react-navigation
     // instead of in a new tab or with a page refresh (which is the default behavior of an anchor tag)

--- a/src/libs/Navigation/linkingConfig.js
+++ b/src/libs/Navigation/linkingConfig.js
@@ -1,16 +1,16 @@
 import ROUTES from '../../ROUTES';
 import SCREENS from '../../SCREENS';
+import CONST from '../../CONST';
 
 export default {
     prefixes: [
         'new-expensify://',
         'expensify-cash://', // DEPRECATED
-        'https://new.expensify.com',
         'https://www.expensify.cash',
         'https://staging.expensify.cash',
         'http://localhost',
-        'https://new.expensify.com',
-        'https://staging.new.expensify.com',
+        CONST.NEW_EXPENSIFY_URL,
+        CONST.NEW_EXPENSIFY_STAGING_URL,
     ],
     config: {
         initialRouteName: SCREENS.HOME,

--- a/src/libs/Navigation/linkingConfig.js
+++ b/src/libs/Navigation/linkingConfig.js
@@ -10,7 +10,7 @@ export default {
         'https://staging.expensify.cash',
         'http://localhost',
         CONST.NEW_EXPENSIFY_URL,
-        CONST.NEW_EXPENSIFY_STAGING_URL,
+        'https://staging.new.expensify.com',
     ],
     config: {
         initialRouteName: SCREENS.HOME,


### PR DESCRIPTION
### Details
When a New Expensify link is handled in the app we currently open it in a new tab by default. If we use the `target="_self"` attribute then the link refreshes the page. This is happening because `react-navigation` is not set up to handle internal links. As a workaround, we will replace any links that begin with `https://new.expensify.com` with links that target the `Navigation.navigate()` method so we can navigate internally.

### Fixed Issues
$ https://github.com/Expensify/App/issues/5157

### Tests / QA Steps
1. Send a message to another user with a link like `https://new.expensify.com/settings`
2. Tap the link and verify the settings page opens and the app does not reload

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [x] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
https://user-images.githubusercontent.com/32969087/132744112-8941af5f-aea8-42ff-972d-cf3c4802c782.mp4

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
