### PR TITLE
Add a placeholder to the TaxID field

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -532,6 +532,7 @@ export default {
         legalBusinessName: 'Legal business name',
         companyWebsite: 'Company website',
         taxIDNumber: 'Tax ID number',
+        taxIDNumberPlaceholder: '9 digits, no hyphens',
         companyType: 'Company type',
         incorporationDate: 'Incorporation date',
         industryClassificationCode: 'Industry classification code',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -534,6 +534,7 @@ export default {
         legalBusinessName: 'Nombre comercial legal',
         companyWebsite: 'Página web de la empresa',
         taxIDNumber: 'Número de identificación fiscal',
+        taxIDNumberPlaceholder: '9 dígitos, sin guiones',
         companyType: 'Tipo de empresa',
         incorporationDate: 'Fecha de incorporación',
         industryClassificationCode: 'Código de clasificación industrial',

--- a/src/pages/ReimbursementAccount/CompanyStep.js
+++ b/src/pages/ReimbursementAccount/CompanyStep.js
@@ -241,6 +241,7 @@ class CompanyStep extends React.Component {
                         onChangeText={value => this.clearErrorAndSetValue('companyTaxID', value)}
                         value={this.state.companyTaxID}
                         disabled={shouldDisableCompanyTaxID}
+                        placeholder={this.props.translate('companyStep.taxIDNumberPlaceholder')}
                         errorText={this.getErrorText('companyTaxID')}
                     />
                     <View style={styles.mt4}>


### PR DESCRIPTION
### Details
Add a placeholder for the Tax ID field to encourage using 9 digits

### Fixed Issues
[Slack thread](https://expensify.slack.com/archives/C020EPP9B9A/p1632721850224300)

### Tests & QA

1. Navigate to `/bank-account/company`
2. Focus on the TaxID number field
3. Verify that you now see a placeholder

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
![Screen Shot 2021-09-27 at 11 32 34](https://user-images.githubusercontent.com/1805746/134883339-44ad2fcb-011a-4469-b8f4-c6a3b8d3dcda.png)

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android

<!-- Insert screenshots of your changes on the Android platform-->
