### PR TITLE
Set loading to false when requestorStep is submittted

### DIFF
--- a/src/libs/actions/BankAccounts.js
+++ b/src/libs/actions/BankAccounts.js
@@ -708,6 +708,7 @@ function setupWithdrawalAccount(data) {
                             // Requestor Step still needs to run Onfido
                             achData.sdkToken = sdkToken;
                             goToWithdrawalAccountSetupStep(CONST.BANK_ACCOUNT.STEP.REQUESTOR, achData);
+                            Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {loading: false});
                             return;
                         }
                     } else if (requestorResponse) {
@@ -725,6 +726,7 @@ function setupWithdrawalAccount(data) {
                         if (!_.isEmpty(questions)) {
                             achData.questions = questions;
                             goToWithdrawalAccountSetupStep(CONST.BANK_ACCOUNT.STEP.REQUESTOR, achData);
+                            Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {loading: false});
                             return;
                         }
                     }


### PR DESCRIPTION
@tgolen @marcaaron 

We no longer set loading to false at the beginning of the callback block for `BankAccount_SetupWithdrawal()`. I believe we did this because while [this block](https://github.com/Expensify/App/blame/2ae2fd8bde251149028fde6fdad2dd65514131e3/src/libs/actions/BankAccounts.js#L686-L780) completed, we sometimes show the user the previous and incorrect step before we properly render the correct step.

When we moved setting loading to false [here](https://github.com/Expensify/App/pull/5703/files#diff-448c3537222b5e687caa8f06585ace6feae03d751f243e1590383fb6a33693e8R749) and [here](https://github.com/Expensify/App/pull/5703/files#diff-448c3537222b5e687caa8f06585ace6feae03d751f243e1590383fb6a33693e8R793), we forgot to add it to the Requestor Step.



### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/180760

### Tests / QA Steps
1. Add a VBA using the (1) flow in the SO
2. Verify that you can properly reach the Onfido flow
3. Verify that when you click submit in the "Beneficial Owners" step, you don't see it quickly flash back before getting to the next step

**What we do NOT want:** You can see that after submission the Beneficial Owners step flashes back
![5ze1TCrV3j](https://user-images.githubusercontent.com/12980144/136860796-c6cab599-cf58-4f4d-ad48-65a9017899d6.gif)

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
