### PR TITLE
Fix blank screen displayed on Company Step VBA flow

### DIFF
--- a/src/pages/ReimbursementAccount/CompanyStep.js
+++ b/src/pages/ReimbursementAccount/CompanyStep.js
@@ -235,7 +235,7 @@ class CompanyStep extends React.Component {
                         errorText={this.getErrorText('companyName')}
                     />
                     {!this.state.manualAddress && (
-                        <div>
+                        <>
                             <AddressSearch
                                 label={this.props.translate('common.companyAddress')}
                                 containerStyles={[styles.mt4]}
@@ -249,10 +249,10 @@ class CompanyStep extends React.Component {
                             >
                                 Can&apos;t find your address? Enter it manually
                             </TextLink>
-                        </div>
+                        </>
                     )}
                     {this.state.manualAddress && (
-                        <div>
+                        <>
                             <ExpensiTextInput
                                 label={this.props.translate('common.companyAddress')}
                                 containerStyles={[styles.mt4]}
@@ -287,7 +287,7 @@ class CompanyStep extends React.Component {
                                 value={this.state.addressZipCode}
                                 errorText={this.getErrorText('addressZipCode')}
                             />
-                        </div>
+                        </>
                     )}
 
                     <ExpensiTextInput


### PR DESCRIPTION
### Details
Removes bad usages of `<div>` from Company Step

cc @AndrewGable @Gonals 

### Fixed Issues
$ https://github.com/Expensify/App/issues/6322

### Tests
1. Log in to NewDot
2. Go to any Worksplace
3. Tap Connect bank account
4. Tap Continue
5. Choose the Chase Bank account
6. Put username: user_good, password:pass_good
7. Select Saving bank account
8. Tap Save and Continue
9. Verify the app does not crash

### QA Steps
Same as above.

### Tested On

- [X] Web
- [X] Mobile Web
- [X] Desktop
- [X] iOS
- [X] Android

### Screenshots

#### Web

https://user-images.githubusercontent.com/22219519/142037982-a6d45aa7-b70b-4b14-9d67-75c61cd42f0f.mov

#### Mobile Web

https://user-images.githubusercontent.com/22219519/142042027-896de820-4f82-4089-91df-e4903b9cc965.mov

#### Desktop

https://user-images.githubusercontent.com/22219519/142038407-6756e097-128a-451d-8967-945e3c02b167.mov

#### iOS

https://user-images.githubusercontent.com/22219519/142038112-c1a88e94-f032-4ff8-bad2-01bff85a2f0a.mov

#### Android

https://user-images.githubusercontent.com/22219519/142042044-ad1631c4-b14d-4a97-9e4e-37a8905fb330.mov


