### PR TITLE
change pronoun input margin to value for grouped form elements

### DIFF
--- a/src/pages/settings/Profile/ProfilePage.js
+++ b/src/pages/settings/Profile/ProfilePage.js
@@ -219,7 +219,7 @@ class ProfilePage extends Component {
                             style={[styles.mt4, styles.mb4]}
                         />
                         <View style={styles.mb6}>
-                            <View style={styles.mb1}>
+                            <View style={styles.mb2}>
                                 <ExpensiPicker
                                     label={this.props.translate('profilePage.preferredPronouns')}
                                     onChange={(pronouns) => {

--- a/src/pages/settings/Profile/ProfilePage.js
+++ b/src/pages/settings/Profile/ProfilePage.js
@@ -219,30 +219,30 @@ class ProfilePage extends Component {
                             style={[styles.mt4, styles.mb4]}
                         />
                         <View style={styles.mb6}>
-                            <View style={styles.mb2}>
-                                <ExpensiPicker
-                                    label={this.props.translate('profilePage.preferredPronouns')}
-                                    onChange={(pronouns) => {
-                                        const hasSelfSelectedPronouns = pronouns === CONST.PRONOUNS.SELF_SELECT;
-                                        this.setState({
-                                            pronouns: hasSelfSelectedPronouns ? '' : pronouns,
-                                            hasSelfSelectedPronouns,
-                                        });
-                                    }}
-                                    items={pronounsList}
-                                    placeholder={{
-                                        value: '',
-                                        label: this.props.translate('profilePage.selectYourPronouns'),
-                                    }}
-                                    value={pronounsPickerValue}
-                                />
-                            </View>
+                            <ExpensiPicker
+                                label={this.props.translate('profilePage.preferredPronouns')}
+                                onChange={(pronouns) => {
+                                    const hasSelfSelectedPronouns = pronouns === CONST.PRONOUNS.SELF_SELECT;
+                                    this.setState({
+                                        pronouns: hasSelfSelectedPronouns ? '' : pronouns,
+                                        hasSelfSelectedPronouns,
+                                    });
+                                }}
+                                items={pronounsList}
+                                placeholder={{
+                                    value: '',
+                                    label: this.props.translate('profilePage.selectYourPronouns'),
+                                }}
+                                value={pronounsPickerValue}
+                            />
                             {this.state.hasSelfSelectedPronouns && (
-                                <ExpensiTextInput
-                                    value={this.state.pronouns}
-                                    onChangeText={pronouns => this.setState({pronouns})}
-                                    placeholder={this.props.translate('profilePage.selfSelectYourPronoun')}
-                                />
+                                <View style={styles.mt2}>
+                                    <ExpensiTextInput
+                                        value={this.state.pronouns}
+                                        onChangeText={pronouns => this.setState({pronouns})}
+                                        placeholder={this.props.translate('profilePage.selfSelectYourPronoun')}
+                                    />
+                                </View>
                             )}
                         </View>
                         <LoginField


### PR DESCRIPTION
### Details
Increased the margin between the pronoun elements.

### Fixed Issues

$ https://github.com/Expensify/App/issues/5556

### QA Steps

1. View Profile
2. Change preferred pronouns to Self-select
3. The margin between the pronoun form elements is equal to that between First name and Last name


### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
Web
![image](https://user-images.githubusercontent.com/47184118/144756038-7737d45e-55ca-40aa-aaa8-b6e4ef791d58.png)

Tablet mobile web
![image](https://user-images.githubusercontent.com/47184118/144756094-6e2c553d-f9c1-4e0e-ac4f-ec3a86fea928.png)

Mobile Web
![image](https://user-images.githubusercontent.com/47184118/144756130-cb9b2122-d1ad-454a-a317-b092c886d79e.png)

iOS
![image](https://user-images.githubusercontent.com/47184118/144755887-36149956-c6bd-4a42-8bb0-4cd246f5d35c.png)

Android
![image](https://user-images.githubusercontent.com/47184118/144756662-a394cb2b-f176-4e6e-8b2f-6b8b5dfe8318.png)



