### PR TITLE
Make resizeMode dynamic

### DIFF
--- a/src/components/ImageView/index.js
+++ b/src/components/ImageView/index.js
@@ -213,7 +213,7 @@ class ImageView extends PureComponent {
                     <Image
                         source={{uri: this.props.url}}
                         style={getZoomSizingStyle(this.state.isZoomed, this.state.imgWidth, this.state.imgHeight, this.state.zoomScale)}
-                        resizeMode="contain"
+                        resizeMode={this.state.isZoomed ? 'contain' : 'center'}
                     />
                 </Pressable>
             </View>


### PR DESCRIPTION
### Details

Make `resizeMode` dynamic to use the `resizeMode` with the value `'center'` when the image is not zoomed, to allow image to be displayed with a size that matches the real image size.

Note: I didn't add screenshots for Android and IOS because I only modified the version of the component that is used for web and desktop.

### Fixed Issues

$ https://github.com/Expensify/App/issues/6076

### Tests | QA Steps

1. Copy this small image of a chilling cat with a sombrero
![image](https://user-images.githubusercontent.com/44479856/138995955-16a014ce-d1a9-4072-b3f9-5b79fdb49ac3.png)
2. Add the image as an attachment and check that it doesn't look stretched before clicking "Send"
3. Send the image to any chat in New Expensify
4. Click on the image thumbnail, it should open modal with the image
5. Check that the image is not stretched and is centered

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<img width="1785" alt="Screen Shot 2021-11-03 at 10 15 54 PM" src="https://user-images.githubusercontent.com/47149004/140261752-2bae76c9-f65b-45d8-bb50-04b9ee1c70c0.png">

#### Mobile Web
<img width="373" alt="Screen Shot 2021-11-03 at 10 39 28 PM" src="https://user-images.githubusercontent.com/47149004/140263615-124ff99f-94b8-40f8-a599-6d0f85fd4310.png">

#### Desktop
<img width="1204" alt="Screen Shot 2021-11-03 at 10 29 41 PM" src="https://user-images.githubusercontent.com/47149004/140262828-b34a9799-858b-4aef-b251-9b2ab650956a.png">

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
