### PR TITLE
Show descriptive message when login format is invalid

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -343,6 +343,9 @@ export default {
     loginForm: {
         pleaseEnterEmailOrPhoneNumber: 'Please enter an email or phone number',
         phoneOrEmail: 'Phone or email',
+        error: {
+            invalidFormatLogin: 'The email or phone number entered is invalid. Please fix the format and try again.',
+        },
     },
     resendValidationForm: {
         linkHasBeenResent: 'Link has been re-sent',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -84,7 +84,7 @@ export default {
         expensifyDoesntHaveAccessToCamera: 'Esta aplicación no tiene acceso a tu cámara, por favor activa el permiso y vuelve a intentarlo.',
         attachmentError: 'Error al adjuntar archivo',
         errorWhileSelectingAttachment: 'Ha ocurrido un error al seleccionar un adjunto, por favor inténtalo de nuevo',
-        errorWhileSelectingCorruptedImage: 'Ha ocurrido un error al seleccionar un adjunto corrupto, por favor intentalo con otro archivo',
+        errorWhileSelectingCorruptedImage: 'Ha ocurrido un error al seleccionar un adjunto corrupto, por favor inténtalo con otro archivo',
         takePhoto: 'Hacer una foto',
         chooseFromGallery: 'Elegir de la galería',
         chooseDocument: 'Elegir documento',
@@ -343,6 +343,9 @@ export default {
     loginForm: {
         pleaseEnterEmailOrPhoneNumber: 'Por favor escribe un email o número de teléfono',
         phoneOrEmail: 'Número de teléfono o email',
+        error: {
+            invalidFormatLogin: 'El email o número de teléfono que has introducido no es válido. Corrígelo e inténtalo de nuevo.',
+        },
     },
     resendValidationForm: {
         linkHasBeenResent: 'El enlace se ha reenviado',
@@ -639,7 +642,7 @@ export default {
         availabilityText: '*Nuestros guías están disponibles de domingo desde las 17.00 CT a viernes hasta las 17.00 CT. Si solicitas una llamada fuera de este horario, te llamaremos de lunes a viernes de 9.00 a 17.00 en tu hora local. El orden de llamada corresponde con el orden de solicitud.',
         callMe: 'Llámame',
         growlMessageOnSave: 'Llamada solicitada.',
-        errorMessageInvalidPhone: 'El teléfono no es valido. Intentalo de nuevo agregando el código de país. P. ej.: +15005550006',
+        errorMessageInvalidPhone: 'El teléfono no es valido. Inténtalo de nuevo agregando el código de país. P. ej.: +15005550006',
         growlMessageEmptyName: 'Por favor ingresa tu nombre completo',
         growlMessageNoPersonalPolicy: 'No he podido encontrar una póliza personal con la que asociar esta llamada a las Guías, compruebe su conexión e inténtelo de nuevo.',
         needHelp: 'Ayuda',

--- a/src/libs/actions/Session.js
+++ b/src/libs/actions/Session.js
@@ -135,8 +135,11 @@ function fetchAccountDetails(login) {
                 } else if (!response.validated) {
                     resendValidationLink(login);
                 }
+            } else if (response.jsonCode === 402) {
+                Onyx.merge(ONYXKEYS.ACCOUNT, {error: translateLocal('loginForm.error.invalidFormatLogin')});
+            } else {
+                Onyx.merge(ONYXKEYS.ACCOUNT, {error: response.message});
             }
-            Onyx.merge(ONYXKEYS.ACCOUNT, {error: response.message});
         })
         .catch(() => {
             Onyx.merge(ONYXKEYS.ACCOUNT, {error: translateLocal('session.offlineMessageRetry')});

--- a/src/pages/signin/LoginForm.js
+++ b/src/pages/signin/LoginForm.js
@@ -3,6 +3,7 @@ import {View} from 'react-native';
 import {withOnyx} from 'react-native-onyx';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
+import Str from 'expensify-common/lib/str';
 import styles from '../../styles/styles';
 import Button from '../../components/Button';
 import Text from '../../components/Text';
@@ -57,6 +58,11 @@ class LoginForm extends React.Component {
     validateAndSubmitForm() {
         if (!this.state.login.trim()) {
             this.setState({formError: 'loginForm.pleaseEnterEmailOrPhoneNumber'});
+            return;
+        }
+
+        if (Str.isValidEmail(this.state.login) || Str.isValidPhone(this.state.login)) {
+            this.setState({formError: 'loginForm.error.invalidFormatLogin'});
             return;
         }
 


### PR DESCRIPTION
### Details
Message about an invalid phone number or email entered instead of only mentioning the email is wrong. I also added a front-end error to avoid relying on the back-end message.

### Fixed Issues
$ https://github.com/Expensify/App/issues/5339

### Tests / QA Steps
1. Navigate to login page
2. Enter several phone numbers or emails that are incorrectly formatted.
3. Press continue
4. Make sure the following error is thrown:
<img width="365" alt="New Expensify 2021-09-20 12-39-11" src="https://user-images.githubusercontent.com/6474442/133990513-837dd3c0-17e3-42f0-95c5-ec0c1176e6a6.png">

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<img width="365" alt="New Expensify 2021-09-20 12-39-11" src="https://user-images.githubusercontent.com/6474442/133990513-837dd3c0-17e3-42f0-95c5-ec0c1176e6a6.png">

#### Mobile Web
<img width="289" alt="iPhone 12 2021-09-20 16-08-02" src="https://user-images.githubusercontent.com/6474442/134016636-97049e61-3171-4424-91db-97da5fd3361f.png">

#### Desktop
<img width="350" alt="New Expensify 2021-09-20 12-51-30" src="https://user-images.githubusercontent.com/6474442/133990842-d1fb832e-4670-4bea-a9d4-955055fd6f53.png">

#### iOS
<img width="372" alt="iPhone 12 2021-09-20 16-00-55" src="https://user-images.githubusercontent.com/6474442/134015538-56937286-ffdd-43b4-9f0a-8263ea015294.png">

#### Android
<img width="352" alt="Android Emulator - Pixel_5_API_30:5554 2021-09-20 16-15-17" src="https://user-images.githubusercontent.com/6474442/134017826-4cd47e25-3451-4971-839b-b1a534665f3c.png">
