### PR TITLE
Remove pointer events from label, modify styling of textinput

### DIFF
--- a/src/components/ExpensiTextInput/ExpensiTextInputLabel/index.js
+++ b/src/components/ExpensiTextInput/ExpensiTextInputLabel/index.js
@@ -19,7 +19,7 @@ const ExpensiTextInputLabel = ({
                 labelScale,
             ),
         ]}
-        selectable={false}
+        pointerEvents='none'
     >
         {label}
     </Animated.Text>

--- a/src/components/ExpensiTextInput/ExpensiTextInputLabel/index.js
+++ b/src/components/ExpensiTextInput/ExpensiTextInputLabel/index.js
@@ -19,7 +19,7 @@ const ExpensiTextInputLabel = ({
                 labelScale,
             ),
         ]}
-        pointerEvents='none'
+        pointerEvents="none"
     >
         {label}
     </Animated.Text>

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -517,7 +517,6 @@ const styles = {
         color: themeColors.textSupporting,
         fontFamily: fontFamily.GTA,
         width: '100%',
-        zIndex: -1,
     },
     expensiTextInputLabelDesktop: {
         transformOrigin: 'left center',
@@ -533,10 +532,11 @@ const styles = {
         fontFamily: fontFamily.GTA,
         fontSize: variables.fontSizeNormal,
         color: themeColors.text,
-        ...spacing.pv0,
+        height: '100%',
         paddingTop: 25,
         paddingBottom: 8,
         paddingHorizontal: 11.5,
+        borderRadius: variables.componentBorderRadiusNormal,
     },
     expensiTextInputDesktop: addOutlineWidth({}, 0),
     expensiTextInputAndroid: left => ({


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
@parasharrajat @marcaaron 
### Details
<!-- Explanation of the change or anything fishy that is going on -->
To fix the initial issue of the label being able to be selected and to loose focus when clicking on it, I set the prop `pointerEvents` to `none`. This allows to remove the `zIndex` prop, and I also removed the `selectable` prop since it has no use now.

> Pretty sure this caused a regression with labels on autofilled forms. Since they have a `z-index` of `-1` they're now hidden <img alt="2021-10-13_13-35-13" width="371" src="https://user-images.githubusercontent.com/32969087/137226928-88b618a0-1aa7-4912-bf56-6c6ea652e4a2.png">
> 
> The autofill also expands beyond the edges but unsure if that was introduced in this PR.


For the issue where the autofill expands beyond the edges, I don't think it was related with the changes I made since I tested it with the same props that had before and actually the result was this:
<img width="198" alt="autofill style" src="https://user-images.githubusercontent.com/53409604/137397540-a55d45cf-6279-4f90-a2b9-ee9e2dab69a1.png">

But I passed the `borderRadius` from the container to the `TextInput` and added a `height` since if no height is set, the blue background overlaps the border from the container. Also removed the `...spacing.pv0` because it has `paddings` props so it had no use.


### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/4515 
$ https://github.com/Expensify/App/pull/5704

### Tested On

- [x] Web
- [ ] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android

### Screenshots

#### Android
![android](https://user-images.githubusercontent.com/53409604/137403263-78a1c14c-eb88-47c0-a2e1-e9c771e8d125.png)

#### iOS
![ios](https://user-images.githubusercontent.com/53409604/137403305-fbad6dd4-935a-4ba5-8d39-5f388aa3371d.png)

#### Desktop
<img width="2048" alt="Desktop" src="https://user-images.githubusercontent.com/53409604/137403091-32a5f3e2-dcab-4c3e-b50e-2ceb3a3095a9.png">

#### Web
<img width="2048" alt="Web" src="https://user-images.githubusercontent.com/53409604/137403096-428674c4-e6ac-4e82-973e-bd01177f5d0e.png">


