### PR TITLE
Attachment preview cut out in comments fixed

### DIFF
--- a/src/components/AnchorForCommentsOnly/BaseAnchorForCommentsOnly/index.native.js
+++ b/src/components/AnchorForCommentsOnly/BaseAnchorForCommentsOnly/index.native.js
@@ -8,6 +8,7 @@ import PressableWithSecondaryInteraction from '../../PressableWithSecondaryInter
 import {showContextMenu} from '../../../pages/home/report/ContextMenu/ReportActionContextMenu';
 import {CONTEXT_MENU_TYPES} from '../../../pages/home/report/ContextMenu/ContextMenuActions';
 import AttachmentView from '../../AttachmentView';
+import styles from '../../../styles/styles';
 
 /*
  * This is a default anchor component for regular links.
@@ -24,9 +25,11 @@ const BaseAnchorForCommentsOnly = ({
     return (
         isAttachment
             ? (
-                <Pressable onPress={() => {
-                    fileDownload(href, fileName);
-                }}
+                <Pressable
+                    style={styles.mw100}
+                    onPress={() => {
+                        fileDownload(href, fileName);
+                    }}
                 >
                     <AttachmentView
                         sourceURL={href}

--- a/src/components/AttachmentView.js
+++ b/src/components/AttachmentView.js
@@ -62,7 +62,7 @@ const AttachmentView = (props) => {
             <View style={styles.mr2}>
                 <Icon src={Paperclip} />
             </View>
-            <Text style={[styles.textStrong]}>{props.file && props.file.name}</Text>
+            <Text style={[styles.textStrong, styles.flexShrink1]}>{props.file && props.file.name}</Text>
             {props.shouldShowDownloadIcon && (
                 <View style={styles.ml2}>
                     <Tooltip text={props.translate('common.download')}>


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/5755

### Tests & QA Steps
1. Send a non-preview attachment file to any user chat.
2. Open and view the attachment preview on iOS & Android devices. 
3. Now attachment preview will not cut off now.

### Tested On
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### iOS
![Simulator Screen Shot - iPhone 12 - 2021-10-21 at 03 49 12](https://user-images.githubusercontent.com/85645967/138181318-a0799b9b-4552-413b-a6f3-f7a759b07864.png)

#### Android
![Screenshot_1634768343](https://user-images.githubusercontent.com/85645967/138181335-639545f0-acf6-4cc1-883d-38162bad1646.png)

