### PR TITLE
Rename route so that we expect traditional query paramters

### DIFF
--- a/src/ROUTES.js
+++ b/src/ROUTES.js
@@ -67,7 +67,7 @@ export default {
     getReportDetailsRoute: reportID => `r/${reportID}/details`,
     VALIDATE_LOGIN: 'v',
     VALIDATE_LOGIN_WITH_VALIDATE_CODE: 'v/:accountID/:validateCode',
-    LOGIN_WITH_SHORT_LIVED_TOKEN: 'transition/:accountID/:email/:shortLivedToken/:encryptedAuthToken/:exitTo',
+    LOGIN_WITH_SHORT_LIVED_TOKEN: 'transition',
 
     // This is a special validation URL that will take the user to /workspace/new after validation. This is used
     // when linking users from e.com in order to share a session in this app.

--- a/src/libs/Navigation/NavigationRoot.js
+++ b/src/libs/Navigation/NavigationRoot.js
@@ -32,7 +32,7 @@ class NavigationRoot extends Component {
         const path = getPathFromState(state, linkingConfig.config);
 
         // Don't log the route transitions from OldDot because they contain authTokens
-        if (path.includes('/transition/')) {
+        if (path.includes('/transition')) {
             Log.info('Navigating from transition link from OldDot using short lived authToken');
         } else {
             Log.info('Navigating to route', false, {path});


### PR DESCRIPTION
@cead22, please review

All we need to do here is change the route and the query params pulled from here are expected to come after `?`.

These lines essentially work the same, it just won't look inbetween the slashes for the params:
https://github.com/Expensify/App/blob/269697b67f504243137637c72b5b8102ae01335a/src/pages/LogInWithShortLivedTokenPage.js#L51-L54

### Details
Discussion from here: https://expensify.slack.com/archives/C020EPP9B9A/p1632347607474000
related to this PR: https://github.com/Expensify/Web-Expensify/pull/31996
and this issue: https://github.com/Expensify/Expensify/issues/177739

### Tests


### QA Steps
Same as here: https://github.com/Expensify/App/pull/5396, but now it should actually work.
@MitchExpensify and @kevinksullivan will be testing this so QA team can skip over this one 👍🏾 

Flow 1: Unvalidated new accounts
1. Create a new account in OldDot that has access to the freePlan beta.
2. Go to settings -> policy -> group and select the free plan here:
![image](https://user-images.githubusercontent.com/19364431/134283153-e83d0550-eff5-47f7-9b05-e21fcaa364e6.png)

3. Verify that a new tab opens and you are logged into NewDot and you are seeing the Workspace Settings page for a newly created Workspace:
![image](https://user-images.githubusercontent.com/19364431/134283736-52c37020-a9f4-4f6d-a91c-b8eba0024e8b.png)
4. Wait a minute
5. Do any action (like add a comment)
6. Check you are not logged out

Flow 2: Existing accounts
1. Log into an account on NewDot Expensify, create a Workspace if you don't already have one using the `+` on the bottom right.
2. Log out of NewDot and then log into that same account on OldDot and go to Settings -> Policy and find your Workspace there. It should have a card icon like these:
![image](https://user-images.githubusercontent.com/19364431/134262812-35531673-c2f0-48ab-9dbb-f58cced40371.png)
3. Click on its name and verify it opens a new tab, automatically logs you in, and brings you to the workspace settings page:
![image](https://user-images.githubusercontent.com/19364431/134262925-c4fd8487-f084-4ffc-98fb-2ef25bfa6c3d.png)
4. Wait a minute
5. Do any action (like add a comment)
6. Check you are not logged out

### Tested On

- [x] Web
- [ ] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
N/A
