### PR TITLE
[CP Stg] Fix iPad pro SignInPageLayout

### DIFF
--- a/src/components/withWindowDimensions.js
+++ b/src/components/withWindowDimensions.js
@@ -71,7 +71,7 @@ export default function (WrappedComponent) {
         onDimensionChange(newDimensions) {
             const {window} = newDimensions;
             const isSmallScreenWidth = window.width <= variables.mobileResponsiveWidthBreakpoint;
-            const isMediumScreenWidth = !isSmallScreenWidth && window.width <= variables.mediumScreenResponsiveWidthBreakpoint;
+            const isMediumScreenWidth = !isSmallScreenWidth && window.width <= variables.tabletResponsiveWidthBreakpoint;
             this.setState({
                 windowHeight: window.height,
                 windowWidth: window.width,

--- a/src/pages/signin/SignInPage.js
+++ b/src/pages/signin/SignInPage.js
@@ -85,7 +85,6 @@ class SignInPage extends Component {
                 <SignInPageLayout
                     welcomeText={welcomeText}
                     shouldShowWelcomeText={showLoginForm || showPasswordForm || !showResendValidationLinkForm}
-                    shouldShowWelcomeScreenshot={showLoginForm}
                 >
                     {/* LoginForm and PasswordForm must use the isVisible prop. This keeps them mounted, but visually hidden
                     so that password managers can access the values. Conditionally rendering these components will break this feature. */}


### PR DESCRIPTION
### Details
1. Fixes the `isMediumScreenWidth` breakpoint when screen is resized (variable was misnamed)
1. Removes an unused prop which was passed to `SignInPageLayout` component.

### Fixed Issues
$ https://github.com/Expensify/App/issues/6667

### Tests / QA Steps.
1. Open the sign-in page
1. Make sure the image on the right side is displayed in full
1. Rotate the device. Make sure the image still is displayed in full.
1. Repeat the previous step.
1. Try on as many different devices as you want. I was able to reproduce this issue on an iPad Pro after rotating from landscape to portrait mode, and saw that it was fixed by the changes in this PR.

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
#### Web
![image](https://user-images.githubusercontent.com/47436092/145454041-15688f2d-2362-4857-bc0c-454fe0b67c8f.png)

![image](https://user-images.githubusercontent.com/47436092/145454077-aa401750-3e65-470b-9c8b-ac4173720757.png)
