### PR TITLE
HttpUtils abortable requests

### DIFF
--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -182,6 +182,10 @@ Network.registerResponseHandler((queuedRequest, response) => {
 });
 
 Network.registerErrorHandler((queuedRequest, error) => {
+    if (error.name === 'AbortError') {
+        Log.info('[API] request aborted', false, queuedRequest);
+        return;
+    }
     if (queuedRequest.command !== 'Log') {
         Log.hmmm('[API] Handled error when making request', error);
     } else {

--- a/src/libs/actions/SignInRedirect.js
+++ b/src/libs/actions/SignInRedirect.js
@@ -1,6 +1,7 @@
 import Onyx from 'react-native-onyx';
 import SignoutManager from '../SignoutManager';
 import ONYXKEYS from '../../ONYXKEYS';
+import HttpUtils from '../HttpUtils';
 
 let currentActiveClients;
 Onyx.connect({
@@ -20,6 +21,7 @@ Onyx.connect({
  * @param {String} errorMessage
  */
 function clearStorageAndRedirect(errorMessage) {
+    HttpUtils.abortPendingRequests();
     const activeClients = currentActiveClients;
     const preferredLocale = currentPreferredLocale;
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Add functionality to let requests be aborted
Abort any leftover requests during sign out

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/2642

### Tests
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

#### All platforms 
1. Throttle the network speed from dev tools (e.g. 2kbps download speed)
2. Accumulate some pending requests by switching chats or switching between tabs
3. Log out while requests are still running
4. Observe pending requests are getting canceled

#### Mobile 
Similar to the steps above - we're trying to have pending requests  when we log out
On Android, there are throttling options in the Emulator network settings 
On iOS there aren't but it's still possible (see the attached video):
1. Pull down the notifications bar a few times to create pending requests (resulting from app re-focus)
2. Log out while requests are still running
3. Observe aborted request logs in the terminal

### QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

See if you can do any of the **Tests** above
If not, try to log in and then log out as fast as possible, there should be no weird behavior afterwards 
- like being unable to login again
- or any other problems when you log back in

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [x] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
https://user-images.githubusercontent.com/12156624/142845213-da3ab1c8-09eb-4df7-9537-a9c0edb4135b.mov

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
https://user-images.githubusercontent.com/12156624/142843603-034fd832-d4ea-4528-b1c3-c2bdbddb37fb.mov

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
