### PR TITLE
[No QA] Use XCode 12.5.1 for deploy

### DIFF
--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   SHOULD_DEPLOY_PRODUCTION: ${{ github.event_name == 'release' }}
-  DEVELOPER_DIR: /Applications/Xcode_12.5.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_12.5.1.app/Contents/Developer
 
 jobs:
   validateActor:


### PR DESCRIPTION
cc @Jag96 @AndrewGable 

### Details
Use XCode 12.5.1 for deploy, hopefully should fix gem errors [such as these](https://github.com/Expensify/App/runs/3967167223?check_suite_focus=true).

### Fixed Issues
$ n/a – unblock deploys

### Tests
Send it and see if it works.

### QA Steps
None.
