### PR TITLE
Only show plaid option when first trying to add a VBA on NewDot

### DIFF
--- a/src/pages/ReimbursementAccount/BankAccountStep.js
+++ b/src/pages/ReimbursementAccount/BankAccountStep.js
@@ -48,10 +48,10 @@ class BankAccountStep extends React.Component {
         this.addManualAccount = this.addManualAccount.bind(this);
         this.addPlaidAccount = this.addPlaidAccount.bind(this);
         this.state = {
-            // One of CONST.BANK_ACCOUNT.SETUP_TYPE
             hasAcceptedTerms: ReimbursementAccountUtils.getDefaultStateForField(props, 'acceptTerms', true),
             routingNumber: ReimbursementAccountUtils.getDefaultStateForField(props, 'routingNumber'),
             accountNumber: ReimbursementAccountUtils.getDefaultStateForField(props, 'accountNumber'),
+            bankNotFound: ReimbursementAccountUtils.getDefaultStateForField(props, 'setupType', 'plaid') === 'manual',
         };
 
         // Keys in this.errorTranslationKeys are associated to inputs, they are a subset of the keys found in this.state
@@ -182,7 +182,10 @@ class BankAccountStep extends React.Component {
                             <MenuItem
                                 icon={Bank}
                                 title={this.props.translate('bankAccount.logIntoYourBank')}
-                                onPress={() => setBankAccountSubStep(CONST.BANK_ACCOUNT.SETUP_TYPE.PLAID)}
+                                onPress={() => {
+                                    updateReimbursementAccountDraft({setupType: 'plaid'});
+                                    setBankAccountSubStep(CONST.BANK_ACCOUNT.SETUP_TYPE.PLAID);
+                                }}
                                 disabled={this.props.isPlaidDisabled || !this.props.user.validated}
                                 shouldShowRightIcon
                             />
@@ -191,13 +194,18 @@ class BankAccountStep extends React.Component {
                                     {this.props.translate('bankAccount.error.tooManyAttempts')}
                                 </Text>
                             )}
-                            <MenuItem
-                                icon={Paycheck}
-                                title={this.props.translate('bankAccount.connectManually')}
-                                disabled={!this.props.user.validated}
-                                onPress={() => setBankAccountSubStep(CONST.BANK_ACCOUNT.SETUP_TYPE.MANUAL)}
-                                shouldShowRightIcon
-                            />
+                            {(this.props.isPlaidDisabled || this.state.bankNotFound) && (
+                                <MenuItem
+                                    icon={Paycheck}
+                                    title={this.props.translate('bankAccount.connectManually')}
+                                    disabled={!this.props.user.validated}
+                                    onPress={() => {
+                                        updateReimbursementAccountDraft({setupType: 'manual'});
+                                        setBankAccountSubStep(CONST.BANK_ACCOUNT.SETUP_TYPE.MANUAL);
+                                    }}
+                                    shouldShowRightIcon
+                                />
+                            )}
                             {!this.props.user.validated && (
                                 <View style={[styles.flexRow, styles.alignItemsCenter, styles.m4]}>
                                     <Text style={[styles.mutedTextLabel, styles.mr4]}>
@@ -231,7 +239,10 @@ class BankAccountStep extends React.Component {
                     <AddPlaidBankAccount
                         text={this.props.translate('bankAccount.plaidBodyCopy')}
                         onSubmit={this.addPlaidAccount}
-                        onExitPlaid={() => setBankAccountSubStep(null)}
+                        onExitPlaid={() => {
+                            this.setState({bankNotFound: true});
+                            setBankAccountSubStep(null);
+                        }}
 
                     />
                 )}


### PR DESCRIPTION
### Details
We only show` Log into your bank` the first time a user tries to connect their VBA. `Connect manually` only shows up if they exit the Plaid flow or if they already have manual data entered from a previous attempt to add a VBA.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/179278

### Tests
1. Log into an account with a Workspace, but without a verified bank account.
2. Navigate to Settings > Select Workspace > Expensify Card > Get started.
3. Verify that you only see the `Log into you bank option` and click it.
4. Exit the Plaid modal that shows up.
5. Now verify that you see both `Log into your bank` and `Connect manually`.
6. Close the modal and reopen it.
7. Verify that you see only `Log into your bank`.
8. Repeat steps 3-5, but this time click `Connect manually`.
9. Exit the flow and verify that you see both `Log into your bank` and `Connect manually`.

### QA Steps
Steps above.

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
