### PR TITLE
Revert "unknown report check" due to regression - unable to create group chats

### DIFF
--- a/src/pages/home/ReportScreen.js
+++ b/src/pages/home/ReportScreen.js
@@ -3,7 +3,6 @@ import {withOnyx} from 'react-native-onyx';
 import PropTypes from 'prop-types';
 import {Keyboard, View} from 'react-native';
 import _ from 'underscore';
-import lodashGet from 'lodash/get';
 import styles from '../../styles/styles';
 import ScreenWrapper from '../../components/ScreenWrapper';
 import HeaderView from './HeaderView';
@@ -147,7 +146,7 @@ class ReportScreen extends React.Component {
      */
     storeCurrentlyViewedReport() {
         const reportID = getReportID(this.props.route);
-        if (_.isNaN(reportID) || !lodashGet(this.props.report, 'reportID', '')) {
+        if (_.isNaN(reportID)) {
             Report.handleInaccessibleReport();
             return;
         }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
Reverting this PR: https://github.com/Expensify/App/pull/5964
- That PR fixed this issue: https://github.com/Expensify/App/issues/5897 so if we merge this revert, let's reopen that issue

cc @parasharrajat 

### Fixes
$ https://github.com/Expensify/App/issues/6609

### Tests
1. Create a new group chat with a unique group of participants (the group chat shouldn't have existed before)
2. You should successfully be navigated to the group and be able to send messages with error warning appearing

### QA Steps
Same as above

### Tested On

- [X] Web
- [x] Mobile Web
- [ ] Desktop
- [x] iOS
- [ ] Android

### Screenshots
Incoming...

#### Web
<!-- Insert screenshots of your changes on the web platform-->
https://user-images.githubusercontent.com/3885503/145019849-784afd6b-0475-480e-b18d-f995f737046f.mov

#### Mobile Web
https://user-images.githubusercontent.com/3885503/145020626-3e1ce3a3-a692-4d21-8456-2a5c4ccb5bd4.mov

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
https://user-images.githubusercontent.com/3885503/145021256-4389ef38-bd48-4c5c-89ed-494d242107ca.mov

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
