### PR TITLE
Add new job to leave comment to new contributor

### DIFF
--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -137,13 +137,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
-  newContributorReminder:
+
+  newContributorWelcomeMessage:
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'OSBotify' }}
     steps:
       # Version: 2.3.4
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
-          fetch-depth: 0
           token: ${{ secrets.OS_BOTIFY_TOKEN }}
 
       - name: Get merged pull request

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -137,3 +137,40 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+  newContributorReminder:
+    runs-on: ubuntu-latest
+    steps:
+      # Version: 2.3.4
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.OS_BOTIFY_TOKEN }}
+
+      - name: Get merged pull request
+        id: getMergedPullRequest
+        # TODO: Point back action actions-ecosystem after https://github.com/actions-ecosystem/action-get-merged-pull-request/pull/223 is merged
+        uses: roryabraham/action-get-merged-pull-request@7a7a194f6ff8f3eef58c822083695a97314ebec1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get PR count for ${{ steps.getMergedPullRequest.outputs.author }}
+        run: echo "PR_COUNT=$(gh pr list --author ${{ steps.getMergedPullRequest.outputs.author }} --state any | grep -c '')" >> $GITHUB_ENV
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comment on ${{ steps.getMergedPullRequest.outputs.author }}\'s first pull request!
+        if: ${{ fromJSON(env.PR_COUNT) == 1 }}
+        uses: actions-ecosystem/action-create-comment@cd098164398331c50e7dfdd0dfa1b564a1873fac
+        with:
+          github_token: ${{ secrets.OS_BOTIFY_TOKEN }}
+          number: ${{ steps.getMergedPullRequest.outputs.number }}
+          body: |
+            @${{ steps.getMergedPullRequest.outputs.author }}, Great job getting your first Expensify/App pull request over the finish line! :tada:
+            
+            I know there's a lot of information in our [contributing guidelines](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md), so here are some points to take note of :memo::
+
+            1. Now that your first PR has been merged, you can be hired for another issue. Once you've completed a few issues, you may be eligible to work on more than one job at a time. 
+            2. Once your PR is deployed to our staging servers, it will undergo quality assurance (QA) testing. If we find that it doesn't work as expected or causes a regression, you'll be responsible for fixing it. Typically, we would revert this PR and give you another chance to create a similar PR without causing a regression.
+            3. Once your PR is deployed to _production_, we start a 7-day timer :alarm_clock:. After it has been on production for 7 days without causing any regressions, then we pay out the Upwork job. :moneybag:
+
+            So it might take a while before you're paid for your work, but we typically post multiple new jobs every day, so there's plenty of opportunity. I hope you've had a positive experience contributing to this repo! :blush:


### PR DESCRIPTION
Hey @roryabraham , I added you as a reviewer as I think you know very well how this is supposed to be implemented :) 

I didn't spot any problem with the code provided in the GH issue besides changing `çount` for `count` 

### Details

Add new job "newContributorReminder" to `preDeploy.yml`. Steps in this job:

1. Checkout repository
2. Find last merged PR to get author
3. Get count of PR's done by this author
4. If count of PR's is exactly 1, leave a comment in the merged PR reminding the contributor about things to expect/responsibilities.


I have these doubts about this:

1. I would add the `internal QA` label, is that correct in this case?
2. In the first step, should we keep `fetch-depth: 0` for the `uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f`? I left it there because removing it would only make sense to me for performance reasons, but I guess that's not too important here. Fetching with a narrower scope could make it miss somethings we need to find? The PR's?
3. What happen if two different first contributors' PRs are merged about the same time. Would this job be able to run between each of these PRs? or probably one of them would miss it. I'm guessing that this would be a very rare case, and if one contributor misses his comment, it's not a big deal, but anyway I'm curious about that case :)



### Fixed Issues

$ https://github.com/Expensify/Expensify/issues/176233

### Tests

- Create a PR and merge it with an account that has not done any PR before
- The PR should get the new comment
- Do a PR again with the same account and merge it
- The new PR shouldn't get the new comment

### QA Steps

Reach out to @aldo-expensify to perform QA of this issue