### PR TITLE
Remove autofocus from the Edit messages and focus on the manual action

### DIFF
--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -80,6 +80,13 @@ class ReportActionItem extends Component {
             || this.state.isContextMenuActive !== nextState.isContextMenuActive;
     }
 
+    componentDidUpdate(prevProps) {
+        if (!prevProps.draftMessage && this.props.draftMessage) {
+            // Only focus the input when user edits a message, skip it for existing drafts being edited of the report.
+            this.textInput.focus();
+        }
+    }
+
     /**
      * Show the ReportActionContextMenu modal popover.
      *
@@ -127,6 +134,7 @@ class ReportActionItem extends Component {
                             draftMessage={this.props.draftMessage}
                             reportID={this.props.reportID}
                             index={this.props.index}
+                            ref={el => this.textInput = el}
                     />
                 );
         }

--- a/src/pages/home/report/ReportActionItemMessageEdit.js
+++ b/src/pages/home/report/ReportActionItemMessageEdit.js
@@ -28,11 +28,18 @@ const propTypes = {
     /** Position index of the report action in the overall report FlatList view */
     index: PropTypes.number.isRequired,
 
+    /** A ref to forward to the text input */
+    forwardedRef: PropTypes.func,
+
     /** Window Dimensions Props */
     ...windowDimensionsPropTypes,
 
     /** Localization props */
     ...withLocalizePropTypes,
+};
+
+const defaultProps = {
+    forwardedRef: () => {},
 };
 
 class ReportActionItemMessageEdit extends React.Component {
@@ -125,7 +132,10 @@ class ReportActionItemMessageEdit extends React.Component {
                 <View style={[styles.chatItemComposeBox, styles.flexRow, styles.chatItemComposeBoxColor]}>
                     <TextInputFocusable
                         multiline
-                        ref={el => this.textInput = el}
+                        ref={(el) => {
+                            this.textInput = el;
+                            this.props.forwardedRef(el);
+                        }}
                         onChangeText={this.updateDraft} // Debounced saveDraftComment
                         onKeyPress={this.triggerSaveOrCancel}
                         defaultValue={this.state.draft}
@@ -135,7 +145,6 @@ class ReportActionItemMessageEdit extends React.Component {
                             scrollToIndex({animated: true, index: this.props.index}, true);
                             toggleReportActionComposeView(false);
                         }}
-                        autoFocus
                         selection={this.state.selection}
                         onSelectionChange={this.onSelectionChange}
                     />
@@ -161,7 +170,11 @@ class ReportActionItemMessageEdit extends React.Component {
 }
 
 ReportActionItemMessageEdit.propTypes = propTypes;
+ReportActionItemMessageEdit.defaultProps = defaultProps;
 export default compose(
     withLocalize,
     withWindowDimensions,
-)(ReportActionItemMessageEdit);
+)(React.forwardRef((props, ref) => (
+    /* eslint-disable-next-line react/jsx-props-no-spreading */
+    <ReportActionItemMessageEdit {...props} forwardedRef={ref} />
+)));


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
#### Issues
1. Keyboard does not open on android.  https://github.com/Expensify/App/issues/5637


### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/5896

### Tests | QA Steps
1. Open a report on Mobile.
2. Edit a recent message visible on the screen. Input should be focused.
3. Scroll back in the history. Edit any message.
4. Edit another message.
5. Go back to LHN.
6. Switch to another chat.
7. back to LHN.
8. Open the first report.
9. Now You should see the edit boxes for the last edit messages. But no focus should be placed automatically.
10. Scroll back in the history until you reach the message that was edited. No keyboard should be shown while scrolling.


### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web | Desktop
<!-- Insert screenshots of your changes on the web platform-->

https://user-images.githubusercontent.com/24370807/140316018-67855243-5eca-4c00-987c-6e4866bbe8e1.mp4


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

https://user-images.githubusercontent.com/24370807/140316115-da976977-7301-46e9-8192-7b0cd7370744.mp4


#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->

https://user-images.githubusercontent.com/24370807/140316177-079f4ed4-c249-449d-b216-c4f5552d63b6.mp4

