### PR TITLE
Update meta tag description

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3,14 +3,14 @@
 <head>
     <meta charset="utf-8" />
     <title>New Expensify</title>
-    <meta name="description" content="Chat and payments are now the same thing. Launching Summer 2021, join the waitlist to be first in line!">
+    <meta name="description" content="Corporate cards, reimbursements, receipt scanning, invoicing, and bill pay. One app, all free.">
     <meta property="twitter:card" content="summary">
     <meta property="twitter:site" content="@expensify">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="New Expensify">
     <meta property="og:url" content="https://new.expensify.com">
     <meta property="og:title" content="New Expensify - Chat with friends to send and receive money">
-    <meta property="og:description" content="Chat and payments are now the same thing. Launching Summer 2021, join the waitlist to be first in line!">
+    <meta property="og:description" content="Corporate cards, reimbursements, receipt scanning, invoicing, and bill pay. One app, all free.">
     <meta property="og:image" content="https://new.expensify.com/og-preview-image.png">
     <link rel="stylesheet" type="text/css" href="/css/fonts.css" />
     <link rel="stylesheet" type="text/css" href="/css/pdf.css" />


### PR DESCRIPTION
cc @davidcardoza can you sign off the final copy please?

### Details
Update the app description in the `<meta>` tags, for apps that show link previews.

### Fixed Issues

$ https://github.com/Expensify/App/issues/5737

### Tests
1. Launch ngrok so you can have a public-facing URL for NewDot
2. Copy the URL in an app that does "previews", e.g. Whatsapp, Twitter, FB, etc.
3. Make sure the preview shows the updated description, and **not** some text that mentions summer 2021.

### QA Steps
1. In WhatsApp or Twitter or FB, post a link to https://staging.new.expensify.com
2. Make sure the preview description says "Corporate cards, reimbursements, receipt scanning, invoicing, and bill pay. One app, all free." like on the screenshot

![image](https://user-images.githubusercontent.com/2229301/136635679-62cdfd8e-e882-458c-ba33-2fac73025de1.png)
