### PR TITLE
Update labels in VBA flow to have correct spacing

### DIFF
--- a/src/pages/ReimbursementAccount/CompanyStep.js
+++ b/src/pages/ReimbursementAccount/CompanyStep.js
@@ -200,6 +200,7 @@ class CompanyStep extends React.Component {
                                 onChangeText={value => this.clearErrorAndSetValue('addressCity', value)}
                                 value={this.state.addressCity}
                                 errorText={this.getErrorText('addressCity')}
+                                translateX={-14}
                             />
                         </View>
                         <View style={[styles.flex1]}>
@@ -261,6 +262,7 @@ class CompanyStep extends React.Component {
                                 value={this.state.incorporationDate}
                                 placeholder={this.props.translate('companyStep.incorporationDatePlaceholder')}
                                 errorText={this.getErrorText('incorporationDate')}
+                                translateX={-14}
                             />
                         </View>
                         <View style={[styles.flex1]}>

--- a/src/pages/ReimbursementAccount/IdentityForm.js
+++ b/src/pages/ReimbursementAccount/IdentityForm.js
@@ -84,6 +84,7 @@ const IdentityForm = ({
                             onFieldChange('firstName', val);
                         }}
                         errorText={error === translateLocal('bankAccount.error.firstName') ? error : ''}
+                        translateX={-10}
                     />
                 </View>
                 <View style={[styles.flex2]}>
@@ -97,6 +98,7 @@ const IdentityForm = ({
                             onFieldChange('lastName', val);
                         }}
                         errorText={error === translateLocal('bankAccount.error.lastName') ? error : ''}
+                        translateX={-10}
                     />
                 </View>
             </View>
@@ -150,6 +152,7 @@ const IdentityForm = ({
                             onFieldChange('city', val);
                         }}
                         errorText={error === translateLocal('bankAccount.error.addressCity') ? error : ''}
+                        translateX={-14}
                     />
                 </View>
                 <View style={[styles.flex1]}>


### PR DESCRIPTION
### Details
This PR updates some labels that had incorrect spacing on iOS and Android while navigating the VBA flow. This fix uses the translateX prop introduced in https://github.com/Expensify/App/pull/3414 to make these changes, eventually, we may want to refactor that since the spacing is not uniform for all inputs across the app, but for N6 this approach will work.

### Fixed Issues
Fixes issue from discussion in [slack](https://expensify.slack.com/archives/C020EPP9B9A/p1631901215047800)

### Tests/QA
1. Create a new workspace and go through the VBA flow, confirm all of the labels have proper spacing
    1. Confirm `First Name`, `Last Name`, `City`, `Incorporation Date` specifically, as this PR fixes those

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
Company Info

| Web | iOS | Android |
|---|---|---|
| ![image](https://user-images.githubusercontent.com/3981102/133849553-7c07d240-7a32-4c36-9e80-e804a601d22e.png) | ![image](https://user-images.githubusercontent.com/3981102/133849589-999974af-38d1-49db-bc6d-1cf08ff4ac17.png) | ![image](https://user-images.githubusercontent.com/3981102/133849603-641dd263-6e4e-4ccb-b804-8ee76d9839af.png) |

Personal Info

| Web | iOS | Android |
|---|---|---|
| ![image](https://user-images.githubusercontent.com/3981102/133849666-039c0ec3-cd81-4b77-bccc-32799dbff5f2.png) | ![image](https://user-images.githubusercontent.com/3981102/133849697-3196219e-75e5-410a-bea0-85db94146b6a.png) | ![image](https://user-images.githubusercontent.com/3981102/133849722-58d2875c-d20b-4b04-b16a-9440d44a4fc3.png) |



