### PR TITLE
[WIP] check if Onyx is ready when app is authenticating

### DIFF
--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -17,10 +17,17 @@ Onyx.connect({
     callback: val => credentials = val,
 });
 
+let isOnyxReady = false;
 let authToken;
 Onyx.connect({
     key: ONYXKEYS.SESSION,
-    callback: val => authToken = val ? val.authToken : null,
+    callback: val => setTimeout(() => { // TODO: remove setTimeout
+    // callback: (val) => {
+        authToken = val ? val.authToken : null;
+        isOnyxReady = true;
+
+    // },
+    }, 1000),
 });
 
 /**
@@ -80,7 +87,14 @@ function addDefaultValuesToParameters(command, parameters) {
 }
 
 // Tie into the network layer to add auth token to the parameters of all requests
-Network.registerParameterEnhancer(addDefaultValuesToParameters);
+Network.registerParameterEnhancer((command, parameters) => {
+    if (isOnyxReady) {
+        return addDefaultValuesToParameters(command, parameters);
+    }
+
+    // TODO: log this to the server
+    console.debug(`Onyx is not ready in Network.registerParameterEnhancer with command '${command}'`);
+});
 
 /**
  * @throws {Error} If the "parameters" object has a null or undefined value for any of the given parameterNames


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Problem
<!-- Explanation of the change or anything fishy that is going on -->

There's an [issue](https://github.com/Expensify/App/issues/5619) on Android where the user is logged out randomly. We're not 100% sure about the root cause, but one possibility is the existence of a race condition between the async storage and the networks requests; the `Onyx.connect` callback to retrieve the stored `authToken` could be called after the `Network.registerParameterEnhancer` callbacks (which adds the `authToken` in the requests) and if the `authToken` is not ready when a request is made then the user is logged out.

I was able to reproduce this scenario by adding a `setTimeout` in the `Onyx.connect` callback (more details in this [comment](https://github.com/Expensify/App/issues/5619#issuecomment-941751331)):

https://user-images.githubusercontent.com/6829422/137043249-89fe6943-ce38-452e-8704-a509d5ebdcef.mov

### Proposed workaround and solution

I think the long-term solution should be a restructuring of the handling between the async storage and the network layer in order to wait first for the async storage (Onyx) to be resolved to then set up the network layer.

But since we're only 100% sure if this race condition exists and is the cause of the random logout I propose to add a flag to check if `authToken` is ready from Onyx and log to the server a message if the race condition happens. This flag also skips adding the default parameters when Onyx is not ready; in that way, we avoid making a request without the `authToken` (which hasn't been retrieved from Onyx) and thus avoid logging out the user. 

If the race condition exists, the message `Onyx is not ready in Network.registerParameterEnhancer` is logged to the server, so with that can be sure that:

- A. Onyx not being ready could be the real issue and will require restructuring the app bootstrapping to wait first for Onyx to be ready before making any network request.

&nbsp;&nbsp;or 

- B. If the random logout is still happening and the message is not found in the logs we ensure that a delay in `Onyx.connect` is not the culprit of the random logout.

---

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/5619

### Tests
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
