### PR TITLE
Avoid logging AuthToken from transition links

### DIFF
--- a/src/libs/Navigation/NavigationRoot.js
+++ b/src/libs/Navigation/NavigationRoot.js
@@ -30,7 +30,13 @@ class NavigationRoot extends Component {
         }
 
         const path = getPathFromState(state, linkingConfig.config);
-        Log.info('Navigating to route', false, {path});
+
+        // Don't log the route transitions from OldDot because they contain authTokens
+        if (path.includes('/transition/')) {
+            Log.info('Navigating from transition link from OldDot using short lived authToken');
+        } else {
+            Log.info('Navigating to route', false, {path});
+        }
         setCurrentURL(path);
     }
 


### PR DESCRIPTION
CC: @marcaaron

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
Follow up to a problem identified here: https://github.com/Expensify/App/pull/5396#issuecomment-925172880

### Tests
Same as Web QA done locally

### QA Steps
Exact same as this PR: https://github.com/Expensify/App/pull/5396
After you've navigated to NewDot successfully, open up the JS console and search for the log line: `Navigating from transition link from OldDot using short lived authToken` and verify you don't see any huge authToken in the logs like here: https://github.com/Expensify/App/pull/5396#issuecomment-925172880

![image](https://user-images.githubusercontent.com/19364431/134413644-aa8a5c7f-cf2f-45e3-bc57-32eed0894a97.png)


### Tested On

- [x] Web
- [x] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
N/A
