### PR TITLE
Update payments page to use Expensify logo for Expensify Card

### DIFF
--- a/assets/images/bankicons/expensify.svg
+++ b/assets/images/bankicons/expensify.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 25.2.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 100 100" style="enable-background:new 0 0 100 100;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#0B1B34;}
+	.st1{fill:#03D47C;}
+	.st2{fill:#0185FF;}
+	.st3{fill:#FED607;}
+</style>
+<path class="st0" d="M34,73h32v-9.5H45.7v-8.9H63v-9.7H45.7v-8.5H66V27H34V73z"/>
+<path class="st1" d="M90,50c0,9.6-3.4,18.4-9,25.3l7.1,7.1c7.4-8.7,11.9-20,11.9-32.4c0-12.2-4.4-23.4-11.6-32l-7.1,7.1
+	C86.7,31.9,90,40.6,90,50z"/>
+<path class="st2" d="M75.3,81c-6.9,5.6-15.7,9-25.3,9c-9.4,0-18.1-3.3-24.9-8.7L18,88.4c8.7,7.3,19.9,11.6,32,11.6
+	c12.4,0,23.7-4.5,32.4-11.9L75.3,81z"/>
+<path class="st3" d="M19.3,75.7C13.5,68.7,10,59.8,10,50c0-22.1,17.9-40,40-40c9.8,0,18.7,3.5,25.7,9.3l7.1-7.1C74,4.6,62.5,0,50,0
+	C22.4,0,0,22.4,0,50c0,12.5,4.6,24,12.2,32.8L19.3,75.7z"/>
+</svg>

--- a/src/components/Icon/BankIcons.js
+++ b/src/components/Icon/BankIcons.js
@@ -123,8 +123,8 @@ export default function getBankIcon(bankName, isCard) {
         bankIcon.icon = getAssetIcon(bankName.toLowerCase(), isCard);
     }
 
-    // For default icon & expensify (for now) the icon size should not be set.
-    if (![Expensify, CreditCard, Bank].includes(bankIcon.icon)) {
+    // For default icons the icon size should not be set.
+    if (![CreditCard, Bank].includes(bankIcon.icon)) {
         bankIcon.iconSize = variables.iconSizeExtraLarge;
     }
 

--- a/src/components/Icon/BankIcons.js
+++ b/src/components/Icon/BankIcons.js
@@ -1,4 +1,4 @@
-import {Bank, CreditCard, ExpensifyCard} from './Expensicons';
+import {Bank, CreditCard} from './Expensicons';
 import AmericanExpress from '../../../assets/images/bankicons/american-express.svg';
 import BankOfAmerica from '../../../assets/images/bankicons/bank-of-america.svg';
 import BB_T from '../../../assets/images/bankicons/bb-t.svg';
@@ -8,6 +8,7 @@ import Chase from '../../../assets/images/bankicons/chase.svg';
 import CitiBank from '../../../assets/images/bankicons/citibank.svg';
 import CitizensBank from '../../../assets/images/bankicons/citizens-bank.svg';
 import Discover from '../../../assets/images/bankicons/discover.svg';
+import Expensify from '../../../assets/images/bankicons/expensify.svg';
 import Fidelity from '../../../assets/images/bankicons/fidelity.svg';
 import HuntingtonBank from '../../../assets/images/bankicons/huntington-bank.svg';
 import NavyFederalCreditUnion from '../../../assets/images/bankicons/navy-federal-credit-union.svg';
@@ -28,7 +29,7 @@ import variables from '../../styles/variables';
 
 function getAssetIcon(bankName, isCard) {
     if (bankName === 'expensify card') {
-        return ExpensifyCard;
+        return Expensify;
     }
 
     if (bankName.includes('americanexpress')) {
@@ -123,7 +124,7 @@ export default function getBankIcon(bankName, isCard) {
     }
 
     // For default icon & expensify (for now) the icon size should not be set.
-    if (![ExpensifyCard, CreditCard, Bank].includes(bankIcon.icon)) {
+    if (![Expensify, CreditCard, Bank].includes(bankIcon.icon)) {
         bankIcon.iconSize = variables.iconSizeExtraLarge;
     }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Updates the icon used in the payments section of the app for the Expensify Card. For other cards, we're using the logo of the issuer. In this case, since Expensify is the issuer, the logo being used is the Expensify logo. 

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/4723
--->
$ https://github.com/Expensify/App/issues/5215

### Tests
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->
1. Go to Settings > Payments in an account that has an Expensify Card assigned and is also importing other cards
2. Look at the list of Payment methods
3. Make sure the Expensify Card is showing the Expensify logo 
4. Make sure all other logos are showing as expected


### QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->
1. Go to Settings > Payments in an account that has an Expensify Card assigned and is also importing other cards
2. Look at the list of Payment methods
3. Make sure the Expensify Card is showing the Expensify logo 
4. Make sure all other logos are showing as expected

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
![image](https://user-images.githubusercontent.com/1371996/133162847-59fa456e-b469-49b7-8246-3fc29cce3d6b.png)

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
![image](https://user-images.githubusercontent.com/1371996/133164710-b750a562-4c7d-4015-a86d-537325cfa4f0.png)

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
![image](https://user-images.githubusercontent.com/1371996/133163718-445a12d3-a484-47a7-b76a-33a712d9c7ab.png)

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
<img width="373" alt="Screen Shot 2021-09-14 at 12 49 06 PM" src="https://user-images.githubusercontent.com/1371996/133300011-ef132521-1898-406f-963a-c9b81188d746.png">

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
![image](https://user-images.githubusercontent.com/1371996/133167004-5fe38285-4fbc-4604-9a93-42788b507199.png)
