### PR TITLE
Fix OldDot -> NewDot workspace validation

### DIFF
--- a/src/pages/home/sidebar/SidebarScreen.js
+++ b/src/pages/home/sidebar/SidebarScreen.js
@@ -29,7 +29,7 @@ import NameValuePair from '../../../libs/actions/NameValuePair';
 
 const propTypes = {
     /* Beta features list */
-    betas: PropTypes.arrayOf(PropTypes.string).isRequired,
+    betas: PropTypes.arrayOf(PropTypes.string),
 
     /* Flag for new users used to open the Global Create menu on first load */
     isFirstTimeNewExpensifyUser: PropTypes.bool.isRequired,
@@ -37,6 +37,10 @@ const propTypes = {
     ...windowDimensionsPropTypes,
 
     ...withLocalizePropTypes,
+};
+
+const defaultProps = {
+    betas: [],
 };
 
 class SidebarScreen extends Component {
@@ -179,6 +183,7 @@ class SidebarScreen extends Component {
 }
 
 SidebarScreen.propTypes = propTypes;
+SidebarScreen.defaultProps = defaultProps;
 export default compose(
     withLocalize,
     withWindowDimensions,

--- a/src/pages/workspace/WorkspaceCardPage.js
+++ b/src/pages/workspace/WorkspaceCardPage.js
@@ -31,7 +31,7 @@ const propTypes = {
     /* Onyx Props */
 
     /** Beta features list */
-    betas: PropTypes.arrayOf(PropTypes.string).isRequired,
+    betas: PropTypes.arrayOf(PropTypes.string),
 
     /** The details about the user that is signed in */
     user: PropTypes.shape({
@@ -59,6 +59,7 @@ const propTypes = {
 };
 
 const defaultProps = {
+    betas: [],
     user: {
         isFromPublicDomain: false,
         isUsingExpensifyCard: false,


### PR DESCRIPTION
### Details
So here's what we were doing before:

1. The `WorkspaceSidebar` component was dependent upon two optional props, `allPolicies` and `policy`. The order in which these props would be provided via Onyx is not guaranteed.
1. To check if we've linked to a valid policy, we were waiting for `allPolicies` to load, then checking to see if the individual policy was still not loaded. If it was not, we'd assume it was invalid. So we were making the false assumption that both the `allPolicies` and `policy` props would be loaded at the same time.
1. To fix this, we really need to know whether the policy was found in Onyx or not, but unfortunately there's no way to tell the difference between a default value for an Onyx prop, and an Onyx prop just never showing up. So instead, we wait for `allPolicies` to load, and check if the linked policy (taken from the URL) is included in the list of policies. If not, we assume the policy is invalid.

### Fixed Issues
Fixes bug discussed in [this PR](https://github.com/Expensify/App/pull/5396) and in slack [here](https://expensify.slack.com/archives/C03TQ48KC/p1632344718095600).

### Tests / QA Steps
1. Log into NewDot.
1. If you don't already have a workspace, click on the global create menu and create one.
1. Close the NewDot tab.
1. Open OldDot in another tab, log in with the same account, and go to `/admin_policies`
1. Click on the workspace.
1. Verify that NewDot opens in a new tab and displays the workspace without any issue.
1. Log out of NewDot, and close the tab again.
1. Back in OldDot, click on the workspace again.
1. Verify that NewDot opens in a new tab and displays the workspace without any issue.
1. Log out of NewDot, and close the tab again.
1. Open a second OldDot/admin_policies page in another tab or window.
1. Delete the workspace in the second OldDot tab.
1. Back in the first OldDot/admin_policies page, click on the workspace again.
1. Verify that NewDot opens in a new tab, displays the workspace for a moment, then navigates home and displays an `Invalid Workspace` error.

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android
