### PR TITLE
Fix Promo colors on login screen for native devices

### DIFF
--- a/src/components/SVGImage/index.js
+++ b/src/components/SVGImage/index.js
@@ -1,18 +1,7 @@
 import React from 'react';
 import {Image} from 'react-native';
-import PropTypes from 'prop-types';
 import {getWidthAndHeightStyle} from '../../styles/styles';
-
-const propTypes = {
-    /** The asset to render. */
-    src: PropTypes.string.isRequired,
-
-    /** The width of the icon. */
-    width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-
-    /** The height of the icon. */
-    height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-};
+import propTypes from './propTypes';
 
 const SVGImage = ({width, height, src}) => (
     <Image
@@ -22,5 +11,6 @@ const SVGImage = ({width, height, src}) => (
 );
 
 SVGImage.propTypes = propTypes;
+SVGImage.displayName = 'SVGImage';
 
 export default SVGImage;

--- a/src/components/SVGImage/index.js
+++ b/src/components/SVGImage/index.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import {Image} from 'react-native';
+import PropTypes from 'prop-types';
+import {getWidthAndHeightStyle} from '../../styles/styles';
+
+const propTypes = {
+    /** The asset to render. */
+    src: PropTypes.string.isRequired,
+
+    /** The width of the icon. */
+    width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+
+    /** The height of the icon. */
+    height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+};
+
+const SVGImage = ({width, height, src}) => (
+    <Image
+        style={getWidthAndHeightStyle(width, height)}
+        source={src}
+    />
+);
+
+SVGImage.propTypes = propTypes;
+
+export default SVGImage;

--- a/src/components/SVGImage/index.native.js
+++ b/src/components/SVGImage/index.native.js
@@ -1,0 +1,27 @@
+
+import React from 'react';
+import {SvgCssUri} from 'react-native-svg';
+import PropTypes from 'prop-types';
+
+const propTypes = {
+    /** The asset to render. */
+    src: PropTypes.string.isRequired,
+
+    /** The width of the icon. */
+    width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+
+    /** The height of the icon. */
+    height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+};
+
+const SVGImage = ({width, height, src}) => (
+    <SvgCssUri
+        width={width}
+        height={height}
+        uri={src}
+    />
+);
+
+SVGImage.propTypes = propTypes;
+
+export default SVGImage;

--- a/src/components/SVGImage/index.native.js
+++ b/src/components/SVGImage/index.native.js
@@ -1,18 +1,7 @@
 
 import React from 'react';
 import {SvgCssUri} from 'react-native-svg';
-import PropTypes from 'prop-types';
-
-const propTypes = {
-    /** The asset to render. */
-    src: PropTypes.string.isRequired,
-
-    /** The width of the icon. */
-    width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-
-    /** The height of the icon. */
-    height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-};
+import propTypes from './propTypes';
 
 const SVGImage = ({width, height, src}) => (
     <SvgCssUri
@@ -23,5 +12,6 @@ const SVGImage = ({width, height, src}) => (
 );
 
 SVGImage.propTypes = propTypes;
+SVGImage.displayName = 'SVGImage';
 
 export default SVGImage;

--- a/src/components/SVGImage/index.native.js
+++ b/src/components/SVGImage/index.native.js
@@ -1,4 +1,3 @@
-
 import React from 'react';
 import {SvgCssUri} from 'react-native-svg';
 import propTypes from './propTypes';

--- a/src/components/SVGImage/propTypes.js
+++ b/src/components/SVGImage/propTypes.js
@@ -1,0 +1,14 @@
+import PropTypes from 'prop-types';
+
+const propTypes = {
+    /** The asset to render. */
+    src: PropTypes.string.isRequired,
+
+    /** The width of the image. */
+    width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+
+    /** The height of the image. */
+    height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+};
+
+export default propTypes;

--- a/src/pages/signin/SignInPageLayout/SignInPageLayoutWide.js
+++ b/src/pages/signin/SignInPageLayout/SignInPageLayoutWide.js
@@ -2,12 +2,14 @@ import React from 'react';
 import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
-import styles from '../../../styles/styles';
+import SVGImage from '../../../components/SVGImage';
+import styles, {getBackgroundColorStyle, getLoginPagePromoStyle} from '../../../styles/styles';
 import ExpensifyCashLogo from '../../../components/ExpensifyCashLogo';
 import Text from '../../../components/Text';
 import variables from '../../../styles/variables';
 import TermsAndLicenses from '../TermsAndLicenses';
 import withLocalize, {withLocalizePropTypes} from '../../../components/withLocalize';
+import CONST from '../../../CONST';
 
 const propTypes = {
     /** The children to show inside the layout */
@@ -26,12 +28,11 @@ const propTypes = {
     ...withLocalizePropTypes,
 };
 
-const backgroundStyles = [styles.backgroundBlue, styles.backgroundGreen, styles.backgroundOrange, styles.backgroundPink];
-const backgroundStyle = backgroundStyles[_.random(0, 3)];
+const backgroundStyle = getLoginPagePromoStyle();
 
 const SignInPageLayoutWide = props => (
     <View style={[styles.flex1, styles.signInPageInner]}>
-        <View style={[styles.flex1, styles.flexRow, styles.dFlex, styles.flexGrow1]}>
+        <View style={[styles.flex1, styles.flexRow, styles.alignItemsStretch, styles.flexGrow1]}>
             <View style={[styles.signInPageWideLeftContainer, styles.dFlex, styles.flexColumn, styles.ph6]}>
                 <View style={[
                     styles.flex1,
@@ -50,9 +51,9 @@ const SignInPageLayoutWide = props => (
                             />
                         </View>
                         {props.shouldShowWelcomeText && (
-                        <Text style={[styles.mv5, styles.textLabel, styles.h3]}>
-                            {props.welcomeText}
-                        </Text>
+                            <Text style={[styles.mv5, styles.textLabel, styles.h3]}>
+                                {props.welcomeText}
+                            </Text>
                         )}
                         <View>
                             {props.children}
@@ -65,13 +66,17 @@ const SignInPageLayoutWide = props => (
             </View>
             <View style={[
                 styles.flexGrow1,
-                styles.dFlex,
                 styles.flexRow,
-                styles.background100,
-                backgroundStyle,
+                getBackgroundColorStyle(backgroundStyle.backgroundColor),
                 props.isMediumScreenWidth && styles.alignItemsCenter,
             ]}
-            />
+            >
+                <SVGImage
+                    width="100%"
+                    height="100%"
+                    src={backgroundStyle.backgroundImageUri}
+                />
+            </View>
         </View>
     </View>
 );

--- a/src/pages/signin/SignInPageLayout/SignInPageLayoutWide.js
+++ b/src/pages/signin/SignInPageLayout/SignInPageLayoutWide.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import {View} from 'react-native';
 import PropTypes from 'prop-types';
-import _ from 'underscore';
 import SVGImage from '../../../components/SVGImage';
 import styles, {getBackgroundColorStyle, getLoginPagePromoStyle} from '../../../styles/styles';
 import ExpensifyCashLogo from '../../../components/ExpensifyCashLogo';
@@ -9,7 +8,6 @@ import Text from '../../../components/Text';
 import variables from '../../../styles/variables';
 import TermsAndLicenses from '../TermsAndLicenses';
 import withLocalize, {withLocalizePropTypes} from '../../../components/withLocalize';
-import CONST from '../../../CONST';
 
 const propTypes = {
     /** The children to show inside the layout */
@@ -32,7 +30,7 @@ const backgroundStyle = getLoginPagePromoStyle();
 
 const SignInPageLayoutWide = props => (
     <View style={[styles.flex1, styles.signInPageInner]}>
-        <View style={[styles.flex1, styles.flexRow, styles.alignItemsStretch, styles.flexGrow1]}>
+        <View style={[styles.flex1, styles.flexRow, styles.flexGrow1]}>
             <View style={[styles.signInPageWideLeftContainer, styles.dFlex, styles.flexColumn, styles.ph6]}>
                 <View style={[
                     styles.flex1,
@@ -66,7 +64,6 @@ const SignInPageLayoutWide = props => (
             </View>
             <View style={[
                 styles.flexGrow1,
-                styles.flexRow,
                 getBackgroundColorStyle(backgroundStyle.backgroundColor),
                 props.isMediumScreenWidth && styles.alignItemsCenter,
             ]}

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -175,30 +175,6 @@ const styles = {
         textTransform: 'uppercase',
     },
 
-    background100: {
-        backgroundSize: '100% 100%',
-    },
-
-    backgroundGreen: {
-        backgroundColor: colors.green,
-        backgroundImage: `url(${CONST.CLOUDFRONT_URL}/images/homepage/brand-stories/freeplan_green.svg)`,
-    },
-
-    backgroundOrange: {
-        backgroundColor: colors.orange,
-        backgroundImage: `url(${CONST.CLOUDFRONT_URL}/images/homepage/brand-stories/freeplan_orange.svg)`,
-    },
-
-    backgroundPink: {
-        backgroundColor: colors.pink,
-        backgroundImage: `url(${CONST.CLOUDFRONT_URL}/images/homepage/brand-stories/freeplan_pink.svg)`,
-    },
-
-    backgroundBlue: {
-        backgroundColor: colors.blue,
-        backgroundImage: `url(${CONST.CLOUDFRONT_URL}/images/homepage/brand-stories/freeplan_blue.svg)`,
-    },
-
     colorReversed: {
         color: themeColors.textReversed,
     },
@@ -2463,6 +2439,11 @@ function getEmojiPickerStyle(isSmallScreenWidth) {
     };
 }
 
+/**
+ * Get the random promo color and image for Login page
+ *
+ * @return {Object}
+ */
 function getLoginPagePromoStyle() {
     const promos = [
         {

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1,3 +1,4 @@
+import _ from 'underscore';
 import fontFamily from './fontFamily';
 import addOutlineWidth from './addOutlineWidth';
 import themeColors from './themes/default';
@@ -2462,6 +2463,28 @@ function getEmojiPickerStyle(isSmallScreenWidth) {
     };
 }
 
+function getLoginPagePromoStyle() {
+    const promos = [
+        {
+            backgroundColor: colors.green,
+            backgroundImageUri: `${CONST.CLOUDFRONT_URL}/images/homepage/brand-stories/freeplan_green.svg`,
+        },
+        {
+            backgroundColor: colors.orange,
+            backgroundImageUri: `${CONST.CLOUDFRONT_URL}/images/homepage/brand-stories/freeplan_orange.svg`,
+        },
+        {
+            backgroundColor: colors.pink,
+            backgroundImageUri: `${CONST.CLOUDFRONT_URL}/images/homepage/brand-stories/freeplan_pink.svg`,
+        },
+        {
+            backgroundColor: colors.blue,
+            backgroundImageUri: `${CONST.CLOUDFRONT_URL}/images/homepage/brand-stories/freeplan_blue.svg`,
+        },
+    ];
+    return promos[_.random(0, 3)];
+}
+
 export default styles;
 export {
     getSafeAreaPadding,
@@ -2483,4 +2506,5 @@ export {
     getModalPaddingStyles,
     getFontFamilyMonospace,
     getEmojiPickerStyle,
+    getLoginPagePromoStyle,
 };


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/6070

### Tests | QA Steps
1. Launch the app
2. Observe the PromoColor image on the login page

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web | Desktop
<!-- Insert screenshots of your changes on the web platform-->
![image](https://user-images.githubusercontent.com/24370807/140009375-47f93762-5e66-4a0a-971f-ee86bf5d69b2.png)

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
![image](https://user-images.githubusercontent.com/24370807/140009407-96d1c63e-152a-4596-a059-8e89c4edbfc0.png)

#### iPAD
<!-- Insert screenshots of your changes on the iOS platform-->
![Screenshot 2021-11-03 10:28:29](https://user-images.githubusercontent.com/24370807/140011819-893b4cf6-308b-48ce-a65f-dd5697c3c412.png)

#### Android Tablet
<!-- Insert screenshots of your changes on the Android platform-->
![Screenshot 2021-11-03 09:47:39](https://user-images.githubusercontent.com/24370807/140009445-e96ae6e1-6e1c-4bd4-9cef-21d329d1f6f9.png)
