### PR TITLE
Fix infinite loop in withFullPolicy HOC

### DIFF
--- a/src/pages/workspace/withFullPolicy.js
+++ b/src/pages/workspace/withFullPolicy.js
@@ -2,6 +2,7 @@ import _ from 'underscore';
 import lodashGet from 'lodash/get';
 import React from 'react';
 import PropTypes from 'prop-types';
+import Str from 'expensify-common/lib/str';
 import {withOnyx} from 'react-native-onyx';
 import {useNavigationState} from '@react-navigation/native';
 import CONST from '../../CONST';
@@ -9,7 +10,8 @@ import getComponentDisplayName from '../../libs/getComponentDisplayName';
 import * as Policy from '../../libs/actions/Policy';
 import ONYXKEYS from '../../ONYXKEYS';
 
-let previousRoute = '';
+let previousRouteName = '';
+let previousRoutePolicyID = '';
 
 /**
  * @param {Object} route
@@ -17,6 +19,19 @@ let previousRoute = '';
  */
 function getPolicyIDFromRoute(route) {
     return lodashGet(route, 'params.policyID', '');
+}
+
+/**
+ * @param {String} routeName
+ * @param {String} policyID
+ * @returns {Boolean}
+ */
+function isPreviousRouteInSameWorkspace(routeName, policyID) {
+    return (
+        Str.startsWith(routeName, 'Workspace')
+        && Str.startsWith(previousRouteName, 'Workspace')
+        && policyID === previousRoutePolicyID
+    );
 }
 
 const fullPolicyPropTypes = {
@@ -74,11 +89,12 @@ export default function (WrappedComponent) {
         const currentRoute = _.last(useNavigationState(state => state.routes || []));
         const policyID = getPolicyIDFromRoute(currentRoute);
 
-        if (_.isString(policyID) && !previousRoute.includes(policyID)) {
+        if (_.isString(policyID) && !_.isEmpty(policyID) && !isPreviousRouteInSameWorkspace(currentRoute.name, policyID)) {
             Policy.loadFullPolicy(policyID);
         }
 
-        previousRoute = lodashGet(currentRoute, 'path', '');
+        previousRouteName = currentRoute.name;
+        previousRoutePolicyID = policyID;
 
         const rest = _.omit(props, ['forwardedRef', 'policy']);
         return (


### PR DESCRIPTION
### Details
We were previously relying on a route's `path` param (the visible path for the route in the URL). The problem is that param is optional, and is only present if the app is opened via a deep-link (or via direct URL manipulation on web). Instead, we'll rely on the route name, which is required, and the route params, which will be there if provided.

### Fixed Issues
$ https://github.com/Expensify/App/issues/6526

### Tests
1. Sign into NewDot with a new account.
1. Create a workspace.
1. Verify using logs or the network console that the infinite loop is gone.
1. Refresh the page on the homepage.
1. Go to /settings. Verify using logs or the network console that no full policy is loaded.
1. Click on an existing workspace. Verify using logs or the network console that the full policy is loaded.
1. Refresh the page. Verify using logs or the network console that the full policy is loaded.
1. Click on the back arrow. Verify you are taken back to the settings page.
Click on an existing workspace. Verify using logs or the network console that the full policy is loaded.
Click on a workspace sub-page. Verify using logs or the network console that no full policy is loaded.
Refresh the page on one of the workspace sub-pages. Verify using logs or the network console that the full policy is loaded.
Click on the x to close the modal. Verify that the full settings modal closes.

### QA Steps
1. Sign into NewDot with a new account.
1. Create a workspace.
1. Verify using the network console that there is no infinite loop performing `GET` requests to fetch a policy.

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android
