### PR TITLE
Fix error condition for policy create

### DIFF
--- a/src/libs/actions/Policy.js
+++ b/src/libs/actions/Policy.js
@@ -237,8 +237,10 @@ function create(name = '') {
                 role: CONST.POLICY.ROLE.ADMIN,
             });
         }).then(() => {
-            Navigation.dismissModal();
-            Navigation.navigate(ROUTES.getWorkspaceCardRoute(res.policyID));
+            if (res) {
+                Navigation.dismissModal();
+                Navigation.navigate(ROUTES.getWorkspaceCardRoute(res.policyID));
+            }
         });
 }
 


### PR DESCRIPTION
CC: @marcaaron @mananjadhav 

### Details
Fixes this an error that could create a weird experience if our app is offline.

### Fixed Issues
Error was caught in PR here: https://github.com/Expensify/App/pull/4481/files#r709771608

### Tests
No practical way to test that this error except for Expensify Engineers. To do this you can kill auth in the VM (sudo service auth stop) and try to click the Create New Workspace like in the QA steps (disconnect auth after step 1). You'll see an error and a workspace won't be created.

### QA Steps
Make sure policy creation works as it did normally before.
1. Log into a NewDot account without a Workspace
2. Click on Create New Workspace after clicking on the green `+` at the bottom left
3. Verify a workspace is created and you are taken to the settings page

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
![image](https://user-images.githubusercontent.com/19364431/136232849-375a5d8b-34f0-4929-aa61-067456e08228.png)
![image](https://user-images.githubusercontent.com/19364431/136232959-d8989aaa-7765-42c5-b61c-d07af3c56410.png)



