### PR TITLE
Adding support for chunked chats

### DIFF
--- a/src/libs/Pusher/EventType.js
+++ b/src/libs/Pusher/EventType.js
@@ -4,6 +4,8 @@
  */
 export default {
     REPORT_COMMENT: 'reportComment',
+    REPORT_COMMENT_CHUNK: 'chunked-reportComment',
+    REPORT_COMMENT_EDIT_CHUNK: 'chunked-reportCommentEdit',
     REPORT_COMMENT_EDIT: 'reportCommentEdit',
     REPORT_TOGGLE_PINNED: 'reportTogglePinned',
     PREFERRED_LOCALE: 'preferredLocale',

--- a/src/libs/Pusher/pusher.js
+++ b/src/libs/Pusher/pusher.js
@@ -124,6 +124,7 @@ function bindEventToChannel(channel, eventName, eventCallback = () => {}, isChun
             eventCallback(data);
             return;
         }
+
         // If we are chunking the requests, we need to construct a rolling list of all packets that have come through
         // Pusher. If we've completed one of these full packets, we'll combine the data and act on the event that it's
         // assigned to.

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -714,6 +714,24 @@ function subscribeToUserEvents() {
                 {error, pusherChannelName, eventName: Pusher.TYPE.REPORT_COMMENT},
             );
         });
+    
+    // Live-update a report's actions when a 'chunked report comment' event is received.
+    Pusher.subscribe(pusherChannelName, Pusher.TYPE.REPORT_COMMENT_CHUNK, (pushJSON) => {
+        Log.info(
+            `[Report] Handled ${Pusher.TYPE.REPORT_COMMENT_CHUNK} event sent by Pusher`, false, {reportID: pushJSON.reportID},
+        );
+        updateReportWithNewAction(pushJSON.reportID, pushJSON.reportAction, pushJSON.notificationPreference);
+    }, true,
+    () => {
+        NetworkConnection.triggerReconnectionCallbacks('pusher re-subscribed to private user channel');
+    })
+        .catch((error) => {
+            Log.info(
+                '[Report] Failed to subscribe to Pusher channel',
+                false,
+                {error, pusherChannelName, eventName: Pusher.TYPE.REPORT_COMMENT_CHUNK},
+            );
+        });
 
     // Live-update a report's actions when an 'edit comment' event is received.
     Pusher.subscribe(pusherChannelName, Pusher.TYPE.REPORT_COMMENT_EDIT, (pushJSON) => {
@@ -734,7 +752,25 @@ function subscribeToUserEvents() {
                 {error, pusherChannelName, eventName: Pusher.TYPE.REPORT_COMMENT_EDIT},
             );
         });
-
+    // Live-update a report's actions when an 'edit comment chunk' event is received.
+    Pusher.subscribe(pusherChannelName, Pusher.TYPE.REPORT_COMMENT_EDIT_CHUNK, (pushJSON) => {
+        Log.info(
+            `[Report] Handled ${Pusher.TYPE.REPORT_COMMENT_EDIT_CHUNK} event sent by Pusher`, false, {
+                reportActionID: pushJSON.reportActionID,
+            },
+        );
+        updateReportActionMessage(pushJSON.reportID, pushJSON.sequenceNumber, pushJSON.message);
+    }, false,
+    () => {
+        NetworkConnection.triggerReconnectionCallbacks('pusher re-subscribed to private user channel');
+    })
+        .catch((error) => {
+            Log.info(
+                '[Report] Failed to subscribe to Pusher channel',
+                false,
+                {error, pusherChannelName, eventName: Pusher.TYPE.REPORT_COMMENT_EDIT_CHUNK},
+            );
+        });
     // Live-update a report's pinned state when a 'report toggle pinned' event is received.
     Pusher.subscribe(pusherChannelName, Pusher.TYPE.REPORT_TOGGLE_PINNED, (pushJSON) => {
         Log.info(

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -741,7 +741,7 @@ function subscribeToUserEvents() {
             },
         );
         updateReportActionMessage(pushJSON.reportID, pushJSON.sequenceNumber, pushJSON.message);
-    }, false,
+    }, true,
     () => {
         NetworkConnection.triggerReconnectionCallbacks('pusher re-subscribed to private user channel');
     })

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -741,7 +741,7 @@ function subscribeToUserEvents() {
             },
         );
         updateReportActionMessage(pushJSON.reportID, pushJSON.sequenceNumber, pushJSON.message);
-    }, true,
+    }, false,
     () => {
         NetworkConnection.triggerReconnectionCallbacks('pusher re-subscribed to private user channel');
     })
@@ -761,7 +761,7 @@ function subscribeToUserEvents() {
             },
         );
         updateReportActionMessage(pushJSON.reportID, pushJSON.sequenceNumber, pushJSON.message);
-    }, false,
+    }, true,
     () => {
         NetworkConnection.triggerReconnectionCallbacks('pusher re-subscribed to private user channel');
     })

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -714,7 +714,7 @@ function subscribeToUserEvents() {
                 {error, pusherChannelName, eventName: Pusher.TYPE.REPORT_COMMENT},
             );
         });
-    
+
     // Live-update a report's actions when a 'chunked report comment' event is received.
     Pusher.subscribe(pusherChannelName, Pusher.TYPE.REPORT_COMMENT_CHUNK, (pushJSON) => {
         Log.info(
@@ -752,6 +752,7 @@ function subscribeToUserEvents() {
                 {error, pusherChannelName, eventName: Pusher.TYPE.REPORT_COMMENT_EDIT},
             );
         });
+
     // Live-update a report's actions when an 'edit comment chunk' event is received.
     Pusher.subscribe(pusherChannelName, Pusher.TYPE.REPORT_COMMENT_EDIT_CHUNK, (pushJSON) => {
         Log.info(
@@ -771,6 +772,7 @@ function subscribeToUserEvents() {
                 {error, pusherChannelName, eventName: Pusher.TYPE.REPORT_COMMENT_EDIT_CHUNK},
             );
         });
+
     // Live-update a report's pinned state when a 'report toggle pinned' event is received.
     Pusher.subscribe(pusherChannelName, Pusher.TYPE.REPORT_TOGGLE_PINNED, (pushJSON) => {
         Log.info(

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -700,6 +700,24 @@ function subscribeToUserEvents() {
                 {error, pusherChannelName, eventName: Pusher.TYPE.REPORT_COMMENT},
             );
         });
+    
+    // Live-update a report's actions when a 'chunked report comment' event is received.
+    Pusher.subscribe(pusherChannelName, Pusher.TYPE.REPORT_COMMENT_CHUNK, (pushJSON) => {
+        Log.info(
+            `[Report] Handled ${Pusher.TYPE.REPORT_COMMENT_CHUNK} event sent by Pusher`, false, {reportID: pushJSON.reportID},
+        );
+        updateReportWithNewAction(pushJSON.reportID, pushJSON.reportAction, pushJSON.notificationPreference);
+    }, true,
+    () => {
+        NetworkConnection.triggerReconnectionCallbacks('pusher re-subscribed to private user channel');
+    })
+        .catch((error) => {
+            Log.info(
+                '[Report] Failed to subscribe to Pusher channel',
+                false,
+                {error, pusherChannelName, eventName: Pusher.TYPE.REPORT_COMMENT_CHUNK},
+            );
+        });
 
     // Live-update a report's actions when an 'edit comment' event is received.
     Pusher.subscribe(pusherChannelName, Pusher.TYPE.REPORT_COMMENT_EDIT, (pushJSON) => {
@@ -720,7 +738,25 @@ function subscribeToUserEvents() {
                 {error, pusherChannelName, eventName: Pusher.TYPE.REPORT_COMMENT_EDIT},
             );
         });
-
+    // Live-update a report's actions when an 'edit comment chunk' event is received.
+    Pusher.subscribe(pusherChannelName, Pusher.TYPE.REPORT_COMMENT_EDIT_CHUNK, (pushJSON) => {
+        Log.info(
+            `[Report] Handled ${Pusher.TYPE.REPORT_COMMENT_EDIT_CHUNK} event sent by Pusher`, false, {
+                reportActionID: pushJSON.reportActionID,
+            },
+        );
+        updateReportActionMessage(pushJSON.reportID, pushJSON.sequenceNumber, pushJSON.message);
+    }, false,
+    () => {
+        NetworkConnection.triggerReconnectionCallbacks('pusher re-subscribed to private user channel');
+    })
+        .catch((error) => {
+            Log.info(
+                '[Report] Failed to subscribe to Pusher channel',
+                false,
+                {error, pusherChannelName, eventName: Pusher.TYPE.REPORT_COMMENT_EDIT_CHUNK},
+            );
+        });
     // Live-update a report's pinned state when a 'report toggle pinned' event is received.
     Pusher.subscribe(pusherChannelName, Pusher.TYPE.REPORT_TOGGLE_PINNED, (pushJSON) => {
         Log.info(


### PR DESCRIPTION

### Details
Adding new events for pusher with chunked push notifications.

### Fixed Issues
$ https://github.com/Expensify/App/issues/3797

### Tests
1. Run new.E locally pointing to production Web-E
2. Open two different accounts and start a chat with each other
3. Write (or paste) any messages that are bigger than 10240 characters
4. Verify that the message will appear for the receiver without needing to reload the chat.

### QA Steps
1. Run new.E locally pointing to production Web-E
2. Open two different accounts and start a chat with each other
3. Write (or paste) any messages that are bigger than 10240 characters
4. Verify that the message will appear for the receiver without needing to reload the chat.

### Tested On

- [X] Web
- [X] Mobile Web
- [X] Desktop
- [X] iOS
- [X] Android

### Screenshots

#### Web/Desktop/iOS/Android

https://user-images.githubusercontent.com/5818999/145457568-2c01b9b4-7212-412a-aeae-6c755fd5047e.mov


