### PR TITLE
Allow users to enter addresses manually when needed

### DIFF
--- a/src/pages/ReimbursementAccount/CompanyStep.js
+++ b/src/pages/ReimbursementAccount/CompanyStep.js
@@ -24,7 +24,7 @@ import TextLink from '../../components/TextLink';
 import StatePicker from '../../components/StatePicker';
 import withLocalize, {withLocalizePropTypes} from '../../components/withLocalize';
 import {
-    isValidDate, isRequiredFulfilled, isValidURL, isValidPhoneWithSpecialChars,
+    isValidDate, isRequiredFulfilled, isValidURL, isValidPhoneWithSpecialChars, isValidAddress, isValidZipCode,
 } from '../../libs/ValidationUtils';
 import compose from '../../libs/compose';
 import ONYXKEYS from '../../ONYXKEYS';
@@ -145,6 +145,16 @@ class CompanyStep extends React.Component {
     validate() {
         const errors = {};
 
+        if (this.state.manualAddress) {
+            if (!isValidAddress(this.state.addressStreet)) {
+                errors.addressStreet = true;
+            }
+
+            if (!isValidZipCode(this.state.addressZipCode)) {
+                errors.addressZipCode = true;
+            }
+        }
+
         if (!isValidURL(this.state.website)) {
             errors.website = true;
         }
@@ -205,13 +215,62 @@ class CompanyStep extends React.Component {
                         disabled={shouldDisableCompanyName}
                         errorText={this.getErrorText('companyName')}
                     />
-                    <AddressSearch
-                        label={this.props.translate('common.companyAddress')}
-                        containerStyles={[styles.mt4]}
-                        value={this.getFormattedAddressValue()}
-                        onChangeText={(fieldName, value) => this.clearErrorAndSetValue(fieldName, value)}
-                        errorText={this.getErrorText('addressStreet')}
-                    />
+                    {!this.state.manualAddress && (
+                        <div>
+                            <AddressSearch
+                                label={this.props.translate('common.companyAddress')}
+                                containerStyles={[styles.mt4]}
+                                value={this.getFormattedAddressValue()}
+                                onChangeText={(fieldName, value) => this.clearErrorAndSetValue(fieldName, value)}
+                                errorText={this.getErrorText('addressStreet')}
+                            />
+                            <TextLink
+                                style={[styles.textMicro]}
+                                onPress={() => this.setState({manualAddress: true})}
+                            >
+                                Can&apos;t find your address? Enter it manually
+                            </TextLink>
+                        </div>
+                    )}
+                    {this.state.manualAddress && (
+                        <div>
+                            <ExpensiTextInput
+                                label={this.props.translate('common.companyAddress')}
+                                containerStyles={[styles.mt4]}
+                                onChangeText={value => this.clearErrorAndSetValue('addressStreet', value)}
+                                value={this.state.addressStreet}
+                                errorText={this.getErrorText('addressStreet')}
+                            />
+                            <Text style={[styles.mutedTextLabel, styles.mt1]}>{this.props.translate('common.noPO')}</Text>
+                            <View style={[styles.flexRow, styles.mt4]}>
+                                <View style={[styles.flex2, styles.mr2]}>
+                                    <ExpensiTextInput
+                                        label={this.props.translate('common.city')}
+                                        onChangeText={value => this.clearErrorAndSetValue('addressCity', value)}
+                                        value={this.state.addressCity}
+                                        errorText={this.getErrorText('addressCity')}
+                                        translateX={-14}
+                                    />
+                                </View>
+                                <View style={[styles.flex1]}>
+                                    <StatePicker
+                                        onChange={value => this.clearErrorAndSetValue('addressState', value)}
+                                        value={this.state.addressState}
+                                        hasError={this.getErrors().addressState}
+                                    />
+                                </View>
+                            </View>
+                            <ExpensiTextInput
+                                label={this.props.translate('common.zip')}
+                                containerStyles={[styles.mt4]}
+                                keyboardType={CONST.KEYBOARD_TYPE.PHONE_PAD}
+                                onChangeText={value => this.clearErrorAndSetValue('addressZipCode', value)}
+                                value={this.state.addressZipCode}
+                                errorText={this.getErrorText('addressZipCode')}
+                            />
+                        </div>
+                    )}
+
                     <ExpensiTextInput
                         label={this.props.translate('common.phoneNumber')}
                         containerStyles={[styles.mt4]}

--- a/src/pages/ReimbursementAccount/IdentityForm.js
+++ b/src/pages/ReimbursementAccount/IdentityForm.js
@@ -7,6 +7,9 @@ import styles from '../../styles/styles';
 import withLocalize, {withLocalizePropTypes} from '../../components/withLocalize';
 import CONST from '../../CONST';
 import DatePicker from '../../components/DatePicker';
+import TextLink from '../../components/TextLink';
+import StatePicker from '../../components/StatePicker';
+import Text from '../../components/Text';
 
 
 const propTypes = {
@@ -41,6 +44,9 @@ const propTypes = {
 
         /** Last 4 digits of SSN */
         ssnLast4: PropTypes.string,
+
+        /** Whether the address pieces should be entered manually */
+        manualAddress: PropTypes.bool,
     }),
 
     /** Any errors that can arise from form validation */
@@ -60,6 +66,7 @@ const defaultProps = {
         zipCode: '',
         dob: '',
         ssnLast4: '',
+        manualAddress: false,
     },
     errors: {},
 };
@@ -69,7 +76,7 @@ const IdentityForm = ({
     translate, values, onFieldChange, style, errors,
 }) => {
     const {
-        firstName, lastName, street, city, state, zipCode, dob, ssnLast4,
+        firstName, lastName, street, city, state, zipCode, dob, ssnLast4, manualAddress,
     } = values;
 
     // dob field has multiple validations/errors, we are handling it temporarily like this.
@@ -132,13 +139,63 @@ const IdentityForm = ({
                 errorText={errors.ssnLast4 ? translate('bankAccount.error.ssnLast4') : ''}
                 maxLength={CONST.BANK_ACCOUNT.MAX_LENGTH.SSN}
             />
-            <AddressSearch
-                label={translate('common.personalAddress')}
-                containerStyles={[styles.mt4]}
-                value={getFormattedAddressValue()}
-                onChangeText={(fieldName, value) => onFieldChange(fieldName, value)}
-                errorText={errors.street ? translate('bankAccount.error.addressStreet') : ''}
-            />
+            {!manualAddress && (
+                <div>
+                    <AddressSearch
+                        label={translate('common.personalAddress')}
+                        containerStyles={[styles.mt4]}
+                        value={getFormattedAddressValue()}
+                        onChangeText={(fieldName, value) => onFieldChange(fieldName, value)}
+                        errorText={errors.street ? translate('bankAccount.error.addressStreet') : ''}
+                    />
+                    <TextLink
+                        style={[styles.textMicro]}
+                        onPress={() => onFieldChange('manualAddress', true)}
+                    >
+                        Can&apos;t find your address? Enter it manually
+                    </TextLink>
+                </div>
+            )}
+            {manualAddress && (
+                <div>
+                    <ExpensiTextInput
+                        label={translate('common.personalAddress')}
+                        containerStyles={[styles.mt4]}
+                        value={street}
+                        onChangeText={value => onFieldChange('addressStreet', value)}
+                        errorText={errors.street ? translate('bankAccount.error.address') : ''}
+                    />
+                    <Text style={[styles.mutedTextLabel, styles.mt1]}>{translate('common.noPO')}</Text>
+                    <View style={[styles.flexRow, styles.mt4]}>
+                        <View style={[styles.flex2, styles.mr2]}>
+                            <ExpensiTextInput
+                                label={translate('common.city')}
+                                value={city}
+                                onChangeText={value => onFieldChange('addressCity', value)}
+                                errorText={errors.city ? translate('bankAccount.error.addressCity') : ''}
+                                translateX={-14}
+                            />
+                        </View>
+                        <View style={[styles.flex1]}>
+                            <StatePicker
+                                value={state}
+                                onChange={value => onFieldChange('addressState', value)}
+                                errorText={errors.state ? translate('bankAccount.error.addressState') : ''}
+                                hasError={Boolean(errors.state)}
+                            />
+                        </View>
+                    </View>
+                    <ExpensiTextInput
+                        label={translate('common.zip')}
+                        containerStyles={[styles.mt4]}
+                        keyboardType={CONST.KEYBOARD_TYPE.NUMERIC}
+                        value={zipCode}
+                        onChangeText={value => onFieldChange('addressZipCode', value)}
+                        errorText={errors.zipCode ? translate('bankAccount.error.zipCode') : ''}
+                        maxLength={CONST.BANK_ACCOUNT.MAX_LENGTH.ZIP_CODE}
+                    />
+                </div>
+            )}
         </View>
     );
 };

--- a/src/pages/ReimbursementAccount/RequestorStep.js
+++ b/src/pages/ReimbursementAccount/RequestorStep.js
@@ -85,25 +85,31 @@ class RequestorStep extends React.Component {
      * Clear the error associated to inputKey if found and store the inputKey new value in the state.
      *
      * @param {String} inputKey
-     * @param {String} value
+     * @param {String|Boolean} value
      */
     clearErrorAndSetValue(inputKey, value) {
-        const renamedFields = {
-            addressStreet: 'requestorAddressStreet',
-            addressCity: 'requestorAddressCity',
-            addressState: 'requestorAddressState',
-            addressZipCode: 'requestorAddressZipCode',
-        };
-        const renamedInputKey = lodashGet(renamedFields, inputKey, inputKey);
-        const newState = {[renamedInputKey]: value};
-        this.setState(newState);
-        updateReimbursementAccountDraft(newState);
+        if (inputKey === 'manualAddress') {
+            this.setState({
+                manualAddress: value,
+            });
+        } else {
+            const renamedFields = {
+                addressStreet: 'requestorAddressStreet',
+                addressCity: 'requestorAddressCity',
+                addressState: 'requestorAddressState',
+                addressZipCode: 'requestorAddressZipCode',
+            };
+            const renamedInputKey = lodashGet(renamedFields, inputKey, inputKey);
+            const newState = {[renamedInputKey]: value};
+            this.setState(newState);
+            updateReimbursementAccountDraft(newState);
 
-        // dob field has multiple validations/errors, we are handling it temporarily like this.
-        if (inputKey === 'dob') {
-            this.clearError('dobAge');
+            // dob field has multiple validations/errors, we are handling it temporarily like this.
+            if (inputKey === 'dob') {
+                this.clearError('dobAge');
+            }
+            this.clearError(inputKey);
         }
-        this.clearError(inputKey);
     }
 
     /**
@@ -210,6 +216,7 @@ class RequestorStep extends React.Component {
                                 zipCode: this.state.requestorAddressZipCode,
                                 dob: this.state.dob,
                                 ssnLast4: this.state.ssnLast4,
+                                manualAddress: this.state.manualAddress,
                             }}
                             errors={this.props.reimbursementAccount.errors}
                         />


### PR DESCRIPTION

cc @tgolen 
### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/183067
$ https://github.com/Expensify/Expensify/issues/183908

### Tests
- Log into NewDot
- If you don't have one, create a workspace
- Open the workspace and click `Connect Bank account`. You can use [our test account](https://stackoverflow.com/c/expensify/questions/342)
- Make it to the `Company information` step.
- Do some regression test to make sure the `Company address` field still works as expected: You should be able to select an address from the drop-down menu and move to the next step. Entering a free text address should stop you from moving forward.
- Click on `Can't find your address? Enter it manually`:
<img width="360" alt="Screen Shot 2021-11-04 at 5 25 53 PM" src="https://user-images.githubusercontent.com/19366280/140379072-821501a7-465d-487e-9dc3-0ac49c29c05d.png">

- Fields to enter the address manually should show up:
<img width="367" alt="Screen Shot 2021-11-04 at 5 28 03 PM" src="https://user-images.githubusercontent.com/19366280/140379441-6f05e38c-b34f-4645-8703-9afde235f780.png">

- Populating all the fields should allow you to go to the next step. You should not be able to move forward with empty fields OR with a PO box address on the street field.
- Move ahead to the `Personal Information` step. There's another address field in there. It should behave the same

### QA Steps
Same as testing

### Tested On

- [X] Web
- [x] Mobile Web
- [X] Desktop
- [ ] iOS
- [x] Android

