### PR TITLE
Show Empty Chat with draft messages in LHN

### DIFF
--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -357,7 +357,6 @@ function getOptions(reports, personalDetails, activeReportID, {
     searchValue = '',
     showChatPreviewLine = false,
     showReportsWithNoComments = false,
-    showReportsWithDrafts = false,
     hideReadReports = false,
     sortByAlphaAsc = false,
     forcePolicyNamePreview = false,
@@ -397,11 +396,10 @@ function getOptions(reports, personalDetails, activeReportID, {
         const reportContainsIOUDebt = iouReportOwner && iouReportOwner !== currentUserLogin;
         const shouldFilterReportIfEmpty = !showReportsWithNoComments && report.lastMessageTimestamp === 0;
         const shouldFilterReportIfRead = hideReadReports && report.unreadActionCount === 0;
-        const shouldShowReportIfHasDraft = showReportsWithDrafts && hasDraftComment;
         const shouldFilterReport = shouldFilterReportIfEmpty || shouldFilterReportIfRead;
         if (report.reportID !== activeReportID
             && !report.isPinned
-            && !shouldShowReportIfHasDraft
+            && !hasDraftComment
             && shouldFilterReport
             && !reportContainsIOUDebt) {
             return;
@@ -685,7 +683,6 @@ function getSidebarOptions(
         prioritizePinnedReports: true,
         prioritizeIOUDebts: true,
         prioritizeReportsWithDraftComments: true,
-        showReportsWithDrafts: true,
     };
     if (priorityMode === CONST.PRIORITY_MODE.GSD) {
         sideBarOptions = {

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -685,12 +685,12 @@ function getSidebarOptions(
         prioritizePinnedReports: true,
         prioritizeIOUDebts: true,
         prioritizeReportsWithDraftComments: true,
+        showReportsWithDrafts: true,
     };
     if (priorityMode === CONST.PRIORITY_MODE.GSD) {
         sideBarOptions = {
             hideReadReports: true,
             sortByAlphaAsc: true,
-            showReportsWithDrafts: true,
         };
     }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/6619

### Tests | QA Steps
1. Make sure the focus Mode is not on from the Preference Page.
1. Open any new chat that does not have any messages yet.
2. Check that it is listed in LHN when active.
3. Create a draft message on the same chat.
4. Switch to another chat.
5. Confirm that the old chat is still visible in LHN with the pencil icon.
6. Open the old chat.
7. Clear the draft.
8. Switch to another chat.
9. Confirm that chat is not more visible in LHN.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

https://user-images.githubusercontent.com/24370807/145628834-d9e41fc3-2fe1-44f4-9644-d2049e73d54a.mp4


I think other videos are not needed I just moved one flag from Focus mode to both modes and thus it should work if it works on one platform.
#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
