### PR TITLE
[NO QA]Import from the GPG key from the right directory

### DIFF
--- a/.github/workflows/createNewVersion.yml
+++ b/.github/workflows/createNewVersion.yml
@@ -31,7 +31,7 @@ jobs:
           LARGE_SECRET_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
 
       - name: Import the GPG Key
-        run: gpg --import OSBotify-private-key.asc
+        run: cd .github/workflows && gpg --import OSBotify-private-key.asc
 
       - name: Set up git
         run: |


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
In https://github.com/Expensify/App/pull/6368 we added the GPG key needed to sign commits, but the GH action failed to import the key. This was because we were trying to import from the wrong directory, this PR fixes that.

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
Fixes broken GH Action https://github.com/Expensify/App/runs/4268916534?check_suite_focus=true

### Tests
1. CP this PR and verify the version commit is signed correctly
