### PR TITLE
Update the PR template to not use actual issue numbers in comments

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,9 +11,9 @@ It MUST be an entire link to the issue; otherwise, the linking will not work as 
 
 Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):
 
-$ https://github.com/Expensify/App/issues/4723
+$ https://github.com/Expensify/App/issues/<number-of-the-issue>
 
-Do NOT only link the issue number like this: $ #1234
+Do NOT only link the issue number like this: $ #<number-of-the-issue>
 --->
 $ GH_LINK
 


### PR DESCRIPTION

<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

Coming from [this](https://expensify.slack.com/archives/C03TQ48KC/p1631749789283400) thread in Slack, the PR template example numbers are being mistakenly parsed as actual linked issues causing problems in our flow. 

To solve it, we will not use actual numbers so our parser does not catch it.

### Fixed Issues
N/A

### Tests 
No tests needed.