### PR TITLE
[NoQA] Add mention about not using Github keywords to Contributing Guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ In this scenario, it’s possible that you found a bug or enhancement that we ha
 	3. Lint - All code must pass lint checks before a merge of a pull request
 13. Please never force push when a PR review has already started (because this messes with the PR review history)
 14. Please, pay attention to the pull request template, especially to how we require issues to be linked with the PR. We have processes in place to help us manage the open source issues and to pay contributors on time. If Github keywords such as `fixes` are used to link issue to PR, this will automatically close the related issue once the PR is merged and break our flow. Please, do not use these keywords and use format stated in the PR template.
-15. Upon submission of a PR, please include a numbered list of explicit testing steps for each platform (Web, Desktop, iOS, and Android) to confirm the fix works as expected and there are no regressions.
+15. Upon submission of a PR, please include a numbered list of explicit testing steps for each platform (Web, Desktop, iOS, Android, and Mobile Web) to confirm the fix works as expected and there are no regressions.
 16. Please add a screenshot of the app running on each platform (Web, Desktop, iOS, Android, Mobile Web). If you are unable to build to iOS/OSX due to using a Windows machine, please let the reviewers know so they can double check that platform themselves.
 
 #### Timeline expectations and asking for help along the way

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ In this scenario, it’s possible that you found a bug or enhancement that we ha
 	2. Tests - All tests must pass before a merge of a pull request
 	3. Lint - All code must pass lint checks before a merge of a pull request
 13. Please never force push when a PR review has already started (because this messes with the PR review history)
-14. Please pay attention to the pull request template, especially to how we link PRs with issues they fix. Please make sure you don't use Github keywords such as `fixes` in your PR description, as this can break our current automated steps for issue management. Please follow the PR template format carefully.
+14. Please pay attention to the pull request template, especially to how we link PRs with issues they fix. Make sure you don't use Github keywords such as `fixes` in your PR description, as this can break our current automated steps for issue management. Follow the PR template format carefully.
 15. Upon submission of a PR, please include a numbered list of explicit testing steps for each platform (Web, Desktop, iOS, Android, and Mobile Web) to confirm the fix works as expected and there are no regressions.
 16. Please add a screenshot of the app running on each platform (Web, Desktop, iOS, Android, Mobile Web). If you are unable to build to iOS/OSX due to using a Windows machine, please let the reviewers know so they can double check that platform themselves.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ In this scenario, it’s possible that you found a bug or enhancement that we ha
 	2. Tests - All tests must pass before a merge of a pull request
 	3. Lint - All code must pass lint checks before a merge of a pull request
 13. Please never force push when a PR review has already started (because this messes with the PR review history)
-14. Please, pay attention to the pull request template, especially to how we require issues to be linked with the PR. We have processes in place to help us manage the open source issues and to pay contributors on time. If Github keywords such as `fixes` are used to link issue to PR, this will automatically close the related issue once the PR is merged and break our flow. Please, do not use these keywords and use format stated in the PR template.
+14. Please pay attention to the pull request template, especially to how we link PRs with issues they fix. Please make sure you don't use Github keywords such as `fixes` in your PR description, as this can break our current automated steps for issue management. Please follow the PR template format carefully.
 15. Upon submission of a PR, please include a numbered list of explicit testing steps for each platform (Web, Desktop, iOS, Android, and Mobile Web) to confirm the fix works as expected and there are no regressions.
 16. Please add a screenshot of the app running on each platform (Web, Desktop, iOS, Android, Mobile Web). If you are unable to build to iOS/OSX due to using a Windows machine, please let the reviewers know so they can double check that platform themselves.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,8 +96,9 @@ In this scenario, it’s possible that you found a bug or enhancement that we ha
 	2. Tests - All tests must pass before a merge of a pull request
 	3. Lint - All code must pass lint checks before a merge of a pull request
 13. Please never force push when a PR review has already started (because this messes with the PR review history)
-14. Upon submission of a PR, please include a numbered list of explicit testing steps for each platform (Web, Desktop, iOS, and Android) to confirm the fix works as expected and there are no regressions.
-15. Please add a screenshot of the app running on each platform (Web, Desktop, iOS, Android, Mobile Web). If you are unable to build to iOS/OSX due to using a Windows machine, please let the reviewers know so they can double check that platform themselves.
+14. Please, pay attention to the pull request template, especially to how we require issues to be linked with the PR. We have processes in place to help us manage the open source issues and to pay contributors on time. If Github keywords such as `fixes` are used to link issue to PR, this will automatically close the related issue once the PR is merged and break our flow. Please, do not use these keywords and use format stated in the PR template.
+15. Upon submission of a PR, please include a numbered list of explicit testing steps for each platform (Web, Desktop, iOS, and Android) to confirm the fix works as expected and there are no regressions.
+16. Please add a screenshot of the app running on each platform (Web, Desktop, iOS, Android, Mobile Web). If you are unable to build to iOS/OSX due to using a Windows machine, please let the reviewers know so they can double check that platform themselves.
 
 #### Timeline expectations and asking for help along the way
 - If you have made a change to your pull request and are ready for another review, leave a comment that says "Updated" on the pull request  itself.


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
cc @mallenexpensify and @Beamanator 

### Details
<!-- Explanation of the change or anything fishy that is going on -->

As part of an effort to make sure we have high percentage of PRs using the expected format so our contributor management flows work well, we are updating the Contributing guidelines to give more insight to external person about why we need to use non-standard way of linking issues.

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/Expensify/issues/177296

### Tests
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->
❌ 
