### PR TITLE
Corrected: IOU - Unable to enter some combination of decimal numbers

### DIFF
--- a/src/pages/iou/steps/IOUAmountPage.js
+++ b/src/pages/iou/steps/IOUAmountPage.js
@@ -101,7 +101,7 @@ class IOUAmountPage extends React.Component {
      */
     validateAmount(amount) {
         const decimalNumberRegex = new RegExp(/^\d+(,\d+)*(\.\d{0,3})?$/, 'i');
-        return amount === '' || (decimalNumberRegex.test(amount) && ((parseFloat(amount) * 100).toString().length <= CONST.IOU.AMOUNT_MAX_LENGTH));
+        return amount === '' || (decimalNumberRegex.test(amount) && (parseFloat((amount * 100).toFixed(3)).toString().length <= CONST.IOU.AMOUNT_MAX_LENGTH));
     }
 
     /**


### PR DESCRIPTION
@puneetlath  and @deetergp pr is ready for review.

### Details
User was not able to enter some combination of amount, so corrected that problem.

### Fixed Issues
$ https://github.com/Expensify/App/issues/5579

### Tests | QA Steps

1. Run app on any platform
2. Navigate to a conversation
3. Click on the + button in the compose box.
4. Select Request Money
5. Try to enter 19.1, 19.4, 19.6, 19.9 or try to enter 1, 4, 6, 9 after decimal point for the numbers 16, 17, 18 (18.4 or 17.9)

Now User will be able to enter any combination of decimal numbers.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web
https://user-images.githubusercontent.com/7823358/135340413-97fcb2c1-e22a-4474-80af-dbd99c465353.mov

#### Mobile Web
https://user-images.githubusercontent.com/7823358/135340602-26002e59-3254-477f-a893-1d23e0529fd6.mov

#### Desktop
https://user-images.githubusercontent.com/7823358/135340533-417da57f-3f2f-4678-b51f-161a182b63a4.mov

#### iOS
https://user-images.githubusercontent.com/7823358/135340722-88a30290-308e-4eb0-8796-4575bca1a9e7.mov

#### Android
https://user-images.githubusercontent.com/7823358/135340769-6be663bd-a175-41f9-a2a9-20b271fa1a7c.mov

