### PR TITLE
Fix issue with zoom behaviour of PDF being inconsistent in Safari mobile

### DIFF
--- a/src/components/PDFView/index.js
+++ b/src/components/PDFView/index.js
@@ -1,6 +1,6 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {View} from 'react-native';
+import {View, Dimensions} from 'react-native';
 import {Document, Page} from 'react-pdf/dist/esm/entry.webpack';
 import styles from '../../styles/styles';
 import withWindowDimensions, {windowDimensionsPropTypes} from '../withWindowDimensions';
@@ -28,6 +28,7 @@ class PDFView extends PureComponent {
         super(props);
         this.state = {
             numPages: null,
+            windowWidth: Dimensions.get('window').width,
         };
         this.onDocumentLoadSuccess = this.onDocumentLoadSuccess.bind(this);
     }
@@ -43,15 +44,16 @@ class PDFView extends PureComponent {
     }
 
     render() {
-        const {isSmallScreenWidth, windowWidth} = this.props;
-        const pdfContainerWidth = windowWidth - 100;
+        const {isSmallScreenWidth} = this.props;
+        const pdfContainerWidth = this.state.windowWidth - 100;
         const pageWidthOnLargeScreen = (pdfContainerWidth <= variables.pdfPageMaxWidth)
             ? pdfContainerWidth : variables.pdfPageMaxWidth;
-        const pageWidth = isSmallScreenWidth ? windowWidth - 30 : pageWidthOnLargeScreen;
+        const pageWidth = isSmallScreenWidth ? this.state.windowWidth - 30 : pageWidthOnLargeScreen;
 
         return (
             <View
                 style={[styles.PDFView, this.props.style]}
+                onLayout={event => this.setState({windowWidth: event.nativeEvent.layout.width})}
             >
                 <Document
                     loading={<FullScreenLoadingIndicator />}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
inconsistent behaviour was caused by Dimensions 'change' listener returning invalid window sizes when zooming in or out. 
We've settled on using pdf container's width to determine the page width.

### Fixed Issues
$ https://github.com/Expensify/App/issues/4867

### Tests
1) run `npm run web`
2) navigate to any chat that has a pdf attachment
3) click on pdf attachment to open it
4) zoom in as close as possible, zoom out
5) validate that zoom is consistent and layout isn't changing


### QA Steps
Same as `Tests`

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [ ] iOS
- [x] Android

### Screenshots
Device: iPhone X
OS: iOS 14.7.1

https://user-images.githubusercontent.com/9059945/136993579-68f2a693-27a6-4c16-95c3-a54a01e82026.mp4


https://user-images.githubusercontent.com/9059945/136993612-10eb960d-343a-4bf2-9867-9d9e08b7ef3b.mp4


