### PR TITLE
Strip prefix and translate pronouns when needed

### DIFF
--- a/src/components/ReportWelcomeText.js
+++ b/src/components/ReportWelcomeText.js
@@ -10,6 +10,7 @@ import withLocalize, {withLocalizePropTypes} from './withLocalize';
 import compose from '../libs/compose';
 import {getPersonalDetailsForLogins} from '../libs/OptionsListUtils';
 import ONYXKEYS from '../ONYXKEYS';
+import CONST from '../CONST';
 
 
 const personalDetailsPropTypes = PropTypes.shape({
@@ -53,10 +54,15 @@ const ReportWelcomeText = (props) => {
             const longName = displayName || Str.removeSMSDomain(login);
             const longNameLocalized = Str.isSMSLogin(longName) ? props.toLocalPhone(longName) : longName;
             const shortName = firstName || longNameLocalized;
+            let finalPronouns = pronouns;
+            if (pronouns && pronouns.startsWith(CONST.PRONOUNS.PREFIX)) {
+                const localeKey = pronouns.replace(CONST.PRONOUNS.PREFIX, '');
+                finalPronouns = props.translate(`pronouns.${localeKey}`);
+            }
             return {
                 displayName: isMultipleParticipant ? shortName : longNameLocalized,
                 tooltip: Str.removeSMSDomain(login),
-                pronouns,
+                pronouns: finalPronouns,
             };
         },
     );


### PR DESCRIPTION
### Details
Small change to make sure we correctly display the pronouns. Thanks @parasharrajat for [proposing the solution](https://github.com/Expensify/App/issues/6416#issuecomment-976439513)

### Fixed Issues

$ https://github.com/Expensify/App/issues/6416

### Tests/ QA Steps
1. Start a new conversation in Newdot with someone you have never chatted with that has pronouns set.
2. Make sure the pronouns are correctly displayed:
<img width="646" alt="Screen Shot 2021-11-23 at 3 37 51 PM" src="https://user-images.githubusercontent.com/19366280/143044360-ebcc1621-f3a3-4619-9277-3788c2b1c848.png">


### Tested On

- [X] Web
- [] Mobile Web
- [X] Desktop
- [X] iOS
- [X] Android

