### PR TITLE
Fix: line height issues of button

### DIFF
--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -50,7 +50,6 @@ const Text = React.forwardRef(({
         ...finalStyles,
         ...s,
     }), {});
-
     const componentStyle = {
         color,
         fontSize,
@@ -59,7 +58,7 @@ const Text = React.forwardRef(({
         ...mergedStyles,
     };
 
-    if (componentStyle.fontSize === variables.fontSizeNormal) {
+    if (!componentStyle.lineHeight && componentStyle.fontSize === variables.fontSizeNormal) {
         componentStyle.lineHeight = variables.fontSizeNormalHeight;
     }
 

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -209,6 +209,10 @@ const styles = {
         fontSize: variables.fontSizeNormal,
         fontWeight: fontWeightBold,
         textAlign: 'center',
+
+        // It is needed to unset the Lineheight. We don't need it for buttons as button always contains single line of text.
+        // It allows to vertically center the text.
+        lineHeight: undefined,
     },
 
     buttonSmall: {
@@ -232,15 +236,13 @@ const styles = {
 
     buttonSmallText: {
         fontSize: variables.fontSizeSmall,
-        lineHeight: 16,
         fontFamily: fontFamily.GTA_BOLD,
         fontWeight: fontWeightBold,
         textAlign: 'center',
     },
 
     buttonLargeText: {
-        fontSize: variables.fontSizeLarge,
-        lineHeight: 18,
+        fontSize: variables.fontSizeNormal,
         fontFamily: fontFamily.GTA_BOLD,
         fontWeight: fontWeightBold,
         textAlign: 'center',


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
 
1. Allow the Text component to override the default line-height.
2. Removed the Line-height from Button Text to vertically center any size button.

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/5333

### Tests | QA Steps
1. Create a workspace.
2. Enter Expensify Card tab.
3. See the "Get Started" and "Help" buttons are properly aligned on the vertical axis.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web | Desktop
<!-- Insert screenshots of your changes on the web platform-->
![image](https://user-images.githubusercontent.com/24370807/134566583-c25921fc-e44a-42be-bb8a-92f053f45e26.png)

#### Mobile Web

![Screenshot 2021-09-24 00:24:09](https://user-images.githubusercontent.com/24370807/134566878-05f78643-a8cf-4009-93e3-fa494ddbe295.png)


#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
![Screenshot 2021-09-24 00:12:25](https://user-images.githubusercontent.com/24370807/134565376-8b865d8f-ac44-4581-86e1-22db35cf2d03.png)
