### PR TITLE
Remove lineHeight from baseFontStyle to stop text from flowing into links

### DIFF
--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -2196,7 +2196,6 @@ const webViewStyles = {
     baseFontStyle: {
         color: themeColors.text,
         fontSize: variables.fontSizeNormal,
-        lineHeight: variables.fontSizeNormalHeight,
         fontFamily: fontFamily.GTA,
         flex: 1,
     },


### PR DESCRIPTION
@Jag96 

### Details
Implements @meetmangukiya's proposal [here](https://github.com/Expensify/App/issues/4911#issuecomment-914939906) to prevent text from flowing into links on iOS.

### Fixed Issues
$ https://github.com/Expensify/App/issues/4911

### Tests/QA Steps
- Create a chat message with a long link inside of it as well as a good amount of standard text.
- Make sure that the standard text does not flow into the link text.

### Tested On
- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web
<img width="903" alt="Screen Shot 2021-11-01 at 3 10 46 PM" src="https://user-images.githubusercontent.com/4741899/139748730-e7e7e50a-728e-4fcc-b001-41a86eecb3d3.png">

#### Mobile Web
<img width="296" alt="Screen Shot 2021-11-01 at 3 15 26 PM" src="https://user-images.githubusercontent.com/4741899/139749313-8008bc63-f13a-4c81-8a1b-8039bda14f85.png">

#### Desktop
<img width="570" alt="Screen Shot 2021-11-01 at 3 17 40 PM" src="https://user-images.githubusercontent.com/4741899/139749401-e9fc63d4-4347-4081-a14f-6364d73c1503.png">

#### iOS
<img width="281" alt="Screen Shot 2021-11-01 at 3 14 16 PM" src="https://user-images.githubusercontent.com/4741899/139749115-ce19b9a9-2deb-4944-b3e1-c3ca0d51475e.png">

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
