### PR TITLE
Corrected Cannot Remove Yourself banner shown again and again problem while inviting new member

### DIFF
--- a/src/components/CheckboxWithTooltip/CheckboxWithTooltipForMobileWebAndNative.js
+++ b/src/components/CheckboxWithTooltip/CheckboxWithTooltipForMobileWebAndNative.js
@@ -11,12 +11,14 @@ class CheckboxWithTooltipForMobileWebAndNative extends React.Component {
         this.showGrowlOrTriggerOnPress = this.showGrowlOrTriggerOnPress.bind(this);
     }
 
-    componentDidUpdate() {
+    componentDidUpdate(prevProps) {
         if (!this.props.toggleTooltip) {
             return;
         }
 
-        Growl.show(this.props.text, this.props.growlType, 3000);
+        if (prevProps.toggleTooltip !== this.props.toggleTooltip) {
+            Growl.show(this.props.text, this.props.growlType, 3000);
+        }
     }
 
     /**


### PR DESCRIPTION
@johnmlee101  PR is ready for review.

### Details
“Cannot remove yourself from workspace” banner is shown over and over again while inviting a new member, so within this pr corrected that problem.

### Fixed Issues
$ https://github.com/Expensify/App/issues/6287

### Tests | QA Steps

1. Navigate to add member screen.
2. Tap on check box against own account once.
3. Now tap on invite button to invite a new member
4. The banner keeps on popping up.
5. Even sending app to background and resuming or swiping down from notification panel also shows same behaviour.

**QA Check:**  Within this pr we corrected this issue so it will not show `Cannot Remove Yourself ...`  banner again and again.

**Note:** This issue occurring for iOS, Android and MobileWeb only.  Web and Desktop has different behaviour as shown in screenshot so this issue not applicable for Web and Desktop.

**Note:** Within iOS and Android screen recording it will not show gap at left and right of the Growl message (i.e. Growl message touch at left and right of screen). Please ignore it because it is different issue https://github.com/Expensify/App/issues/6530


### Tested On

- [x] iOS
- [x] Android
- [x] Mobile Web
- [x] Web
- [x] Desktop

### Screenshots

#### iOS
https://user-images.githubusercontent.com/7823358/144090792-5312f8f2-d1f7-424e-a46b-951d6c38d484.mov

#### Android
https://user-images.githubusercontent.com/7823358/144090871-a81250db-6b19-4740-bdda-1492438f920b.mp4

#### Mobile Web
https://user-images.githubusercontent.com/7823358/144090957-14db9dca-ac69-4e11-ad63-ec83ae5dd8a1.mov

#### Web
<img width="1000" alt="Web" src="https://user-images.githubusercontent.com/7823358/144091060-9420b8d1-cbbf-411d-96ca-0803ffc575c3.png">

#### Desktop
<img width="985" alt="Desktop" src="https://user-images.githubusercontent.com/7823358/144091125-4a7de324-536e-4b0c-b178-28e7d4195279.png">
