### PR TITLE
Have expenses page links direct to correct filters

### DIFF
--- a/src/pages/workspace/reimburse/WorkspaceReimburseNoVBAView.js
+++ b/src/pages/workspace/reimburse/WorkspaceReimburseNoVBAView.js
@@ -31,7 +31,7 @@ const WorkspaceReimburseNoVBAView = ({translate, policyID}) => (
             menuItems={[
                 {
                     title: translate('workspace.reimburse.viewAllReceipts'),
-                    onPress: () => openOldDotLink(`expenses?param={"policyID":"${policyID}"}`),
+                    onPress: () => openOldDotLink(`expenses?policyIDList=${policyID}&billableReimbursable=reimbursable&submitterEmail=%2B%2B`),
                     icon: Receipt,
                     shouldShowRightIcon: true,
                     iconRight: NewWindow,

--- a/src/pages/workspace/reimburse/WorkspaceReimburseVBAView.js
+++ b/src/pages/workspace/reimburse/WorkspaceReimburseVBAView.js
@@ -29,7 +29,7 @@ const WorkspaceReimburseVBAView = ({translate, policyID}) => (
             menuItems={[
                 {
                     title: translate('workspace.reimburse.viewAllReceipts'),
-                    onPress: () => openOldDotLink(`expenses?param={"policyIDList":"${policyID}"}`),
+                    onPress: () => openOldDotLink(`expenses?policyIDList=${policyID}&billableReimbursable=reimbursable&submitterEmail=%2B%2B`),
                     icon: Receipt,
                     shouldShowRightIcon: true,
                     iconRight: NewWindow,


### PR DESCRIPTION
Pullerbearing ()
cc @tgolen 

### Details
Update the URL params to direct the "View all receipts" link to the expenses page with the correct filters turned on.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/180928

### Tests
1. Go to NewDot and create a workspace
1. Click on the reimburse receipts page
1. Then click view all receipts to be redirected to OldDot
1. Make sure that you see the correct policy selected in the Policy selector, the reimbursable/billable switch set to reimbursable, and the Submitter dropdown set to "All Submitters"
<img width="1413" alt="Screen Shot 2021-10-12 at 8 38 12 PM" src="https://user-images.githubusercontent.com/4741899/137063825-e45538ad-bccf-49fa-876d-ea35a49455c9.png">

