### PR TITLE
Allow scrolling for Report Group Details Page

### DIFF
--- a/src/pages/DetailsPage.js
+++ b/src/pages/DetailsPage.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View} from 'react-native';
+import {View, ScrollView} from 'react-native';
 import PropTypes from 'prop-types';
 import {withOnyx} from 'react-native-onyx';
 import Str from 'expensify-common/lib/str';
@@ -93,7 +93,7 @@ const DetailsPage = (props) => {
                 ]}
             >
                 {details ? (
-                    <View>
+                    <ScrollView>
                         <View style={styles.pageWrapper}>
                             <Avatar
                                 containerStyles={[styles.avatarLarge, styles.mb3]}
@@ -149,7 +149,7 @@ const DetailsPage = (props) => {
                                 </View>
                             ) : null}
                         </View>
-                    </View>
+                    </ScrollView>
                 ) : null}
             </View>
         </ScreenWrapper>

--- a/src/pages/ReportDetailsPage.js
+++ b/src/pages/ReportDetailsPage.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {withOnyx} from 'react-native-onyx';
 import Str from 'expensify-common/lib/str';
 import _ from 'underscore';
-import {View} from 'react-native';
+import {View, ScrollView} from 'react-native';
 import lodashGet from 'lodash/get';
 import Avatar from '../components/Avatar';
 import compose from '../libs/compose';
@@ -123,7 +123,7 @@ class ReportDetailsPage extends Component {
                     onBackButtonPress={() => Navigation.goBack()}
                     onCloseButtonPress={() => Navigation.dismissModal(true)}
                 />
-                <View style={[styles.flex1]}>
+                <ScrollView style={[styles.flex1]}>
                     <View style={[styles.m5]}>
                         <View
                             style={styles.reportDetailsTitleContainer}
@@ -198,7 +198,7 @@ class ReportDetailsPage extends Component {
                             />
                         );
                     })}
-                </View>
+                </ScrollView>
             </ScreenWrapper>
         );
     }


### PR DESCRIPTION
@Expensify/pullerbear 
@TomatoToaster @jasperhuangg (suggested by github)

### Details
If you go to a group's details page, the page is not scrollable. This is an issue if you go to that page on mobile, and rotate to landscape. You need to scroll to get to members:
![SfslPPLTCa](https://user-images.githubusercontent.com/12980144/144179642-63b2e7a3-27c1-4f91-89ca-022a5bd33a00.gif)


### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ [GH_LINK](https://github.com/Expensify/App/issues/6495)

### TestsQA
Have a report group made. I had to create a new account/domain for it to show up. 
1. Go to group
2. Click on the group title for details
3. Rotate to landscape
4. Scroll down, verify that you can

### QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [x] iOS
- [ ] Android

