### PR TITLE
Show first & last name length errors on front end

### DIFF
--- a/src/components/FullNameInputRow.js
+++ b/src/components/FullNameInputRow.js
@@ -18,8 +18,14 @@ const propTypes = {
     /** Used to prefill the firstName input, can also be used to make it a controlled input */
     firstName: PropTypes.string,
 
+    /** Error message to display below firstName input */
+    firstNameError: PropTypes.string,
+
     /** Used to prefill the lastName input, can also be used to make it a controlled input */
     lastName: PropTypes.string,
+
+    /** Error message to display below lastName input */
+    lastNameError: PropTypes.string,
 
     /** Additional styles to add after local styles */
     style: PropTypes.oneOfType([
@@ -29,14 +35,17 @@ const propTypes = {
 };
 const defaultProps = {
     firstName: '',
+    firstNameError: '',
     lastName: '',
+    lastNameError: '',
     style: {},
 };
 
 const FullNameInputRow = ({
     translate,
     onChangeFirstName, onChangeLastName,
-    firstName, lastName,
+    firstName, firstNameError,
+    lastName, lastNameError,
     style,
 }) => {
     const additionalStyles = _.isArray(style) ? style : [style];
@@ -46,6 +55,7 @@ const FullNameInputRow = ({
                 <ExpensiTextInput
                     label={translate('common.firstName')}
                     value={firstName}
+                    errorText={firstNameError}
                     onChangeText={onChangeFirstName}
                     placeholder={translate('profilePage.john')}
                     translateX={-10}
@@ -55,6 +65,7 @@ const FullNameInputRow = ({
                 <ExpensiTextInput
                     label={translate('common.lastName')}
                     value={lastName}
+                    errorText={lastNameError}
                     onChangeText={onChangeLastName}
                     placeholder={translate('profilePage.doe')}
                     translateX={-10}

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -379,6 +379,12 @@ export default {
             invalidFormatEmailLogin: 'The email entered is invalid. Please fix the format and try again.',
         },
     },
+    personalDetails: {
+        error: {
+            firstNameLength: 'First name shouldn\'t be longer than 50 characters',
+            lastNameLength: 'Last name shouldn\'t be longer than 50 characters',
+        },
+    },
     resendValidationForm: {
         linkHasBeenResent: 'Link has been re-sent',
         weSentYouMagicSignInLink: ({login}) => `We've sent a magic sign in link to ${login}. Check your Inbox and your Spam folder and wait 5-10 minutes before trying again.`,

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -379,6 +379,12 @@ export default {
             invalidFormatEmailLogin: 'El email introducido no es válido. Corrígelo e inténtalo de nuevo.',
         },
     },
+    personalDetails: {
+        error: {
+            firstNameLength: 'El nombre no debe tener más de 50 caracteres',
+            lastNameLength: 'El apellido no debe tener más de 50 caracteres',
+        },
+    },
     resendValidationForm: {
         linkHasBeenResent: 'El enlace se ha reenviado',
         weSentYouMagicSignInLink: ({login}) => `Hemos enviado un enlace mágico de inicio de sesión a ${login}. Verifica tu bandeja de entrada y tu carpeta de correo no deseado y espera de 5 a 10 minutos antes de intentarlo de nuevo.`,

--- a/src/libs/ValidationUtils.js
+++ b/src/libs/ValidationUtils.js
@@ -231,11 +231,11 @@ function isNumericWithSpecialChars(input) {
 }
 
 /**
- * Checks weather a given first or last name is valid
+ * Checks whether a given first or last name is valid length
  * @param {String} name
  * @returns {Boolean}
  */
-function isValidFirstOrLastName(name) {
+function isValidLengthForFirstOrLastName(name) {
     return name.length <= 50;
 }
 
@@ -254,6 +254,6 @@ export {
     isValidURL,
     validateIdentity,
     isNumericWithSpecialChars,
-    isValidFirstOrLastName,
+    isValidLengthForFirstOrLastName,
     isValidPaypalUsername,
 };

--- a/src/libs/ValidationUtils.js
+++ b/src/libs/ValidationUtils.js
@@ -230,6 +230,15 @@ function isNumericWithSpecialChars(input) {
     return /^\+?\d*$/.test(input.replace(/[()-]/g, ''));
 }
 
+/**
+ * Checks weather a given first or last name is valid
+ * @param {String} name
+ * @returns {Boolean}
+ */
+function isValidFirstOrLastName(name) {
+    return name.length <= 50;
+}
+
 export {
     meetsAgeRequirements,
     isValidAddress,
@@ -245,5 +254,6 @@ export {
     isValidURL,
     validateIdentity,
     isNumericWithSpecialChars,
+    isValidFirstOrLastName,
     isValidPaypalUsername,
 };

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -12,7 +12,7 @@ import {isDefaultRoom} from '../reportUtils';
 import {getReportIcons, getDefaultAvatar} from '../OptionsListUtils';
 import Growl from '../Growl';
 import {translateLocal} from '../translate';
-import {isValidFirstOrLastName} from '../ValidationUtils';
+import {isValidLengthForFirstOrLastName} from '../ValidationUtils';
 
 let currentUserEmail = '';
 Onyx.connect({
@@ -75,8 +75,8 @@ function getDisplayName(login, personalDetail) {
  */
 function getFirstAndLastNameErrors(firstName, lastName) {
     return {
-        firstName: isValidFirstOrLastName(firstName) ? '' : translateLocal('personalDetails.error.firstNameLength'),
-        lastName: isValidFirstOrLastName(lastName) ? '' : translateLocal('personalDetails.error.lastNameLength'),
+        firstName: isValidLengthForFirstOrLastName(firstName) ? '' : translateLocal('personalDetails.error.firstNameLength'),
+        lastName: isValidLengthForFirstOrLastName(lastName) ? '' : translateLocal('personalDetails.error.lastNameLength'),
     };
 }
 

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -12,7 +12,7 @@ import {isDefaultRoom} from '../reportUtils';
 import {getReportIcons, getDefaultAvatar} from '../OptionsListUtils';
 import Growl from '../Growl';
 import {translateLocal} from '../translate';
-import {isValidFirstOrLastName} from '../../libs/ValidationUtils';
+import {isValidFirstOrLastName} from '../ValidationUtils';
 
 let currentUserEmail = '';
 Onyx.connect({

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -75,8 +75,8 @@ function getDisplayName(login, personalDetail) {
  */
 function getFirstAndLastNameErrors(firstName, lastName) {
     return {
-        firstName: isValidLengthForFirstOrLastName(firstName) ? '' : translateLocal('personalDetails.error.firstNameLength'),
-        lastName: isValidLengthForFirstOrLastName(lastName) ? '' : translateLocal('personalDetails.error.lastNameLength'),
+        firstNameError: isValidLengthForFirstOrLastName(firstName) ? '' : translateLocal('personalDetails.error.firstNameLength'),
+        lastNameError: isValidLengthForFirstOrLastName(lastName) ? '' : translateLocal('personalDetails.error.lastNameLength'),
     };
 }
 

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -12,6 +12,7 @@ import {isDefaultRoom} from '../reportUtils';
 import {getReportIcons, getDefaultAvatar} from '../OptionsListUtils';
 import Growl from '../Growl';
 import {translateLocal} from '../translate';
+import {isValidFirstOrLastName} from '../../libs/ValidationUtils';
 
 let currentUserEmail = '';
 Onyx.connect({
@@ -62,6 +63,21 @@ function getDisplayName(login, personalDetail) {
     const fullName = (`${firstName} ${lastName}`).trim();
 
     return fullName || userLogin;
+}
+
+/**
+ * Returns object with first and last name errors. If either are valid,
+ * those errors get returned as empty strings.
+ *
+ * @param {String} firstName
+ * @param {String} lastName
+ * @returns {Object}
+ */
+function getFirstAndLastNameErrors(firstName, lastName) {
+    return {
+        firstName: isValidFirstOrLastName(firstName) ? '' : translateLocal('personalDetails.error.firstNameLength'),
+        lastName: isValidFirstOrLastName(lastName) ? '' : translateLocal('personalDetails.error.lastNameLength'),
+    };
 }
 
 /**
@@ -304,6 +320,7 @@ export {
     getFromReportParticipants,
     getDisplayName,
     getDefaultAvatar,
+    getFirstAndLastNameErrors,
     setPersonalDetails,
     setAvatar,
     deleteAvatar,

--- a/src/pages/RequestCallPage.js
+++ b/src/pages/RequestCallPage.js
@@ -178,9 +178,9 @@ class RequestCallPage extends Component {
      * @returns {Boolean}
      */
     validateInputs() {
-        if (_.isEmpty(this.state.firstName.trim()) || _.isEmpty(this.state.lastName.trim())) {
+        let firstOrLastNameEmpty = _.isEmpty(this.state.firstName.trim()) || _.isEmpty(this.state.lastName.trim());
+        if (firstOrLastNameEmpty) {
             Growl.error(this.props.translate('requestCallPage.growlMessageEmptyName'));
-            return false;
         }
 
         const phoneNumberError = this.getPhoneNumberError();
@@ -191,7 +191,7 @@ class RequestCallPage extends Component {
             lastNameError: nameErrors.lastName,
             phoneNumberError,
         });
-        return _.isEmpty(phoneNumberError) && _.isEmpty(nameErrors.firstName) && _.isEmpty(nameErrors.lastName);
+        return !firstOrLastNameEmpty && _.isEmpty(phoneNumberError) && _.isEmpty(nameErrors.firstName) && _.isEmpty(nameErrors.lastName);
     }
 
     render() {

--- a/src/pages/RequestCallPage.js
+++ b/src/pages/RequestCallPage.js
@@ -125,16 +125,17 @@ class RequestCallPage extends Component {
 
     /**
      * Gets proper phone number error message depending on phoneNumber input value.
+     * @param {String} phoneNumber
      * @returns {String}
      */
-    getPhoneNumberError() {
-        if (_.isEmpty(this.state.phoneNumber.trim())) {
+    getPhoneNumberError(phoneNumber) {
+        if (_.isEmpty(phoneNumber.trim())) {
             return this.props.translate('messages.noPhoneNumber');
-        } else if (!Str.isValidPhone(this.state.phoneNumber)) {
-            return this.props.translate('messages.errorMessageInvalidPhone');
-        } else {
-            return '';
         }
+        if (!Str.isValidPhone(phoneNumber)) {
+            return this.props.translate('messages.errorMessageInvalidPhone');
+        }
+        return '';
     }
 
     /**
@@ -170,7 +171,7 @@ class RequestCallPage extends Component {
     }
 
     validatePhoneInput() {
-        this.setState({phoneNumberError: this.getPhoneNumberError()});
+        this.setState((prevState) => ({phoneNumberError: this.getPhoneNumberError(prevState.phoneNumber)}));
     }
 
     /**
@@ -178,18 +179,20 @@ class RequestCallPage extends Component {
      * @returns {Boolean}
      */
     validateInputs() {
-        let firstOrLastNameEmpty = _.isEmpty(this.state.firstName.trim()) || _.isEmpty(this.state.lastName.trim());
+        const firstOrLastNameEmpty = _.isEmpty(this.state.firstName.trim()) || _.isEmpty(this.state.lastName.trim());
         if (firstOrLastNameEmpty) {
             Growl.error(this.props.translate('requestCallPage.growlMessageEmptyName'));
         }
 
-        const phoneNumberError = this.getPhoneNumberError();
-        const nameErrors = getFirstAndLastNameErrors(this.state.firstName, this.state.lastName);
+        this.setState((prevState) => {
+            const phoneNumberError = this.getPhoneNumberError(prevState.phoneNumber);
+            const nameErrors = getFirstAndLastNameErrors(prevState.firstName, prevState.lastName);
 
-        this.setState({
-            firstNameError: nameErrors.firstName,
-            lastNameError: nameErrors.lastName,
-            phoneNumberError,
+            return {
+                firstNameError: nameErrors.firstName,
+                lastNameError: nameErrors.lastName,
+                phoneNumberError,
+            };
         });
         return !firstOrLastNameEmpty && _.isEmpty(phoneNumberError) && _.isEmpty(nameErrors.firstName) && _.isEmpty(nameErrors.lastName);
     }

--- a/src/pages/RequestCallPage.js
+++ b/src/pages/RequestCallPage.js
@@ -184,14 +184,14 @@ class RequestCallPage extends Component {
         }
 
         const phoneNumberError = this.getPhoneNumberError();
-        const {firstName, lastName} = getFirstAndLastNameErrors(this.state.firstName, this.state.lastName);
+        const {firstNameError, lastNameError} = getFirstAndLastNameErrors(this.state.firstName, this.state.lastName);
 
         this.setState({
-            firstNameError: firstName,
-            lastNameError: lastName,
+            firstNameError,
+            lastNameError,
             phoneNumberError,
         });
-        return !firstOrLastNameEmpty && _.isEmpty(phoneNumberError) && _.isEmpty(firstName) && _.isEmpty(lastName);
+        return !firstOrLastNameEmpty && _.isEmpty(phoneNumberError) && _.isEmpty(firstNameError) && _.isEmpty(lastNameError);
     }
 
     render() {

--- a/src/pages/RequestCallPage.js
+++ b/src/pages/RequestCallPage.js
@@ -125,14 +125,13 @@ class RequestCallPage extends Component {
 
     /**
      * Gets proper phone number error message depending on phoneNumber input value.
-     * @param {String} phoneNumber
      * @returns {String}
      */
-    getPhoneNumberError(phoneNumber) {
-        if (_.isEmpty(phoneNumber.trim())) {
+    getPhoneNumberError() {
+        if (_.isEmpty(this.state.phoneNumber.trim())) {
             return this.props.translate('messages.noPhoneNumber');
         }
-        if (!Str.isValidPhone(phoneNumber)) {
+        if (!Str.isValidPhone(this.state.phoneNumber)) {
             return this.props.translate('messages.errorMessageInvalidPhone');
         }
         return '';
@@ -171,7 +170,7 @@ class RequestCallPage extends Component {
     }
 
     validatePhoneInput() {
-        this.setState((prevState) => ({phoneNumberError: this.getPhoneNumberError(prevState.phoneNumber)}));
+        this.setState({phoneNumberError: this.getPhoneNumberError()});
     }
 
     /**
@@ -184,17 +183,15 @@ class RequestCallPage extends Component {
             Growl.error(this.props.translate('requestCallPage.growlMessageEmptyName'));
         }
 
-        this.setState((prevState) => {
-            const phoneNumberError = this.getPhoneNumberError(prevState.phoneNumber);
-            const nameErrors = getFirstAndLastNameErrors(prevState.firstName, prevState.lastName);
+        const phoneNumberError = this.getPhoneNumberError();
+        const {firstName, lastName} = getFirstAndLastNameErrors(this.state.firstName, this.state.lastName);
 
-            return {
-                firstNameError: nameErrors.firstName,
-                lastNameError: nameErrors.lastName,
-                phoneNumberError,
-            };
+        this.setState({
+            firstNameError: firstName,
+            lastNameError: lastName,
+            phoneNumberError,
         });
-        return !firstOrLastNameEmpty && _.isEmpty(phoneNumberError) && _.isEmpty(nameErrors.firstName) && _.isEmpty(nameErrors.lastName);
+        return !firstOrLastNameEmpty && _.isEmpty(phoneNumberError) && _.isEmpty(firstName) && _.isEmpty(lastName);
     }
 
     render() {

--- a/src/pages/settings/Profile/ProfilePage.js
+++ b/src/pages/settings/Profile/ProfilePage.js
@@ -192,13 +192,13 @@ class ProfilePage extends Component {
     }
 
     validateInputs() {
-        const {firstName, lastName} = getFirstAndLastNameErrors(this.state.firstName, this.state.lastName);
+        const {firstNameError, lastNameError} = getFirstAndLastNameErrors(this.state.firstName, this.state.lastName);
 
         this.setState({
-            firstNameError: firstName,
-            lastNameError: lastName,
+            firstNameError,
+            lastNameError,
         });
-        return _.isEmpty(firstName) && _.isEmpty(lastName);
+        return _.isEmpty(firstNameError) && _.isEmpty(lastNameError);
     }
 
     render() {

--- a/src/pages/settings/Profile/ProfilePage.js
+++ b/src/pages/settings/Profile/ProfilePage.js
@@ -8,7 +8,7 @@ import _ from 'underscore';
 import HeaderWithCloseButton from '../../../components/HeaderWithCloseButton';
 import Navigation from '../../../libs/Navigation/Navigation';
 import ScreenWrapper from '../../../components/ScreenWrapper';
-import {setPersonalDetails, setAvatar, deleteAvatar} from '../../../libs/actions/PersonalDetails';
+import {getFirstAndLastNameErrors, setPersonalDetails, setAvatar, deleteAvatar} from '../../../libs/actions/PersonalDetails';
 import ROUTES from '../../../ROUTES';
 import ONYXKEYS from '../../../ONYXKEYS';
 import CONST from '../../../CONST';
@@ -87,7 +87,9 @@ class ProfilePage extends Component {
 
         this.state = {
             firstName,
+            firstNameError: '',
             lastName,
+            lastNameError: '',
             pronouns: currentUserPronouns,
             selfSelectedPronouns: initialSelfSelectedPronouns,
             selectedTimezone: timezone.selected || CONST.DEFAULT_TIME_ZONE.selected,
@@ -95,10 +97,11 @@ class ProfilePage extends Component {
             logins: this.getLogins(props.user.loginList),
         };
 
-        this.pronounDropdownValues = pronounsList.map(pronoun => ({value: pronoun, label: pronoun}));
-        this.updatePersonalDetails = this.updatePersonalDetails.bind(this);
-        this.setAutomaticTimezone = this.setAutomaticTimezone.bind(this);
         this.getLogins = this.getLogins.bind(this);
+        this.pronounDropdownValues = pronounsList.map(pronoun => ({value: pronoun, label: pronoun}));
+        this.setAutomaticTimezone = this.setAutomaticTimezone.bind(this);
+        this.updatePersonalDetails = this.updatePersonalDetails.bind(this);
+        this.validateInputs = this.validateInputs.bind(this);
     }
 
     componentDidUpdate(prevProps) {
@@ -166,6 +169,10 @@ class ProfilePage extends Component {
             isAutomaticTimezone,
         } = this.state;
 
+        if (!this.validateInputs()) {
+            return;
+        }
+
         setPersonalDetails({
             firstName: firstName.trim(),
             lastName: lastName.trim(),
@@ -177,6 +184,16 @@ class ProfilePage extends Component {
                 selected: selectedTimezone,
             },
         }, true);
+    }
+
+    validateInputs() {
+        const nameErrors = getFirstAndLastNameErrors(this.state.firstName, this.state.lastName);
+
+        this.setState({
+            firstNameError: nameErrors.firstName,
+            lastNameError: nameErrors.lastName,
+        });
+        return _.isEmpty(nameErrors.firstName) && _.isEmpty(nameErrors.lastName);
     }
 
     render() {
@@ -217,7 +234,9 @@ class ProfilePage extends Component {
                         </Text>
                         <FullNameInputRow
                             firstName={this.state.firstName}
+                            firstNameError={this.state.firstNameError}
                             lastName={this.state.lastName}
+                            lastNameError={this.state.lastNameError}
                             onChangeFirstName={firstName => this.setState({firstName})}
                             onChangeLastName={lastName => this.setState({lastName})}
                             style={[styles.mt4, styles.mb4]}

--- a/src/pages/settings/Profile/ProfilePage.js
+++ b/src/pages/settings/Profile/ProfilePage.js
@@ -192,15 +192,13 @@ class ProfilePage extends Component {
     }
 
     validateInputs() {
-        this.setState((prevState) => {
-            const nameErrors = getFirstAndLastNameErrors(prevState.firstName, prevState.lastName);
+        const {firstName, lastName} = getFirstAndLastNameErrors(this.state.firstName, this.state.lastName);
 
-            return {
-                firstNameError: nameErrors.firstName,
-                lastNameError: nameErrors.lastName,
-            };
+        this.setState({
+            firstNameError: firstName,
+            lastNameError: lastName,
         });
-        return _.isEmpty(nameErrors.firstName) && _.isEmpty(nameErrors.lastName);
+        return _.isEmpty(firstName) && _.isEmpty(lastName);
     }
 
     render() {

--- a/src/pages/settings/Profile/ProfilePage.js
+++ b/src/pages/settings/Profile/ProfilePage.js
@@ -8,7 +8,12 @@ import _ from 'underscore';
 import HeaderWithCloseButton from '../../../components/HeaderWithCloseButton';
 import Navigation from '../../../libs/Navigation/Navigation';
 import ScreenWrapper from '../../../components/ScreenWrapper';
-import {getFirstAndLastNameErrors, setPersonalDetails, setAvatar, deleteAvatar} from '../../../libs/actions/PersonalDetails';
+import {
+    getFirstAndLastNameErrors,
+    setPersonalDetails,
+    setAvatar,
+    deleteAvatar,
+} from '../../../libs/actions/PersonalDetails';
 import ROUTES from '../../../ROUTES';
 import ONYXKEYS from '../../../ONYXKEYS';
 import CONST from '../../../CONST';
@@ -187,11 +192,13 @@ class ProfilePage extends Component {
     }
 
     validateInputs() {
-        const nameErrors = getFirstAndLastNameErrors(this.state.firstName, this.state.lastName);
+        this.setState((prevState) => {
+            const nameErrors = getFirstAndLastNameErrors(prevState.firstName, prevState.lastName);
 
-        this.setState({
-            firstNameError: nameErrors.firstName,
-            lastNameError: nameErrors.lastName,
+            return {
+                firstNameError: nameErrors.firstName,
+                lastNameError: nameErrors.lastName,
+            };
         });
         return _.isEmpty(nameErrors.firstName) && _.isEmpty(nameErrors.lastName);
     }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Idea coming from here: https://github.com/Expensify/App/issues/5091#issuecomment-941681642 - we're starting to standardize showing input errors when submitting the form - validating on the front end instead of on the back-end. This speeds up users seeing errors and prevents some unnecessary API calls.

### Related Issues
Related to: https://github.com/Expensify/App/issues/5091

### Tests
1. Log in with any account

Profile page:
2. Open your profile page (Settings -> Profile)
3. Add a first & last name over 50 characters (ex: `012345678901234567890123456789012345678901234567890`)
4. Try to save the form, verify you see red outlined fields & errors under each
    - ![Screen Shot 2021-10-20 at 11 35 16 AM](https://user-images.githubusercontent.com/3885503/138143021-9dfb4ab0-e51e-460a-adf9-3dcaac5d0a9e.png)
5. Change your first name to be between 0 and 50 characters
6. Resubmit the form, verify you only see the last name field with red outline & error underneath
7. Change your last name to be between 0 and 50 characters
8. Resubmit the form, verify there's no errors and you see the success growl

Request call page:
1. Navigate to your chat with Concierge, click the "Request call" icon
2. Repeat tests from profile page, verifying you see:
    - Errors under both name inputs when their lengths are > 50 characters
    - No errors under either input when their lengths are between 1 and 50 characters
    - An error shows if either the first or last names are empty
    - You still see phone number errors if it's empty or if it's an invalid phone number

### QA Steps
Same as above

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
Profile Page:
![Screen Shot 2021-10-20 at 11 35 16 AM](https://user-images.githubusercontent.com/3885503/138143021-9dfb4ab0-e51e-460a-adf9-3dcaac5d0a9e.png)

Request a call:

https://user-images.githubusercontent.com/3885503/138144719-95599f85-c8ff-4b3d-a02d-53935a59371f.mov

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
Profile Page:
![Screen Shot 2021-10-20 at 12 20 39 PM](https://user-images.githubusercontent.com/3885503/138149431-517bc7e3-0f91-45d9-a8a1-69456081647b.png)

Request a call:

https://user-images.githubusercontent.com/3885503/138149437-f5ef686e-4fce-4325-acaa-84926381b17e.mov

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
Profile Page:
![Screen Shot 2021-10-20 at 11 57 31 AM](https://user-images.githubusercontent.com/3885503/138146200-2da24337-d670-4ef0-b40c-9d3cf1de4e6b.png)

Request a call:

https://user-images.githubusercontent.com/3885503/138147459-72d0d0d7-e567-4413-9f91-10f947feca54.mov

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
Profile Page:
![Screen Shot 2021-10-20 at 12 16 56 PM](https://user-images.githubusercontent.com/3885503/138148887-5415f26a-b6c5-4617-b6ba-64319a415faa.png)

Request a call:

https://user-images.githubusercontent.com/3885503/138149020-27eba4a2-b055-456a-861e-82206a9cfb29.mov

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
Profile Page:
![Screen Shot 2021-10-20 at 12 04 20 PM](https://user-images.githubusercontent.com/3885503/138147165-45ba0607-4516-421e-9d23-ce5496432b2a.png)

Request a call:

https://user-images.githubusercontent.com/3885503/138147987-5ee753a9-2fba-4bfc-a94b-c781ff5a269e.mov
