### PR TITLE
Remove div usage in Onfido Web

### DIFF
--- a/src/components/Onfido/index.js
+++ b/src/components/Onfido/index.js
@@ -9,6 +9,7 @@ import variables from '../../styles/variables';
 import colors from '../../styles/colors';
 import fontWeightBold from '../../styles/fontWeight/bold';
 import fontFamily from '../../styles/fontFamily';
+import {View} from 'react-native-web';
 
 const propTypes = {
     ...withLocalizePropTypes,
@@ -103,7 +104,7 @@ class Onfido extends React.Component {
 
     render() {
         return (
-            <div id={CONST.ONFIDO.CONTAINER_ID} />
+            <View nativeID={CONST.ONFIDO.CONTAINER_ID} />
         );
     }
 }

--- a/src/components/Onfido/index.js
+++ b/src/components/Onfido/index.js
@@ -1,7 +1,7 @@
 import './index.css';
 import lodashGet from 'lodash/get';
 import React from 'react';
-import {View} from 'react-native-web';
+import {View} from 'react-native';
 import * as OnfidoSDK from 'onfido-sdk-ui';
 import withLocalize, {withLocalizePropTypes} from '../withLocalize';
 import onfidoPropTypes from './onfidoPropTypes';

--- a/src/components/Onfido/index.js
+++ b/src/components/Onfido/index.js
@@ -1,6 +1,7 @@
 import './index.css';
 import lodashGet from 'lodash/get';
 import React from 'react';
+import {View} from 'react-native-web';
 import * as OnfidoSDK from 'onfido-sdk-ui';
 import withLocalize, {withLocalizePropTypes} from '../withLocalize';
 import onfidoPropTypes from './onfidoPropTypes';
@@ -9,7 +10,6 @@ import variables from '../../styles/variables';
 import colors from '../../styles/colors';
 import fontWeightBold from '../../styles/fontWeight/bold';
 import fontFamily from '../../styles/fontFamily';
-import {View} from 'react-native-web';
 
 const propTypes = {
     ...withLocalizePropTypes,


### PR DESCRIPTION
### Details
Replaces `div` with a `View`

### Fixed Issues
$ https://github.com/Expensify/App/issues/6465

### Tests

1. Launch the Desktop app and login
2. Tap on [+] and select Send money > enter amount > next
3. Enter the email of a user you will send money to in the field 'Name, email or phone"
4. Tap on Continue for "Verify identity" page
5. Verify that the Onfido flow starts. 

Note: closing the modal will make the desktop app crash until [this fix](https://github.com/Expensify/App/pull/6461) is merged.

### QA Steps
Steps above.

### Tested On

- [X] Web
- [ ] Mobile Web
- [X] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web

https://user-images.githubusercontent.com/22219519/143295275-542acab5-6682-4318-ace0-49c928adc69a.mov

#### Mobile Web



#### Desktop
https://user-images.githubusercontent.com/22219519/143295288-da7c3481-a44c-45dc-88bf-c2857e9c457e.mov

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
