### PR TITLE
Disable submit button if Paypal username is unchanged

### DIFF
--- a/src/pages/settings/Payments/AddPayPalMePage.js
+++ b/src/pages/settings/Payments/AddPayPalMePage.js
@@ -105,6 +105,7 @@ class AddPayPalMePage extends React.Component {
                             onPress={this.setPayPalMeUsername}
                             pressOnEnter
                             style={[styles.mt3]}
+                            isDisabled={this.state.payPalMeUsername === this.props.payPalMeUsername}
                             text={this.props.payPalMeUsername
                                 ? this.props.translate('addPayPalMePage.editPayPalAccount')
                                 : this.props.translate('addPayPalMePage.addPayPalAccount')}


### PR DESCRIPTION
### Fixed Issues
https://expensify.slack.com/archives/C01GTK53T8Q/p1638198130032000

### Tests/QA
1. Navigate to the payments page (Settings > Payments)
2. Click your existing Paypal.me username, or click "Add payment method" and select Paypal.me
3. If you haven't set one yet, set one first, then repeat [2]. 
4. Verify that the button is disabled.
5. Change the username. Verify it becomes reenabled.


### Tested On



- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web
https://user-images.githubusercontent.com/31285285/144114130-b87a9a6e-b136-4898-b0c0-e0b5ef99ce77.mp4

#### Android
https://user-images.githubusercontent.com/31285285/144114712-52f4a6e8-5bbd-49c9-9767-6e9fce5037f1.mp4

#### iOS
https://user-images.githubusercontent.com/31285285/144114173-ce02c63d-17fc-4c18-b964-8ff5046a35be.mp4

#### Desktop
https://user-images.githubusercontent.com/31285285/144114189-528f5ba9-e523-442f-b160-37023cf61826.mp4

#### Mobile Web
https://user-images.githubusercontent.com/31285285/144114419-56159f29-19f4-46af-9147-556645e7f550.MOV