### PR TITLE
Encode oldDot links with param in the URL

### DIFF
--- a/src/pages/workspace/card/WorkspaceCardVBAWithECardView.js
+++ b/src/pages/workspace/card/WorkspaceCardVBAWithECardView.js
@@ -27,7 +27,7 @@ const WorkspaceCardVBAWithECardView = props => (
             },
             {
                 title: props.translate('workspace.common.reconcileCards'),
-                onPress: () => Link.openOldDotLink('domain_companycards?param={"section":"cardReconciliation"}'),
+                onPress: () => Link.openOldDotLink(encodeURI('domain_companycards?param={"section":"cardReconciliation"}')),
                 icon: Expensicons.ReceiptSearch,
                 shouldShowRightIcon: true,
                 iconRight: Expensicons.NewWindow,

--- a/src/pages/workspace/invoices/WorkspaceInvoicesFirstSection.js
+++ b/src/pages/workspace/invoices/WorkspaceInvoicesFirstSection.js
@@ -23,7 +23,7 @@ const WorkspaceInvoicesFirstSection = props => (
         menuItems={[
             {
                 title: props.translate('workspace.invoices.sendInvoice'),
-                onPress: () => Link.openOldDotLink('reports?param={"createInvoice":true}'),
+                onPress: () => Link.openOldDotLink(encodeURI('reports?param={"createInvoice":true}')),
                 icon: Expensicons.Send,
                 shouldShowRightIcon: true,
                 iconRight: Expensicons.NewWindow,


### PR DESCRIPTION
### Details
Encode OldDot urls with param so we are already logged in when redirected.

### Fixed Issues
$ https://github.com/Expensify/App/issues/6484

### Tests
1. Log into an account with the Expensify Card enabled.
2. Select a workspace and navigate to `Issue corporate cards`.
3. Click on Reconcile cards and verify that an OldDot page opens and you are logged in.
4. Perform steps 2-3 but this time in `Send invoices > Send invoice`

### QA Steps
1. Log into an account with the Expensify Card enabled.
2. Select a workspace and navigate to `Issue corporate cards`.
3. Click on Reconcile cards and verify that an OldDot page opens and you are logged in.
4. Perform steps 2-3 but this time in `Send invoices > Send invoice`

### Tested On

- [X] Web
- [X] Mobile Web
- [X] Desktop
- [X] iOS
- [X] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web

https://user-images.githubusercontent.com/22219519/143506420-2c8fa7e8-881a-46a7-bcce-66eeb58f5657.mov

#### Mobile Web
https://user-images.githubusercontent.com/22219519/143506423-827a5058-318c-4734-9524-5ec53176e133.mov

#### Desktop

https://user-images.githubusercontent.com/22219519/143506519-fa69ba90-d71a-419e-9cd6-088668d3dafb.mov

#### iOS

https://user-images.githubusercontent.com/22219519/143506450-e282557a-ed7e-4a44-8f93-5293598ba4b7.mov

#### Android

https://user-images.githubusercontent.com/22219519/143506453-80c94654-b351-48de-951a-d336ef0f86a5.mov
