### PR TITLE
[No QA] Add contributing guideline note about unique proposals

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,7 @@ In this scenario, it’s possible that you found a bug or enhancement that we ha
 #### Propose a solution for the job
 4. After you reproduce the issue, make a proposal for your solution and post it as a comment in the corresponding GitHub issue (linked in the Upwork job). Your solution proposal should include a brief technical explanation of the changes you will make.
     - Note: If you post a proposed solution in an issue that has not been tagged with the `External` label, Expensify has the right to use your proposal to fix said issue, without providing compensation for your solution.
+    - Note: Before submitting a proposal on an issue, be sure to read any other existing proposals. Any new proposal should be substantively different from existing proposals.
 5. Pause at this step until Expensify provides feedback on your proposal (do not begin coding or creating a pull request yet).
 6. If your solution proposal is accepted, Expensify will hire you on Upwork and assign the GitHub issue to you.
 


### PR DESCRIPTION
### Details
Adds a clarifying note to the contributing guidelines. Coming from [this slack thread](https://expensify.slack.com/archives/C01SKUP7QR0/p1633506665030400).

### Fixed Issues
n/a

### Tests
None.

### QA Steps
No QA.
