### PR TITLE
Include defaultRendererProps in InlineCodeBlock component

### DIFF
--- a/src/components/HTMLEngineProvider/BaseHTMLEngineProvider.js
+++ b/src/components/HTMLEngineProvider/BaseHTMLEngineProvider.js
@@ -164,12 +164,14 @@ function CodeRenderer(props) {
         fontStyle: undefined,
     };
 
+    const defaultRendererProps = _.omit(props, ['TDefaultRenderer', 'style']);
+
     return (
         <InlineCodeBlock
+            defaultRendererProps={defaultRendererProps}
             TDefaultRenderer={props.TDefaultRenderer}
             boxModelStyle={boxModelStyle}
             textStyle={{...textStyle, ...textStyleOverride}}
-            defaultRendererProps={props.defaultRendererProps}
             key={props.key}
         />
     );


### PR DESCRIPTION
cc @roryabraham 

### Details
It looks like this was introduced in https://github.com/Expensify/App/pull/6234, the issue here was that we weren't passing any value for `defaultRendererProps` to the InlineCodeBlock component, which has `defaultRendererProps` as a required prop.

### Fixed Issues
https://github.com/Expensify/App/issues/6269

### Tests/QA
1. Start a chat and send a message with inline code blocks (text between opening and closing ```), confirm no errors occur
2. Start a chat and send a message with single line code blocks (text between opening and closing `), confirm no errors occur

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android