### PR TITLE
[NOQA] Fix broken link to app structure section of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 * [Local Development](#local-development)
 * [Running The Tests](#running-the-tests)
 * [Debugging](#debugging)
-* [Structure of the app](#app-structure-and-conventions)
+* [App Structure and Conventions](#app-structure-and-conventions)
 * [Philosophy](#Philosophy)
 * [Internationalization](#Internationalization)
 * [Deploying](#deploying)
@@ -124,7 +124,7 @@ Our React Native Android app now uses the `Hermes` JS engine which requires your
 
 ---
 
-# App structure and conventions
+# App Structure and Conventions
 
 ## Onyx
 This is a persistent storage solution wrapped in a Pub/Sub library. In general that means:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 * [Local Development](#local-development)
 * [Running The Tests](#running-the-tests)
 * [Debugging](#debugging)
-* [Structure of the app](#structure-of-the-app)
+* [Structure of the app](#app-structure-and-conventions)
 * [Philosophy](#Philosophy)
 * [Internationalization](#Internationalization)
 * [Deploying](#deploying)


### PR DESCRIPTION

### Details

Simply fix a broken link in the table of contents.

### Tests

- Open the [Readme against this branch](https://github.com/Expensify/App/blob/jules-updateReadmeContentsTableLink/README.md)
- Tap 'App Structure and Conventions' in the table of contents
- You should be navigated to the 'App Structure and Conventions' section of the readme

### QA Steps

NA

### Tested On

- [X] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
N/A