### PR TITLE
Fix avatar warning for incorrect propType

### DIFF
--- a/src/pages/ReportDetailsPage.js
+++ b/src/pages/ReportDetailsPage.js
@@ -133,7 +133,7 @@ class ReportDetailsPage extends Component {
                                 isArchivedRoom={isArchivedRoom(this.props.report)}
                                 containerStyles={[styles.singleAvatarLarge, styles.mb4]}
                                 imageStyles={[styles.singleAvatarLarge]}
-                                source={{uri: this.props.report.icons[0]}}
+                                source={this.props.report.icons[0]}
                             />
                             <View style={styles.reportDetailsRoomInfo}>
                                 <DisplayNames


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This PR fixes a warning where we are passing in the incorrect prop type for the Avatar component on the ReportDetailsPage
<img src='https://user-images.githubusercontent.com/3981102/142058350-955a10bb-4ae0-4acf-aea7-6875693ed385.png' width='400'/>

### Fixed Issues
N/A

### Tests/QA
1. Log into an account and navigate to a room (e.g. #announce)
2. Tap on the header to access the room details
3. Confirm there is no console error, and that the icon appears

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

| Web | Mobile |
|---|---|
| ![image](https://user-images.githubusercontent.com/3981102/142058649-6b4589eb-3ffa-4441-bdb0-bd10a57a0e60.png) | ![image](https://user-images.githubusercontent.com/3981102/142058704-e9646b8a-4e37-4bfd-b415-571bfd76173c.png) |

