### PR TITLE
Fix: margin for Save button on Password page

### DIFF
--- a/src/pages/settings/PasswordPage.js
+++ b/src/pages/settings/PasswordPage.js
@@ -236,7 +236,6 @@ class PasswordPage extends Component {
                     <FixedFooter style={[styles.flexGrow0]}>
                         <ExpensifyButton
                             success
-                            style={[styles.mb2]}
                             isLoading={this.props.account.loading}
                             text={this.props.translate('common.save')}
                             onPress={this.submit}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/6497

### Tests | QA Steps
1. Open the Change Password page from the Settings menu page.
2. Observe the gap around the Save Button.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web | Desktop | Mobile Web |  iOS | Android
<!-- Insert screenshots of your changes on the web platform-->
![image](https://user-images.githubusercontent.com/24370807/144910965-5b753011-dfbf-4da8-a7da-dc106c3f297c.png)
