### PR TITLE
Reset instead of deleting achData

### DIFF
--- a/src/libs/actions/BankAccounts.js
+++ b/src/libs/actions/BankAccounts.js
@@ -867,8 +867,15 @@ function resetFreePlanBankAccount() {
                 return;
             }
 
-            // Clear reimbursement account, draft user input, and the bank account list
-            Onyx.set(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {});
+            // Reset reimbursement account, and clear draft user input, and the bank account list
+            const achData = {
+                useOnfido: true,
+                policyID: '',
+                isInSetup: true,
+                domainLimit: 0,
+                currentStep: CONST.BANK_ACCOUNT.STEP.BANK_ACCOUNT,
+            };
+            Onyx.set(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {achData});
             Onyx.set(ONYXKEYS.REIMBURSEMENT_ACCOUNT_DRAFT, null);
             Onyx.set(ONYXKEYS.BANK_ACCOUNT_LIST, []);
 


### PR DESCRIPTION
cc: @marcaaron related to https://github.com/Expensify/App/pull/5828

### Details

Sets basic ACHData, including `currentStep`, in case the user deletes their VBA and then immediately goes to add another. 
Previously we'd just wipe out the `reimbursementAccount` onyx key so we'd get an error when trying to call `API.BankAccount_SetupWithdrawal` because `currentStep` was missing. 

### Fixed Issues
$ https://github.com/Expensify/App/issues/6246

### Tests
Same as QA steps

### QA Steps
1. Go to any Workspace and select Connect bank account
2. Add a bank account following VBA flow
3. After the bank account is validated - tap disconnect bank account
4. Go to any Workspace and select Connect bank account
5. Continue VBA flow
6. After entering chase bank credentials select saving accounts
7. Confirm you're successfully routed to the company step after selecting the savings account

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web

https://user-images.githubusercontent.com/16747822/140581050-bf7bc992-921a-4b4e-9554-f2e7415f2125.mp4

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS

https://user-images.githubusercontent.com/16747822/140584147-396e84d3-a32f-4aea-afb5-9e1a218c6e9b.mov

#### Android

https://user-images.githubusercontent.com/16747822/140584159-a9408005-69d0-42df-bc52-1ea17b420446.mp4

