### PR TITLE
[CP Staging] Fix same name policy rooms and policy room title and mobile app crashing when creating policy room

### DIFF
--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -142,8 +142,8 @@ function getChatReportName(fullReport, chatType) {
             : '')}`;
     }
 
-    // For a basic policy room, return its originally name
-    if (chatType === CONST.REPORT.CHAT_TYPE.POLICY_ROOM) {
+    // For a basic policy room, return its original name
+    if (ReportUtils.isPolicyRoom({chatType})) {
         return fullReport.reportName;
     }
 

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -142,7 +142,7 @@ function getChatReportName(fullReport, chatType) {
             : '')}`;
     }
 
-    // For normal policy room return its originally name
+    // For a basic policy room, return its originally name
     if (chatType === CONST.REPORT.CHAT_TYPE.POLICY_ROOM) {
         return fullReport.reportName;
     }

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -125,7 +125,7 @@ function getParticipantEmailsFromReport({sharedReportList}) {
 }
 
 /**
- * Returns the title for a default room or generates one based on the participants
+ * Returns the title for a default room, a policy room or generates one based on the participants
  *
  * @param {Object} fullReport
  * @param {String} chatType

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -142,6 +142,11 @@ function getChatReportName(fullReport, chatType) {
             : '')}`;
     }
 
+    // For normal policy room return its originally name
+    if (chatType === CONST.REPORT.CHAT_TYPE.POLICY_ROOM) {
+        return fullReport.reportName
+    }
+
     const {sharedReportList} = fullReport;
     return _.chain(sharedReportList)
         .map(participant => participant.email)

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -144,7 +144,7 @@ function getChatReportName(fullReport, chatType) {
 
     // For normal policy room return its originally name
     if (chatType === CONST.REPORT.CHAT_TYPE.POLICY_ROOM) {
-        return fullReport.reportName
+        return fullReport.reportName;
     }
 
     const {sharedReportList} = fullReport;

--- a/src/pages/home/HeaderView.js
+++ b/src/pages/home/HeaderView.js
@@ -86,7 +86,8 @@ const HeaderView = (props) => {
         },
     );
     const isDefaultChatRoom = ReportUtils.isDefaultRoom(props.report);
-    const title = isDefaultChatRoom
+    const isPolicyRoom = ReportUtils.isPolicyRoom(props.report);
+    const title = isDefaultChatRoom || isPolicyRoom
         ? props.report.reportName
         : _.map(displayNamesWithTooltips, ({displayName}) => displayName).join(', ');
 

--- a/src/pages/home/HeaderView.js
+++ b/src/pages/home/HeaderView.js
@@ -85,8 +85,8 @@ const HeaderView = (props) => {
             };
         },
     );
-    const isDefaultChatRoom = ReportUtils.isDefaultRoom(props.report);
     const isPolicyRoom = ReportUtils.isPolicyRoom(props.report);
+    const isDefaultChatRoom = ReportUtils.isDefaultRoom(props.report);
     const title = isDefaultChatRoom || isPolicyRoom
         ? props.report.reportName
         : _.map(displayNamesWithTooltips, ({displayName}) => displayName).join(', ');
@@ -146,7 +146,7 @@ const HeaderView = (props) => {
                                     tooltipEnabled
                                     numberOfLines={1}
                                     textStyles={[styles.headerText]}
-                                    shouldUseFullTitle={isDefaultChatRoom}
+                                    shouldUseFullTitle={isDefaultChatRoom || isPolicyRoom}
                                 />
                                 {isDefaultChatRoom && (
                                     <ExpensifyText


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
cc @TomatoToaster  asking you for a review as you have worked on the original PR.

Adding `CP Staging` label as it fixes two deploy blockers.
### Details
<!-- Explanation of the change or anything fishy that is going on -->

For the new Create room page, we are fixing parsing the `reportName`. Currently, we have been turning the `reportName` into an empty string, therefore we have not recognized that the value is same (if nothing is typed, the value is `#`).

At the same time, on mobile as the `reportName` is an empty string, [this line](https://github.com/Expensify/App/blob/ecce01202e51c4a39bbea913280a47ab7d4e0755/src/pages/home/HeaderView.js#L114) is false and nothing is shown in the `View` component, which causes the app to fail. By making sure the `reportName` wont be an empty string, this should not happen.

This also fixes the policy room title not showing.

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/6709
$ https://github.com/Expensify/App/issues/6712
$ https://github.com/Expensify/App/issues/6731

### Tests
1. Click "New Room" in the global create menu. Verify it takes you to `<baseURL>/workspace/new-room`.
2. Verify the Room Name input functions correctly:
    - Type spaces, verify that they appear as underscores.
    - Try to type non-alphanumeric characters (besides underscores) into the room name input, verify nothing shows up.
    - Turn your caps-lock and type in the room name input, verify everything appears as lowercase.
2. Click the dropdown. Verify that all the workspaces (policies) shown match up to the "Free Plan" policies shown for the same account in OldDot (Settings > Policies)
3. Type `test_room_name` into the room name input and select a workspace. Click "Create Room". Verify that the room is created and that you navigate to the room (`<baseURL>/r/<reportID>`).
    - NOTE: The room name in the header, the room's entry in the LHN, and the default text won't show up correctly yet. Just verify that you are navigated to a new report. I will open up a separate PR for this, since it'll make this one too cluttered.
4. Navigate back to `<baseURL>/workspace/new-room`. Select the same workspace you used in [4]. Then, type `test_room_name` into the Room Name input. Verify that the `A room with this name already exists` error message displays (in real-time as you finish typing `test_room_name`).
5. Change the workspace in the workspace dropdown. Verify the error disappears. Reselect the same workspace, and verify the error appears again.
6. Delete the last `e` off of the room name. Verify the error disappears. Add the last `e` back, and verify the error appears again.

### QA Steps
Same as the above tests with account which has appropriate betas accessible.

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [x] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->
https://user-images.githubusercontent.com/31285285/142488925-91679c72-7f4b-4109-986a-86eb8341d8a5.mp4

With the policy room title:
![image](https://user-images.githubusercontent.com/36083550/145785510-7418c3e3-c487-4430-90da-b824db7a1cd5.png)
