### PR TITLE
Add AddressSearch related fields missing renaming in "Additional information" step

### DIFF
--- a/src/pages/ReimbursementAccount/BeneficialOwnersStep.js
+++ b/src/pages/ReimbursementAccount/BeneficialOwnersStep.js
@@ -134,8 +134,15 @@ class BeneficialOwnersStep extends React.Component {
      */
     clearErrorAndSetBeneficialOwnerValue(ownerIndex, inputKey, value) {
         this.setState((prevState) => {
+            const renamedFields = {
+                addressStreet: 'street',
+                addressCity: 'city',
+                addressState: 'state',
+                addressZipCode: 'zipCode',
+            };
+            const renamedInputKey = lodashGet(renamedFields, inputKey, inputKey);
             const beneficialOwners = [...prevState.beneficialOwners];
-            beneficialOwners[ownerIndex] = {...beneficialOwners[ownerIndex], [inputKey]: value};
+            beneficialOwners[ownerIndex] = {...beneficialOwners[ownerIndex], [renamedInputKey]: value};
             updateReimbursementAccountDraft({beneficialOwners});
             return {beneficialOwners};
         });

--- a/src/pages/ReimbursementAccount/RequestorStep.js
+++ b/src/pages/ReimbursementAccount/RequestorStep.js
@@ -89,10 +89,6 @@ class RequestorStep extends React.Component {
      */
     clearErrorAndSetValue(inputKey, value) {
         const renamedFields = {
-            street: 'requestorAddressStreet',
-            city: 'requestorAddressCity',
-            state: 'requestorAddressState',
-            zipCode: 'requestorAddressZipCode',
             addressStreet: 'requestorAddressStreet',
             addressCity: 'requestorAddressCity',
             addressState: 'requestorAddressState',


### PR DESCRIPTION
### Details

Just like with `RequestorStep.js` ("Personal Information" step), the field names in `IdentityForm.js` don't match anymore  with the names we finally use to store them in each "Beneficial owner" in `BeneficialOwnersStep.js` ("Additional Information" step). Added field name mapping to translate them.

### Fixed Issues

$ https://github.com/Expensify/Expensify/issues/181598

### Tests / QA

1. Create NewDot account, verify it, login
2. Create a workspace and start the process of adding a VBA
3. Go through the first, second and third step using (3) from this [SO](https://stackoverflow.com/c/expensify/questions/342/525#525)
4. When you get to the "Additional information", check "Somebody else owns more than 25% of" to add a "Beneficial owner" 
5. Input an address and click on a result suggested by the autocomplete, then click "Save & Continue" (No need to fill all fields)
6. Expected result: The "Personal address" field should not have an error

![Screen Shot 2021-10-21 at 10 06 17 AM](https://user-images.githubusercontent.com/87341702/138324598-01cd7c3f-149b-48bf-a8ae-452f81419633.png)

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
