### PR TITLE
Removing draft comments param

### DIFF
--- a/src/pages/home/sidebar/SidebarLinks.js
+++ b/src/pages/home/sidebar/SidebarLinks.js
@@ -97,7 +97,6 @@ class SidebarLinks extends React.Component {
         const sidebarOptions = getSidebarOptions(
             props.reports,
             props.personalDetails,
-            props.draftComments,
             activeReportID,
             props.priorityMode,
             props.betas,

--- a/src/pages/home/sidebar/SidebarLinks.js
+++ b/src/pages/home/sidebar/SidebarLinks.js
@@ -274,9 +274,6 @@ export default compose(
         reports: {
             key: ONYXKEYS.COLLECTION.REPORT,
         },
-        draftComments: {
-            key: ONYXKEYS.COLLECTION.REPORT_DRAFT_COMMENT,
-        },
         personalDetails: {
             key: ONYXKEYS.PERSONAL_DETAILS,
         },

--- a/tests/unit/OptionsListUtilsTest.js
+++ b/tests/unit/OptionsListUtilsTest.js
@@ -565,7 +565,6 @@ describe('OptionsListUtils', () => {
                 const results = OptionsListUtils.getSidebarOptions(
                     reportsWithAddedPinnedMessagelessReport,
                     PERSONAL_DETAILS,
-                    0,
                     CONST.PRIORITY_MODE.DEFAULT,
                 );
 
@@ -597,7 +596,7 @@ describe('OptionsListUtils', () => {
         () => setReportWithDraft(1, true)
             .then(() => {
                 // When we call getSidebarOptions() with no search value
-                const results = OptionsListUtils.getSidebarOptions(REPORTS, PERSONAL_DETAILS, 0, CONST.PRIORITY_MODE.GSD);
+                const results = OptionsListUtils.getSidebarOptions(REPORTS, PERSONAL_DETAILS, CONST.PRIORITY_MODE.GSD);
 
                 // Then expect all of the reports to be shown both multiple and single participant except the
                 // report that has no lastMessageTimestamp and the chat with Thor who's message is read

--- a/tests/unit/OptionsListUtilsTest.js
+++ b/tests/unit/OptionsListUtilsTest.js
@@ -565,6 +565,7 @@ describe('OptionsListUtils', () => {
                 const results = OptionsListUtils.getSidebarOptions(
                     reportsWithAddedPinnedMessagelessReport,
                     PERSONAL_DETAILS,
+                    0,
                     CONST.PRIORITY_MODE.DEFAULT,
                 );
 
@@ -596,7 +597,7 @@ describe('OptionsListUtils', () => {
         () => setReportWithDraft(1, true)
             .then(() => {
                 // When we call getSidebarOptions() with no search value
-                const results = OptionsListUtils.getSidebarOptions(REPORTS, PERSONAL_DETAILS, CONST.PRIORITY_MODE.GSD);
+                const results = OptionsListUtils.getSidebarOptions(REPORTS, PERSONAL_DETAILS, 0, CONST.PRIORITY_MODE.GSD);
 
                 // Then expect all of the reports to be shown both multiple and single participant except the
                 // report that has no lastMessageTimestamp and the chat with Thor who's message is read


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
The draftComments param for getSideBarOptions was removed [here](https://github.com/Expensify/App/commit/2a591b5efb820392c22d349179bc6313cb9716d6#diff-733528d957ae6a80eb863637fa5d54278c89c6121998f3574fa8c0aba935daebL657). But at that time the usages were still passing draftComments so the method was receiving params in wrong order. The fixes here should correct that.

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/6231

### Tests
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
1. Go to the App. Select #focus in preferences.
2. Confirm only pinned chats show.

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
