### PR TITLE
Revert "[No QA] Run CP workflow on macOS"

### DIFF
--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -60,7 +60,7 @@ jobs:
   cherryPick:
     needs: [validateActor, createNewVersion]
     if: ${{ always() && fromJSON(needs.validateActor.outputs.IS_DEPLOYER) }}
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       # Version: 2.3.4
       - name: Checkout staging branch


### PR DESCRIPTION
Reverts Expensify/App#6344

We need to run this on linux, so reverting macOS change

More context in https://github.com/Expensify/App/pull/6344#issuecomment-971767451