### PR TITLE
Resolution of Issue #6592

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -27,7 +27,7 @@
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"
-        android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
+        android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode|screenLayout|smallestScreenSize"
         android:launchMode="singleTask"
         android:exported="true"
         android:windowSoftInputMode="adjustResize">


### PR DESCRIPTION
@parasharrajat 

### Details
Adding missing set of keys in andoird:configChanges resolves problem and app does not crash in split screen mode after this change.

### Fixed Issues
$ https://github.com/Expensify/App/issues/6592

### QA Steps

1. Open the app in a Android device
2. Press and hold the recents button in the nav bar to activate splitscreen mode

### Tested On
- [ ] Android

### Screenshots
![1639148181101](https://user-images.githubusercontent.com/5493716/145594844-83e0d946-1955-4709-9e3c-a7c2d0d64aa2.JPEG)
![1639148091611](https://user-images.githubusercontent.com/5493716/145594834-dae8bde3-b46d-492c-a767-8646833d387b.JPEG)

#### Android
![1639148091611](https://user-images.githubusercontent.com/5493716/145594834-dae8bde3-b46d-492c-a767-8646833d387b.JPEG)
