### PR TITLE
Update copy for 'Invite people' step

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -644,8 +644,8 @@ export default {
             cardReadyTagline: 'Your Expensify Cards are ready to go!',
         },
         invite: {
-            invitePeople: 'Invite people',
-            invitePeoplePrompt: 'Invite colleagues to your workspace.',
+            invitePeople: 'Invite new members',
+            invitePeoplePrompt: 'Invite new members to your workspace.',
             personalMessagePrompt: 'Add a personal message (optional)',
             enterEmailOrPhone: 'Emails or phone numbers',
             EmailOrPhonePlaceholder: 'Enter comma-separated list of emails or phone numbers',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -646,8 +646,8 @@ export default {
             cardReadyTagline: 'Tus tarjetas Expensify están listas para usar!',
         },
         invite: {
-            invitePeople: 'Invitar a la gente',
-            invitePeoplePrompt: 'Invita a tus compañeros a tu espacio de trabajo.',
+            invitePeople: 'Invitar nuevos miembros',
+            invitePeoplePrompt: 'Invita nuevos miembros a tu espacio de trabajo.',
             personalMessagePrompt: 'Agregar un mensaje personal (Opcional)',
             enterEmailOrPhone: 'Correos electrónicos o números de teléfono',
             EmailOrPhonePlaceholder: 'Introduce una lista de correos electrónicos o números de teléfono separado por comas',


### PR DESCRIPTION
cc @kevinksullivan 

### Details
Replace the use of the words "colleagues" and "people" to "member" in the Invite step.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/180154

### QA Steps / Tests
1. Open an existing Workspace, or create one
2. In the Workspace editor, open the People section
3. Click the Invite button
4. Make sure the title of the right hand panel that opens is `Invite New Members` (`Invitar nuevos miembros` in Spanish)
5. Make sure that the text below the title reads `Invite new members to your workspace.` (`Invita nuevos miembros a tu espacio de trabajo.` in Spanish)

### Tested On

- [x] Web
- [x] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
- English
![image](https://user-images.githubusercontent.com/2229301/136081727-9ba9ac0c-534c-428f-a831-7ab15fd70473.png)

- Spanish
![image](https://user-images.githubusercontent.com/2229301/136081771-1161efe2-548e-453b-aef7-b1426156258b.png)
