### PR TITLE
[No QA] Update Spanish translation

### DIFF
--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -598,7 +598,7 @@ export default {
         reviewingInfo: '¡Gracias! Estamos revisando tu información y nos comunicaremos contigo en breve. Consulte su chat con Concierge ',
         forNextSteps: ' para conocer los próximos pasos para terminar de configurar su cuenta bancaria.',
         letsChatCTA: '¡Sí, vamos a chatear!',
-        letsChatText: '¡Gracias por hacer eso! Todavía tenemos que solucionar un par de cosas, pero será más fácil por chat. ¿Listo para charlar?',
+        letsChatText: '¡Gracias! Todavía tenemos que solucionar un par de cosas, pero será más fácil por chat. ¿Listo para charlar?',
         letsChatTitle: '¡Vamos a chatear!',
     },
     beneficialOwnersStep: {
@@ -732,7 +732,7 @@ export default {
             accountDescriptionNoCards: 'Esta cuenta bancaria se utilizará para reembolsar gastos y cobrar y pagar facturas, todo desde la misma cuenta. Concierge puede ayudarte a añadir tu correo de trabajo para activar la Tarjeta Expensify.',
             accountDescriptionWithCards: 'Esta cuenta bancaria se utilizará para emitir tarjetas corporativas, reembolsar gastos y cobrar y pagar facturas, todo desde la misma cuenta.',
             chatWithConcierge: 'Chat con Concierge',
-            letsFinishInChat: '¡Acabemos en el chat!',
+            letsFinishInChat: '¡Continuemos en el chat!',
             almostDone: '¡Casi listo!',
         },
     },


### PR DESCRIPTION
Spanish translation didn't make any sense.

### Fixed Issues
$ https://github.com/Expensify/App/issues/5990

### Tests

1. Navigate to add bank account flow (app must be in spanish)
2. Add a Verifying bank account (must go through onfido flow)
3. Reach the "Let's finish in chat" Modal. 
4. Spanish copy should have been updated, instead of "Acabemos en el chat" and "Gracias por hacer eso", it should say "Continuemos en el chat" and "Gracias" respectively.

### QA Steps
No QA.

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
