### PR TITLE
[N6] Use AddressSearch for identity form

### DIFF
--- a/src/pages/ReimbursementAccount/IdentityForm.js
+++ b/src/pages/ReimbursementAccount/IdentityForm.js
@@ -76,6 +76,23 @@ const IdentityForm = ({
     const dobErrorText = (errors.dob ? translate('bankAccount.error.dob') : '')
         || (errors.dobAge ? translate('bankAccount.error.age') : '');
 
+    const getFormattedAddressValue = () => {
+        let addressString = '';
+        if (street) {
+            addressString += `${street}, `;
+        }
+        if (city) {
+            addressString += `${city}, `;
+        }
+        if (state) {
+            addressString += `${state}, `;
+        }
+        if (zipCode) {
+            addressString += `${zipCode}`;
+        }
+        return addressString;
+    };
+
     return (
         <View style={style}>
             <View style={[styles.flexRow]}>
@@ -118,8 +135,9 @@ const IdentityForm = ({
             <AddressSearch
                 label={translate('common.personalAddress')}
                 containerStyles={[styles.mt4]}
-                value={`${street} ${city} ${state} ${zipCode}`}
+                value={getFormattedAddressValue()}
                 onChangeText={(fieldName, value) => onFieldChange(fieldName, value)}
+                errorText={errors.street ? translate('bankAccount.error.addressStreet') : ''}
             />
         </View>
     );

--- a/src/pages/ReimbursementAccount/IdentityForm.js
+++ b/src/pages/ReimbursementAccount/IdentityForm.js
@@ -1,11 +1,10 @@
 import React from 'react';
 import {View} from 'react-native';
 import PropTypes from 'prop-types';
-import StatePicker from '../../components/StatePicker';
 import ExpensiTextInput from '../../components/ExpensiTextInput';
+import AddressSearch from '../../components/AddressSearch';
 import styles from '../../styles/styles';
 import withLocalize, {withLocalizePropTypes} from '../../components/withLocalize';
-import Text from '../../components/Text';
 import CONST from '../../CONST';
 import DatePicker from '../../components/DatePicker';
 
@@ -116,41 +115,11 @@ const IdentityForm = ({
                 errorText={errors.ssnLast4 ? translate('bankAccount.error.ssnLast4') : ''}
                 maxLength={CONST.BANK_ACCOUNT.MAX_LENGTH.SSN}
             />
-            <ExpensiTextInput
+            <AddressSearch
                 label={translate('common.personalAddress')}
                 containerStyles={[styles.mt4]}
-                value={street}
-                onChangeText={value => onFieldChange('street', value)}
-                errorText={errors.street ? translate('bankAccount.error.address') : ''}
-            />
-            <Text style={[styles.mutedTextLabel, styles.mt1]}>{translate('common.noPO')}</Text>
-            <View style={[styles.flexRow, styles.mt4]}>
-                <View style={[styles.flex2, styles.mr2]}>
-                    <ExpensiTextInput
-                        label={translate('common.city')}
-                        value={city}
-                        onChangeText={value => onFieldChange('city', value)}
-                        errorText={errors.city ? translate('bankAccount.error.addressCity') : ''}
-                        translateX={-14}
-                    />
-                </View>
-                <View style={[styles.flex1]}>
-                    <StatePicker
-                        value={state}
-                        onChange={value => onFieldChange('state', value)}
-                        errorText={errors.state ? translate('bankAccount.error.addressState') : ''}
-                        hasError={Boolean(errors.state)}
-                    />
-                </View>
-            </View>
-            <ExpensiTextInput
-                label={translate('common.zip')}
-                containerStyles={[styles.mt4]}
-                keyboardType={CONST.KEYBOARD_TYPE.NUMERIC}
-                value={zipCode}
-                onChangeText={value => onFieldChange('zipCode', value)}
-                errorText={errors.zipCode ? translate('bankAccount.error.zipCode') : ''}
-                maxLength={CONST.BANK_ACCOUNT.MAX_LENGTH.ZIP_CODE}
+                value={`${street} ${city} ${state} ${zipCode}`}
+                onChangeText={(fieldName, value) => onFieldChange(fieldName, value)}
             />
         </View>
     );

--- a/src/pages/ReimbursementAccount/RequestorStep.js
+++ b/src/pages/ReimbursementAccount/RequestorStep.js
@@ -92,7 +92,6 @@ class RequestorStep extends React.Component {
             city: 'requestorAddressCity',
             state: 'requestorAddressState',
             zipCode: 'requestorAddressZipCode',
-
             addressStreet: 'requestorAddressStreet',
             addressCity: 'requestorAddressCity',
             addressState: 'requestorAddressState',

--- a/src/pages/ReimbursementAccount/RequestorStep.js
+++ b/src/pages/ReimbursementAccount/RequestorStep.js
@@ -92,6 +92,11 @@ class RequestorStep extends React.Component {
             city: 'requestorAddressCity',
             state: 'requestorAddressState',
             zipCode: 'requestorAddressZipCode',
+
+            addressStreet: 'requestorAddressStreet',
+            addressCity: 'requestorAddressCity',
+            addressState: 'requestorAddressState',
+            addressZipCode: 'requestorAddressZipCode',
         };
         const renamedInputKey = lodashGet(renamedFields, inputKey, inputKey);
         const newState = {[renamedInputKey]: value};


### PR DESCRIPTION
### Details

Thanks for the review! Here we're simply replacing the address fields on the personal info step with a new `AddressSearch` component.

### Fixed Issues

$ https://github.com/Expensify/Expensify/issues/180829


### Tests / QA Steps
1. Head on over to new.expensify.com.dev or https://staging.new.expensify.com/
2. Make and Validate a new account
3. The Create Menu should pop up at the lower left, but if it doesn't click the green plus button down there
4. Click 'New Workspace' (then click 'Expensify Card' if you're on mobile)
5. Click 'Get Started' in the modal that pops up
6. Click 'Connect Manually' in the VBA modal that comes up on the right hand side
7. Use the following info for the first step
    a) Routing number 011401533
    b) Account number 1111222233331111
8. Click 'Save & Continue'
9. Type 42 in the 'Company Address' field
10. Verify that the address suggestions appear.
11. Click one of them and verify that it enters that data into the 'Company Address' field and that you are able to continue to the next step

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web
![Screen Shot 2021-10-13 at 9 43 25 AM](https://user-images.githubusercontent.com/2438855/137177165-db5f58db-6da4-45da-8c1c-2a66806147a5.png)

#### Mobile Web
![Screen Shot 2021-10-13 at 10 44 40 AM](https://user-images.githubusercontent.com/2438855/137185676-2671127e-40ed-45b9-8d8c-6a73a64899e0.png)

#### Desktop
![Screen Shot 2021-10-13 at 7 44 03 AM](https://user-images.githubusercontent.com/2438855/137156478-6dfb50eb-9517-46b7-9519-9bbc8f217bdc.png)

#### iOS
![Screen Shot 2021-10-13 at 7 54 36 AM](https://user-images.githubusercontent.com/2438855/137158543-aee9b205-bb50-4154-af13-482c7f0d810a.png)

#### Android
![Screen Shot 2021-10-13 at 10 25 59 AM](https://user-images.githubusercontent.com/2438855/137183038-3232c403-9ff0-4ff9-bc01-53839bc5941f.png)

