### PR TITLE
Re-add autoFocus prop for ExpensiText components

### DIFF
--- a/src/components/ExpensiTextInput/baseExpensiTextInputPropTypes.js
+++ b/src/components/ExpensiTextInput/baseExpensiTextInputPropTypes.js
@@ -32,6 +32,8 @@ const propTypes = {
     ignoreLabelTranslateX: PropTypes.bool,
 
     forceActiveLabel: PropTypes.bool,
+    
+    autoFocus: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -43,6 +45,7 @@ const defaultProps = {
     translateX: -22,
     inputStyle: [],
     ignoreLabelTranslateX: false,
+    autoFocus: false,
 
     /**
      * To be able to function as either controlled or uncontrolled component we should not

--- a/src/components/ExpensiTextInput/baseExpensiTextInputPropTypes.js
+++ b/src/components/ExpensiTextInput/baseExpensiTextInputPropTypes.js
@@ -32,7 +32,8 @@ const propTypes = {
     ignoreLabelTranslateX: PropTypes.bool,
 
     forceActiveLabel: PropTypes.bool,
-    
+
+    /** Should the input auto focus? */
     autoFocus: PropTypes.bool,
 };
 


### PR DESCRIPTION
@roryabraham will you please review this?

### Details
This is a regression from https://github.com/Expensify/App/commit/2231d55a6ddf189042c680979e4981c6c00d178b, we just need to ensure that autoFocus is still included.

### Fixed Issues
$ https://github.com/Expensify/App/issues/6298

### Tests/QA
1. Log in and open a chat
2. Click on the `+` button and select `Request Money` or `Send Money`
3. Enter a value and hit `Next`
4. Confirm that the `What's It For` input on the following screen autoFocuses and you can see both the label and the placeholder

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

| Web | Mobile |
|---|---|
| ![image](https://user-images.githubusercontent.com/3981102/141834809-85ff9334-f3fd-4ae4-8695-72f5caa5b2e8.png) | ![image](https://user-images.githubusercontent.com/3981102/141835461-fb59f286-cc76-4f34-83bb-d643f1dfaf38.png) |


