### PR TITLE
Block Enter key bubbling to the composer, on selecting LHN row via `Enter`

### DIFF
--- a/src/pages/home/sidebar/OptionRow.js
+++ b/src/pages/home/sidebar/OptionRow.js
@@ -128,11 +128,15 @@ const OptionRow = (props) => {
             };
         },
     );
+
     return (
         <Hoverable>
             {hovered => (
                 <TouchableOpacity
-                    onPress={() => props.onSelectRow(props.option)}
+                    onPress={(e) => {
+                        e.preventDefault();
+                        props.onSelectRow(props.option);
+                    }}
                     disabled={props.disableRowInteractivity}
                     activeOpacity={0.8}
                     style={[


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/6386

### Tests | QA Steps
1. Click on the LHN on the top to not have anything selected
2. Using the `Tab` key, select a chat
3. Click Enter to open the page


### Tested On

- [x] Web
- [x] Mobile Web (Not affected)
- [x] Desktop
- [x] iOS  (Not affected)
- [x] Android  (Not affected)

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web | Desktop
<!-- Insert screenshots of your changes on the web platform-->

https://user-images.githubusercontent.com/24370807/143935957-72b66d70-f4e7-4d88-a86a-18724f9f8b78.mp4


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
