### PR TITLE
Corrected infinite loading problem if non-image file uploaded for profile image

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -232,6 +232,8 @@ export default {
         setMyTimezoneAutomatically: 'Set my timezone automatically',
         timezone: 'Timezone',
         growlMessageOnSave: 'Your profile was successfully saved',
+        invalidFileMessage: 'Invalid file. Please try a different image.',
+        avatarUploadFailureMessage: 'An error occurred uploading the avatar, please try again.',
         online: 'Online',
         offline: 'Offline',
         syncing: 'Syncing',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -232,6 +232,8 @@ export default {
         setMyTimezoneAutomatically: 'Configura mi zona horaria automáticamente',
         timezone: 'Zona horaria',
         growlMessageOnSave: 'Tu perfil se ha guardado correctamente',
+        invalidFileMessage: 'Archivo inválido. Pruebe con una imagen diferente.',
+        avatarUploadFailureMessage: 'No se pudo subir el avatar. Por favor, inténtalo de nuevo.',
         online: 'En línea',
         offline: 'Desconectado',
         syncing: 'Sincronizando',

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -305,7 +305,7 @@ function setAvatar(file) {
     API.User_UploadAvatar({file})
         .then((response) => {
             // Once we get the s3url back, update the personal details for the user with the new avatar URL
-            if (response.jsonCode !== 200) { 
+            if (response.jsonCode !== 200) {
                 const error = new Error();
                 error.jsonCode = response.jsonCode;
                 throw error;

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -305,13 +305,12 @@ function setAvatar(file) {
     API.User_UploadAvatar({file})
         .then((response) => {
             // Once we get the s3url back, update the personal details for the user with the new avatar URL
-            if (response.jsonCode === 200) {
-                setPersonalDetails({avatar: response.s3url, avatarUploading: false}, true);
-            } else {
+            if (response.jsonCode !== 200) { 
                 const error = new Error();
                 error.jsonCode = response.jsonCode;
                 throw error;
             }
+            setPersonalDetails({avatar: response.s3url, avatarUploading: false}, true);
         })
         .catch((error) => {
             setPersonalDetails({avatarUploading: false});

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -302,12 +302,25 @@ function fetchLocalCurrency() {
  */
 function setAvatar(file) {
     setPersonalDetails({avatarUploading: true});
-    API.User_UploadAvatar({file}).then((response) => {
-        // Once we get the s3url back, update the personal details for the user with the new avatar URL
-        if (response.jsonCode === 200) {
-            setPersonalDetails({avatar: response.s3url, avatarUploading: false}, true);
-        }
-    });
+    API.User_UploadAvatar({file})
+        .then((response) => {
+            // Once we get the s3url back, update the personal details for the user with the new avatar URL
+            if (response.jsonCode === 200) {
+                setPersonalDetails({avatar: response.s3url, avatarUploading: false}, true);
+            } else {
+                const error = new Error();
+                error.jsonCode = response.jsonCode;
+                throw error;
+            }
+        })
+        .catch((error) => {
+            setPersonalDetails({avatarUploading: false});
+            if (error.jsonCode === 405 || error.jsonCode === 502) {
+                Growl.show(translateLocal('profilePage.invalidFileMessage'), CONST.GROWL.ERROR, 3000);
+            } else {
+                Growl.show(translateLocal('profilePage.avatarUploadFailureMessage'), CONST.GROWL.ERROR, 3000);
+            }
+        });
 }
 
 /**


### PR DESCRIPTION
@thienlnam  PR  is ready for review.

### Details
Whenever non image file uploaded for profile image it will show infinite loading. User can not do anything thereafter, so corrected this problem.
 
### Fixed Issues
$ https://github.com/Expensify/App/issues/5593

### Tests | QA Steps
1. Navigate to settings
2. Click on Profile
3. Click on the edit icon in the avatar
4. On the file browser, select to display all files
5. Select a non-image file

When invalid image file uploaded, Now it will show error message as `Invalid file. Please try a different image.` User will not stuck with loader, and try again with valid image file.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web
https://user-images.githubusercontent.com/7823358/140073472-bf217da2-0157-4dbe-b331-ef7c108d8b00.mp4

#### Mobile Web
https://user-images.githubusercontent.com/7823358/140073780-828e44ac-cfb9-43fe-ad93-983f1387e0d8.mp4

#### Desktop
https://user-images.githubusercontent.com/7823358/140073852-f35a48f3-0dd3-4b8e-8cd7-d74b9da27075.mp4

#### iOS
https://user-images.githubusercontent.com/7823358/140073929-51c0fc47-a29a-4e36-b093-176d52e17196.mov

#### Android
https://user-images.githubusercontent.com/7823358/140074037-80177c11-0e55-4dbe-b65e-c936c8e04428.mp4
