### PR TITLE
[No QA] Cleanup unnecessary usages of `compose()`

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -648,7 +648,7 @@ From React's documentation -
 >Props and composition give you all the flexibility you need to customize a component’s look and behavior in an explicit and safe way. Remember that components may accept arbitrary props, including primitive values, React elements, or functions.
 >If you want to reuse non-UI functionality between components, we suggest extracting it into a separate JavaScript module. The components may import it and use that function, object, or a class, without extending it.
 
-Use an HOC a.k.a. *[Higher order component](https://reactjs.org/docs/higher-order-components.html)* if you find a use case where you need inheritance. Some examples of useful HOC:
+Use an HOC a.k.a. *[Higher order component](https://reactjs.org/docs/higher-order-components.html)* if you find a use case where you need inheritance.
 
 If several HOC need to be combined there is a `compose()` utility. But we should not use this utility when there is only one HOC.
 

--- a/STYLE.md
+++ b/STYLE.md
@@ -648,7 +648,25 @@ From React's documentation -
 >Props and composition give you all the flexibility you need to customize a component’s look and behavior in an explicit and safe way. Remember that components may accept arbitrary props, including primitive values, React elements, or functions.
 >If you want to reuse non-UI functionality between components, we suggest extracting it into a separate JavaScript module. The components may import it and use that function, object, or a class, without extending it.
 
-Use *[Higher order components](https://reactjs.org/docs/higher-order-components.html)* if you find a use case where you need inheritance.
+Use an HOC a.k.a. *[Higher order component](https://reactjs.org/docs/higher-order-components.html)* if you find a use case where you need inheritance. Some examples of useful HOC:
+
+If several HOC need to be combined there is a `compose()` utility. But we should not use this utility when there is only one HOC.
+
+```javascript
+// Bad
+export default compose(
+    withLocalize,
+)(MyComponent);
+
+// Good
+export default compose(
+    withLocalize,
+    withWindowDimensions,
+)(MyComponent);
+
+// Good
+export default withLocalize(MyComponent)
+```
 
 **Note:** If you find that none of these approaches work for you, please ask an Expensify engineer for guidance via Slack or GitHub.
 

--- a/src/components/HeaderWithCloseButton.js
+++ b/src/components/HeaderWithCloseButton.js
@@ -123,4 +123,4 @@ HeaderWithCloseButton.propTypes = propTypes;
 HeaderWithCloseButton.defaultProps = defaultProps;
 HeaderWithCloseButton.displayName = 'HeaderWithCloseButton';
 
-export default compose(withLocalize)(HeaderWithCloseButton);
+export default withLocalize(HeaderWithCloseButton);

--- a/src/components/HeaderWithCloseButton.js
+++ b/src/components/HeaderWithCloseButton.js
@@ -7,7 +7,6 @@ import styles from '../styles/styles';
 import Header from './Header';
 import Icon from './Icon';
 import {Close, Download, BackArrow} from './Icon/Expensicons';
-import compose from '../libs/compose';
 import withLocalize, {withLocalizePropTypes} from './withLocalize';
 import Tooltip from './Tooltip';
 import InboxCallButton from './InboxCallButton';

--- a/src/components/ImageView/index.js
+++ b/src/components/ImageView/index.js
@@ -6,7 +6,6 @@ import {
 import styles, {getZoomCursorStyle, getZoomSizingStyle} from '../../styles/styles';
 import canUseTouchScreen from '../../libs/canUseTouchscreen';
 import withWindowDimensions, {windowDimensionsPropTypes} from '../withWindowDimensions';
-import compose from '../../libs/compose';
 
 const propTypes = {
     /** URL to full-sized image */

--- a/src/components/ImageView/index.js
+++ b/src/components/ImageView/index.js
@@ -223,6 +223,4 @@ class ImageView extends PureComponent {
 }
 
 ImageView.propTypes = propTypes;
-export default compose(
-    withWindowDimensions,
-)(ImageView);
+export default withWindowDimensions(ImageView);

--- a/src/components/InboxCallButton.js
+++ b/src/components/InboxCallButton.js
@@ -39,4 +39,4 @@ const InboxCallButton = props => (
 InboxCallButton.propTypes = propTypes;
 InboxCallButton.defaultProps = defaultProps;
 InboxCallButton.displayName = 'InboxCallButton';
-export default compose(withLocalize)(InboxCallButton);
+export default withLocalize(InboxCallButton);

--- a/src/components/InboxCallButton.js
+++ b/src/components/InboxCallButton.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styles from '../styles/styles';
 import withLocalize, {withLocalizePropTypes} from './withLocalize';
-import compose from '../libs/compose';
 import Navigation from '../libs/Navigation/Navigation';
 import ROUTES from '../ROUTES';
 import Tooltip from './Tooltip';

--- a/src/pages/LogInWithShortLivedTokenPage.js
+++ b/src/pages/LogInWithShortLivedTokenPage.js
@@ -3,7 +3,6 @@ import lodashGet from 'lodash/get';
 import PropTypes from 'prop-types';
 import {withOnyx} from 'react-native-onyx';
 import ROUTES from '../ROUTES';
-import compose from '../libs/compose';
 import ONYXKEYS from '../ONYXKEYS';
 import {signInWithShortLivedToken} from '../libs/actions/Session';
 import FullScreenLoadingIndicator from '../components/FullscreenLoadingIndicator';

--- a/src/pages/LogInWithShortLivedTokenPage.js
+++ b/src/pages/LogInWithShortLivedTokenPage.js
@@ -98,13 +98,11 @@ class LogInWithShortLivedTokenPage extends Component {
 LogInWithShortLivedTokenPage.propTypes = propTypes;
 LogInWithShortLivedTokenPage.defaultProps = defaultProps;
 
-export default compose(
-    withOnyx({
-        session: {
-            key: ONYXKEYS.SESSION,
-        },
-        betas: {
-            key: ONYXKEYS.BETAS,
-        },
-    }),
-)(LogInWithShortLivedTokenPage);
+export default withOnyx({
+    session: {
+        key: ONYXKEYS.SESSION,
+    },
+    betas: {
+        key: ONYXKEYS.BETAS,
+    },
+})(LogInWithShortLivedTokenPage);

--- a/src/pages/settings/Payments/AddDebitCardPage.js
+++ b/src/pages/settings/Payments/AddDebitCardPage.js
@@ -1,5 +1,4 @@
 import React, {Component} from 'react';
-import {withOnyx} from 'react-native-onyx';
 import {
     View,
     ScrollView,
@@ -13,7 +12,6 @@ import StatePicker from '../../../components/StatePicker';
 import Text from '../../../components/Text';
 import TextLink from '../../../components/TextLink';
 import withLocalize, {withLocalizePropTypes} from '../../../components/withLocalize';
-import compose from '../../../libs/compose';
 import {addBillingCard} from '../../../libs/actions/PaymentMethods';
 import Button from '../../../components/Button';
 import KeyboardAvoidingView from '../../../components/KeyboardAvoidingView';

--- a/src/pages/settings/Payments/AddDebitCardPage.js
+++ b/src/pages/settings/Payments/AddDebitCardPage.js
@@ -241,8 +241,4 @@ DebitCardPage.propTypes = propTypes;
 DebitCardPage.defaultProps = defaultProps;
 DebitCardPage.displayName = 'DebitCardPage';
 
-export default compose(
-    withLocalize,
-    withOnyx({
-    }),
-)(DebitCardPage);
+export default withLocalize(DebitCardPage);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Clean up incorrect usages of `compose()`

### Fixed Issues
$ https://github.com/Expensify/App/issues/6000

### Tests / QA Steps

All of these changes should be syntax and shouldn't have any bearing on the app behavior.
Therefore, we just need to run regular regressions.

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
