### PR TITLE
Step counter problem corrected on bank account step

### DIFF
--- a/src/pages/ReimbursementAccount/BankAccountStep.js
+++ b/src/pages/ReimbursementAccount/BankAccountStep.js
@@ -168,7 +168,7 @@ class BankAccountStep extends React.Component {
             <View style={[styles.flex1, styles.justifyContentBetween]}>
                 <HeaderWithCloseButton
                     title={this.props.translate('bankAccount.addBankAccount')}
-                    stepCounter={this.state.bankAccountAddMethod && {step: 1, total: 5}}
+                    stepCounter={subStep && {step: 1, total: 5}}
                     onCloseButtonPress={Navigation.dismissModal}
                     onBackButtonPress={() => setBankAccountSubStep(null)}
                     shouldShowBackButton={Boolean(subStep)}


### PR DESCRIPTION
@TomatoToaster Pr is ready, please review it.

### Details
Step counter was not displayed on bank account steps, so corrected that problem.

### Fixed Issues
$ https://github.com/Expensify/App/issues/5580

### Tests | QA Steps

1. Go to /bank-account/new
2. Select option "Connect manually"
3. Verify the step counter in routing number/account number entry page
QA - Now Step 1 of 5 shows on bank account step.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<img width="858" alt="Web" src="https://user-images.githubusercontent.com/7823358/135315764-ab18efb0-bcfd-4ca5-ba70-e91af8dc3781.png">

#### Mobile Web
<img width="462" alt="Mobile Web" src="https://user-images.githubusercontent.com/7823358/135315863-462e5872-f94a-4539-9f44-207f1afcbc9f.png">

#### Desktop
<img width="930" alt="Desktop" src="https://user-images.githubusercontent.com/7823358/135315938-a1849663-1905-4c7e-8bbb-783a6499e2b8.png">

#### iOS
<img width="464" alt="iOS" src="https://user-images.githubusercontent.com/7823358/135316018-1632638f-397a-4296-9b37-6593c45d63a6.png">

#### Android
<img width="549" alt="Android" src="https://user-images.githubusercontent.com/7823358/135316096-ce21cfc5-86ac-414a-94fa-bd993ccd0364.png">


