### PR TITLE
Change State field in Company Info to 'Incorporation state'

### DIFF
--- a/src/components/StatePicker.js
+++ b/src/components/StatePicker.js
@@ -11,6 +11,9 @@ const STATES = _.map(CONST.STATES, ({stateISO}) => ({
 }));
 
 const propTypes = {
+    /** The label for the field */
+    label: PropTypes.string,
+
     /** A callback method that is called when the value changes and it received the selected value as an argument */
     onChange: PropTypes.func.isRequired,
 
@@ -21,6 +24,7 @@ const propTypes = {
 };
 
 const defaultProps = {
+    label: '',
     value: '',
 };
 
@@ -30,7 +34,7 @@ const StatePicker = props => (
         items={STATES}
         onChange={props.onChange}
         value={props.value}
-        label={props.translate('common.state')}
+        label={props.label || props.translate('common.state')}
         hasError={props.hasError}
         errorText={props.errorText}
     />

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -567,6 +567,7 @@ export default {
         taxIDNumberPlaceholder: '9 digits, no hyphens',
         companyType: 'Company type',
         incorporationDate: 'Incorporation date',
+        incorporationState: 'Incorporation state',
         industryClassificationCode: 'Industry classification code',
         confirmCompanyIsNot: 'I confirm that this company is not on the',
         listOfRestrictedBusinesses: 'list of restricted businesses',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -569,6 +569,7 @@ export default {
         taxIDNumberPlaceholder: '9 dígitos, sin guiones',
         companyType: 'Tipo de empresa',
         incorporationDate: 'Fecha de incorporación',
+        incorporationState: 'Estado de incorporación',
         industryClassificationCode: 'Código de clasificación industrial',
         confirmCompanyIsNot: 'Confirmo que esta empresa no está en el',
         listOfRestrictedBusinesses: 'lista de negocios restringidos',

--- a/src/pages/ReimbursementAccount/CompanyStep.js
+++ b/src/pages/ReimbursementAccount/CompanyStep.js
@@ -226,7 +226,7 @@ class CompanyStep extends React.Component {
                         />
                     </View>
                     <View style={[styles.flexRow, styles.mt4]}>
-                        <View style={[styles.flex2, styles.mr2]}>
+                        <View style={[styles.flex1, styles.mr2]}>
                             <DatePicker
                                 label={this.props.translate('companyStep.incorporationDate')}
                                 onChange={value => this.clearErrorAndSetValue('incorporationDate', value)}
@@ -238,6 +238,7 @@ class CompanyStep extends React.Component {
                         </View>
                         <View style={[styles.flex1]}>
                             <StatePicker
+                                label={this.props.translate('companyStep.incorporationState')}
                                 onChange={value => this.clearErrorAndSetValue('incorporationState', value)}
                                 value={this.state.incorporationState}
                                 hasError={this.getErrors().incorporationState}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/180751


### Tests/ QA Steps
1. Log into your account in NewDot and go to an existing workspace.
2. Select `Connect Bank Account` and add [one manually](https://stackoverflow.com/c/expensify/questions/342)
3. In the `Company Information` Step, make sure the last fields look like this:
<img width="384" alt="Screen Shot 2021-10-11 at 3 15 47 PM" src="https://user-images.githubusercontent.com/19366280/136796451-e81dd0eb-f3fb-4e17-a7d7-f2af6e8f2a20.png">


### Tested On

- [X] Web
- [ ] Mobile Web
- [X] Desktop
- [ ] iOS
- [ ] Android
