### PR TITLE
Redirect NewDot staging links in the same tab just like production links

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -132,6 +132,7 @@ const CONST = {
     STAGING_SECURE_URL: 'https://staging-secure.expensify.com/',
     NEWDOT: 'new.expensify.com',
     NEW_EXPENSIFY_URL,
+    NEW_EXPENSIFY_URL_STAGING: 'https://staging.new.expensify.com',
     OPTION_TYPE: {
         REPORT: 'report',
         PERSONAL_DETAIL: 'personalDetail',

--- a/src/CONST.js
+++ b/src/CONST.js
@@ -132,7 +132,7 @@ const CONST = {
     STAGING_SECURE_URL: 'https://staging-secure.expensify.com/',
     NEWDOT: 'new.expensify.com',
     NEW_EXPENSIFY_URL,
-    NEW_EXPENSIFY_URL_STAGING: 'https://staging.new.expensify.com',
+    STAGING_NEW_EXPENSIFY_URL: 'https://staging.new.expensify.com',
     OPTION_TYPE: {
         REPORT: 'report',
         PERSONAL_DETAIL: 'personalDetail',

--- a/src/components/HTMLEngineProvider/BaseHTMLEngineProvider.js
+++ b/src/components/HTMLEngineProvider/BaseHTMLEngineProvider.js
@@ -74,7 +74,7 @@ function AnchorRenderer({tnode, key, style}) {
     const fileName = lodashGet(tnode, 'domNode.children[0].data', '');
     const parentStyle = lodashGet(tnode, 'parent.styles.nativeTextRet', {});
     const internalExpensifyPath = (htmlAttribs.href.startsWith(CONST.NEW_EXPENSIFY_URL) && htmlAttribs.href.replace(CONST.NEW_EXPENSIFY_URL, ''))
-        || (htmlAttribs.href.startsWith(CONST.NEW_EXPENSIFY_URL_STAGING) && htmlAttribs.href.replace(CONST.NEW_EXPENSIFY_URL_STAGING, ''));
+        || (htmlAttribs.href.startsWith(CONST.STAGING_NEW_EXPENSIFY_URL) && htmlAttribs.href.replace(CONST.STAGING_NEW_EXPENSIFY_URL, ''));
 
     // If we are handling a New Expensify link then we will assume this should be opened by the app internally. This ensures that the links are opened internally via react-navigation
     // instead of in a new tab or with a page refresh (which is the default behavior of an anchor tag)

--- a/src/components/HTMLEngineProvider/BaseHTMLEngineProvider.js
+++ b/src/components/HTMLEngineProvider/BaseHTMLEngineProvider.js
@@ -72,7 +72,9 @@ function AnchorRenderer({tnode, key, style}) {
     // An auth token is needed to download Expensify chat attachments
     const isAttachment = Boolean(htmlAttribs['data-expensify-source']);
     const fileName = lodashGet(tnode, 'domNode.children[0].data', '');
-    const internalExpensifyPath = htmlAttribs.href.startsWith(CONST.NEW_EXPENSIFY_URL) && htmlAttribs.href.replace(CONST.NEW_EXPENSIFY_URL, '');
+    const internalExpensifyPath = (htmlAttribs.href.startsWith(CONST.NEW_EXPENSIFY_URL) && htmlAttribs.href.replace(CONST.NEW_EXPENSIFY_URL, ''))
+        || (htmlAttribs.href.startsWith(CONST.NEW_EXPENSIFY_URL_STAGING) && htmlAttribs.href.replace(CONST.NEW_EXPENSIFY_URL_STAGING, ''));
+
 
     // If we are handling a New Expensify link then we will assume this should be opened by the app internally. This ensures that the links are opened internally via react-navigation
     // instead of in a new tab or with a page refresh (which is the default behavior of an anchor tag)

--- a/src/libs/Navigation/linkingConfig.js
+++ b/src/libs/Navigation/linkingConfig.js
@@ -10,7 +10,7 @@ export default {
         'https://staging.expensify.cash',
         'http://localhost',
         CONST.NEW_EXPENSIFY_URL,
-        'https://staging.new.expensify.com',
+        CONST.NEW_EXPENSIFY_URL_STAGING,
     ],
     config: {
         initialRouteName: SCREENS.HOME,

--- a/src/libs/Navigation/linkingConfig.js
+++ b/src/libs/Navigation/linkingConfig.js
@@ -10,7 +10,7 @@ export default {
         'https://staging.expensify.cash',
         'http://localhost',
         CONST.NEW_EXPENSIFY_URL,
-        CONST.NEW_EXPENSIFY_URL_STAGING,
+        CONST.STAGING_NEW_EXPENSIFY_URL,
     ],
     config: {
         initialRouteName: SCREENS.HOME,


### PR DESCRIPTION
CC: @luacmartins  @marcaaron @ctkochan22 


### Details

Follow up from this discussion on slack: https://expensify.slack.com/archives/C03TQ48KC/p1631576910170000

Related to this issue and testing it on staging
$ https://github.com/Expensify/Expensify/issues/176437

### Tests
Same as Web QA done locally.

### QA Steps
Send this exact message to yourself or any other user: `testing https://staging.new.expensify.com/settings` and verify that clicking on the hyper link opens the settings page in the same tab without opening a new page.

### Tested On

- [x] Web
- [x] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
![image](https://user-images.githubusercontent.com/19364431/133294393-377f0cdc-dd15-49c1-bf7f-6fd2ded83813.png)
![image](https://user-images.githubusercontent.com/19364431/133294424-6d95caf5-99ba-4f2f-ae45-863d472cfd73.png)

