### PR TITLE
Remove KeyboardSpacer component from NewChatPage

### DIFF
--- a/src/pages/NewChatPage.js
+++ b/src/pages/NewChatPage.js
@@ -9,7 +9,6 @@ import {getNewChatOptions, getHeaderMessage} from '../libs/OptionsListUtils';
 import ONYXKEYS from '../ONYXKEYS';
 import styles from '../styles/styles';
 import {fetchOrCreateChatReport} from '../libs/actions/Report';
-import KeyboardSpacer from '../components/KeyboardSpacer';
 import CONST, {EXPENSIFY_EMAILS} from '../CONST';
 import withWindowDimensions, {windowDimensionsPropTypes} from '../components/withWindowDimensions';
 import HeaderWithCloseButton from '../components/HeaderWithCloseButton';
@@ -263,7 +262,6 @@ class NewChatPage extends Component {
                                         hideAdditionalOptionStates
                                         forceTextUnreadStyle
                                     />
-                                    {!this.props.isGroupChat && <KeyboardSpacer />}
                                     {this.props.isGroupChat && lodashGet(this.state, 'selectedOptions', []).length > 0 && (
                                         <FixedFooter>
                                             <Button


### PR DESCRIPTION
### Fixed Issues
$ https://github.com/Expensify/App/issues/6097

### Tests / QA Steps.
1. Run the app on a _physical device_.
1. Click on the FAB and select `New Chat`.
1. Verify that results in the list are not obscured.
1. Close the new chat modal.
1. Click on the FAB and select `New Group`.
1. Verify that results in the list are not obscured.

### Tested On

- [ ] Web
- [x] Mobile Web
- [ ] Desktop
- [x] iOS
- [x] Android

### Screenshots
#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
|New Chat|New Group|
|--------|---------|
|![IMG_40C933BF7118-1](https://user-images.githubusercontent.com/47436092/139312189-83fe31c5-e271-4fbb-8e3a-0870d2d2aa4d.jpeg)|![IMG_CACC2A48D871-1](https://user-images.githubusercontent.com/47436092/139312199-a461deb6-45f4-4f62-a756-e611843b0e48.jpeg)|

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS

|New Chat|New Group|
|--------|---------|
|![IMG_09FE61201532-1](https://user-images.githubusercontent.com/47436092/139311430-4b4272d1-56b0-4645-beaf-498886049c5f.jpeg)|![IMG_D78696B16444-1](https://user-images.githubusercontent.com/47436092/139311446-26d7c491-021d-4d1f-a38b-f0afc9e0597d.jpeg)|

#### Android

|New Chat|New Group|
|---|---|
|![image](https://user-images.githubusercontent.com/47436092/139313938-d384124d-b332-4919-90a0-9727af211aeb.png)|![image](https://user-images.githubusercontent.com/47436092/139314039-50496714-a793-4132-be65-1f09a409ca76.png)|
