### PR TITLE
Set the fastlane build_app param manageAppVersionAndBuildNumber

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -108,7 +108,10 @@ platform :ios do
 
     build_app(
         workspace: "./ios/NewExpensify.xcworkspace",
-        scheme: "NewExpensify"
+        scheme: "NewExpensify",
+        export_options: {
+            manageAppVersionAndBuildNumber: false
+        }
     )
 
     begin
@@ -150,7 +153,7 @@ platform :ios do
       api_key_path: "./ios/ios-fastlane-json-key.json",
 
       # Skip HTMl report verification
-      force: true, 
+      force: true,
 
       # VERSION will be set to the full build_number e.g. '1.0.92.0'
       build_number: ENV["VERSION"],


### PR DESCRIPTION
### Details
Xcode 13 added a new "feature" that auto manages the build number for apps. This flag prevents that feature which breaks our versioning. More info here: https://github.com/Expensify/Expensify/issues/180187#issuecomment-938158022

Reference issue: https://github.com/Expensify/Expensify/issues/180187

### Tests
Tested in Mobile-E deploy process, will monitor deploys in newDot to make sure this doesn't cause errors.

### QA Steps
none
