### PR TITLE
Added properties to fix layout on ipad

### DIFF
--- a/src/components/SVGImage/index.js
+++ b/src/components/SVGImage/index.js
@@ -7,6 +7,7 @@ const SVGImage = props => (
     <Image
         style={StyleUtils.getWidthAndHeightStyle(props.width, props.height)}
         source={props.src}
+        resizeMode={props.resizeMode}
     />
 );
 

--- a/src/components/SVGImage/propTypes.js
+++ b/src/components/SVGImage/propTypes.js
@@ -9,6 +9,9 @@ const propTypes = {
 
     /** The height of the image. */
     height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+
+    /** The resize mode of the image. */
+    resizeMode: PropTypes.oneOf('cover', 'contain', 'stretch', 'repeat', 'center'),
 };
 
 export default propTypes;

--- a/src/pages/signin/SignInPageLayout/SignInPageLayoutWide.js
+++ b/src/pages/signin/SignInPageLayout/SignInPageLayoutWide.js
@@ -73,6 +73,7 @@ const SignInPageLayoutWide = props => (
                     width="100%"
                     height="100%"
                     src={backgroundStyle.backgroundImageUri}
+                    resizeMode={props.isMediumScreenWidth ? 'contain' : 'cover'}
                 />
             </View>
         </View>


### PR DESCRIPTION
### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues

$ https://github.com/Expensify/App/issues/6486

### Tests
For example:
1. Open new.E on iPad portrait
2. Login page should show with full text showing.
### Tested On

- [X] Web
- [ ] Mobile Web
- [ ] Desktop
- [X] iOS (iPad)
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
![image](https://user-images.githubusercontent.com/5818999/144900499-5d8acb38-f40c-4178-9d66-6e46e1f49254.png)

#### iOS
![image](https://user-images.githubusercontent.com/5818999/144900562-4ed81c97-8fb4-4c6e-a4a7-d864dcb9b632.png)
