### PR TITLE
Use h1 (19px) style for header instead of textXLarge (24px)

### DIFF
--- a/src/pages/workspace/WorkspaceSection.js
+++ b/src/pages/workspace/WorkspaceSection.js
@@ -42,7 +42,7 @@ const WorkspaceSection = ({
         <View style={styles.pageWrapper}>
             <View style={[styles.flexRow, styles.alignItemsCenter, styles.w100]}>
                 <View style={[styles.flexShrink1]}>
-                    <Text style={[styles.textXLarge]}>{title}</Text>
+                    <Text style={[styles.h1]}>{title}</Text>
                 </View>
                 <View style={[styles.flexGrow1, styles.flexRow, styles.justifyContentEnd]}>
                     {icon && <Icon src={icon} height={80} width={80} />}

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -141,13 +141,6 @@ const styles = {
         fontSize: variables.fontSizeLarge,
     },
 
-    textXLarge: {
-        color: themeColors.heading,
-        fontFamily: fontFamily.GTA_BOLD,
-        fontSize: variables.fontSizeXLarge,
-        fontWeight: fontWeightBold,
-    },
-
     textXXXLarge: {
         color: themeColors.heading,
         fontFamily: fontFamily.GTA_BOLD,

--- a/src/styles/variables.js
+++ b/src/styles/variables.js
@@ -19,7 +19,6 @@ export default {
     fontSizeLarge: 17,
     fontSizeHero: 36,
     fontSizeh1: 19,
-    fontSizeXLarge: 24,
     fontSizeXXXLarge: 32,
     fontSizeNormalHeight: 20,
     lineHeightHero: 40,


### PR DESCRIPTION
### Details
Reduce size of headers to 19px following designs.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/181056

### Tests / QA

1. Create a NewDot account, verify it, log in
2. Create a Workspace
3. From the workspace menu:
![Screen Shot 2021-10-13 at 6 11 08 PM](https://user-images.githubusercontent.com/87341702/137233769-a8305b7e-41e9-4099-a15e-7b7bf4a23662.png)
4. Enter in `Issue corporate cards` and check that the title `Unlock free Expensify Cards` has font size `19px`
![Screen Shot 2021-10-13 at 6 12 10 PM](https://user-images.githubusercontent.com/87341702/137233858-2175ca05-8b06-4153-b438-f0793af170e8.png)
5. Check the same thing for the following titles:
    1. `Reimburse receipts` section titles:
        - `Capture receipts`
        - `Unlock next-day reimbursements`
    2. `Pay bills` section titles:
        - `Manage your bills`
        - `Unlock online bill payment`
    3. `Send invoices` section titles:
        - `Invoice clients and customers`
        - `Unlock online invoice collection`
    4. `Book travel` section titles:
        - `Unlock Concierge travel booking`
    5. `Connect bank account` section titles:
        - `Streamline payments`

6. Connect a VBA using the section (3) of this [SO answer](https://stackoverflow.com/c/expensify/a/525/419)
7. Some new titles will appear in the following sections, check their font size to be `19px`:
    1. `Issue corporate cards` section titles:
         - `Cards are ready!` (post VBA-connected)
    2. `Reimburse receipts` section titles:
         - `Fast reimbursements = happy members!` (post VBA-connected)
    3. `Pay bills` section titles:
         - `Hassle-free bills!` (post VBA-connected)
    4. `Send invoices` section titles:
         - `Money back, in a flash!` (post VBA-connected)
    5. `Book travel` section titles:
         - `Pack your bags!` (post VBA-connected)

8. During the process of adding a VBA, depending on the flow (try different options of the [SO](https://stackoverflow.com/c/expensify/a/525/419)), we should encounter the titles:
    - `Almost done!`
    - `Let’s finish in chat!`
    - `One more thing!`
    - `All set!`
9. Check that these titles also have font size `19px`



### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
