### PR TITLE
Use pdf container width instead of windows width to calculate page width

### DIFF
--- a/src/components/PDFView/index.js
+++ b/src/components/PDFView/index.js
@@ -1,6 +1,6 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {View} from 'react-native';
+import {View, Dimensions} from 'react-native';
 import {Document, Page} from 'react-pdf/dist/esm/entry.webpack';
 import styles from '../../styles/styles';
 import withWindowDimensions, {windowDimensionsPropTypes} from '../withWindowDimensions';
@@ -28,6 +28,7 @@ class PDFView extends PureComponent {
         super(props);
         this.state = {
             numPages: null,
+            windowWidth: Dimensions.get('window').width,
         };
         this.onDocumentLoadSuccess = this.onDocumentLoadSuccess.bind(this);
     }
@@ -43,15 +44,16 @@ class PDFView extends PureComponent {
     }
 
     render() {
-        const {isSmallScreenWidth, windowWidth} = this.props;
-        const pdfContainerWidth = windowWidth - 100;
+        const {isSmallScreenWidth} = this.props;
+        const pdfContainerWidth = this.state.windowWidth - 100;
         const pageWidthOnLargeScreen = (pdfContainerWidth <= variables.pdfPageMaxWidth)
             ? pdfContainerWidth : variables.pdfPageMaxWidth;
-        const pageWidth = isSmallScreenWidth ? windowWidth - 30 : pageWidthOnLargeScreen;
+        const pageWidth = isSmallScreenWidth ? this.state.windowWidth - 30 : pageWidthOnLargeScreen;
 
         return (
             <View
                 style={[styles.PDFView, this.props.style]}
+                onLayout={event => this.setState({windowWidth: event.nativeEvent.layout.width})}
             >
                 <Document
                     loading={<FullScreenLoadingIndicator />}


### PR DESCRIPTION
### Details
inconsistent behaviour was caused by Dimensions 'change' listener returning invalid window sizes when zooming in or out.
We've settled on using pdf container's width to determine the page width.

### Fixed Issues

$ https://github.com/Expensify/App/issues/4867

### Tests

1. run `npm run web`
2. navigate to any chat that has a pdf attachment
3. click on pdf attachment to open it
4. zoom in as close as possible, zoom out
5. validate that zoom is consistent and layout isn't changing

### QA Steps
Same as `Tests`


### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [ ] iOS
- [x] Android

### Screenshots

iPhone X running iOS 14.7.1 (Safari)




https://user-images.githubusercontent.com/9059945/136998549-0ea97653-bee5-4a06-9068-d4a543a732df.mp4


https://user-images.githubusercontent.com/9059945/136998582-8e0be37d-7a26-4454-be52-af1ef127f970.mp4


OnePlus 6 running Android 11 (Chrome)

https://user-images.githubusercontent.com/9059945/137028226-9d1ae920-de0a-4130-b82b-8c56aee87dfc.mp4

Chrome for MacOS

https://user-images.githubusercontent.com/9059945/137028528-0f3200e4-d560-4f76-a86e-19afef8b511f.mp4

Native MacOS app


https://user-images.githubusercontent.com/9059945/137028743-c0ddc561-9d34-438e-8075-332d15986ca9.mp4

iPad Pro simulator running iOS 15 (Safari)

https://user-images.githubusercontent.com/9059945/137028969-f02c3a4b-402a-4b8b-8dc2-2734fa4a79a3.mp4


I've also tested native android app, but that's irrelevant, since changes are made only to [PDFView/index.js](https://github.com/Expensify/App/blob/main/src/components/PDFView/index.js) file, while native applications are using [PDFView/index.native.js](https://github.com/Expensify/App/blob/main/src/components/PDFView/index.native.js)

