### PR TITLE
Only accept "address" result from google API - validate address_components before using it

### DIFF
--- a/src/components/AddressSearch.js
+++ b/src/components/AddressSearch.js
@@ -74,6 +74,7 @@ const AddressSearch = (props) => {
             query={{
                 key: 'AIzaSyC4axhhXtpiS-WozJEsmlL3Kg3kXucbZus',
                 language: props.preferredLocale,
+                types: 'address',
             }}
             requestUrl={{
                 useOnPlatform: 'web',

--- a/src/components/AddressSearch.js
+++ b/src/components/AddressSearch.js
@@ -52,11 +52,11 @@ const AddressSearch = (props) => {
             return false;
         }
         if (!_.some(addressComponents, component => _.includes(component.types, 'street_number'))) {
-            // No Street number
+            // Missing Street number
             return false;
         }
         if (_.some(addressComponents, component => _.includes(component.types, 'post_box'))) {
-            // PO box
+            // Reject PO box
             return false;
         }
         return true;

--- a/src/components/AddressSearch.js
+++ b/src/components/AddressSearch.js
@@ -47,8 +47,23 @@ const AddressSearch = (props) => {
             .value();
     };
 
+    const validateAddressComponents = (addressComponents) => {
+        if (!addressComponents) {
+            return false;
+        }
+        if (!_.some(addressComponents, component => _.includes(component.types, 'street_number'))) {
+            // No Street number
+            return false;
+        }
+        if (_.some(addressComponents, component => _.includes(component.types, 'post_box'))) {
+            // PO box
+            return false;
+        }
+        return true;
+    };
+
     const saveLocationDetails = (details) => {
-        if (details.address_components) {
+        if (validateAddressComponents(details.address_components)) {
             // Gather the values from the Google details
             const streetNumber = getAddressComponent(details, 'street_number', 'long_name');
             const streetName = getAddressComponent(details, 'route', 'long_name');
@@ -61,6 +76,12 @@ const AddressSearch = (props) => {
             props.onChangeText('addressCity', city);
             props.onChangeText('addressState', state);
             props.onChangeText('addressZipCode', zipCode);
+        } else {
+            // Clear the values associated to the address, so our validations catch the problem
+            props.onChangeText('addressStreet', null);
+            props.onChangeText('addressCity', null);
+            props.onChangeText('addressState', null);
+            props.onChangeText('addressZipCode', null);
         }
     };
 
@@ -75,6 +96,7 @@ const AddressSearch = (props) => {
                 key: 'AIzaSyC4axhhXtpiS-WozJEsmlL3Kg3kXucbZus',
                 language: props.preferredLocale,
                 types: 'address',
+                components: 'country:us',
             }}
             requestUrl={{
                 useOnPlatform: 'web',


### PR DESCRIPTION
### Details

We were getting results that were not full addresses from the google places API. An example of this is a "premise" type of result, which has the street name and number missing. i.e. search "88 Kearney Street", there are results that will cause the bug.

Adding this new parameter will prevent us from getting this kind of result and we only get full addresses:

https://developers.google.com/maps/documentation/places/web-service/supported_types#table3

As @roryabraham pointed up here (great catch!): https://github.com/Expensify/App/issues/5840#issuecomment-943556452, it is not enough to add `types: 'address'`. Using this we can still get results that are 'routes', which don't have a street number.

To fix this, I added the function `validateAddressComponents` to verify the `address_components` checking point (2) and (3) in @roryabraham 's suggestions https://github.com/Expensify/App/issues/5840#issuecomment-943580068 (thanks again 😝 )

If we `validateAddressComponents` we nullify the values `addressStreet`, `addressCity`, `addressState`, `addressZipCode` so our form regular validations will trigger on submit. If we don't nullify, we would keep the old values while showing the user something different in the UI.

I didn't try to set any error from the `AddressSearch` because our approach so far has been that the form validation and setting errors is a responsibility of the form and not the individual input components.

I think it is acceptable to do this verification here as it can be analog to verifying the format of a date in a date input. If the date format is totally wrong, the date input component would reject the date and call on change with undefined or null.



### Fixed Issues
$ https://github.com/Expensify/App/issues/5840

### Tests / QA

1. Create a NewDot account, verify it, log in
2. Create a workspace and start adding a VBA
3. Use information in (3) from this [SO](https://stackoverflow.com/c/expensify/a/525/419) in the first step (Connect bank account)
4. You should be in "Company information" step
5. Input "88 Kearney Street" in "Company address" field and click the "88 Kearny Street, San Francisco, CA, USA" result
6. Click "Save & continue"
7. Expected result: the "Company address" field should not have any error (is valid) ![Screen Shot 2021-10-14 at 12 41 50 PM](https://user-images.githubusercontent.com/87341702/137384767-8fa5e482-2f5b-425e-bbd6-a459fc3c0c39.png)
8. Refresh the page, make sure the url is "/bank-account/company"
9. Expected result: the "Company address" field should have the correct information (no undefined text in between)![Screen Shot 2021-10-14 at 12 42 23 PM](https://user-images.githubusercontent.com/87341702/137384851-a4f3b727-e440-4ba3-b441-8f8f5b75d9af.png)
10. Input "25220 Quail Ridge Road, Escondido, CA 97027" and select the "Quail Ridge Road, Escondido, CA, USA" result
11. Click "Save & continue"
12. Expected result: the "Company address" field should have the error
![Screen Shot 2021-10-14 at 12 40 11 PM](https://user-images.githubusercontent.com/87341702/137384523-7856dc56-c431-4014-8372-d9cc3d443868.png)
because the selected result is missing the street number.
13. Refresh the page, make sure the url is "/bank-account/company"
14. Expected result: the "Company address" field should be empty
![Screen Shot 2021-10-14 at 12 41 17 PM](https://user-images.githubusercontent.com/87341702/137384671-c33cfeda-27e1-469e-b78b-55ab09e94ad9.png)


### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
