### PR TITLE
Fix: search page order

### DIFF
--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -352,7 +352,7 @@ function getOptions(reports, personalDetails, activeReportID, {
     includeRecentReports = false,
     prioritizePinnedReports = false,
     prioritizeDefaultRoomsInSearch = false,
-    prioritizeOneToOneReportsInSearch = false,
+    sortByReportTypeInSearch = false,
     sortByLastMessageTimestamp = false,
     searchValue = '',
     showChatPreviewLine = false,
@@ -510,9 +510,15 @@ function getOptions(reports, personalDetails, activeReportID, {
     }
 
     // If we are prioritizing 1:1 chats in search, do it only once we started searching
-    if (prioritizeOneToOneReportsInSearch && searchValue !== '') {
-        const [oneToOneReports, otherReports] = _.partition(recentReportOptions, option => !!option.login);
-        recentReportOptions = oneToOneReports.concat(otherReports);
+    if (sortByReportTypeInSearch && searchValue !== '') {
+        recentReportOptions = lodashOrderBy(recentReportOptions, [(option) => {
+            if (option.isDefaultChatRoom || option.isArchivedRoom) {
+                return 3;
+            } if (!option.login) {
+                return 2;
+            }
+            return 1;
+        }], ['asc']);
     }
 
     if (includePersonalDetails) {
@@ -584,7 +590,7 @@ function getSearchOptions(
         maxRecentReportsToShow: 0, // Unlimited
         prioritizePinnedReports: false,
         prioritizeDefaultRoomsInSearch: false,
-        prioritizeOneToOneReportsInSearch: true,
+        sortByReportTypeInSearch: true,
         showChatPreviewLine: true,
         showReportsWithNoComments: true,
         includePersonalDetails: true,

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -352,6 +352,7 @@ function getOptions(reports, personalDetails, activeReportID, {
     includeRecentReports = false,
     prioritizePinnedReports = false,
     prioritizeDefaultRoomsInSearch = false,
+    prioritizeOneToOneReportsInSearch = false,
     sortByLastMessageTimestamp = false,
     searchValue = '',
     showChatPreviewLine = false,
@@ -508,6 +509,12 @@ function getOptions(reports, personalDetails, activeReportID, {
         recentReportOptions = reportsSplitByDefaultChatRoom[0].concat(reportsSplitByDefaultChatRoom[1]);
     }
 
+    // If we are prioritizing 1:1 chats in search, do it only once we started searching
+    if (prioritizeOneToOneReportsInSearch && searchValue !== '') {
+        const [oneToOneReports, otherReports] = _.partition(recentReportOptions, option => !!option.login);
+        recentReportOptions = oneToOneReports.concat(otherReports);
+    }
+
     if (includePersonalDetails) {
         // Next loop over all personal details removing any that are selectedUsers or recentChats
         _.each(allPersonalDetailsOptions, (personalDetailOption) => {
@@ -576,7 +583,8 @@ function getSearchOptions(
         includeMultipleParticipantReports: true,
         maxRecentReportsToShow: 0, // Unlimited
         prioritizePinnedReports: false,
-        prioritizeDefaultRoomsInSearch: true,
+        prioritizeDefaultRoomsInSearch: false,
+        prioritizeOneToOneReportsInSearch: true,
         showChatPreviewLine: true,
         showReportsWithNoComments: true,
         includePersonalDetails: true,

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -514,7 +514,8 @@ function getOptions(reports, personalDetails, activeReportID, {
         recentReportOptions = lodashOrderBy(recentReportOptions, [(option) => {
             if (option.isDefaultChatRoom || option.isArchivedRoom) {
                 return 3;
-            } if (!option.login) {
+            }
+            if (!option.login) {
                 return 2;
             }
             return 1;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/6359

### Tests | QA Steps
1. Open the Search page.
2. Search for something.
3. Order of results should be https://github.com/Expensify/App/issues/6359#issuecomment-976021754.


### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web | Android | Mobile Web | Desktop | iOS
<!-- Insert screenshots of your changes on the web platform-->

https://user-images.githubusercontent.com/24370807/144112868-5bc20ed2-d861-4523-91a1-df487ce9dd99.mp4
