### PR TITLE
Ensures mini actions menu will disappear when attachment modal opens up

### DIFF
--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -139,7 +139,7 @@ class ReportActionItem extends Component {
                 preventDefaultContentMenu={!this.props.draftMessage}
 
             >
-                <Hoverable resetsOnClickOutside={false}>
+                <Hoverable resetsOnClickOutside>
                     {hovered => (
                         <View>
                             {this.props.shouldDisplayNewIndicator && (


### PR DESCRIPTION
### Details
The `={false}` value of the prop was forcing the mini action menu to keep visible even when it lost the focus.

### Fixed Issues
https://github.com/Expensify/App/issues/5972

### Tests
When tapping to open the attachment, should NOT show the mini actions menu after closing the attachments modal

### QA Steps
1. Navigate to a conversation
2. Send an image
3. Open the image preview
4. Click on the top right X to close the modal
5. Close the modal

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [X] iOS
- [x] Android

### Recording

- Web https://www.dropbox.com/s/vt1vat6ib52bcb7/MINI_ACTION_TEST_WEB.mp4?dl=0
- Mobile Web https://www.dropbox.com/s/78icy876lrzodxq/MINI_ACTION_TEST_WEB_IOS.mp4?dl=0
- Desktop https://www.dropbox.com/s/8v8hmkrfbj7046t/MINI_ACTION_TEST_DESKTOP.mp4?dl=0
- iOS https://www.dropbox.com/s/6j9ofxvtrjuncnm/MINI_ACTION_IOS.mp4?dl=0
- Android https://www.dropbox.com/s/jmax9etffmz3k9g/MINI_ACTIONS_ANDROID.mp4?dl=0
