### PR TITLE
Fix Additional Information Text Margin

### DIFF
--- a/src/components/CheckboxWithLabel.js
+++ b/src/components/CheckboxWithLabel.js
@@ -64,6 +64,7 @@ const CheckboxWithLabel = ({
                         styles.w100,
                         styles.flexRow,
                         styles.flexWrap,
+                        styles.flexShrink1,
                         styles.alignItemsCenter,
                     ]}
                 >

--- a/src/pages/ReimbursementAccount/BeneficialOwnersStep.js
+++ b/src/pages/ReimbursementAccount/BeneficialOwnersStep.js
@@ -149,7 +149,7 @@ class BeneficialOwnersStep extends React.Component {
                         <Text>{this.props.translate('beneficialOwnersStep.checkAllThatApply')}</Text>
                     </Text>
                     <CheckboxWithLabel
-                        style={[styles.mb2, styles.mr2]}
+                        style={[styles.mb2]}
                         isChecked={this.state.ownsMoreThan25Percent}
                         onPress={() => this.toggleCheckbox('ownsMoreThan25Percent')}
                         LabelComponent={() => (
@@ -160,7 +160,7 @@ class BeneficialOwnersStep extends React.Component {
                         )}
                     />
                     <CheckboxWithLabel
-                        style={[styles.mb2, styles.mr2]}
+                        style={[styles.mb2]}
                         isChecked={this.state.hasOtherBeneficialOwners}
                         onPress={() => {
                             this.setState((prevState) => {

--- a/src/pages/ReimbursementAccount/BeneficialOwnersStep.js
+++ b/src/pages/ReimbursementAccount/BeneficialOwnersStep.js
@@ -224,7 +224,7 @@ class BeneficialOwnersStep extends React.Component {
                             )}
                         </View>
                     )}
-                    <Text style={[styles.textStrong, styles.mv5]}>
+                    <Text style={[styles.mv5]}>
                         {this.props.translate('beneficialOwnersStep.agreement')}
                     </Text>
                     <CheckboxWithLabel

--- a/src/pages/ReimbursementAccount/BeneficialOwnersStep.js
+++ b/src/pages/ReimbursementAccount/BeneficialOwnersStep.js
@@ -224,7 +224,7 @@ class BeneficialOwnersStep extends React.Component {
                             )}
                         </View>
                     )}
-                    <Text style={[styles.textStrong, styles.mb5]}>
+                    <Text style={[styles.textStrong, styles.mv5]}>
                         {this.props.translate('beneficialOwnersStep.agreement')}
                     </Text>
                     <CheckboxWithLabel
@@ -235,7 +235,7 @@ class BeneficialOwnersStep extends React.Component {
                             <View style={[styles.flexRow]}>
                                 <Text>{this.props.translate('common.iAcceptThe')}</Text>
                                 <TextLink href="https://use.expensify.com/achterms">
-                                    {`${this.props.translate('beneficialOwnersStep.termsAndConditions')}.`}
+                                    {`${this.props.translate('beneficialOwnersStep.termsAndConditions')}`}
                                 </TextLink>
                             </View>
                         )}


### PR DESCRIPTION
### Details
This PR fixes the margin on the additional information page.

### Fixed Issues
$ https://github.com/Expensify/App/issues/5343

### Tests
1. Login to NewDot using an account with a Workspace and without the Expensify Card.
2. Navigate to '/bank-account/contract' or follow [these steps](https://stackoverflow.com/c/expensify/questions/342) to get to the additional information step.
3. Verify that the horizontal margins look like the images below.

### QA Steps
Steps above.

### Tested On

- [X] Web
- [X] Mobile Web
- [X] Desktop
- [X] iOS
- [X] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web

![web](https://user-images.githubusercontent.com/22219519/134063671-1d6472c8-cfd9-43a9-aa9e-86630411ebee.png)

#### Mobile Web

![mweb](https://user-images.githubusercontent.com/22219519/134063634-bb7b2183-1590-4bd1-9239-0ee92fa14f81.png)

#### Desktop

![desktop](https://user-images.githubusercontent.com/22219519/134063661-a06b09b3-6add-45b1-8d8c-6bc8921244f4.png)

#### iOS

![ios](https://user-images.githubusercontent.com/22219519/134063711-021e5217-0509-4c8a-b103-9861e67e73d2.png)

#### Android

![android](https://user-images.githubusercontent.com/22219519/134063736-e5e01861-1988-41e1-95d4-59934b9ee1c6.png)

