### PR TITLE
[Internal QA] Fixes detox binary path

### DIFF
--- a/package.json
+++ b/package.json
@@ -209,7 +209,7 @@
     "runnerConfig": "tests/e2e/config.json",
     "configurations": {
       "ios.sim.debug": {
-        "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/expensify.cash.app",
+        "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/new expensify.app",
         "build": "xcodebuild -workspace ios/NewExpensify.xcworkspace -scheme NewExpensify -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build | xcpretty",
         "type": "ios.simulator",
         "name": "iPhone 11"


### PR DESCRIPTION
### Details
Fixes detox binary path

### Fixed Issues
$ https://github.com/Expensify/App/issues/5698

### Tests
1. `cd ~/App`
2. `npm run detox-build`
3. `npm run detox-test`
4. Verify that the tests run and succeed.

### QA Steps
Internal QA. Steps above.

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
