### PR TITLE
Show NEW marker over unread messages, while scroll back from viewing history

### DIFF
--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -399,11 +399,15 @@ class ReportActionsView extends React.Component {
      * @param {Boolean} [shouldResetLocalCount=false] Whether count should increment or reset
      */
     updateLocalUnreadActionCount(shouldResetLocalCount = false) {
-        this.setState(prevState => ({
-            localUnreadActionCount: shouldResetLocalCount
+        this.setState((prevState) => {
+            const localUnreadActionCount = shouldResetLocalCount
                 ? this.props.report.unreadActionCount
-                : prevState.localUnreadActionCount + this.props.report.unreadActionCount,
-        }));
+                : prevState.localUnreadActionCount + this.props.report.unreadActionCount;
+            this.updateUnreadIndicatorPosition(localUnreadActionCount);
+            return {
+                localUnreadActionCount,
+            };
+        });
     }
 
     /**

--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -404,9 +404,7 @@ class ReportActionsView extends React.Component {
                 ? this.props.report.unreadActionCount
                 : prevState.localUnreadActionCount + this.props.report.unreadActionCount;
             this.updateUnreadIndicatorPosition(localUnreadActionCount);
-            return {
-                localUnreadActionCount,
-            };
+            return {localUnreadActionCount};
         });
     }
 


### PR DESCRIPTION

<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/5021

### Tests & QA Steps
1. Open any user chat.
2. Scroll and view old messages
3. When new messages arrive a `new messages` badge will show

Fixed:
When clicking on the `new messages` badge, now will show `NEW` unread indicator above the unread messages.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
https://user-images.githubusercontent.com/85645967/134817498-9ff0ab84-eb32-483a-8cab-43fb3ecf2c16.mov

#### Mobile Web
https://user-images.githubusercontent.com/85645967/134817517-0afd6ca4-a7f8-4120-b458-0c319a9c7f19.mp4

#### Desktop
https://user-images.githubusercontent.com/85645967/134817518-10fb8428-c764-408a-b59a-95cfc5b62259.mov

#### iOS
https://user-images.githubusercontent.com/85645967/134817552-48b0d462-3fb8-4022-974f-a5055b6678e0.mp4

#### Android
https://user-images.githubusercontent.com/85645967/134817511-31f258ea-7864-4c21-b493-e97af35080a6.mov
