### PR TITLE
check if report.icons and report.icons[0] exists

### DIFF
--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -230,10 +230,11 @@ function createOption(personalDetailList, report, draftComments, {
             ? lastMessageText
             : Str.removeSMSDomain(personalDetail.login);
     }
+    const icons = (report && report.icons && report.icons[0]) ? report.icons : [personalDetail.avatar];
     return {
         text,
         alternateText,
-        icons: report ? report.icons : [personalDetail.avatar],
+        icons,
         tooltipText,
         participantsList: personalDetailList,
 

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -230,12 +230,10 @@ function createOption(personalDetailList, report, draftComments, {
             ? lastMessageText
             : Str.removeSMSDomain(personalDetail.login);
     }
-
-    const icons = lodashGet(report, 'icons', [personalDetail.avatar]);
     return {
         text,
         alternateText,
-        icons,
+        icons: lodashGet(report, 'icons', [personalDetail.avatar]),
         tooltipText,
         participantsList: personalDetailList,
 

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -230,7 +230,8 @@ function createOption(personalDetailList, report, draftComments, {
             ? lastMessageText
             : Str.removeSMSDomain(personalDetail.login);
     }
-    const icons = (report && report.icons && report.icons[0]) ? report.icons : [personalDetail.avatar];
+
+    const icons = lodashGet(report, 'icons', [personalDetail.avatar]);
     return {
         text,
         alternateText,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Context: https://github.com/Expensify/App/issues/5232

Sometimes the avatars disappear from the LHN and I was only able to reproduce the issue after logging out and loging in again with a different account. 

I found out the value of `report.actions` sometimes is `undefined` or has an array with an empty string (`['']`). This is because the links of the avatar thumbnails are fetched after inserting the `simplifiedReports` into Onyx: 

<img width="500" alt="Screen Shot 2021-09-20 at 16 03 26" src="https://user-images.githubusercontent.com/6829422/134089045-d5c48efc-bd62-435f-9170-96c930a546f6.png">

here ^ `PersonalDetails.getFromReportParticipants(Object.values(simplifiedReports))` is called to fetch the avatar thumbnails asynchronously (using `API.PersonalDetails_GetForEmails`), which resolves after calling
`Onyx.mergeCollection(ONYXKEYS.COLLECTION.REPORT, simplifiedReports)` which triggers a re-render synchronously and calls the function `createOption` before fetching the avatars:

<img width="500" alt="Screen Shot 2021-09-20 at 16 17 18" src="https://user-images.githubusercontent.com/6829422/134089065-95aea184-35e8-4d7b-a484-495a672bb528.png">

My hypothesis is that the avatar won't appear if `API.PersonalDetails_GetForEmails` doesn't resolve because of a connection issue (i.e. internet goes offline exactly when the app is fetching the avatars). So I added more conditions to check not only if the `report` object exists but also the `icons` and `icons[0]` has a valid value; I found sometimes `icons[0]` is an empty string too: https://github.com/Expensify/App/blob/main/src/libs/OptionsListUtils.js#L760 (which is called in `PersonalDetails.getFromReportParticipants`).

Seems the issue was only reproducible on Desktop and Web.

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/5232

### Tests
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Log in
2. Log out
3. Log in with a different account
--->
1. Log in
2. Log out
3. Log in with a different account

### QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->
1. Log in
2. Log out
3. Log in with a different account

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
<img width="500" alt="Screen Shot 2021-09-20 at 18 35 51" src="https://user-images.githubusercontent.com/6829422/134090213-97f239f0-cfaf-4aad-bec2-e8089eedb43a.png">

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
<img width="300" alt="" src="https://user-images.githubusercontent.com/6829422/134090274-4b11ab0c-3b08-4450-97e9-e5ecfbed22f8.png">

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
<img width="500" alt="Screen Shot 2021-09-20 at 18 38 32" src="https://user-images.githubusercontent.com/6829422/134090408-c174bfa6-846c-4b1e-90ae-1c296dfc9f5d.png">

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
