### PR TITLE
Allow uploading drivers license like we do on OldDot

### DIFF
--- a/src/components/Onfido/index.js
+++ b/src/components/Onfido/index.js
@@ -24,6 +24,9 @@ class Onfido extends React.Component {
                         forceCrossDevice: true,
                         showCountrySelection: false,
                         documentTypes: {
+                            driving_licence: {
+                                country: null,
+                            },
                             national_identity_card: {
                                 country: null,
                             },


### PR DESCRIPTION
### Details

These changes only affect web. I noticed that we do not allow uploading a driver's license on NewDot but do on OldDot. When selecting `Identity card` option Onfido will not allow me to upload by state driver's license. This PR fixes that by enabling the specific option for driver's licenses.

<img width="1440" alt="2021-09-21_06-50-15" src="https://user-images.githubusercontent.com/32969087/134216615-b54d7965-3ab2-484f-b9cc-c95a87ceef29.png">
<img width="722" alt="2021-09-21_06-49-43" src="https://user-images.githubusercontent.com/32969087/134216639-10ae0935-17e2-4912-b36b-c2f99dbf278c.png">

### Fixed Issues
$ https://github.com/Expensify/App/issues/5395

### Tests
1. Go through VBA flow for a [Verifying bank account](https://stackoverflow.com/c/expensify/questions/342)
1. When you reach the Onfido flow verify there is an option for a driver's license
2. Upload a US Driver's License
2. Verify you are able to do so without issue and pass the Onfido step

### QA Steps

Internal QA

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- N/A iOS
- N/A Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
