### PR TITLE
Re-render ReportActionsView when report icons change

### DIFF
--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -189,6 +189,10 @@ class ReportActionsView extends React.Component {
             return true;
         }
 
+        if (!_.isEqual(lodashGet(this.props.report, 'icons', []), lodashGet(nextProps.report, 'icons', []))) {
+            return true;
+        }
+
         return false;
     }
 


### PR DESCRIPTION
### Fixed Issues
$ https://github.com/Expensify/App/issues/6675

### Tests / QA Steps
1. Create a new group with at least 4 members.
1. Verify that the empty state avatars are visible:

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots

#### Web
![image](https://user-images.githubusercontent.com/47436092/145486443-15c0ec8c-db38-4eb8-8bc8-afb5fd1bb740.png)

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
