### PR TITLE
fix: Secondary login page

### DIFF
--- a/src/pages/settings/AddSecondaryLoginPage.js
+++ b/src/pages/settings/AddSecondaryLoginPage.js
@@ -20,6 +20,7 @@ import compose from '../../libs/compose';
 import FixedFooter from '../../components/FixedFooter';
 import ExpensiTextInput from '../../components/ExpensiTextInput';
 import userPropTypes from './userPropTypes';
+import LoginUtil from '../../libs/LoginUtil';
 
 const propTypes = {
     /* Onyx Props */
@@ -63,19 +64,17 @@ class AddSecondaryLoginPage extends Component {
     }
 
     onSecondaryLoginChange(login) {
-        if (this.formType === CONST.LOGIN_TYPE.EMAIL) {
-            this.setState({login});
-        } else if (this.formType === CONST.LOGIN_TYPE.PHONE
-            && (CONST.REGEX.DIGITS_AND_PLUS.test(login) || login === '')) {
-            this.setState({login});
-        }
+        this.setState({login});
     }
 
     /**
      * Add a secondary login to a user's account
      */
     submitForm() {
-        User.setSecondaryLoginAndNavigate(this.state.login, this.state.password);
+        const login = this.formType === CONST.LOGIN_TYPE.PHONE
+            ? LoginUtil.getPhoneNumberWithoutSpecialChars(this.state.login)
+            : this.state.login;
+        User.setSecondaryLoginAndNavigate(login, this.state.password);
     }
 
     /**
@@ -84,8 +83,12 @@ class AddSecondaryLoginPage extends Component {
      * @returns {Boolean}
      */
     validateForm() {
+        const login = this.formType === CONST.LOGIN_TYPE.PHONE
+            ? LoginUtil.getPhoneNumberWithoutSpecialChars(this.state.login)
+            : this.state.login;
+
         const validationMethod = this.formType === CONST.LOGIN_TYPE.PHONE ? Str.isValidPhone : Str.isValidEmail;
-        return !this.state.password || !validationMethod(this.state.login);
+        return !this.state.password || !validationMethod(login);
     }
 
     render() {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR also update the behaviour of phone input for Add Login page. 
1. It will allow the user to enter any text into the input previously it was only accepting the + and digits.

I noticed that there are no frontend errors for phone input on this page. error is thrown after it is received from the backend.

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/6414

### Tests | QA Steps

1. Navigate to NewDot and login
2. Go to settings > profile
3. Tap add phone number
4. Input a phone number using any of symbols -, (, ) or spaces (e.g. +1 (222) 222 2222)


### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web | Mobile Web | Desktop
<!-- Insert screenshots of your changes on the web platform-->
![image](https://user-images.githubusercontent.com/24370807/143080999-f455d569-7820-4beb-896e-0192b039ba55.png)

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
