### PR TITLE
Skip showing create for new users if user already has a workspace

### DIFF
--- a/src/pages/home/sidebar/SidebarScreen.js
+++ b/src/pages/home/sidebar/SidebarScreen.js
@@ -29,10 +29,12 @@ import Performance from '../../../libs/Performance';
 import NameValuePair from '../../../libs/actions/NameValuePair';
 
 const propTypes = {
-    /* Beta features list */
+    /* Onyx Props */
+
+    /** Beta features list */
     betas: PropTypes.arrayOf(PropTypes.string).isRequired,
 
-    /* Flag for new users used to open the Global Create menu on first load */
+    /** Flag for new users used to open the Global Create menu on first load */
     isFirstTimeNewExpensifyUser: PropTypes.bool.isRequired,
 
     /** The list of this user's policies */

--- a/src/pages/home/sidebar/SidebarScreen.js
+++ b/src/pages/home/sidebar/SidebarScreen.js
@@ -2,6 +2,7 @@ import React, {Component} from 'react';
 import {View} from 'react-native';
 import {withOnyx} from 'react-native-onyx';
 import PropTypes from 'prop-types';
+import _ from 'underscore';
 import styles from '../../../styles/styles';
 import SidebarLinks from './SidebarLinks';
 import PopoverMenu from '../../../components/PopoverMenu';
@@ -34,9 +35,22 @@ const propTypes = {
     /* Flag for new users used to open the Global Create menu on first load */
     isFirstTimeNewExpensifyUser: PropTypes.bool.isRequired,
 
+    /** The list of this user's policies */
+    policies: PropTypes.objectOf(PropTypes.shape({
+        /** The type of the policy */
+        type: PropTypes.string,
+
+        /** The user's role in the policy */
+        role: PropTypes.string,
+    })),
+
     ...windowDimensionsPropTypes,
 
     ...withLocalizePropTypes,
+};
+
+const defaultProps = {
+    policies: {},
 };
 
 class SidebarScreen extends Component {
@@ -58,13 +72,21 @@ class SidebarScreen extends Component {
         Timing.start(CONST.TIMING.SIDEBAR_LOADED, true);
 
         if (this.props.isFirstTimeNewExpensifyUser) {
-            // For some reason, the menu doesn't open without the timeout
-            setTimeout(() => {
-                this.toggleCreateMenu();
+            const hasFreePolicy = _.chain(this.props.policies)
+                .some(policy => policy && policy.type === CONST.POLICY.TYPE.FREE && policy.role === CONST.POLICY.ROLE.ADMIN)
+                .value();
 
-                // Set the NVP back to false (this may need to be moved if this NVP is used for anything else later)
-                NameValuePair.set(CONST.NVP.IS_FIRST_TIME_NEW_EXPENSIFY_USER, false, ONYXKEYS.NVP_IS_FIRST_TIME_NEW_EXPENSIFY_USER);
-            }, 200);
+            // If user doesn't have any free policies (workspaces) set up, automatically open create menu
+            if (!hasFreePolicy) {
+                // For some reason, the menu doesn't open without the timeout
+                setTimeout(() => {
+                    this.toggleCreateMenu();
+                }, 200);
+            }
+
+            // Set the NVP to false so we don't automatically open the menu again
+            // Note: this may need to be moved if this NVP is used for anything else later
+            NameValuePair.set(CONST.NVP.IS_FIRST_TIME_NEW_EXPENSIFY_USER, false, ONYXKEYS.NVP_IS_FIRST_TIME_NEW_EXPENSIFY_USER);
         }
     }
 
@@ -177,6 +199,7 @@ class SidebarScreen extends Component {
 }
 
 SidebarScreen.propTypes = propTypes;
+SidebarScreen.defaultProps = defaultProps;
 export default compose(
     withLocalize,
     withWindowDimensions,
@@ -186,6 +209,9 @@ export default compose(
         },
         isFirstTimeNewExpensifyUser: {
             key: ONYXKEYS.NVP_IS_FIRST_TIME_NEW_EXPENSIFY_USER,
+        },
+        policies: {
+            key: ONYXKEYS.COLLECTION.POLICY,
         },
     }),
 )(SidebarScreen);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
cc @kevinksullivan @MitchExpensify  @mateomorris 

### Details
<!-- Explanation of the change or anything fishy that is going on -->
In [this comment](https://github.com/Expensify/App/issues/5047#issuecomment-918723531) we discovered that the global create menu still shows up if a user has a workspace, which is not what we want. This PR fixes that.

### Fixed Issues
$ https://github.com/Expensify/App/issues/5047 (part 2)

### Tests
New test:
1. Run the app locally (on whatever device you're testing on)
2. Create a brand new account in expensify.com.dev
3. Go to https://www.expensify.com.dev/admin_policies, create a free plan
    - You'll be redirected to http://localhost:8080/workspace/<your-new-workspace-id>/card
4. Verify the global create menu doesn't pop up

#### To make sure there's no regressions (from the [original PR](https://github.com/Expensify/App/pull/5214)):
Ensure that menu opens for new users & existing users logging in for the first time since update 
1. Sign in
2. Validate that menu opens
3. Refresh 
4. Validate menu doesn't open

Ensure that menu doesn't open for existing users who the menu has already opened for
1. Sign in
2. Validate that menu doesn't open

### QA Steps
New test:
1. Create a brand new account in expensify.com
2. Go to https://www.staging.expensify.com/admin_policies, create a free plan
    - You'll be redirected to https://staging.new.expensify.com/workspace/<your-new-workspace-id>/card
3. Verify the global create menu doesn't pop up behind

#### To make sure there's no regressions (from the [original PR](https://github.com/Expensify/App/pull/5214)):
Using a brand new account: 
1. Sign in after signing up
2. Verify that the global create menu opens automatically 

Using an existing account which hasn't seen the menu open automatically yet
1. Sign in
2. Verify that the global create menu opens automatically 

Using the same existing account
1. Refresh the page
2. Verify that the global create menu _doesn't_ open

### Tested On

- [X] Web
- [ ] Mobile Web (having trouble with this)
- ~Desktop~ (Can't test here since we don't have a desktop old expensify app that could open the desktop new expensify app)
- ~iOS~ (Can't create a workspace from old mobile expensify)
- ~Android~ (Can't create a workspace from old mobile expensify)

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
https://user-images.githubusercontent.com/3885503/133268194-0dd627d2-6fee-4f76-8fe9-27dc5c9b69dd.mov

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
Really difficult to get this... May only be possible in staging

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
N/A

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
N/A

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
N/A
