### PR TITLE
Address #5047 - Open global create when a user logs in for the first time

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -221,6 +221,7 @@ const CONST = {
         },
     },
     NVP: {
+        IS_FIRST_TIME_NEW_EXPENSIFY_USER: 'isFirstTimeNewExpensifyUser',
         BLOCKED_FROM_CONCIERGE: 'private_blockedFromConcierge',
         PAYPAL_ME_ADDRESS: 'expensify_payPalMeAddress',
         PRIORITY_MODE: 'priorityMode',

--- a/src/ONYXKEYS.js
+++ b/src/ONYXKEYS.js
@@ -5,6 +5,9 @@ export default {
     // Holds information about the users account that is logging in
     ACCOUNT: 'account',
 
+    // Boolean flag only true when first set
+    IS_NEW_USER: 'isNewUser',
+
     // Holds an array of client IDs which is used for multi-tabs on web in order to know
     // which tab is the leader, and which ones are the followers
     ACTIVE_CLIENTS: 'activeClients',

--- a/src/ONYXKEYS.js
+++ b/src/ONYXKEYS.js
@@ -6,7 +6,7 @@ export default {
     ACCOUNT: 'account',
 
     // Boolean flag only true when first set
-    IS_NEW_USER: 'isNewUser',
+    NVP_IS_FIRST_TIME_NEW_EXPENSIFY_USER: 'isFirstTimeNewExpensifyUser',
 
     // Holds an array of client IDs which is used for multi-tabs on web in order to know
     // which tab is the leader, and which ones are the followers

--- a/src/components/FAB/FAB.js
+++ b/src/components/FAB/FAB.js
@@ -17,7 +17,7 @@ AnimatedPressable.displayName = 'AnimatedPressable';
 class FAB extends PureComponent {
     constructor(props) {
         super(props);
-        this.animatedValue = new Animated.Value(0);
+        this.animatedValue = new Animated.Value( props.isActive ? 1 : 0);
     }
 
     componentDidUpdate(prevProps) {

--- a/src/components/FAB/FAB.js
+++ b/src/components/FAB/FAB.js
@@ -17,7 +17,7 @@ AnimatedPressable.displayName = 'AnimatedPressable';
 class FAB extends PureComponent {
     constructor(props) {
         super(props);
-        this.animatedValue = new Animated.Value( props.isActive ? 1 : 0);
+        this.animatedValue = new Animated.Value(props.isActive ? 1 : 0);
     }
 
     componentDidUpdate(prevProps) {

--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -167,6 +167,7 @@ class AuthScreens extends React.Component {
 
         // Fetch some data we need on initialization
         NameValuePair.get(CONST.NVP.PRIORITY_MODE, ONYXKEYS.NVP_PRIORITY_MODE, 'default');
+        NameValuePair.get(CONST.NVP.IS_FIRST_TIME_NEW_EXPENSIFY_USER, ONYXKEYS.IS_NEW_USER, true);
 
         API.Get({
             returnValueList: 'nameValuePairs',

--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -167,7 +167,7 @@ class AuthScreens extends React.Component {
 
         // Fetch some data we need on initialization
         NameValuePair.get(CONST.NVP.PRIORITY_MODE, ONYXKEYS.NVP_PRIORITY_MODE, 'default');
-        NameValuePair.get(CONST.NVP.IS_FIRST_TIME_NEW_EXPENSIFY_USER, ONYXKEYS.IS_NEW_USER, true);
+        NameValuePair.get(CONST.NVP.IS_FIRST_TIME_NEW_EXPENSIFY_USER, ONYXKEYS.NVP_IS_FIRST_TIME_NEW_EXPENSIFY_USER, true);
 
         API.Get({
             returnValueList: 'nameValuePairs',

--- a/src/pages/home/sidebar/SidebarScreen.js
+++ b/src/pages/home/sidebar/SidebarScreen.js
@@ -32,7 +32,7 @@ const propTypes = {
     betas: PropTypes.arrayOf(PropTypes.string).isRequired,
 
     /* Flag for new users used to open the Global Create menu on first load */
-    isFirstTimeNewExpensifyUser: PropTypes.bool,
+    isFirstTimeNewExpensifyUser: PropTypes.bool.isRequired,
 
     ...windowDimensionsPropTypes,
 
@@ -61,6 +61,7 @@ class SidebarScreen extends Component {
             // For some reason, the menu doesn't open without the timeout
             setTimeout(() => {
                 this.toggleCreateMenu();
+
                 // Set the NVP back to false (this may need to be moved if this NVP is used for anything else later)
                 NameValuePair.set(CONST.NVP.IS_FIRST_TIME_NEW_EXPENSIFY_USER, false, ONYXKEYS.NVP_IS_FIRST_TIME_NEW_EXPENSIFY_USER);
             }, 200);

--- a/src/pages/home/sidebar/SidebarScreen.js
+++ b/src/pages/home/sidebar/SidebarScreen.js
@@ -25,11 +25,14 @@ import Permissions from '../../../libs/Permissions';
 import ONYXKEYS from '../../../ONYXKEYS';
 import {create} from '../../../libs/actions/Policy';
 import Performance from '../../../libs/Performance';
-import NameValuePair from '../../../libs/actions/NameValuePair'
+import NameValuePair from '../../../libs/actions/NameValuePair';
 
 const propTypes = {
-    /** Beta features list */
+    /* Beta features list */
     betas: PropTypes.arrayOf(PropTypes.string).isRequired,
+
+    /* Flag for new users used to open the Global Create menu on first load */
+    isFirstTimeNewExpensifyUser: PropTypes.bool,
 
     ...windowDimensionsPropTypes,
 
@@ -54,7 +57,7 @@ class SidebarScreen extends Component {
         Performance.markStart(CONST.TIMING.SIDEBAR_LOADED);
         Timing.start(CONST.TIMING.SIDEBAR_LOADED, true);
 
-        if (this.props.isNewUser) {
+        if (this.props.isFirstTimeNewExpensifyUser) {
             // For some reason, the menu doesn't open without the timeout
             setTimeout(() => {
                 this.toggleCreateMenu();
@@ -180,7 +183,7 @@ export default compose(
         betas: {
             key: ONYXKEYS.BETAS,
         },
-        isNewUser: {
+        isFirstTimeNewExpensifyUser: {
             key: ONYXKEYS.NVP_IS_FIRST_TIME_NEW_EXPENSIFY_USER,
         },
     }),

--- a/src/pages/home/sidebar/SidebarScreen.js
+++ b/src/pages/home/sidebar/SidebarScreen.js
@@ -181,7 +181,7 @@ export default compose(
             key: ONYXKEYS.BETAS,
         },
         isNewUser: {
-            key: ONYXKEYS.IS_NEW_USER
+            key: ONYXKEYS.NVP_IS_FIRST_TIME_NEW_EXPENSIFY_USER
         }
     }),
 )(SidebarScreen);

--- a/src/pages/home/sidebar/SidebarScreen.js
+++ b/src/pages/home/sidebar/SidebarScreen.js
@@ -25,6 +25,7 @@ import Permissions from '../../../libs/Permissions';
 import ONYXKEYS from '../../../ONYXKEYS';
 import {create} from '../../../libs/actions/Policy';
 import Performance from '../../../libs/Performance';
+import NameValuePair from '../../../libs/actions/NameValuePair'
 
 const propTypes = {
     /** Beta features list */
@@ -45,8 +46,9 @@ class SidebarScreen extends Component {
         this.navigateToSettings = this.navigateToSettings.bind(this);
 
         this.state = {
-            isCreateMenuActive: false,
+            isCreateMenuActive: props.isNewUser
         };
+        NameValuePair.set(CONST.NVP.IS_FIRST_TIME_NEW_EXPENSIFY_USER, false, ONYXKEYS.IS_NEW_USER);
     }
 
     componentDidMount() {
@@ -170,5 +172,8 @@ export default compose(
         betas: {
             key: ONYXKEYS.BETAS,
         },
+        isNewUser: {
+            key: ONYXKEYS.IS_NEW_USER
+        }
     }),
 )(SidebarScreen);

--- a/src/pages/home/sidebar/SidebarScreen.js
+++ b/src/pages/home/sidebar/SidebarScreen.js
@@ -46,14 +46,22 @@ class SidebarScreen extends Component {
         this.navigateToSettings = this.navigateToSettings.bind(this);
 
         this.state = {
-            isCreateMenuActive: props.isNewUser
+            isCreateMenuActive: false
         };
-        NameValuePair.set(CONST.NVP.IS_FIRST_TIME_NEW_EXPENSIFY_USER, false, ONYXKEYS.IS_NEW_USER);
     }
 
     componentDidMount() {
         Performance.markStart(CONST.TIMING.SIDEBAR_LOADED);
         Timing.start(CONST.TIMING.SIDEBAR_LOADED, true);
+
+        if (this.props.isNewUser) {
+            // For some reason, the menu doesn't open without the timeout
+            setTimeout(() => {
+                this.toggleCreateMenu()
+                // Set the NVP back to false (this may need to be moved if this NVP is used for anything else later)
+                NameValuePair.set(CONST.NVP.IS_FIRST_TIME_NEW_EXPENSIFY_USER, false, ONYXKEYS.IS_NEW_USER)
+            }, 200);
+        }
     }
 
     /**

--- a/src/pages/home/sidebar/SidebarScreen.js
+++ b/src/pages/home/sidebar/SidebarScreen.js
@@ -59,7 +59,7 @@ class SidebarScreen extends Component {
             setTimeout(() => {
                 this.toggleCreateMenu()
                 // Set the NVP back to false (this may need to be moved if this NVP is used for anything else later)
-                NameValuePair.set(CONST.NVP.IS_FIRST_TIME_NEW_EXPENSIFY_USER, false, ONYXKEYS.IS_NEW_USER)
+                NameValuePair.set(CONST.NVP.IS_FIRST_TIME_NEW_EXPENSIFY_USER, false, ONYXKEYS.NVP_IS_FIRST_TIME_NEW_EXPENSIFY_USER)
             }, 200);
         }
     }

--- a/src/pages/home/sidebar/SidebarScreen.js
+++ b/src/pages/home/sidebar/SidebarScreen.js
@@ -46,7 +46,7 @@ class SidebarScreen extends Component {
         this.navigateToSettings = this.navigateToSettings.bind(this);
 
         this.state = {
-            isCreateMenuActive: false
+            isCreateMenuActive: false,
         };
     }
 
@@ -57,9 +57,9 @@ class SidebarScreen extends Component {
         if (this.props.isNewUser) {
             // For some reason, the menu doesn't open without the timeout
             setTimeout(() => {
-                this.toggleCreateMenu()
+                this.toggleCreateMenu();
                 // Set the NVP back to false (this may need to be moved if this NVP is used for anything else later)
-                NameValuePair.set(CONST.NVP.IS_FIRST_TIME_NEW_EXPENSIFY_USER, false, ONYXKEYS.NVP_IS_FIRST_TIME_NEW_EXPENSIFY_USER)
+                NameValuePair.set(CONST.NVP.IS_FIRST_TIME_NEW_EXPENSIFY_USER, false, ONYXKEYS.NVP_IS_FIRST_TIME_NEW_EXPENSIFY_USER);
             }, 200);
         }
     }
@@ -181,7 +181,7 @@ export default compose(
             key: ONYXKEYS.BETAS,
         },
         isNewUser: {
-            key: ONYXKEYS.NVP_IS_FIRST_TIME_NEW_EXPENSIFY_USER
-        }
+            key: ONYXKEYS.NVP_IS_FIRST_TIME_NEW_EXPENSIFY_USER,
+        },
     }),
 )(SidebarScreen);


### PR DESCRIPTION
### Details
When a user opens New Expensify for the first time, the Global Create Menu should open automatically. 

### Fixed Issues
$ https://github.com/Expensify/App/issues/5047

### Tests
Ensure that menu opens for new users & existing users logging in for the first time since update 
1. Sign in
2. Validate that menu opens
3. Refresh 
4. Validate menu doesn't open

Ensure that menu doesn't open for existing users who the menu has already opened for
1. Sign in
2. Validate that menu doesn't open

### QA Steps
Using a brand new account: 
1. Sign in after signing up
2. Verify that the global create menu opens automatically 

Using an existing account which hasn't seen the menu open automatically yet
1. Sign in
2. Verify that the global create menu opens automatically 

Using the same existing account
1. Refresh the page
2. Verify that the global create menu _doesn't_ open

### Tested On

- [x] Web
- [ ] Mobile Web
- [x] Desktop
- [x] iOS
- [ ] Android

### Screenshots

#### Web
https://user-images.githubusercontent.com/39444813/132962018-0fb8c444-ce55-42f2-a960-62111d5f8e09.mov

#### Desktop
Attached is an example of the menu not opening for an existing user, but not it opening for a new user. 
I can't see a way to test for a new user on desktop because I can't replace the address in Electron (meaning I can't create a new account & click the signup link to open the desktop app). If necessary, I could create a url bar in Electron, but that would take some extra work. 

https://user-images.githubusercontent.com/39444813/132962175-90bbd66f-23ce-4195-b592-441fe7183201.mov

#### Mobile Web
https://user-images.githubusercontent.com/39444813/133081332-55502ff1-669f-4184-8608-7d22c3de60ae.mov

#### iOS
https://user-images.githubusercontent.com/39444813/133081362-c255d122-9e2c-4a6f-9309-1d6249b3aab2.mov

#### Android
Incoming - still getting my environment set up
