### PR TITLE
[NO QA]Checkout Cherry Pick using OS_BOTIFY_TOKEN

### DIFF
--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.OS_BOTIFY_TOKEN }}
 
       - uses: softprops/turnstyle@8db075d65b19bf94e6e8687b504db69938dc3c65
         with:


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
We were running into an issue using the `GITHUB_TOKEN` for Cherry Picking a workflow file, this should give us the required permissions to push that file. 

<img width="995" alt="Screen Shot 2021-11-19 at 4 48 49 PM" src="https://user-images.githubusercontent.com/2838819/142704933-78516373-a7ec-4a98-a8fa-c275305900a6.png">

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
Fixed error above, related to https://github.com/Expensify/Expensify/issues/149007

### Tests
1. Merge and then CP this PR
