### PR TITLE
Regression Props Warning

### DIFF
--- a/src/components/AttachmentPicker/index.native.js
+++ b/src/components/AttachmentPicker/index.native.js
@@ -5,7 +5,7 @@ import React, {Component} from 'react';
 import {Alert, Linking, View} from 'react-native';
 import {launchImageLibrary} from 'react-native-image-picker';
 import RNDocumentPicker from 'react-native-document-picker';
-import * as basePropTypes from './AttachmentPickerPropTypes';
+import {propTypes as basePropTypes, defaultProps} from './AttachmentPickerPropTypes';
 import styles from '../../styles/styles';
 import Popover from '../Popover';
 import MenuItem from '../MenuItem';
@@ -302,6 +302,7 @@ class AttachmentPicker extends Component {
 }
 
 AttachmentPicker.propTypes = propTypes;
+AttachmentPicker.defaultProps = defaultProps;
 AttachmentPicker.displayName = 'AttachmentPicker';
 export default compose(
     withWindowDimensions,


### PR DESCRIPTION
@Jag96 

### Details
Refer comment from PR  -> https://github.com/Expensify/App/pull/5095#issuecomment-920480208
Should not show that warning, so handled in the PR. The changes don't affect any expected behavior in production. But based on code changes it looks like affecting native mobile devices, so added tests for that.

### Fixed Issues
$ https://github.com/Expensify/App/issues/4645

### Tests
1.  Run the app in development mode locally on Android and iOS devices.
2. You should not see the warning in this comment

### QA Steps
1. Go to Settings
2. Click Profile
3. Click the pen icon to update or add a photo
4. Click upload photo
5. Refer Fix section below, it should work as shown there.
6. Create a new workspace if you don't have one.
7. Go to Setting
8. Click on your workspace.
9. Tap on the Workspace icon
10. Click the pen icon to update or add a photo
11. Click upload photo

We should show only two options now
- Take photos
- Choose from gallery

### Tested On
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### iOS
##### For Reviewer - No warning now.
https://user-images.githubusercontent.com/85645967/133804208-4c066fbb-1038-4817-a5f0-4ca6b95242b1.mp4

##### For QA
![Simulator Screen Shot - iPhone 12 - 2021-09-17 at 19 54 39](https://user-images.githubusercontent.com/85645967/133802375-6d31fea1-d2d2-4eaf-86a7-56a430859e93.png)

#### Android
##### For QA
![Screenshot_1631889430](https://user-images.githubusercontent.com/85645967/133802400-b68c8492-2e9a-4417-8420-2495a35cbe13.png)
