### PR TITLE
Re-add internationalization beta

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -88,6 +88,7 @@ const CONST = {
         FREE_PLAN: 'freePlan',
         DEFAULT_ROOMS: 'defaultRooms',
         BETA_EXPENSIFY_WALLET: 'expensifyWallet',
+        INTERNATIONALIZATION: 'internationalization',
     },
     BUTTON_STATES: {
         DEFAULT: 'default',

--- a/src/components/LocalePicker.js
+++ b/src/components/LocalePicker.js
@@ -6,6 +6,7 @@ import {setLocale} from '../libs/actions/App';
 import withLocalize, {withLocalizePropTypes} from './withLocalize';
 import ONYXKEYS from '../ONYXKEYS';
 import CONST from '../CONST';
+import Permissions from '../libs/Permissions';
 import {translate} from '../libs/translate';
 import ExpensiPicker from './ExpensiPicker';
 
@@ -16,12 +17,16 @@ const propTypes = {
     /** Indicates size of a picker component and whether to render the label or not */
     size: PropTypes.oneOf(['normal', 'small']),
 
+    /** Beta features list */
+    betas: PropTypes.arrayOf(PropTypes.string),
+
     ...withLocalizePropTypes,
 };
 
 const defaultProps = {
     preferredLocale: CONST.DEFAULT_LOCALE,
     size: 'normal',
+    betas: [],
 };
 
 const localesToLanguages = {
@@ -37,20 +42,26 @@ const localesToLanguages = {
 
 const LocalePicker = ({
     // eslint-disable-next-line no-shadow
-    preferredLocale, translate, size,
-}) => (
-    <ExpensiPicker
-        label={size === 'normal' ? translate('preferencesPage.language') : null}
-        onChange={(locale) => {
-            if (locale !== preferredLocale) {
-                setLocale(locale);
-            }
-        }}
-        items={Object.values(localesToLanguages)}
-        size={size}
-        value={preferredLocale}
-    />
-);
+    preferredLocale, translate, betas, size,
+}) => {
+    if (!Permissions.canUseInternationalization(betas)) {
+        return null;
+    }
+
+    return (
+        <ExpensiPicker
+            label={size === 'normal' ? translate('preferencesPage.language') : null}
+            onChange={(locale) => {
+                if (locale !== preferredLocale) {
+                    setLocale(locale);
+                }
+            }}
+            items={Object.values(localesToLanguages)}
+            size={size}
+            value={preferredLocale}
+        />
+    );
+};
 
 LocalePicker.defaultProps = defaultProps;
 LocalePicker.propTypes = propTypes;
@@ -61,6 +72,9 @@ export default compose(
     withOnyx({
         preferredLocale: {
             key: ONYXKEYS.NVP_PREFERRED_LOCALE,
+        },
+        betas: {
+            key: ONYXKEYS.BETAS,
         },
     }),
 )(LocalePicker);

--- a/src/libs/Permissions.js
+++ b/src/libs/Permissions.js
@@ -55,6 +55,14 @@ function canUseDefaultRooms(betas) {
  * @param {Array<String>} betas
  * @returns {Boolean}
  */
+function canUseInternationalization(betas) {
+    return _.contains(betas, CONST.BETAS.INTERNATIONALIZATION) || canUseAllBetas(betas);
+}
+
+/**
+ * @param {Array<String>} betas
+ * @returns {Boolean}
+ */
 function canUseWallet(betas) {
     return _.contains(betas, CONST.BETAS.BETA_EXPENSIFY_WALLET || canUseAllBetas(betas));
 }
@@ -65,5 +73,6 @@ export default {
     canUsePayWithExpensify,
     canUseFreePlan,
     canUseDefaultRooms,
+    canUseInternationalization,
     canUseWallet,
 };


### PR DESCRIPTION
### Details
In https://github.com/Expensify/App/pull/4967 we removed the internationalization beta, but according to https://github.com/Expensify/App/pull/4967#issuecomment-918222573 we do not yet want to remove it. This PR re-adds the beta (files had changed so GH revert functionality didn't work).

### Fixed Issues
Comment: https://github.com/Expensify/App/pull/4967#issuecomment-918222573

### Tests
1. Update [this line](https://github.com/Expensify/App/blob/0e6fdbf0e3b9f87572701c90c78b2ab73540b3ff/src/libs/Permissions.js#L11) to remove the `isDevelopment()` check.
2. Sign out of the app, on the sign-in page confirm you don't see the option to change from English to Spanish.
3. Sign into an account that is on the beta, confirm you can see the English/Spanish dropdown

### QA Steps
1. Sign out of the app, on the sign-in page confirm you don't see the option to change from English to Spanish
2. Sign into an account that is on the beta, then go to Preferences, confirm you can change from English to Spanish

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android
