### PR TITLE
Fix PayPal.me const usages

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -85,7 +85,7 @@ export default {
         reset: 'Reset',
         done: 'Done',
         debitCard: 'Debit card',
-        payPalMe: 'PayPal.me/',
+        payPalMe: 'PayPal.me',
     },
     attachmentPicker: {
         cameraPermissionRequired: 'Camera permission required',
@@ -281,6 +281,7 @@ export default {
     },
     addPayPalMePage: {
         enterYourUsernameToGetPaidViaPayPal: 'Enter your username to get paid back via PayPal.',
+        payPalMe: 'PayPal.me/',
         yourPayPalUsername: 'Your PayPal username',
         addPayPalAccount: 'Add PayPal account',
         editPayPalAccount: 'Update PayPal account',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -85,7 +85,7 @@ export default {
         reset: 'Restablecer',
         done: 'Listo',
         debitCard: 'Tarjeta de débito',
-        payPalMe: 'PayPal.me/',
+        payPalMe: 'PayPal.me',
     },
     attachmentPicker: {
         cameraPermissionRequired: 'Se necesita permiso para usar la cámara',
@@ -281,6 +281,7 @@ export default {
     },
     addPayPalMePage: {
         enterYourUsernameToGetPaidViaPayPal: 'Escribe tu nombre de usuario para que otros puedan pagarte a través de PayPal.',
+        payPalMe: 'PayPal.me/',
         yourPayPalUsername: 'Tu usuario de PayPal',
         addPayPalAccount: 'Agregar cuenta de PayPal',
         growlMessageOnSave: 'Su nombre de usuario de PayPal se agregó correctamente',

--- a/src/pages/settings/Payments/AddPayPalMePage.js
+++ b/src/pages/settings/Payments/AddPayPalMePage.js
@@ -75,7 +75,7 @@ class AddPayPalMePage extends React.Component {
             <ScreenWrapper>
                 <KeyboardAvoidingView>
                     <HeaderWithCloseButton
-                        title="PayPal.me"
+                        title={this.props.translate('common.payPalMe')}
                         shouldShowBackButton
                         onBackButtonPress={() => Navigation.navigate(ROUTES.SETTINGS_PAYMENTS)}
                         onCloseButtonPress={() => Navigation.dismissModal(true)}
@@ -86,7 +86,7 @@ class AddPayPalMePage extends React.Component {
                                 {this.props.translate('addPayPalMePage.enterYourUsernameToGetPaidViaPayPal')}
                             </Text>
                             <ExpensiTextInput
-                                label={this.props.translate('common.payPalMe')}
+                                label={this.props.translate('addPayPalMePage.payPalMe')}
                                 autoCompleteType="off"
                                 autoCorrect={false}
                                 value={this.state.payPalMeUsername}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This PR fixes a regression from https://github.com/Expensify/App/pull/5940 where the `PayPal.me/` const was added in the wrong place. I've also updated the title of the `AddPayPalMePage.js` header to use a constant.

### Fixed Issues
See [slack post](https://expensify.slack.com/archives/C01GTK53T8Q/p1635360452183200)

### Tests/QA
See screenshots below
1. Log in and go to settings->payments, confirm that when selecting an option you see `PayPal.me` without an extra `/`
2. Click on the PayPal option and confirm that the input placeholder contains the `/`

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
||||
|---|---|---|
| ![image](https://user-images.githubusercontent.com/3981102/139148432-f8653892-c1e5-4826-9906-b33e1ccd8338.png) | ![image](https://user-images.githubusercontent.com/3981102/139148448-434f3362-b2eb-4959-a8e5-733f37d89061.png) | ![image](https://user-images.githubusercontent.com/3981102/139148461-7719fa4c-1aeb-468e-9a36-2287e4e9c510.png) |



