### PR TITLE
[CP-stag] Get CompanyAddress field to autofill and show errors

### DIFF
--- a/src/components/AddressSearch.js
+++ b/src/components/AddressSearch.js
@@ -105,9 +105,14 @@ const AddressSearch = (props) => {
                     separator: [styles.googleSearchSeparator],
                 }}
             />
+            {!_.isEmpty(errorText) && (
+                <InlineErrorText>
+                    {errorText}
+                </InlineErrorText>
+            )}
         </>
     );
-}
+};
 
 AddressSearch.propTypes = propTypes;
 AddressSearch.defaultProps = defaultProps;

--- a/src/components/AddressSearch.js
+++ b/src/components/AddressSearch.js
@@ -7,7 +7,6 @@ import CONFIG from '../CONFIG';
 import withLocalize, {withLocalizePropTypes} from './withLocalize';
 import styles from '../styles/styles';
 import ExpensiTextInput from './ExpensiTextInput';
-import InlineErrorText from './InlineErrorText';
 
 // The error that's being thrown below will be ignored until we fork the
 // react-native-google-places-autocomplete repo and replace the
@@ -66,53 +65,46 @@ const AddressSearch = (props) => {
     };
 
     return (
-        <>
-            <GooglePlacesAutocomplete
-                ref={googlePlacesRef}
-                fetchDetails
-                keepResultsAfterBlur
-                suppressDefaultStyles
-                enablePoweredByContainer={false}
-                onPress={(data, details) => saveLocationDetails(details)}
-                query={{
-                    key: 'AIzaSyC4axhhXtpiS-WozJEsmlL3Kg3kXucbZus',
-                    language: props.preferredLocale,
-                }}
-                requestUrl={{
-                    useOnPlatform: 'web',
-                    url: `${CONFIG.EXPENSIFY.URL_EXPENSIFY_COM}api?command=Proxy_GooglePlaces&proxyUrl=`,
-                }}
-                textInputProps={{
-                    InputComp: ExpensiTextInput,
-                    label: props.label,
-                    containerStyles: props.containerStyles,
-                    errorText: props.errorText,
-                }}
-                styles={{
-                    textInputContainer: [styles.flexColumn],
-                    listView: [
-                        styles.borderTopRounded,
-                        styles.borderBottomRounded,
-                        styles.mt1,
-                        styles.overflowAuto,
-                        styles.borderLeft,
-                        styles.borderRight,
-                    ],
-                    row: [
-                        styles.pv4,
-                        styles.ph3,
-                        styles.overflowAuto,
-                    ],
-                    description: [styles.googleSearchText],
-                    separator: [styles.googleSearchSeparator],
-                }}
-            />
-            {!_.isEmpty(props.errorText) && (
-                <InlineErrorText>
-                    {props.errorText}
-                </InlineErrorText>
-            )}
-        </>
+        <GooglePlacesAutocomplete
+            ref={googlePlacesRef}
+            fetchDetails
+            keepResultsAfterBlur
+            suppressDefaultStyles
+            enablePoweredByContainer={false}
+            onPress={(data, details) => saveLocationDetails(details)}
+            query={{
+                key: 'AIzaSyC4axhhXtpiS-WozJEsmlL3Kg3kXucbZus',
+                language: props.preferredLocale,
+            }}
+            requestUrl={{
+                useOnPlatform: 'web',
+                url: `${CONFIG.EXPENSIFY.URL_EXPENSIFY_COM}api?command=Proxy_GooglePlaces&proxyUrl=`,
+            }}
+            textInputProps={{
+                InputComp: ExpensiTextInput,
+                label: props.label,
+                containerStyles: props.containerStyles,
+                errorText: props.errorText,
+            }}
+            styles={{
+                textInputContainer: [styles.flexColumn],
+                listView: [
+                    styles.borderTopRounded,
+                    styles.borderBottomRounded,
+                    styles.mt1,
+                    styles.overflowAuto,
+                    styles.borderLeft,
+                    styles.borderRight,
+                ],
+                row: [
+                    styles.pv4,
+                    styles.ph3,
+                    styles.overflowAuto,
+                ],
+                description: [styles.googleSearchText],
+                separator: [styles.googleSearchSeparator],
+            }}
+        />
     );
 };
 

--- a/src/components/AddressSearch.js
+++ b/src/components/AddressSearch.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import {LogBox} from 'react-native';
 import {GooglePlacesAutocomplete} from 'react-native-google-places-autocomplete';
@@ -33,55 +33,49 @@ const defaultProps = {
     containerStyles: null,
 };
 
-class AddressSearch extends React.Component {
-    constructor(props) {
-        super(props);
-        this.googlePlacesRef = React.createRef();
-    }
+const AddressSearch = (props) => {
+    const googlePlacesRef = useRef();
+    useEffect(() => {
+        googlePlacesRef.current?.setAddressText(props.value);
+      }, []);
 
-    componentDidMount() {
-        this.googlePlacesRef.current?.setAddressText(this.props.value);
-    }
-
-    getAddressComponent(object, field, nameType) {
+    const getAddressComponent = (object, field, nameType) => {
         return _.chain(object.address_components)
             .find(component => _.contains(component.types, field))
             .get(nameType)
             .value();
     }
 
-    /**
-     * @param {Object} details See https://developers.google.com/maps/documentation/places/web-service/details#PlaceDetailsResponses
-     */
-    saveLocationDetails = (details) => {
+
+    const saveLocationDetails = (details) => {
         if (details.address_components) {
             // Gather the values from the Google details
-            const streetNumber = this.getAddressComponent(details, 'street_number', 'long_name');
-            const streetName = this.getAddressComponent(details, 'route', 'long_name');
-            const city = this.getAddressComponent(details, 'locality', 'long_name');
-            const state = this.getAddressComponent(details, 'administrative_area_level_1', 'short_name');
-            const zipCode = this.getAddressComponent(details, 'postal_code', 'long_name');
+            const streetNumber = getAddressComponent(details, 'street_number', 'long_name');
+            const streetName = getAddressComponent(details, 'route', 'long_name');
+            const city = getAddressComponent(details, 'locality', 'long_name');
+            const state = getAddressComponent(details, 'administrative_area_level_1', 'short_name');
+            const zipCode = getAddressComponent(details, 'postal_code', 'long_name');
 
             // Trigger text change events for each of the individual fields being saved on the server
-            this.props.onChangeText('addressStreet', `${streetNumber} ${streetName}`);
-            this.props.onChangeText('addressCity', city);
-            this.props.onChangeText('addressState', state);
-            this.props.onChangeText('addressZipCode', zipCode);
+            props.onChangeText('addressStreet', `${streetNumber} ${streetName}`);
+            props.onChangeText('addressCity', city);
+            props.onChangeText('addressState', state);
+            props.onChangeText('addressZipCode', zipCode);
         }
     }
 
-    render() {
-        return (
+    return (
+        <>
             <GooglePlacesAutocomplete
-                ref={this.googlePlacesRef}
+                ref={googlePlacesRef}
                 fetchDetails
                 keepResultsAfterBlur
                 suppressDefaultStyles
                 enablePoweredByContainer={false}
-                onPress={(data, details) => this.saveLocationDetails(details)}
+                onPress={(data, details) => saveLocationDetails(details)}
                 query={{
                     key: 'AIzaSyC4axhhXtpiS-WozJEsmlL3Kg3kXucbZus',
-                    language: this.props.preferredLocale,
+                    language: props.preferredLocale,
                 }}
                 requestUrl={{
                     useOnPlatform: 'web',
@@ -89,8 +83,8 @@ class AddressSearch extends React.Component {
                 }}
                 textInputProps={{
                     InputComp: ExpensiTextInput,
-                    label: this.props.label,
-                    containerStyles: this.props.containerStyles,
+                    label: props.label,
+                    containerStyles: props.containerStyles,
                 }}
                 styles={{
                     textInputContainer: [styles.flexColumn],
@@ -111,8 +105,9 @@ class AddressSearch extends React.Component {
                     separator: [styles.googleSearchSeparator],
                 }}
             />
-        );
-    }
+        </>
+    );
+
 }
 
 AddressSearch.propTypes = propTypes;

--- a/src/components/AddressSearch.js
+++ b/src/components/AddressSearch.js
@@ -40,13 +40,13 @@ const AddressSearch = (props) => {
         googlePlacesRef.current?.setAddressText(props.value);
     }, []);
 
+    // eslint-disable-next-line
     const getAddressComponent = (object, field, nameType) => {
         return _.chain(object.address_components)
             .find(component => _.contains(component.types, field))
             .get(nameType)
             .value();
     };
-
 
     const saveLocationDetails = (details) => {
         if (details.address_components) {

--- a/src/components/AddressSearch.js
+++ b/src/components/AddressSearch.js
@@ -68,7 +68,6 @@ const AddressSearch = (props) => {
         <GooglePlacesAutocomplete
             ref={googlePlacesRef}
             fetchDetails
-            keepResultsAfterBlur
             suppressDefaultStyles
             enablePoweredByContainer={false}
             onPress={(data, details) => saveLocationDetails(details)}

--- a/src/components/AddressSearch.js
+++ b/src/components/AddressSearch.js
@@ -7,6 +7,7 @@ import CONFIG from '../CONFIG';
 import withLocalize, {withLocalizePropTypes} from './withLocalize';
 import styles from '../styles/styles';
 import ExpensiTextInput from './ExpensiTextInput';
+import InlineErrorText from './InlineErrorText';
 
 // The error that's being thrown below will be ignored until we fork the
 // react-native-google-places-autocomplete repo and replace the

--- a/src/components/AddressSearch.js
+++ b/src/components/AddressSearch.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import React, { useEffect, useRef } from 'react';
+import React, {useEffect, useRef} from 'react';
 import PropTypes from 'prop-types';
 import {LogBox} from 'react-native';
 import {GooglePlacesAutocomplete} from 'react-native-google-places-autocomplete';
@@ -37,7 +37,7 @@ const AddressSearch = (props) => {
     const googlePlacesRef = useRef();
     useEffect(() => {
         googlePlacesRef.current?.setAddressText(props.value);
-      }, []);
+    }, []);
 
     const getAddressComponent = (object, field, nameType) => {
         return _.chain(object.address_components)

--- a/src/components/AddressSearch.js
+++ b/src/components/AddressSearch.js
@@ -106,9 +106,9 @@ const AddressSearch = (props) => {
                     separator: [styles.googleSearchSeparator],
                 }}
             />
-            {!_.isEmpty(errorText) && (
+            {!_.isEmpty(props.errorText) && (
                 <InlineErrorText>
-                    {errorText}
+                    {props.errorText}
                 </InlineErrorText>
             )}
         </>

--- a/src/components/AddressSearch.js
+++ b/src/components/AddressSearch.js
@@ -86,6 +86,7 @@ const AddressSearch = (props) => {
                     InputComp: ExpensiTextInput,
                     label: props.label,
                     containerStyles: props.containerStyles,
+                    errorText: props.errorText,
                 }}
                 styles={{
                     textInputContainer: [styles.flexColumn],

--- a/src/components/AddressSearch.js
+++ b/src/components/AddressSearch.js
@@ -44,7 +44,7 @@ const AddressSearch = (props) => {
             .find(component => _.contains(component.types, field))
             .get(nameType)
             .value();
-    }
+    };
 
 
     const saveLocationDetails = (details) => {
@@ -62,7 +62,7 @@ const AddressSearch = (props) => {
             props.onChangeText('addressState', state);
             props.onChangeText('addressZipCode', zipCode);
         }
-    }
+    };
 
     return (
         <>
@@ -107,7 +107,6 @@ const AddressSearch = (props) => {
             />
         </>
     );
-
 }
 
 AddressSearch.propTypes = propTypes;

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -428,7 +428,7 @@ export default {
             phoneNumber: 'Please enter a valid phone number',
             companyName: 'Please enter a valid legal business name',
             addressCity: 'Please enter a valid city',
-            addressStreet: 'Please enter a valid address street that is not a PO Box',
+            addressStreet: 'Please enter a valid street address that is not a PO Box',
             addressState: 'Please select a valid state',
             incorporationDate: 'Please enter a valid date',
             incorporationState: 'Please enter a valid state',

--- a/src/pages/ReimbursementAccount/CompanyStep.js
+++ b/src/pages/ReimbursementAccount/CompanyStep.js
@@ -153,6 +153,23 @@ class CompanyStep extends React.Component {
         return _.size(errors) === 0;
     }
 
+    getFormattedAddressValue() {
+        let addressString = '';
+        if (this.state.addressStreet) {
+            addressString += `${this.state.addressStreet}, `;
+        }
+        if (this.state.addressCity) {
+            addressString += `${this.state.addressCity}, `;
+        }
+        if (this.state.addressState) {
+            addressString += `${this.state.addressState}, `;
+        }
+        if (this.state.addressZipCode) {
+            addressString += `${this.state.addressZipCode}`;
+        }
+        return addressString;
+    }
+
     submit() {
         if (!this.validate()) {
             showBankAccountErrorModal();
@@ -191,7 +208,7 @@ class CompanyStep extends React.Component {
                     <AddressSearch
                         label={this.props.translate('common.companyAddress')}
                         containerStyles={[styles.mt4]}
-                        value={`${this.state.addressStreet} ${this.state.addressCity} ${this.state.addressState} ${this.state.addressZipCode}`}
+                        value={this.getFormattedAddressValue()}
                         onChangeText={(fieldName, value) => this.clearErrorAndSetValue(fieldName, value)}
                         errorText={this.getErrorText('addressStreet')}
                     />

--- a/src/pages/ReimbursementAccount/CompanyStep.js
+++ b/src/pages/ReimbursementAccount/CompanyStep.js
@@ -103,6 +103,23 @@ class CompanyStep extends React.Component {
         this.getErrors = () => ReimbursementAccountUtils.getErrors(this.props);
     }
 
+    getFormattedAddressValue() {
+        let addressString = '';
+        if (this.state.addressStreet) {
+            addressString += `${this.state.addressStreet}, `;
+        }
+        if (this.state.addressCity) {
+            addressString += `${this.state.addressCity}, `;
+        }
+        if (this.state.addressState) {
+            addressString += `${this.state.addressState}, `;
+        }
+        if (this.state.addressZipCode) {
+            addressString += `${this.state.addressZipCode}`;
+        }
+        return addressString;
+    }
+
     /**
      * @param {String} value
      */
@@ -151,23 +168,6 @@ class CompanyStep extends React.Component {
         });
         setBankAccountFormValidationErrors(errors);
         return _.size(errors) === 0;
-    }
-
-    getFormattedAddressValue() {
-        let addressString = '';
-        if (this.state.addressStreet) {
-            addressString += `${this.state.addressStreet}, `;
-        }
-        if (this.state.addressCity) {
-            addressString += `${this.state.addressCity}, `;
-        }
-        if (this.state.addressState) {
-            addressString += `${this.state.addressState}, `;
-        }
-        if (this.state.addressZipCode) {
-            addressString += `${this.state.addressZipCode}`;
-        }
-        return addressString;
     }
 
     submit() {

--- a/src/pages/ReimbursementAccount/CompanyStep.js
+++ b/src/pages/ReimbursementAccount/CompanyStep.js
@@ -70,6 +70,10 @@ class CompanyStep extends React.Component {
         // These fields need to be filled out in order to submit the form
         this.requiredFields = [
             'companyName',
+            'addressStreet',
+            'addressCity',
+            'addressState',
+            'addressZipCode',
             'website',
             'companyTaxID',
             'incorporationDate',
@@ -82,6 +86,10 @@ class CompanyStep extends React.Component {
         // Map a field to the key of the error's translation
         this.errorTranslationKeys = {
             companyName: 'bankAccount.error.companyName',
+            companyAddressStreet: 'bankAccount.error.addressStreet',
+            companyAddressCity: 'bankAccount.error.addressCity',
+            companyAddressState: 'bankAccount.error.addressState',
+            companyAddressZIP: 'bankAccount.error.zipCode',
             companyPhone: 'bankAccount.error.phoneNumber',
             website: 'bankAccount.error.website',
             companyTaxID: 'bankAccount.error.taxID',
@@ -185,6 +193,7 @@ class CompanyStep extends React.Component {
                         containerStyles={[styles.mt4]}
                         value={`${this.state.addressStreet}, ${this.state.addressCity}, ${this.state.addressState}, ${this.state.addressZipCode}`}
                         onChangeText={(fieldName, value) => this.clearErrorAndSetValue(fieldName, value)}
+                        errorText={this.getErrorText('companyAddress')}
                     />
                     <ExpensiTextInput
                         label={this.props.translate('common.phoneNumber')}

--- a/src/pages/ReimbursementAccount/CompanyStep.js
+++ b/src/pages/ReimbursementAccount/CompanyStep.js
@@ -204,7 +204,6 @@ class CompanyStep extends React.Component {
                         placeholder={this.props.translate('companyStep.companyPhonePlaceholder')}
                         errorText={this.getErrorText('companyPhone')}
                         maxLength={CONST.PHONE_MAX_LENGTH}
-
                     />
                     <ExpensiTextInput
                         label={this.props.translate('companyStep.companyWebsite')}

--- a/src/pages/ReimbursementAccount/CompanyStep.js
+++ b/src/pages/ReimbursementAccount/CompanyStep.js
@@ -183,7 +183,7 @@ class CompanyStep extends React.Component {
                     <AddressSearch
                         label={this.props.translate('common.companyAddress')}
                         containerStyles={[styles.mt4]}
-                        value={`${this.state.addressStreet} ${this.state.addressCity} ${this.state.addressState} ${this.state.addressZipCode}`}
+                        value={`${this.state.addressStreet}, ${this.state.addressCity}, ${this.state.addressState}, ${this.state.addressZipCode}`}
                         onChangeText={(fieldName, value) => this.clearErrorAndSetValue(fieldName, value)}
                     />
                     <ExpensiTextInput

--- a/src/pages/ReimbursementAccount/CompanyStep.js
+++ b/src/pages/ReimbursementAccount/CompanyStep.js
@@ -86,10 +86,10 @@ class CompanyStep extends React.Component {
         // Map a field to the key of the error's translation
         this.errorTranslationKeys = {
             companyName: 'bankAccount.error.companyName',
-            companyAddressStreet: 'bankAccount.error.addressStreet',
-            companyAddressCity: 'bankAccount.error.addressCity',
-            companyAddressState: 'bankAccount.error.addressState',
-            companyAddressZIP: 'bankAccount.error.zipCode',
+            addressStreet: 'bankAccount.error.addressStreet',
+            addressCity: 'bankAccount.error.addressCity',
+            addressState: 'bankAccount.error.addressState',
+            addressZipCode: 'bankAccount.error.zipCode',
             companyPhone: 'bankAccount.error.phoneNumber',
             website: 'bankAccount.error.website',
             companyTaxID: 'bankAccount.error.taxID',
@@ -191,9 +191,9 @@ class CompanyStep extends React.Component {
                     <AddressSearch
                         label={this.props.translate('common.companyAddress')}
                         containerStyles={[styles.mt4]}
-                        value={`${this.state.addressStreet}, ${this.state.addressCity}, ${this.state.addressState}, ${this.state.addressZipCode}`}
+                        value={`${this.state.addressStreet} ${this.state.addressCity} ${this.state.addressState} ${this.state.addressZipCode}`}
                         onChangeText={(fieldName, value) => this.clearErrorAndSetValue(fieldName, value)}
-                        errorText={this.getErrorText('companyAddress')}
+                        errorText={this.getErrorText('addressStreet')}
                     />
                     <ExpensiTextInput
                         label={this.props.translate('common.phoneNumber')}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

## Details
<!-- Explanation of the change or anything fishy that is going on -->

This PR fixes several things about the Address Picker. 

This component uses a 3rd party package to populate the dropdown list for addresses. After _quite a lot_ of wrestling we decided to just make `AddressSearch` a functional component because that seems to fix our problems immediately. 

## Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/5794
$ https://github.com/Expensify/Expensify/issues/181023

## Tests / Web QA
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### Error reporting

1) Sign in to New Dot with a new account
2) Create a new workspace
3) Connect a new bank account
4) Routing number: 123123123 
    Account Number: 1111222233331111
5) Hit enter. When you're on the Company Information page, immediately hit enter. 
6) Verify that you see the error under the Company Address field and that the border of that field turns red.

### Autofill

1) Sign in to New Dot (new account is fine)
2) Create a new workspace
3) Connect a new bank account
4) Routing number: 123123123
     Account Number: 1111222233331111
5) Input valid information on all fields in the Company Information step (doesn't need to be real info)
6) 
    a) _Variant 1:_ Refresh the page
    b) _Variant 2:_ Hit Submit. When you're on Step 3 (Personal Information) click the back arrow to go back to Step 2 (Company Informaion)
7) Notice that all the fields are auto-filled, including the Company Address. 


## Tested On

- [x] Web
- [x] Mobile Web
- [ ] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->


#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
<img width="560" alt="Screen Shot 2021-10-13 at 3 12 50 PM" src="https://user-images.githubusercontent.com/49007721/137221256-fbf52367-ad41-42df-9de2-a80df640a48f.png">
<img width="560" alt="Screen Shot 2021-10-13 at 3 14 03 PM" src="https://user-images.githubusercontent.com/49007721/137221268-96af47d3-ab3f-42c6-8008-f9e11aade153.png">

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
![Uploading Screen Shot 2021-10-13 at 3.26.02 PM.png…]()
<img width="608" alt="Screen Shot 2021-10-13 at 3 27 53 PM" src="https://user-images.githubusercontent.com/49007721/137221294-1ae383ee-a097-4433-b065-3100b89fb17a.png">

