### PR TITLE
Activate the link only when page is focused

### DIFF
--- a/src/pages/workspace/WorkspaceSidebar.js
+++ b/src/pages/workspace/WorkspaceSidebar.js
@@ -4,6 +4,7 @@ import {View, ScrollView, Pressable} from 'react-native';
 import {withOnyx} from 'react-native-onyx';
 import lodashGet from 'lodash/get';
 import PropTypes from 'prop-types';
+import {withNavigationFocus} from '@react-navigation/compat';
 import Navigation from '../../libs/Navigation/Navigation';
 import ROUTES from '../../ROUTES';
 import styles from '../../styles/styles';
@@ -30,6 +31,9 @@ import Tooltip from '../../components/Tooltip';
 import variables from '../../styles/variables';
 
 const propTypes = {
+    /** Whether the current screen is focused. */
+    isFocused: PropTypes.bool.isRequired,
+
     /** Policy for the current route */
     policy: PropTypes.shape({
         /** ID of the policy */
@@ -55,7 +59,7 @@ const defaultProps = {
 };
 
 const WorkspaceSidebar = ({
-    translate, isSmallScreenWidth, policy, allPolicies,
+    translate, isSmallScreenWidth, policy, allPolicies, isFocused,
 }) => {
     const menuItems = [
         {
@@ -162,18 +166,21 @@ const WorkspaceSidebar = ({
                             </Pressable>
                         </View>
                     </View>
-                    {menuItems.map(item => (
-                        <MenuItem
-                            key={item.translationKey}
-                            title={translate(item.translationKey)}
-                            icon={item.icon}
-                            iconRight={item.iconRight}
-                            onPress={() => item.action()}
-                            wrapperStyle={!isSmallScreenWidth && item.isActive ? styles.activeComponentBG : undefined}
-                            focused={item.isActive}
-                            shouldShowRightIcon
-                        />
-                    ))}
+                    {menuItems.map((item) => {
+                        const shouldFocus = isSmallScreenWidth ? !isFocused && item.isActive : item.isActive;
+                        return (
+                            <MenuItem
+                                key={item.translationKey}
+                                title={translate(item.translationKey)}
+                                icon={item.icon}
+                                iconRight={item.iconRight}
+                                onPress={() => item.action()}
+                                wrapperStyle={shouldFocus ? styles.activeComponentBG : undefined}
+                                focused={shouldFocus}
+                                shouldShowRightIcon
+                            />
+                        );
+                    })}
                 </View>
             </ScrollView>
         </ScreenWrapper>
@@ -187,6 +194,7 @@ WorkspaceSidebar.displayName = 'WorkspaceSidebar';
 export default compose(
     withLocalize,
     withWindowDimensions,
+    withNavigationFocus,
     withOnyx({
         policy: {
             key: (props) => {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/5331

### Tests | QA Steps

#### Mobile| Mobile Web
1. Create| Open Workspace on mobile.
2. Open the Invite Page.
3. Go back to the Workspace setting screen.
4. No Tab should be shown as selected.

#### Web | Desktop
1. Create| Open Workspace on web| desktop.
2. Open the Invite Page.
4. Respective Tab should be shown as selected in the sidebar based on the page opened in the Workspace Modal.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web | Desktop
<!-- Insert screenshots of your changes on the web platform-->
![Screenshot 2021-09-20 at 22-17-37 New Expensify - Chat with friends to send and receive money](https://user-images.githubusercontent.com/24370807/134042064-5840953b-df51-4bce-af22-948798f37845.png)

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
![Screenshot 2021-09-20 at 22-16-43 New Expensify - Chat with friends to send and receive money](https://user-images.githubusercontent.com/24370807/134042076-a40b7042-3849-490a-96ce-4fbfcbd9d61c.png)

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
![Screenshot 2021-09-20 22:17:22](https://user-images.githubusercontent.com/24370807/134042108-b0a197b8-e959-43ba-b2c6-1f3037d21602.png)
