### PR TITLE
fix: translations for Native AttachmentPicker

### DIFF
--- a/src/components/AttachmentPicker/index.native.js
+++ b/src/components/AttachmentPicker/index.native.js
@@ -86,12 +86,12 @@ class AttachmentPicker extends Component {
         this.menuItemData = [
             {
                 icon: Camera,
-                text: this.props.translate('attachmentPicker.takePhoto'),
+                textTranslationKey: 'attachmentPicker.takePhoto',
                 pickAttachment: () => this.showImagePicker(launchCamera),
             },
             {
                 icon: Gallery,
-                text: this.props.translate('attachmentPicker.chooseFromGallery'),
+                textTranslationKey: 'attachmentPicker.chooseFromGallery',
                 pickAttachment: () => this.showImagePicker(launchImageLibrary),
             },
         ];
@@ -102,7 +102,7 @@ class AttachmentPicker extends Component {
             this.menuItemData.push(
                 {
                     icon: Paperclip,
-                    text: this.props.translate('attachmentPicker.chooseDocument'),
+                    textTranslationKey: 'attachmentPicker.chooseDocument',
                     pickAttachment: () => this.showDocumentPicker(),
                 },
             );
@@ -286,9 +286,9 @@ class AttachmentPicker extends Component {
                         {
                              this.menuItemData.map(item => (
                                  <MenuItem
-                                     key={item.text}
+                                     key={item.textTranslationKey}
                                      icon={item.icon}
-                                     title={item.text}
+                                     title={this.props.translate(item.textTranslationKey)}
                                      onPress={() => this.selectItem(item)}
                                  />
                              ))


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
https://github.com/Expensify/App/issues/5103#issuecomment-916179089

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/4723
--->
$ https://github.com/Expensify/App/issues/5103

### Tests | QA Steps

 1. Log in NewDot mobile app.
 2. Open any chat.
 3. Tap on + sign > Add Attachment.
 4. Observe the language of the opened Menu. 
 2. Navigate to Settings > Preferences
 3. Set the language to Spanish(if not already selected).
 3. Close the Settings page by clicking close(top-right).
 4. Open the previous chat.
 4. Tap on + sign > Add Attachment.
 4. Observe the language of the opened Menu. 


### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->

https://user-images.githubusercontent.com/24370807/132904632-339b0464-3c5e-4773-b38f-c1c6026275b4.mp4

