### PR TITLE
Prevent tappable bank account in EnableStep

### DIFF
--- a/src/components/MenuItem.js
+++ b/src/components/MenuItem.js
@@ -34,6 +34,7 @@ const defaultProps = {
     subtitle: undefined,
     iconType: 'icon',
     onPress: () => {},
+    interactive: true,
 };
 
 const MenuItem = ({
@@ -54,6 +55,7 @@ const MenuItem = ({
     disabled,
     subtitle,
     iconType,
+    interactive,
 }) => {
     const additionalWrapperStyles = _.isArray(wrapperStyle) ? wrapperStyle : [wrapperStyle];
     return (
@@ -67,7 +69,7 @@ const MenuItem = ({
             }}
             style={({hovered, pressed}) => ([
                 styles.popoverMenuItem,
-                getButtonBackgroundColorStyle(getButtonState(focused || hovered, pressed, success, disabled)),
+                getButtonBackgroundColorStyle(getButtonState(focused || hovered, pressed, success, disabled, interactive)),
                 ...additionalWrapperStyles,
             ])}
             disabled={disabled}
@@ -87,7 +89,7 @@ const MenuItem = ({
                                     width={iconWidth}
                                     height={iconHeight}
                                     fill={iconFill || getIconFillColor(
-                                        getButtonState(focused || hovered, pressed, success, disabled),
+                                        getButtonState(focused || hovered, pressed, success, disabled, interactive),
                                     )}
                                 />
                             </View>
@@ -110,7 +112,7 @@ const MenuItem = ({
                                 style={[
                                     styles.popoverMenuText,
                                     styles.ml3,
-                                    (disabled ? styles.disabledText : undefined),
+                                    (interactive && disabled ? styles.disabledText : undefined),
                                 ]}
                                 numberOfLines={1}
                             >
@@ -138,7 +140,7 @@ const MenuItem = ({
                             <View style={styles.popoverMenuIcon}>
                                 <Icon
                                     src={iconRight}
-                                    fill={getIconFillColor(getButtonState(focused || hovered, pressed, success, disabled))}
+                                    fill={getIconFillColor(getButtonState(focused || hovered, pressed, success, disabled, interactive))}
                                 />
                             </View>
                         )}

--- a/src/components/MenuItem.js
+++ b/src/components/MenuItem.js
@@ -1,3 +1,4 @@
+import _ from 'underscore';
 import React from 'react';
 import {
     View, Pressable,
@@ -19,7 +20,7 @@ const propTypes = {
 const defaultProps = {
     badgeText: undefined,
     shouldShowRightIcon: false,
-    wrapperStyle: {},
+    wrapperStyle: [],
     success: false,
     icon: undefined,
     iconWidth: undefined,
@@ -32,6 +33,7 @@ const defaultProps = {
     disabled: false,
     subtitle: undefined,
     iconType: 'icon',
+    onPress: () => {},
 };
 
 const MenuItem = ({
@@ -52,97 +54,100 @@ const MenuItem = ({
     disabled,
     subtitle,
     iconType,
-}) => (
-    <Pressable
-        onPress={(e) => {
-            if (disabled) {
-                return;
-            }
+}) => {
+    const additionalWrapperStyles = _.isArray(wrapperStyle) ? wrapperStyle : [wrapperStyle];
+    return (
+        <Pressable
+            onPress={(e) => {
+                if (disabled) {
+                    return;
+                }
 
-            onPress(e);
-        }}
-        style={({hovered, pressed}) => ([
-            styles.popoverMenuItem,
-            getButtonBackgroundColorStyle(getButtonState(focused || hovered, pressed, success, disabled)),
-            wrapperStyle,
-        ])}
-        disabled={disabled}
-    >
-        {({hovered, pressed}) => (
-            <>
-                <View style={styles.flexRow}>
-                    {(icon && iconType === CONST.ICON_TYPE_ICON) && (
-                        <View
-                            style={[
-                                styles.popoverMenuIcon,
-                                ...iconStyles,
-                            ]}
-                        >
-                            <Icon
-                                src={icon}
-                                width={iconWidth}
-                                height={iconHeight}
-                                fill={iconFill || getIconFillColor(
-                                    getButtonState(focused || hovered, pressed, success, disabled),
-                                )}
-                            />
-                        </View>
-                    )}
-                    {(icon && iconType === CONST.ICON_TYPE_AVATAR) && (
-                        <View
-                            style={[
-                                styles.popoverMenuIcon,
-                                ...iconStyles,
-                            ]}
-                        >
-                            <Avatar
-                                imageStyles={[styles.avatarNormal, styles.alignSelfCenter]}
-                                source={icon}
-                            />
-                        </View>
-                    )}
-                    <View style={[styles.justifyContentCenter, styles.menuItemTextContainer]}>
-                        <Text
-                            style={[
-                                styles.popoverMenuText,
-                                styles.ml3,
-                                (disabled ? styles.disabledText : undefined),
-                            ]}
-                            numberOfLines={1}
-                        >
-                            {title}
-                        </Text>
-                        {description && (
-                            <Text style={[styles.textLabelSupporting, styles.ml3, styles.mt1]}>
-                                {description}
+                onPress(e);
+            }}
+            style={({hovered, pressed}) => ([
+                styles.popoverMenuItem,
+                getButtonBackgroundColorStyle(getButtonState(focused || hovered, pressed, success, disabled)),
+                ...additionalWrapperStyles,
+            ])}
+            disabled={disabled}
+        >
+            {({hovered, pressed}) => (
+                <>
+                    <View style={styles.flexRow}>
+                        {(icon && iconType === CONST.ICON_TYPE_ICON) && (
+                            <View
+                                style={[
+                                    styles.popoverMenuIcon,
+                                    ...iconStyles,
+                                ]}
+                            >
+                                <Icon
+                                    src={icon}
+                                    width={iconWidth}
+                                    height={iconHeight}
+                                    fill={iconFill || getIconFillColor(
+                                        getButtonState(focused || hovered, pressed, success, disabled),
+                                    )}
+                                />
+                            </View>
+                        )}
+                        {(icon && iconType === CONST.ICON_TYPE_AVATAR) && (
+                            <View
+                                style={[
+                                    styles.popoverMenuIcon,
+                                    ...iconStyles,
+                                ]}
+                            >
+                                <Avatar
+                                    imageStyles={[styles.avatarNormal, styles.alignSelfCenter]}
+                                    source={icon}
+                                />
+                            </View>
+                        )}
+                        <View style={[styles.justifyContentCenter, styles.menuItemTextContainer]}>
+                            <Text
+                                style={[
+                                    styles.popoverMenuText,
+                                    styles.ml3,
+                                    (disabled ? styles.disabledText : undefined),
+                                ]}
+                                numberOfLines={1}
+                            >
+                                {title}
                             </Text>
+                            {description && (
+                                <Text style={[styles.textLabelSupporting, styles.ml3, styles.mt1]}>
+                                    {description}
+                                </Text>
+                            )}
+                        </View>
+                    </View>
+                    <View style={[styles.flexRow, styles.menuItemTextContainer]}>
+                        {badgeText && <Badge text={badgeText} badgeStyles={[styles.alignSelfCenter]} />}
+                        {subtitle && (
+                            <View style={[styles.justifyContentCenter, styles.mr1]}>
+                                <Text
+                                    style={styles.textLabelSupporting}
+                                >
+                                    {subtitle}
+                                </Text>
+                            </View>
+                        )}
+                        {shouldShowRightIcon && (
+                            <View style={styles.popoverMenuIcon}>
+                                <Icon
+                                    src={iconRight}
+                                    fill={getIconFillColor(getButtonState(focused || hovered, pressed, success, disabled))}
+                                />
+                            </View>
                         )}
                     </View>
-                </View>
-                <View style={[styles.flexRow, styles.menuItemTextContainer]}>
-                    {badgeText && <Badge text={badgeText} badgeStyles={[styles.alignSelfCenter]} />}
-                    {subtitle && (
-                        <View style={[styles.justifyContentCenter, styles.mr1]}>
-                            <Text
-                                style={styles.textLabelSupporting}
-                            >
-                                {subtitle}
-                            </Text>
-                        </View>
-                    )}
-                    {shouldShowRightIcon && (
-                        <View style={styles.popoverMenuIcon}>
-                            <Icon
-                                src={iconRight}
-                                fill={getIconFillColor(getButtonState(focused || hovered, pressed, success, disabled))}
-                            />
-                        </View>
-                    )}
-                </View>
-            </>
-        )}
-    </Pressable>
-);
+                </>
+            )}
+        </Pressable>
+    );
+};
 
 MenuItem.propTypes = propTypes;
 MenuItem.defaultProps = defaultProps;

--- a/src/components/MenuItem.js
+++ b/src/components/MenuItem.js
@@ -56,100 +56,97 @@ const MenuItem = ({
     subtitle,
     iconType,
     interactive,
-}) => {
-    const additionalWrapperStyles = _.isArray(wrapperStyle) ? wrapperStyle : [wrapperStyle];
-    return (
-        <Pressable
-            onPress={(e) => {
-                if (disabled) {
-                    return;
-                }
+}) => (
+    <Pressable
+        onPress={(e) => {
+            if (disabled) {
+                return;
+            }
 
-                onPress(e);
-            }}
-            style={({hovered, pressed}) => ([
-                styles.popoverMenuItem,
-                getButtonBackgroundColorStyle(getButtonState(focused || hovered, pressed, success, disabled, interactive)),
-                ...additionalWrapperStyles,
-            ])}
-            disabled={disabled}
-        >
-            {({hovered, pressed}) => (
-                <>
-                    <View style={styles.flexRow}>
-                        {(icon && iconType === CONST.ICON_TYPE_ICON) && (
-                            <View
-                                style={[
-                                    styles.popoverMenuIcon,
-                                    ...iconStyles,
-                                ]}
-                            >
-                                <Icon
-                                    src={icon}
-                                    width={iconWidth}
-                                    height={iconHeight}
-                                    fill={iconFill || getIconFillColor(
-                                        getButtonState(focused || hovered, pressed, success, disabled, interactive),
-                                    )}
-                                />
-                            </View>
-                        )}
-                        {(icon && iconType === CONST.ICON_TYPE_AVATAR) && (
-                            <View
-                                style={[
-                                    styles.popoverMenuIcon,
-                                    ...iconStyles,
-                                ]}
-                            >
-                                <Avatar
-                                    imageStyles={[styles.avatarNormal, styles.alignSelfCenter]}
-                                    source={icon}
-                                />
-                            </View>
-                        )}
-                        <View style={[styles.justifyContentCenter, styles.menuItemTextContainer]}>
-                            <Text
-                                style={[
-                                    styles.popoverMenuText,
-                                    styles.ml3,
-                                    (interactive && disabled ? styles.disabledText : undefined),
-                                ]}
-                                numberOfLines={1}
-                            >
-                                {title}
-                            </Text>
-                            {description && (
-                                <Text style={[styles.textLabelSupporting, styles.ml3, styles.mt1]}>
-                                    {description}
-                                </Text>
-                            )}
+            onPress(e);
+        }}
+        style={({hovered, pressed}) => ([
+            styles.popoverMenuItem,
+            getButtonBackgroundColorStyle(getButtonState(focused || hovered, pressed, success, disabled, interactive)),
+            ..._.isArray(wrapperStyle) ? wrapperStyle : [wrapperStyle],
+        ])}
+        disabled={disabled}
+    >
+        {({hovered, pressed}) => (
+            <>
+                <View style={styles.flexRow}>
+                    {(icon && iconType === CONST.ICON_TYPE_ICON) && (
+                        <View
+                            style={[
+                                styles.popoverMenuIcon,
+                                ...iconStyles,
+                            ]}
+                        >
+                            <Icon
+                                src={icon}
+                                width={iconWidth}
+                                height={iconHeight}
+                                fill={iconFill || getIconFillColor(
+                                    getButtonState(focused || hovered, pressed, success, disabled, interactive),
+                                )}
+                            />
                         </View>
-                    </View>
-                    <View style={[styles.flexRow, styles.menuItemTextContainer]}>
-                        {badgeText && <Badge text={badgeText} badgeStyles={[styles.alignSelfCenter]} />}
-                        {subtitle && (
-                            <View style={[styles.justifyContentCenter, styles.mr1]}>
-                                <Text
-                                    style={styles.textLabelSupporting}
-                                >
-                                    {subtitle}
-                                </Text>
-                            </View>
+                    )}
+                    {(icon && iconType === CONST.ICON_TYPE_AVATAR) && (
+                        <View
+                            style={[
+                                styles.popoverMenuIcon,
+                                ...iconStyles,
+                            ]}
+                        >
+                            <Avatar
+                                imageStyles={[styles.avatarNormal, styles.alignSelfCenter]}
+                                source={icon}
+                            />
+                        </View>
+                    )}
+                    <View style={[styles.justifyContentCenter, styles.menuItemTextContainer]}>
+                        <Text
+                            style={[
+                                styles.popoverMenuText,
+                                styles.ml3,
+                                (interactive && disabled ? styles.disabledText : undefined),
+                            ]}
+                            numberOfLines={1}
+                        >
+                            {title}
+                        </Text>
+                        {description && (
+                            <Text style={[styles.textLabelSupporting, styles.ml3, styles.mt1]}>
+                                {description}
+                            </Text>
                         )}
-                        {shouldShowRightIcon && (
-                            <View style={styles.popoverMenuIcon}>
-                                <Icon
-                                    src={iconRight}
-                                    fill={getIconFillColor(getButtonState(focused || hovered, pressed, success, disabled, interactive))}
-                                />
-                            </View>
-                        )}
                     </View>
-                </>
-            )}
-        </Pressable>
-    );
-};
+                </View>
+                <View style={[styles.flexRow, styles.menuItemTextContainer]}>
+                    {badgeText && <Badge text={badgeText} badgeStyles={[styles.alignSelfCenter]} />}
+                    {subtitle && (
+                        <View style={[styles.justifyContentCenter, styles.mr1]}>
+                            <Text
+                                style={styles.textLabelSupporting}
+                            >
+                                {subtitle}
+                            </Text>
+                        </View>
+                    )}
+                    {shouldShowRightIcon && (
+                        <View style={styles.popoverMenuIcon}>
+                            <Icon
+                                src={iconRight}
+                                fill={getIconFillColor(getButtonState(focused || hovered, pressed, success, disabled, interactive))}
+                            />
+                        </View>
+                    )}
+                </View>
+            </>
+        )}
+    </Pressable>
+);
 
 MenuItem.propTypes = propTypes;
 MenuItem.defaultProps = defaultProps;

--- a/src/components/menuItemPropTypes.js
+++ b/src/components/menuItemPropTypes.js
@@ -54,6 +54,9 @@ const propTypes = {
 
     /** Flag to choose between avatar image or an icon */
     iconType: PropTypes.oneOf([CONST.ICON_TYPE_AVATAR, CONST.ICON_TYPE_ICON]),
+
+    /** Whether the menu item should be interactive at all */
+    interactive: PropTypes.bool,
 };
 
 export default propTypes;

--- a/src/components/menuItemPropTypes.js
+++ b/src/components/menuItemPropTypes.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import CONST from '../CONST';
+import stylePropTypes from '../styles/stylePropTypes';
 
 const propTypes = {
     /** Text to be shown as badge near the right end. */
@@ -7,10 +8,10 @@ const propTypes = {
 
     /** Any additional styles to apply */
     // eslint-disable-next-line react/forbid-prop-types
-    wrapperStyle: PropTypes.object,
+    wrapperStyle: stylePropTypes,
 
     /** Function to fire when component is pressed */
-    onPress: PropTypes.func.isRequired,
+    onPress: PropTypes.func,
 
     /** Icon to display on the left side of component */
     icon: PropTypes.oneOfType([PropTypes.elementType, PropTypes.string]),

--- a/src/libs/getButtonState.js
+++ b/src/libs/getButtonState.js
@@ -7,9 +7,14 @@ import CONST from '../CONST';
  * @param {Boolean} [isPressed]
  * @param {Boolean} [isComplete]
  * @param {Boolean} [isDisabled]
+ * @param {Boolean} [isInteractive]
  * @returns {String}
  */
-export default function (isActive = false, isPressed = false, isComplete = false, isDisabled = false) {
+export default function (isActive = false, isPressed = false, isComplete = false, isDisabled = false, isInteractive = true) {
+    if (!isInteractive) {
+        return CONST.BUTTON_STATES.DEFAULT;
+    }
+
     if (isDisabled) {
         return CONST.BUTTON_STATES.DISABLED;
     }

--- a/src/pages/ReimbursementAccount/EnableStep.js
+++ b/src/pages/ReimbursementAccount/EnableStep.js
@@ -21,6 +21,7 @@ import confettiPop from '../../../assets/images/confetti-pop.gif';
 import Icon from '../../components/Icon';
 import WorkspaceSection from '../workspace/WorkspaceSection';
 import {ConciergeBlue} from '../../components/Icon/Illustrations';
+import themeColors from '../../styles/themes/default';
 
 const propTypes = {
     /** Are we loading payment methods? */
@@ -95,8 +96,8 @@ class EnableStep extends React.Component {
                             icon={icon}
                             iconWidth={iconSize}
                             iconHeight={iconSize}
-                            onPress={() => {}}
-                            wrapperStyle={{paddingHorizontal: 0, marginBottom: 12}}
+                            disabled
+                            wrapperStyle={[styles.buttonDefaultBackgroundColor, styles.ph0, styles.mb3]}
                         />
                         <Text>
                             {!isUsingExpensifyCard

--- a/src/pages/ReimbursementAccount/EnableStep.js
+++ b/src/pages/ReimbursementAccount/EnableStep.js
@@ -97,7 +97,8 @@ class EnableStep extends React.Component {
                             iconWidth={iconSize}
                             iconHeight={iconSize}
                             disabled
-                            wrapperStyle={[styles.buttonDefaultBackgroundColor, styles.ph0, styles.mb3]}
+                            interactive={false}
+                            wrapperStyle={[styles.ph0, styles.mb3]}
                         />
                         <Text>
                             {!isUsingExpensifyCard

--- a/src/pages/ReimbursementAccount/EnableStep.js
+++ b/src/pages/ReimbursementAccount/EnableStep.js
@@ -21,7 +21,6 @@ import confettiPop from '../../../assets/images/confetti-pop.gif';
 import Icon from '../../components/Icon';
 import WorkspaceSection from '../workspace/WorkspaceSection';
 import {ConciergeBlue} from '../../components/Icon/Illustrations';
-import themeColors from '../../styles/themes/default';
 
 const propTypes = {
     /** Are we loading payment methods? */

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1812,7 +1812,7 @@ const styles = {
         zIndex: 10,
     },
 
-    reimbursementAccountFullScreenLoading: {
+    vbaFullScreenLoading: {
         backgroundColor: themeColors.componentBG,
         opacity: 0.8,
         justifyContent: 'flex-start',

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -217,10 +217,6 @@ const styles = {
         ...spacing.ph3,
     },
 
-    buttonDefaultBackgroundColor: {
-        backgroundColor: themeColors.buttonDefaultBG,
-    },
-
     buttonText: {
         color: themeColors.heading,
         fontFamily: fontFamily.GTA_BOLD,

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -217,6 +217,10 @@ const styles = {
         ...spacing.ph3,
     },
 
+    buttonDefaultBackgroundColor: {
+        backgroundColor: themeColors.buttonDefaultBG,
+    },
+
     buttonText: {
         color: themeColors.heading,
         fontFamily: fontFamily.GTA_BOLD,
@@ -1812,7 +1816,7 @@ const styles = {
         zIndex: 10,
     },
 
-    vbaFullScreenLoading: {
+    reimbursementAccountFullScreenLoading: {
         backgroundColor: themeColors.componentBG,
         opacity: 0.8,
         justifyContent: 'flex-start',


### PR DESCRIPTION
### Details

We need the UI from MenuItem but it should not be tappable. This enables us to reuse this view for display purposes only by adding an `interactive` state to the various styles.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/180913

### Tests
1. Add a VBA and get all the way to the validation step
2. Verify that the bank account UI shown here is not clickable or interactive in any way
![2021-10-12_14-49-34](https://user-images.githubusercontent.com/32969087/137048316-3859b069-9c83-492d-8931-1bfe9c1fef8e.png)

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
