### PR TITLE
[CP Stg] Only navigate to Onfido if we're in the Send Money flow

### DIFF
--- a/src/components/ButtonWithMenu.js
+++ b/src/components/ButtonWithMenu.js
@@ -2,14 +2,11 @@ import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {View} from 'react-native';
 import _ from 'underscore';
-import {withOnyx} from 'react-native-onyx';
 import styles from '../styles/styles';
 import Button from './Button';
 import ButtonWithDropdown from './ButtonWithDropdown';
 import PopoverMenu from './PopoverMenu';
-import ONYXKEYS from '../ONYXKEYS';
 import CONST from '../CONST';
-import userWalletPropTypes from '../pages/EnablePayments/userWalletPropTypes';
 import Navigation from '../libs/Navigation/Navigation';
 import ROUTES from '../ROUTES';
 
@@ -30,7 +27,7 @@ const propTypes = {
     isDisabled: PropTypes.bool,
 
     /** Menu options to display */
-    /** [{text: 'Pay with Expensify', icon: Wallet}, {text: 'PayPal', icon: PayPal}, {text: 'Venmo', icon: Venmo}] */
+    /** e.g. [{text: 'Pay with Expensify', icon: Wallet}, {text: 'PayPal', icon: PayPal}, {text: 'Venmo', icon: Venmo}] */
     options: PropTypes.arrayOf(PropTypes.shape({
         text: PropTypes.string.isRequired,
         icon: PropTypes.elementType,
@@ -38,9 +35,6 @@ const propTypes = {
         iconHeight: PropTypes.number,
         iconDescription: PropTypes.string,
     })).isRequired,
-
-    /** The user's current wallet status and step */
-    userWallet: userWalletPropTypes.isRequired,
 };
 
 const defaultProps = {
@@ -120,8 +114,4 @@ class ButtonWithMenu extends PureComponent {
 ButtonWithMenu.propTypes = propTypes;
 ButtonWithMenu.defaultProps = defaultProps;
 
-export default withOnyx({
-    userWallet: {
-        key: ONYXKEYS.USER_WALLET,
-    },
-})(ButtonWithMenu);
+export default ButtonWithMenu;

--- a/src/components/ButtonWithMenu.js
+++ b/src/components/ButtonWithMenu.js
@@ -54,12 +54,6 @@ class ButtonWithMenu extends PureComponent {
         };
     }
 
-    componentDidMount() {
-        if (!this.props.userWallet.tierName || this.props.userWallet.tierName === CONST.WALLET.TIER_NAME.SILVER) {
-            Navigation.navigate(ROUTES.IOU_ENABLE_PAYMENTS);
-        }
-    }
-
     setMenuVisibility(isMenuVisible) {
         this.setState({isMenuVisible});
     }

--- a/src/components/ButtonWithMenu.js
+++ b/src/components/ButtonWithMenu.js
@@ -6,9 +6,6 @@ import styles from '../styles/styles';
 import Button from './Button';
 import ButtonWithDropdown from './ButtonWithDropdown';
 import PopoverMenu from './PopoverMenu';
-import CONST from '../CONST';
-import Navigation from '../libs/Navigation/Navigation';
-import ROUTES from '../ROUTES';
 
 const propTypes = {
     /** Text to display for the menu header */

--- a/src/pages/iou/IOUModal.js
+++ b/src/pages/iou/IOUModal.js
@@ -80,7 +80,7 @@ const propTypes = {
     }).isRequired,
 
     /** The user's current wallet status and step */
-    userWallet: userWalletPropTypes.isRequired,
+    ...userWalletPropTypes,
 
     ...withLocalizePropTypes,
 };
@@ -94,6 +94,7 @@ const defaultProps = {
         localCurrencyCode: CONST.CURRENCY.USD,
     },
     iouType: CONST.IOU.IOU_TYPE.REQUEST,
+    userWallet: {},
 };
 
 // Determines type of step to display within Modal, value provides the title for that page.

--- a/src/pages/iou/IOUModal.js
+++ b/src/pages/iou/IOUModal.js
@@ -80,7 +80,7 @@ const propTypes = {
     }).isRequired,
 
     /** The user's current wallet status and step */
-    ...userWalletPropTypes,
+    userWallet: userWalletPropTypes.userWallet,
 
     ...withLocalizePropTypes,
 };

--- a/src/pages/iou/IOUModal.js
+++ b/src/pages/iou/IOUModal.js
@@ -122,6 +122,8 @@ class IOUModal extends Component {
             payPalMeAddress: lodashGet(personalDetails, 'payPalMeAddress', ''),
             phoneNumber: lodashGet(personalDetails, 'phoneNumber', ''),
         }));
+        this.isSendRequest = props.iouType === CONST.IOU.IOU_TYPE.SEND;
+        this.hasGoldWallet = props.userWallet.tierName && props.userWallet.tiername === CONST.WALLET.TIER_NAME.GOLD;
 
         this.state = {
             currentStepIndex: 0,
@@ -179,7 +181,7 @@ class IOUModal extends Component {
                     currency: this.props.iou.selectedCurrencyCode,
                 },
             );
-            if (this.props.iouType === CONST.IOU.IOU_TYPE.SEND) {
+            if (this.isSendRequest) {
                 return this.props.translate('iou.send', {
                     amount: formattedAmount,
                 });
@@ -191,7 +193,7 @@ class IOUModal extends Component {
             );
         }
         if (currentStepIndex === 0) {
-            if (this.props.iouType === CONST.IOU.IOU_TYPE.SEND) {
+            if (this.isSendRequest) {
                 return this.props.translate('iou.sendMoney');
             }
             return this.props.translate(this.props.hasMultipleParticipants ? 'iou.splitBill' : 'iou.requestMoney');
@@ -247,8 +249,8 @@ class IOUModal extends Component {
     createTransaction(splits) {
         const reportID = lodashGet(this.props, 'route.params.reportID', '');
 
-        if (this.props.iouType === CONST.IOU.IOU_TYPE.SEND
-            && (!this.props.userWallet.tierName || this.props.userWallet.tierName === CONST.WALLET.TIER_NAME.SILVER)) {
+        // If the user is trying to send money, then they need to upgrade to a GOLD wallet
+        if (this.isSendRequest && !this.hasGoldWallet) {
             Navigation.navigate(ROUTES.IOU_ENABLE_PAYMENTS);
             return;
         }

--- a/src/pages/iou/IOUModal.js
+++ b/src/pages/iou/IOUModal.js
@@ -26,8 +26,8 @@ import Tooltip from '../../components/Tooltip';
 import CONST from '../../CONST';
 import KeyboardAvoidingView from '../../components/KeyboardAvoidingView';
 import * as PersonalDetails from '../../libs/actions/PersonalDetails';
-import userWalletPropTypes from "../EnablePayments/userWalletPropTypes";
-import ROUTES from "../../ROUTES";
+import userWalletPropTypes from '../EnablePayments/userWalletPropTypes';
+import ROUTES from '../../ROUTES';
 
 /**
  * IOU modal for requesting money and splitting bills.
@@ -125,9 +125,6 @@ class IOUModal extends Component {
         this.state = {
             currentStepIndex: 0,
             participants: participantsWithDetails,
-
-            // Set default payment type to "Elsewhere"
-            paymentType: CONST.IOU.PAYMENT_TYPE.ELSEWHERE,
 
             // amount is currency in decimal format
             amount: '',
@@ -249,9 +246,10 @@ class IOUModal extends Component {
     createTransaction(splits) {
         const reportID = lodashGet(this.props, 'route.params.reportID', '');
 
-        if (this.props.iouType === CONST.IOU.IOU_TYPE.SEND && this.state.paymentType === CONST.IOU.PAYMENT_TYPE.EXPENSIFY &&
-            (!this.props.userWallet.tierName || this.props.userWallet.tierName === CONST.WALLET.TIER_NAME.SILVER)) {
+        if (this.props.iouType === CONST.IOU.IOU_TYPE.SEND
+            && (!this.props.userWallet.tierName || this.props.userWallet.tierName === CONST.WALLET.TIER_NAME.SILVER)) {
             Navigation.navigate(ROUTES.IOU_ENABLE_PAYMENTS);
+            return;
         }
 
         // Only splits from a group DM has a reportID

--- a/src/pages/iou/IOUModal.js
+++ b/src/pages/iou/IOUModal.js
@@ -26,6 +26,8 @@ import Tooltip from '../../components/Tooltip';
 import CONST from '../../CONST';
 import KeyboardAvoidingView from '../../components/KeyboardAvoidingView';
 import * as PersonalDetails from '../../libs/actions/PersonalDetails';
+import userWalletPropTypes from "../EnablePayments/userWalletPropTypes";
+import ROUTES from "../../ROUTES";
 
 /**
  * IOU modal for requesting money and splitting bills.
@@ -77,6 +79,9 @@ const propTypes = {
         avatar: PropTypes.string,
     }).isRequired,
 
+    /** The user's current wallet status and step */
+    userWallet: userWalletPropTypes.isRequired,
+
     ...withLocalizePropTypes,
 };
 
@@ -120,6 +125,9 @@ class IOUModal extends Component {
         this.state = {
             currentStepIndex: 0,
             participants: participantsWithDetails,
+
+            // Set default payment type to "Elsewhere"
+            paymentType: CONST.IOU.PAYMENT_TYPE.ELSEWHERE,
 
             // amount is currency in decimal format
             amount: '',
@@ -240,6 +248,11 @@ class IOUModal extends Component {
      */
     createTransaction(splits) {
         const reportID = lodashGet(this.props, 'route.params.reportID', '');
+
+        if (this.props.iouType === CONST.IOU.IOU_TYPE.SEND && this.state.paymentType === CONST.IOU.PAYMENT_TYPE.EXPENSIFY &&
+            (!this.props.userWallet.tierName || this.props.userWallet.tierName === CONST.WALLET.TIER_NAME.SILVER)) {
+            Navigation.navigate(ROUTES.IOU_ENABLE_PAYMENTS);
+        }
 
         // Only splits from a group DM has a reportID
         // Check if reportID is a number
@@ -389,6 +402,9 @@ export default compose(
         },
         myPersonalDetails: {
             key: ONYXKEYS.MY_PERSONAL_DETAILS,
+        },
+        userWallet: {
+            key: ONYXKEYS.USER_WALLET,
         },
     }),
 )(IOUModal);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Moved the wallet check from the ButtonWithMenu component to IOUModal. Now we will only go to the Onfido flow once a user tries to pay.

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/pull/5928

### Tests / QA Steps
1. Using an account with a silver wallet (or no wallet), select the "Send Money" option in the global create menu.
2. Select someone to send money to; it doesn't matter who. Type in any amount.
3. Verify you are taken to the Confirmation page, and click on the "Pay with Expensify" option in green.
4. Verify you are taken to the Onfido verification flow and that you don't proceed with the Send Money flow.
5. Verify that clicking the close button in the header takes you back to your IOU request.
6. Next, select the "Request Money" option in the global create menu.
7. Follow the full flow to request money from anyone and verify the Onfido verification flow does not pop up.

### Tested On

- [ ] Web
- [ ] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
![Kapture 2021-10-27 at 13 48 56](https://user-images.githubusercontent.com/24466196/139144796-a16d9b4a-97ef-482f-8025-d68f7616708b.gif)

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
![Kapture 2021-10-27 at 15 03 03](https://user-images.githubusercontent.com/24466196/139153851-304fa7b2-b607-4364-bd50-8c16a5bd3120.gif)

#### iOS
![Screen Shot 2021-10-27 at 2 19 19 PM](https://user-images.githubusercontent.com/24466196/139148739-6608071c-fd22-43e8-9a1d-47eb51e81066.png)
![Screen Shot 2021-10-27 at 2 19 00 PM](https://user-images.githubusercontent.com/24466196/139148743-44b97c46-e563-4583-b5c1-2bfaad41363e.png)
![Screen Shot 2021-10-27 at 2 18 54 PM](https://user-images.githubusercontent.com/24466196/139148746-6c63a8e7-7bc7-460f-8681-90031ffe2534.png)


#### Android
<!-- Insert screenshots of your changes on the Android platform-->

<img width="405" alt="Screen Shot 2021-10-27 at 2 43 02 PM" src="https://user-images.githubusercontent.com/24466196/139151888-16867d69-4cfe-456c-ab04-0e09c8749083.png">
<img width="406" alt="Screen Shot 2021-10-27 at 2 43 42 PM" src="https://user-images.githubusercontent.com/24466196/139151864-3c2ca62b-92b7-430b-86b6-856306e763a5.png">
<img width="404" alt="Screen Shot 2021-10-27 at 2 43 20 PM" src="https://user-images.githubusercontent.com/24466196/139151879-c6ca7fc4-5d2c-43ec-90ff-60b3a9461682.png">

