### PR TITLE
Workspace Settings page - Fix offline behavior

### DIFF
--- a/src/pages/workspace/WorkspaceSettingsPage.js
+++ b/src/pages/workspace/WorkspaceSettingsPage.js
@@ -105,19 +105,16 @@ class WorkspaceSettingsPage extends React.Component {
     }
 
     submit() {
-        Policy.updateLocalPolicyValues(this.props.policy.id, {isPolicyUpdating: true});
+        const name = this.state.name.trim();
+        const avatarURL = this.state.avatarURL;
+        const outputCurrency = this.state.currency;
+        Policy.updateLocalPolicyValues(this.props.policy.id, {name, avatarURL, outputCurrency});
 
         // Wait for the upload avatar promise to finish before updating the policy
         this.uploadAvatarPromise.then(() => {
-            const name = this.state.name.trim();
-            const avatarURL = this.state.avatarURL;
-            const policyID = this.props.policy.id;
-            const currency = this.state.currency;
-
-            Policy.update(policyID, {name, avatarURL, outputCurrency: currency}, true);
-        }).catch(() => {
-            Policy.updateLocalPolicyValues(this.props.policy.id, {isPolicyUpdating: false});
+            Policy.update(this.props.policy.id, {name, avatarURL, outputCurrency});
         });
+        Growl.success(this.props.translate('workspace.common.growlMessageOnSave'));
     }
 
     render() {


### PR DESCRIPTION
Previously, when clicking "Save" on the workspace settings page, we'd only update Onyx after the promise to the `UpdatePolicy` API command resolved. When this happened offline, the promise would never resolve, meaning we'd never update `isPolicyUpdating` for the policy in Onyx, leading to a confusing infinite spinner.

Let's update the local values directly for the workspace and queue the API request in the background. This means that the local values will be updated while offline, and the queued API command will be made once the user goes back online.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/180965

### Tests
1. Navigate to the "Workspace Settings" page.
2. Turn off your internet connection for the device you're using.
3. Update the currency and name for the workspace. Click "Save".
4. Verify a success growl appears. Then, turn your internet connection back on.
5. Reload the page or re-open the app. 
6. Verify that the updated currency, avatarURL, and name are displayed.

### QA Steps
1. Navigate to the "Workspace Settings" page.
2. Turn off your internet connection for the device you're using.
3. Update the currency and name for the workspace. Click "Save".
4. Verify a success growl appears. Then, turn your internet connection back on, and give the app a few seconds to make any failed API calls that were queued offline.
5. Reload the page or close/re-open the app. 
6. Verify that the updated currency, avatarURL, and name are displayed.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web
https://user-images.githubusercontent.com/31285285/137764691-6abb61f3-a572-4e90-a625-6ea3725b667e.mp4

#### Mobile Web
https://user-images.githubusercontent.com/31285285/137764740-4f8c4aeb-2915-41d8-8653-efccc43ef04c.mov

#### Desktop
https://user-images.githubusercontent.com/31285285/137764785-b5d45566-30ae-4dfc-91bf-bc1a4e80663d.mp4

#### iOS
https://user-images.githubusercontent.com/31285285/137764896-b7360def-4fe4-4c60-9412-4990c07126f6.mp4

#### Android
https://user-images.githubusercontent.com/31285285/137768599-0e466780-86b0-4630-a536-7c835405245d.mp4


