### PR TITLE
Encode secondary login URL

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -179,7 +179,7 @@ const CONST = {
     PRIVACY_URL: 'https://use.expensify.com/privacy',
     LICENSES_URL: 'https://use.expensify.com/licenses',
     PLAY_STORE_URL: 'https://play.google.com/store/apps/details?id=com.expensify.chat&hl=en',
-    ADD_SECONDARY_LOGIN_URL: 'settings?param=%7B%22section%22:%22account%22,%22openModal%22:%22secondaryLogin%22%7D',
+    ADD_SECONDARY_LOGIN_URL: `settings?param=${encodeURIComponent('{"section":"account","openModal":"secondaryLogin"}')}`,
     MANAGE_CARDS_URL: 'domain_companycards',
     FEES_URL: 'https://use.expensify.com/fees',
     CFPB_PREPAID_URL: 'https://cfpb.gov/prepaid',

--- a/src/CONST.js
+++ b/src/CONST.js
@@ -179,7 +179,7 @@ const CONST = {
     PRIVACY_URL: 'https://use.expensify.com/privacy',
     LICENSES_URL: 'https://use.expensify.com/licenses',
     PLAY_STORE_URL: 'https://play.google.com/store/apps/details?id=com.expensify.chat&hl=en',
-    ADD_SECONDARY_LOGIN_URL: `settings?param=${encodeURIComponent('{"section":"account","openModal":"secondaryLogin"}')}`,
+    ADD_SECONDARY_LOGIN_URL: encodeURI('settings?param={"section":"account","openModal":"secondaryLogin"}'),
     MANAGE_CARDS_URL: 'domain_companycards',
     FEES_URL: 'https://use.expensify.com/fees',
     CFPB_PREPAID_URL: 'https://cfpb.gov/prepaid',

--- a/src/CONST.js
+++ b/src/CONST.js
@@ -179,7 +179,7 @@ const CONST = {
     PRIVACY_URL: 'https://use.expensify.com/privacy',
     LICENSES_URL: 'https://use.expensify.com/licenses',
     PLAY_STORE_URL: 'https://play.google.com/store/apps/details?id=com.expensify.chat&hl=en',
-    ADD_SECONDARY_LOGIN_URL: 'settings?param={%22section%22:%22account%22}',
+    ADD_SECONDARY_LOGIN_URL: 'settings?param=%7B%22section%22:%22account%22,%22openModal%22:%22secondaryLogin%22%7D',
     MANAGE_CARDS_URL: 'domain_companycards',
     FEES_URL: 'https://use.expensify.com/fees',
     CFPB_PREPAID_URL: 'https://cfpb.gov/prepaid',

--- a/src/pages/ReimbursementAccount/EnableStep.js
+++ b/src/pages/ReimbursementAccount/EnableStep.js
@@ -23,6 +23,7 @@ import * as Illustrations from '../../components/Icon/Illustrations';
 import * as BankAccounts from '../../libs/actions/BankAccounts';
 import * as Link from '../../libs/actions/Link';
 import * as User from '../../libs/actions/User';
+import CONST from '../../CONST';
 
 const propTypes = {
     /** Are we loading payment methods? */
@@ -76,7 +77,7 @@ class EnableStep extends React.Component {
                 title: this.props.translate('workspace.bankAccount.addWorkEmail'),
                 icon: Expensicons.Mail,
                 onPress: () => {
-                    Link.openOldDotLink('settings?param={"section":"account","openModal":"secondaryLogin"}');
+                    Link.openOldDotLink(CONST.ADD_SECONDARY_LOGIN_URL);
                     User.subscribeToExpensifyCardUpdates();
                 },
                 shouldShowRightIcon: true,

--- a/src/pages/workspace/card/WorkspaceCardVBANoECardView.js
+++ b/src/pages/workspace/card/WorkspaceCardVBANoECardView.js
@@ -12,6 +12,7 @@ import * as Link from '../../../libs/actions/Link';
 import * as User from '../../../libs/actions/User';
 import ONYXKEYS from '../../../ONYXKEYS';
 import compose from '../../../libs/compose';
+import CONST from '../../../CONST';
 
 const propTypes = {
     ...withLocalizePropTypes,
@@ -27,7 +28,7 @@ const WorkspaceCardVBANoECardView = props => (
                     title: props.translate('workspace.card.addWorkEmail'),
                     onPress: () => {
                         Navigation.dismissModal();
-                        Link.openOldDotLink('settings?param={"section":"account","openModal":"secondaryLogin"}');
+                        Link.openOldDotLink(CONST.ADD_SECONDARY_LOGIN_URL);
                         User.subscribeToExpensifyCardUpdates();
                     },
                     icon: Expensicons.Mail,


### PR DESCRIPTION
### Details
iOS treats URL encoding a bit differently and I had to adjust it to be able to deeplink into the secondary login page in OldDot.

### Fixed Issues
$ https://github.com/Expensify/App/issues/6475

### Tests

1. Launch the app and login with gmail account
2. Initiate VBA flow and add an "Open" bank account. [Instructions](https://stackoverflow.com/c/expensify/questions/342).
3. At the last step tap "Add work email address"
4. Verify that OldDot opens in the accounts page and the add secondary login modal opens.

### QA Steps
1. Launch the app and login with gmail account
2. Initiate VBA flow and add an "Open" bank account. [Instructions](https://stackoverflow.com/c/expensify/questions/342).
3. At the last step tap "Add work email address"
4. Verify that OldDot opens in the accounts page and the add secondary login modal opens.

### Tested On

- [X] Web
- [X] Mobile Web
- [X] Desktop
- [X] iOS
- [X] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web

https://user-images.githubusercontent.com/22219519/143485387-71e16a3e-09a1-4734-9557-b2f21bcbe902.mov

#### Mobile Web

https://user-images.githubusercontent.com/22219519/143485402-b47396f1-bacb-4abc-aef3-416a51ac27ec.mov

#### Desktop

https://user-images.githubusercontent.com/22219519/143485408-293d2e6e-c422-4321-b8d7-187995ce927e.mov

#### iOS

https://user-images.githubusercontent.com/22219519/143485415-8f7bfa0a-a71e-4df5-9fe5-c0b41c5fbad0.mov

#### Android

https://user-images.githubusercontent.com/22219519/143485500-d2f3ebe0-7d5c-457b-9f67-c8651fde73f2.mov


