### PR TITLE
Place incorporation date and state fields in the Company information form on separate rows to avoid overflowing labels

### DIFF
--- a/src/pages/ReimbursementAccount/CompanyStep.js
+++ b/src/pages/ReimbursementAccount/CompanyStep.js
@@ -250,25 +250,23 @@ class CompanyStep extends React.Component {
                             hasError={this.getErrors().incorporationType}
                         />
                     </View>
-                    <View style={[styles.flexRow, styles.mt4]}>
-                        <View style={[styles.flex1, styles.mr2]}>
-                            <DatePicker
-                                label={this.props.translate('companyStep.incorporationDate')}
-                                onChange={value => this.clearErrorAndSetValue('incorporationDate', value)}
-                                value={this.state.incorporationDate}
-                                placeholder={this.props.translate('companyStep.incorporationDatePlaceholder')}
-                                errorText={this.getErrorText('incorporationDate')}
-                                translateX={-14}
-                            />
-                        </View>
-                        <View style={[styles.flex1]}>
-                            <StatePicker
-                                label={this.props.translate('companyStep.incorporationState')}
-                                onChange={value => this.clearErrorAndSetValue('incorporationState', value)}
-                                value={this.state.incorporationState}
-                                hasError={this.getErrors().incorporationState}
-                            />
-                        </View>
+                    <View style={styles.mt4}>
+                        <DatePicker
+                            label={this.props.translate('companyStep.incorporationDate')}
+                            onChange={value => this.clearErrorAndSetValue('incorporationDate', value)}
+                            value={this.state.incorporationDate}
+                            placeholder={this.props.translate('companyStep.incorporationDatePlaceholder')}
+                            errorText={this.getErrorText('incorporationDate')}
+                            translateX={-14}
+                        />
+                    </View>
+                    <View style={styles.mt4}>
+                        <StatePicker
+                            label={this.props.translate('companyStep.incorporationState')}
+                            onChange={value => this.clearErrorAndSetValue('incorporationState', value)}
+                            value={this.state.incorporationState}
+                            hasError={this.getErrors().incorporationState}
+                        />
                     </View>
                     <CheckboxWithLabel
                         isChecked={this.state.hasNoConnectionToCannabis}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Fix the overflowing labels for the Spanish translations of the `Incorporation date` and `Incorporation state` by having each field on a separate row instead of on the same row.

![Screen Shot 2021-10-18 at 12 21 41 PM](https://user-images.githubusercontent.com/12268372/137697956-e15b034e-a378-403d-a427-d286c90728dd.png)


### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
(Partially fixes) https://github.com/Expensify/App/issues/5904 

### Tests/ QA Steps

1. Change language preference to Spanish by going to profile > preferences > language
2. Navigate to the Company information step of the bank account flow by going to `/bank-account/company` or Workspace > Connect bank account
3. Verify that the labels for the date and state picker are clearly visible

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web

![Screen Shot 2021-10-18 at 12 17 08 PM](https://user-images.githubusercontent.com/12268372/137697081-cc7ca79a-a957-4d8c-b3de-cbc30ee9c6e1.png)

#### Mobile Web

![Screen Shot 2021-10-18 at 12 36 35 PM](https://user-images.githubusercontent.com/12268372/137697146-18f72d3e-0f22-476c-abb7-e98794e3c36a.png)

#### Desktop

![Screen Shot 2021-10-18 at 12 40 42 PM](https://user-images.githubusercontent.com/12268372/137697898-c2ba8168-4bd4-420c-a495-61fc0d799009.png)

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
