### PR TITLE
Remove password requirement for setting up withdrawal account

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -58,7 +58,6 @@ export default {
         isRequiredField: 'is a required field',
         whatThis: 'What\'s this?',
         iAcceptThe: 'I accept the ',
-        passwordCannotBeBlank: 'Password cannot be blank',
         remove: 'Remove',
         admin: 'Admin',
         dateFormat: 'YYYY-MM-DD',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -58,7 +58,6 @@ export default {
         isRequiredField: 'es un campo obligatorio',
         whatThis: '¿Qué es esto?',
         iAcceptThe: 'Acepto los ',
-        passwordCannotBeBlank: 'La contraseña no puede estar vacía',
         remove: 'Eliminar',
         admin: 'Administrador',
         dateFormat: 'AAAA-MM-DD',

--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -968,7 +968,7 @@ function BankAccount_SetupWithdrawal(parameters) {
 
     requireParameters(['currentStep'], parameters, commandName);
     return Network.post(
-        commandName, {additionalData: JSON.stringify(additionalData), password: parameters.password},
+        commandName, {additionalData: JSON.stringify(additionalData)},
         CONST.NETWORK.METHOD.POST,
         true,
     );

--- a/src/pages/ReimbursementAccount/CompanyStep.js
+++ b/src/pages/ReimbursementAccount/CompanyStep.js
@@ -58,7 +58,6 @@ class CompanyStep extends React.Component {
             incorporationDate: ReimbursementAccountUtils.getDefaultStateForField(props, 'incorporationDate'),
             incorporationState: ReimbursementAccountUtils.getDefaultStateForField(props, 'incorporationState'),
             hasNoConnectionToCannabis: ReimbursementAccountUtils.getDefaultStateForField(props, 'hasNoConnectionToCannabis', false),
-            password: '',
         };
 
         // These fields need to be filled out in order to submit the form
@@ -73,7 +72,6 @@ class CompanyStep extends React.Component {
             'incorporationDate',
             'incorporationState',
             'incorporationType',
-            'password',
             'companyPhone',
             'hasNoConnectionToCannabis',
         ];
@@ -89,7 +87,6 @@ class CompanyStep extends React.Component {
             companyTaxID: 'bankAccount.error.taxID',
             incorporationDate: 'bankAccount.error.incorporationDate',
             incorporationType: 'bankAccount.error.companyType',
-            password: 'common.passwordCannotBeBlank',
             hasNoConnectionToCannabis: 'bankAccount.error.restrictedBusiness',
         };
 
@@ -274,23 +271,6 @@ class CompanyStep extends React.Component {
                             />
                         </View>
                     </View>
-                    <ExpensiTextInput
-                        label={`Expensify ${this.props.translate('common.password')}`}
-                        containerStyles={[styles.mt4]}
-                        secureTextEntry
-                        textContentType="password"
-                        onChangeText={(value) => {
-                            this.setState({password: value});
-                            this.clearError('password');
-                        }}
-                        value={this.state.password}
-                        onSubmitEditing={this.submit}
-                        errorText={this.getErrorText('password')}
-
-                        // Use new-password to prevent an autoComplete bug https://github.com/Expensify/Expensify/issues/173177
-                        // eslint-disable-next-line react/jsx-props-no-multi-spaces
-                        autoCompleteType="new-password"
-                    />
                     <CheckboxWithLabel
                         isChecked={this.state.hasNoConnectionToCannabis}
                         onPress={() => {


### PR DESCRIPTION
### Details
Per [this thread](https://expensify.slack.com/archives/C020EPP9B9A/p1632722241230600) we want to remove the password requirement for adding a withdrawal account. This PR updates the UI to not include the password field for the `Company Step`, and removes the password param for the `BankAccount_SetupWithdrawal` API call.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/179271

### Tests
0. If https://github.com/Expensify/Auth/pull/5973 isn't merged, check out that branch to test locally
1. Create a new account and create a workspace
2. Click `Get Started` to go through the VBA flow, follow https://stackoverflow.com/c/expensify/questions/342/525#525
3. Confirm that when you get to the `Company Information` step, the password field doesn't appear
<img src='https://user-images.githubusercontent.com/3981102/134993898-93ac7daf-d128-4e3c-9d00-19ef3888b840.png' width='400'/>
4. Confirm you can submit the form, and that there is no error regarding the password

### QA Steps
Tag @Jag96 and I can run through the QA steps for this on staging

### Tested On
- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
Screenshot in the tests section
