### PR TITLE
Refactor uses of react-native Text to ExpensifyText

### DIFF
--- a/src/components/CurrentWalletBalance.js
+++ b/src/components/CurrentWalletBalance.js
@@ -1,6 +1,5 @@
 import React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {ActivityIndicator, Text} from 'react-native';
+import {ActivityIndicator} from 'react-native';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
 import {withOnyx} from 'react-native-onyx';
@@ -9,6 +8,7 @@ import withLocalize, {withLocalizePropTypes} from './withLocalize';
 import compose from '../libs/compose';
 import themeColors from '../styles/themes/default';
 import ONYXKEYS from '../ONYXKEYS';
+import ExpensifyText from './ExpensifyText';
 
 const propTypes = {
     /** The user's wallet account */
@@ -40,11 +40,11 @@ const CurrentWalletBalance = (props) => {
         {style: 'currency', currency: 'USD'},
     );
     return (
-        <Text
+        <ExpensifyText
             style={[styles.textXXXLarge, styles.pv5, styles.alignSelfCenter]}
         >
             {`${formattedBalance}`}
-        </Text>
+        </ExpensifyText>
     );
 };
 

--- a/src/components/ExpensiPicker.js
+++ b/src/components/ExpensiPicker.js
@@ -1,9 +1,9 @@
 import _ from 'underscore';
 import React, {PureComponent} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {Text, View} from 'react-native';
+import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import Picker from './Picker';
+import ExpensifyText from './ExpensifyText';
 import styles from '../styles/styles';
 import InlineErrorText from './InlineErrorText';
 
@@ -47,7 +47,7 @@ class ExpensiPicker extends PureComponent {
                     ]}
                 >
                     {this.props.label && (
-                        <Text style={[styles.expensiPickerLabel, styles.textLabelSupporting]}>{this.props.label}</Text>
+                        <ExpensifyText style={[styles.expensiPickerLabel, styles.textLabelSupporting]}>{this.props.label}</ExpensifyText>
                     )}
                     <Picker
                         onOpen={() => this.setState({isOpen: true})}

--- a/src/components/ExpensifyText.js
+++ b/src/components/ExpensifyText.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
+// importing react-native Text as base for ExpensifyText component
 // eslint-disable-next-line no-restricted-imports
 import {Text as RNText} from 'react-native';
 import fontFamily from '../styles/fontFamily';

--- a/src/components/ExpensifyText.js
+++ b/src/components/ExpensifyText.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
-
-// importing react-native Text as base for ExpensifyText component
 // eslint-disable-next-line no-restricted-imports
 import {Text as RNText} from 'react-native';
 import fontFamily from '../styles/fontFamily';

--- a/src/components/ExpensifyText.js
+++ b/src/components/ExpensifyText.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
+
 // importing react-native Text as base for ExpensifyText component
 // eslint-disable-next-line no-restricted-imports
 import {Text as RNText} from 'react-native';

--- a/src/components/InlineCodeBlock/index.js
+++ b/src/components/InlineCodeBlock/index.js
@@ -1,7 +1,6 @@
 import React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {Text} from 'react-native';
 import inlineCodeBlockPropTypes from './inlineCodeBlockPropTypes';
+import ExpensifyText from '../ExpensifyText';
 
 const InlineCodeBlock = (props) => {
     const TDefaultRenderer = props.TDefaultRenderer;
@@ -10,11 +9,11 @@ const InlineCodeBlock = (props) => {
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...props.defaultRendererProps}
         >
-            <Text
+            <ExpensifyText
                 style={{...props.boxModelStyle, ...props.textStyle}}
             >
                 {props.defaultRendererProps.tnode.data}
-            </Text>
+            </ExpensifyText>
         </TDefaultRenderer>
     );
 };

--- a/src/components/PressableWithSecondaryInteraction/index.android.js
+++ b/src/components/PressableWithSecondaryInteraction/index.android.js
@@ -1,9 +1,9 @@
 import _ from 'underscore';
 import React, {forwardRef} from 'react';
 import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
-// eslint-disable-next-line no-restricted-imports
-import {Pressable, Platform, Text as RNText} from 'react-native';
+import {Pressable, Platform} from 'react-native';
 import * as pressableWithSecondaryInteractionPropTypes from './pressableWithSecondaryInteractionPropTypes';
+import ExpensifyText from '../ExpensifyText';
 
 /**
  * Triggers haptic feedback, and calls onSecondaryInteraction
@@ -34,7 +34,7 @@ function handleLongPress(event, props) {
  */
 const PressableWithSecondaryInteraction = (props) => {
     // Use Text node for inline mode to prevent content overflow.
-    const Node = props.inline ? RNText : Pressable;
+    const Node = props.inline ? ExpensifyText : Pressable;
     return (
         <Node
             ref={props.forwardedRef}

--- a/src/components/PressableWithSecondaryInteraction/index.ios.js
+++ b/src/components/PressableWithSecondaryInteraction/index.ios.js
@@ -1,9 +1,9 @@
 import _ from 'underscore';
 import React, {forwardRef} from 'react';
 import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
-// eslint-disable-next-line no-restricted-imports
-import {Pressable, Text as RNText} from 'react-native';
+import {Pressable} from 'react-native';
 import * as pressableWithSecondaryInteractionPropTypes from './pressableWithSecondaryInteractionPropTypes';
+import ExpensifyText from '../ExpensifyText';
 
 /**
  * This is a special Pressable that calls onSecondaryInteraction when LongPressed.
@@ -13,7 +13,7 @@ import * as pressableWithSecondaryInteractionPropTypes from './pressableWithSeco
  */
 const PressableWithSecondaryInteraction = (props) => {
     // Use Text node for inline mode to prevent content overflow.
-    const Node = props.inline ? RNText : Pressable;
+    const Node = props.inline ? ExpensifyText : Pressable;
     return (
         <Node
             ref={props.forwardedRef}

--- a/src/pages/home/report/MarkerBadge/index.js
+++ b/src/pages/home/report/MarkerBadge/index.js
@@ -1,9 +1,9 @@
 import React, {PureComponent} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {Animated, Text, View} from 'react-native';
+import {Animated, View} from 'react-native';
 import PropTypes from 'prop-types';
 import styles from '../../../../styles/styles';
 import ExpensifyButton from '../../../../components/ExpensifyButton';
+import ExpensifyText from '../../../../components/ExpensifyText';
 import Icon from '../../../../components/Icon';
 import * as Expensicons from '../../../../components/Icon/Expensicons';
 import themeColors from '../../../../styles/themes/default';
@@ -85,7 +85,7 @@ class MarkerBadge extends PureComponent {
                             ContentComponent={() => (
                                 <View style={[styles.flexRow]}>
                                     <Icon small src={Expensicons.DownArrow} fill={themeColors.textReversed} />
-                                    <Text
+                                    <ExpensifyText
                                         selectable={false}
                                         style={[
                                             styles.ml2,
@@ -97,7 +97,7 @@ class MarkerBadge extends PureComponent {
                                             'reportActionsViewMarkerBadge.newMsg',
                                             {count: this.props.count},
                                         )}
-                                    </Text>
+                                    </ExpensifyText>
                                 </View>
                             )}
                             shouldRemoveRightBorderRadius

--- a/src/pages/settings/Payments/PaymentMethodList.js
+++ b/src/pages/settings/Payments/PaymentMethodList.js
@@ -1,13 +1,13 @@
 import _ from 'underscore';
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-// eslint-disable-next-line no-restricted-imports
-import {FlatList, Text} from 'react-native';
+import {FlatList} from 'react-native';
 import {withOnyx} from 'react-native-onyx';
 import lodashGet from 'lodash/get';
 import styles from '../../../styles/styles';
 import * as StyleUtils from '../../../styles/StyleUtils';
 import MenuItem from '../../../components/MenuItem';
+import ExpensifyText from '../../../components/ExpensifyText';
 import compose from '../../../libs/compose';
 import withLocalize, {withLocalizePropTypes} from '../../../components/withLocalize';
 import ONYXKEYS from '../../../ONYXKEYS';
@@ -173,11 +173,11 @@ class PaymentMethodList extends Component {
         }
 
         return (
-            <Text
+            <ExpensifyText
                 style={[styles.popoverMenuItem]}
             >
                 {item.text}
-            </Text>
+            </ExpensifyText>
         );
     }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
We recently [updated](https://github.com/Expensify/App/issues/3133) our custom `Text` component to be called `ExpensifyText` to more clearly distinguish it from the `react-native` component with the same name. We also [added a new rule](https://github.com/Expensify/App/pull/6583) to our ESLint config preventing the import of the default `Text` component from `react-native`. This is because we want people to use our custom component instead. 

There were a handful of instances of the default `react-native` component being used in our code-base. This PR updates those to use our custom component instead. The only file that still imports `Text` from `react-native` is our `ExpensifyText` component, which is built on top of the `react-native` one.  

cc @madmax330 since you reviewed the ESLint PR. 

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
https://github.com/Expensify/App/issues/6585

### Tests
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->
Open the page for each component that was changed and ensured the text looks the same/normal. 

### QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->
Check each component to make sure the text looks normal. Here's how to get to each component. 

CurrentWalletBalance and PaymentMethodList:
1. log into an account that has no payment methods added
2. tap the profile icon
3. Tap payments
4. Make sure the wallet balance (the big $ amount) and the rest of the text on the page look normal 

ExpensiPicker:
1. log into any account
2. tap the profile icon
3. tap profile
4. make sure the text in the "preferred pronounces" dropdown looks normal
 
InlineCodeBlock and PressableWithSecondaryInteraction:
1. Send someone a message that includes a url (i.e. `www.expensify.com`)
2. Make sure the text looks normal
3. Make sure you're able to long-press the text and have the "copy link to clipboard" menu show up
4. Send someone a message that includes a code block by wrapping the text in "`" characters. 
5. Make sure the text looks normal 

MarkerBadge:
1. Navigate to a chat that has more messages in the history than what shows on the screen
2. Scroll to the top
3. From another window, send a message from the other account that is in that chat
4. Notice the "1 new message" indicator now showing in the original account
5. Make sure the text in that indicator looks normal 

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
CurrentWalletBalance and PaymentMethodList:
![image](https://user-images.githubusercontent.com/1371996/145443201-194943ad-98de-45ea-a331-9ad1d1cb8266.png)

ExpensiPicker:
<img width="1373" alt="Screen Shot 2021-12-08 at 6 28 49 PM" src="https://user-images.githubusercontent.com/1371996/145442607-5b1102ae-743b-48e7-9ffc-fd87426ef2fd.png">

InlineCodeBlock and PressableWithSecondaryInteraction:
<img width="1290" alt="Screen Shot 2021-12-09 at 12 08 14 PM" src="https://user-images.githubusercontent.com/1371996/145443046-6b5db278-06f9-4e0a-8e2e-7a363a6cdbfe.png">

MarkerBadge:
<img width="1277" alt="Screen Shot 2021-12-09 at 11 59 48 AM" src="https://user-images.githubusercontent.com/1371996/145442712-02e9bcf9-8bbc-4e7c-b795-338bcaed098e.png">

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
CurrentWalletBalance and PaymentMethodList:
<img width="363" alt="Screen Shot 2021-12-09 at 12 35 22 PM" src="https://user-images.githubusercontent.com/1371996/145460671-231ffc18-7908-49ea-a635-0e0397364768.png">

ExpensiPicker:
<img width="371" alt="Screen Shot 2021-12-09 at 12 35 34 PM" src="https://user-images.githubusercontent.com/1371996/145460695-5dbbf8ee-8848-4c67-baed-c3637051d0ce.png">

InlineCodeBlock and PressableWithSecondaryInteraction:
<img width="362" alt="Screen Shot 2021-12-09 at 12 35 46 PM" src="https://user-images.githubusercontent.com/1371996/145460715-a0f9a3cf-f936-4a99-9fe0-7a705568ffa1.png">

MarkerBadge:
<img width="371" alt="Screen Shot 2021-12-09 at 12 36 01 PM" src="https://user-images.githubusercontent.com/1371996/145460728-2bd210ee-59ac-45c1-abcd-096ade3aebfe.png">

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
CurrentWalletBalance and PaymentMethodList:
<img width="886" alt="Screen Shot 2021-12-09 at 2 12 26 PM" src="https://user-images.githubusercontent.com/1371996/145460756-fc727b3e-b25d-43ba-97d7-df426fba878e.png">

ExpensiPicker:
<img width="884" alt="Screen Shot 2021-12-09 at 2 12 38 PM" src="https://user-images.githubusercontent.com/1371996/145460773-5b148a93-f750-4347-9e16-0ad0290faf86.png">

InlineCodeBlock and PressableWithSecondaryInteraction:
<img width="880" alt="Screen Shot 2021-12-09 at 2 12 47 PM" src="https://user-images.githubusercontent.com/1371996/145460789-1e15caee-8e92-4546-9077-dda59c5b05dc.png">

MarkerBadge:
<img width="881" alt="Screen Shot 2021-12-09 at 2 13 07 PM" src="https://user-images.githubusercontent.com/1371996/145460808-169f62f6-94ba-487a-b2b8-3f969a4835d2.png">

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
CurrentWalletBalance and PaymentMethodList:
<img width="384" alt="Screen Shot 2021-12-08 at 8 19 13 PM" src="https://user-images.githubusercontent.com/1371996/145444045-a20bf796-0681-47f9-bcfe-cff53f4629aa.png">

ExpensiPicker:
<img width="390" alt="Screen Shot 2021-12-08 at 8 19 41 PM" src="https://user-images.githubusercontent.com/1371996/145444021-0f64733e-8a19-441c-bbbc-cdc8ca3be2aa.png">

InlineCodeBlock and PressableWithSecondaryInteraction:
<img width="387" alt="Screen Shot 2021-12-08 at 8 21 49 PM" src="https://user-images.githubusercontent.com/1371996/145444002-92d1b098-f31f-48e2-9dac-3dbfe90e4e16.png">

MarkerBadge:
<img width="386" alt="Screen Shot 2021-12-09 at 12 31 49 PM" src="https://user-images.githubusercontent.com/1371996/145461054-f835f804-2f76-4683-b053-f9d6daa2e11c.png">

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
CurrentWalletBalance and PaymentMethodList:
<img width="330" alt="Screen Shot 2021-12-08 at 7 43 26 PM" src="https://user-images.githubusercontent.com/1371996/145444109-287c3df4-77ca-4884-80b5-d0157faf177e.png">

ExpensiPicker:
<img width="324" alt="Screen Shot 2021-12-08 at 7 43 53 PM" src="https://user-images.githubusercontent.com/1371996/145444102-65e8cc12-c2d7-417f-b6bb-c205bd8e344b.png">

InlineCodeBlock and PressableWithSecondaryInteraction:
<img width="328" alt="Screen Shot 2021-12-08 at 7 44 45 PM" src="https://user-images.githubusercontent.com/1371996/145444090-b3fdd471-8044-4220-82cc-1b00e2a77b38.png">

MarkerBadge:
<img width="332" alt="Screen Shot 2021-12-09 at 12 26 27 PM" src="https://user-images.githubusercontent.com/1371996/145445808-1c7e9f6e-3019-4e9d-bd22-ac31a3a0dd70.png">
