### PR TITLE
Fix typo on workspace page

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -605,7 +605,7 @@ export default {
             addEmail: 'Add email',
             tagline: 'The smartest corporate card in the room.',
             publicCopy: 'In order to use the Expensify Card you must use your company\'s private domain. Go ahead and add your private email address as a secondary login.',
-            privateCopy: 'Just swipe your Expensify card and your expenses are done, its that simple!',
+            privateCopy: 'Just swipe your Expensify card and your expenses are done, it\'s that simple!',
             getStarted: 'Get started',
             finishSetup: 'Finish setup',
             manageCards: 'Manage cards',


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Fixes a typo on the Workspace page

### Fixed Issues
Fixes issue found in [slack](https://expensify.slack.com/archives/C020EPP9B9A/p1631897615024100)

### Tests/QA
1. Create a new workspace for Expensify Card
2. Confirm the text reads `Just swipe your Expensify card and your expenses are done, it's that simple!`

![image](https://user-images.githubusercontent.com/3981102/133827541-758da76e-4d7c-4e2c-85f6-7bd8fbf26263.png)
