### PR TITLE
Moves all free plan beta checks to use free plan soft launch beta

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -88,6 +88,7 @@ const CONST = {
         IOU: 'IOU',
         PAY_WITH_EXPENSIFY: 'payWithExpensify',
         FREE_PLAN: 'freePlan',
+        FREE_PLAN_SOFT_LAUNCH: 'freePlanSoftLaunch',
         DEFAULT_ROOMS: 'defaultRooms',
         BETA_EXPENSIFY_WALLET: 'expensifyWallet',
         INTERNATIONALIZATION: 'internationalization',

--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -120,7 +120,7 @@ let hasLoadedPolicies = false;
 function loadPoliciesBehindBeta(betas) {
     // When removing the freePlan beta, simply load the policyList and the policySummaries in componentDidMount().
     // Policy info loading should not be blocked behind the defaultRooms beta alone.
-    if (!hasLoadedPolicies && (Permissions.canUseFreePlan(betas) || Permissions.canUseDefaultRooms(betas))) {
+    if (!hasLoadedPolicies && (Permissions.canUseFreePlanSoftLaunch(betas) || Permissions.canUseDefaultRooms(betas))) {
         getPolicyList();
         getPolicySummaries();
         hasLoadedPolicies = true;

--- a/src/libs/Navigation/Navigation.js
+++ b/src/libs/Navigation/Navigation.js
@@ -200,7 +200,7 @@ function isActiveRoute(routePath) {
  *
  * Example:
  * ```jsx
- * if (!Permissions.canUseFreePlan(this.props.betas)) {
+ * if (!Permissions.canUseFreePlanSoftLaunch(this.props.betas)) {
  *     return <Navigation.DismissModal />;
  * }
  * ```

--- a/src/libs/Permissions.js
+++ b/src/libs/Permissions.js
@@ -47,6 +47,14 @@ function canUseFreePlan(betas) {
  * @param {Array<String>} betas
  * @returns {Boolean}
  */
+function canUseFreePlanSoftLaunch(betas) {
+    return _.contains(betas, CONST.BETAS.FREE_PLAN_SOFT_LAUNCH) || canUseAllBetas(betas);
+}
+
+/**
+ * @param {Array<String>} betas
+ * @returns {Boolean}
+ */
 function canUseDefaultRooms(betas) {
     return _.contains(betas, CONST.BETAS.DEFAULT_ROOMS) || canUseAllBetas(betas);
 }
@@ -72,6 +80,7 @@ export default {
     canUseIOU,
     canUsePayWithExpensify,
     canUseFreePlan,
+    canUseFreePlanSoftLaunch,
     canUseDefaultRooms,
     canUseInternationalization,
     canUseWallet,

--- a/src/pages/LoginWithValidateCode2FAPage.js
+++ b/src/pages/LoginWithValidateCode2FAPage.js
@@ -70,7 +70,7 @@ class LoginWithValidateCode2FAPage extends Component {
             // and by calling dismissModal(), the /v/... route is removed from history so the user will get taken to `/`
             // if they cancel out of the new workspace modal.
             Navigation.dismissModal();
-            if (Permissions.canUseFreePlan(this.props.betas)) {
+            if (Permissions.canUseFreePlanSoftLaunch(this.props.betas)) {
                 this.rerouteToRelevantPage();
             }
         }
@@ -78,7 +78,7 @@ class LoginWithValidateCode2FAPage extends Component {
 
     componentDidUpdate() {
         // Betas can be loaded a little after a user is authenticated, so check again if the betas have been updated
-        if (this.props.session.authToken && Permissions.canUseFreePlan(this.props.betas)) {
+        if (this.props.session.authToken && Permissions.canUseFreePlanSoftLaunch(this.props.betas)) {
             this.rerouteToRelevantPage();
         }
     }

--- a/src/pages/LoginWithValidateCodePage.js
+++ b/src/pages/LoginWithValidateCodePage.js
@@ -47,7 +47,7 @@ class LoginWithValidateCodePage extends Component {
             // and by calling dismissModal(), the /v/... route is removed from history so the user will get taken to `/`
             // if they cancel out of the new workspace modal.
             Navigation.dismissModal();
-            if (Permissions.canUseFreePlan(this.props.betas)) {
+            if (Permissions.canUseFreePlanSoftLaunch(this.props.betas)) {
                 this.rerouteToRelevantPage();
             }
             return;
@@ -60,7 +60,7 @@ class LoginWithValidateCodePage extends Component {
 
     componentDidUpdate() {
         // Betas can be loaded a little after a user is authenticated, so check again if the betas have been updated
-        if (this.props.session.authToken && Permissions.canUseFreePlan(this.props.betas)) {
+        if (this.props.session.authToken && Permissions.canUseFreePlanSoftLaunch(this.props.betas)) {
             this.rerouteToRelevantPage();
         }
     }

--- a/src/pages/ReimbursementAccount/ReimbursementAccountPage.js
+++ b/src/pages/ReimbursementAccount/ReimbursementAccountPage.js
@@ -138,7 +138,7 @@ class ReimbursementAccountPage extends React.Component {
     }
 
     render() {
-        if (!Permissions.canUseFreePlan(this.props.betas)) {
+        if (!Permissions.canUseFreePlanSoftLaunch(this.props.betas)) {
             console.debug('Not showing new bank account page because user is not on free plan beta');
             Navigation.dismissModal();
             return null;

--- a/src/pages/home/sidebar/SidebarScreen.js
+++ b/src/pages/home/sidebar/SidebarScreen.js
@@ -172,7 +172,7 @@ class SidebarScreen extends Component {
                                         onSelected: () => Navigation.navigate(ROUTES.IOU_BILL),
                                     },
                                 ] : []),
-                                ...(Permissions.canUseFreePlan(this.props.betas) && !isAdminOfFreePolicy(this.props.allPolicies) ? [
+                                ...(Permissions.canUseFreePlanSoftLaunch(this.props.betas) && !isAdminOfFreePolicy(this.props.allPolicies) ? [
                                     {
                                         icon: NewWorkspace,
                                         iconWidth: 46,

--- a/src/pages/workspace/WorkspaceCardPage.js
+++ b/src/pages/workspace/WorkspaceCardPage.js
@@ -109,7 +109,7 @@ const WorkspaceCardPage = ({
         }
     };
 
-    if (!Permissions.canUseFreePlan(betas)) {
+    if (!Permissions.canUseFreePlanSoftLaunch(betas)) {
         console.debug('Not showing workspace card page because user is not on free plan beta');
         return <Navigation.DismissModal />;
     }

--- a/src/pages/workspace/WorkspaceEditorPage.js
+++ b/src/pages/workspace/WorkspaceEditorPage.js
@@ -85,7 +85,7 @@ class WorkspaceEditorPage extends React.Component {
     render() {
         const {policy} = this.props;
 
-        if (!Permissions.canUseFreePlan(this.props.betas)) {
+        if (!Permissions.canUseFreePlanSoftLaunch(this.props.betas)) {
             console.debug('Not showing workspace editor page because user is not on free plan beta');
             return <Navigation.DismissModal />;
         }

--- a/src/pages/workspace/WorkspacePeoplePage.js
+++ b/src/pages/workspace/WorkspacePeoplePage.js
@@ -208,7 +208,7 @@ class WorkspacePeoplePage extends React.Component {
     }
 
     render() {
-        if (!Permissions.canUseFreePlan(this.props.betas)) {
+        if (!Permissions.canUseFreePlanSoftLaunch(this.props.betas)) {
             console.debug('Not showing workspace people page because user is not on free plan beta');
             return <Navigation.DismissModal />;
         }


### PR DESCRIPTION
Needs https://github.com/Expensify/Web-Expensify/pull/32022

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/178653

### Tests
- Does not apply to QA: force permissions.canUseFreePlan to return false and permissions.canUseFreePlanSoftLaunch to return true
- On oldDot, on a new account on a new domain, go to Settings > Policies > Group and check you can see the free plan option, click it and you should be taken to newDot workflow page, close that modal
- On oldDot delete the newly created policy
- Refresh newDot
- Check the big plus button has the option to create a new workspace and that it works


### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

