### PR TITLE
Skintone Emoji Border Radius and Size

### DIFF
--- a/src/pages/home/report/EmojiPickerMenuItem.js
+++ b/src/pages/home/report/EmojiPickerMenuItem.js
@@ -18,11 +18,6 @@ const propTypes = {
 
     /** Whether this menu item is currently highlighted or not */
     isHighlighted: PropTypes.bool,
-
-    /** Override default emojiItem style */
-    // eslint-disable-next-line react/forbid-prop-types
-    emojiItemStyle: PropTypes.any,
-
 };
 
 const EmojiPickerMenuItem = props => (
@@ -34,7 +29,7 @@ const EmojiPickerMenuItem = props => (
             styles.pv1,
             getButtonBackgroundColorStyle(getButtonState(false, pressed)),
             props.isHighlighted ? styles.emojiItemHighlighted : {},
-            props.emojiItemStyle ? props.emojiItemStyle : styles.emojiItem,
+            styles.emojiItem,
         ])}
     >
         <Hoverable onHoverIn={props.onHover}>
@@ -50,7 +45,6 @@ EmojiPickerMenuItem.displayName = 'EmojiPickerMenuItem';
 EmojiPickerMenuItem.defaultProps = {
     isHighlighted: false,
     onHover: () => {},
-    emojiItemStyle: undefined,
 };
 
 // Significantly speeds up re-renders of the EmojiPickerMenu's FlatList

--- a/src/pages/home/report/EmojiSkinToneList.js
+++ b/src/pages/home/report/EmojiSkinToneList.js
@@ -68,7 +68,7 @@ class EmojiSkinToneList extends Component {
                                 styles.alignItemsCenter,
                             ]}
                         >
-                            <Text style={[styles.emojiText, styles.ph1]}>
+                            <Text style={[styles.emojiText, styles.ph2]}>
                                 {selectedEmoji.code}
                             </Text>
                             <Text style={[styles.emojiSkinToneTitle]}>

--- a/src/pages/home/report/EmojiSkinToneList.js
+++ b/src/pages/home/report/EmojiSkinToneList.js
@@ -52,7 +52,7 @@ class EmojiSkinToneList extends Component {
     render() {
         const selectedEmoji = getSkinToneEmojiFromIndex(this.props.preferredSkinTone);
         return (
-            <View style={[styles.flexRow, styles.p1, styles.ph3]}>
+            <View style={[styles.flexRow, styles.p1, styles.ph4]}>
                 {
                     !this.state.isSkinToneListVisible && (
                         <Pressable

--- a/src/pages/home/report/EmojiSkinToneList.js
+++ b/src/pages/home/report/EmojiSkinToneList.js
@@ -68,7 +68,7 @@ class EmojiSkinToneList extends Component {
                                 styles.alignItemsCenter,
                             ]}
                         >
-                            <Text style={[styles.emojiText, styles.ph2]}>
+                            <Text style={[styles.emojiText, styles.ph2, styles.emojiItem]}>
                                 {selectedEmoji.code}
                             </Text>
                             <Text style={[styles.emojiSkinToneTitle]}>

--- a/src/pages/home/report/EmojiSkinToneList.js
+++ b/src/pages/home/report/EmojiSkinToneList.js
@@ -79,21 +79,19 @@ class EmojiSkinToneList extends Component {
                 }
                 {
                     this.state.isSkinToneListVisible && (
-                        <View>
-                            <View style={[styles.flexRow]}>
-                                {
-                                    skinTones.map(skinToneEmoji => (
-                                        <EmojiPickerMenuItem
-                                            onPress={() => this.updateSelectedSkinTone(skinToneEmoji)}
-                                            onHover={() => this.setState({highlightedIndex: skinToneEmoji.skinTone})}
-                                            key={skinToneEmoji.code}
-                                            emojiItemStyle={styles.emojiSkinToneItem}
-                                            emoji={skinToneEmoji.code}
-                                            isHighlighted={skinToneEmoji.skinTone === this.state.highlightedIndex}
-                                        />
-                                    ))
+
+                        <View style={[styles.flexRow, styles.flex1]}>
+                            {
+                                skinTones.map(skinToneEmoji => (
+                                    <EmojiPickerMenuItem
+                                        onPress={() => this.updateSelectedSkinTone(skinToneEmoji)}
+                                        onHover={() => this.setState({highlightedIndex: skinToneEmoji.skinTone})}
+                                        key={skinToneEmoji.code}
+                                        emoji={skinToneEmoji.code}
+                                        isHighlighted={skinToneEmoji.skinTone === this.state.highlightedIndex}
+                                    />
+                                ))
                                 }
-                            </View>
                         </View>
                     )
                 }

--- a/src/pages/home/report/EmojiSkinToneList.js
+++ b/src/pages/home/report/EmojiSkinToneList.js
@@ -45,7 +45,7 @@ class EmojiSkinToneList extends Component {
      * @param {object} skinToneEmoji
      */
     updateSelectedSkinTone(skinToneEmoji) {
-        this.setState(prev => ({isSkinToneListVisible: !prev.isSkinToneListVisible}));
+        this.setState(prev => ({isSkinToneListVisible: !prev.isSkinToneListVisible, highlightedIndex: skinToneEmoji.skinTone}));
         this.props.updatePreferredSkinTone(skinToneEmoji.skinTone);
     }
 

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1177,6 +1177,9 @@ const styles = {
 
     emojiSkinToneItem: {
         width: 'auto',
+        minWidth: 36,
+        textAlign: 'center',
+        borderRadius: 8,
         ...spacing.ph1,
     },
 

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1175,14 +1175,6 @@ const styles = {
         borderRadius: 8,
     },
 
-    emojiSkinToneItem: {
-        width: 'auto',
-        minWidth: 36,
-        textAlign: 'center',
-        borderRadius: 8,
-        ...spacing.ph1,
-    },
-
     emojiItemHighlighted: {
         transition: '0.2s ease',
         backgroundColor: themeColors.buttonDefaultBG,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

@stitesExpensify Can you please review this?

### Details
- Added `borderRadius` to Skin tone Emoji
- Aligned skin tone picker with rest of the emojis

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/4723

Do NOT only link the issue number like this: $ #1234
--->
$ https://github.com/Expensify/App/issues/5247

### Tests
1. Checked Emoji Skintones on all platforms
2. Verified the default highlighted skintone

<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### QA Steps

**Emoji Size**
1. Go to EmojiPicker
2. Hover over any Emoji
3. Click on Choose Skintone and hover over any skintone
4. Verify size is same for both of them.


**Emoji Retention**
1. Open EmojiPicker
2. Click on "Change default skin tone"
3. Choose one of the skin tones.
4. Click on the "Change default skin tone" again
5. Verify the selected skin tone in step 3, is highlighted by default.

<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<img width="437" alt="Screenshot 2021-09-15 at 12 29 16 AM" src="https://user-images.githubusercontent.com/3069065/133319381-57100358-cc4f-44ba-a0af-a1ae09794ace.png">

**Updated**
<img width="361" alt="web-skintone-list-alignment" src="https://user-images.githubusercontent.com/3069065/134217485-89f520d5-5db5-4ea6-bfc5-616c200fdc96.png">
<img width="384" alt="web-skintone-picker-alignment" src="https://user-images.githubusercontent.com/3069065/134217471-dee25997-e876-4879-80bb-288a8948a390.png">

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

<img width="405" alt="mweb-skintone-picker-alignment" src="https://user-images.githubusercontent.com/3069065/134217528-16b982ec-be4a-4cc9-8c9a-a43a06025ac6.png">
<img width="362" alt="mweb-skintone-list-alignment" src="https://user-images.githubusercontent.com/3069065/134217542-36d2b490-31a0-4b62-8c28-ec4ee6e9d8be.png">


#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
![image](https://user-images.githubusercontent.com/3069065/133319408-26312a3c-2ba0-4b8f-9359-403d36a64f77.png)

**Updated**

<img width="456" alt="desktop-skintone-picker-alignment" src="https://user-images.githubusercontent.com/3069065/134217589-69b29ebf-9677-4203-817d-8336c08af4c4.png">
<img width="423" alt="desktop-skintone-list-alignment" src="https://user-images.githubusercontent.com/3069065/134217604-0e2066b6-7edf-406a-a75a-1d7b93fc0a5e.png">


#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
<img width="453" alt="ios-skintone-picker-alignment" src="https://user-images.githubusercontent.com/3069065/134218564-b62d85da-4499-4bc7-ac8a-81dfd80d9cb6.png">
<img width="455" alt="ios-skintone-list-alignment png" src="https://user-images.githubusercontent.com/3069065/134218575-88008980-cabc-4d03-bbab-ee7ca1d34e2a.png">

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
<img width="387" alt="android-skintone-picker-alignment" src="https://user-images.githubusercontent.com/3069065/134218625-2c23e111-909a-4c3e-902b-f7e3ea1b1f1c.png">
<img width="343" alt="android-skintone-list-alignment" src="https://user-images.githubusercontent.com/3069065/134218631-f4306ab6-3217-4c1b-838c-cdaf377e1434.png">


