### PR TITLE
Disable landscape view on phones

### DIFF
--- a/android/app/src/main/java/com/expensify/chat/MainActivity.java
+++ b/android/app/src/main/java/com/expensify/chat/MainActivity.java
@@ -1,6 +1,7 @@
 package com.expensify.chat;
 
 import android.os.Bundle;
+import android.content.pm.ActivityInfo;
 import com.facebook.react.ReactActivity;
 import com.zoontek.rnbootsplash.RNBootSplash;
 
@@ -18,6 +19,9 @@ public class MainActivity extends ReactActivity {
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
+    if (getResources().getBoolean(R.bool.portrait_only)) {
+      setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+    }
     RNBootSplash.init(R.drawable.bootsplash, MainActivity.this); // <- display the generated bootsplash.xml drawable over our MainActivity
   }
 }

--- a/android/app/src/main/res/values-large/orientation.xml
+++ b/android/app/src/main/res/values-large/orientation.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="portrait_only">false</bool>
+</resources>

--- a/android/app/src/main/res/values-sw600dp/orientation.xml
+++ b/android/app/src/main/res/values-sw600dp/orientation.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="portrait_only">false</bool>
+</resources>

--- a/android/app/src/main/res/values/orientation.xml
+++ b/android/app/src/main/res/values/orientation.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="portrait_only">true</bool>
+</resources>

--- a/ios/NewExpensify/Info.plist
+++ b/ios/NewExpensify/Info.plist
@@ -104,9 +104,14 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -850,7 +850,7 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 7b423f9e248eae65987838148c36eec1dbfe0b53
-  FBReactNativeSpec: 884d4cc2b011759361797a4035c47e10099393b5
+  FBReactNativeSpec: 9f813f735901d719751da82f0365b5c506c28f14
   Firebase: 54cdc8bc9c9b3de54f43dab86e62f5a76b47034f
   FirebaseABTesting: c3e48ebf5e7e5c674c5a131c68e941d7921d83dc
   FirebaseAnalytics: 4751d6a49598a2b58da678cc07df696bcd809ab9


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
We [decided](https://expensify.slack.com/archives/C01GTK53T8Q/p1638475724148200?thread_ts=1638471596.142900&cid=C01GTK53T8Q) to disable landscape view on phones, but keep it on tablets. 

### Fixed Issues
$ https://github.com/Expensify/App/issues/6568

### Tests
1. Launch the app on a **phone** and verify that the app orientation **doesn't change** when you rotate the phone.
2. Launch the app on a **tablet** and verify that the app orientation **changes** when you rotate the tablet.

### QA Steps
Steps above.

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS

https://user-images.githubusercontent.com/22219519/144950348-83fd0232-c2b5-40e3-9257-f86acd133838.mov

https://user-images.githubusercontent.com/22219519/144950439-bfe0bec4-f86f-482b-913a-e795a861628c.mov

#### Android

https://user-images.githubusercontent.com/22219519/144950337-694508eb-b91c-4b97-990c-363a48eba68e.mov

https://user-images.githubusercontent.com/22219519/144950339-0b57eb20-b1af-4472-81d0-11978eb8893f.mov

