### PR TITLE
fix issue 6326: Chat - Magnifying glass displayed anywhere

### DIFF
--- a/src/components/ImageView/index.js
+++ b/src/components/ImageView/index.js
@@ -19,6 +19,7 @@ class ImageView extends PureComponent {
         this.scrollableRef = null;
         this.canUseTouchScreen = canUseTouchScreen();
         this.state = {
+            containerHeight: 0,
             isZoomed: false,
             isDragging: false,
             isMouseDown: false,
@@ -162,19 +163,23 @@ class ImageView extends PureComponent {
         return (
             <View
                 ref={el => this.scrollableRef = el}
+                onLayout={(e) => {
+                    this.setState({containerHeight: e.nativeEvent.layout.height});
+                }}
                 style={[
                     styles.imageViewContainer,
                     styles.overflowScroll,
                     styles.noScrollbars,
+                    styles.pRelative,
                 ]}
             >
                 <Pressable
-                    style={[
-                        styles.w100,
-                        styles.h100,
-                        styles.flex1,
-                        getZoomCursorStyle(this.state.isZoomed, this.state.isDragging),
-                    ]}
+                    style={{
+                        ...getZoomSizingStyle(this.state.isZoomed, this.state.imgWidth, this.state.imgHeight, this.state.zoomScale, this.state.containerHeight),
+                        ...getZoomCursorStyle(this.state.isZoomed, this.state.isDragging),
+                        ...this.state.isZoomed ? styles.pRelative : styles.pAbsolute,
+                        ...styles.flex1,
+                    }}
                     onPressIn={(e) => {
                         const {pageX, pageY} = e.nativeEvent;
                         this.setState({
@@ -212,7 +217,10 @@ class ImageView extends PureComponent {
                 >
                     <Image
                         source={{uri: this.props.url}}
-                        style={getZoomSizingStyle(this.state.isZoomed, this.state.imgWidth, this.state.imgHeight, this.state.zoomScale)}
+                        style={[
+                            styles.h100,
+                            styles.w100,
+                        ]}
                         resizeMode={this.state.isZoomed ? 'contain' : 'center'}
                     />
                 </Pressable>

--- a/src/components/ImageView/index.js
+++ b/src/components/ImageView/index.js
@@ -42,8 +42,7 @@ class ImageView extends PureComponent {
             return;
         }
         Image.getSize(this.props.url, (width, height) => {
-            const scale = Math.max(this.props.windowWidth / width, this.props.windowHeight / height);
-            this.setImageRegion(width, height, scale);
+            this.setImageRegion(width, height);
         });
         document.addEventListener('mousemove', this.trackMovement.bind(this));
     }
@@ -60,9 +59,8 @@ class ImageView extends PureComponent {
      * When open image, set image left/right/top/bottom point and width, height
      * @param {Boolean} width image width
      * @param {Boolean} height image height
-     * @param {Boolean} scale zoomscale when click zoom
      */
-    setImageRegion(width, height, scale) {
+    setImageRegion(width, height) {
         let imgLeft = (this.props.windowWidth - width) / 2;
         let imgRight = ((this.props.windowWidth - width) / 2) + width;
         let imgTop = (this.props.windowHeight - height) / 2;
@@ -87,7 +85,7 @@ class ImageView extends PureComponent {
         }
 
         this.setState({
-            imgWidth: width, imgHeight: height, zoomScale: scale, imageLeft: imgLeft, imageTop: imgTop, imageRight: imgRight, imageBottom: imgBottom,
+            imgWidth: width, imgHeight: height, imageLeft: imgLeft, imageTop: imgTop, imageRight: imgRight, imageBottom: imgBottom,
         });
     }
 
@@ -164,7 +162,14 @@ class ImageView extends PureComponent {
             <View
                 ref={el => this.scrollableRef = el}
                 onLayout={(e) => {
-                    this.setState({containerHeight: e.nativeEvent.layout.height});
+                    const {width, height} = e.nativeEvent.layout;
+                    const imageWidth = this.state.imgWidth;
+                    const imageHeight = this.state.imgHeight;
+                    const scale = imageHeight && imageWidth ? Math.min(width / imageWidth, height / imageHeight) : 0;
+                    this.setState({
+                        containerHeight: height,
+                        zoomScale: scale,
+                    });
                 }}
                 style={[
                     styles.imageViewContainer,

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -2296,18 +2296,30 @@ function getZoomCursorStyle(isZoomed, isDragging) {
  * @param {Number} imgWidth
  * @param {Number} imgHeight
  * @param {Number} zoomScale
+ * @param {Number} containerHeight
  * @return {Object}
  */
-function getZoomSizingStyle(isZoomed, imgWidth, imgHeight, zoomScale) {
+function getZoomSizingStyle(isZoomed, imgWidth, imgHeight, zoomScale, containerHeight) {
     if (imgWidth === 0 || imgHeight === 0) {
         return {
             height: isZoomed ? '250%' : '100%',
             width: isZoomed ? '250%' : '100%',
         };
     }
+    if (isZoomed) {
+        return {
+            height: `${(imgHeight * zoomScale)}px`,
+            width: `${(imgWidth * zoomScale)}px`,
+        };
+    }
+
+    const top = `${(containerHeight - imgHeight) / 2}px`;
+    const left = `calc(50% - ${imgWidth / 2}px)`;
     return {
-        height: isZoomed ? `${(imgHeight * zoomScale)}px` : '100%',
-        width: isZoomed ? `${(imgWidth * zoomScale)}px` : '100%',
+        height: `${imgHeight}px`,
+        width: `${imgWidth}px`,
+        top,
+        left,
     };
 }
 


### PR DESCRIPTION
### Details
- Because `cursor: zoom-in` style was assigned to the ancient of the `Image` component, this cursor was displayed out of the image area.
To resolve it, I reassign this style to image (Actually, I assigned it to `Pressable` component because the `Image` component is wrapped by it).
- While reassigning this style, I had to keep the center alignment of the image in the modal.
For center alignment, I calculated the offset based on modal size and image size.
- When the image is expanded, it was using scaled width and height. I have kept this code like below
```
   if (isZoomed) {
        return {
            height: `${(imgHeight * zoomScale)}px`,
            width: `${(imgWidth * zoomScale)}px`,
        };
    }
```

### Fixed Issues
$ [GH_LINK](https://github.com/Expensify/App/issues/6326)

### Tests

1. Send the image to someone.
2. Click the image thumbnail in the chatbox.
3. Modal is open to display the image.
4. Image is center aligned.
5. Check the cursor while hovering around the image.
6. Check the zoom in and zoom out functionality.



### QA Steps
1. Send the image to someone.
2. Click the image thumbnail in the chatbox.
3. Check the center alignment of an image in the modal.
5. Check the cursor while hovering around the image.
6. Check the zoom in and zoom out functionality.


### Tested On
This issue is just a hovering issue, don't need to check for mobile platforms.
- [x] Web
- [ ] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android

### Screenshots

#### Web
[web fix video](https://drive.google.com/file/d/1DKGHBaSYwr4MJgAk6yMwJYj9P7_M264L/view?usp=sharing)

#### Desktop
[desktop fix video](https://drive.google.com/file/d/1KzE5WtSgUj6ivmeVJvhPfkw_U-UqRxyi/view?usp=sharing)
