### PR TITLE
[No QA] Quick copy update to the VBANoECard message

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -652,7 +652,7 @@ export default {
             header: 'Unlock free Expensify Cards',
             headerWithEcard: 'Cards are ready!',
             noVBACopy: 'Connect a bank account to issue unlimited Expensify Cards for your workspace members and access all of these incredible benefits:',
-            VBANoECardCopy: 'Issue unlimited Expensify Cards for your workspace members, as well as all of these incredible benefits:',
+            VBANoECardCopy: 'Add a work email address to issue unlimited Expensify Cards for your workspace members, as well as all of these incredible benefits:',
             conciergeCanHelp: 'Concierge can help you add a work email address to enable the Expensify Card.',
             VBAWithECardCopy: 'Enjoy all these incredible benefits:',
             benefit1: 'Up to 2% cash back',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -654,7 +654,7 @@ export default {
             header: 'Desbloquea Tarjetas Expensify gratis',
             headerWithEcard: '¡Tus tarjetas están listas!',
             noVBACopy: 'Conecta una cuenta bancaria para emitir Tarjetas Expensify ilimitadas para los miembros de tu espacio de trabajo y acceder a todas estas increíbles ventajas:',
-            VBANoECardCopy: 'Emite Tarjetas Expensify ilimitadas para los miembros de tu espacio de trabajo y accede a todas estas increíbles ventajas:',
+            VBANoECardCopy: 'Agrega tu correo electrónico de trabajo para emitir Tarjetas Expensify ilimitadas para los miembros de tu espacio de trabajo y acceder a todas estas increíbles ventajas:',
             conciergeCanHelp: 'Concierge te puede ayudar a añadir un correo electrónico de trabajo para activar la Tarjeta Expensify.',
             VBAWithECardCopy: 'Disfruta de todas estas increíbles ventajas:',
             benefit1: 'Hasta un 2% de devolución en tus gastos',


### PR DESCRIPTION
### Details
The copy is wrong in the `VBANoECard` message scenario, it should read: `Add a work email address to issue unlimited Expensify Cards for your workspace members, as well as all of these incredible benefits:`

I've also updated the Spanish based on [this thread](https://expensify.slack.com/archives/C21FRDWCV/p1634296904078900). 

### Fixed Issues

$ https://github.com/Expensify/Expensify/issues/181178

### Tests
None

### QA Steps
1. Sign-up to NewDot with a public email address
2. Click the `+` icon and `New workspace` 
3. Click `connect bank account` and `connect manually`
4. Add a VBA ([#2](https://stackoverflow.com/c/expensify/questions/342/525#525) in this SO)
4. Validate the three amounts to complete the flow
5. Verify that this copy is displayed on the `Issue corporate cards` page of the workspace editor:

> Header: Unlock free Expensify Cards
> Copy: Add a work email address to issue unlimited Expensify Cards for your workspace members, as well as all of these incredible benefits:
> 
> - Up to 2% cash back
> - Digital and physical cards
> - No personal liability
> - Customizable limits
> 
> Concierge can help you add a work email address to enable the Expensify Card.
> Button: [Chat with Concierge]

### Tested On
None
