### PR TITLE
Load policy list when url from Linking.getInitialURL is not available

### DIFF
--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -170,6 +170,7 @@ class AuthScreens extends React.Component {
         // Load policies, maybe creating a new policy first.
         Linking.getInitialURL()
             .then((url) => {
+                // url is null on mobile unless the app was opened via a deeplink
                 if (url) {
                     const path = new URL(url).pathname;
                     const exitTo = new URLSearchParams(url).get('exitTo');

--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -170,10 +170,14 @@ class AuthScreens extends React.Component {
         // Load policies, maybe creating a new policy first.
         Linking.getInitialURL()
             .then((url) => {
-                const path = new URL(url).pathname;
-                const exitTo = new URLSearchParams(url).get('exitTo');
-                const shouldCreateFreePolicy = Str.startsWith(path, Str.normalizeUrl(ROUTES.LOGIN_WITH_SHORT_LIVED_TOKEN)) && exitTo === ROUTES.WORKSPACE_NEW;
-                getPolicyList(shouldCreateFreePolicy);
+                if (url) {
+                    const path = new URL(url).pathname;
+                    const exitTo = new URLSearchParams(url).get('exitTo');
+                    const shouldCreateFreePolicy = Str.startsWith(path, Str.normalizeUrl(ROUTES.LOGIN_WITH_SHORT_LIVED_TOKEN)) && exitTo === ROUTES.WORKSPACE_NEW;
+                    getPolicyList(shouldCreateFreePolicy);
+                } else {
+                    getPolicyList(false);
+                }
             });
 
         // Refresh the personal details, timezone and betas every 30 minutes


### PR DESCRIPTION
### Details

The `url` parameter is `null` when passed to our callback (see `Linking.getInitialURL`) when we open NewDot without using deeplink.

See slack conversation https://expensify.slack.com/archives/C9YU7BX5M/p1634263597215200?thread_ts=1634173120.171900&cid=C9YU7BX5M

Not sure if this is a good solution or if it could have some unwanted side effect. @roryabraham cc

### Fixed Issues
$ https://github.com/Expensify/App/issues/5865

### Tests / QA

1. Create an account in OldDot in web
2. Create a Free group policy in OldDot -> this will create a new Workspace in NewDot 
3. Do that a few times (3 times? :) )
4. Log out of NewDot
5. Log in in new Dot
6. You should see the 3? workspaces you created

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
