### PR TITLE
Updated logic so when attendee deselected it will not move below attendee up

### DIFF
--- a/src/components/IOUConfirmationList.js
+++ b/src/components/IOUConfirmationList.js
@@ -386,13 +386,11 @@ class IOUConfirmationList extends Component {
         }
 
         this.setState((prevState) => {
-            const newParticipants = _.reject(prevState.participants, participant => (
-                participant.login === option.login
-            ));
-
-            newParticipants.push({
-                ...option,
-                selected: !option.selected,
+            const newParticipants = _.map(prevState.participants, (participant) => {
+                if (participant.login === option.login) {
+                    return {...option, selected: !option.selected};
+                }
+                return participant;
             });
             return {participants: newParticipants};
         });


### PR DESCRIPTION
@puneetlath  @tgolen  PR is ready for review.

### Details
From Group split bill when an attendee is deselected at that time below attendee within deselected list is moving up 1 position in the list. So correct that problem.
Proposal: https://github.com/Expensify/App/issues/6120#issuecomment-955158588
Approval:  https://github.com/Expensify/App/issues/6120#issuecomment-956512113

### Fixed Issues
$ https://github.com/Expensify/App/issues/6120

### Tests | QA Steps
1. Go to https://staging.new.expensify.com and login
2. Select a group chat
3. Click split bill
4. Proceed to final confirmation page
5. Deselect the last attendee in the list and one above the last

Now when an attendee deselected at that time below attendee will not move up 1 position in the list. 

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web
https://user-images.githubusercontent.com/7823358/139924335-5eacebc0-3d0e-4133-983b-af027ace4b96.mov

#### Mobile Web
https://user-images.githubusercontent.com/7823358/139924391-e2b9a796-336b-41dc-9dec-492dad2301ab.mov

#### Desktop
https://user-images.githubusercontent.com/7823358/139924493-9936ec94-68dc-4265-ac23-124437578430.mov

#### iOS
https://user-images.githubusercontent.com/7823358/139924717-eccc54d7-8f33-4d53-94ef-970ca35b4a68.mov

#### Android
https://user-images.githubusercontent.com/7823358/139924833-1301e1e1-6721-40b4-806d-9ddf0add5ba0.mov
