### PR TITLE
Do not save user password in reimbursementAccountDraft

### DIFF
--- a/src/pages/ReimbursementAccount/CompanyStep.js
+++ b/src/pages/ReimbursementAccount/CompanyStep.js
@@ -278,7 +278,10 @@ class CompanyStep extends React.Component {
                         containerStyles={[styles.mt4]}
                         secureTextEntry
                         textContentType="password"
-                        onChangeText={value => this.clearErrorAndSetValue('password', value)}
+                        onChangeText={(value) => {
+                            this.setState({password: value});
+                            this.clearError('password');
+                        }}
                         value={this.state.password}
                         onSubmitEditing={this.submit}
                         errorText={this.getErrorText('password')}


### PR DESCRIPTION
### Details
We should not save user passwords in `reimbursementAccountDraft`

### Fixed Issues
$ https://github.com/Expensify/App/issues/5428

### Tests
1. Login to an account with a Workspace and without Expensify Cards.
2. Navigate to `Settings > Select Workspace > Expensify Card > Get started` to start the VBA flow.
3. After entering your password in the `Company step`, open the console and click on the `Application` tab.
4. Notice that the password is not saved in the `reimbursementAccountDraft` key.

### QA Steps
Steps above.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
