### PR TITLE
Use the full screen loader for PDF View

### DIFF
--- a/src/components/PDFView/index.js
+++ b/src/components/PDFView/index.js
@@ -5,6 +5,7 @@ import {Document, Page} from 'react-pdf/dist/esm/entry.webpack';
 import styles from '../../styles/styles';
 import withWindowDimensions, {windowDimensionsPropTypes} from '../withWindowDimensions';
 import variables from '../../styles/variables';
+import FullScreenLoadingIndicator from '../FullscreenLoadingIndicator';
 
 const propTypes = {
     /** URL to full-sized image */
@@ -53,6 +54,7 @@ class PDFView extends PureComponent {
                 style={[styles.PDFView, this.props.style]}
             >
                 <Document
+                    loading={<FullScreenLoadingIndicator visible />}
                     file={this.props.sourceURL}
                     options={{
                         cMapUrl: 'cmaps/',

--- a/src/components/PDFView/index.native.js
+++ b/src/components/PDFView/index.native.js
@@ -4,6 +4,7 @@ import {View} from 'react-native';
 import PDF from 'react-native-pdf';
 import styles, {getWidthAndHeightStyle} from '../../styles/styles';
 import withWindowDimensions, {windowDimensionsPropTypes} from '../withWindowDimensions';
+import FullScreenLoadingIndicator from '../FullscreenLoadingIndicator';
 
 const propTypes = {
     /** URL to full-sized image */
@@ -31,6 +32,7 @@ const defaultProps = {
 const PDFView = props => (
     <View style={[styles.flex1, props.style]}>
         <PDF
+            activityIndicator={<FullScreenLoadingIndicator visible />}
             source={{uri: props.sourceURL}}
             style={[
                 styles.imageModalPDF,


### PR DESCRIPTION
Thanks @parasharrajat for the pointer and sorry I had to make this quick change last minute and couldn't UpWork it. 

### Details
Using the `loading` prop for the Web view to show our custom `FullscreenLoadingIndicator` and using the `activityIndicator` prop to show the same on Native. 

### Fixed Issues
$ https://github.com/Expensify/App/issues/4997

### Tests & QA Steps

1. Send a PDF as an attachment to a chat
2. Once the PDF is uploaded and you can see the thumbnail, click on it
3. Verify that you see the standard circle loading instead of `Loading PDF...`

### Tested On

- [x] Web
- [x] Mobile Web
- [ ] Desktop
- [ ] iOS
- [x] Android

### Screenshots

#### Web

![screencast 2021-09-21 18-19-10](https://user-images.githubusercontent.com/1805746/134208823-616e88ec-5e5f-44e1-9a24-2dcb52cae65d.gif)

#### Mobile Web
![screencast 2021-09-21 18-20-28](https://user-images.githubusercontent.com/1805746/134208869-2d3714fd-ed9c-414e-abc3-be93e3e90f55.gif)

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
https://user-images.githubusercontent.com/1805746/134209022-80953482-9087-4338-a2ef-0881405961fb.mp4