### PR TITLE
Adds background to label

### DIFF
--- a/src/components/ExpensiTextInput/BaseExpensiTextInput.js
+++ b/src/components/ExpensiTextInput/BaseExpensiTextInput.js
@@ -172,6 +172,8 @@ class BaseExpensiTextInput extends Component {
                         >
                             {hasLabel ? (
                                 <>
+                                    {/* Adding this background to the label only for multiline text input, 
+                                    to prevent text overlaping with label when scrolling */}
                                     {multiline ? (
                                         <View
                                             style={styles.expensiTextInputLabelBackground}

--- a/src/components/ExpensiTextInput/BaseExpensiTextInput.js
+++ b/src/components/ExpensiTextInput/BaseExpensiTextInput.js
@@ -171,16 +171,22 @@ class BaseExpensiTextInput extends Component {
                             ]}
                         >
                             {hasLabel ? (
-                                <ExpensiTextInputLabel
-                                    label={label}
-                                    labelTranslateX={
-                                        ignoreLabelTranslateX
-                                            ? new Animated.Value(0)
-                                            : this.state.labelTranslateX
-                                    }
-                                    labelTranslateY={this.state.labelTranslateY}
-                                    labelScale={this.state.labelScale}
-                                />
+                                <>
+                                    {multiline ? (
+                                        <View 
+                                            style={styles.expensiTextInputLabelBackground}/>
+                                    ) : null}
+                                    <ExpensiTextInputLabel
+                                        label={label}
+                                        labelTranslateX={
+                                            ignoreLabelTranslateX
+                                                ? new Animated.Value(0)
+                                                : this.state.labelTranslateX
+                                        }
+                                        labelTranslateY={this.state.labelTranslateY}
+                                        labelScale={this.state.labelScale}
+                                    />
+                                </>
                             ) : null}
                             <TextInput
                                 ref={(ref) => {

--- a/src/components/ExpensiTextInput/BaseExpensiTextInput.js
+++ b/src/components/ExpensiTextInput/BaseExpensiTextInput.js
@@ -173,8 +173,9 @@ class BaseExpensiTextInput extends Component {
                             {hasLabel ? (
                                 <>
                                     {multiline ? (
-                                        <View 
-                                            style={styles.expensiTextInputLabelBackground}/>
+                                        <View
+                                            style={styles.expensiTextInputLabelBackground}
+                                        />
                                     ) : null}
                                     <ExpensiTextInputLabel
                                         label={label}

--- a/src/components/ExpensiTextInput/BaseExpensiTextInput.js
+++ b/src/components/ExpensiTextInput/BaseExpensiTextInput.js
@@ -172,13 +172,9 @@ class BaseExpensiTextInput extends Component {
                         >
                             {hasLabel ? (
                                 <>
-                                    {/* Adding this background to the label only for multiline text input, 
+                                    {/* Adding this background to the label only for multiline text input,
                                     to prevent text overlaping with label when scrolling */}
-                                    {multiline ? (
-                                        <View
-                                            style={styles.expensiTextInputLabelBackground}
-                                        />
-                                    ) : null}
+                                    {multiline && <View style={styles.expensiTextInputLabelBackground} />}
                                     <ExpensiTextInputLabel
                                         label={label}
                                         labelTranslateX={

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -535,7 +535,7 @@ const styles = {
         position: 'absolute',
         top: 0,
         width: '100%',
-        height: 28,
+        height: 25,
         backgroundColor: themeColors.componentBG,
         borderTopRightRadius: variables.componentBorderRadiusNormal,
         borderTopLeftRadius: variables.componentBorderRadiusNormal,

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -521,6 +521,7 @@ const styles = {
         justifyContent: 'center',
         height: '100%',
         backgroundColor: themeColors.componentBG,
+        overflow: 'hidden',
     },
     expensiTextInputLabel: {
         position: 'absolute',

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -531,6 +531,15 @@ const styles = {
         fontFamily: fontFamily.GTA,
         width: '100%',
     },
+    expensiTextInputLabelBackground: {
+        position: 'absolute',
+        top: 0,
+        width: '100%',
+        height: 28,
+        backgroundColor: themeColors.componentBG,
+        borderTopRightRadius: variables.componentBorderRadiusNormal,
+        borderTopLeftRadius: variables.componentBorderRadiusNormal,
+    },
     expensiTextInputLabelDesktop: {
         transformOrigin: 'left center',
     },
@@ -550,6 +559,7 @@ const styles = {
         paddingBottom: 8,
         paddingHorizontal: 11.5,
         borderRadius: variables.componentBorderRadiusNormal,
+        zIndex: -1,
     },
     expensiTextInputDesktop: addOutlineWidth({}, 0),
     expensiTextInputAndroid: left => ({


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

@parasharrajat 
### Details
<!-- Explanation of the change or anything fishy that is going on -->
Adds a background to the label, to avoid overlapping text when `TextInput` is multiline.

Added `zIndex` -1 to the `TextInput`, because is needed in `iOS` if this isn't set, the text still overlaps.

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/4515
$ https://github.com/Expensify/App/pull/5704

### Tests
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

1. Add a large text to a multiline `TextInput`.
2. Select a value in `TextInput` with autofill enabled and multiline. (Label background should be white)
3. Select a value in `TextInput with autofill enabled and non-multiline. (Label background should be the same color as autofill background)

### QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

1. Add a large text to a multiline `TextInput`.
2. Select a value in `TextInput` with autofill enabled and multiline. (Label background should be white)
3. Select a value in `TextInput with autofill enabled and non-multiline. (Label background should be the same color as autofill background)

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

https://user-images.githubusercontent.com/53409604/138167037-cdd2beaa-8f56-4f6e-8766-2caa103586e3.mov


#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

https://user-images.githubusercontent.com/53409604/138166533-fb672007-6f0a-438a-b6a5-2a9fdf6529ac.mov


#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

https://user-images.githubusercontent.com/53409604/138166517-38915cc1-da98-4eb8-aa55-6d648a81e47d.mp4


#### Android
<!-- Insert screenshots of your changes on the Android platform-->

https://user-images.githubusercontent.com/53409604/138166502-d925c61a-cf5a-4472-997e-435d3a86e8e3.mov


