### PR TITLE
Encode encryptedAuthToken in front end 

### DIFF
--- a/src/libs/addEncryptedAuthTokenToURL.js
+++ b/src/libs/addEncryptedAuthTokenToURL.js
@@ -15,5 +15,5 @@ Onyx.connect({
  * @returns {String}
  */
 export default function (url) {
-    return `${url}?encryptedAuthToken=${encryptedAuthToken}`;
+    return `${url}?encryptedAuthToken=${encodeURIComponent(encryptedAuthToken)}`;
 }


### PR DESCRIPTION
### Details

This is a necessary step so we can switch off of passing the `encryptedAuthToken` in the `/transition` links when moving from OldDot to NewDot. In the changes here we will no longer be url encoding the `encryptedAuthToken` before sending it via JSON response to `Expensify/App`. Tested this change and there are no negative effects of "double encoding" since the urls should already arrive urlencoded.

### Fixed Issues (Related to)
https://github.com/Expensify/Expensify/issues/178434

### Tests 
1. Test against current Web-Expensify master (`npm run grunt` first)
1. Do QA steps

### QA Steps
1. Sign up for a new account in OldDot (mobile user agent)
1. Tap "Join"
1. Tap "Set up my company for free"
![2021-09-27_09-36-44](https://user-images.githubusercontent.com/32969087/134974623-2dc83a6c-e28c-4921-8a3a-0774434045da.png)
1. Verify NewDot opens up to a workspace
1. Close the workspace window and navigate to the Concierge chat
1. Upload an attachment
1. Verify the attachment is visible
![2021-09-27_09-44-30](https://user-images.githubusercontent.com/32969087/134974650-03b40caf-8191-4df9-8c93-267904d4cb84.png)

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
