### PR TITLE
Fix endless spinner on "Send link" cause by not unpausing the request queue

### DIFF
--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -60,6 +60,7 @@ function addDefaultValuesToParameters(command, parameters) {
             console.debug('A request was made without an authToken', {command, parameters});
             Network.pauseRequestQueue();
             Network.clearRequestQueue();
+            Network.unpauseRequestQueue();
             return;
         }
 


### PR DESCRIPTION
### Details

Unpause the request queue after clearing it

### Fixed Issues
$ https://github.com/Expensify/App/issues/5324

### Tests

Hard to reproduce consistently

For example:
1. Set a `console.error` or `debugger` inside `Network.js::pauseRequestQueue` to confirm that the problem happened.
2. Go to NewDot (localhost:8080) 
3. Throttle network speed to "Slow 3G" using chrome tools (Network tab)
4. Log in, Log out, repeatedly until you notice `pauseRequestQueue` was called after logging out.
5. Try to log in with a new account
6. Click the "Resend link" button
![Screen Shot 2021-09-21 at 2 02 27 PM](https://user-images.githubusercontent.com/87341702/134247232-c45700b3-c106-40c3-ad4c-a0c80fcdae60.png)
7. Expected result: load, then finish. It shouldn't get stuck in an endless spinner.

It can be good also to hardcode the `email` and `password` so you don't have to type it for each login.


### QA Steps

Same as `Tests`, but won't be able to modify the code to set the `console.error` or `debugger` to notice when the problem happened.

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
