### PR TITLE
Add type-safety checks in navigation functions

### DIFF
--- a/src/libs/Navigation/Navigation.js
+++ b/src/libs/Navigation/Navigation.js
@@ -38,6 +38,10 @@ function setDidTapNotification() {
  * @private
  */
 function openDrawer() {
+    if (!navigationRef.isReady()) {
+        console.debug('[Navigation] openDrawer failed because navigation ref was not yet ready');
+        return;
+    }
     navigationRef.current.dispatch(DrawerActions.openDrawer());
 }
 
@@ -46,6 +50,10 @@ function openDrawer() {
  * @private
  */
 function closeDrawer() {
+    if (!navigationRef.isReady()) {
+        console.debug('[Navigation] closeDrawer failed because navigation ref was not yet ready');
+        return;
+    }
     navigationRef.current.dispatch(DrawerActions.closeDrawer());
 }
 
@@ -65,6 +73,11 @@ function getDefaultDrawerState(isSmallScreenWidth) {
  * @param {Boolean} shouldOpenDrawer
  */
 function goBack(shouldOpenDrawer = true) {
+    if (!navigationRef.isReady()) {
+        console.debug('[Navigation] goBack failed because navigation ref was not yet ready');
+        return;
+    }
+
     if (!navigationRef.current.canGoBack()) {
         console.debug('Unable to go back');
         if (shouldOpenDrawer) {
@@ -81,6 +94,11 @@ function goBack(shouldOpenDrawer = true) {
  * @param {String} route
  */
 function navigate(route = ROUTES.HOME) {
+    if (!navigationRef.isReady()) {
+        console.debug('[Navigation] navigate failed because navigation ref was not yet ready');
+        return;
+    }
+
     if (route === ROUTES.HOME) {
         if (isLoggedIn) {
             openDrawer();
@@ -110,6 +128,11 @@ function navigate(route = ROUTES.HOME) {
  * @param {Boolean} shouldOpenDrawer
  */
 function dismissModal(shouldOpenDrawer = false) {
+    if (!navigationRef.isReady()) {
+        console.debug('[Navigation] dismissModal failed because navigation ref was not yet ready');
+        return;
+    }
+
     const normalizedShouldOpenDrawer = _.isBoolean(shouldOpenDrawer)
         ? shouldOpenDrawer
         : false;


### PR DESCRIPTION
### Details
Makes sure that the `navigationRef` is ready before trying to access `current`.

### Fixed Issues
Slack threads:

- https://expensify.slack.com/archives/C020EPP9B9A/p1632433314327000
- https://expensify.slack.com/archives/C020EPP9B9A/p1632433003319900
- https://expensify.slack.com/archives/C020EPP9B9A/p1632429118275000

### Tests / QA Steps
1. Go to https://staging.expensify.com/ on a mobile device.
1. Sign into an account.
1. Press `Set up my company for free`
1. Verify that you are taken to the workspace modal in NewDot (no white screen or infinite loading spinner). If you did not already have a workspace for this account, a new one should be created. Otherwise, a new workspace should not be created.
1. Sign out from NewDot.
1. Go to https://staging.expensify.com/ on a mobile device.
1. Sign into an account.
1. Press `Split bills & chat with friends`
1. Verify that you are taken to the NewDot homepage without any issues.

### Tested On

- [ ] Web
- [x] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
