### PR TITLE
Add Payment Method fill when menu is active

### DIFF
--- a/src/pages/settings/Payments/PaymentMethodList.js
+++ b/src/pages/settings/Payments/PaymentMethodList.js
@@ -26,7 +26,7 @@ const propTypes = {
     /** Are we loading payments from the server? */
     isLoadingPayments: PropTypes.bool,
 
-    /** Is payment options in menu visible to user? */
+    /** Is the payment options menu open / active? */
     isAddPaymentMenuActive: PropTypes.bool,
 
     /** User's paypal.me username if they have one */
@@ -138,8 +138,8 @@ class PaymentMethodList extends Component {
             onPress: e => this.props.onPress(e),
             key: 'addPaymentMethodButton',
             disabled: this.props.isLoadingPayments,
-            wrapperStyle: this.props.isAddPaymentMenuActive ? [getButtonBackgroundColorStyle(CONST.BUTTON_STATES.ACTIVE)] : [],
-            iconFill: this.props.isAddPaymentMenuActive ? getIconFillColor(CONST.BUTTON_STATES.ACTIVE) : null,
+            iconFill: this.props.isAddPaymentMenuActive ? getIconFillColor(CONST.BUTTON_STATES.PRESSED) : null,
+            wrapperStyle: this.props.isAddPaymentMenuActive ? [getButtonBackgroundColorStyle(CONST.BUTTON_STATES.PRESSED)] : [],
         });
 
         return combinedPaymentMethods;
@@ -163,9 +163,9 @@ class PaymentMethodList extends Component {
                     icon={item.icon}
                     key={item.key}
                     disabled={item.disabled}
+                    iconFill={item.iconFill}
                     iconHeight={item.iconSize}
                     iconWidth={item.iconSize}
-                    iconFill={item.iconFill}
                     wrapperStyle={item.wrapperStyle}
                 />
             );

--- a/src/pages/settings/Payments/PaymentMethodList.js
+++ b/src/pages/settings/Payments/PaymentMethodList.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import {FlatList, Text} from 'react-native';
 import {withOnyx} from 'react-native-onyx';
 import lodashGet from 'lodash/get';
-import styles from '../../../styles/styles';
+import styles, {getButtonBackgroundColorStyle, getIconFillColor} from '../../../styles/styles';
 import MenuItem from '../../../components/MenuItem';
 import compose from '../../../libs/compose';
 import withLocalize, {withLocalizePropTypes} from '../../../components/withLocalize';
@@ -25,6 +25,9 @@ const propTypes = {
 
     /** Are we loading payments from the server? */
     isLoadingPayments: PropTypes.bool,
+
+    /** Is payment options in menu visible to user? */
+    isAddPaymentMenuActive: PropTypes.bool,
 
     /** User's paypal.me username if they have one */
     payPalMeUsername: PropTypes.string,
@@ -52,6 +55,7 @@ const defaultProps = {
     bankAccountList: [],
     cardList: [],
     isLoadingPayments: false,
+    isAddPaymentMenuActive: false,
 };
 
 class PaymentMethodList extends Component {
@@ -134,6 +138,8 @@ class PaymentMethodList extends Component {
             onPress: e => this.props.onPress(e),
             key: 'addPaymentMethodButton',
             disabled: this.props.isLoadingPayments,
+            wrapperStyle: this.props.isAddPaymentMenuActive ? [getButtonBackgroundColorStyle(CONST.BUTTON_STATES.ACTIVE)] : [],
+            iconFill: this.props.isAddPaymentMenuActive ? getIconFillColor(CONST.BUTTON_STATES.ACTIVE) : null,
         });
 
         return combinedPaymentMethods;
@@ -159,6 +165,8 @@ class PaymentMethodList extends Component {
                     disabled={item.disabled}
                     iconHeight={item.iconSize}
                     iconWidth={item.iconSize}
+                    iconFill={item.iconFill}
+                    wrapperStyle={item.wrapperStyle}
                 />
             );
         }

--- a/src/pages/settings/Payments/PaymentsPage.js
+++ b/src/pages/settings/Payments/PaymentsPage.js
@@ -128,6 +128,7 @@ class PaymentsPage extends React.Component {
                             onPress={this.paymentMethodPressed}
                             style={[styles.flex4]}
                             isLoadingPayments={this.props.isLoadingPaymentMethods}
+                            isAddPaymentMenuActive={this.state.shouldShowAddPaymentMenu}
                         />
                     </ScrollView>
                     <Popover


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Add fill background to `Add Payment method` when payment options are active.

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/5915

### Tests & QA Steps
1. Go to Settings > Payments
2. Tap or click on the `Add Payment Method` button
3. Payment options will be shown, also now `Add Payment Method` will have active background fill

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<img width="1440" alt="Screenshot 2021-10-23 at 12 32 07 AM" src="https://user-images.githubusercontent.com/85645967/138569122-8888459e-be40-42e6-8854-b7444a896f24.png">

#### Mobile Web
![Simulator Screen Shot - iPhone 12 - 2021-10-23 at 01 55 29](https://user-images.githubusercontent.com/85645967/138569167-220e408d-96d3-4f29-813d-c33baad7d6d6.png)

#### Desktop
<img width="1201" alt="Screenshot 2021-10-23 at 1 54 30 AM" src="https://user-images.githubusercontent.com/85645967/138569173-c0ebfaf9-6705-44f7-9997-d95a28bb3ca1.png">

#### iOS
![Simulator Screen Shot - iPhone 12 - 2021-10-23 at 01 54 47](https://user-images.githubusercontent.com/85645967/138569187-03e51038-0074-41c2-aa8a-ce6d26b5317e.png)

#### Android
![Screenshot_1634934344](https://user-images.githubusercontent.com/85645967/138569200-ddbe4e66-0152-4985-bc34-538b167d5699.png)
