### PR TITLE
Fix: Modal and screen closing with single `esacpe` keypress

### DIFF
--- a/src/components/Modal/BaseModal.js
+++ b/src/components/Modal/BaseModal.js
@@ -39,7 +39,7 @@ class BaseModal extends PureComponent {
      */
     hideModal(callHideCallback = true) {
         if (this.props.shouldSetModalVisibility) {
-            setModalVisibility(false);
+            setModalVisibility(false, true);
         }
         if (callHideCallback) {
             this.props.onModalHide();
@@ -79,7 +79,7 @@ class BaseModal extends PureComponent {
                 onBackButtonPress={this.props.onClose}
                 onModalShow={() => {
                     if (this.props.shouldSetModalVisibility) {
-                        setModalVisibility(true);
+                        setModalVisibility(true, true);
                     }
                     this.props.onModalShow();
                 }}

--- a/src/components/Modal/BaseModal.js
+++ b/src/components/Modal/BaseModal.js
@@ -7,7 +7,7 @@ import styles, {getModalPaddingStyles, getSafeAreaPadding} from '../../styles/st
 import themeColors from '../../styles/themes/default';
 import {propTypes as modalPropTypes, defaultProps as modalDefaultProps} from './ModalPropTypes';
 import getModalStyles from '../../styles/getModalStyles';
-import {setModalVisibility} from '../../libs/actions/Modal';
+import {setModalVisibility, willAlertModalBecomeVisible} from '../../libs/actions/Modal';
 
 const propTypes = {
     ...modalPropTypes,
@@ -26,6 +26,12 @@ class BaseModal extends PureComponent {
         super(props);
 
         this.hideModal = this.hideModal.bind(this);
+    }
+
+    componentDidUpdate(prevProps) {
+        if (prevProps.isVisible !== this.props.isVisible) {
+            willAlertModalBecomeVisible(this.props.isVisible);
+        }
     }
 
     componentWillUnmount() {

--- a/src/components/Modal/BaseModal.js
+++ b/src/components/Modal/BaseModal.js
@@ -45,7 +45,7 @@ class BaseModal extends PureComponent {
      */
     hideModal(callHideCallback = true) {
         if (this.props.shouldSetModalVisibility) {
-            setModalVisibility(false, true);
+            setModalVisibility(false);
         }
         if (callHideCallback) {
             this.props.onModalHide();
@@ -85,7 +85,7 @@ class BaseModal extends PureComponent {
                 onBackButtonPress={this.props.onClose}
                 onModalShow={() => {
                     if (this.props.shouldSetModalVisibility) {
-                        setModalVisibility(true, true);
+                        setModalVisibility(true);
                     }
                     this.props.onModalShow();
                 }}

--- a/src/components/ScreenWrapper.js
+++ b/src/components/ScreenWrapper.js
@@ -40,8 +40,8 @@ const propTypes = {
 
     /** Details about any modals being used */
     modal: PropTypes.shape({
-        /** Indicates if there is a modal currently visible or not */
-        isVisible: PropTypes.bool,
+        /** Indicates if there is a Alert modal currently visible or not */
+        isAlertModalVisible: PropTypes.bool,
     }),
 
 };
@@ -67,7 +67,7 @@ class ScreenWrapper extends React.Component {
 
     componentDidMount() {
         this.unsubscribeEscapeKey = KeyboardShortcut.subscribe('Escape', () => {
-            if (!this.props.modal.isVisible) {
+            if (!this.props.modal.isAlertModalVisible) {
                 Navigation.dismissModal();
             }
         }, [], true);
@@ -88,6 +88,7 @@ class ScreenWrapper extends React.Component {
     }
 
     render() {
+        console.debug('modal visibility', this.props.modal.isAlertModalVisible);
         return (
             <SafeAreaInsetsContext.Consumer>
                 {(insets) => {

--- a/src/components/ScreenWrapper.js
+++ b/src/components/ScreenWrapper.js
@@ -41,7 +41,7 @@ const propTypes = {
     /** Details about any modals being used */
     modal: PropTypes.shape({
         /** Indicates if there is a Alert modal currently visible or not */
-        isAlertModalVisible: PropTypes.bool,
+        willAlertModalBecomeVisible: PropTypes.bool,
     }),
 
 };
@@ -67,7 +67,7 @@ class ScreenWrapper extends React.Component {
 
     componentDidMount() {
         this.unsubscribeEscapeKey = KeyboardShortcut.subscribe('Escape', () => {
-            if (!this.props.modal.isAlertModalVisible) {
+            if (!this.props.modal.willAlertModalBecomeVisible) {
                 Navigation.dismissModal();
             }
         }, [], true);
@@ -88,7 +88,7 @@ class ScreenWrapper extends React.Component {
     }
 
     render() {
-        console.debug('modal visibility', this.props.modal.isAlertModalVisible);
+        console.debug('modal visibility', this.props.modal.willAlertModalBecomeVisible);
         return (
             <SafeAreaInsetsContext.Consumer>
                 {(insets) => {

--- a/src/components/ScreenWrapper.js
+++ b/src/components/ScreenWrapper.js
@@ -4,11 +4,14 @@ import PropTypes from 'prop-types';
 import {View} from 'react-native';
 import {withNavigation} from '@react-navigation/compat';
 import {SafeAreaInsetsContext} from 'react-native-safe-area-context';
+import {withOnyx} from 'react-native-onyx';
 import styles, {getSafeAreaPadding} from '../styles/styles';
 import HeaderGap from './HeaderGap';
 import KeyboardShortcut from '../libs/KeyboardShortcut';
 import onScreenTransitionEnd from '../libs/onScreenTransitionEnd';
 import Navigation from '../libs/Navigation/Navigation';
+import compose from '../libs/compose';
+import ONYXKEYS from '../ONYXKEYS';
 
 const propTypes = {
     /** Array of additional styles to add */
@@ -34,6 +37,13 @@ const propTypes = {
         // Method to attach listener to Navigation state.
         addListener: PropTypes.func.isRequired,
     }),
+
+    /** Details about any modals being used */
+    modal: PropTypes.shape({
+        /** Indicates if there is a modal currently visible or not */
+        isVisible: PropTypes.bool,
+    }),
+
 };
 
 const defaultProps = {
@@ -44,6 +54,7 @@ const defaultProps = {
     navigation: {
         addListener: () => {},
     },
+    modal: {},
 };
 
 class ScreenWrapper extends React.Component {
@@ -56,7 +67,9 @@ class ScreenWrapper extends React.Component {
 
     componentDidMount() {
         this.unsubscribeEscapeKey = KeyboardShortcut.subscribe('Escape', () => {
-            Navigation.dismissModal();
+            if (!this.props.modal.isVisible) {
+                Navigation.dismissModal();
+            }
         }, [], true);
 
         this.unsubscribeTransitionEnd = onScreenTransitionEnd(this.props.navigation, () => {
@@ -116,4 +129,11 @@ class ScreenWrapper extends React.Component {
 ScreenWrapper.propTypes = propTypes;
 ScreenWrapper.defaultProps = defaultProps;
 ScreenWrapper.displayName = 'ScreenWrapper';
-export default withNavigation(ScreenWrapper);
+export default compose(
+    withNavigation,
+    withOnyx({
+        modal: {
+            key: ONYXKEYS.MODAL,
+        },
+    }),
+)(ScreenWrapper);

--- a/src/components/ScreenWrapper.js
+++ b/src/components/ScreenWrapper.js
@@ -40,7 +40,7 @@ const propTypes = {
 
     /** Details about any modals being used */
     modal: PropTypes.shape({
-        /** Indicates if there is a Alert modal currently visible or not */
+        /** Indicates when an Alert modal is about to be visible */
         willAlertModalBecomeVisible: PropTypes.bool,
     }),
 
@@ -88,7 +88,6 @@ class ScreenWrapper extends React.Component {
     }
 
     render() {
-        console.debug('modal visibility', this.props.modal.willAlertModalBecomeVisible);
         return (
             <SafeAreaInsetsContext.Consumer>
                 {(insets) => {

--- a/src/libs/actions/Modal.js
+++ b/src/libs/actions/Modal.js
@@ -4,10 +4,11 @@ import ONYXKEYS from '../../ONYXKEYS';
 /**
  * Allows other parts of the app to know when a modal has been opened or closed
  *
- * @param {bool} isVisible
+ * @param {Boolean} isVisible
+ * @param {Boolean} isAlert
  */
-function setModalVisibility(isVisible) {
-    Onyx.merge(ONYXKEYS.MODAL, {isVisible});
+function setModalVisibility(isVisible, isAlert) {
+    Onyx.merge(ONYXKEYS.MODAL, {isVisible, isAlertModalVisible: isAlert ? isVisible : false});
 }
 
 export {

--- a/src/libs/actions/Modal.js
+++ b/src/libs/actions/Modal.js
@@ -5,13 +5,22 @@ import ONYXKEYS from '../../ONYXKEYS';
  * Allows other parts of the app to know when a modal has been opened or closed
  *
  * @param {Boolean} isVisible
- * @param {Boolean} isAlert
  */
-function setModalVisibility(isVisible, isAlert) {
-    Onyx.merge(ONYXKEYS.MODAL, {isVisible, isAlertModalVisible: isAlert ? isVisible : false});
+function setModalVisibility(isVisible) {
+    Onyx.merge(ONYXKEYS.MODAL, {isVisible});
+}
+
+/**
+ * Allows other parts of app to know that an alert modal is about to open.
+ * This will trigger as soon as a modal is opened but not yet visible while animation is running.
+ *
+ * @param {Boolean} isVisible
+ */
+function willAlertModalBecomeVisible(isVisible) {
+    Onyx.merge(ONYXKEYS.MODAL, {willAlertModalBecomeVisible: isVisible});
 }
 
 export {
-    // eslint-disable-next-line import/prefer-default-export
     setModalVisibility,
+    willAlertModalBecomeVisible,
 };


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/5769

### Tests | QA Steps

1. Navigate to Workspace settings on the web.
2. Navigate to members
3. Check one from the list of members and click on the remove button.
4. Once the remove modal appears, press the `esc` button.
5. Only Confirm modal should close.
6. Press Esc again.
7. Now the Settings Modal should close.


### Tested On

- [x] Web
- [ ] Mobile Web [No Escape key]
- [x] Desktop
- [ ] iOS [No Escape key]
- [ ] Android [No Escape key]

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web | Desktop
<!-- Insert screenshots of your changes on the web platform-->

https://user-images.githubusercontent.com/24370807/137516779-ce4417d9-6607-47a6-9382-b9481e6bb942.mp4



#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
