### PR TITLE
fix: email overflow in Details page on Mobile devices

### DIFF
--- a/src/components/CommunicationsLink.js
+++ b/src/components/CommunicationsLink.js
@@ -36,6 +36,7 @@ const CommunicationsLink = props => (
         {props.isSmallScreenWidth
             ? (
                 <Pressable
+                    style={styles.mw100}
                     onPress={() => Linking.openURL(
                         props.type === CONST.LOGIN_TYPE.PHONE
                             ? `tel:${props.value}`

--- a/src/pages/DetailsPage.js
+++ b/src/pages/DetailsPage.js
@@ -110,7 +110,7 @@ const DetailsPage = ({
                                         type={isSMSLogin ? CONST.LOGIN_TYPE.PHONE : CONST.LOGIN_TYPE.EMAIL}
                                         value={isSMSLogin ? getPhoneNumber(details) : details.login}
                                     >
-                                        <Text numberOfLines={1}>
+                                        <Text numberOfLines={1} style={[styles.w100]}>
                                             {isSMSLogin
                                                 ? toLocalPhone(getPhoneNumber(details))
                                                 : details.login}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/5422

### Tests | QA Steps

1. Go to staging.new.expensify.com on MWeb.
2. Login with any account
3. Select user with long email
4. Click on user Profile.
5. Email should be trimmed with an ellipsis instead of oveflowing.


### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web | Desktop
<!-- Insert screenshots of your changes on the web platform-->
![image](https://user-images.githubusercontent.com/24370807/134826865-baaf5c95-fffe-4e53-a49f-59c250b2b99f.png)

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
![Screenshot 2021-09-27 04:24:44](https://user-images.githubusercontent.com/24370807/134826932-d95f2e11-aa0e-4b4c-91fe-c680bc75a384.png)

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
![Screenshot 2021-09-27 04:48:44](https://user-images.githubusercontent.com/24370807/134827599-d20b2e58-3bad-4e1f-8569-c1bcba1c6d32.png)
