### PR TITLE
Make sure that we reduce the unread message count when we delete an unread message

### DIFF
--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -538,7 +538,12 @@ function setNewMarkerPosition(reportID, sequenceNumber) {
 function updateReportActionMessage(reportID, sequenceNumber, message) {
     const actionToMerge = {};
     actionToMerge[sequenceNumber] = {message: [message]};
-    Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`, actionToMerge);
+    Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`, actionToMerge).then(() => {
+        // If the message is deleted, update the last read in case the deleted message is being counted in the unreadActionCount
+        if (!message.text) {
+            setLocalLastRead(reportID, lastReadSequenceNumbers[reportID]);
+        }
+    });
 
     // If this is the most recent message, update the lastMessageText in the report object as well
     if (sequenceNumber === reportMaxSequenceNumbers[reportID]) {

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -539,10 +539,13 @@ function updateReportActionMessage(reportID, sequenceNumber, message) {
     const actionToMerge = {};
     actionToMerge[sequenceNumber] = {message: [message]};
     Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`, actionToMerge).then(() => {
-        // If the message is deleted, update the last read in case the deleted message is being counted in the unreadActionCount
-        if (!message.text) {
-            setLocalLastRead(reportID, lastReadSequenceNumbers[reportID]);
+        // Don't do anything for messages that aren't deleted.
+        if (message.html) {
+            return;
         }
+
+        // If the message is deleted, update the last read in case the deleted message is being counted in the unreadActionCount
+        setLocalLastRead(reportID, lastReadSequenceNumbers[reportID]);
     });
 
     // If this is the most recent message, update the lastMessageText in the report object as well

--- a/src/libs/actions/ReportActions.js
+++ b/src/libs/actions/ReportActions.js
@@ -83,15 +83,15 @@ function getDeletedCommentsCount(reportID, sequenceNumber) {
         return 0;
     }
 
-    return _.reduce(reportActions[reportID], (deletedMessages, action) => {
+    return _.reduce(reportActions[reportID], (numDeletedMessages, action) => {
         if (action.actionName !== CONST.REPORT.ACTIONS.TYPE.ADDCOMMENT || action.sequenceNumber <= sequenceNumber) {
-            return deletedMessages;
+            return numDeletedMessages;
         }
 
         // Empty ADDCOMMENT actions typically mean they have been deleted
         const message = _.first(lodashGet(action, 'message', null));
         const html = lodashGet(message, 'html', '');
-        return _.isEmpty(html) ? deletedMessages + 1 : deletedMessages;
+        return _.isEmpty(html) ? numDeletedMessages + 1 : numDeletedMessages;
     }, 0);
 }
 


### PR DESCRIPTION
@Julesssss please review
cc @parasharrajat

### Details
This will call `setLocalLastRead` when we see that the message being updated is getting deleted. Also a small change to make a variable name a bit clearer.

### Fixed Issues
$ https://github.com/Expensify/App/issues/6472

### Tests/QA
1. From account A, send account B a message. Make sure that Account B is logged in but not viewing the message of accountA
2. From Account A, delete the message you just sent
3. From account B, verify that the unread indicator for your app does not show anything

Video:
https://user-images.githubusercontent.com/4741899/145924224-69ac2239-bc67-495c-84db-5b2e8539d62f.mp4

---

1. From account A, send account B **two messages.** Make sure that Account B is logged in but not viewing the messages of accountA
2. From Account A, delete the first message you just sent
3. From account B, verify that the unread indicator for your app shows `1`

Video:
https://user-images.githubusercontent.com/4741899/145924341-b8f5ea80-1e36-40e5-a832-f1360098e334.mp4



---

1. From account A, send account B **two messages.** Make sure that Account B is logged in but not viewing the messages of accountA
2. From Account A, delete the **second** message you just sent
3. From account B, verify that the unread indicator for your app shows `1`

Video:
https://user-images.githubusercontent.com/4741899/145924454-2dc772b3-0dcd-4e90-b759-b1eb6c7dc48e.mp4


