### PR TITLE
Fix output currency

### DIFF
--- a/src/libs/actions/Policy.js
+++ b/src/libs/actions/Policy.js
@@ -46,7 +46,7 @@ function getSimplifiedEmployeeList(employeeList) {
  * @param {String} fullPolicy.name
  * @param {String} fullPolicy.role
  * @param {String} fullPolicy.type
- * @param {String} fullPolicy.value.outputCurrency
+ * @param {String} fullPolicy.outputCurrency
  * @param {Object} fullPolicy.value.employeeList
  * @param {String} [fullPolicy.value.avatarURL]
  * @returns {Object}
@@ -57,7 +57,7 @@ function getSimplifiedPolicyObject(fullPolicy) {
         name: fullPolicy.name,
         role: fullPolicy.role,
         type: fullPolicy.type,
-        outputCurrency: lodashGet(fullPolicy, 'value.outputCurrency', ''),
+        outputCurrency: fullPolicy.outputCurrency,
         employeeList: getSimplifiedEmployeeList(lodashGet(fullPolicy, 'value.employeeList')),
         avatarURL: lodashGet(fullPolicy, 'value.avatarURL', ''),
     };


### PR DESCRIPTION
### Details
Only full policy has outputCurrency inside `value` but both have it outside. 

### Fixed Issues
https://expensify.slack.com/archives/C020EPP9B9A/p1633790363192500

### Tests
- Go to: Settings > select a worskpace > general settings
- Change the currency
- Click save
- Close the right hand modals
- Reload page
- Open the same general settings, check the currency shown is the one you just saved

### Tested On

- [x ] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

