### PR TITLE
Remove early return from isFromPublicDomain if domain is public

### DIFF
--- a/src/libs/actions/User.js
+++ b/src/libs/actions/User.js
@@ -239,12 +239,6 @@ function getDomainInfo() {
                 const {isFromPublicDomain} = response;
                 Onyx.merge(ONYXKEYS.USER, {isFromPublicDomain});
 
-                // If the user is not on a public domain we'll want to know whether they are on a domain that has
-                // already provisioned the Expensify card
-                if (isFromPublicDomain) {
-                    return;
-                }
-
                 API.User_IsUsingExpensifyCard()
                     .then(({isUsingExpensifyCard}) => {
                         Onyx.merge(ONYXKEYS.USER, {isUsingExpensifyCard});


### PR DESCRIPTION
### Details
We added the ability to auto approving Expensify Cards for users with private domain as secondary logins. This PR removes the early return from `isFromPublicDomain` so we can determine if the user has Expensify Cards enabled in their account.

### Fixed Issues
$ https://github.com/Expensify/App/issues/6337

### Tests
1. Log into NewDot with a public domain email, e.g. `@gmail.com`.
2. Open the browser console and verify that `isUsingExpensifyCards` is set to false.

### QA Steps
Steps above.

### Tested On

- [X] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
![Screen Shot 2021-11-16 at 3 56 22 PM](https://user-images.githubusercontent.com/22219519/142079419-31d3ea15-0221-4eec-9a47-472e78d35b99.png)

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
