### PR TITLE
Allow dropdown arrow to be clicked on select inputs

### DIFF
--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -575,6 +575,7 @@ const styles = {
         iconContainer: {
             top: 16,
             right: 12,
+            zIndex: -1,
         },
         inputWeb: {
             appearance: 'none',


### PR DESCRIPTION
### Details
Allows users to open dropdown by clicking over the dropdown icon.

### Fixed Issues
$ https://github.com/Expensify/App/issues/6324

### Tests
1. Login to NewDot
2. Select any Workspace
3. Click on `Add bank account` and `Connect manually`
4. Enter `011401533` and `1111222233331111` for routing and account number, respectively.
5. On the company step, verify that clicking on the dropdown arrow icon in the select inputs opens the input.

### QA Steps
Steps above.

### Tested On

- [X] Web
- [X] Mobile Web
- [X] Desktop
- [X] iOS
- [X] Android

### Screenshots

#### Web

https://user-images.githubusercontent.com/22219519/142043808-5b1e35dd-47f2-4691-96e6-c3392a19f8ea.mov

#### Mobile Web

https://user-images.githubusercontent.com/22219519/142043960-07978c13-3bea-4998-bf46-a00ea9d5bf65.mov

#### Desktop

https://user-images.githubusercontent.com/22219519/142043860-85a8592e-6e44-407e-b3b0-0787943fd850.mov

#### iOS

https://user-images.githubusercontent.com/22219519/142043878-7eeaff41-8336-4d40-ad08-88db22815cc3.mov

#### Android

https://user-images.githubusercontent.com/22219519/142043895-8decd1ab-f687-424a-9415-98142c450a46.mov
