### PR TITLE
Fix: scroll issue for workspace pages

### DIFF
--- a/src/pages/workspace/WorkspacePageWithSections.js
+++ b/src/pages/workspace/WorkspacePageWithSections.js
@@ -74,7 +74,6 @@ class WorkspacePageWithSections extends React.Component {
                 />
                 <ScrollView
                     style={[styles.settingsPageBackground, styles.flex1, styles.w100]}
-                    contentContainerStyle={[styles.flex1]}
                 >
                     <View style={[styles.w100, styles.flex1]}>
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/6496

### Tests |  QA Steps
1. Navigate to workspace settings
 2. Change the orientation to landscape
  3. Click on any of the options.
  4. Scroll the page.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web | Desktop
<!-- Insert screenshots of your changes on the web platform-->
![image](https://user-images.githubusercontent.com/24370807/144111613-46ae8145-9aa4-4f58-b14d-070f634164e9.png)

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->


#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->

https://user-images.githubusercontent.com/24370807/144111988-63041270-bfbe-497b-b7f7-b51a1ebeb446.mp4


