### PR TITLE
Improvement Payment options Padding

### DIFF
--- a/src/pages/settings/Payments/PaymentsPage.js
+++ b/src/pages/settings/Payments/PaymentsPage.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {ScrollView} from 'react-native';
+import {ScrollView, View} from 'react-native';
 import {withOnyx} from 'react-native-onyx';
 import PropTypes from 'prop-types';
 import PaymentMethodList from './PaymentMethodList';
@@ -143,18 +143,20 @@ class PaymentsPage extends React.Component {
                             left: this.state.anchorPositionLeft,
                         }}
                     >
-                        {!this.props.payPalMeUsername && (
+                        <View style={styles.pr15}>
+                            {!this.props.payPalMeUsername && (
+                                <MenuItem
+                                    title={this.props.translate('common.payPalMe')}
+                                    icon={PayPal}
+                                    onPress={() => this.addPaymentMethodTypePressed(PAYPAL)}
+                                />
+                            )}
                             <MenuItem
-                                title={this.props.translate('common.payPalMe')}
-                                icon={PayPal}
-                                onPress={() => this.addPaymentMethodTypePressed(PAYPAL)}
+                                title={this.props.translate('common.debitCard')}
+                                icon={CreditCard}
+                                onPress={() => this.addPaymentMethodTypePressed(DEBIT_CARD)}
                             />
-                        )}
-                        <MenuItem
-                            title={this.props.translate('common.debitCard')}
-                            icon={CreditCard}
-                            onPress={() => this.addPaymentMethodTypePressed(DEBIT_CARD)}
-                        />
+                        </View>
                     </Popover>
                 </KeyboardAvoidingView>
             </ScreenWrapper>

--- a/src/styles/utilities/spacing.js
+++ b/src/styles/utilities/spacing.js
@@ -264,6 +264,10 @@ export default {
         paddingRight: 32,
     },
 
+    pr15: {
+        paddingRight: 60,
+    },
+
     pl5: {
         paddingLeft: 20,
     },


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/5906

### Tests & QA Steps
1. Go to Settings -> Payments
2. Click on Add Payment method
3. In Web / Desktop, the payment options width will be increased now.

### Tested On
- [x] Web
- [x] Desktop

#### To Ensure Any UI Breaks - Tests well!
- [x] Mobile Web
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<img width="1440" alt="Screenshot 2021-11-04 at 2 03 07 AM" src="https://user-images.githubusercontent.com/85645967/140190159-0bbb490f-5ff6-43dd-83a1-4c53751cf875.png">

#### Desktop
<img width="1199" alt="Screenshot 2021-11-04 at 2 17 24 AM" src="https://user-images.githubusercontent.com/85645967/140190231-020ca9bf-4731-4852-9c9d-bfd88c6cd1b2.png">

#### iOS
![Simulator Screen Shot - iPhone 12 - 2021-11-04 at 02 12 43](https://user-images.githubusercontent.com/85645967/140190315-5f7e8fae-0e37-48b3-8015-4f78e8e9ad18.png)

#### Mobile Web 
![Simulator Screen Shot - iPhone 12 - 2021-11-04 at 02 11 53](https://user-images.githubusercontent.com/85645967/140190306-6814fe7d-53dc-4204-ac17-18c206f321de.png)

#### Android
![Screenshot_1635972224](https://user-images.githubusercontent.com/85645967/140190297-e9094087-1d6b-4a64-956a-ba3f1daaab02.png)