### PR TITLE
[No QA] Update webpack path for apple app association

### DIFF
--- a/config/webpack/webpack.common.js
+++ b/config/webpack/webpack.common.js
@@ -51,7 +51,7 @@ const webpackConfig = {
                 {from: 'assets/css', to: 'css'},
                 {from: 'node_modules/react-pdf/dist/esm/Page/AnnotationLayer.css', to: 'css/AnnotationLayer.css'},
                 {from: 'assets/images/shadow.png', to: 'images/shadow.png'},
-                {from: 'apple-app-site-association'},
+                {from: '.well-known/apple-app-site-association'},
 
                 // These files are copied over as per instructions here
                 // https://github.com/wojtekmaj/react-pdf#copying-cmaps


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This fixes the path for the apple-app-association file in webpack, which is causing GH actions failures on [desktop](https://github.com/Expensify/App/runs/4291419001?check_suite_focus=true)

### Fixed Issues
Related to https://github.com/Expensify/App/pull/6385

### Tests
Run `npm run desktop-build` locally and confirm no errors happen.

### QA
None

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
