### PR TITLE
[NO-QA] Refactor duplicated personalDetailsPropTypes

### DIFF
--- a/src/pages/NewChatPage.js
+++ b/src/pages/NewChatPage.js
@@ -16,27 +16,14 @@ import ScreenWrapper from '../components/ScreenWrapper';
 import FullScreenLoadingIndicator from '../components/FullscreenLoadingIndicator';
 import withLocalize, {withLocalizePropTypes} from '../components/withLocalize';
 import compose from '../libs/compose';
-
-const personalDetailsPropTypes = PropTypes.shape({
-    /** The login of the person (either email or phone number) */
-    login: PropTypes.string.isRequired,
-
-    /** The URL of the person's avatar (there should already be a default avatar if
-    the person doesn't have their own avatar uploaded yet) */
-    avatar: PropTypes.string.isRequired,
-
-    /** This is either the user's full name, or their login if full name is an empty string */
-    displayName: PropTypes.string.isRequired,
-
-    ...withLocalizePropTypes,
-});
+import personalDetailsPropType from './personalDetailsPropType';
 
 const propTypes = {
     /** Beta features list */
     betas: PropTypes.arrayOf(PropTypes.string).isRequired,
-
-    /** All of the personal details for everyone */
-    personalDetails: PropTypes.objectOf(personalDetailsPropTypes).isRequired,
+    
+    /** The personal details of the person who is logged in */
+    personalDetails: personalDetailsPropType.isRequired,
 
     /** All reports shared with the user */
     reports: PropTypes.shape({
@@ -50,6 +37,8 @@ const propTypes = {
     }).isRequired,
 
     ...windowDimensionsPropTypes,
+
+    ...withLocalizePropTypes,
 };
 
 class NewChatPage extends Component {

--- a/src/pages/NewChatPage.js
+++ b/src/pages/NewChatPage.js
@@ -22,7 +22,7 @@ const propTypes = {
     /** Beta features list */
     betas: PropTypes.arrayOf(PropTypes.string).isRequired,
     
-    /** The personal details of the person who is logged in */
+    /** All of the personal details for everyone */
     personalDetails: personalDetailsPropType.isRequired,
 
     /** All reports shared with the user */

--- a/src/pages/NewChatPage.js
+++ b/src/pages/NewChatPage.js
@@ -21,7 +21,7 @@ import personalDetailsPropType from './personalDetailsPropType';
 const propTypes = {
     /** Beta features list */
     betas: PropTypes.arrayOf(PropTypes.string).isRequired,
-    
+
     /** All of the personal details for everyone */
     personalDetails: personalDetailsPropType.isRequired,
 

--- a/src/pages/NewGroupPage.js
+++ b/src/pages/NewGroupPage.js
@@ -19,25 +19,14 @@ import compose from '../libs/compose';
 import Button from '../components/Button';
 import KeyboardAvoidingView from '../components/KeyboardAvoidingView';
 import FixedFooter from '../components/FixedFooter';
-
-const personalDetailsPropTypes = PropTypes.shape({
-    /** The login of the person (either email or phone number) */
-    login: PropTypes.string.isRequired,
-
-    /** The URL of the person's avatar (there should already be a default avatar if
-    the person doesn't have their own avatar uploaded yet) */
-    avatar: PropTypes.string.isRequired,
-
-    /** This is either the user's full name, or their login if full name is an empty string */
-    displayName: PropTypes.string.isRequired,
-});
+import personalDetailsPropType from './personalDetailsPropType';
 
 const propTypes = {
     /** Beta features list */
     betas: PropTypes.arrayOf(PropTypes.string).isRequired,
 
     /** All of the personal details for everyone */
-    personalDetails: PropTypes.objectOf(personalDetailsPropTypes).isRequired,
+    personalDetails: personalDetailsPropType.isRequired,
 
     /** All reports shared with the user */
     reports: PropTypes.shape({

--- a/src/pages/SearchPage.js
+++ b/src/pages/SearchPage.js
@@ -19,18 +19,7 @@ import CONST from '../CONST';
 import FullScreenLoadingIndicator from '../components/FullscreenLoadingIndicator';
 import withLocalize, {withLocalizePropTypes} from '../components/withLocalize';
 import compose from '../libs/compose';
-
-const personalDetailsPropTypes = PropTypes.shape({
-    /** The login of the person (either email or phone number) */
-    login: PropTypes.string.isRequired,
-
-    /** The URL of the person's avatar (there should already be a default avatar if
-    the person doesn't have their own avatar uploaded yet) */
-    avatar: PropTypes.string.isRequired,
-
-    /** This is either the user's full name, or their login if full name is an empty string */
-    displayName: PropTypes.string.isRequired,
-});
+import personalDetailsPropType from './personalDetailsPropType';
 
 const propTypes = {
     /* Onyx Props */
@@ -39,7 +28,7 @@ const propTypes = {
     betas: PropTypes.arrayOf(PropTypes.string).isRequired,
 
     /** All of the personal details for everyone */
-    personalDetails: PropTypes.objectOf(personalDetailsPropTypes).isRequired,
+    personalDetails: personalDetailsPropType.isRequired,
 
     /** All reports shared with the user */
     reports: PropTypes.shape({

--- a/src/pages/iou/steps/IOUParticipantsPage/IOUParticipantsRequest.js
+++ b/src/pages/iou/steps/IOUParticipantsPage/IOUParticipantsRequest.js
@@ -8,18 +8,7 @@ import ONYXKEYS from '../../../../ONYXKEYS';
 import withLocalize, {withLocalizePropTypes} from '../../../../components/withLocalize';
 import compose from '../../../../libs/compose';
 import {EXCLUDED_IOU_EMAILS} from '../../../../CONST';
-
-const personalDetailsPropTypes = PropTypes.shape({
-    /** The login of the person (either email or phone number) */
-    login: PropTypes.string.isRequired,
-
-    /** The URL of the person's avatar (there should already be a default avatar if the person doesn't have
-     * their own avatar uploaded yet) */
-    avatar: PropTypes.string.isRequired,
-
-    /** This is either the user's full name, or their login if full name is an empty string */
-    displayName: PropTypes.string.isRequired,
-});
+import personalDetailsPropType from '../../../personalDetailsPropType';
 
 const propTypes = {
     /** Beta features list */
@@ -32,7 +21,7 @@ const propTypes = {
     onAddParticipants: PropTypes.func.isRequired,
 
     /** All of the personal details for everyone */
-    personalDetails: PropTypes.objectOf(personalDetailsPropTypes).isRequired,
+    personalDetails: PropTypes.objectOf(personalDetailsPropType).isRequired,
 
     /** All reports shared with the user */
     reports: PropTypes.shape({

--- a/src/pages/iou/steps/IOUParticipantsPage/IOUParticipantsSplit.js
+++ b/src/pages/iou/steps/IOUParticipantsPage/IOUParticipantsSplit.js
@@ -13,18 +13,7 @@ import compose from '../../../../libs/compose';
 import Button from '../../../../components/Button';
 import Text from '../../../../components/Text';
 import FixedFooter from '../../../../components/FixedFooter';
-
-const personalDetailsPropTypes = PropTypes.shape({
-    // The login of the person (either email or phone number)
-    login: PropTypes.string.isRequired,
-
-    // The URL of the person's avatar (there should already be a default avatar if
-    // the person doesn't have their own avatar uploaded yet)
-    avatar: PropTypes.string.isRequired,
-
-    // This is either the user's full name, or their login if full name is an empty string
-    displayName: PropTypes.string.isRequired,
-});
+import personalDetailsPropType from '../../../personalDetailsPropType';
 
 const propTypes = {
     /** Beta features list */
@@ -51,7 +40,7 @@ const propTypes = {
     })),
 
     /** All of the personal details for everyone */
-    personalDetails: PropTypes.objectOf(personalDetailsPropTypes).isRequired,
+    personalDetails: PropTypes.objectOf(personalDetailsPropType).isRequired,
 
     /** All reports shared with the user */
     reports: PropTypes.shape({


### PR DESCRIPTION
### Details
Simply replaces the duplicated PropType with the previously defined file.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/181507

### Tests

N/A. I tested many areas of the app for regressions. Testing will be covered by the regular deploy checklist regression testing. 

### QA Steps
N/A

### Tested On

- [X] Web
- [x] Mobile Web
- [ ] Desktop
- [ ] iOS
- [x] Android

### Screenshots


#### Web

![Screenshot 2021-10-18 at 18 02 54](https://user-images.githubusercontent.com/10736861/137776853-b27ac431-2f34-4b49-b159-1395dfff6aae.png)

#### Mobile Web
![Screenshot_1634576937](https://user-images.githubusercontent.com/10736861/137776934-7147341e-1bd7-4d8e-a38e-f05a795e4d6f.png)



#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android

![Screenshot_1634576817](https://user-images.githubusercontent.com/10736861/137776945-bcb564a6-1be2-4ee1-a4df-339479d1a46b.png)

