### PR TITLE
Revert "Supports big screens mobile devices for popover menu"

### DIFF
--- a/src/components/Popover/index.native.js
+++ b/src/components/Popover/index.native.js
@@ -13,17 +13,20 @@ const propTypes = {
  * This is a convenience wrapper around the Modal component for a responsive Popover.
  * On small screen widths, it uses BottomDocked modal type, and a Popover type on wide screen widths.
  */
-const Popover = props => (
-    <Modal
-        type={props.isSmallScreenWidth ? CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED : CONST.MODAL.MODAL_TYPE.POPOVER}
-        popoverAnchorPosition={props.isSmallScreenWidth ? undefined : props.anchorPosition}
-        // eslint-disable-next-line react/jsx-props-no-spreading
-        {...props}
-        fullscreen={props.isSmallScreenWidth ? true : props.fullscreen}
-        animationIn={props.isSmallScreenWidth ? undefined : props.animationIn}
-        animationOut={props.isSmallScreenWidth ? undefined : props.animationOut}
-    />
-);
+const Popover = (props) => {
+    const propsWithoutAnimation = _.omit(props, ['animationIn', 'animationOut', 'popoverAnchorPosition', 'disableAnimation']);
+    return (
+        <Modal
+            type={CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED}
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            {...propsWithoutAnimation}
+
+            // Mobile will always has fullscreen menu
+            // eslint-disable-next-line react/jsx-props-no-multi-spaces
+            fullscreen
+        />
+    );
+};
 
 Popover.propTypes = propTypes;
 Popover.defaultProps = defaultProps;

--- a/src/components/PopoverMenu/BasePopoverMenu.js
+++ b/src/components/PopoverMenu/BasePopoverMenu.js
@@ -35,7 +35,6 @@ class BasePopoverMenu extends PureComponent {
                 onModalHide={this.props.onMenuHide}
                 animationIn={this.props.animationIn}
                 animationOut={this.props.animationOut}
-                isSmallScreenWidth={this.props.isSmallScreenWidth}
                 disableAnimation={this.props.disableAnimation}
             >
                 <View style={this.props.isSmallScreenWidth ? {} : styles.createMenuContainer}>

--- a/src/pages/home/sidebar/SidebarScreen.js
+++ b/src/pages/home/sidebar/SidebarScreen.js
@@ -148,7 +148,6 @@ class SidebarScreen extends Component {
                             isVisible={this.state.isCreateMenuActive}
                             anchorPosition={styles.createMenuPositionSidebar}
                             onItemSelected={this.onCreateMenuItemSelected}
-                            isSmallScreenWidth={this.props.isSmallScreenWidth}
                             menuItems={[
                                 {
                                     icon: Expensicons.ChatBubble,


### PR DESCRIPTION
Reverts Expensify/App#6278

https://github.com/Expensify/App/pull/6278 caused the following deploy blockers, so reverting to unblock the deploy:

Fixes https://github.com/Expensify/App/issues/6520
Fixes https://github.com/Expensify/App/issues/6519
Fixes https://github.com/Expensify/App/issues/6522

### Tests
1. Open app and login
2. Go to any chat
3. Tap on + > Add Attachment
4. Confirm the menu is properly shown
5. Click on avatar
6. Select Profile
7. Click on camera icon where avatar is, at the top of screen
8. Click on upload photo pop up at the bottom of the screen
9. Confirm the menu is properly shown
10. Select any message from LHN.
11. Open the emoji box.
12. Confirm the menu is properly shown (no space on outside)

| Add Attachment | Avatar | Emojis |
|---|---|---|
| ![image](https://user-images.githubusercontent.com/3981102/143963335-fe2e0f29-6eb4-471d-84ac-2710cfb18d30.png) | ![image](https://user-images.githubusercontent.com/3981102/143963500-cfff155f-e063-4c9d-91ef-19b724de9797.png) | ![image](https://user-images.githubusercontent.com/3981102/143963527-79d6ed8c-1175-45c3-b00e-1addfae470b9.png) |

