### PR TITLE
Capitalize Save & Continue

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -41,7 +41,7 @@ export default {
         pin: 'Pin',
         unPin: 'Unpin',
         back: 'Back',
-        saveAndContinue: 'Save & continue',
+        saveAndContinue: 'Save & Continue',
         settings: 'Settings',
         termsOfService: 'Terms of service',
         people: 'People',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -41,7 +41,7 @@ export default {
         pin: 'Fijar',
         unPin: 'Desfijar',
         back: 'Volver',
-        saveAndContinue: 'Guardar y continuar',
+        saveAndContinue: 'Guardar y Continuar',
         settings: 'Configuración',
         termsOfService: 'Términos de servicio',
         people: 'Personas',


### PR DESCRIPTION
### Details
Keeps button text consistent

### Fixed Issues
Fixes https://github.com/Expensify/App/issues/5421

### Tests/QA
Note from Ionatan: this is no QA since we reverted this change
1. Launch the app
2. Log in with expensifail account
3. Click on deeplink https://staging.new.expensify.com/bank-account/contract
4. Verify "Save and continue" button

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
![image](https://user-images.githubusercontent.com/3981102/134437729-313f8137-5a2b-4968-ae19-6843a8b49e10.png)
