### PR TITLE
Pass translateX prop to TextInput component

### DIFF
--- a/src/components/ExpensiTextInput/BaseExpensiTextInput.js
+++ b/src/components/ExpensiTextInput/BaseExpensiTextInput.js
@@ -198,6 +198,7 @@ class BaseExpensiTextInput extends Component {
                                 onBlur={this.onBlur}
                                 onChangeText={this.setValue}
                                 onPressOut={this.props.onPress}
+                                translateX={this.props.translateX}
                             />
                         </View>
                     </TouchableWithoutFeedback>


### PR DESCRIPTION
cc @roryabraham 

### Details
This PR updates the ExpensiTextInput component to pass translateX to the child TextInput component, fixing an issue on Android where all inputs had extra space. Adding CP Staging label to fix deploy blocker.

### Fixed Issues
$ https://github.com/Expensify/App/issues/6321

### Tests/QA
1. Sign out of newdot and focus the sign in input, confirm there is no extra space at the beginning
2. Sign into newdot and confirm other inputs do not have extra space at the beginning. The inputs in settings->change password is an example that doesn't pass translateX, so those also confirm there are no regressions.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

| Web | Android | iOS |
|---|---|---|
| ![image](https://user-images.githubusercontent.com/3981102/142085600-164e359e-e1fd-4f3c-bbe8-2e9d0cb66f8e.png) | ![image](https://user-images.githubusercontent.com/3981102/142085301-3916167a-15f8-470f-a882-06702bff2d4a.png) | ![image](https://user-images.githubusercontent.com/3981102/142085438-532fc8b1-0197-4336-9d11-ff11a77ef1f7.png) |


