### PR TITLE
[NO QA]Add a try/catch for build in review error for iOS

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -111,23 +111,31 @@ platform :ios do
         scheme: "NewExpensify"
     )
 
-    upload_to_testflight(
-        api_key_path: "./ios/ios-fastlane-json-key.json",
-        distribute_external: true,
-        notify_external_testers: true,
-        changelog: "Thank you for beta testing New Expensify, this version includes bug fixes and improvements.",
-        groups: ["Beta"],
-        demo_account_required: true,
-        beta_app_review_info: {
-            contact_email: ENV["APPLE_CONTACT_EMAIL"],
-            contact_first_name: "Andrew",
-            contact_last_name: "Gable",
-            contact_phone: ENV["APPLE_CONTACT_PHONE"],
-            demo_account_name: ENV["APPLE_DEMO_EMAIL"],
-            demo_account_password: ENV["APPLE_DEMO_PASSWORD"],
-            notes: "Use the account provided. Thank you for the review."
-        }
-    )
+    begin
+      upload_to_testflight(
+          api_key_path: "./ios/ios-fastlane-json-key.json",
+          distribute_external: true,
+          notify_external_testers: true,
+          changelog: "Thank you for beta testing New Expensify, this version includes bug fixes and improvements.",
+          groups: ["Beta"],
+          demo_account_required: true,
+          beta_app_review_info: {
+              contact_email: ENV["APPLE_CONTACT_EMAIL"],
+              contact_first_name: "Andrew",
+              contact_last_name: "Gable",
+              contact_phone: ENV["APPLE_CONTACT_PHONE"],
+              demo_account_name: ENV["APPLE_DEMO_EMAIL"],
+              demo_account_password: ENV["APPLE_DEMO_PASSWORD"],
+              notes: "Use the account provided. Thank you for the review."
+          }
+      )
+    rescue Exception => e
+      if e.message.include? "Another build is in review"
+        UI.important("Another build is already in external beta review. Skipping external beta review submission")
+      else
+        raise
+      end
+    end
 
     upload_symbols_to_crashlytics(
       dsym_path: lane_context[SharedValues::DSYM_OUTPUT_PATH],


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Adds a try/catch for the error message we were receiving for the iOS errors.

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/Expensify/issues/178492

### Tests
1. Merge this PR
2. Verify we do not see iOS build errors like https://github.com/Expensify/App/runs/3747787438
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### QA Steps
N/A