### PR TITLE
Fix `TextLink` text wrapping

### DIFF
--- a/src/components/TextLink.js
+++ b/src/components/TextLink.js
@@ -1,7 +1,7 @@
 import _ from 'underscore';
 import React from 'react';
 import PropTypes from 'prop-types';
-import {Pressable, Linking} from 'react-native';
+import {Linking} from 'react-native';
 import Text from './Text';
 import styles from '../styles/styles';
 import stylePropTypes from '../styles/stylePropTypes';
@@ -33,7 +33,10 @@ const defaultProps = {
 const TextLink = (props) => {
     const additionalStyles = _.isArray(props.style) ? props.style : [props.style];
     return (
-        <Pressable
+        <Text
+            style={[styles.link, ...additionalStyles]}
+            accessibilityRole="link"
+            href={props.href}
             onPress={(e) => {
                 e.preventDefault();
                 if (props.onPress) {
@@ -43,15 +46,9 @@ const TextLink = (props) => {
 
                 Linking.openURL(props.href);
             }}
-            accessibilityRole="link"
-            href={props.href}
         >
-            {({hovered, pressed}) => (
-                <Text style={[styles.link, (hovered || pressed) ? styles.linkHovered : undefined, ...additionalStyles]}>
-                    {props.children}
-                </Text>
-            )}
-        </Pressable>
+            {props.children}
+        </Text>
     );
 };
 


### PR DESCRIPTION
Previously, we assumed that `TextLink` components behaved like `Text` components–i.e. if the text exceeds with the width of the container, it should wrap. However, this wasn't happening because we were using a `Pressable` internally for `TextLink` components, which was causing some strange behavior with how `TextLink` components were displaying when used in-line with other text. 

This fixes `TextLink` to use `Text` under the hood. It gets rid of the ability for us to apply additional styles on hover/press.

#### Before
![](https://utest-dl.s3.amazonaws.com/12102/26469/337764/null/bugAttachment/Bug5299147_Spanish_2610.jpg?AWSAccessKeyId=AKIAJ2UIWMJ2OMC3UCQQ&Expires=1666842488&Signature=9cv9JpkMbGE8idz1gEXgMYcDulA%3D)

#### After
![Simulator Screen Shot - iPhone 13 - 2021-10-29 at 13 26 02](https://user-images.githubusercontent.com/31285285/139497684-6e741b44-f665-4da9-9f13-ac6d8955680c.png)


### Fixed Issues
$ https://github.com/Expensify/App/issues/6078

### Tests
1. Create a file called `edit_content.diff` in your App directory with the following:
```
diff --git src/pages/EnablePayments/index.js src/pages/EnablePayments/index.js
index 8012df050..7c329f587 100644
--- src/pages/EnablePayments/index.js
+++ src/pages/EnablePayments/index.js
@@ -28,11 +28,12 @@ class EnablePaymentsPage extends React.Component {
    }

    render() {
-        if (_.isEmpty(this.props.userWallet)) {
-            return <FullScreenLoadingIndicator />;
-        }
+        // if (_.isEmpty(this.props.userWallet)) {
+        //     return <FullScreenLoadingIndicator />;
+        // }

-        const currentStep = this.props.userWallet.currentStep || CONST.WALLET.STEP.ONFIDO;
+        // const currentStep = this.props.userWallet.currentStep || CONST.WALLET.STEP.ONFIDO;
+        const currentStep = CONST.WALLET.STEP.ONFIDO;
        return (
            <ScreenWrapper>
                {currentStep === CONST.WALLET.STEP.ONFIDO && <OnfidoStep />}
diff --git src/pages/ReimbursementAccount/ReimbursementAccountPage.js src/pages/ReimbursementAccount/ReimbursementAccountPage.js
index 757fd7ab1..3e7abb986 100644
--- src/pages/ReimbursementAccount/ReimbursementAccountPage.js
+++ src/pages/ReimbursementAccount/ReimbursementAccountPage.js
@@ -159,7 +159,7 @@ class ReimbursementAccountPage extends React.Component {
        // mounts which will set the achData.currentStep after the account data is fetched and overwrite the logical
        // next step.
        const achData = lodashGet(this.props, 'reimbursementAccount.achData', {});
-        const currentStep = achData.currentStep || CONST.BANK_ACCOUNT.STEP.BANK_ACCOUNT;
+        const currentStep = CONST.BANK_ACCOUNT.STEP.REQUESTOR || achData.currentStep || CONST.BANK_ACCOUNT.STEP.BANK_ACCOUNT;
        if (this.props.reimbursementAccount.loading) {
            const isSubmittingVerificationsData = _.contains([
                CONST.BANK_ACCOUNT.STEP.COMPANY,
diff --git src/pages/iou/IOUModal.js src/pages/iou/IOUModal.js
index 2957a4c28..59d1c99b0 100755
--- src/pages/iou/IOUModal.js
+++ src/pages/iou/IOUModal.js
@@ -250,7 +250,7 @@ class IOUModal extends Component {
        const reportID = lodashGet(this.props, 'route.params.reportID', '');

        // If the user is trying to send money, then they need to upgrade to a GOLD wallet
-        if (this.isSendRequest && !this.hasGoldWallet) {
+        if (true){//this.isSendRequest && !this.hasGoldWallet) {
            Navigation.navigate(ROUTES.IOU_ENABLE_PAYMENTS);
            return;
        }
```
2. Apply this diff. This will allow us to navigate through the Send Money flow to the Onfido Flow without having to set up the test account's wallet.
```
patch -p0 -i edit_content.diff
```
3. Sign into NewDot, click the global create menu > Send Money.
4. Click through the steps until you're taken to a modal "Verify Identity".
5. Verify that the text links display correctly (as in the screenshots below).
6. Navigate to Preferences and change the language to Spanish.
7. Repeat steps 3-5 again, verify everything displays correctly in Spanish.

### QA Steps
Test Account:
- username: `janeil21@mbakingzl.com`
- password: `asdfASDF00`
1. Sign into NewDot with the test account, click the global create menu > Send Money.
2. Click through the steps until you're taken to a modal "Verify Identity".
3. Verify that the text links display correctly (as in the screenshots below).
4. Sign into OldDot with the test account and run the following in the console:
```js
NVP.set('preferredLocale', 'es')
```
5. Repeat steps 1-3 again, verify everything displays correctly in Spanish.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<img width="1792" alt="Screen Shot 2021-10-29 at 1 46 15 PM" src="https://user-images.githubusercontent.com/31285285/139499705-1cf4378f-60ce-4d5b-a9ba-c56bc0f6e824.png">

#### Mobile Web
<img width="375" alt="Screen Shot 2021-10-29 at 1 56 48 PM" src="https://user-images.githubusercontent.com/31285285/139500725-86358bb1-eb5b-438e-a2cf-e12515e428d1.png">

#### Desktop
<img width="1201" alt="Screen Shot 2021-10-29 at 1 47 11 PM" src="https://user-images.githubusercontent.com/31285285/139499770-4039b579-1234-457d-aaed-df6899b8d412.png">

#### iOS
![Simulator Screen Shot - iPhone 13 - 2021-10-29 at 13 26 02](https://user-images.githubusercontent.com/31285285/139497684-6e741b44-f665-4da9-9f13-ac6d8955680c.png)

#### Android
![Screenshot_20211029-140120_New Expensify](https://user-images.githubusercontent.com/31285285/139501236-90654e34-c4fc-4687-b3c0-b1652bed9065.jpg)


