### PR TITLE
Fix draft value not displaying in datepicker

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -850,7 +850,7 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 7b423f9e248eae65987838148c36eec1dbfe0b53
-  FBReactNativeSpec: 9f813f735901d719751da82f0365b5c506c28f14
+  FBReactNativeSpec: 3930028959767285f556bd187e13b896deee31fe
   Firebase: 54cdc8bc9c9b3de54f43dab86e62f5a76b47034f
   FirebaseABTesting: c3e48ebf5e7e5c674c5a131c68e941d7921d83dc
   FirebaseAnalytics: 4751d6a49598a2b58da678cc07df696bcd809ab9

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -850,7 +850,7 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 7b423f9e248eae65987838148c36eec1dbfe0b53
-  FBReactNativeSpec: 3930028959767285f556bd187e13b896deee31fe
+  FBReactNativeSpec: 9f813f735901d719751da82f0365b5c506c28f14
   Firebase: 54cdc8bc9c9b3de54f43dab86e62f5a76b47034f
   FirebaseABTesting: c3e48ebf5e7e5c674c5a131c68e941d7921d83dc
   FirebaseAnalytics: 4751d6a49598a2b58da678cc07df696bcd809ab9

--- a/src/components/ExpensiTextInput/BaseExpensiTextInput.js
+++ b/src/components/ExpensiTextInput/BaseExpensiTextInput.js
@@ -188,7 +188,7 @@ class BaseExpensiTextInput extends Component {
                                 }}
                                 // eslint-disable-next-line
                                 {...inputProps}
-                                value={this.props.value}
+                                value={this.value}
                                 placeholder={(this.state.isFocused || !this.props.label) ? this.props.placeholder : null}
                                 placeholderTextColor={themeColors.placeholderText}
                                 underlineColorAndroid="transparent"


### PR DESCRIPTION
### Details
Introduced here https://github.com/Expensify/App/pull/6234. Updated `BaseExpensiTextInput` to use `this.value` instead of `this.props.value`.

### Fixed Issues
$ https://github.com/Expensify/App/issues/6521

### Tests
1. Log into NewDot.
2. Create a Workspace and click on Connect bank account
3. Click on Connect manually and enter 011401533 for routing number and 1111222233331111 for account number. Click Save and continue
4. In the Company step enter random values and click Save & continue.
5. Go back and verify that the previously entered date is saved.

### QA Steps
Steps above.

### Tested On

- [X] Web
- [X] Mobile Web
- [X] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web

https://user-images.githubusercontent.com/22219519/143964608-49d4464e-5d31-420b-a55c-3682361badf7.mov

#### Mobile Web

https://user-images.githubusercontent.com/22219519/143964719-cd54e9e5-d638-418a-aee6-736cffda0eae.mov

#### Desktop

https://user-images.githubusercontent.com/22219519/143964617-77a19720-f616-4b2d-82fb-415d8e2fad04.mov

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
