### PR TITLE
Remove lingering border from AddressSearch component

### DIFF
--- a/src/components/AddressSearch.js
+++ b/src/components/AddressSearch.js
@@ -86,7 +86,7 @@ const AddressSearch = (props) => {
 
         // We use the View height to determine if we should hide the border and margin of the listView dropdown
         // to prevent a lingering border when there are no address suggestions.
-        // The height of the input + error message is 94 pixels
+        // The height of the input + wrapped error message is 112 pixels
         <View
             onLayout={(event) => {
                 const {height} = event.nativeEvent.layout;

--- a/src/components/AddressSearch.js
+++ b/src/components/AddressSearch.js
@@ -145,8 +145,7 @@ const AddressSearch = (props) => {
                 // We use the height of the element to determine if we should hide the border of the listView dropdown
                 // to prevent a lingering border when there are no address suggestions.
                 // The height of the empty element is 2px (1px height for each top and bottom borders)
-                const {height} = event.nativeEvent.layout;
-                setDisplayListViewBorder(height > 2);
+                setDisplayListViewBorder(event.nativeEvent.layout.height > 2);
             }}
         />
     );

--- a/src/components/AddressSearch.js
+++ b/src/components/AddressSearch.js
@@ -45,7 +45,7 @@ class AddressSearch extends React.Component {
         this.googlePlacesRef = React.createRef();
     }
 
-    componentDidMount() {
+    componentDidUpdate() {
         if (!this.googlePlacesRef.current) {
             return;
         }

--- a/src/components/AddressSearch.js
+++ b/src/components/AddressSearch.js
@@ -45,10 +45,10 @@ class AddressSearch extends React.Component {
         this.googlePlacesRef = React.createRef();
     }
 
-    componentDidUpdate() {
-        if (!this.googlePlacesRef.current) {
-            return;
-        }
+    componentDidMount() {
+        // if (!this.googlePlacesRef.current) {
+        //     return;
+        // }
 
         this.googlePlacesRef.current.setAddressText(this.props.value);
     }

--- a/src/components/AddressSearch.js
+++ b/src/components/AddressSearch.js
@@ -126,6 +126,7 @@ const AddressSearch = (props) => {
             styles={{
                 textInputContainer: [styles.flexColumn],
                 listView: [
+                    !displayListViewBorder && styles.googleListView,
                     displayListViewBorder && styles.borderTopRounded,
                     displayListViewBorder && styles.borderBottomRounded,
                     displayListViewBorder && styles.mt1,

--- a/src/components/AddressSearch.js
+++ b/src/components/AddressSearch.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import React from 'react';
+import React, {useEffect, useState, useRef} from 'react';
 import PropTypes from 'prop-types';
 import {LogBox, View} from 'react-native';
 import {GooglePlacesAutocomplete} from 'react-native-google-places-autocomplete';
@@ -35,25 +35,18 @@ const defaultProps = {
     containerStyles: null,
 };
 
-class AddressSearch extends React.Component {
-    constructor(props) {
-        super(props);
+const AddressSearch = (props) => {
+    const googlePlacesRef = useRef();
+    const [display, setDisplay] = useState(false);
+    useEffect(() => {
+        if (!googlePlacesRef.current) {
+            return;
+        }
 
-        this.state = {
-            displayListViewBorder: false,
-        };
-        this.googlePlacesRef = React.createRef();
-    }
+        googlePlacesRef.current.setAddressText(props.value);
+    }, []);
 
-    componentDidMount() {
-        // if (!this.googlePlacesRef.current) {
-        //     return;
-        // }
-
-        this.googlePlacesRef.current.setAddressText(this.props.value);
-    }
-
-    saveLocationDetails(details) {
+    const saveLocationDetails = (details) => {
         const addressComponents = details.address_components;
         if (isAddressValidForVBA(addressComponents)) {
             // Gather the values from the Google details
@@ -68,10 +61,10 @@ class AddressSearch extends React.Component {
             const zipCode = getAddressComponent(addressComponents, 'postal_code', 'long_name');
 
             // Trigger text change events for each of the individual fields being saved on the server
-            this.props.onChangeText('addressStreet', `${streetNumber} ${streetName}`);
-            this.props.onChangeText('addressCity', city);
-            this.props.onChangeText('addressState', state);
-            this.props.onChangeText('addressZipCode', zipCode);
+            props.onChangeText('addressStreet', `${streetNumber} ${streetName}`);
+            props.onChangeText('addressCity', city);
+            props.onChangeText('addressState', state);
+            props.onChangeText('addressZipCode', zipCode);
         } else {
             // Clear the values associated to the address, so our validations catch the problem
             Log.hmmm('[AddressSearch] Search result failed validation: ', {
@@ -79,77 +72,75 @@ class AddressSearch extends React.Component {
                 address_components: addressComponents,
                 place_id: details.place_id,
             });
-            this.props.onChangeText('addressStreet', null);
-            this.props.onChangeText('addressCity', null);
-            this.props.onChangeText('addressState', null);
-            this.props.onChangeText('addressZipCode', null);
+            props.onChangeText('addressStreet', null);
+            props.onChangeText('addressCity', null);
+            props.onChangeText('addressState', null);
+            props.onChangeText('addressZipCode', null);
         }
-    }
+    };
 
-    render() {
-        return (
+    return (
 
-            // We use the View height to determine if we should hide the border and margin of the listView dropdown
-            // to prevent a lingering border when there are no address suggestions
-            <View
-                onLayout={(event) => {
-                    const {height} = event.nativeEvent.layout;
-                    return height > 74 ? this.setState({displayListViewBorder: true}) : this.setState({displayListViewBorder: false});
+        // We use the View height to determine if we should hide the border and margin of the listView dropdown
+        // to prevent a lingering border when there are no address suggestions
+        <View
+            onLayout={(event) => {
+                const {height} = event.nativeEvent.layout;
+                return height > 74 ? setDisplay(true) : setDisplay(false);
+            }}
+        >
+            <GooglePlacesAutocomplete
+                ref={googlePlacesRef}
+                fetchDetails
+                suppressDefaultStyles
+                enablePoweredByContainer={false}
+                onPress={(data, details) => saveLocationDetails(details)}
+                query={{
+                    key: 'AIzaSyC4axhhXtpiS-WozJEsmlL3Kg3kXucbZus',
+                    language: props.preferredLocale,
+                    types: 'address',
+                    components: 'country:us',
                 }}
-            >
-                <GooglePlacesAutocomplete
-                    ref={this.googlePlacesRef}
-                    fetchDetails
-                    suppressDefaultStyles
-                    enablePoweredByContainer={false}
-                    onPress={(data, details) => this.saveLocationDetails(details)}
-                    query={{
-                        key: 'AIzaSyC4axhhXtpiS-WozJEsmlL3Kg3kXucbZus',
-                        language: this.props.preferredLocale,
-                        types: 'address',
-                        components: 'country:us',
-                    }}
-                    requestUrl={{
-                        useOnPlatform: 'web',
-                        url: `${CONFIG.EXPENSIFY.URL_EXPENSIFY_COM}api?command=Proxy_GooglePlaces&proxyUrl=`,
-                    }}
-                    textInputProps={{
-                        InputComp: ExpensiTextInput,
-                        label: this.props.label,
-                        containerStyles: this.props.containerStyles,
-                        errorText: this.props.errorText,
-                        onChangeText: (text) => {
-                            const isTextValid = !_.isEmpty(text) && _.isEqual(text, this.props.value);
+                requestUrl={{
+                    useOnPlatform: 'web',
+                    url: `${CONFIG.EXPENSIFY.URL_EXPENSIFY_COM}api?command=Proxy_GooglePlaces&proxyUrl=`,
+                }}
+                textInputProps={{
+                    InputComp: ExpensiTextInput,
+                    label: props.label,
+                    containerStyles: props.containerStyles,
+                    errorText: props.errorText,
+                    onChangeText: (text) => {
+                        const isTextValid = !_.isEmpty(text) && _.isEqual(text, props.value);
 
-                            // Ensure whether an address is selected already or has address value initialized.
-                            if (!_.isEmpty(this.googlePlacesRef.current.getAddressText()) && !isTextValid) {
-                                this.saveLocationDetails({});
-                            }
-                        },
-                    }}
-                    styles={{
-                        textInputContainer: [styles.flexColumn],
-                        listView: [
-                            this.state.displayListViewBorder && styles.borderTopRounded,
-                            this.state.displayListViewBorder && styles.borderBottomRounded,
-                            this.state.displayListViewBorder && styles.mt1,
-                            styles.overflowAuto,
-                            styles.borderLeft,
-                            styles.borderRight,
-                        ],
-                        row: [
-                            styles.pv4,
-                            styles.ph3,
-                            styles.overflowAuto,
-                        ],
-                        description: [styles.googleSearchText],
-                        separator: [styles.googleSearchSeparator],
-                    }}
-                />
-            </View>
-        );
-    }
-}
+                        // Ensure whether an address is selected already or has address value initialized.
+                        if (!_.isEmpty(googlePlacesRef.current.getAddressText()) && !isTextValid) {
+                            saveLocationDetails({});
+                        }
+                    },
+                }}
+                styles={{
+                    textInputContainer: [styles.flexColumn],
+                    listView: [
+                        display && styles.borderTopRounded,
+                        display && styles.borderBottomRounded,
+                        display && styles.mt1,
+                        styles.overflowAuto,
+                        styles.borderLeft,
+                        styles.borderRight,
+                    ],
+                    row: [
+                        styles.pv4,
+                        styles.ph3,
+                        styles.overflowAuto,
+                    ],
+                    description: [styles.googleSearchText],
+                    separator: [styles.googleSearchSeparator],
+                }}
+            />
+        </View>
+    );
+};
 
 AddressSearch.propTypes = propTypes;
 AddressSearch.defaultProps = defaultProps;

--- a/src/components/AddressSearch.js
+++ b/src/components/AddressSearch.js
@@ -9,6 +9,7 @@ import styles from '../styles/styles';
 import ExpensiTextInput from './ExpensiTextInput';
 import Log from '../libs/Log';
 import {getAddressComponent, isAddressValidForVBA} from '../libs/GooglePlacesUtils';
+import display from '../styles/utilities/display';
 
 // The error that's being thrown below will be ignored until we fork the
 // react-native-google-places-autocomplete repo and replace the
@@ -37,7 +38,7 @@ const defaultProps = {
 
 const AddressSearch = (props) => {
     const googlePlacesRef = useRef();
-    const [display, setDisplay] = useState(false);
+    const [displayListViewBorder, setDisplayListViewBorder] = useState(false);
     useEffect(() => {
         if (!googlePlacesRef.current) {
             return;
@@ -82,11 +83,12 @@ const AddressSearch = (props) => {
     return (
 
         // We use the View height to determine if we should hide the border and margin of the listView dropdown
-        // to prevent a lingering border when there are no address suggestions
+        // to prevent a lingering border when there are no address suggestions. 
+        // The height of the input + error message is 94 pixels
         <View
             onLayout={(event) => {
                 const {height} = event.nativeEvent.layout;
-                return height > 74 ? setDisplay(true) : setDisplay(false);
+                return height > 94 ? setDisplayListViewBorder(true) : setDisplayListViewBorder(false);
             }}
         >
             <GooglePlacesAutocomplete
@@ -122,9 +124,9 @@ const AddressSearch = (props) => {
                 styles={{
                     textInputContainer: [styles.flexColumn],
                     listView: [
-                        display && styles.borderTopRounded,
-                        display && styles.borderBottomRounded,
-                        display && styles.mt1,
+                        displayListViewBorder && styles.borderTopRounded,
+                        displayListViewBorder && styles.borderBottomRounded,
+                        displayListViewBorder && styles.mt1,
                         styles.overflowAuto,
                         styles.borderLeft,
                         styles.borderRight,

--- a/src/components/AddressSearch.js
+++ b/src/components/AddressSearch.js
@@ -1,7 +1,7 @@
 import _ from 'underscore';
-import React, {useEffect, useRef} from 'react';
+import React, {useEffect, useState, useRef} from 'react';
 import PropTypes from 'prop-types';
-import {LogBox} from 'react-native';
+import {LogBox, View} from 'react-native';
 import {GooglePlacesAutocomplete} from 'react-native-google-places-autocomplete';
 import CONFIG from '../CONFIG';
 import withLocalize, {withLocalizePropTypes} from './withLocalize';
@@ -37,6 +37,7 @@ const defaultProps = {
 
 const AddressSearch = (props) => {
     const googlePlacesRef = useRef();
+    const [display, setDisplay] = useState(false);
     useEffect(() => {
         if (!googlePlacesRef.current) {
             return;
@@ -79,55 +80,64 @@ const AddressSearch = (props) => {
     };
 
     return (
-        <GooglePlacesAutocomplete
-            ref={googlePlacesRef}
-            fetchDetails
-            suppressDefaultStyles
-            enablePoweredByContainer={false}
-            onPress={(data, details) => saveLocationDetails(details)}
-            query={{
-                key: 'AIzaSyC4axhhXtpiS-WozJEsmlL3Kg3kXucbZus',
-                language: props.preferredLocale,
-                types: 'address',
-                components: 'country:us',
+        <View 
+            // We use the View height to determine if we should hide the border and margin of the listView dropdown
+            // to prevent a lingering border when there are no address suggestions
+            onLayout={(event) => {
+                const {height} = event.nativeEvent.layout;
+                height > 74 ? setDisplay(true) : setDisplay(false);s
             }}
-            requestUrl={{
-                useOnPlatform: 'web',
-                url: `${CONFIG.EXPENSIFY.URL_EXPENSIFY_COM}api?command=Proxy_GooglePlaces&proxyUrl=`,
-            }}
-            textInputProps={{
-                InputComp: ExpensiTextInput,
-                label: props.label,
-                containerStyles: props.containerStyles,
-                errorText: props.errorText,
-                onChangeText: (text) => {
-                    const isTextValid = !_.isEmpty(text) && _.isEqual(text, props.value);
-
-                    // Ensure whether an address is selected already or has address value initialized.
-                    if (!_.isEmpty(googlePlacesRef.current.getAddressText()) && !isTextValid) {
-                        saveLocationDetails({});
-                    }
-                },
-            }}
-            styles={{
-                textInputContainer: [styles.flexColumn],
-                listView: [
-                    styles.borderTopRounded,
-                    styles.borderBottomRounded,
-                    styles.mt1,
-                    styles.overflowAuto,
-                    styles.borderLeft,
-                    styles.borderRight,
-                ],
-                row: [
-                    styles.pv4,
-                    styles.ph3,
-                    styles.overflowAuto,
-                ],
-                description: [styles.googleSearchText],
-                separator: [styles.googleSearchSeparator],
-            }}
-        />
+        >
+            <GooglePlacesAutocomplete
+                ref={googlePlacesRef}
+                fetchDetails
+                suppressDefaultStyles
+                enablePoweredByContainer={false}
+                onPress={(data, details) => saveLocationDetails(details)}
+                query={{
+                    key: 'AIzaSyC4axhhXtpiS-WozJEsmlL3Kg3kXucbZus',
+                    language: props.preferredLocale,
+                    types: 'address',
+                    components: 'country:us',
+                }}
+                requestUrl={{
+                    useOnPlatform: 'web',
+                    url: `${CONFIG.EXPENSIFY.URL_EXPENSIFY_COM}api?command=Proxy_GooglePlaces&proxyUrl=`,
+                }}
+                textInputProps={{
+                    InputComp: ExpensiTextInput,
+                    label: props.label,
+                    containerStyles: props.containerStyles,
+                    errorText: props.errorText,
+                    onChangeText: (text) => {
+                        const isTextValid = !_.isEmpty(text) && _.isEqual(text, props.value);
+    
+                        // Ensure whether an address is selected already or has address value initialized.
+                        if (!_.isEmpty(googlePlacesRef.current.getAddressText()) && !isTextValid) {
+                            saveLocationDetails({});
+                        }
+                    },
+                }}
+                styles={{
+                    textInputContainer: [styles.flexColumn],
+                    listView: [
+                        display && styles.borderTopRounded,
+                        display && styles.borderBottomRounded,
+                        display && styles.mt1,
+                        styles.overflowAuto,
+                        styles.borderLeft,
+                        styles.borderRight,
+                    ],
+                    row: [
+                        styles.pv4,
+                        styles.ph3,
+                        styles.overflowAuto,
+                    ],
+                    description: [styles.googleSearchText],
+                    separator: [styles.googleSearchSeparator],
+                }}
+            />
+        </View>
     );
 };
 

--- a/src/components/AddressSearch.js
+++ b/src/components/AddressSearch.js
@@ -40,7 +40,7 @@ class AddressSearch extends React.Component {
         super(props);
 
         this.state = {
-            displayDropdownBorder: false,
+            displayListViewBorder: false,
         };
         this.googlePlacesRef = React.createRef();
     }
@@ -94,7 +94,7 @@ class AddressSearch extends React.Component {
             <View
                 onLayout={(event) => {
                     const {height} = event.nativeEvent.layout;
-                    return height > 74 ? this.setState({displayDropdownBorder: true}) : this.setState({displayDropdownBorder: false});
+                    return height > 74 ? this.setState({displayListViewBorder: true}) : this.setState({displayListViewBorder: false});
                 }}
             >
                 <GooglePlacesAutocomplete
@@ -130,9 +130,9 @@ class AddressSearch extends React.Component {
                     styles={{
                         textInputContainer: [styles.flexColumn],
                         listView: [
-                            this.state.displayDropdownBorder && styles.borderTopRounded,
-                            this.state.displayDropdownBorder && styles.borderBottomRounded,
-                            this.state.displayDropdownBorder && styles.mt1,
+                            this.state.displayListViewBorder && styles.borderTopRounded,
+                            this.state.displayListViewBorder && styles.borderBottomRounded,
+                            this.state.displayListViewBorder && styles.mt1,
                             styles.overflowAuto,
                             styles.borderLeft,
                             styles.borderRight,

--- a/src/components/AddressSearch.js
+++ b/src/components/AddressSearch.js
@@ -85,7 +85,7 @@ const AddressSearch = (props) => {
             // to prevent a lingering border when there are no address suggestions
             onLayout={(event) => {
                 const {height} = event.nativeEvent.layout;
-                height > 74 ? setDisplay(true) : setDisplay(false);s
+                height > 74 ? setDisplay(true) : setDisplay(false);
             }}
         >
             <GooglePlacesAutocomplete

--- a/src/components/AddressSearch.js
+++ b/src/components/AddressSearch.js
@@ -41,7 +41,7 @@ class AddressSearch extends React.Component {
 
         this.state = {
             displayDropdownBorder: false,
-        }
+        };
         this.googlePlacesRef = React.createRef();
     }
 
@@ -84,11 +84,11 @@ class AddressSearch extends React.Component {
             this.props.onChangeText('addressState', null);
             this.props.onChangeText('addressZipCode', null);
         }
-    };
+    }
 
     render() {
         return (
-    
+
             // We use the View height to determine if we should hide the border and margin of the listView dropdown
             // to prevent a lingering border when there are no address suggestions
             <View
@@ -120,7 +120,7 @@ class AddressSearch extends React.Component {
                         errorText: this.props.errorText,
                         onChangeText: (text) => {
                             const isTextValid = !_.isEmpty(text) && _.isEqual(text, this.props.value);
-    
+
                             // Ensure whether an address is selected already or has address value initialized.
                             if (!_.isEmpty(this.googlePlacesRef.current.getAddressText()) && !isTextValid) {
                                 this.saveLocationDetails({});
@@ -149,7 +149,7 @@ class AddressSearch extends React.Component {
             </View>
         );
     }
-};
+}
 
 AddressSearch.propTypes = propTypes;
 AddressSearch.defaultProps = defaultProps;

--- a/src/components/AddressSearch.js
+++ b/src/components/AddressSearch.js
@@ -80,12 +80,13 @@ const AddressSearch = (props) => {
     };
 
     return (
-        <View 
-            // We use the View height to determine if we should hide the border and margin of the listView dropdown
-            // to prevent a lingering border when there are no address suggestions
+
+        // We use the View height to determine if we should hide the border and margin of the listView dropdown
+        // to prevent a lingering border when there are no address suggestions
+        <View
             onLayout={(event) => {
                 const {height} = event.nativeEvent.layout;
-                height > 74 ? setDisplay(true) : setDisplay(false);
+                return height > 74 ? setDisplay(true) : setDisplay(false);
             }}
         >
             <GooglePlacesAutocomplete
@@ -111,7 +112,7 @@ const AddressSearch = (props) => {
                     errorText: props.errorText,
                     onChangeText: (text) => {
                         const isTextValid = !_.isEmpty(text) && _.isEqual(text, props.value);
-    
+
                         // Ensure whether an address is selected already or has address value initialized.
                         if (!_.isEmpty(googlePlacesRef.current.getAddressText()) && !isTextValid) {
                             saveLocationDetails({});

--- a/src/components/AddressSearch.js
+++ b/src/components/AddressSearch.js
@@ -35,6 +35,9 @@ const defaultProps = {
     containerStyles: null,
 };
 
+// Do not convert to class component! setAddressText only works in functional components!
+// Reference: https://github.com/FaridSafi/react-native-google-places-autocomplete/issues/609#issuecomment-886133839
+
 const AddressSearch = (props) => {
     const googlePlacesRef = useRef();
     const [displayListViewBorder, setDisplayListViewBorder] = useState(false);
@@ -87,7 +90,7 @@ const AddressSearch = (props) => {
         <View
             onLayout={(event) => {
                 const {height} = event.nativeEvent.layout;
-                return height > 94 ? setDisplayListViewBorder(true) : setDisplayListViewBorder(false);
+                return height > 112 ? setDisplayListViewBorder(true) : setDisplayListViewBorder(false);
             }}
         >
             <GooglePlacesAutocomplete

--- a/src/components/AddressSearch.js
+++ b/src/components/AddressSearch.js
@@ -37,7 +37,6 @@ const defaultProps = {
 
 // Do not convert to class component! setAddressText only works in functional components!
 // Reference: https://github.com/FaridSafi/react-native-google-places-autocomplete/issues/609#issuecomment-886133839
-
 const AddressSearch = (props) => {
     const googlePlacesRef = useRef();
     const [displayListViewBorder, setDisplayListViewBorder] = useState(false);

--- a/src/components/AddressSearch.js
+++ b/src/components/AddressSearch.js
@@ -9,7 +9,6 @@ import styles from '../styles/styles';
 import ExpensiTextInput from './ExpensiTextInput';
 import Log from '../libs/Log';
 import {getAddressComponent, isAddressValidForVBA} from '../libs/GooglePlacesUtils';
-import display from '../styles/utilities/display';
 
 // The error that's being thrown below will be ignored until we fork the
 // react-native-google-places-autocomplete repo and replace the
@@ -83,7 +82,7 @@ const AddressSearch = (props) => {
     return (
 
         // We use the View height to determine if we should hide the border and margin of the listView dropdown
-        // to prevent a lingering border when there are no address suggestions. 
+        // to prevent a lingering border when there are no address suggestions.
         // The height of the input + error message is 94 pixels
         <View
             onLayout={(event) => {

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -2108,6 +2108,10 @@ const styles = {
         fontFamily: fontFamily.GTA,
         flex: 1,
     },
+
+    googleListView: {
+        transform: [{scale: 0}],
+    }
 };
 
 const baseCodeTagStyles = {

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -2111,7 +2111,7 @@ const styles = {
 
     googleListView: {
         transform: [{scale: 0}],
-    }
+    },
 };
 
 const baseCodeTagStyles = {


### PR DESCRIPTION
### Details
Not my favorite solution, but it's a temporary workaround to compensate for the limitations of the library. 
Wrapped the AddressSearch component in a View to track it's hide and dynamically hide the lingering border.

cc @aldo-expensify @Luke9389 

### Fixed Issues
$ https://github.com/Expensify/App/issues/5810

### Tests
1. On NewDot, navigate to `/bank-account/company`
2. Type in an address that does not exist, e.g. `asdasdas`
3. Verify that there is no lingering border below the input
4. Now, type in an address that exists and select it from the dropdown.
5. Click on the input again and verify that there is no lingering border.

### QA Steps
Steps above.

### Tested On

- [X] Web
- [ ] Mobile Web
- [X] Desktop
- [X] iOS
- [X] Android

### Screenshots
#### Web

https://user-images.githubusercontent.com/22219519/139493256-ed0366da-1137-48df-923e-02db7f618d5a.mov

#### Mobile Web
The component is failing to connect to www.expensify.com.dev on the simulator and returns no address results. We might be missing some config here. This is happening on the main branch as well.

#### Desktop

https://user-images.githubusercontent.com/22219519/139493277-38d3f14d-26c5-447e-9dba-3fd1bef7c93c.mov

#### iOS

https://user-images.githubusercontent.com/22219519/139493296-ea2fa9af-a629-4a2d-afd1-bbd1a1192895.mov

#### Android

https://user-images.githubusercontent.com/22219519/139493305-eadde9eb-d548-4ea8-9b80-2a6177470478.mov
