### PR TITLE
Remove the step counter from "Let's finish in chat" step of VBA flow

### DIFF
--- a/src/components/HeaderWithCloseButton.js
+++ b/src/components/HeaderWithCloseButton.js
@@ -85,7 +85,7 @@ const HeaderWithCloseButton = props => (
             )}
             <Header
                 title={props.title}
-                subtitle={props.stepCounter && shouldShowStepCounter ? props.translate('stepCounter', props.stepCounter) : ''}
+                subtitle={props.stepCounter && props.shouldShowStepCounter ? props.translate('stepCounter', props.stepCounter) : ''}
             />
             <View style={[styles.reportOptions, styles.flexRow, styles.pr5]}>
                 {

--- a/src/components/HeaderWithCloseButton.js
+++ b/src/components/HeaderWithCloseButton.js
@@ -36,6 +36,9 @@ const propTypes = {
     /** Whether we should show a inbox call button */
     shouldShowInboxCallButton: PropTypes.bool,
 
+    /** Whether we should show the step counter */
+    shouldShowStepCounter: PropTypes.bool,
+
     /** The task ID to associate with the call button, if we show it */
     inboxCallTaskID: PropTypes.string,
 

--- a/src/components/HeaderWithCloseButton.js
+++ b/src/components/HeaderWithCloseButton.js
@@ -57,6 +57,7 @@ const defaultProps = {
     shouldShowBorderBottom: false,
     shouldShowDownloadButton: false,
     shouldShowInboxCallButton: false,
+    shouldShowStepCounter: true,
     inboxCallTaskID: '',
     stepCounter: null,
 };
@@ -84,7 +85,7 @@ const HeaderWithCloseButton = props => (
             )}
             <Header
                 title={props.title}
-                subtitle={props.stepCounter ? props.translate('stepCounter', props.stepCounter) : ''}
+                subtitle={props.stepCounter && shouldShowStepCounter ? props.translate('stepCounter', props.stepCounter) : ''}
             />
             <View style={[styles.reportOptions, styles.flexRow, styles.pr5]}>
                 {

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -604,7 +604,7 @@ export default {
         reviewingInfo: 'Thanks! We\'re reviewing your information, and will be in touch shortly. Please check your chat with Concierge ',
         forNextSteps: ' for next steps to finish setting up your bank account.',
         letsChatCTA: 'Yes, let\'s chat!',
-        letsChatText: 'Thanks for doing that! We have a couple more things to work out, but it’ll be easier over chat. Ready to chat?',
+        letsChatText: 'Thanks for doing that! We need your help verifying a few pieces of information, but we can work this out quickly over chat. Ready?',
         letsChatTitle: 'Let\'s chat!',
     },
     beneficialOwnersStep: {

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -606,7 +606,7 @@ export default {
         reviewingInfo: '¡Gracias! Estamos revisando tu información y nos comunicaremos contigo en breve. Consulte su chat con Concierge ',
         forNextSteps: ' para conocer los próximos pasos para terminar de configurar su cuenta bancaria.',
         letsChatCTA: '¡Sí, vamos a chatear!',
-        letsChatText: '¡Gracias! Todavía tenemos que solucionar un par de cosas, pero será más fácil por chat. ¿Listo para charlar?',
+        letsChatText: '¡Gracias! Necesitamos tu ayuda para verificar la información, pero podemos hacerlo rápidamente a través del chat. ¿Estás listo?',
         letsChatTitle: '¡Vamos a chatear!',
     },
     beneficialOwnersStep: {

--- a/src/pages/ReimbursementAccount/ValidationStep.js
+++ b/src/pages/ReimbursementAccount/ValidationStep.js
@@ -164,9 +164,11 @@ class ValidationStep extends React.Component {
             <View style={[styles.flex1, styles.justifyContentBetween]}>
                 <HeaderWithCloseButton
                     title={this.props.translate('workspace.common.bankAccount')}
+                    stepCounter={{step: 5, total: 5}}
                     onCloseButtonPress={Navigation.dismissModal}
                     onBackButtonPress={() => Navigation.goBack()}
                     shouldShowBackButton
+                    shouldShowStepCounter={!isVerifying}
                 />
                 {maxAttemptsReached && (
                     <View style={[styles.m5, styles.flex1]}>

--- a/src/pages/ReimbursementAccount/ValidationStep.js
+++ b/src/pages/ReimbursementAccount/ValidationStep.js
@@ -164,7 +164,6 @@ class ValidationStep extends React.Component {
             <View style={[styles.flex1, styles.justifyContentBetween]}>
                 <HeaderWithCloseButton
                     title={this.props.translate('workspace.common.bankAccount')}
-                    stepCounter={{step: 5, total: 5}}
                     onCloseButtonPress={Navigation.dismissModal}
                     onBackButtonPress={() => Navigation.goBack()}
                     shouldShowBackButton


### PR DESCRIPTION
### Details
Removed step counter and changed copy in Validation step.

### Fixed Issues
$ https://github.com/Expensify/App/issues/6123

### Tests
1. Login to an account in NewDot and create a Workspace.
2. Navigate to `Settings > Select Workspace > Connect bank account`
3. Follow the steps in [this SO](https://stackoverflow.com/c/expensify/questions/342) to add a `Pending` bank account, but in the company step enter `111222333` as the tax ID.
4. Go through the flow until you reach the validation step.
5. Verify that you do not see the step counter and the copy reads as follows:

> Thanks for doing that! We need your help verifying a few pieces of information, but we can work this out quickly over chat. Ready?

### QA Steps
Steps above.

### Tested On

- [X] Web
- [X] Mobile Web
- [X] Desktop
- [X] iOS
- [X] Android

### Screenshots

#### Web

![web](https://user-images.githubusercontent.com/22219519/139913112-f98a47e9-f93c-4347-9da5-8e3e7606c0c6.png)

#### Mobile Web

![mweb](https://user-images.githubusercontent.com/22219519/139913133-3226a9ea-2376-4ec3-be08-edb707ad692e.png)

#### Desktop

<img width="1197" alt="desktop" src="https://user-images.githubusercontent.com/22219519/139913148-09a60efe-9ee9-4f50-9f5f-022e5f310d67.png">

#### iOS
![ios](https://user-images.githubusercontent.com/22219519/139913160-4d8ee0f6-1863-4141-a4cf-c1eec0671323.png)

#### Android
![android](https://user-images.githubusercontent.com/22219519/139913174-6fc42718-7164-48ad-bac0-c920c477c877.png)
