### PR TITLE
Icon rounding issue resolved

### DIFF
--- a/android/app/src/main/java/com/expensify/chat/CustomNotificationProvider.java
+++ b/android/app/src/main/java/com/expensify/chat/CustomNotificationProvider.java
@@ -80,18 +80,25 @@ public class CustomNotificationProvider extends ReactNotificationProvider {
         return builder;
     }
 
+    /**
+     * Creates a canvas to draw a circle and then draws the bitmap avatar within that circle
+     * to clip off the area of the bitmap outside the circular path and returns a circular
+     * bitmap.
+     *
+     * @param bitmap The bitmap image to modify.
+     */
     public Bitmap getCroppedBitmap(Bitmap bitmap) {
        Bitmap output = Bitmap.createBitmap(bitmap.getWidth(),
             bitmap.getHeight(), Config.ARGB_8888);
        Canvas canvas = new Canvas(output);
 
-       final int color = 0xff424242;
+       final int defaultBackgroundColor = 0xff424242;
        final Paint paint = new Paint();
        final Rect rect = new Rect(0, 0, bitmap.getWidth(), bitmap.getHeight());
 
        paint.setAntiAlias(true);
        canvas.drawARGB(0, 0, 0, 0);
-       paint.setColor(color);
+       paint.setColor(defaultBackgroundColor);
        canvas.drawCircle(bitmap.getWidth() / 2, bitmap.getHeight() / 2,
             bitmap.getWidth() / 2, paint);
        paint.setXfermode(new PorterDuffXfermode(Mode.SRC_IN));

--- a/android/app/src/main/java/com/expensify/chat/CustomNotificationProvider.java
+++ b/android/app/src/main/java/com/expensify/chat/CustomNotificationProvider.java
@@ -2,6 +2,12 @@ package com.expensify.chat;
 
 import android.content.Context;
 import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.Rect;
+import android.graphics.Bitmap.Config;
+import android.graphics.PorterDuffXfermode;
+import android.graphics.PorterDuff.Mode;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.util.TypedValue;
@@ -72,6 +78,25 @@ public class CustomNotificationProvider extends ReactNotificationProvider {
         }
 
         return builder;
+    }
+
+    public Bitmap getCroppedBitmap(Bitmap bitmap) {
+       Bitmap output = Bitmap.createBitmap(bitmap.getWidth(),
+            bitmap.getHeight(), Config.ARGB_8888);
+       Canvas canvas = new Canvas(output);
+
+       final int color = 0xff424242;
+       final Paint paint = new Paint();
+       final Rect rect = new Rect(0, 0, bitmap.getWidth(), bitmap.getHeight());
+
+       paint.setAntiAlias(true);
+       canvas.drawARGB(0, 0, 0, 0);
+       paint.setColor(color);
+       canvas.drawCircle(bitmap.getWidth() / 2, bitmap.getHeight() / 2,
+            bitmap.getWidth() / 2, paint);
+       paint.setXfermode(new PorterDuffXfermode(Mode.SRC_IN));
+       canvas.drawBitmap(bitmap, rect, rect, paint);
+       return output;
     }
 
     /**
@@ -208,7 +233,7 @@ public class CustomNotificationProvider extends ReactNotificationProvider {
 
         try {
             Bitmap bitmap = future.get(MAX_ICON_FETCH_WAIT_TIME_SECONDS, TimeUnit.SECONDS);
-            return IconCompat.createWithBitmap(bitmap);
+            return IconCompat.createWithBitmap(getCroppedBitmap(bitmap));
         } catch (InterruptedException e) {
             Log.e(TAG,"Failed to fetch icon", e);
             Thread.currentThread().interrupt();


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
The android push notification icon will now be rounded. For some reason the push notifications weren't working on the debug build, so had to do my tests on release builds.

### Fixed Issues
The Custom Notification Provider was being used to make a custom layout for notifications in which a bitmap was being used for user's avatar which was being displayed in a. square shape. I added the code to clip the bitmap over a circular path to fix this issue.
$ https://github.com/Expensify/App/issues/6132

### Tests
1. Log in with account A on Android
2. Log in with account B on web
3. Send some message from account B to account A
4. Check the push notifications now the user avatar is rounded.

### QA Steps
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that 1. Log in with account A on Android
2. Log in with account B on web
3. Send some message from account B to account A
4. Check the push notifications now the user avatar is rounded.

### Tested On

- [x] Android

### Screenshots
Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was 
tested on all platforms

(This was an Android only issue hence only added screen shot of Android)

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
![409caa6f-1193-47f8-a070-dfaa9d3bbe19](https://user-images.githubusercontent.com/48583869/146178643-a32a02c2-04a0-4fc5-b0b7-7202a7bd43ba.jpeg)

