### PR TITLE
Revert "Skip showing create for new users if user already has a workspace"

### DIFF
--- a/src/pages/home/sidebar/SidebarScreen.js
+++ b/src/pages/home/sidebar/SidebarScreen.js
@@ -2,7 +2,6 @@ import React, {Component} from 'react';
 import {View} from 'react-native';
 import {withOnyx} from 'react-native-onyx';
 import PropTypes from 'prop-types';
-import _ from 'underscore';
 import styles from '../../../styles/styles';
 import SidebarLinks from './SidebarLinks';
 import PopoverMenu from '../../../components/PopoverMenu';
@@ -29,30 +28,15 @@ import Performance from '../../../libs/Performance';
 import NameValuePair from '../../../libs/actions/NameValuePair';
 
 const propTypes = {
-    /* Onyx Props */
-
-    /** Beta features list */
+    /* Beta features list */
     betas: PropTypes.arrayOf(PropTypes.string).isRequired,
 
-    /** Flag for new users used to open the Global Create menu on first load */
+    /* Flag for new users used to open the Global Create menu on first load */
     isFirstTimeNewExpensifyUser: PropTypes.bool.isRequired,
-
-    /** The list of this user's policies */
-    policies: PropTypes.objectOf(PropTypes.shape({
-        /** The type of the policy */
-        type: PropTypes.string,
-
-        /** The user's role in the policy */
-        role: PropTypes.string,
-    })),
 
     ...windowDimensionsPropTypes,
 
     ...withLocalizePropTypes,
-};
-
-const defaultProps = {
-    policies: {},
 };
 
 class SidebarScreen extends Component {
@@ -74,21 +58,13 @@ class SidebarScreen extends Component {
         Timing.start(CONST.TIMING.SIDEBAR_LOADED, true);
 
         if (this.props.isFirstTimeNewExpensifyUser) {
-            const hasFreePolicy = _.chain(this.props.policies)
-                .some(policy => policy && policy.type === CONST.POLICY.TYPE.FREE && policy.role === CONST.POLICY.ROLE.ADMIN)
-                .value();
+            // For some reason, the menu doesn't open without the timeout
+            setTimeout(() => {
+                this.toggleCreateMenu();
 
-            // If user doesn't have any free policies (workspaces) set up, automatically open create menu
-            if (!hasFreePolicy) {
-                // For some reason, the menu doesn't open without the timeout
-                setTimeout(() => {
-                    this.toggleCreateMenu();
-                }, 200);
-            }
-
-            // Set the NVP to false so we don't automatically open the menu again
-            // Note: this may need to be moved if this NVP is used for anything else later
-            NameValuePair.set(CONST.NVP.IS_FIRST_TIME_NEW_EXPENSIFY_USER, false, ONYXKEYS.NVP_IS_FIRST_TIME_NEW_EXPENSIFY_USER);
+                // Set the NVP back to false (this may need to be moved if this NVP is used for anything else later)
+                NameValuePair.set(CONST.NVP.IS_FIRST_TIME_NEW_EXPENSIFY_USER, false, ONYXKEYS.NVP_IS_FIRST_TIME_NEW_EXPENSIFY_USER);
+            }, 200);
         }
     }
 
@@ -201,7 +177,6 @@ class SidebarScreen extends Component {
 }
 
 SidebarScreen.propTypes = propTypes;
-SidebarScreen.defaultProps = defaultProps;
 export default compose(
     withLocalize,
     withWindowDimensions,
@@ -214,9 +189,6 @@ export default compose(
         },
         isFirstTimeNewExpensifyUser: {
             key: ONYXKEYS.NVP_IS_FIRST_TIME_NEW_EXPENSIFY_USER,
-        },
-        policies: {
-            key: ONYXKEYS.COLLECTION.POLICY,
         },
     }),
 )(SidebarScreen);


### PR DESCRIPTION
Reverts Expensify/App#5244 so we can unblock the new dot deploy and get the latest code out for testing and such

cc @Beamanator 