### PR TITLE
iPhoneX Landscape UI

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import {LocaleContextProvider} from './components/withLocalize';
 import OnyxProvider from './components/OnyxProvider';
 import HTMLEngineProvider from './components/HTMLEngineProvider';
 import ComposeProviders from './components/ComposeProviders';
+import SafeArea from './components/SafeArea';
 
 LogBox.ignoreLogs([
     // Basically it means that if the app goes in the background and back to foreground on Android,
@@ -25,6 +26,7 @@ const App = () => (
         components={[
             OnyxProvider,
             SafeAreaProvider,
+            SafeArea,
             LocaleContextProvider,
             HTMLEngineProvider,
         ]}

--- a/src/components/Modal/BaseModal.js
+++ b/src/components/Modal/BaseModal.js
@@ -116,11 +116,15 @@ class BaseModal extends PureComponent {
                         const {
                             paddingTop: safeAreaPaddingTop,
                             paddingBottom: safeAreaPaddingBottom,
+                            paddingLeft: safeAreaPaddingLeft,
+                            paddingRight: safeAreaPaddingRight,
                         } = getSafeAreaPadding(insets);
 
                         const modalPaddingStyles = getModalPaddingStyles({
                             safeAreaPaddingTop,
                             safeAreaPaddingBottom,
+                            safeAreaPaddingLeft,
+                            safeAreaPaddingRight,
                             shouldAddBottomSafeAreaPadding,
                             shouldAddTopSafeAreaPadding,
                             modalContainerStylePaddingTop: modalContainerStyle.paddingTop,

--- a/src/components/SafeArea/index.ios.js
+++ b/src/components/SafeArea/index.ios.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import {SafeAreaView} from 'react-native-safe-area-context';
+import PropTypes from 'prop-types';
+import styles from '../../styles/styles';
+
+const SafeArea = props => (
+    <SafeAreaView style={[styles.iPhoneXSafeArea]} edges={['left', 'right']}>
+        {props.children}
+    </SafeAreaView>
+);
+
+SafeArea.propTypes = {
+    /** App content */
+    children: PropTypes.node.isRequired,
+};
+
+export default SafeArea;

--- a/src/components/SafeArea/index.js
+++ b/src/components/SafeArea/index.js
@@ -1,0 +1,1 @@
+export default ({children}) => children;

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1847,7 +1847,7 @@ const styles = {
         alignItems: 'center',
         flexDirection: 'row',
         justifyContent: 'space-between',
-        shadowColor: '#000',
+        shadowColor: colors.black,
         ...spacing.p5,
     },
 
@@ -2089,6 +2089,11 @@ const styles = {
     googleListView: {
         transform: [{scale: 0}],
     },
+
+    iPhoneXSafeArea: {
+        backgroundColor: '#000000',
+        flex: 1,
+    },
 };
 
 const baseCodeTagStyles = {
@@ -2192,6 +2197,8 @@ function getSafeAreaPadding(insets) {
     return {
         paddingTop: insets.top,
         paddingBottom: insets.bottom * variables.safeInsertPercentage,
+        paddingLeft: insets.left * variables.safeInsertPercentage,
+        paddingRight: insets.right * variables.safeInsertPercentage,
     };
 }
 
@@ -2404,6 +2411,8 @@ function getModalPaddingStyles({
     shouldAddTopSafeAreaPadding,
     safeAreaPaddingTop,
     safeAreaPaddingBottom,
+    safeAreaPaddingLeft,
+    safeAreaPaddingRight,
     modalContainerStylePaddingTop,
     modalContainerStylePaddingBottom,
 }) {
@@ -2414,6 +2423,8 @@ function getModalPaddingStyles({
         paddingBottom: shouldAddBottomSafeAreaPadding
             ? (modalContainerStylePaddingBottom || 0) + safeAreaPaddingBottom
             : modalContainerStylePaddingBottom || 0,
+        paddingLeft: safeAreaPaddingLeft || 0,
+        paddingRight: safeAreaPaddingRight || 0,
     };
 }
 

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1847,7 +1847,7 @@ const styles = {
         alignItems: 'center',
         flexDirection: 'row',
         justifyContent: 'space-between',
-        shadowColor: colors.black,
+        shadowColor: '#000',
         ...spacing.p5,
     },
 
@@ -2091,7 +2091,7 @@ const styles = {
     },
 
     iPhoneXSafeArea: {
-        backgroundColor: '#000000',
+        backgroundColor: colors.black,
         flex: 1,
     },
 };


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Added `SafeArea` for iPhone X to prevent its notch from blocking the UI

### Fixed Issues
$ https://github.com/Expensify/App/issues/5926

### Tests
N/A

### QA Steps
![Screen Shot 2021-11-13 at 8 48 49 AM](https://user-images.githubusercontent.com/11542415/141604599-6765f183-1a7a-4079-97a2-b1f72c6849b8.png)

1. Launch the app with iPhone X or newer models that have a notch.
2. Rotate the phone to landscape mode
3. Confirm all content is visible

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

#### iOS
![Screen Shot 2021-11-13 at 8 49 38 AM](https://user-images.githubusercontent.com/11542415/141604637-626956e0-6c9c-4290-ab28-036fa49f16da.png)