### PR TITLE
padding using wrapperStyle

### DIFF
--- a/src/pages/settings/Payments/PaymentsPage.js
+++ b/src/pages/settings/Payments/PaymentsPage.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {ScrollView, View} from 'react-native';
+import {ScrollView} from 'react-native';
 import {withOnyx} from 'react-native-onyx';
 import PropTypes from 'prop-types';
 import PaymentMethodList from './PaymentMethodList';
@@ -143,20 +143,20 @@ class PaymentsPage extends React.Component {
                             left: this.state.anchorPositionLeft,
                         }}
                     >
-                        <View style={styles.pr15}>
-                            {!this.props.payPalMeUsername && (
-                                <MenuItem
-                                    title={this.props.translate('common.payPalMe')}
-                                    icon={PayPal}
-                                    onPress={() => this.addPaymentMethodTypePressed(PAYPAL)}
-                                />
-                            )}
+                        {!this.props.payPalMeUsername && (
                             <MenuItem
-                                title={this.props.translate('common.debitCard')}
-                                icon={CreditCard}
-                                onPress={() => this.addPaymentMethodTypePressed(DEBIT_CARD)}
+                                title={this.props.translate('common.payPalMe')}
+                                icon={PayPal}
+                                onPress={() => this.addPaymentMethodTypePressed(PAYPAL)}
+                                wrapperStyle={styles.pr15}
                             />
-                        </View>
+                        )}
+                        <MenuItem
+                            title={this.props.translate('common.debitCard')}
+                            icon={CreditCard}
+                            onPress={() => this.addPaymentMethodTypePressed(DEBIT_CARD)}
+                            wrapperStyle={styles.pr15}
+                        />
                     </Popover>
                 </KeyboardAvoidingView>
             </ScreenWrapper>


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

PR https://github.com/Expensify/App/pull/6196 caused a regression, so fixing the regression using the solution already provided [here](https://github.com/Expensify/App/issues/5906#issuecomment-948999691). First just passing the style using `wrapperStyle`

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/5906
$ https://github.com/Expensify/App/issues/6232

### Tests & QA Steps
1. Go to Settings -> Payments
2. Click on Add Payment method
3. In Web / Desktop, the payment option's full width will be responsive now.

### Tested On
- [x] Web
- [x] Desktop

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
https://user-images.githubusercontent.com/85645967/140473525-a694964a-844d-4ced-ab60-55cf2853f44e.mov

#### Desktop
https://user-images.githubusercontent.com/85645967/140473573-dd7db7ef-aed6-4732-afe8-77215f8a08aa.mov
