### PR TITLE
Restrict NewDot deep/universal links to specific paths on Android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -63,12 +63,6 @@
             <category android:name="android.intent.category.BROWSABLE"/>
             <data android:scheme="https" android:host="staging.new.expensify.com" />
         </intent-filter>
-        <intent-filter>
-            <action android:name="android.intent.action.VIEW"/>
-            <category android:name="android.intent.category.DEFAULT"/>
-            <category android:name="android.intent.category.BROWSABLE"/>
-            <data android:scheme="https" android:host="staging.new.expensify.com" />
-        </intent-filter>
       </activity>
       <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
       android:theme="@style/AppTheme">
+
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"
@@ -31,6 +32,7 @@
         android:exported="true"
         android:windowSoftInputMode="adjustResize">
       </activity>
+
       <activity
         android:name="com.zoontek.rnbootsplash.RNBootSplashActivity"
         android:theme="@style/BootTheme"
@@ -44,26 +46,12 @@
             <category android:name="android.intent.category.DEFAULT"/>
             <category android:name="android.intent.category.BROWSABLE"/>
             <data android:scheme="expensify-cash"/>
-        </intent-filter>
-        <intent-filter>
-            <action android:name="android.intent.action.VIEW"/>
-            <category android:name="android.intent.category.DEFAULT"/>
-            <category android:name="android.intent.category.BROWSABLE"/>
             <data android:scheme="new-expensify"/>
-        </intent-filter>
-        <intent-filter>
-            <action android:name="android.intent.action.VIEW"/>
-            <category android:name="android.intent.category.DEFAULT"/>
-            <category android:name="android.intent.category.BROWSABLE"/>
             <data android:scheme="https" android:host="new.expensify.com" />
-        </intent-filter>
-        <intent-filter>
-            <action android:name="android.intent.action.VIEW"/>
-            <category android:name="android.intent.category.DEFAULT"/>
-            <category android:name="android.intent.category.BROWSABLE"/>
             <data android:scheme="https" android:host="staging.new.expensify.com" />
         </intent-filter>
       </activity>
+
       <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
 
       <meta-data android:name="com.urbanairship.reactnative.AIRSHIP_EXTENDER"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -45,8 +45,12 @@
             <action android:name="android.intent.action.VIEW"/>
             <category android:name="android.intent.category.DEFAULT"/>
             <category android:name="android.intent.category.BROWSABLE"/>
+
+            <!-- Custom URI handlers. Used to intercept Urban Airship deep links. -->
             <data android:scheme="expensify-cash"/>
             <data android:scheme="new-expensify"/>
+
+            <!-- Web URL handlers. Used to intercept web links. -->
             <data android:scheme="https" android:host="new.expensify.com" />
             <data android:scheme="https" android:host="staging.new.expensify.com" />
         </intent-filter>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -59,8 +59,9 @@
             <category android:name="android.intent.category.BROWSABLE"/>
 
             <!-- Production URLs -->
-            <data android:scheme="https" android:host="new.expensify.com" android:pathPrefix="/settings"/>
             <data android:scheme="https" android:host="new.expensify.com" android:pathPrefix="/r"/>
+            <data android:scheme="https" android:host="new.expensify.com" android:pathPrefix="/settings"/>
+            <data android:scheme="https" android:host="new.expensify.com" android:pathPrefix="/setpassword"/>
             <data android:scheme="https" android:host="new.expensify.com" android:pathPrefix="/details"/>
             <data android:scheme="https" android:host="new.expensify.com" android:pathPrefix="/v"/>
             <data android:scheme="https" android:host="new.expensify.com" android:pathPrefix="/bank-account"/>
@@ -68,9 +69,9 @@
             <data android:scheme="https" android:host="new.expensify.com" android:pathPrefix="/enable-payments"/>
 
             <!-- Staging URLs -->
-            <data android:scheme="https" android:host="staging.new.expensify.com" android:pathPrefix="/settings"/>
             <data android:scheme="https" android:host="staging.new.expensify.com" android:pathPrefix="/r"/>
-            <data android:scheme="https" android:host="staging.new.expensify.com" android:pathPrefix="/details"/>
+            <data android:scheme="https" android:host="staging.new.expensify.com" android:pathPrefix="/settings"/>
+            <data android:scheme="https" android:host="staging.new.expensify.com" android:pathPrefix="/setpassword"/>
             <data android:scheme="https" android:host="staging.new.expensify.com" android:pathPrefix="/v"/>
             <data android:scheme="https" android:host="staging.new.expensify.com" android:pathPrefix="/bank-account"/>
             <data android:scheme="https" android:host="staging.new.expensify.com" android:pathPrefix="/iou"/>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -37,22 +37,44 @@
         android:name="com.zoontek.rnbootsplash.RNBootSplashActivity"
         android:theme="@style/BootTheme"
         android:launchMode="singleTask">
+
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />
         </intent-filter>
+
+        <!-- Custom URI handlers. Used to intercept Urban Airship deep links. -->
+        <intent-filter>
+            <action android:name="android.intent.action.VIEW"/>
+            <category android:name="android.intent.category.DEFAULT"/>
+            <category android:name="android.intent.category.BROWSABLE"/>
+            <data android:scheme="expensify-cash"/>
+            <data android:scheme="new-expensify"/>
+        </intent-filter>
+
+        <!-- Web URL handlers. Used to intercept web links. -->
         <intent-filter>
             <action android:name="android.intent.action.VIEW"/>
             <category android:name="android.intent.category.DEFAULT"/>
             <category android:name="android.intent.category.BROWSABLE"/>
 
-            <!-- Custom URI handlers. Used to intercept Urban Airship deep links. -->
-            <data android:scheme="expensify-cash"/>
-            <data android:scheme="new-expensify"/>
+            <!-- Production URLs -->
+            <data android:scheme="https" android:host="new.expensify.com" android:pathPrefix="/settings"/>
+            <data android:scheme="https" android:host="new.expensify.com" android:pathPrefix="/r"/>
+            <data android:scheme="https" android:host="new.expensify.com" android:pathPrefix="/details"/>
+            <data android:scheme="https" android:host="new.expensify.com" android:pathPrefix="/v"/>
+            <data android:scheme="https" android:host="new.expensify.com" android:pathPrefix="/bank-account"/>
+            <data android:scheme="https" android:host="new.expensify.com" android:pathPrefix="/iou"/>
+            <data android:scheme="https" android:host="new.expensify.com" android:pathPrefix="/enable-payments"/>
 
-            <!-- Web URL handlers. Used to intercept web links. -->
-            <data android:scheme="https" android:host="new.expensify.com" />
-            <data android:scheme="https" android:host="staging.new.expensify.com" />
+            <!-- Staging URLs -->
+            <data android:scheme="https" android:host="staging.new.expensify.com" android:pathPrefix="/settings"/>
+            <data android:scheme="https" android:host="staging.new.expensify.com" android:pathPrefix="/r"/>
+            <data android:scheme="https" android:host="staging.new.expensify.com" android:pathPrefix="/details"/>
+            <data android:scheme="https" android:host="staging.new.expensify.com" android:pathPrefix="/v"/>
+            <data android:scheme="https" android:host="staging.new.expensify.com" android:pathPrefix="/bank-account"/>
+            <data android:scheme="https" android:host="staging.new.expensify.com" android:pathPrefix="/iou"/>
+            <data android:scheme="https" android:host="staging.new.expensify.com" android:pathPrefix="/enable-payments"/>
         </intent-filter>
       </activity>
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -72,6 +72,7 @@
             <data android:scheme="https" android:host="staging.new.expensify.com" android:pathPrefix="/r"/>
             <data android:scheme="https" android:host="staging.new.expensify.com" android:pathPrefix="/settings"/>
             <data android:scheme="https" android:host="staging.new.expensify.com" android:pathPrefix="/setpassword"/>
+            <data android:scheme="https" android:host="staging.new.expensify.com" android:pathPrefix="/details"/>
             <data android:scheme="https" android:host="staging.new.expensify.com" android:pathPrefix="/v"/>
             <data android:scheme="https" android:host="staging.new.expensify.com" android:pathPrefix="/bank-account"/>
             <data android:scheme="https" android:host="staging.new.expensify.com" android:pathPrefix="/iou"/>


### PR DESCRIPTION
### Details
We need to restrict universal/deep-link handling to specific, supported paths. This is because the NewDot app was intercepting every web URL to open the app, but did not handle these links gracefully. For example, the N6 inbox card should open the NewDot webpage and create a new workspace automatically. The NewDot mobile app was intercepting the link but showing erros and getting stuck at the homepage. 

This already works correctly for iOS, so this PR aligns Android with iOS. Restricting deep links to specific paths fixes the above issue AND aligns NewDot with OldDot. 

Part 1 of [a three part issue](https://github.com/Expensify/Expensify/issues/179366#issuecomment-952132976)

_Later on we will probably want to intercept additional URLs and handle them within the app, but this is a lot of work and not yet necessary._

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
https://github.com/Expensify/Expensify/issues/179366

### Tests

**Run these tests on Android only**
- Install both the NewDot (build from this branch) and OldDot (any version/environment is fine) mobile apps
- Send this text as an email to yourself (ideally using Gmail)
```
https://expensify.com > open browser
https://expensify.com/inbox > open OldDot app
https://expensify.com/anUnhandledPath > open browser

https://new.expensify.com > open browser
https://new.expensify.com/settings > open NewDot app
https://new.expensify.com/anUnhandledPath > open browser
```
- On mobile, open the email and tap the links, one by one
- Each link should open the app or browser (this is attached to each link)
- You might see the 'Which app would you like to open' prompt, which is a special case:
    - If the desired outcome is 'open browser' and you have the option to open in app, this is a fail
    - If the desired outcome is 'NewDot / OldDot app' and you have the option to open in both apps, this is a fail
    - If the desired outcome is 'NewDot / OldDot app' and you have the option to open in app or browser, this is a success

**Android**
https://user-images.githubusercontent.com/10736861/139106960-22338e5e-f870-4eb7-83b6-6c54db7b3f2a.mp4

**iOS**
https://user-images.githubusercontent.com/10736861/139107214-69d91793-30a1-4b51-ae48-f4e2bf329636.mp4

### QA Steps

Run the test steps listed above

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop 
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
![Screenshot 2021-10-27 at 17 26 54](https://user-images.githubusercontent.com/10736861/139109002-9e928b92-6aa0-4f63-aa18-2361dc17c9c7.png)

#### Desktop
<img width="1195" alt="Screenshot 2021-10-27 at 17 23 57" src="https://user-images.githubusercontent.com/10736861/139107259-14e6312f-2ecf-459a-9640-f5d7fb324865.png">

#### iOS
^ see screencast in issue description

#### Android
^ see screencast in issue description
