### PR TITLE
Updated header text in test transaction step of VBA flow

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -662,6 +662,7 @@ export default {
             travel: 'Book travel',
             members: 'Manage members',
             bankAccount: 'Connect bank account',
+            testTransactions: 'Test transactions',
             issueAndManageCards: 'Issue and manage cards',
             reconcileCards: 'Reconcile cards',
             growlMessageOnSave: 'Your workspace settings were successfully saved!',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -664,6 +664,7 @@ export default {
             travel: 'Reservar viaje',
             members: 'Gestionar miembros',
             bankAccount: 'Conectar cuenta bancaria',
+            testTransactions: 'Transacciones de prueba',
             issueAndManageCards: 'Emitir y gestionar tarjetas',
             reconcileCards: 'Reconciliar tarjetas',
             growlMessageOnSave: '¡La configuración del espacio de trabajo se ha guardado correctamente!',

--- a/src/pages/ReimbursementAccount/ValidationStep.js
+++ b/src/pages/ReimbursementAccount/ValidationStep.js
@@ -163,7 +163,7 @@ class ValidationStep extends React.Component {
         return (
             <View style={[styles.flex1, styles.justifyContentBetween]}>
                 <HeaderWithCloseButton
-                    title={this.props.translate('workspace.common.bankAccount')}
+                    title={this.props.translate('workspace.common.testTransactions')}
                     stepCounter={{step: 5, total: 5}}
                     onCloseButtonPress={Navigation.dismissModal}
                     onBackButtonPress={() => Navigation.goBack()}


### PR DESCRIPTION
@parasharrajat  @mountiny PR is ready for review.

### Details
Updated header text in test transaction step of VBA flow to **Test transactions** (Previously it was "Connect bank account")

### Fixed Issues
$ https://github.com/Expensify/App/issues/6315

### Tests | QA Steps
1. Create a workspace
2. Go to Connect bank account page within the workspace editor
3. Tap Connect manually and go through VBA steps
4. Arrive at step 5 to enter validation amounts

**QA Check:** On this page it should show **Test transactions** in header (Previously it was "Connect bank account")

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots (EN)

#### Web
<img width="854" alt="Web-En" src="https://user-images.githubusercontent.com/7823358/143442909-a4c91fc9-71bf-404f-aa03-dda0913afbd3.png">

#### Mobile Web
<img width="466" alt="MobileWeb-En" src="https://user-images.githubusercontent.com/7823358/143442944-cade40cd-b005-49e8-a14d-fea9998831c8.png">

#### Desktop
<img width="840" alt="Desktop-En" src="https://user-images.githubusercontent.com/7823358/143442993-96cd1db9-5027-435d-95c8-7d1305024204.png">

#### iOS
<img width="463" alt="iOS-En" src="https://user-images.githubusercontent.com/7823358/143443044-f8bb1caf-ca3a-42f1-a57c-0f2be9d93817.png">

#### Android
<img width="553" alt="Android-En" src="https://user-images.githubusercontent.com/7823358/143443106-8e0b72a8-3d71-4ca3-b349-394cf35ae486.png">


### Screenshots (ES)

#### Web
<img width="854" alt="Web-Es" src="https://user-images.githubusercontent.com/7823358/143443473-25f56d35-8603-45be-8cf9-1c2eba2301d2.png">

#### Mobile Web
<img width="466" alt="MobileWeb-Es" src="https://user-images.githubusercontent.com/7823358/143443521-5bcdd77a-e7e2-4452-8574-649ea9039590.png">

#### Desktop
<img width="840" alt="Desktop-Es" src="https://user-images.githubusercontent.com/7823358/143443572-da0203d0-eed0-4522-a326-6057e83d37d3.png">

#### iOS
<img width="463" alt="iOS-Es" src="https://user-images.githubusercontent.com/7823358/143443634-6318eb55-ed54-43d7-b4ca-a3b26bd278e7.png">

#### Android
<img width="551" alt="Android-Es" src="https://user-images.githubusercontent.com/7823358/143443705-a52a1c5f-17b0-4d63-a0c1-9b66a12890bc.png">
