### PR TITLE
Don't dismiss the Reimbursement Account Page after validating a withdrawal account

### DIFF
--- a/src/libs/actions/BankAccounts.js
+++ b/src/libs/actions/BankAccounts.js
@@ -9,7 +9,6 @@ import * as API from '../API';
 import BankAccount from '../models/BankAccount';
 import Growl from '../Growl';
 import {translateLocal} from '../translate';
-import Navigation from '../Navigation/Navigation';
 
 /**
  * List of bank accounts. This data should not be stored in Onyx since it contains unmasked PANs.

--- a/src/libs/actions/BankAccounts.js
+++ b/src/libs/actions/BankAccounts.js
@@ -577,12 +577,7 @@ function validateBankAccount(bankAccountID, validateCode) {
                             achData: {state: BankAccount.STATE.OPEN},
                         };
 
-                        if (isUsingExpensifyCard) {
-                            Navigation.dismissModal();
-                        } else {
-                            reimbursementAccount.achData.currentStep = CONST.BANK_ACCOUNT.STEP.ENABLE;
-                        }
-
+                        reimbursementAccount.achData.currentStep = CONST.BANK_ACCOUNT.STEP.ENABLE;
                         Onyx.merge(ONYXKEYS.USER, {isUsingExpensifyCard});
                         Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, reimbursementAccount);
                     });

--- a/src/libs/actions/BankAccounts.js
+++ b/src/libs/actions/BankAccounts.js
@@ -566,7 +566,6 @@ function validateBankAccount(bankAccountID, validateCode) {
     API.BankAccount_Validate({bankAccountID, validateCode})
         .then((response) => {
             if (response.jsonCode === 200) {
-                Growl.show('Bank Account successfully validated!', CONST.GROWL.SUCCESS, 5000);
                 Onyx.set(ONYXKEYS.REIMBURSEMENT_ACCOUNT_DRAFT, null);
                 API.User_IsUsingExpensifyCard()
                     .then(({isUsingExpensifyCard}) => {

--- a/src/pages/ReimbursementAccount/ReimbursementAccountForm.js
+++ b/src/pages/ReimbursementAccount/ReimbursementAccountForm.js
@@ -11,6 +11,7 @@ import reimbursementAccountPropTypes from './reimbursementAccountPropTypes';
 import compose from '../../libs/compose';
 import ONYXKEYS from '../../ONYXKEYS';
 import FormAlertWithSubmitButton from '../../components/FormAlertWithSubmitButton';
+import CONST from '../../CONST';
 
 const propTypes = {
     /** ACH data for the withdrawal account actively being set up */
@@ -34,6 +35,12 @@ class ReimbursementAccountForm extends React.Component {
             // @TODO once all validation errors show in multiples we can remove this check
             || lodashGet(this.props, 'reimbursementAccount.error', '').length > 0;
 
+        const currentStep = lodashGet(
+            this.props,
+            'reimbursementAccount.achData.currentStep',
+            CONST.BANK_ACCOUNT.STEP.BANK_ACCOUNT,
+        );
+
         return (
             <ScrollView
                 style={[styles.w100, styles.flex1]}
@@ -47,7 +54,7 @@ class ReimbursementAccountForm extends React.Component {
                 </View>
                 <FormAlertWithSubmitButton
                     isAlertVisible={isErrorVisible}
-                    buttonText={this.props.translate('common.saveAndContinue')}
+                    buttonText={currentStep === CONST.BANK_ACCOUNT.STEP.VALIDATION ? this.props.translate('validationStep.buttonText') : this.props.translate('common.saveAndContinue')}
                     onSubmit={this.props.onSubmit}
                     onFixTheErrorsLinkPressed={() => {
                         this.form.scrollTo({y: 0, animated: true});


### PR DESCRIPTION
@luacmartins please review

### Details
Make sure we don't close the Reimbursement Account Page after validating a withdrawal account, regardless if you have the Expensify Card or not.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/180851

### Tests
1. Create workspace
2. Go to `connect bank account` page
3. Select `Connect bank account` and use steps in [option (1) of this SO](https://stackoverflow.com/c/expensify/questions/342/525#525)
4. Enter validation amounts to finalize setup
5. Make sure that the right docked modal stays open after you finish the setup.
![Kapture 2021-10-13 at 11 32 21](https://user-images.githubusercontent.com/4741899/137192990-71068c1a-e48f-4035-9d7c-125fe5a1fbae.gif)


