### PR TITLE
Prevent cannot read property of undefined for  href.startsWith

### DIFF
--- a/src/components/HTMLEngineProvider/BaseHTMLEngineProvider.js
+++ b/src/components/HTMLEngineProvider/BaseHTMLEngineProvider.js
@@ -90,8 +90,9 @@ function AnchorRenderer(props) {
     const isAttachment = Boolean(htmlAttribs['data-expensify-source']);
     const fileName = lodashGet(props.tnode, 'domNode.children[0].data', '');
     const parentStyle = lodashGet(props.tnode, 'parent.styles.nativeTextRet', {});
-    const internalExpensifyPath = (htmlAttribs.href.startsWith(CONST.NEW_EXPENSIFY_URL) && htmlAttribs.href.replace(CONST.NEW_EXPENSIFY_URL, ''))
-        || (htmlAttribs.href.startsWith(CONST.STAGING_NEW_EXPENSIFY_URL) && htmlAttribs.href.replace(CONST.STAGING_NEW_EXPENSIFY_URL, ''));
+    const attrHref = htmlAttribs.href || '';
+    const internalExpensifyPath = (attrHref.startsWith(CONST.NEW_EXPENSIFY_URL) && attrHref.replace(CONST.NEW_EXPENSIFY_URL, ''))
+        || (attrHref.startsWith(CONST.STAGING_NEW_EXPENSIFY_URL) && attrHref.replace(CONST.STAGING_NEW_EXPENSIFY_URL, ''));
 
     // If we are handling a New Expensify link then we will assume this should be opened by the app internally. This ensures that the links are opened internally via react-navigation
     // instead of in a new tab or with a page refresh (which is the default behavior of an anchor tag)
@@ -114,7 +115,7 @@ function AnchorRenderer(props) {
             <Text
                 style={styles.link}
                 onPress={() => {
-                    Linking.openURL(htmlAttribs.href);
+                    Linking.openURL(attrHref);
                 }}
             >
                 <TNodeChildrenRenderer tnode={props.tnode} />
@@ -124,7 +125,7 @@ function AnchorRenderer(props) {
 
     return (
         <AnchorForCommentsOnly
-            href={htmlAttribs.href}
+            href={attrHref}
             isAuthTokenRequired={isAttachment}
 
             // Unless otherwise specified open all links in


### PR DESCRIPTION
### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/185343

### Tests
Same as QA steps. I only managed to reproduce the bug by hardcoding an undefined href, then made sure that without the fix, I got the blank page like in the original issue, and that my changes fixed it.

![image](https://user-images.githubusercontent.com/2463975/143246959-91247047-1835-4e15-80c5-458db0c9c428.png)

### QA Steps
1. From a workspace, send a link in a discussion
2. Clicking on the link should open the link in a new tab

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

