### PR TITLE
changed logic to use 2 decimals instead of 3

### DIFF
--- a/src/pages/iou/steps/IOUAmountPage.js
+++ b/src/pages/iou/steps/IOUAmountPage.js
@@ -118,8 +118,8 @@ class IOUAmountPage extends React.Component {
      * @returns {Boolean}
      */
     validateAmount(amount) {
-        const decimalNumberRegex = new RegExp(/^\d+(,\d+)*(\.\d{0,3})?$/, 'i');
-        return amount === '' || (decimalNumberRegex.test(amount) && (parseFloat((amount * 100).toFixed(3)).toString().length <= CONST.IOU.AMOUNT_MAX_LENGTH));
+        const decimalNumberRegex = new RegExp(/^\d+(,\d+)*(\.\d{0,2})?$/, 'i');
+        return amount === '' || (decimalNumberRegex.test(amount) && (parseFloat((amount * 100).toFixed(2)).toString().length <= CONST.IOU.AMOUNT_MAX_LENGTH));
     }
 
     /**


### PR DESCRIPTION
cc: @rushatgabhane 
### Details
We were allowing 3 decimal cases in the amount field on Send Money/Request money. Changed it to 2.

### Fixed Issues
$ https://github.com/Expensify/App/issues/6286


QA Steps:

1. Navigate to a conversation
2. Request money
3. Verify you cannot enter an amount with 3 decimal places.