### PR TITLE
Close AddressSearch results on blur

### DIFF
--- a/src/components/AddressSearch.js
+++ b/src/components/AddressSearch.js
@@ -75,7 +75,6 @@ class AddressSearch extends React.Component {
             <GooglePlacesAutocomplete
                 ref={this.googlePlacesRef}
                 fetchDetails
-                keepResultsAfterBlur
                 suppressDefaultStyles
                 enablePoweredByContainer={false}
                 onPress={(data, details) => this.saveLocationDetails(details)}

--- a/src/components/ExpensiTextInput/BaseExpensiTextInput.js
+++ b/src/components/ExpensiTextInput/BaseExpensiTextInput.js
@@ -75,14 +75,14 @@ class BaseExpensiTextInput extends Component {
         }
     }
 
-    onFocus() {
-        if (this.props.onFocus) { this.props.onFocus(); }
+    onFocus(event) {
+        if (this.props.onFocus) { this.props.onFocus(event); }
         this.setState({isFocused: true});
         this.activateLabel();
     }
 
-    onBlur() {
-        if (this.props.onBlur) { this.props.onBlur(); }
+    onBlur(event) {
+        if (this.props.onBlur) { this.props.onBlur(event); }
         this.setState({isFocused: false});
         this.deactivateLabel();
     }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

- Remove `keepResultsAfterBlur` prop from `GooglePlacesAutocomplete` so it closes on blur
- Pass down `event` to `onBlur` and `onFocus` in `BaseExpensiTextInput`. `GooglePlacesAutocomplete` will pass an `onBlur` callback that checks if the focus is changing to a result on blur. If we don't pass the `event` parameter, it fails to check that and closes the results list too soon.

### Fixed Issues

$ https://github.com/Expensify/Expensify/issues/181023

### Tests / QA

1. Sign in to New Dot with a new account
2. Create a new workspace
3. Connect a new bank account
    Routing number: 123123123
    Account Number: 1111222233331111
4. Hit enter, you should get to the Company Information page
5. Start typing a `Company address`, you should see some suggested addresses appearing.
6. Don't click any, click another field.
7. The list of suggested addresses should disappear (close on blur).
8. Start typing again in the `Company address` field and select one of the results
9. The result list should disappear and the `Company address` should have the value of the selected result.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web

https://user-images.githubusercontent.com/87341702/137223293-4f05242f-82e2-47cb-8982-ea0461057f12.mov

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
