### PR TITLE
Update popover menu check to use isEmpty

### DIFF
--- a/src/components/PopoverMenu/BasePopoverMenu.js
+++ b/src/components/PopoverMenu/BasePopoverMenu.js
@@ -37,7 +37,7 @@ class BasePopoverMenu extends PureComponent {
                 animationOut={this.props.animationOut}
             >
                 <View style={this.props.isSmallScreenWidth ? {} : styles.createMenuContainer}>
-                    {this.props.headerText && (
+                    {!_.isEmpty(this.props.headerText) && (
                         <View style={styles.createMenuItem}>
                             <Text
                                 style={[styles.createMenuHeaderText, styles.ml3]}


### PR DESCRIPTION
cc @parasharrajat 

### Details
This PR fixes an issue where an empty string value used in a conditional render results in a mobile crash. The explanation of why this happens and why this is my recommended fix can be found in https://github.com/Expensify/App/issues/6198#issuecomment-960345451.

### Fixed Issues
$ https://github.com/Expensify/App/issues/6198

### Tests/QA
1. Launch the app and login with expensifail account
2. Click the FAB button and select Send money
3. Enter an amount and tap Next button
4. Select an attendee from the list
5. Tap the payment selection button.
6. Confirm options show up

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
| iOS | Web |
|---|---|
| ![image](https://user-images.githubusercontent.com/3981102/140239100-ef04f9b8-ec18-4887-92f6-0d6680d420b8.png) | ![image](https://user-images.githubusercontent.com/3981102/140239279-c87cf1d6-9b11-44dc-a5e0-64108c2d59a7.png) |
