### PR TITLE
Fix infinite spinner on OldDot transition

### DIFF
--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -262,15 +262,16 @@ class AuthScreens extends React.Component {
      * - We have not already loaded policies
      */
     loadPoliciesBehindBeta() {
-        // When removing the freePlan beta, simply load the policyList and the policySummaries in componentDidMount().
-        // Policy info loading should not be blocked behind the defaultRooms beta alone.
-        if (!this.hasLoadedPolicies
-            && !isTransitionOrNewWorkspacePage(this.props.currentURL)
-            && (Permissions.canUseFreePlan(this.props.betas) || Permissions.canUseDefaultRooms(this.props.betas))) {
-            getPolicyList();
-            getPolicySummaries();
-            this.hasLoadedPolicies = true;
+        // Do not load policies if we're not in the correct betas or if we're in the process of creating a new policy
+        if (this.hasLoadedPolicies
+            || isTransitionOrNewWorkspacePage(this.props.currentURL)
+            || !Permissions.canUseFreePlan(this.props.betas)
+            || !Permissions.canUseDefaultRooms(this.props.betas)) {
+            return;
         }
+        getPolicyList();
+        getPolicySummaries();
+        this.hasLoadedPolicies = true;
     }
 
     render() {

--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -231,6 +231,14 @@ class AuthScreens extends React.Component {
             return true;
         }
 
+        /*
+         * We don't want to unnecessarily re-render this component every time the `currentURL` prop changes,
+         * but we do want to re-render when we're switching from `transition` or `workspace/new` to any other page.
+         * Re-rendering in that case will re-trigger `componentDidUpdate` and `loadPoliciesBehindBeta`,
+         * which we only want to do after we're done with the `transition` and `workspace/new` pages.
+         * If we don't wait to load the policies until after we're done with those pages,
+         * we may accidentally overwrite the newly-created policy and land on an infinite loading spinner.
+         */
         if (isTransitionOrNewWorkspacePage(this.props.currentURL) && !isTransitionOrNewWorkspacePage(nextProps.currentURL)) {
             return true;
         }

--- a/src/libs/Url.js
+++ b/src/libs/Url.js
@@ -1,3 +1,5 @@
+import Str from 'expensify-common/lib/str';
+
 /**
  * Add / to the end of any URL if not present
  * @param {String} url
@@ -10,7 +12,14 @@ function addTrailingForwardSlash(url) {
     return url;
 }
 
+function removeLeadingForwardSlash(url) {
+    if (Str.startsWith(url, '/')) {
+        return url.slice(1);
+    }
+    return url;
+}
+
 export {
-    // eslint-disable-next-line import/prefer-default-export
     addTrailingForwardSlash,
+    removeLeadingForwardSlash,
 };

--- a/src/libs/Url.js
+++ b/src/libs/Url.js
@@ -12,6 +12,12 @@ function addTrailingForwardSlash(url) {
     return url;
 }
 
+/**
+ * Remove / from the beginning of any URL if present
+ *
+ * @param {String} url
+ * @returns {String}
+ */
 function removeLeadingForwardSlash(url) {
     if (Str.startsWith(url, '/')) {
         return url.slice(1);

--- a/src/pages/LogInWithShortLivedTokenPage.js
+++ b/src/pages/LogInWithShortLivedTokenPage.js
@@ -52,11 +52,6 @@ const defaultProps = {
 };
 
 class LogInWithShortLivedTokenPage extends Component {
-    constructor(props) {
-        super(props);
-        this.state = {hasRun: false};
-    }
-
     componentDidMount() {
         const accountID = parseInt(lodashGet(this.props.route.params, 'accountID', ''), 10);
         const email = lodashGet(this.props.route.params, 'email', '');
@@ -69,11 +64,11 @@ class LogInWithShortLivedTokenPage extends Component {
         }
 
         signInWithShortLivedToken(accountID, email, shortLivedToken, encryptedAuthToken);
-        this.setState({hasRun: true});
     }
 
     componentDidUpdate() {
-        if (this.state.hasRun || !this.props.betas) {
+        const email = lodashGet(this.props.route.params, 'email', '');
+        if (!this.props.betas || !this.props.session.authToken || email !== this.props.session.email) {
             return;
         }
 


### PR DESCRIPTION
### Details
This PR fixes two related race conditions:

#### `LoginWithShortLivedTokenPage` race condition explanation
1. Page loads, beta/session props are not present yet.
1. Calls `Session.signInWithShortLivedToken`
1. Before call to `API.createLogin` or betas load, LogInWithShortLivedTokenPage immediately runs `this.setState({hasRun: true});`
1. In `componentDidUpdate`, `this.state.hasRun` is true, and then we are stuck in LogInWithShortLivedTokenPage / infinite spinner forever.

#### `LoginWithShortLivedTokenPage` race condition fix
Get rid of `hasRun` state just navigate to `exitTo` once betas are loaded and we are logged into the correct account.

#### `AuthScreens` race condition explanation
1. We send an API request to create the policy
1. We send API requests to fetch existing policies.
1. First API request returns and policy is added to Onyx.
1. Second API request(s) return, but at the time when the API was collecting the list of policies to send in the response, the new policy hadn't been created yet. So it's missing from this response and we remove it from Onyx.

#### `AuthScreens` race condition fix
Don't load policies until after we've finished with the `transition` and `workspace/new` pages. That way, the new workspace won't be overwritten.

### Fixed Issues
$ https://github.com/Expensify/App/issues/5518

### Tests
1. Add a `setTimeout` of `1000` around [these lines](https://github.com/Expensify/App/blob/a2f873a444bf8909e8742eca1341db0ec4d4a498/src/libs/Navigation/AppNavigator/AuthScreens.js#L124-L126). This consistently reproduced the `AuthScreens` race condition before these changes.
2. Make sure Web-E is up-to-date, run grunt, and then run ngrok
3. In a mobile browser, visit your ngrok url. This should open OldDot on dev.
4. Sign in with a new account.
5. Click `Set up my company for free`.
6. Verify that you are taken into NewDot, a new workspace is created, and you are shown the workspace settings page. You should not get stuck on an infinite spinner.

### QA Steps
1. In a mobile browser, visit https://staging.expensify.com/
1. Sign in with a new account under a domain in the `freeCard` beta, such as `chivito.pw`
1. Click on `Set up my company for free`
1. Verify that:
    - You are taken into New Expensify
    - A new workspace is created
    - You are shown the workspace settings page
    - You do not get stuck on an infinite spinner.
1. Repeat steps 1-4 20 times to verify that the race condition is eradicated (sorry 😓)

### Tested On

- [ ] Web
- [x] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
https://user-images.githubusercontent.com/47436092/135006383-fd228198-4b59-49d0-b1de-4269dba090d9.mov

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
