### PR TITLE
[No QA] Bumping Xcode version to fix iOS tests failing on Travis

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,7 +6,7 @@ on:
     branches-ignore: [staging, production]
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_12.5.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_12.5.1.app/Contents/Developer
 
 jobs:
   test:


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

iOS tests are failing, so we need to figure out how to fix em
One idea was to bump the XCode version found in e2e.yml

Slack discussion: https://expensify.slack.com/archives/C01GTK53T8Q/p1634754414008400
Evidence for bumping: https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md#xcode


We'll see if the iOS tests pass here. 
Edit: Looks like they did! I think we should be good to merge this. 
