### PR TITLE
Resolve issue with pdf attachment not being scrollable in preview page before sending on Android

### DIFF
--- a/src/components/AttachmentModal.js
+++ b/src/components/AttachmentModal.js
@@ -63,11 +63,26 @@ class AttachmentModal extends PureComponent {
             isConfirmModalOpen: false,
             file: null,
             sourceURL: props.sourceURL,
+            modalType: CONST.MODAL.MODAL_TYPE.CENTERED_UNSWIPEABLE,
         };
 
         this.submitAndClose = this.submitAndClose.bind(this);
         this.closeConfirmModal = this.closeConfirmModal.bind(this);
         this.isValidSize = this.isValidSize.bind(this);
+    }
+
+    /**
+     * If our attachment is a PDF, return the unswipeable Modal type.
+     * @param {String} sourceUrl
+     * @param {Object} file
+     * @returns {String}
+     */
+    getModalType(sourceUrl, file) {
+        const modalType = (sourceUrl
+            && (Str.isPDF(sourceUrl) || (file && Str.isPDF(file.name || this.props.translate('attachmentView.unknownFilename')))))
+            ? CONST.MODAL.MODAL_TYPE.CENTERED_UNSWIPEABLE
+            : CONST.MODAL.MODAL_TYPE.CENTERED;
+        return modalType;
     }
 
     /**
@@ -110,17 +125,10 @@ class AttachmentModal extends PureComponent {
         const attachmentViewStyles = this.props.isSmallScreenWidth
             ? [styles.imageModalImageCenterContainer]
             : [styles.imageModalImageCenterContainer, styles.p5];
-
-        // If our attachment is a PDF, make the Modal unswipeable
-        const modalType = (this.state.sourceURL
-                && (Str.isPDF(this.state.sourceURL) || (this.state.file
-                    && Str.isPDF(this.state.file.name || this.props.translate('attachmentView.unknownFilename')))))
-            ? CONST.MODAL.MODAL_TYPE.CENTERED_UNSWIPEABLE
-            : CONST.MODAL.MODAL_TYPE.CENTERED;
         return (
             <>
                 <Modal
-                    type={modalType}
+                    type={this.state.modalType}
                     onSubmit={this.submitAndClose}
                     onClose={() => this.setState({isModalOpen: false})}
                     isVisible={this.state.isModalOpen}
@@ -172,9 +180,15 @@ class AttachmentModal extends PureComponent {
                         }
                         if (file instanceof File) {
                             const source = URL.createObjectURL(file);
-                            this.setState({isModalOpen: true, sourceURL: source, file});
+                            const modalType = this.getModalType(source, file);
+                            this.setState({
+                                isModalOpen: true, sourceURL: source, file, modalType,
+                            });
                         } else {
-                            this.setState({isModalOpen: true, sourceURL: file.uri, file});
+                            const modalType = this.getModalType(file.uri, file);
+                            this.setState({
+                                isModalOpen: true, sourceURL: file.uri, file, modalType,
+                            });
                         }
                     },
                     show: () => {


### PR DESCRIPTION


### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues

https://github.com/Expensify/App/issues/5291

### QA Steps
1. Open application on an Android phone
2. Navigate to any conversation
3. Press "+" icon at the bottom left
4. Select "Add attachment"
5. Select "Choose document"
6. Select a PDF file that has at least 2 pages
7. Verify that file can be scrolled

### Tested On

- [x] Web
- [ ] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web

https://user-images.githubusercontent.com/9059945/141172524-62385ac7-72d6-4706-ae1d-2d065c250f98.mp4


#### iOS


https://user-images.githubusercontent.com/9059945/141172615-f3763e0b-42e8-4c30-a0dd-88d628bd0faf.MP4


#### Android

https://user-images.githubusercontent.com/9059945/141172844-1f7a932c-97a5-4d25-b317-e63b364a27b8.mp4



