### PR TITLE
Make sure we go to settings page rather than card route when creating a new workspace

### DIFF
--- a/src/libs/actions/Policy.js
+++ b/src/libs/actions/Policy.js
@@ -127,7 +127,7 @@ function create(name = '', shouldAutomaticallyReroute = true) {
             const policyID = lodashGet(res, 'policyID');
             if (shouldAutomaticallyReroute) {
                 Navigation.dismissModal();
-                Navigation.navigate(policyID ? ROUTES.getWorkspaceCardRoute(policyID) : ROUTES.HOME);
+                Navigation.navigate(policyID ? ROUTES.getWorkspaceInitialRoute(policyID) : ROUTES.HOME);
             }
             return Promise.resolve(policyID);
         });


### PR DESCRIPTION
@TomatoToaster please review

### Details
We were navigating to the card route but as @MitchExpensify says [here](https://expensify.slack.com/archives/C9YU7BX5M/p1634342727263500?thread_ts=1634332838.256400&cid=C9YU7BX5M) it should be navigating to the Workspace editor page.

### Fixed Issues
None

### Tests
1. Log into a NewDot account without a Workspace
2. Click on Create New Workspace after clicking on the green `+` at the bottom left
3. Verify a workspace is created and you are taken to the settings page