### PR TITLE
Clean Old password when user click goBack

### DIFF
--- a/src/pages/signin/PasswordForm.js
+++ b/src/pages/signin/PasswordForm.js
@@ -62,10 +62,19 @@ class PasswordForm extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
-        if (prevProps.isVisible || !this.props.isVisible) {
-            return;
+        if (!prevProps.isVisible && this.props.isVisible) {
+            this.input.focus();
         }
-        this.input.focus();
+        if (prevProps.isVisible && !this.props.isVisible && this.state.password) {
+            this.clearPassword();
+        }
+    }
+
+    /**
+     * Clear Password from the state
+     */
+    clearPassword() {
+        this.setState({password: ''}, this.input.clear);
     }
 
     /**


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Follow up PR of https://github.com/Expensify/App/pull/5275 to SignInPage.

### Tests |QA Steps
1. Go to the login page.
2. Add an email manually.
3. Press continue and add password on the next page manually.
4. Click Go back.
5. Add the email again.
6. Click continue and confirm that there is no password on the next page.
7. Click go back.
8. Select an email from the password Manager.
9. Confirm that email is autofill.
10 click continue and confirm that there is a password auto-filled for that email.


### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web | Desktop
<!-- Insert screenshots of your changes on the web platform-->

https://user-images.githubusercontent.com/24370807/145724260-58da2e33-e113-472d-9910-3192ad397d6b.mp4


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
