### PR TITLE
Tiny improvement on the getShouldShowAlertPrompt method

### DIFF
--- a/src/pages/workspace/WorkspaceInvitePage.js
+++ b/src/pages/workspace/WorkspaceInvitePage.js
@@ -107,7 +107,7 @@ class WorkspaceInvitePage extends React.Component {
      * @returns {Boolean}
      */
     getShouldShowAlertPrompt() {
-        return _.size(lodashGet(this.props.policy, 'errors', {})) > 0 || lodashGet(this.props.policy, 'alertMessage').length > 0;
+        return _.size(lodashGet(this.props.policy, 'errors', {})) > 0 || lodashGet(this.props.policy, 'alertMessage', '').length > 0;
     }
 
     clearErrors() {

--- a/src/pages/workspace/WorkspaceInvitePage.js
+++ b/src/pages/workspace/WorkspaceInvitePage.js
@@ -107,7 +107,7 @@ class WorkspaceInvitePage extends React.Component {
      * @returns {Boolean}
      */
     getShouldShowAlertPrompt() {
-        return _.size(lodashGet(this.props.policy, 'errors', {})) > 0 || lodashGet(this.props.policy, 'alertMessage.length') > 0;
+        return _.size(lodashGet(this.props.policy, 'errors', {})) > 0 || lodashGet(this.props.policy, 'alertMessage').length > 0;
     }
 
     clearErrors() {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

Implementing a tiny improvement that @marcaaron  suggested here: https://github.com/Expensify/App/pull/5729#discussion_r725212074

### Related to
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):


Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
https://github.com/Expensify/App/pull/5729#discussion_r725212074

### Tests
Same as Web QA done locally 

### QA Steps

1. Launch App and login
2. Create a workspace
3. Navigate to the People
4. Click on the "Invite" button
5. Verify you can see the invite modal on the right hand side like in the screenshot below
### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
<img width="374" alt="Screen Shot 2021-10-08 at 12 11 16 PM" src="https://user-images.githubusercontent.com/49007721/136631814-4d0acf96-7891-4a8d-af16-6d8dfbb715a7.png">


