### PR TITLE
Stop loading default chat room initally for those outside of beta

### DIFF
--- a/src/libs/Navigation/AppNavigator/MainDrawerNavigator.js
+++ b/src/libs/Navigation/AppNavigator/MainDrawerNavigator.js
@@ -46,8 +46,7 @@ const getInitialReportScreenParams = (reports, ignoreDefaultRooms) => {
 };
 
 const MainDrawerNavigator = (props) => {
-    const initialParams =  getInitialReportScreenParams(props.reports, !Permissions.canUseDefaultRooms(props.betas));
-    debugger;
+    const initialParams = getInitialReportScreenParams(props.reports, !Permissions.canUseDefaultRooms(props.betas));
 
     // Wait until reports are fetched and there is a reportID in initialParams
     if (!initialParams.reportID) {

--- a/src/libs/Navigation/AppNavigator/MainDrawerNavigator.js
+++ b/src/libs/Navigation/AppNavigator/MainDrawerNavigator.js
@@ -6,6 +6,7 @@ import {withOnyx} from 'react-native-onyx';
 import FullScreenLoadingIndicator from '../../../components/FullscreenLoadingIndicator';
 import ONYXKEYS from '../../../ONYXKEYS';
 import SCREENS from '../../../SCREENS';
+import Permissions from '../../Permissions';
 
 // Screens
 import ReportScreen from '../../../pages/home/ReportScreen';
@@ -18,15 +19,26 @@ const propTypes = {
     reports: PropTypes.objectOf(PropTypes.shape({
         reportID: PropTypes.number,
     })),
+
+    /** Beta features list */
+    betas: PropTypes.arrayOf(PropTypes.string),
 };
 
 const defaultProps = {
     reports: {},
+    betas: [],
 };
 
 
-const getInitialReportScreenParams = (reports) => {
-    const last = findLastAccessedReport(reports);
+/**
+ * Get the most recently accessed report for the user
+ *
+ * @param {Object} reports
+ * @param {Boolean} [ignoreDefaultRooms]
+ * @returns {Object}
+ */
+const getInitialReportScreenParams = (reports, ignoreDefaultRooms) => {
+    const last = findLastAccessedReport(reports, ignoreDefaultRooms);
 
     // Fallback to empty if for some reason reportID cannot be derived - prevents the app from crashing
     const reportID = lodashGet(last, 'reportID', '');
@@ -34,7 +46,8 @@ const getInitialReportScreenParams = (reports) => {
 };
 
 const MainDrawerNavigator = (props) => {
-    const initialParams = getInitialReportScreenParams(props.reports);
+    const initialParams =  getInitialReportScreenParams(props.reports, !Permissions.canUseDefaultRooms(props.betas));
+    debugger;
 
     // Wait until reports are fetched and there is a reportID in initialParams
     if (!initialParams.reportID) {
@@ -66,6 +79,9 @@ MainDrawerNavigator.displayName = 'MainDrawerNavigator';
 export default withOnyx({
     reports: {
         key: ONYXKEYS.COLLECTION.REPORT,
+    },
+    betas: {
+        key: ONYXKEYS.BETAS,
     },
 })(MainDrawerNavigator);
 export {getInitialReportScreenParams};

--- a/src/libs/reportUtils.js
+++ b/src/libs/reportUtils.js
@@ -77,24 +77,6 @@ function canDeleteReportAction(reportAction) {
         && reportAction.actionName === CONST.REPORT.ACTIONS.TYPE.ADDCOMMENT;
 }
 
-
-/**
- * Given a collection of reports returns the most recently accessed one
- *
- * @param {Record<String, {lastVisitedTimestamp, reportID}>|Array<{lastVisitedTimestamp, reportID}>} reports
- * @param {Boolean} [ignoreDefaultRooms]
- * @returns {Object}
- */
-function findLastAccessedReport(reports, ignoreDefaultRooms) {
-    let sortedReports = sortReportsByLastVisited(reports);
-
-    if (ignoreDefaultRooms) {
-        sortedReports = _.filter(sortedReports, report => !isDefaultRoom(report))
-    }
-
-    return _.last(sortedReports);
-}
-
 /**
  * Whether the provided report is a default room
  * @param {Object} report
@@ -107,6 +89,23 @@ function isDefaultRoom(report) {
         CONST.REPORT.CHAT_TYPE.POLICY_ANNOUNCE,
         CONST.REPORT.CHAT_TYPE.DOMAIN_ALL,
     ], lodashGet(report, ['chatType'], ''));
+}
+
+/**
+ * Given a collection of reports returns the most recently accessed one
+ *
+ * @param {Record<String, {lastVisitedTimestamp, reportID}>|Array<{lastVisitedTimestamp, reportID}>} reports
+ * @param {Boolean} [ignoreDefaultRooms]
+ * @returns {Object}
+ */
+function findLastAccessedReport(reports, ignoreDefaultRooms) {
+    let sortedReports = sortReportsByLastVisited(reports);
+
+    if (ignoreDefaultRooms) {
+        sortedReports = _.filter(sortedReports, report => !isDefaultRoom(report));
+    }
+
+    return _.last(sortedReports);
 }
 
 /**

--- a/src/libs/reportUtils.js
+++ b/src/libs/reportUtils.js
@@ -82,10 +82,17 @@ function canDeleteReportAction(reportAction) {
  * Given a collection of reports returns the most recently accessed one
  *
  * @param {Record<String, {lastVisitedTimestamp, reportID}>|Array<{lastVisitedTimestamp, reportID}>} reports
+ * @param {Boolean} [ignoreDefaultRooms]
  * @returns {Object}
  */
-function findLastAccessedReport(reports) {
-    return _.last(sortReportsByLastVisited(reports));
+function findLastAccessedReport(reports, ignoreDefaultRooms) {
+    let sortedReports = sortReportsByLastVisited(reports);
+
+    if (ignoreDefaultRooms) {
+        sortedReports = _.filter(sortedReports, report => !isDefaultRoom(report))
+    }
+
+    return _.last(sortedReports);
 }
 
 /**

--- a/src/pages/home/ReportScreen.js
+++ b/src/pages/home/ReportScreen.js
@@ -154,6 +154,9 @@ class ReportScreen extends React.Component {
         }
 
         const reportID = getReportID(this.props.route);
+        console.log('HEY LOOK AT THIS -------------------------');
+        console.log(reportID);
+        console.log(this.props.report);
         return (
             <ScreenWrapper style={[styles.appContent, styles.flex1]}>
                 <HeaderView

--- a/src/pages/home/ReportScreen.js
+++ b/src/pages/home/ReportScreen.js
@@ -159,9 +159,11 @@ class ReportScreen extends React.Component {
             return null;
         }
 
-        if (!Permissions.canUseDefaultRooms() && isDefaultRoom(this.props.report)) {
+        if (!Permissions.canUseDefaultRooms(this.props.betas) && isDefaultRoom(this.props.report)) {
             return null;
         }
+
+        const reportID = getReportID(this.props.route);
 
         return (
             <ScreenWrapper style={[styles.appContent, styles.flex1]}>

--- a/src/pages/home/ReportScreen.js
+++ b/src/pages/home/ReportScreen.js
@@ -10,6 +10,8 @@ import Navigation from '../../libs/Navigation/Navigation';
 import ROUTES from '../../ROUTES';
 import {handleInaccessibleReport, updateCurrentlyViewedReportID, addAction} from '../../libs/actions/Report';
 import ONYXKEYS from '../../ONYXKEYS';
+import Permissions from '../../libs/Permissions';
+import {isDefaultRoom} from '../../libs/reportUtils';
 
 import ReportActionsView from './report/ReportActionsView';
 import ReportActionCompose from './report/ReportActionCompose';
@@ -54,6 +56,9 @@ const propTypes = {
 
     /** Array of report actions for this report */
     reportActions: PropTypes.objectOf(PropTypes.shape(ReportActionPropTypes)),
+
+    /** Beta features list */
+    betas: PropTypes.arrayOf(PropTypes.string),
 };
 
 const defaultProps = {
@@ -67,6 +72,7 @@ const defaultProps = {
         maxSequenceNumber: 0,
         hasOutstandingIOU: false,
     },
+    betas: [],
 };
 
 /**
@@ -153,10 +159,10 @@ class ReportScreen extends React.Component {
             return null;
         }
 
-        const reportID = getReportID(this.props.route);
-        console.log('HEY LOOK AT THIS -------------------------');
-        console.log(reportID);
-        console.log(this.props.report);
+        if (!Permissions.canUseDefaultRooms() && isDefaultRoom(this.props.report)) {
+            return null;
+        }
+
         return (
             <ScreenWrapper style={[styles.appContent, styles.flex1]}>
                 <HeaderView
@@ -210,5 +216,8 @@ export default withOnyx({
     },
     report: {
         key: ({route}) => `${ONYXKEYS.COLLECTION.REPORT}${getReportID(route)}`,
+    },
+    betas: {
+        key: ONYXKEYS.BETAS,
     },
 })(ReportScreen);

--- a/src/pages/home/ReportScreen.js
+++ b/src/pages/home/ReportScreen.js
@@ -164,7 +164,6 @@ class ReportScreen extends React.Component {
         }
 
         const reportID = getReportID(this.props.route);
-
         return (
             <ScreenWrapper style={[styles.appContent, styles.flex1]}>
                 <HeaderView


### PR DESCRIPTION
@deetergp, please review when you get the chance
CC: @yuwenmemon

### Details

There was an edge case we didn't consider when putting default rooms behind betas. If a domain has a `domainAll` room (which we make behind the scenes for domains that aren't in the defaultRooms beta) and a user gets created after that room is made, they will actually see that room when they first log in (i.e. it'll be their "last accessed chat report"). They should see the concierge chat first, but that chat will be created after their account is made (which happens after the domainAll room was made).

This PR makes it so new users won't land on a default domainAll room the first time they log in. This also prevents users from seeing a default room if they aren't in the beta and somehow managed to open a default chat room (to stop other edge cases we might have missed.

Also this is relevant to N6, since we're likely to see a lot of new users sign up and use NewDot with this.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/177836

### Tests
Same as Web QA, but done locally. I used `clitools.sh` for making the domain, admin account, and second account. To test a user being outside of the default rooms beta locally, I made this line false: https://github.com/Expensify/App/blob/0e6fdbf0e3b9f87572701c90c78b2ab73540b3ff/src/libs/Permissions.js#L51

### QA Steps
1. Find a domain whose users won't be in the freePlan beta.
2. Invite a new account to that domain (can be similar to amal+something@expensifail.com). Avoid signing in with the email sent to the newly created user.
3. Log into that account on NewDot before joining on OldDot. You can do this by entering the email in NewDot and then using the magic sign in link from there. You might have to set a password at this point too.
4. Verify that the first report you see is the concierge one and not

### Tested On

- [x] Web
- [x] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
This is what it looks like now if you try to access a report by URL (11073 is a domainAll room)
![image](https://user-images.githubusercontent.com/19364431/134029370-c2d44ec4-ab7f-44b0-9bff-63415d3c6d24.png)

#### Mobile Web
Same thing is a blank screen on mobile obviously, but users should never be able to see this report anyway without manually entering into the url like I did.
![image](https://user-images.githubusercontent.com/19364431/134034083-cef29127-4b60-4721-b948-abae90337fce.png)

