### PR TITLE
Revert "Moves all free plan beta checks to use free plan soft launch beta"

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -88,7 +88,6 @@ const CONST = {
         IOU: 'IOU',
         PAY_WITH_EXPENSIFY: 'payWithExpensify',
         FREE_PLAN: 'freePlan',
-        FREE_PLAN_SOFT_LAUNCH: 'freePlanSoftLaunch',
         DEFAULT_ROOMS: 'defaultRooms',
         BETA_EXPENSIFY_WALLET: 'expensifyWallet',
         INTERNATIONALIZATION: 'internationalization',

--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -120,7 +120,7 @@ let hasLoadedPolicies = false;
 function loadPoliciesBehindBeta(betas) {
     // When removing the freePlan beta, simply load the policyList and the policySummaries in componentDidMount().
     // Policy info loading should not be blocked behind the defaultRooms beta alone.
-    if (!hasLoadedPolicies && (Permissions.canUseFreePlanSoftLaunch(betas) || Permissions.canUseDefaultRooms(betas))) {
+    if (!hasLoadedPolicies && (Permissions.canUseFreePlan(betas) || Permissions.canUseDefaultRooms(betas))) {
         getPolicyList();
         getPolicySummaries();
         hasLoadedPolicies = true;

--- a/src/libs/Navigation/Navigation.js
+++ b/src/libs/Navigation/Navigation.js
@@ -200,7 +200,7 @@ function isActiveRoute(routePath) {
  *
  * Example:
  * ```jsx
- * if (!Permissions.canUseFreePlanSoftLaunch(this.props.betas)) {
+ * if (!Permissions.canUseFreePlan(this.props.betas)) {
  *     return <Navigation.DismissModal />;
  * }
  * ```

--- a/src/libs/Permissions.js
+++ b/src/libs/Permissions.js
@@ -47,14 +47,6 @@ function canUseFreePlan(betas) {
  * @param {Array<String>} betas
  * @returns {Boolean}
  */
-function canUseFreePlanSoftLaunch(betas) {
-    return _.contains(betas, CONST.BETAS.FREE_PLAN_SOFT_LAUNCH) || canUseAllBetas(betas);
-}
-
-/**
- * @param {Array<String>} betas
- * @returns {Boolean}
- */
 function canUseDefaultRooms(betas) {
     return _.contains(betas, CONST.BETAS.DEFAULT_ROOMS) || canUseAllBetas(betas);
 }
@@ -80,7 +72,6 @@ export default {
     canUseIOU,
     canUsePayWithExpensify,
     canUseFreePlan,
-    canUseFreePlanSoftLaunch,
     canUseDefaultRooms,
     canUseInternationalization,
     canUseWallet,

--- a/src/pages/LoginWithValidateCode2FAPage.js
+++ b/src/pages/LoginWithValidateCode2FAPage.js
@@ -70,7 +70,7 @@ class LoginWithValidateCode2FAPage extends Component {
             // and by calling dismissModal(), the /v/... route is removed from history so the user will get taken to `/`
             // if they cancel out of the new workspace modal.
             Navigation.dismissModal();
-            if (Permissions.canUseFreePlanSoftLaunch(this.props.betas)) {
+            if (Permissions.canUseFreePlan(this.props.betas)) {
                 this.rerouteToRelevantPage();
             }
         }
@@ -78,7 +78,7 @@ class LoginWithValidateCode2FAPage extends Component {
 
     componentDidUpdate() {
         // Betas can be loaded a little after a user is authenticated, so check again if the betas have been updated
-        if (this.props.session.authToken && Permissions.canUseFreePlanSoftLaunch(this.props.betas)) {
+        if (this.props.session.authToken && Permissions.canUseFreePlan(this.props.betas)) {
             this.rerouteToRelevantPage();
         }
     }

--- a/src/pages/LoginWithValidateCodePage.js
+++ b/src/pages/LoginWithValidateCodePage.js
@@ -47,7 +47,7 @@ class LoginWithValidateCodePage extends Component {
             // and by calling dismissModal(), the /v/... route is removed from history so the user will get taken to `/`
             // if they cancel out of the new workspace modal.
             Navigation.dismissModal();
-            if (Permissions.canUseFreePlanSoftLaunch(this.props.betas)) {
+            if (Permissions.canUseFreePlan(this.props.betas)) {
                 this.rerouteToRelevantPage();
             }
             return;
@@ -60,7 +60,7 @@ class LoginWithValidateCodePage extends Component {
 
     componentDidUpdate() {
         // Betas can be loaded a little after a user is authenticated, so check again if the betas have been updated
-        if (this.props.session.authToken && Permissions.canUseFreePlanSoftLaunch(this.props.betas)) {
+        if (this.props.session.authToken && Permissions.canUseFreePlan(this.props.betas)) {
             this.rerouteToRelevantPage();
         }
     }

--- a/src/pages/ReimbursementAccount/ReimbursementAccountPage.js
+++ b/src/pages/ReimbursementAccount/ReimbursementAccountPage.js
@@ -138,7 +138,7 @@ class ReimbursementAccountPage extends React.Component {
     }
 
     render() {
-        if (!Permissions.canUseFreePlanSoftLaunch(this.props.betas)) {
+        if (!Permissions.canUseFreePlan(this.props.betas)) {
             console.debug('Not showing new bank account page because user is not on free plan beta');
             Navigation.dismissModal();
             return null;

--- a/src/pages/home/sidebar/SidebarScreen.js
+++ b/src/pages/home/sidebar/SidebarScreen.js
@@ -172,7 +172,7 @@ class SidebarScreen extends Component {
                                         onSelected: () => Navigation.navigate(ROUTES.IOU_BILL),
                                     },
                                 ] : []),
-                                ...(Permissions.canUseFreePlanSoftLaunch(this.props.betas) && !isAdminOfFreePolicy(this.props.allPolicies) ? [
+                                ...(Permissions.canUseFreePlan(this.props.betas) && !isAdminOfFreePolicy(this.props.allPolicies) ? [
                                     {
                                         icon: NewWorkspace,
                                         iconWidth: 46,

--- a/src/pages/workspace/WorkspaceCardPage.js
+++ b/src/pages/workspace/WorkspaceCardPage.js
@@ -109,7 +109,7 @@ const WorkspaceCardPage = ({
         }
     };
 
-    if (!Permissions.canUseFreePlanSoftLaunch(betas)) {
+    if (!Permissions.canUseFreePlan(betas)) {
         console.debug('Not showing workspace card page because user is not on free plan beta');
         return <Navigation.DismissModal />;
     }

--- a/src/pages/workspace/WorkspaceEditorPage.js
+++ b/src/pages/workspace/WorkspaceEditorPage.js
@@ -85,7 +85,7 @@ class WorkspaceEditorPage extends React.Component {
     render() {
         const {policy} = this.props;
 
-        if (!Permissions.canUseFreePlanSoftLaunch(this.props.betas)) {
+        if (!Permissions.canUseFreePlan(this.props.betas)) {
             console.debug('Not showing workspace editor page because user is not on free plan beta');
             return <Navigation.DismissModal />;
         }

--- a/src/pages/workspace/WorkspacePeoplePage.js
+++ b/src/pages/workspace/WorkspacePeoplePage.js
@@ -208,7 +208,7 @@ class WorkspacePeoplePage extends React.Component {
     }
 
     render() {
-        if (!Permissions.canUseFreePlanSoftLaunch(this.props.betas)) {
+        if (!Permissions.canUseFreePlan(this.props.betas)) {
             console.debug('Not showing workspace people page because user is not on free plan beta');
             return <Navigation.DismissModal />;
         }


### PR DESCRIPTION
Reverts Expensify/App#5485

I fucked up the beta. Since we are blocked on deploying App to prod, we need to use the old beta for the soft launch and a new beta for the hard launch.