### PR TITLE
Copy changed to Start a Call

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -107,7 +107,7 @@ export default {
         nameEmailOrPhoneNumber: 'Name, email, or phone number',
     },
     videoChatButtonAndMenu: {
-        tooltip: 'Video chat',
+        tooltip: 'Start a Call',
         zoom: 'Zoom',
         googleMeet: 'Google Meet',
     },

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -107,7 +107,7 @@ export default {
         nameEmailOrPhoneNumber: 'Nombre, email o número de teléfono',
     },
     videoChatButtonAndMenu: {
-        tooltip: 'Videollamada',
+        tooltip: 'Iniciar una llamada',
         zoom: 'Zoom',
         googleMeet: 'Google Meet',
     },


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Just a copy change from "Video chat" to "Start a Call".

### Fixed Issues
$ #4941 

### Tests & QA Steps
1. Open any user chat on the web or Desktop, hover over the  📞  icon.
2. Tooltip should show `Start a Call`or `Iniciar una llamada` based on language preferences.

### Tested On
- [x] Web
- [x] Desktop

### Screenshots

#### Web
<img width="1440" alt="Screenshot 2021-09-10 at 9 58 19 AM" src="https://user-images.githubusercontent.com/85645967/132799983-c4c61d42-17e7-49fa-bc20-0765979a76cd.png">
<img width="1438" alt="Screenshot 2021-09-10 at 9 57 54 AM" src="https://user-images.githubusercontent.com/85645967/132799993-1b1bef5f-7d61-48bf-a112-d3eef41ef5be.png">

#### Desktop
<img width="1200" alt="Screenshot 2021-09-10 at 10 06 01 AM" src="https://user-images.githubusercontent.com/85645967/132800493-a51db3a1-c203-46df-bed2-4170ceee6c9c.png">
<img width="1196" alt="Screenshot 2021-09-10 at 10 06 27 AM" src="https://user-images.githubusercontent.com/85645967/132800496-5a67677d-a05c-44fa-a348-0d15cf257a4c.png">

