### PR TITLE
Bumped Expensify Common hash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28052,8 +28052,8 @@
       }
     },
     "expensify-common": {
-      "version": "git://github.com/Expensify/expensify-common.git#a78cc23afe54d487ce2b7bafefa07e58d0280612",
-      "from": "git://github.com/Expensify/expensify-common.git#a78cc23afe54d487ce2b7bafefa07e58d0280612",
+      "version": "git://github.com/Expensify/expensify-common.git#b5d9167a26cfd40beebdfb79958b3bbed1af7b64",
+      "from": "git://github.com/Expensify/expensify-common.git#b5d9167a26cfd40beebdfb79958b3bbed1af7b64",
       "requires": {
         "classnames": "2.3.1",
         "clipboard": "2.0.4",
@@ -28109,11 +28109,6 @@
           "requires": {
             "lru-cache": "^6.0.0"
           }
-        },
-        "underscore": {
-          "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
-          "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
         },
         "yallist": {
           "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "electron-log": "^4.3.5",
     "electron-serve": "^1.0.0",
     "electron-updater": "^4.3.4",
-    "expensify-common": "git://github.com/Expensify/expensify-common.git#a78cc23afe54d487ce2b7bafefa07e58d0280612",
+    "expensify-common": "git://github.com/Expensify/expensify-common.git#b5d9167a26cfd40beebdfb79958b3bbed1af7b64",
     "expo-haptics": "^10.0.0",
     "file-loader": "^6.0.0",
     "html-entities": "^1.3.1",


### PR DESCRIPTION

Bumping the E-Common hash here. This got skipped on at least one PR–which isn't ideal–but I think we're fine to just get up to date. 

