### PR TITLE
[Hold Web-E #32014] Check all emails in loginList for a private domain

### DIFF
--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -744,19 +744,16 @@ function User_GetBetas() {
 
 /**
  * @param {Object} parameters
- * @param {Array} parameters.emailList
+ * @param {String} parameters.email
  * @param {Boolean} [parameters.requireCertainty]
  * @returns {Promise}
  */
 function User_IsFromPublicDomain(parameters) {
     const commandName = 'User_IsFromPublicDomain';
-    requireParameters(['emailList'], parameters, commandName);
+    requireParameters(['email'], parameters, commandName);
     return Network.post(commandName, {
+        ...{requireCertainty: true},
         ...parameters,
-        ...{
-            requireCertainty: true,
-            emailList: parameters.emailList.join(','),
-        },
     });
 }
 

--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -744,16 +744,19 @@ function User_GetBetas() {
 
 /**
  * @param {Object} parameters
- * @param {String} parameters.email
+ * @param {Array} parameters.emailList
  * @param {Boolean} [parameters.requireCertainty]
  * @returns {Promise}
  */
 function User_IsFromPublicDomain(parameters) {
     const commandName = 'User_IsFromPublicDomain';
-    requireParameters(['email'], parameters, commandName);
+    requireParameters(['emailList'], parameters, commandName);
     return Network.post(commandName, {
-        ...{requireCertainty: true},
         ...parameters,
+        ...{
+            requireCertainty: true,
+            emailList: parameters.emailList.join(','),
+        },
     });
 }
 

--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -184,7 +184,6 @@ class AuthScreens extends React.Component {
         PersonalDetails.fetchPersonalDetails();
         User.getUserDetails();
         User.getBetas();
-        User.getDomainInfo();
         PersonalDetails.fetchLocalCurrency();
         fetchAllReports(true, true);
         fetchCountryCodeByRequestIP();

--- a/src/libs/Pusher/EventType.js
+++ b/src/libs/Pusher/EventType.js
@@ -7,4 +7,5 @@ export default {
     REPORT_COMMENT_EDIT: 'reportCommentEdit',
     REPORT_TOGGLE_PINNED: 'reportTogglePinned',
     PREFERRED_LOCALE: 'preferredLocale',
+    ACCOUNT_VALIDATED: 'accountValidated',
 };

--- a/src/libs/actions/User.js
+++ b/src/libs/actions/User.js
@@ -67,6 +67,58 @@ function getBetas() {
 }
 
 /**
+ * Fetch the public domain info for the current user, including secondary logins.
+ *
+ * This API is a bit weird in that it sometimes depends on information being cached in bedrock.
+ * If the info for the domain is not in bedrock, then it creates an asynchronous bedrock job to gather domain info.
+ * If that happens, this function will automatically retry itself in 10 minutes.
+ *
+ * @param {Array} loginList
+ */
+function getDomainInfo(loginList) {
+    // First we filter out any domains that are in the list of common public domains
+    const emailList = _.filter(loginList, email => (
+        !_.contains(COMMON_PUBLIC_DOMAINS, Str.extractEmailDomain(email))
+    ));
+
+    // If there are no emails left, we have a public domain
+    if (!emailList.length) {
+        Onyx.merge(ONYXKEYS.USER, {isFromPublicDomain: true});
+        return;
+    }
+
+    // Check the API for the remaining uncommon domains
+    API.User_IsFromPublicDomain({emailList: emailList.join(',')})
+        .then((response) => {
+            if (response.jsonCode === 200) {
+                const {isFromPublicDomain} = response;
+                Onyx.merge(ONYXKEYS.USER, {isFromPublicDomain});
+
+                // If the user is not on a public domain we'll want to know whether they are on a domain that has
+                // already provisioned the Expensify card
+                if (isFromPublicDomain) {
+                    return;
+                }
+
+                API.User_IsUsingExpensifyCard()
+                    .then(({isUsingExpensifyCard}) => {
+                        Onyx.merge(ONYXKEYS.USER, {isUsingExpensifyCard});
+                    });
+            } else {
+                // If the command failed, we'll retry again in 10 minutes,
+                // arbitrarily chosen giving Bedrock time to resolve the ClearbitCheckPublicEmail job for this email.
+                const RETRY_TIMEOUT = 600_000;
+
+                // eslint-disable-next-line max-len
+                console.debug(`Command User_IsFromPublicDomain returned error code: ${response.jsonCode}. Most likely, this means that the domain ${Str.extractEmail(sessionEmail)} is not in the bedrock cache. Retrying in ${RETRY_TIMEOUT / 1000 / 60} minutes`);
+                Timers.register(setTimeout(() => {
+                    getDomainInfo(loginList);
+                }, RETRY_TIMEOUT));
+            }
+        });
+}
+
+/**
  * Fetches the data needed for user settings
  */
 function getUserDetails() {
@@ -210,58 +262,6 @@ function isBlockedFromConcierge(expiresAt) {
     }
 
     return moment().isBefore(moment(expiresAt), 'day');
-}
-
-/**
- * Fetch the public domain info for the current user, including secondary logins.
- *
- * This API is a bit weird in that it sometimes depends on information being cached in bedrock.
- * If the info for the domain is not in bedrock, then it creates an asynchronous bedrock job to gather domain info.
- * If that happens, this function will automatically retry itself in 10 minutes.
- *
- * @param {Array} loginList
- */
-function getDomainInfo(loginList) {
-    // First we filter out any domains that are in the list of common public domains
-    const emailList = _.filter(loginList, email => (
-        !_.contains(COMMON_PUBLIC_DOMAINS, Str.extractEmailDomain(email))
-    ));
-
-    // If there are no emails left, we have a public domain
-    if (!emailList.length) {
-        Onyx.merge(ONYXKEYS.USER, {isFromPublicDomain: true});
-        return;
-    }
-
-    // Check the API for the remaining uncommon domains
-    API.User_IsFromPublicDomain({emailList: emailList.join(',')})
-        .then((response) => {
-            if (response.jsonCode === 200) {
-                const {isFromPublicDomain} = response;
-                Onyx.merge(ONYXKEYS.USER, {isFromPublicDomain});
-
-                // If the user is not on a public domain we'll want to know whether they are on a domain that has
-                // already provisioned the Expensify card
-                if (isFromPublicDomain) {
-                    return;
-                }
-
-                API.User_IsUsingExpensifyCard()
-                    .then(({isUsingExpensifyCard}) => {
-                        Onyx.merge(ONYXKEYS.USER, {isUsingExpensifyCard});
-                    });
-            } else {
-                // If the command failed, we'll retry again in 10 minutes,
-                // arbitrarily chosen giving Bedrock time to resolve the ClearbitCheckPublicEmail job for this email.
-                const RETRY_TIMEOUT = 600_000;
-
-                // eslint-disable-next-line max-len
-                console.debug(`Command User_IsFromPublicDomain returned error code: ${response.jsonCode}. Most likely, this means that the domain ${Str.extractEmail(sessionEmail)} is not in the bedrock cache. Retrying in ${RETRY_TIMEOUT / 1000 / 60} minutes`);
-                Timers.register(setTimeout(() => {
-                    getDomainInfo(loginList);
-                }, RETRY_TIMEOUT));
-            }
-        });
 }
 
 /**

--- a/src/libs/actions/User.js
+++ b/src/libs/actions/User.js
@@ -88,11 +88,11 @@ function getDomainInfo(loginList) {
     }
 
     // Check the API for the remaining uncommon domains
-    API.User_IsFromPublicDomain()
+    API.User_IsFromPublicDomain({emailList})
         .then((response) => {
             if (response.jsonCode === 200) {
                 const {isFromPublicDomain} = response;
-                Onyx.merge(ONYXKEYS.USER, {email: sessionEmail});
+                Onyx.merge(ONYXKEYS.USER, {isFromPublicDomain});
 
                 // If the user is not on a public domain we'll want to know whether they are on a domain that has
                 // already provisioned the Expensify card
@@ -141,8 +141,11 @@ function getUserDetails() {
             const blockedFromConcierge = lodashGet(response, `nameValuePairs.${CONST.NVP.BLOCKED_FROM_CONCIERGE}`, {});
             Onyx.merge(ONYXKEYS.NVP_BLOCKED_FROM_CONCIERGE, blockedFromConcierge);
 
-            // Get domainInfo for user
-            const emailList = _.map(loginList, userLogin => userLogin.partnerUserID);
+            // Get list of validated logins and fetch domain info
+            const emailList = _.chain(loginList)
+                .filter(userLogin => userLogin.validatedDate)
+                .map(userLogin => userLogin.partnerUserID)
+                .value();
             getDomainInfo(emailList);
 
             const preferredSkinTone = lodashGet(response, `nameValuePairs.${CONST.NVP.PREFERRED_EMOJI_SKIN_TONE}`, {});

--- a/src/libs/actions/User.js
+++ b/src/libs/actions/User.js
@@ -266,6 +266,15 @@ function isBlockedFromConcierge(expiresAt) {
 }
 
 /**
+ * Sets isFromPublicDomain in Onyx.
+ *
+ * @param {Boolean} isFromPublicDomain
+ */
+function setIsFromPublicDomain(isFromPublicDomain) {
+    Onyx.merge(ONYXKEYS.USER, {isFromPublicDomain});
+}
+
+/**
  * Initialize our pusher subscription to listen for user changes
  */
 function subscribeToUserEvents() {
@@ -290,6 +299,18 @@ function subscribeToUserEvents() {
                 {error, pusherChannelName, eventName: Pusher.TYPE.PREFERRED_LOCALE},
             );
         });
+
+    // Live-update if a user has private domains listed as primary or secondary logins.
+    Pusher.subscribe(pusherChannelName, Pusher.TYPE.ACCOUNT_VALIDATED, (pushJSON) => {
+        setIsFromPublicDomain(pushJSON.isFromPublicDomain);
+    })
+    .catch((error) => {
+        Log.info(
+            '[User] Failed to subscribe to Pusher channel',
+            false,
+            {error, pusherChannelName, eventName: Pusher.TYPE.ACCOUNT_VALIDATED},
+        );
+    });
 }
 
 /**

--- a/src/libs/actions/User.js
+++ b/src/libs/actions/User.js
@@ -88,7 +88,7 @@ function getDomainInfo(loginList) {
     }
 
     // Check the API for the remaining uncommon domains
-    API.User_IsFromPublicDomain({emailList: emailList.join(',')})
+    API.User_IsFromPublicDomain({emailList})
         .then((response) => {
             if (response.jsonCode === 200) {
                 const {isFromPublicDomain} = response;

--- a/src/libs/actions/User.js
+++ b/src/libs/actions/User.js
@@ -111,9 +111,7 @@ function getDomainInfo(loginList) {
 
                 // eslint-disable-next-line max-len
                 console.debug(`Command User_IsFromPublicDomain returned error code: ${response.jsonCode}. Most likely, this means that the domain ${Str.extractEmail(sessionEmail)} is not in the bedrock cache. Retrying in ${RETRY_TIMEOUT / 1000 / 60} minutes`);
-                Timers.register(setTimeout(() => {
-                    getDomainInfo(loginList);
-                }, RETRY_TIMEOUT));
+                Timers.register(setTimeout(() => getDomainInfo(loginList), RETRY_TIMEOUT));
             }
         });
 }

--- a/src/libs/actions/User.js
+++ b/src/libs/actions/User.js
@@ -304,13 +304,13 @@ function subscribeToUserEvents() {
     Pusher.subscribe(pusherChannelName, Pusher.TYPE.ACCOUNT_VALIDATED, (pushJSON) => {
         setIsFromPublicDomain(pushJSON.isFromPublicDomain);
     })
-    .catch((error) => {
-        Log.info(
-            '[User] Failed to subscribe to Pusher channel',
-            false,
-            {error, pusherChannelName, eventName: Pusher.TYPE.ACCOUNT_VALIDATED},
-        );
-    });
+        .catch((error) => {
+            Log.info(
+                '[User] Failed to subscribe to Pusher channel',
+                false,
+                {error, pusherChannelName, eventName: Pusher.TYPE.ACCOUNT_VALIDATED},
+            );
+        });
 }
 
 /**

--- a/src/libs/actions/User.js
+++ b/src/libs/actions/User.js
@@ -88,11 +88,11 @@ function getDomainInfo(loginList) {
     }
 
     // Check the API for the remaining uncommon domains
-    API.User_IsFromPublicDomain({emailList})
+    API.User_IsFromPublicDomain()
         .then((response) => {
             if (response.jsonCode === 200) {
                 const {isFromPublicDomain} = response;
-                Onyx.merge(ONYXKEYS.USER, {isFromPublicDomain});
+                Onyx.merge(ONYXKEYS.USER, {email: sessionEmail});
 
                 // If the user is not on a public domain we'll want to know whether they are on a domain that has
                 // already provisioned the Expensify card


### PR DESCRIPTION
### Details
Attempt 2 of https://github.com/Expensify/App/pull/5037

Ensure accounts with a private domain secondary login can create a workspace via the "Get Started" button in workspace configuration.

Related Web-E PR: https://github.com/Expensify/Web-Expensify/pull/32014

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/176225

### Tests
1. Create an account with a public domain login. e.g. `@gmail.com`.
2. Login to NewDot and navigate to `+ > New Workspace` and verify that you see `Add Email` in the card page.
3. Click on Add email and it will redirect you to OldDot.
4. Now add a secondary public domain login with a public domain that is not in our common list of domains, e.g. `@facebook.com`.
5. Validate the secondary login and go back to NewDot.
6. Verify that you still see `Add email`
7. Repeat steps 4-6, but this time with a private domain, e.g. `@expensify.com` and verify that `Add email` changed to `Get started`.

Pro tip: you can validate the secondary logins by running `../script/clitools.sh validator:secondaryLogin`

### QA Steps
Steps above.

### Tested On

- [x] Web
- [ ] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web

https://user-images.githubusercontent.com/22219519/135359129-54ad92fb-3595-4388-9253-f84f4854a02a.mov

#### Mobile Web

<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop

https://user-images.githubusercontent.com/22219519/135359148-8a603e51-596b-4554-a025-3eec1720bec9.mov

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
