### PR TITLE
[No QA] Fix broken onyx logger. Update react-native-onyx.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38566,8 +38566,8 @@
       }
     },
     "react-native-onyx": {
-      "version": "git+https://github.com/Expensify/react-native-onyx.git#6eadd7f73fca87e6551e43607ec78f645e17ef50",
-      "from": "git+https://github.com/Expensify/react-native-onyx.git#6eadd7f73fca87e6551e43607ec78f645e17ef50",
+      "version": "git+https://github.com/Expensify/react-native-onyx.git#a1de049c9e23bb8ca4f90f334f112f44edc3fe02",
+      "from": "git+https://github.com/Expensify/react-native-onyx.git#a1de049c9e23bb8ca4f90f334f112f44edc3fe02",
       "requires": {
         "ascii-table": "0.0.9",
         "expensify-common": "git+https://github.com/Expensify/expensify-common.git#2e5cff552cf132da90a3fb9756e6b4fb6ae7b40c",
@@ -38624,11 +38624,6 @@
             "prop-types": "^15.6.2",
             "scheduler": "^0.18.0"
           }
-        },
-        "underscore": {
-          "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
-          "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -38566,8 +38566,8 @@
       }
     },
     "react-native-onyx": {
-      "version": "git+https://github.com/Expensify/react-native-onyx.git#a1de049c9e23bb8ca4f90f334f112f44edc3fe02",
-      "from": "git+https://github.com/Expensify/react-native-onyx.git#a1de049c9e23bb8ca4f90f334f112f44edc3fe02",
+      "version": "git+https://github.com/Expensify/react-native-onyx.git#ccb64c738b8bbe933b8997eb177f864e5139bd8d",
+      "from": "git+https://github.com/Expensify/react-native-onyx.git#ccb64c738b8bbe933b8997eb177f864e5139bd8d",
       "requires": {
         "ascii-table": "0.0.9",
         "expensify-common": "git+https://github.com/Expensify/expensify-common.git#2e5cff552cf132da90a3fb9756e6b4fb6ae7b40c",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "react-native-image-picker": "^4.0.3",
     "react-native-keyboard-spacer": "^0.4.1",
     "react-native-modal": "^11.10.0",
-    "react-native-onyx": "git+https://github.com/Expensify/react-native-onyx.git#a1de049c9e23bb8ca4f90f334f112f44edc3fe02",
+    "react-native-onyx": "git+https://github.com/Expensify/react-native-onyx.git#ccb64c738b8bbe933b8997eb177f864e5139bd8d",
     "react-native-pdf": "^6.2.2",
     "react-native-performance": "^2.0.0",
     "react-native-permissions": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "react-native-image-picker": "^4.0.3",
     "react-native-keyboard-spacer": "^0.4.1",
     "react-native-modal": "^11.10.0",
-    "react-native-onyx": "git+https://github.com/Expensify/react-native-onyx.git#6eadd7f73fca87e6551e43607ec78f645e17ef50",
+    "react-native-onyx": "git+https://github.com/Expensify/react-native-onyx.git#a1de049c9e23bb8ca4f90f334f112f44edc3fe02",
     "react-native-pdf": "^6.2.2",
     "react-native-performance": "^2.0.0",
     "react-native-permissions": "^3.0.1",

--- a/src/Expensify.js
+++ b/src/Expensify.js
@@ -26,9 +26,6 @@ Onyx.registerLogger(({level, message}) => {
     }
 });
 
-Onyx.merge('test', 'derp');
-Onyx.set('test', 'derp');
-
 const propTypes = {
     /* Onyx Props */
 

--- a/src/Expensify.js
+++ b/src/Expensify.js
@@ -2,7 +2,7 @@ import lodashGet from 'lodash/get';
 import PropTypes from 'prop-types';
 import React, {PureComponent} from 'react';
 import {View, AppState} from 'react-native';
-import {withOnyx} from 'react-native-onyx';
+import Onyx, {withOnyx} from 'react-native-onyx';
 
 import BootSplash from './libs/BootSplash';
 import * as ActiveClientManager from './libs/ActiveClientManager';
@@ -16,6 +16,18 @@ import Visibility from './libs/Visibility';
 import GrowlNotification from './components/GrowlNotification';
 import {growlRef} from './libs/Growl';
 import StartupTimer from './libs/StartupTimer';
+import Log from './libs/Log';
+
+Onyx.registerLogger(({level, message}) => {
+    if (level === 'alert') {
+        Log.alert(message);
+    } else {
+        Log.info(message);
+    }
+});
+
+Onyx.merge('test', 'derp');
+Onyx.set('test', 'derp');
 
 const propTypes = {
     /* Onyx Props */

--- a/src/Expensify.js
+++ b/src/Expensify.js
@@ -21,6 +21,7 @@ import Log from './libs/Log';
 Onyx.registerLogger(({level, message}) => {
     if (level === 'alert') {
         Log.alert(message);
+        console.error(message);
     } else {
         Log.info(message);
     }

--- a/src/setup/index.js
+++ b/src/setup/index.js
@@ -2,7 +2,6 @@ import Onyx from 'react-native-onyx';
 import ONYXKEYS from '../ONYXKEYS';
 import CONST from '../CONST';
 import listenToStorageEvents from '../libs/listenToStorageEvents';
-import Log from '../libs/Log';
 import platformSetup from './platformSetup';
 import {canCaptureOnyxMetrics} from '../libs/canCaptureMetrics';
 
@@ -38,14 +37,6 @@ export default function () {
         registerStorageEventListener: (onStorageEvent) => {
             listenToStorageEvents(onStorageEvent);
         },
-    });
-
-    Onyx.registerLogger(({level, message}) => {
-        if (level === 'alert') {
-            Log.alert(message, 0, {}, false);
-        } else {
-            Log.client(message);
-        }
     });
 
     // Perform any other platform-specific setup


### PR DESCRIPTION
### Details

- Adding some logs in https://github.com/Expensify/react-native-onyx/pull/105 to detect if/when we are calling `Onyx.set()` directly after `Onyx.merge()` and this PR is holding on that change.
- Noticed that the Onyx logger broke after being moved [here](https://github.com/Expensify/App/blob/adaf1c0ce5ef9e3cb3c6c55c9bb8b7fffe157bee/src/setup/index.js#L43-L49).

### Fixed Issues
N/A

### Tests

### QA Steps
No QA

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android