### PR TITLE
Wrap PDF in TouchableWithoutFeedback

### DIFF
--- a/src/components/PDFView/index.native.js
+++ b/src/components/PDFView/index.native.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {View, TouchableWithoutFeedback} from 'react-native';
+import {TouchableWithoutFeedback} from 'react-native';
 import PDF from 'react-native-pdf';
 import styles, {getWidthAndHeightStyle} from '../../styles/styles';
 import withWindowDimensions, {windowDimensionsPropTypes} from '../withWindowDimensions';

--- a/src/components/PDFView/index.native.js
+++ b/src/components/PDFView/index.native.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {View} from 'react-native';
+import {View, TouchableWithoutFeedback} from 'react-native';
 import PDF from 'react-native-pdf';
 import styles, {getWidthAndHeightStyle} from '../../styles/styles';
 import withWindowDimensions, {windowDimensionsPropTypes} from '../withWindowDimensions';
@@ -31,14 +31,16 @@ const defaultProps = {
 
 const PDFView = props => (
     <View style={[styles.flex1, props.style]}>
-        <PDF
-            activityIndicator={<FullScreenLoadingIndicator />}
-            source={{uri: props.sourceURL}}
-            style={[
-                styles.imageModalPDF,
-                getWidthAndHeightStyle(props.windowWidth, props.windowHeight),
-            ]}
-        />
+        <TouchableWithoutFeedback>
+            <PDF
+                activityIndicator={<FullScreenLoadingIndicator />}
+                source={{uri: props.sourceURL}}
+                style={[
+                    styles.imageModalPDF,
+                    getWidthAndHeightStyle(props.windowWidth, props.windowHeight),
+                ]}
+            />
+        </TouchableWithoutFeedback>
     </View>
 );
 

--- a/src/components/PDFView/index.native.js
+++ b/src/components/PDFView/index.native.js
@@ -30,18 +30,16 @@ const defaultProps = {
  */
 
 const PDFView = props => (
-    <View style={[styles.flex1, props.style]}>
-        <TouchableWithoutFeedback>
-            <PDF
-                activityIndicator={<FullScreenLoadingIndicator />}
-                source={{uri: props.sourceURL}}
-                style={[
-                    styles.imageModalPDF,
-                    getWidthAndHeightStyle(props.windowWidth, props.windowHeight),
-                ]}
-            />
-        </TouchableWithoutFeedback>
-    </View>
+    <TouchableWithoutFeedback style={[styles.flex1, props.style]}>
+        <PDF
+            activityIndicator={<FullScreenLoadingIndicator />}
+            source={{uri: props.sourceURL}}
+            style={[
+                styles.imageModalPDF,
+                getWidthAndHeightStyle(props.windowWidth, props.windowHeight),
+            ]}
+        />
+    </TouchableWithoutFeedback>
 );
 
 PDFView.propTypes = propTypes;


### PR DESCRIPTION
### Details
Trap events bubbling up from PDF preview to avoid opening the context menu with two fingers.

### Fixed Issues

$ https://github.com/Expensify/App/issues/5870

### Tests | QA Steps

1. Open a report on mobile
2. Send a PDF 
3. Open the preview (Tap on the PDF thumbnail)
4. Hold 2 fingers over the PDF, you shouldn't be able to see the context menu

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
