### PR TITLE
Sync Logout across tabs

### DIFF
--- a/src/libs/actions/SignInRedirect.js
+++ b/src/libs/actions/SignInRedirect.js
@@ -44,11 +44,12 @@ function redirectToSignIn(errorMessage) {
             if (activeClients && activeClients.length > 0) {
                 Onyx.set(ONYXKEYS.ACTIVE_CLIENTS, activeClients);
             }
+
             const session = {
                 // We must set the authToken to null so that signOut action is triggered across other clients
-                // https://github.com/Expensify/App/issues/4971#issuecomment-916101493
                 authToken: null,
             };
+
             if (errorMessage) {
                 session.error = errorMessage;
             }

--- a/src/libs/actions/SignInRedirect.js
+++ b/src/libs/actions/SignInRedirect.js
@@ -47,6 +47,10 @@ function redirectToSignIn(errorMessage) {
             if (activeClients && activeClients.length > 0) {
                 Onyx.set(ONYXKEYS.ACTIVE_CLIENTS, activeClients);
             }
+
+            // We must set the authToken to null so that signOut action is triggered across other clients
+            // https://github.com/Expensify/App/issues/4971#issuecomment-916101493
+            Onyx.set(ONYXKEYS.SESSION, {authToken: null});
         });
 }
 

--- a/src/libs/actions/SignInRedirect.js
+++ b/src/libs/actions/SignInRedirect.js
@@ -41,16 +41,18 @@ function redirectToSignIn(errorMessage) {
             if (preferredLocale) {
                 Onyx.set(ONYXKEYS.NVP_PREFERRED_LOCALE, preferredLocale);
             }
-            if (errorMessage) {
-                Onyx.set(ONYXKEYS.SESSION, {error: errorMessage});
-            }
             if (activeClients && activeClients.length > 0) {
                 Onyx.set(ONYXKEYS.ACTIVE_CLIENTS, activeClients);
             }
-
-            // We must set the authToken to null so that signOut action is triggered across other clients
-            // https://github.com/Expensify/App/issues/4971#issuecomment-916101493
-            Onyx.set(ONYXKEYS.SESSION, {authToken: null});
+            const session = {
+                // We must set the authToken to null so that signOut action is triggered across other clients
+                // https://github.com/Expensify/App/issues/4971#issuecomment-916101493
+                authToken: null,
+            };
+            if (errorMessage) {
+                session.error = errorMessage;
+            }
+            Onyx.merge(ONYXKEYS.SESSION, session);
         });
 }
 

--- a/src/libs/actions/SignInRedirect.js
+++ b/src/libs/actions/SignInRedirect.js
@@ -53,6 +53,8 @@ function redirectToSignIn(errorMessage) {
             if (errorMessage) {
                 session.error = errorMessage;
             }
+
+            // `Onyx.clear` reinitialize the Onyx instance with initial values so use `Onyx.merge` instead of `Onyx.set`.
             Onyx.merge(ONYXKEYS.SESSION, session);
         });
 }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
https://github.com/Expensify/App/issues/4971#issuecomment-916101493

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/4723
--->
$ https://github.com/Expensify/App/issues/4971

### Tests | QA Steps
1. Sign in to New Expensify in one tab (A), open a second tab (B) with New Expensify (you should be signed in automatically)
2. In tab A, sign out then sign in with a new account
3. In tab B, the user should be automatically signed out.

### Tested On

- [x] Web
- [x] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

https://user-images.githubusercontent.com/24370807/132887291-f72a9ebb-0b03-42ec-9190-2f1a734e17a8.mp4


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
