### PR TITLE
Use fundlist instead of cardlist for payment methods

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -96,10 +96,6 @@ const CONST = {
         COMPLETE: 'complete',
         DISABLED: 'disabled',
     },
-    CARD_TYPES: {
-        /** This is a default card type that all users have. It is just a placeholder, not an actual card */
-        DEFAULT_CASH: '__CASH__',
-    },
     BANK_ACCOUNT_TYPES: {
         WALLET: 'WALLET',
     },

--- a/src/libs/actions/PaymentMethods.js
+++ b/src/libs/actions/PaymentMethods.js
@@ -11,7 +11,7 @@ import CONST from '../../CONST';
  */
 function getPaymentMethods() {
     return API.Get({
-        returnValueList: 'bankAccountList, cardList, userWallet, nameValuePairs',
+        returnValueList: 'bankAccountList, fundList, userWallet, nameValuePairs',
         name: 'paypalMeAddress',
         includeDeleted: false,
         includeNotIssued: false,
@@ -21,7 +21,7 @@ function getPaymentMethods() {
             Onyx.multiSet({
                 [ONYXKEYS.USER_WALLET]: lodashGet(response, 'userWallet', {}),
                 [ONYXKEYS.BANK_ACCOUNT_LIST]: lodashGet(response, 'bankAccountList', []),
-                [ONYXKEYS.CARD_LIST]: lodashGet(response, 'cardList', []),
+                [ONYXKEYS.CARD_LIST]: lodashGet(response, 'fundList', []),
                 [ONYXKEYS.NVP_PAYPAL_ME_ADDRESS]:
                     lodashGet(response, ['nameValuePairs', CONST.NVP.PAYPAL_ME_ADDRESS], ''),
             });

--- a/src/pages/settings/Payments/PaymentMethodList.js
+++ b/src/pages/settings/Payments/PaymentMethodList.js
@@ -103,23 +103,20 @@ class PaymentMethodList extends Component {
         });
 
         _.each(this.props.cardList, (card) => {
-            // Add all cards besides the "cash" card
-            if (card.cardName !== CONST.CARD_TYPES.DEFAULT_CASH) {
-                const formattedCardNumber = card.cardNumber
-                    ? `${this.props.translate('paymentMethodList.cardLastFour')} ${card.cardNumber.slice(-4)}`
-                    : null;
-                const {icon, iconSize} = getBankIcon(card.bank, true);
-                combinedPaymentMethods.push({
-                    type: MENU_ITEM,
-                    title: card.cardName,
-                    // eslint-disable-next-line
-                    description: formattedCardNumber,
-                    icon,
-                    iconSize,
-                    onPress: e => this.props.onPress(e, card.cardID),
-                    key: `card-${card.cardID}`,
-                });
-            }
+            const formattedCardNumber = card.cardNumber
+                ? `${this.props.translate('paymentMethodList.cardLastFour')} ${card.cardNumber.slice(-4)}`
+                : null;
+            const {icon, iconSize} = getBankIcon(card.bank, true);
+            combinedPaymentMethods.push({
+                type: MENU_ITEM,
+                title: card.addressName,
+                // eslint-disable-next-line
+                description: formattedCardNumber,
+                icon,
+                iconSize,
+                onPress: e => this.props.onPress(e, card.cardID),
+                key: `card-${card.cardID}`,
+            });
         });
 
         if (this.props.payPalMeUsername) {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
When I initially implemented this I used the `cardList` instead of the `fundList`. `cardList` is used for scraped/imported cards, we actually want billing cards which is `fundList`

### Fixed Issues
$ https://github.com/Expensify/App/issues/5205

### Tests
1. Log into an account with a billing card and an expensify card
2. Go to settings->payments and make sure you see the debit card, but not the expensify card

### QA Steps
1. Log into an account with a billing card and an expensify card
2. Go to settings->payments and make sure you see the debit card, but not the expensify card

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
![2021-09-10_17-35-08](https://user-images.githubusercontent.com/42391420/132927821-2c4244f3-263f-4d9c-94ce-fdf3cd5a8627.png)
