### PR TITLE
#4902 improve participants local time display

### DIFF
--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -12,6 +12,7 @@ import _ from 'underscore';
 import lodashGet from 'lodash/get';
 import {withOnyx} from 'react-native-onyx';
 import lodashIntersection from 'lodash/intersection';
+import moment from 'moment';
 import styles, {getButtonBackgroundColorStyle, getIconFillColor} from '../../../styles/styles';
 import themeColors from '../../../styles/themes/default';
 import TextInputFocusable from '../../../components/TextInputFocusable';
@@ -269,6 +270,16 @@ class ReportActionCompose extends React.Component {
     }
 
     /**
+     * Get timezone's UTC offset in minutes
+     *
+     * @param {String} [timezone]
+     * @return {Number}
+     */
+    getTimezoneOffset(timezone) {
+        return moment().tz(timezone).utcOffset();
+    }
+
+    /**
      * Focus the composer text input
      * @param {Boolean} [shouldelay=false] Impose delay before focusing the composer
      * @memberof ReportActionCompose
@@ -456,7 +467,7 @@ class ReportActionCompose extends React.Component {
             && !hasMultipleParticipants
             && reportRecipient
             && reportRecipientTimezone
-            && currentUserTimezone.selected !== reportRecipientTimezone.selected;
+            && this.getTimezoneOffset(currentUserTimezone.selected) !== this.getTimezoneOffset(reportRecipientTimezone.selected);
 
         // Prevents focusing and showing the keyboard while the drawer is covering the chat.
         const isComposeDisabled = this.props.isDrawerOpen && this.props.isSmallScreenWidth;

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -270,16 +270,6 @@ class ReportActionCompose extends React.Component {
     }
 
     /**
-     * Get timezone's UTC offset in minutes
-     *
-     * @param {String} [timezone]
-     * @return {Number}
-     */
-    getTimezoneOffset(timezone) {
-        return moment().tz(timezone).utcOffset();
-    }
-
-    /**
      * Focus the composer text input
      * @param {Boolean} [shouldelay=false] Impose delay before focusing the composer
      * @memberof ReportActionCompose
@@ -467,7 +457,7 @@ class ReportActionCompose extends React.Component {
             && !hasMultipleParticipants
             && reportRecipient
             && reportRecipientTimezone
-            && this.getTimezoneOffset(currentUserTimezone.selected) !== this.getTimezoneOffset(reportRecipientTimezone.selected);
+            && moment().tz(currentUserTimezone.selected).utcOffset() !== moment().tz(reportRecipientTimezone.selected).utcOffset();
 
         // Prevents focusing and showing the keyboard while the drawer is covering the chat.
         const isComposeDisabled = this.props.isDrawerOpen && this.props.isSmallScreenWidth;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Updates the `shouldShowReportRecipientLocalTime` value expression to compare UTC offset instead of raw timezone names.

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/4723
--->
$ https://github.com/Expensify/App/issues/4902

### Tests / QA Steps
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

Assume that timezone A and timezone B have the same UTC offset, but different names. Example: Europe/Moscow and Europe/Istanbul (both are UTC +3).

1. Log in with account A
2. Go to profile settings
3. Manually set timezone to timezone A
4. Log in with account B
5. Go to profile settings
6. Manually set timezone to timezone B
7. Open chat with account A
8. The recipients local time should not be shown since both timezones have the same UTC offset.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

On screenshots below I have timezone Europe/Istanbul and my participant has Europe/Moscow. Both are UTC +3 and participants local time is not shown.

#### Web
<!-- Insert screenshots of your changes on the web platform-->
![DeepinScreenshot_select-area_20210909202636](https://user-images.githubusercontent.com/64093836/132733550-33f07117-48e5-411b-b50f-00bfb2276c90.png)

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
<img width="312" alt="Simulator Screen Shot - iPhone 12 - 2021-09-09 at 20 53 47" src="https://user-images.githubusercontent.com/64093836/132738339-21a1d3db-43b3-4d37-98f4-6a1f91e1ca91.png">

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
<img width="1312" alt="Screen Shot 2021-09-09 at 20 56 32" src="https://user-images.githubusercontent.com/64093836/132738317-3fbc09b1-958f-43d9-9636-442fb20d76e0.png">

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
<img width="312" alt="Simulator Screen Shot - iPhone 12 - 2021-09-09 at 20 51 12" src="https://user-images.githubusercontent.com/64093836/132738275-4d089852-140f-47a0-a56c-d1c193e009a2.png">

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
<img width="312" alt="Screenshot_1631210201" src="https://user-images.githubusercontent.com/64093836/132738005-fb48f0b2-2793-4496-9db3-1785b6c23c6f.png">