### PR TITLE
Open OldDot links on Safari

### DIFF
--- a/src/libs/actions/Link.js
+++ b/src/libs/actions/Link.js
@@ -35,9 +35,24 @@ function showGrowlIfOffline() {
  */
 function openOldDotLink(url) {
     if (!showGrowlIfOffline()) {
+        // Safari blocks opening new windows inside async calls.
+        // The workaround is to open a new window before the async call and then update its location to the correct url
+        const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+        let windowRef;
+
+        if (isSafari) {
+            windowRef = window.open();
+        }
+
         API.GetShortLivedAuthToken().then(({shortLivedAuthToken}) => {
             // eslint-disable-next-line max-len
-            Linking.openURL(`${CONFIG.EXPENSIFY.URL_EXPENSIFY_COM}${url}${url.indexOf('?') === -1 ? '?' : '&'}authToken=${shortLivedAuthToken}&email=${encodeURIComponent(currentUserEmail)}`);
+            const oldDotURL = `${CONFIG.EXPENSIFY.URL_EXPENSIFY_COM}${url}${url.indexOf('?') === -1 ? '?' : '&'}authToken=${shortLivedAuthToken}&email=${encodeURIComponent(currentUserEmail)}`;
+
+            if (isSafari) {
+                windowRef.location = oldDotURL;
+            } else {
+                Linking.openURL(oldDotURL);
+            }
         });
     }
 }

--- a/src/libs/actions/Link.js
+++ b/src/libs/actions/Link.js
@@ -7,6 +7,7 @@ import {translateLocal} from '../translate';
 import CONST from '../../CONST';
 import * as API from '../API';
 import CONFIG from '../../CONFIG';
+import asyncOpenURL from '../asyncOpenURL';
 
 let isNetworkOffline = false;
 Onyx.connect({
@@ -35,25 +36,9 @@ function showGrowlIfOffline() {
  */
 function openOldDotLink(url) {
     if (!showGrowlIfOffline()) {
-        // Safari blocks opening new windows inside async calls.
-        // The workaround is to open a new window before the async call and then update its location to the correct url
-        const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
-        let windowRef;
-
-        if (isSafari) {
-            windowRef = window.open();
-        }
-
-        API.GetShortLivedAuthToken().then(({shortLivedAuthToken}) => {
-            // eslint-disable-next-line max-len
-            const oldDotURL = `${CONFIG.EXPENSIFY.URL_EXPENSIFY_COM}${url}${url.indexOf('?') === -1 ? '?' : '&'}authToken=${shortLivedAuthToken}&email=${encodeURIComponent(currentUserEmail)}`;
-
-            if (isSafari) {
-                windowRef.location = oldDotURL;
-            } else {
-                Linking.openURL(oldDotURL);
-            }
-        });
+        // eslint-disable-next-line max-len
+        const buildOldDotURL = ({shortLivedAuthToken}) => `${CONFIG.EXPENSIFY.URL_EXPENSIFY_COM}${url}${url.indexOf('?') === -1 ? '?' : '&'}authToken=${shortLivedAuthToken}&email=${encodeURIComponent(currentUserEmail)}`;
+        asyncOpenURL(API.GetShortLivedAuthToken(), buildOldDotURL);
     }
 }
 

--- a/src/libs/asyncOpenURL/index.js
+++ b/src/libs/asyncOpenURL/index.js
@@ -5,7 +5,7 @@ export default function asyncOpenURL(promise, url) {
         return;
     }
 
-    promise.then(() => {
-        Linking.openURL(url);
+    promise.then((params) => {
+        Linking.openURL(typeof url === 'string' ? url : url(params));
     });
 }

--- a/src/libs/asyncOpenURL/index.website.js
+++ b/src/libs/asyncOpenURL/index.website.js
@@ -14,14 +14,14 @@ export default function asyncOpenURL(promise, url) {
     const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
 
     if (!isSafari) {
-        promise.then(() => {
-            Linking.openURL(url);
+        promise.then((params) => {
+            Linking.openURL(typeof url === 'string' ? url : url(params));
         });
     } else {
         const windowRef = window.open();
         promise
-            .then(() => {
-                windowRef.location = url;
+            .then((params) => {
+                windowRef.location = typeof url === 'string' ? url : url(params);
             })
             .catch(() => windowRef.close());
     }


### PR DESCRIPTION
### Details
Safari blocks any pop up windows that are open within async calls. This PR adds a workaround to correctly open async links in Safari.

cc @tgolen 

### Fixed Issues
$ https://github.com/Expensify/App/issues/5798

### Tests
1. Log in to NewDot in Safari
2. Create a Workspace
3. Click on `Pay Bills > View All Bills`
4. Verify that the OldDot page opens
5. Repeat steps 3-4 for `Reimburse Receipts > View All Receipts`, `Send Invoices > Send Invoice`, and `Send Invoices > View All Invoices`.
6. Repeat steps 3-5 on Chrome

### QA Steps
Steps above.

### Tested On

- [X] Web
- [X] Mobile Web
- [X] Desktop
- [X] iOS
- [X] Android

### Screenshots

#### Web

https://user-images.githubusercontent.com/22219519/137074310-cde6b4ad-ec5b-4577-81ba-39759970f174.mov

https://user-images.githubusercontent.com/22219519/137074321-62a680f3-76b1-44b3-9b65-e5809c798d5f.mov

#### Mobile Web

https://user-images.githubusercontent.com/22219519/137074331-f1fb8520-84b4-4789-807b-cc631fbaf7e9.mov

#### Desktop

https://user-images.githubusercontent.com/22219519/137074344-18d63930-6de9-48a8-8a87-af22580a34e8.mov

#### iOS

https://user-images.githubusercontent.com/22219519/137074352-b1ebab3c-66c0-439e-a23e-2122c1fcac40.mov

#### Android

https://user-images.githubusercontent.com/22219519/137074439-ab81bfb7-3003-4080-b34f-ef4c3c98f020.mov

Note: my android emulator is not connecting to my VM, so the webpage does not load. However, the link shown in the browser is correct.