### PR TITLE
Fix warning, re-fix 'Welcome screen is not fully displayed on large screen iPad' issue

### DIFF
--- a/src/components/SVGImage/propTypes.js
+++ b/src/components/SVGImage/propTypes.js
@@ -11,7 +11,7 @@ const propTypes = {
     height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
 
     /** The resize mode of the image. */
-    resizeMode: PropTypes.oneOf('cover', 'contain', 'stretch', 'repeat', 'center'),
+    resizeMode: PropTypes.oneOf(['cover', 'contain', 'stretch', 'repeat', 'center']),
 };
 
 export default propTypes;

--- a/src/pages/signin/SignInPageLayout/index.js
+++ b/src/pages/signin/SignInPageLayout/index.js
@@ -51,6 +51,7 @@ const SignInPageLayout = (props) => {
                         width="100%"
                         height="100%"
                         src={backgroundStyle.backgroundImageUri}
+                        resizeMode={props.isMediumScreenWidth ? 'contain' : 'cover'}
                     />
                 </View>
             </View>


### PR DESCRIPTION
Pullerbear review (cc @danieldoglas @NikkiWines)

### Details
Fixes 2 things:
- The PR https://github.com/Expensify/App/pull/6597 caused this warning to be logged on app init:
![image](https://user-images.githubusercontent.com/2229301/145149256-222e2980-0750-4330-ac6e-f859f73c24ea.png)

- It seems like part of the fix from that PR was removed in https://github.com/Expensify/App/pull/6137/commits/a09676841bd1887818fb8264721e66650e158739, and the bug was reintroduced(?)

### Fixed Issues
No GH issue

### Tests / QA
1. Open the sign-in page on all platforms
2. Make sure the image on the right side is displayed in full

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [x] iOS (Safari on iPad)
- [ ] Android


### Screenshots

- iPad
![image](https://user-images.githubusercontent.com/2229301/145149104-8e33d290-8116-4804-a638-28dcf998522c.png)

- Web
![image](https://user-images.githubusercontent.com/2229301/145149164-4f79381e-17e0-42b2-8959-9a578328cedf.png)
