### PR TITLE
Add detail about including Upwork link for invite to Slack

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ This project and everyone participating in it is governed by the Expensify [Code
 At this time, we are not hiring contractors in Crimea, North Korea, Russia, Iran, Cuba, or Syria.
 
 ## Asking Questions
-If you have any general questions, please ask in the #expensify-open-source Slack channel. To request an invite to the channel, just email contributors@expensify.com with the subject `Slack Channel Invite` and we'll send you an invite! The Expensify team will not be able to respond to direct messages in Slack.
+If you have any general questions, please ask in the #expensify-open-source Slack channel. To request an invite to the channel, just email contributors@expensify.com with the subject `Slack Channel Invite` and include a link to your Upwork profile. We'll send you an invite! The Expensify team will not be able to respond to direct messages in Slack.
 
 If you are hired for an Upwork job and have any job-specific questions, please ask in the GitHub issue or pull request. This will ensure that the person addressing your question has as much context as possible.
 


### PR DESCRIPTION
Add details about providing Upwork link when requesting access to #expensify-open-source Slack

Per this [Slack convo](https://expensify.slack.com/archives/C01SKUP7QR0/p1634740386238300) - we want a contributor to provide a link to their Upwork profile when emailing contributors@expensify.com asking for access to slack. This will help ensure they are legit. 

### Details

Adding the details to this line: 

![image](https://user-images.githubusercontent.com/51066321/139222029-750ca801-d7e4-4675-9181-2bfe5307be97.png)

### Fixed Issues

Issue described in Slack [here](https://expensify.slack.com/archives/C01SKUP7QR0/p1634740386238300). 

### Tests
NONE
