### PR TITLE
Fix Privacy link on Invite People page

### DIFF
--- a/src/pages/workspace/WorkspaceInvitePage.js
+++ b/src/pages/workspace/WorkspaceInvitePage.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {View, ScrollView} from 'react-native';
+import {View, ScrollView, Pressable, Linking} from 'react-native';
 import {withOnyx} from 'react-native-onyx';
 import Str from 'expensify-common/lib/str';
 import _ from 'underscore';
@@ -15,13 +15,17 @@ import Button from '../../components/Button';
 import compose from '../../libs/compose';
 import ONYXKEYS from '../../ONYXKEYS';
 import {invite} from '../../libs/actions/Policy';
-import TextLink from '../../components/TextLink';
 import Growl from '../../libs/Growl';
 import ExpensiTextInput from '../../components/ExpensiTextInput';
 import FixedFooter from '../../components/FixedFooter';
 import KeyboardAvoidingView from '../../components/KeyboardAvoidingView';
 import {isSystemUser} from '../../libs/userUtils';
 import {addSMSDomainIfPhoneNumber} from '../../libs/OptionsListUtils';
+import Icon from '../../components/Icon';
+import {NewWindow} from '../../components/Icon/Expensicons';
+import variables from '../../styles/variables';
+import themeColors from '../../styles/themes/default';
+import CONST from '../../CONST';
 
 const propTypes = {
     ...withLocalizePropTypes,
@@ -147,9 +151,32 @@ class WorkspaceInvitePage extends React.Component {
                                 placeholder={this.getWelcomeNotePlaceholder()}
                                 onChangeText={text => this.setState({welcomeNote: text})}
                             />
-                            <TextLink href="https://use.expensify.com/privacy">
-                                {this.props.translate('common.privacy')}
-                            </TextLink>
+                                <View style={[styles.mt5, styles.alignSelfStart]}>
+                                    <Pressable
+                                        onPress={(e) => {
+                                            e.preventDefault();
+                                            Linking.openURL(CONST.PRIVACY_URL);
+                                        }}
+                                        accessibilityRole="link"
+                                        href={CONST.PRIVACY_URL}
+                                    >
+                                        {({hovered, pressed}) => (
+                                            <View style={[styles.flexRow]}>
+                                                <Text style={[styles.mr1, styles.label, (hovered || pressed) ? styles.linkMutedHovered : styles.linkMuted]}>
+                                                    {this.props.translate('common.privacyPolicy')}
+                                                </Text>
+                                                <View style={styles.alignSelfCenter}>
+                                                    <Icon
+                                                        src={NewWindow}
+                                                        width={variables.iconSizeSmall}
+                                                        height={variables.iconSizeSmall}
+                                                        fill={(hovered || pressed) ? themeColors.textMutedReversed : themeColors.icon}
+                                                    />
+                                                </View>
+                                            </View>
+                                        )}
+                                    </Pressable>
+                                </View>
                         </View>
                     </ScrollView>
                     <FixedFooter style={[styles.flexGrow0]}>

--- a/src/pages/workspace/WorkspaceInvitePage.js
+++ b/src/pages/workspace/WorkspaceInvitePage.js
@@ -26,7 +26,6 @@ import {addSMSDomainIfPhoneNumber} from '../../libs/OptionsListUtils';
 import Icon from '../../components/Icon';
 import {NewWindow} from '../../components/Icon/Expensicons';
 import variables from '../../styles/variables';
-import themeColors from '../../styles/themes/default';
 import CONST from '../../CONST';
 
 const propTypes = {
@@ -164,7 +163,13 @@ class WorkspaceInvitePage extends React.Component {
                                 >
                                     {({hovered, pressed}) => (
                                         <View style={[styles.flexRow]}>
-                                            <Text style={[styles.mr1, styles.label, (hovered || pressed) ? styles.linkMutedHovered : styles.linkMuted]}>
+                                            <Text
+                                                style={[
+                                                    styles.mr1,
+                                                    styles.label,
+                                                    (hovered || pressed) ? styles.linkMutedHovered : styles.linkMuted,
+                                                ]}
+                                            >
                                                 {this.props.translate('common.privacyPolicy')}
                                             </Text>
                                             <View style={styles.alignSelfCenter}>
@@ -172,7 +177,6 @@ class WorkspaceInvitePage extends React.Component {
                                                     src={NewWindow}
                                                     width={variables.iconSizeSmall}
                                                     height={variables.iconSizeSmall}
-                                                    fill={(hovered || pressed) ? themeColors.textMutedReversed : themeColors.icon}
                                                 />
                                             </View>
                                         </View>

--- a/src/pages/workspace/WorkspaceInvitePage.js
+++ b/src/pages/workspace/WorkspaceInvitePage.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {View, ScrollView, Pressable, Linking} from 'react-native';
+import {
+    View, ScrollView, Pressable, Linking,
+} from 'react-native';
 import {withOnyx} from 'react-native-onyx';
 import Str from 'expensify-common/lib/str';
 import _ from 'underscore';
@@ -151,32 +153,32 @@ class WorkspaceInvitePage extends React.Component {
                                 placeholder={this.getWelcomeNotePlaceholder()}
                                 onChangeText={text => this.setState({welcomeNote: text})}
                             />
-                                <View style={[styles.mt5, styles.alignSelfStart]}>
-                                    <Pressable
-                                        onPress={(e) => {
-                                            e.preventDefault();
-                                            Linking.openURL(CONST.PRIVACY_URL);
-                                        }}
-                                        accessibilityRole="link"
-                                        href={CONST.PRIVACY_URL}
-                                    >
-                                        {({hovered, pressed}) => (
-                                            <View style={[styles.flexRow]}>
-                                                <Text style={[styles.mr1, styles.label, (hovered || pressed) ? styles.linkMutedHovered : styles.linkMuted]}>
-                                                    {this.props.translate('common.privacyPolicy')}
-                                                </Text>
-                                                <View style={styles.alignSelfCenter}>
-                                                    <Icon
-                                                        src={NewWindow}
-                                                        width={variables.iconSizeSmall}
-                                                        height={variables.iconSizeSmall}
-                                                        fill={(hovered || pressed) ? themeColors.textMutedReversed : themeColors.icon}
-                                                    />
-                                                </View>
+                            <View style={[styles.mt5, styles.alignSelfStart]}>
+                                <Pressable
+                                    onPress={(e) => {
+                                        e.preventDefault();
+                                        Linking.openURL(CONST.PRIVACY_URL);
+                                    }}
+                                    accessibilityRole="link"
+                                    href={CONST.PRIVACY_URL}
+                                >
+                                    {({hovered, pressed}) => (
+                                        <View style={[styles.flexRow]}>
+                                            <Text style={[styles.mr1, styles.label, (hovered || pressed) ? styles.linkMutedHovered : styles.linkMuted]}>
+                                                {this.props.translate('common.privacyPolicy')}
+                                            </Text>
+                                            <View style={styles.alignSelfCenter}>
+                                                <Icon
+                                                    src={NewWindow}
+                                                    width={variables.iconSizeSmall}
+                                                    height={variables.iconSizeSmall}
+                                                    fill={(hovered || pressed) ? themeColors.textMutedReversed : themeColors.icon}
+                                                />
                                             </View>
-                                        )}
-                                    </Pressable>
-                                </View>
+                                        </View>
+                                    )}
+                                </Pressable>
+                            </View>
                         </View>
                     </ScrollView>
                     <FixedFooter style={[styles.flexGrow0]}>

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -50,6 +50,16 @@ const styles = {
         color: themeColors.linkHover,
     },
 
+    linkMuted: {
+        color: themeColors.textSupporting,
+        textDecorationColor: themeColors.textSupporting,
+        fontFamily: fontFamily.GTA,
+    },
+
+    linkMutedHovered: {
+        color: themeColors.textMutedReversed,
+    },
+
     h1: {
         color: themeColors.heading,
         fontFamily: fontFamily.GTA_BOLD,


### PR DESCRIPTION
### Details
Fixes the privacy link style on Invite people page.

### Fixed Issues
$ https://github.com/Expensify/App/issues/5344

### Tests
1. Login to NewDot and make sure the account has a Workspace. 
2. Navigate to `/workspace/<Workspace ID>/invite` or `Settings > Select Workspace > People > Invite`
3. Verify that the `Privacy policy` link looks like the one in the screenshots below.
4. Click the link and verify that it opens the privacy policy page.

### QA Steps
Same as above.

### Tested On

- [X] Web
- [X] Mobile Web
- [X] Desktop
- [X] iOS
- [X] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web

![web](https://user-images.githubusercontent.com/22219519/134243210-4676da4a-277f-4ec0-bb74-05073d2f0062.png)

#### Mobile Web

![mweb](https://user-images.githubusercontent.com/22219519/134243476-78c8d926-7360-4511-828d-f558d65cf16f.png)

#### Desktop

<img width="380" alt="desktop" src="https://user-images.githubusercontent.com/22219519/134243917-85eb0dda-85fe-42b8-96fb-a6292e9315bc.png">

#### iOS

![ios](https://user-images.githubusercontent.com/22219519/134243221-94e84611-8452-4e18-8115-fa8f6d2b1891.png)

#### Android
![android](https://user-images.githubusercontent.com/22219519/134244217-59dcbd58-2749-4eb0-b87f-848362a74bc4.png)
