### PR TITLE
[NO QA] Revert "Ensures mini actions menu will disappear when attachment modal opens up"

### DIFF
--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -149,7 +149,7 @@ class ReportActionItem extends Component {
                 preventDefaultContentMenu={!this.props.draftMessage}
 
             >
-                <Hoverable resetsOnClickOutside>
+                <Hoverable resetsOnClickOutside={false}>
                     {hovered => (
                         <View>
                             {this.props.shouldDisplayNewIndicator && (


### PR DESCRIPTION
Reverts Expensify/App#6083

This commit was unsigned, we're going to revert this and then make the same change with a verified commit