### PR TITLE
Only deactivate label if field isn't focused

### DIFF
--- a/src/components/ExpensiTextInput/BaseExpensiTextInput.js
+++ b/src/components/ExpensiTextInput/BaseExpensiTextInput.js
@@ -55,7 +55,7 @@ class BaseExpensiTextInput extends Component {
 
             if (this.props.value) {
                 this.activateLabel();
-            } else {
+            } else if (!this.state.isFocused) {
                 this.deactivateLabel();
             }
         }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This PR fixes an issue where the Expensitext label value will move over the cursor after deleting the content but keeping focus. In the case that the input has a label and a placeholder, this looks especially bad (see https://github.com/Expensify/Expensify/issues/180809).

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/180809

### Tests/QA
1. Create a new account and create a workspace
2. Open the workspace and click `Issue Corporate Cards` and then `Connect Bank Account`. Fill out anything for the values on `Connect Bank Account` and submit to get to the `Company Information` step
3. Confirm that when you get to the `Company Information` step, the phone number placeholder doesn't overlap the label like in https://github.com/Expensify/Expensify/issues/180809 when you enter a value and then remove the value
4. Confirm that the placeholders for all fields behave normally when clicking into and out of them

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<img src='http://g.recordit.co/VyxlCUWdeB.gif' width='400'/> <img src='http://g.recordit.co/tyuSgFtO90.gif' width='400'/>