### PR TITLE
[NO QA] Improve workspace welcome note

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -656,7 +656,7 @@ export default {
             pleaseEnterUniqueLogin: 'That user is already a member of this workspace.',
             genericFailureMessage: 'An error occurred inviting the user to the workspace, please try again.',
             systemUserError: ({email}) => `Sorry, you cannot invite ${email} to a workspace.`,
-            welcomeNote: ({workspaceName}) => `You have been invited to the ${workspaceName} workspace! Download the Expensify mobile app to start tracking your expenses.`,
+            welcomeNote: ({workspaceName}) => `You have been invited to ${workspaceName}! Download the Expensify mobile app to start tracking your expenses.`,
         },
         editor: {
             nameInputLabel: 'Name',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -658,7 +658,7 @@ export default {
             pleaseEnterUniqueLogin: 'Ese usuario ya es miembro de este espacio de trabajo.',
             genericFailureMessage: 'Se produjo un error al invitar al usuario al espacio de trabajo. Vuelva a intentarlo..',
             systemUserError: ({email}) => `Lo sentimos, no puedes invitar a ${email} a un espacio de trabajo.`,
-            welcomeNote: ({workspaceName}) => `¡Has sido invitado a la ${workspaceName} Espacio de trabajo! Descargue la aplicación móvil Expensify para comenzar a rastrear sus gastos.`,
+            welcomeNote: ({workspaceName}) => `¡Has sido invitado a ${workspaceName}! Descargue la aplicación móvil Expensify para comenzar a rastrear sus gastos.`,
         },
         editor: {
             nameInputLabel: 'Nombre',


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
We default to adding "workspace" to the end of a new workspace name, which makes the welcome message read "You have been invited to (someone)'s workspace workspace..."

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/179319

### Tests
1. Sign in to an account w/ a workspace
2. Share the workspace
3. Run `bwm` to send the shared workspace email notification
4. Verify the message text is updated (try in spanish too, if you're so inclined)

### QA Steps
Not needed, just a small copy change

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
Note: only the bottom circled text is fixed in this PR, the email subject will be fixed in Web-E

<img width="978" alt="Screen Shot 2021-10-07 at 11 13 59 AM" src="https://user-images.githubusercontent.com/3885503/136442277-12bc8ed7-5d06-401d-82ac-348069dd691f.png">

#### Mobile Web

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
