### PR TITLE
[No QA] Migrate CLA to main when referencing

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -33,7 +33,7 @@ jobs:
           with:
               path-to-signatures: '${{ github.repository }}/cla.json'
               path-to-document: 'https://github.com/${{ github.repository }}/blob/main/CLA.md'
-              branch: 'master'
+              branch: 'main'
               remote-organization-name: 'Expensify'
               remote-repository-name: 'CLA'
               lock-pullrequest-aftermerge: false


### PR DESCRIPTION
This changes the CLA destination to refer to the `main` branch as we migrate the https://github.com/Expensify/CLA over to use `main` as the primary branch

### Related Issues
https://github.com/Expensify/Expensify/issues/180550


### QA
No QA