### PR TITLE
Corrected blurry image preview within chat list when extra long image used

### DIFF
--- a/src/components/ThumbnailImage.js
+++ b/src/components/ThumbnailImage.js
@@ -1,3 +1,4 @@
+import lodashClamp from 'lodash/clamp';
 import React, {PureComponent} from 'react';
 import {View} from 'react-native';
 import PropTypes from 'prop-types';
@@ -36,7 +37,8 @@ class ThumbnailImage extends PureComponent {
     updateImageSize({width, height}) {
         // Width of the thumbnail works better as a constant than it does
         // a percentage of the screen width since it is relative to each screen
-        const thumbnailScreenWidth = 250;
+        // Note: Clamp minimum width 40px to support touch device
+        const thumbnailScreenWidth = lodashClamp(width, 40, 250);
         const scaleFactor = width / thumbnailScreenWidth;
         const imageHeight = height / scaleFactor;
         this.setState({thumbnailWidth: thumbnailScreenWidth, thumbnailHeight: imageHeight});


### PR DESCRIPTION
@mountiny pull request ready for review.

### Details
When long height image uploaded, chat list thumbnail become blurry in case of less than 250px thumbnail generated. So corrected that problem. i.e. if thumbnail width less then 250px it will consider that width i.e. not stretch to 250px while render within ui. If thumbnail width goes less than 40px then we clamp width to 40px, so such thumbnail shows as 40px width to support the device touch.

Please ignore extra long thumb image having padding at top and bottom etc. It is separate issue. https://github.com/Expensify/App/issues/5162

### Fixed Issues
$ https://github.com/Expensify/App/issues/5092

### Tests
1. Navigate to a conversation
2. Upload extra long height image.
3. Check the image preview in chat list.

### QA Steps
1. Upload  extra long height image. 
2. Once uploaded its generated thumbnail  width will be less than 250px width.
3. Such thumbnail will render  to its original width in chat list, 
4. Some any thumbnail size then 250px it will be render as 250px and height generated accordingly. 

### Tested On

- [X] Web
- [X] Mobile Web
- [X] Desktop
- [X] iOS
- [X] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web

<img width="1465" alt="Web1" src="https://user-images.githubusercontent.com/7823358/132747830-b3268110-ffff-4036-b124-784a1eebbf89.png">

<img width="1421" alt="Web2" src="https://user-images.githubusercontent.com/7823358/132748104-0fa28c65-e35f-4df5-a572-5808968819d9.png">

<img width="1421" alt="Web3" src="https://user-images.githubusercontent.com/7823358/132748201-fd288f2b-896b-4a73-af8e-44995e1fe172.png">

<img width="1465" alt="Web4" src="https://user-images.githubusercontent.com/7823358/132748248-90f2a28d-b02e-4e86-9a83-0328e1293009.png">


#### Mobile Web

<img width="600" alt="MobileWeb1" src="https://user-images.githubusercontent.com/7823358/132748711-17d0b4c5-0b37-42c8-826d-51bf4ecefe68.png">


<img width="600" alt="MobileWeb2" src="https://user-images.githubusercontent.com/7823358/132748786-f52d3fad-80f6-4e27-8f42-edf2ae98dd97.png">


<img width="600" alt="MobileWeb3" src="https://user-images.githubusercontent.com/7823358/132748822-285d5d73-6640-4020-8c75-8e27cb283000.png">


<img width="600" alt="MobileWeb4" src="https://user-images.githubusercontent.com/7823358/132748854-cf52ff7f-c4a4-4c8c-83c2-ebca731596c0.png">


#### Desktop
<img width="1312" alt="Desktop1" src="https://user-images.githubusercontent.com/7823358/132750076-9344ad11-e06d-417e-a444-1d44721fb010.png">

<img width="1268" alt="Desktop2" src="https://user-images.githubusercontent.com/7823358/132750115-098d6e67-dac2-495a-a97e-4b701eacb367.png">

<img width="1268" alt="Desktop3" src="https://user-images.githubusercontent.com/7823358/132750154-574d04f5-22d7-4d36-84e9-a84fc3a7442e.png">

<img width="1312" alt="Desktop4" src="https://user-images.githubusercontent.com/7823358/132750185-c37880f0-7234-4530-8c42-14a5bcd317c2.png">


#### iOS

<img width="564" alt="iOS1" src="https://user-images.githubusercontent.com/7823358/132750329-ec25f531-92d7-47ff-846a-6f10feaef6c5.png">

<img width="564" alt="iOS2" src="https://user-images.githubusercontent.com/7823358/132750387-44ec0b3f-be77-42f2-9016-d7f1df5eaa50.png">

<img width="564" alt="iOS3" src="https://user-images.githubusercontent.com/7823358/132750427-93f7c13f-f2e6-4488-9c54-cebe838692f3.png">


#### Android

<img width="600" alt="Android1" src="https://user-images.githubusercontent.com/7823358/132750495-0a26ca32-d9a1-414b-a6be-b1f5da7fc0c7.png">

<img width="600" alt="Android2" src="https://user-images.githubusercontent.com/7823358/132750511-333d4d3b-6e56-48f7-be9a-8201fc9a1dd3.png">

<img width="600" alt="Android3" src="https://user-images.githubusercontent.com/7823358/132750542-f0b8b580-025c-412f-83a4-ad529b23c6f7.png">

