### PR TITLE
Fix IOU EnablePayment route

### DIFF
--- a/src/libs/Navigation/linkingConfig.js
+++ b/src/libs/Navigation/linkingConfig.js
@@ -143,6 +143,7 @@ export default {
                 screens: {
                     IOU_Request_Root: ROUTES.IOU_REQUEST_WITH_REPORT_ID,
                     IOU_Request_Currency: ROUTES.IOU_REQUEST_CURRENCY,
+                    IOU_Enable_Payments: ROUTES.IOU_ENABLE_PAYMENTS,
                 },
             },
             IOU_Bill: {
@@ -170,7 +171,6 @@ export default {
             EnablePayments: {
                 screens: {
                     EnablePayments_Root: ROUTES.ENABLE_PAYMENTS,
-                    IOU_Enable_Payments: ROUTES.IOU_ENABLE_PAYMENTS,
                 },
             },
             RequestCall: {

--- a/src/libs/Navigation/linkingConfig.js
+++ b/src/libs/Navigation/linkingConfig.js
@@ -143,7 +143,6 @@ export default {
                 screens: {
                     IOU_Request_Root: ROUTES.IOU_REQUEST_WITH_REPORT_ID,
                     IOU_Request_Currency: ROUTES.IOU_REQUEST_CURRENCY,
-                    IOU_Enable_Payments: ROUTES.IOU_ENABLE_PAYMENTS,
                 },
             },
             IOU_Bill: {
@@ -156,6 +155,7 @@ export default {
                 screens: {
                     IOU_Send_Root: ROUTES.IOU_SEND_WITH_REPORT_ID,
                     IOU_Send_Currency: ROUTES.IOU_SEND_CURRENCY,
+                    IOU_Enable_Payments: ROUTES.IOU_ENABLE_PAYMENTS,
                 },
             },
             IOU_Details: {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Moved the `IOU_Enable_Payments` under `IOU_Send`

### Fixed Issues
$ https://github.com/Expensify/App/issues/6473

### Tests

1. Launch the Desktop app and login.
2. Tap on [+] and select Send money > enter amount > next.
3. Enter the email of a user you will send money to in the field 'Name, email or phone".
4. Tap on Continue for "Verify identity" page.
5. Verify that the `EnablePayments` page opens. On web verify that the url is `/iou/enable-payments`.
6. Verify that you can navigate back.

### QA Steps
Steps above.

### Tested On

- [X] Web
- [X] Mobile Web
- [X] Desktop
- [X] iOS
- [X] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web

https://user-images.githubusercontent.com/22219519/143300115-6db89f7a-b935-49da-89d9-23272bd8d79f.mov

#### Mobile Web

https://user-images.githubusercontent.com/22219519/143300129-91908bac-0508-4266-8ea2-b922ddac5b17.mov

#### Desktop

https://user-images.githubusercontent.com/22219519/143300138-d91891fb-0c21-4cc1-8198-0e40f52a454a.mov

#### iOS

https://user-images.githubusercontent.com/22219519/143300145-fbd7797d-ed79-4087-8d6f-63724d0b70da.mov

#### Android

https://user-images.githubusercontent.com/22219519/143300307-a674324c-62ef-405e-92fa-14b3cbfe41f8.mov
