### PR TITLE
[No QA] Run CP workflow on macOS

### DIFF
--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -60,7 +60,7 @@ jobs:
   cherryPick:
     needs: [validateActor, createNewVersion]
     if: ${{ always() && fromJSON(needs.validateActor.outputs.IS_DEPLOYER) }}
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       # Version: 2.3.4
       - name: Checkout staging branch


### PR DESCRIPTION
### Details
Coming from https://github.com/Expensify/App/pull/6199, CP workflow is failing because it relies on PListBuddy, which is only available on macOS.

### Fixed Issues
Fixes this failure: https://github.com/Expensify/App/runs/4233889892?check_suite_focus=true

### Tests
1. Merge this PR.
1. Manually CP https://github.com/Expensify/App/pull/6341
1. See if it works this time.