### PR TITLE
Shiny up the request call page

### DIFF
--- a/assets/images/request-call.svg
+++ b/assets/images/request-call.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 24.3.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 160 100" style="enable-background:new 0 0 160 100;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#0B1B34;stroke-width:2;stroke-miterlimit:10;}
+	.st1{fill:#0185FF;stroke:#FFFFFF;stroke-width:2;stroke-miterlimit:10;}
+	.st2{fill:#0B1B34;}
+	.st3{fill:none;stroke:#FFFFFF;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
+	.st4{fill:#0185FF;stroke:#FFFFFF;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:10;}
+	.st5{fill:#FFFFFF;}
+</style>
+<path class="st0" d="M113,46.7v7.9"/>
+<path class="st1" d="M137.2,72c0.1-11.1-10.8-20.2-24.2-20.2s-24.3,9-24.2,20.2H137.2L137.2,72z"/>
+<path class="st2" d="M130.6,66.1c-1.6-3.4-4.7-6.2-8.5-8L130.6,66.1z"/>
+<path class="st3" d="M130.6,66.1c-1.6-3.4-4.7-6.2-8.5-8"/>
+<path class="st2" d="M117.3,47.7c0-2-2-3.6-4.4-3.6s-4.4,1.6-4.4,3.6H117.3z"/>
+<path class="st1" d="M140.9,79H85l3.7-6.9h48.5L140.9,79z"/>
+<path class="st0" d="M112.6,31.2v7.1"/>
+<path class="st0" d="M101.5,34.2l4,5.1"/>
+<path class="st0" d="M123.7,34.2l-4,5.1"/>
+<path class="st4" d="M20,44.6c0,12.5,10.1,22.6,22.6,22.6c5.4,0,10.3-1.9,14.2-5h18.4L64,51.8c0.8-2.3,1.2-4.7,1.2-7.2
+	C65.2,32.1,55.1,22,42.6,22S20,32.1,20,44.6z"/>
+<path class="st5" d="M40.4,32.6H45v5.7l-1.2,10.4h-2.2l-1.2-10.4V32.6L40.4,32.6z"/>
+<path class="st5" d="M42.7,55.5c1.3,0,2.3-1,2.3-2.3c0-1.3-1-2.3-2.3-2.3c-1.3,0-2.3,1-2.3,2.3C40.4,54.5,41.4,55.5,42.7,55.5z"/>
+</svg>

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -636,10 +636,9 @@ export default {
         },
     },
     requestCallPage: {
-        requestACall: 'Request a call',
-        description: 'Need help with your account configuration? Our team of guides are on hand to help you each step of the way.',
-        instructions: 'Type in your name and phone number, and we’ll give you a call back.',
-        availabilityText: '*Our guides are available from Sunday at 5pm CT to Friday at 5pm CT. Any requests outside this window will be returned 9am - 5pm, Monday - Friday in your local time. Call time is based on the order the call was received.',
+        title: 'Request a call',
+        subtitle: 'Have questions, or need help?',
+        description: 'Our team of guides are on hand to help you each step of the way. Type in your name and phone number, and we’ll give you a call back.',
         callMe: 'Call me',
         growlMessageOnSave: 'Call requested.',
         errorMessageInvalidPhone: 'That doesn’t look like a valid phone number. Try again with the country code. e.g. +15005550006',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -638,10 +638,9 @@ export default {
         },
     },
     requestCallPage: {
-        requestACall: 'Llámame por teléfono',
-        description: '¿Necesitas ayuda configurando tu cuenta? Nuestro equipo de guías puede ayudarte.',
-        instructions: 'Escribe tu nombre y número de teléfono y te llamaremos.',
-        availabilityText: '*Nuestros guías están disponibles de domingo desde las 17.00 CT a viernes hasta las 17.00 CT. Si solicitas una llamada fuera de este horario, te llamaremos de lunes a viernes de 9.00 a 17.00 en tu hora local. El orden de llamada corresponde con el orden de solicitud.',
+        title: 'Llámame por teléfono',
+        subtitle: '¿Tienes preguntas o necesitas ayuda?',
+        description: '¿Necesitas ayuda configurando tu cuenta? Nuestro equipo de guías puede ayudarte. Escribe tu nombre y número de teléfono y te llamaremos.',
         callMe: 'Llámame',
         growlMessageOnSave: 'Llamada solicitada.',
         errorMessageInvalidPhone: 'El teléfono no es valido. Inténtalo de nuevo agregando el código de país. P. ej.: +15005550006',

--- a/src/pages/RequestCallPage.js
+++ b/src/pages/RequestCallPage.js
@@ -22,6 +22,7 @@ import personalDetailsPropType from './personalDetailsPropType';
 import ExpensiTextInput from '../components/ExpensiTextInput';
 import Text from '../components/Text';
 import KeyboardAvoidingView from '../components/KeyboardAvoidingView';
+import RequestCallIcon from '../../assets/images/request-call.svg';
 
 const propTypes = {
     ...withLocalizePropTypes,
@@ -77,6 +78,7 @@ class RequestCallPage extends Component {
         this.onSubmit = this.onSubmit.bind(this);
         this.getPhoneNumber = this.getPhoneNumber.bind(this);
         this.getFirstAndLastName = this.getFirstAndLastName.bind(this);
+        this.validatePhoneInput = this.validatePhoneInput.bind(this);
     }
 
     onSubmit() {
@@ -90,13 +92,7 @@ class RequestCallPage extends Component {
             return;
         }
 
-        if (_.isEmpty(this.state.phoneNumber.trim())) {
-            this.setState({phoneNumberError: this.props.translate('messages.noPhoneNumber')});
-        } else if (!Str.isValidPhone(this.state.phoneNumber)) {
-            this.setState({phoneNumberError: this.props.translate('requestCallPage.errorMessageInvalidPhone')});
-        } else {
-            this.setState({phoneNumberError: ''});
-        }
+        this.validatePhoneInput();
 
         if (shouldNotSubmit) {
             return;
@@ -165,12 +161,22 @@ class RequestCallPage extends Component {
         return {firstName, lastName};
     }
 
+    validatePhoneInput() {
+        if (_.isEmpty(this.state.phoneNumber.trim())) {
+            this.setState({phoneNumberError: this.props.translate('messages.noPhoneNumber')});
+        } else if (!Str.isValidPhone(this.state.phoneNumber)) {
+            this.setState({phoneNumberError: this.props.translate('requestCallPage.errorMessageInvalidPhone')});
+        } else {
+            this.setState({phoneNumberError: ''});
+        }
+    }
+
     render() {
         return (
             <ScreenWrapper>
                 <KeyboardAvoidingView>
                     <HeaderWithCloseButton
-                        title={this.props.translate('requestCallPage.requestACall')}
+                        title={this.props.translate('requestCallPage.title')}
                         shouldShowBackButton
                         onBackButtonPress={() => fetchOrCreateChatReport([
                             this.props.session.email,
@@ -178,19 +184,20 @@ class RequestCallPage extends Component {
                         ], true)}
                         onCloseButtonPress={() => Navigation.dismissModal(true)}
                     />
-                    <ScrollView style={styles.flex1} contentContainerStyle={styles.p5}>
+                    <ScrollView style={styles.flex1} contentContainerStyle={[styles.p5, styles.pt0]}>
+                        <View style={[styles.flex1, styles.flexRow, styles.alignItemsCenter]}>
+                            <Text style={[styles.h1, styles.flex1]}>{this.props.translate('requestCallPage.subtitle')}</Text>
+                            <RequestCallIcon width={160} height={100} style={styles.flex1} />
+                        </View>
                         <Text style={[styles.mb4]}>
                             {this.props.translate('requestCallPage.description')}
-                        </Text>
-                        <Text style={[styles.mt4, styles.mb4]}>
-                            {this.props.translate('requestCallPage.instructions')}
                         </Text>
                         <FullNameInputRow
                             firstName={this.state.firstName}
                             lastName={this.state.lastName}
                             onChangeFirstName={firstName => this.setState({firstName})}
                             onChangeLastName={lastName => this.setState({lastName})}
-                            style={[styles.mt4, styles.mb4]}
+                            style={[styles.mv4]}
                         />
                         <View style={styles.mt4}>
                             <ExpensiTextInput
@@ -200,21 +207,10 @@ class RequestCallPage extends Component {
                                 value={this.state.phoneNumber}
                                 placeholder="+14158675309"
                                 errorText={this.state.phoneNumberError}
-                                onBlur={() => {
-                                    if (_.isEmpty(this.state.phoneNumber.trim())) {
-                                        this.setState({phoneNumberError: this.props.translate('messages.noPhoneNumber')});
-                                    } else if (!Str.isValidPhone(this.state.phoneNumber)) {
-                                        this.setState({phoneNumberError: this.props.translate('requestCallPage.errorMessageInvalidPhone')});
-                                    } else {
-                                        this.setState({phoneNumberError: ''});
-                                    }
-                                }}
+                                onBlur={this.validatePhoneInput}
                                 onChangeText={phoneNumber => this.setState({phoneNumber})}
                             />
                         </View>
-                        <Text style={[styles.mt4, styles.textLabel, styles.colorMuted, styles.mb6]}>
-                            {this.props.translate('requestCallPage.availabilityText')}
-                        </Text>
                     </ScrollView>
                     <FixedFooter>
                         <Button

--- a/src/styles/utilities/spacing.js
+++ b/src/styles/utilities/spacing.js
@@ -264,6 +264,10 @@ export default {
         paddingLeft: 20,
     },
 
+    pt0: {
+        paddingTop: 0,
+    },
+
     pt2: {
         paddingTop: 8,
     },


### PR DESCRIPTION
cc @trjExpensify 

### Details
- Updates the request call page to match OldDot
- Removes the extra information about call scheduling, to be addressed further in [this issue](https://github.com/Expensify/Expensify/issues/179284).

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/179276

### Tests / QA Steps.
1. Open the chat with concierge
1. Click on the call button
1. Verify that the request call modal opens and appears as it does in screenshots below.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web
![image](https://user-images.githubusercontent.com/47436092/134986943-5de93ebd-2ade-4e82-8661-73db4c109df8.png)

#### Mobile Web
<img src="https://user-images.githubusercontent.com/47436092/134988348-d3b9a846-e2b8-4804-a40f-0508c269fb60.png" alt="" width="350px" />

#### Desktop
![image](https://user-images.githubusercontent.com/47436092/134990562-3e52b355-a8b3-45ba-af1c-7d852818bf61.png)

#### iOS
<img src="https://user-images.githubusercontent.com/47436092/134989587-926756a7-e462-4c86-b1a7-91d82b228525.png" alt="" width="350px" />

#### Android
<img src="https://user-images.githubusercontent.com/47436092/134990321-0777bfc1-69e7-4b36-8536-6ea86c7fcfe0.png" alt="" width="350px" />
