### PR TITLE
Fix link to OldDot's reports page

### DIFF
--- a/src/pages/workspace/reimburse/WorkspaceReimburseVBAView.js
+++ b/src/pages/workspace/reimburse/WorkspaceReimburseVBAView.js
@@ -55,7 +55,7 @@ const WorkspaceReimburseVBAView = ({translate, policyID}) => (
                 {
                     title: translate('workspace.reimburse.reimburseReceipts'),
                     // eslint-disable-next-line max-len
-                    onPress: () => openOldDotLink(`/reports?param={"startDate":","endDate":","reportName":","policyID":"${policyID}","from":"all","type":"expense","states":{"Open":false,"Processing":false,"Approved":false,"Reimbursed":false,"Archived":true},"isAdvancedFilterMode":true}`),
+                    onPress: () => openOldDotLink(`reports?param={"startDate":","endDate":","reportName":","policyID":"${policyID}","from":"all","type":"expense","states":{"Open":false,"Processing":false,"Approved":false,"Reimbursed":false,"Archived":true},"isAdvancedFilterMode":true}`),
                     icon: Bank,
                     shouldShowRightIcon: true,
                     iconRight: NewWindow,


### PR DESCRIPTION
### Details
Fix a link to OldDot's reports page

### Fixed Issues
$ https://github.com/Expensify/App/issues/5799

### Tests / QA Steps
1. Using an account that has a VBA, click on your avatar
2. Click on a workspace
3. Click on Reimburse Receipts, then Reimburse Receipts
4. Make sure a new tab opens to the reports page on OldDot, and that the page loads as expected

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
https://user-images.githubusercontent.com/2229301/137189795-ee0b6fac-0797-4c2d-b79b-d119f251d9a8.mov



