### PR TITLE
Fix app crashes tapping the room name in the chat

### DIFF
--- a/src/pages/ReportParticipantsPage.js
+++ b/src/pages/ReportParticipantsPage.js
@@ -91,7 +91,7 @@ const ReportParticipantsPage = (props) => {
                     styles.containerWithSpaceBetween,
                 ]}
             >
-                {participants.length
+                {Boolean(participants.length)
                     && (
                     <OptionsList
                         sections={[{


### PR DESCRIPTION
### Details
Prevents text from rendering inside a `View` by using `Boolean()`. Adding `CP Staging` label as it fixes a deploy blocker.

### Fixed Issues
$ https://github.com/Expensify/App/issues/6740

### Tests
1. Launch the app
2. Log in with an Expensify account
3. Tap on`+` button and `Select New Room`
4. Create a room
5. After room created tap on room name in the chat page
6. Verify that an empty Details page shows up and the app doesn't crash

### QA Steps
Steps above.

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [X] iOS
- [X] Android

### Screenshots

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS

https://user-images.githubusercontent.com/22219519/145894415-27cf76c3-e0b3-41c8-bb1e-2c52fdd016e3.mov

#### Android

https://user-images.githubusercontent.com/22219519/145894555-add3b00b-cbcc-440c-a0ae-1fc31085ab67.mov


