### PR TITLE
Use git+https when loading expensify-common

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23338,8 +23338,8 @@
       }
     },
     "expensify-common": {
-      "version": "git://github.com/Expensify/expensify-common.git#b5d9167a26cfd40beebdfb79958b3bbed1af7b64",
-      "from": "git://github.com/Expensify/expensify-common.git#b5d9167a26cfd40beebdfb79958b3bbed1af7b64",
+      "version": "git+https://github.com/Expensify/expensify-common.git#b5d9167a26cfd40beebdfb79958b3bbed1af7b64",
+      "from": "git+https://github.com/Expensify/expensify-common.git#b5d9167a26cfd40beebdfb79958b3bbed1af7b64",
       "requires": {
         "classnames": "2.3.1",
         "clipboard": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "electron-log": "^4.3.5",
     "electron-serve": "^1.0.0",
     "electron-updater": "^4.3.4",
-    "expensify-common": "git://github.com/Expensify/expensify-common.git#b5d9167a26cfd40beebdfb79958b3bbed1af7b64",
+    "expensify-common": "git+https://github.com/Expensify/expensify-common.git#b5d9167a26cfd40beebdfb79958b3bbed1af7b64",
     "file-loader": "^6.0.0",
     "html-entities": "^1.3.1",
     "lodash": "4.17.21",


### PR DESCRIPTION
@francoisl @Jag96 

### Details
Looks like we hit a brownout related to: https://github.blog/2021-09-01-improving-git-protocol-security-github/

We need to stop using the unencrypted `git://` protocol. Move us over to `git+https://`.

### Fixed Issues
None, but fixes the failing deploy here: https://github.com/Expensify/App/runs/4074554859

### Tests
Ran `npm install` in the `/App` repo, made sure it was successful.