### PR TITLE
Route to the main workspace screen now that it is in rightpane

### DIFF
--- a/src/libs/actions/Policy.js
+++ b/src/libs/actions/Policy.js
@@ -164,7 +164,7 @@ function getPolicyList(shouldCreateNewPolicy = false) {
 
             if (shouldCreateNewPolicy) {
                 Navigation.dismissModal();
-                Navigation.navigate(newPolicyID ? ROUTES.getWorkspaceCardRoute(newPolicyID) : ROUTES.HOME);
+                Navigation.navigate(newPolicyID ? ROUTES.getWorkspaceInitialRoute(newPolicyID) : ROUTES.HOME);
             }
 
             return API.GetPolicyList();


### PR DESCRIPTION
### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/180748

### Tests/ QA Steps
1. Log into oldDot
2. Go to Settings->Policies->New Policy and Select `Free`
3. You should be redirected to NewDot. Make sure the main workspace screen opens in rightpane (not the card one):
<img width="403" alt="Screen Shot 2021-10-11 at 12 08 57 PM" src="https://user-images.githubusercontent.com/19366280/136773004-3c90103c-d3ee-4206-a5cb-6a41bcd38ac4.png">


### Tested On

- [X] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

