### PR TITLE
Add bank icon in header in Plaid flow

### DIFF
--- a/src/components/AddPlaidBankAccount.js
+++ b/src/components/AddPlaidBankAccount.js
@@ -183,7 +183,7 @@ class AddPlaidBankAccount extends React.Component {
                             <Icon
                                 src={getBankIcon(this.state.institution.name).icon}
                                 height={40}
-                                width={41}
+                                width={40}
                             />
                             <Text style={[styles.ml3, styles.textStrong]}>{this.state.institution.name}</Text>
                         </View>

--- a/src/components/AddPlaidBankAccount.js
+++ b/src/components/AddPlaidBankAccount.js
@@ -182,7 +182,7 @@ class AddPlaidBankAccount extends React.Component {
                         )}
                         {/* @TODO there are a bunch of logos to incorporate here to replace this name
                         https://d2k5nsl2zxldvw.cloudfront.net/images/plaid/bg_plaidLogos_12@2x.png */}
-                        <View style={[styles.flexRow, styles.mb5]}>
+                        <View style={[styles.flexRow,styles.alignItemsCenter, styles.mb5]}>
                             <Icon
                                 src={getBankIcon(this.state.institution.name).icon}
                             />

--- a/src/components/AddPlaidBankAccount.js
+++ b/src/components/AddPlaidBankAccount.js
@@ -26,6 +26,7 @@ import * as ReimbursementAccountUtils from '../libs/ReimbursementAccountUtils';
 import ReimbursementAccountForm from '../pages/ReimbursementAccount/ReimbursementAccountForm';
 import getBankIcon from './Icon/BankIcons';
 import Icon from './Icon';
+import variables from '../styles/variables';
 
 const propTypes = {
     ...withLocalizePropTypes,
@@ -182,8 +183,8 @@ class AddPlaidBankAccount extends React.Component {
                         <View style={[styles.flexRow, styles.alignItemsCenter, styles.mb5]}>
                             <Icon
                                 src={getBankIcon(this.state.institution.name).icon}
-                                height={40}
-                                width={40}
+                                height={variables.avatarSizeNormal}
+                                width={variables.avatarSizeNormal}
                             />
                             <Text style={[styles.ml3, styles.textStrong]}>{this.state.institution.name}</Text>
                         </View>

--- a/src/components/AddPlaidBankAccount.js
+++ b/src/components/AddPlaidBankAccount.js
@@ -24,6 +24,9 @@ import ExpensiPicker from './ExpensiPicker';
 import Text from './Text';
 import * as ReimbursementAccountUtils from '../libs/ReimbursementAccountUtils';
 import ReimbursementAccountForm from '../pages/ReimbursementAccount/ReimbursementAccountForm';
+import getBankIcon from './Icon/BankIcons';
+import Icon from './Icon';
+import {Exclamation} from './Icon/Expensicons';
 
 const propTypes = {
     ...withLocalizePropTypes,
@@ -179,7 +182,12 @@ class AddPlaidBankAccount extends React.Component {
                         )}
                         {/* @TODO there are a bunch of logos to incorporate here to replace this name
                         https://d2k5nsl2zxldvw.cloudfront.net/images/plaid/bg_plaidLogos_12@2x.png */}
-                        <Text style={[styles.mb5, styles.h1]}>{this.state.institution.name}</Text>
+                        <View style={[styles.flexRow, styles.mb5]}>
+                            <Icon
+                                src={getBankIcon(this.state.institution.name).icon}
+                            />
+                            <Text style={[styles.ml3, styles.h1]}>{this.state.institution.name}</Text>
+                        </View>
                         <View style={[styles.mb5]}>
                             <ExpensiPicker
                                 label={this.props.translate('addPersonalBankAccountPage.chooseAccountLabel')}

--- a/src/components/AddPlaidBankAccount.js
+++ b/src/components/AddPlaidBankAccount.js
@@ -26,7 +26,6 @@ import * as ReimbursementAccountUtils from '../libs/ReimbursementAccountUtils';
 import ReimbursementAccountForm from '../pages/ReimbursementAccount/ReimbursementAccountForm';
 import getBankIcon from './Icon/BankIcons';
 import Icon from './Icon';
-import {Exclamation} from './Icon/Expensicons';
 
 const propTypes = {
     ...withLocalizePropTypes,
@@ -182,7 +181,7 @@ class AddPlaidBankAccount extends React.Component {
                         )}
                         {/* @TODO there are a bunch of logos to incorporate here to replace this name
                         https://d2k5nsl2zxldvw.cloudfront.net/images/plaid/bg_plaidLogos_12@2x.png */}
-                        <View style={[styles.flexRow,styles.alignItemsCenter, styles.mb5]}>
+                        <View style={[styles.flexRow, styles.alignItemsCenter, styles.mb5]}>
                             <Icon
                                 src={getBankIcon(this.state.institution.name).icon}
                             />

--- a/src/components/AddPlaidBankAccount.js
+++ b/src/components/AddPlaidBankAccount.js
@@ -182,8 +182,10 @@ class AddPlaidBankAccount extends React.Component {
                         <View style={[styles.flexRow, styles.alignItemsCenter, styles.mb5]}>
                             <Icon
                                 src={getBankIcon(this.state.institution.name).icon}
+                                height={40}
+                                width={41}
                             />
-                            <Text style={[styles.ml3, styles.h1]}>{this.state.institution.name}</Text>
+                            <Text style={[styles.ml3, styles.textStrong]}>{this.state.institution.name}</Text>
                         </View>
                         <View style={[styles.mb5]}>
                             <ExpensiPicker

--- a/src/components/AddPlaidBankAccount.js
+++ b/src/components/AddPlaidBankAccount.js
@@ -179,8 +179,6 @@ class AddPlaidBankAccount extends React.Component {
                         {!_.isEmpty(this.props.text) && (
                             <Text style={[styles.mb5]}>{this.props.text}</Text>
                         )}
-                        {/* @TODO there are a bunch of logos to incorporate here to replace this name
-                        https://d2k5nsl2zxldvw.cloudfront.net/images/plaid/bg_plaidLogos_12@2x.png */}
                         <View style={[styles.flexRow, styles.alignItemsCenter, styles.mb5]}>
                             <Icon
                                 src={getBankIcon(this.state.institution.name).icon}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR adds the bank icon on the Plaid bank account selection page when the bank icon is available. When it isn't, we default to the generic bank icon. 

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/Expensify/issues/166782

### Tests
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->
From an account that has a workspace, but no cards set up: 
1. Click on profile image
2. Click on workspace name to go to workspace settings
3. Click `Expensify Card`
4. Click `Get Started`
4. Click `Log into your bank` 
5. Click `Continue`
5. Choose `Chase`
6. Enter `user_good` and `pass_good` for credentials
7. Click `Continue`
7. Land on account selection page and make sure Chase logo is showing before the text and size/alignment looks right
8. Click back arrow
9. Click `Log into your bank` again
10. userClick `Continue`
10. Choose `Wells Fargo`
11. Enter `user_good` and `pass_good` for credentials
12. Click `Continue`
12. Land on account selection page and make sure default bank icon is showing before the text and size/alignment looks right

### QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->
From an account that has a workspace, but no cards set up: 
1. Click on profile image
2. Click on workspace name to go to workspace settings
3. Click `Expensify Card`
4. Click `Get Started`
4. Click `Log into your bank` 
5. Click `Continue`
5. Choose `Chase`
6. Enter `user_good` and `pass_good` for credentials
7. Click `Continue`
7. Land on account selection page and make sure Chase logo is showing before the text and size/alignment looks right
8. Click back arrow
9. Click `Log into your bank` again
10. userClick `Continue`
10. Choose `Wells Fargo`
11. Enter `user_good` and `pass_good` for credentials
12. Click `Continue`
12. Land on account selection page and make sure default bank icon is showing before the text and size/alignment looks right

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
<img width="365" alt="Screen Shot 2021-09-30 at 5 59 28 PM" src="https://user-images.githubusercontent.com/1371996/135654805-2c8d3cb5-4f6b-411e-b9d4-3fd5e062b8a9.png">
<img width="365" alt="Screen Shot 2021-09-30 at 5 59 28 PM" src="https://user-images.githubusercontent.com/1371996/135654783-caa62770-23c3-4fdb-bdfb-118f1fa63d53.png">

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
<img width="365" alt="Screen Shot 2021-09-30 at 5 59 28 PM" src="https://user-images.githubusercontent.com/1371996/135666708-7b0cf970-0cc5-46ab-a2ec-65364e1233cd.png">
<img width="365" alt="Screen Shot 2021-09-30 at 5 59 28 PM" src="https://user-images.githubusercontent.com/1371996/135666768-f245a54b-7754-472e-a9d2-d17078ed15aa.png">

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
<img width="365" alt="Screen Shot 2021-09-30 at 5 59 28 PM" src="https://user-images.githubusercontent.com/1371996/135663473-6c02d143-69c6-484e-9b18-e1e5a3316a7f.png">
<img width="365" alt="Screen Shot 2021-09-30 at 5 59 28 PM" src="https://user-images.githubusercontent.com/1371996/135663531-15677167-d396-4f7b-9ce1-c7aa5203c837.png">

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
<img width="365" alt="Screen Shot 2021-09-30 at 5 59 28 PM" src="https://user-images.githubusercontent.com/1371996/135666322-f408f4b2-629e-423b-b39a-3ace0e2b4de8.png">
<img width="365" alt="Screen Shot 2021-09-30 at 5 59 28 PM" src="https://user-images.githubusercontent.com/1371996/135666406-b218bf10-b6c5-4cd2-b210-033f63b72804.png">

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
<img width="365" alt="Screen Shot 2021-09-30 at 5 59 28 PM" src="https://user-images.githubusercontent.com/1371996/135667754-dcc6adc3-f474-4d24-8316-96ffb656f95b.png">
<img width="365" alt="Screen Shot 2021-09-30 at 5 59 28 PM" src="https://user-images.githubusercontent.com/1371996/135667925-b79c9c55-a4e3-4a18-be18-029486bd691f.png">

