### PR TITLE
Fix switching to manual address when adding bank account

### DIFF
--- a/src/pages/ReimbursementAccount/IdentityForm.js
+++ b/src/pages/ReimbursementAccount/IdentityForm.js
@@ -133,7 +133,7 @@ const IdentityForm = (props) => {
                 errorText={props.errors.ssnLast4 ? props.translate('bankAccount.error.ssnLast4') : ''}
                 maxLength={CONST.BANK_ACCOUNT.MAX_LENGTH.SSN}
             />
-            {props.manualAddress ? (
+            {props.values.manualAddress ? (
                 <>
                     <ExpensiTextInput
                         label={props.translate('common.personalAddress')}

--- a/src/pages/ReimbursementAccount/IdentityForm.js
+++ b/src/pages/ReimbursementAccount/IdentityForm.js
@@ -138,7 +138,7 @@ const IdentityForm = (props) => {
                     <ExpensiTextInput
                         label={props.translate('common.personalAddress')}
                         containerStyles={[styles.mt4]}
-                        value={props.street}
+                        value={props.values.street}
                         onChangeText={value => props.onFieldChange('addressStreet', value)}
                         errorText={props.errors.street ? props.translate('bankAccount.error.address') : ''}
                     />
@@ -147,7 +147,7 @@ const IdentityForm = (props) => {
                         <View style={[styles.flex2, styles.mr2]}>
                             <ExpensiTextInput
                                 label={props.translate('common.city')}
-                                value={props.city}
+                                value={props.values.city}
                                 onChangeText={value => props.onFieldChange('addressCity', value)}
                                 errorText={props.errors.city ? props.translate('bankAccount.error.addressCity') : ''}
                                 translateX={-14}
@@ -155,7 +155,7 @@ const IdentityForm = (props) => {
                         </View>
                         <View style={[styles.flex1]}>
                             <StatePicker
-                                value={props.state}
+                                value={props.values.state}
                                 onChange={value => props.onFieldChange('addressState', value)}
                                 errorText={props.errors.state ? props.translate('bankAccount.error.addressState') : ''}
                                 hasError={Boolean(props.errors.state)}
@@ -166,7 +166,7 @@ const IdentityForm = (props) => {
                         label={props.translate('common.zip')}
                         containerStyles={[styles.mt4]}
                         keyboardType={CONST.KEYBOARD_TYPE.NUMERIC}
-                        value={props.zipCode}
+                        value={props.values.zipCode}
                         onChangeText={value => props.onFieldChange('addressZipCode', value)}
                         errorText={props.errors.zipCode ? props.translate('bankAccount.error.zipCode') : ''}
                         maxLength={CONST.BANK_ACCOUNT.MAX_LENGTH.ZIP_CODE}


### PR DESCRIPTION
Pullerbear review (@cead22)

### Details
When adding a bank account, fix the `Can't find your address? Enter it manually` link.

### Fixed Issues
$ https://github.com/Expensify/App/issues/6323

### Tests / QA
1. Create a workspace
2. Select the "Connect Bank Account"
3. Fill in the details until the step 3 "Personal Information"
4. Start typing an address in the "Personal Address" input, select an option in the dropdown below
5. Click "Can't find your address?"
5. Make sure the UI refreshes with the inputs to manually enter your address
6. Make sure the City, State, and Zip Code inputs are prepopulated with the values from the address you just selected previously

https://user-images.githubusercontent.com/2229301/142062764-d17802cb-3006-4c6e-bff7-99647ce574b2.mov

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android