### PR TITLE
[NO QA] Revert "Revert "Ensures mini actions menu will disappear when attachment modal opens up""

### DIFF
--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -149,7 +149,7 @@ class ReportActionItem extends Component {
                 preventDefaultContentMenu={!this.props.draftMessage}
 
             >
-                <Hoverable resetsOnClickOutside={false}>
+                <Hoverable resetsOnClickOutside>
                     {hovered => (
                         <View>
                             {this.props.shouldDisplayNewIndicator && (


### PR DESCRIPTION
Reverts Expensify/App#6429

This is a revert of a revert so that the code still exists, but it is GPG signed which the original commit was not