### PR TITLE
[CP STAGING] Fix redirect_uri for Plaid web

### DIFF
--- a/src/libs/getPlaidLinkTokenParameters/index.js
+++ b/src/libs/getPlaidLinkTokenParameters/index.js
@@ -3,5 +3,5 @@ import CONFIG from '../../CONFIG';
 
 export default () => {
     const bankAccountRoute = window.location.href.includes('personal') ? ROUTES.BANK_ACCOUNT_PERSONAL : ROUTES.BANK_ACCOUNT;
-    return {redirect_uri: `${CONFIG.EXPENSIFY.URL_EXPENSIFY_CASH}/${bankAccountRoute}`};
+    return {redirect_uri: `${CONFIG.EXPENSIFY.URL_EXPENSIFY_CASH}${bankAccountRoute}`};
 };


### PR DESCRIPTION
### Details
cc @nickmurray47 The `redirect_uri` sent on web is not valid and so the link token does not return from the API.

![2021-12-03_07-08-12](https://user-images.githubusercontent.com/32969087/144644273-bb64b707-93c8-4c77-90e0-c6f9e9532f4d.png)

### Fixed Issues

Deploy blocker -> https://github.com/Expensify/App/pull/6571
https://github.com/Expensify/Expensify/issues/187320

### Tests / QA Steps

1. Create workspace
2. Connect bank account
3. Choose Plaid option
4. Verify the Plaid modal appears and there is no infinite spinner

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
