### PR TITLE
Close sidebar when going to concierge chat

### DIFF
--- a/src/pages/workspace/travel/WorkspaceTravelPage.js
+++ b/src/pages/workspace/travel/WorkspaceTravelPage.js
@@ -25,7 +25,7 @@ const WorkspaceTravelPage = ({translate, route}) => (
     >
         {(hasVBA, policyID) => (
             <>
-                {!hasVBA ? (
+                {hasVBA ? (
                     <WorkspaceTravelNoVBAView policyID={policyID} />
                 ) : (
                     <WorkspaceTravelVBAView />

--- a/src/pages/workspace/travel/WorkspaceTravelPage.js
+++ b/src/pages/workspace/travel/WorkspaceTravelPage.js
@@ -25,7 +25,7 @@ const WorkspaceTravelPage = ({translate, route}) => (
     >
         {(hasVBA, policyID) => (
             <>
-                {hasVBA ? (
+                {!hasVBA ? (
                     <WorkspaceTravelNoVBAView policyID={policyID} />
                 ) : (
                     <WorkspaceTravelVBAView />

--- a/src/pages/workspace/travel/WorkspaceTravelVBAView.js
+++ b/src/pages/workspace/travel/WorkspaceTravelVBAView.js
@@ -13,6 +13,7 @@ import {RocketOrange} from '../../../components/Icon/Illustrations';
 import WorkspaceSection from '../WorkspaceSection';
 import {openSignedInLink} from '../../../libs/actions/App';
 import {navigateToConciergeChat} from '../../../libs/actions/Report';
+import Navigation from '../../../libs/Navigation/Navigation';
 
 const propTypes = {
     ...withLocalizePropTypes,
@@ -32,7 +33,10 @@ const WorkspaceTravelVBAView = ({translate}) => (
             },
             {
                 title: translate('workspace.travel.bookTravelWithConcierge'),
-                onPress: navigateToConciergeChat,
+                onPress: () => {
+                    Navigation.dismissModal();
+                    navigateToConciergeChat();
+                },
                 icon: Concierge,
                 shouldShowRightIcon: true,
             },


### PR DESCRIPTION
### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/180850

### Tests / QA Steps
1. Have a bank account added to your account and a workspace created
2. Go to Settings > Workspace > Book travel
3. Click on the link to book travel with Concierge
4. Verify that you are taken to the concierge chat and the sidebar closes

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
n/a

#### Web
n/a

#### Mobile Web
n/a

#### Desktop
n/a

#### iOS
n/a

#### Android
n/a
