### PR TITLE
Add comment when update protected branch fails

### DIFF
--- a/.github/workflows/updateProtectedBranch.yml
+++ b/.github/workflows/updateProtectedBranch.yml
@@ -97,6 +97,16 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PULL_REQUEST_NUMBER: ${{ steps.createPullRequest.outputs.pr_number }}
+      
+      - name: Leave comment if PR is not mergeable
+        if: ${{ steps.isPullRequestMergeable.outputs.IS_MERGEABLE == 'false' }}
+        uses: actions-ecosystem/action-create-comment@cd098164398331c50e7dfdd0dfa1b564a1873fac
+        with:
+          github_token: ${{ secrets.OS_BOTIFY_TOKEN }}
+          number: ${{ steps.createPullRequest.outputs.pr_number }}
+          body: |
+            @Expensify/mobile-deployers - The Update Protected Branch workflow has failed because this PR was not mergable, 
+            if you are the deployer this week, please resolve the error and merge this PR to continue the deploy process. 
 
       - name: Fail workflow if PR is not mergeable
         if: ${{ steps.isPullRequestMergeable.outputs.IS_MERGEABLE == 'false' }}

--- a/.github/workflows/updateProtectedBranch.yml
+++ b/.github/workflows/updateProtectedBranch.yml
@@ -99,7 +99,7 @@ jobs:
           PULL_REQUEST_NUMBER: ${{ steps.createPullRequest.outputs.pr_number }}
       
       - name: Leave comment if PR is not mergeable
-        if: ${{ steps.isPullRequestMergeable.outputs.IS_MERGEABLE == 'false' }}
+        if: ${{ !fromJSON(steps.isPullRequestMergeable.outputs.IS_MERGEABLE) }}
         uses: actions-ecosystem/action-create-comment@cd098164398331c50e7dfdd0dfa1b564a1873fac
         with:
           github_token: ${{ secrets.OS_BOTIFY_TOKEN }}

--- a/.github/workflows/updateProtectedBranch.yml
+++ b/.github/workflows/updateProtectedBranch.yml
@@ -105,7 +105,7 @@ jobs:
           github_token: ${{ secrets.OS_BOTIFY_TOKEN }}
           number: ${{ steps.createPullRequest.outputs.pr_number }}
           body: |
-            @Expensify/mobile-deployers - The Update Protected Branch workflow has failed because this PR was not mergable, 
+            :bell: @Expensify/mobile-deployers :bell: - The Update Protected Branch workflow has failed because this PR was not mergable. 
             if you are the deployer this week, please resolve the error and merge this PR to continue the deploy process. 
 
       - name: Fail workflow if PR is not mergeable

--- a/.github/workflows/updateProtectedBranch.yml
+++ b/.github/workflows/updateProtectedBranch.yml
@@ -106,7 +106,7 @@ jobs:
           number: ${{ steps.createPullRequest.outputs.pr_number }}
           body: |
             :bell: @Expensify/mobile-deployers :bell: - The Update Protected Branch workflow has failed because this PR was not mergable. 
-            if you are the deployer this week, please resolve the error and merge this PR to continue the deploy process. 
+            If you are the deployer this week, please resolve the error and merge this PR to continue the deploy process. 
 
       - name: Fail workflow if PR is not mergeable
         if: ${{ steps.isPullRequestMergeable.outputs.IS_MERGEABLE == 'false' }}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Adds a comment when the deploy process fails for the mobile deployer to fix the error and merge the PR to continue the deploy process.

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/Expensify/issues/185234

### Tests
1. Force this workflow to fail via these steps: https://github.com/Expensify/App/pull/6706#pullrequestreview-829357869