### PR TITLE
Remove early return for workspace new

### DIFF
--- a/src/libs/actions/Policy.js
+++ b/src/libs/actions/Policy.js
@@ -202,7 +202,10 @@ function createAndGetPolicyList() {
             newPolicyID = policyID;
             return getPolicyList();
         })
-        .then(() => navigateToPolicy(newPolicyID));
+        .then(() => {
+            Navigation.dismissModal();
+            navigateToPolicy(newPolicyID);
+        });
 }
 
 /**

--- a/src/pages/LogInWithShortLivedTokenPage.js
+++ b/src/pages/LogInWithShortLivedTokenPage.js
@@ -73,10 +73,6 @@ class LogInWithShortLivedTokenPage extends Component {
 
         // exitTo is URI encoded because it could contain a variable number of slashes (i.e. "workspace/new" vs "workspace/<ID>/card")
         const exitTo = decodeURIComponent(lodashGet(this.props.route.params, 'exitTo', ''));
-        if (exitTo === ROUTES.WORKSPACE_NEW) {
-            // New workspace creation is handled in AuthScreens, not in its own screen
-            return;
-        }
 
         // In order to navigate to a modal, we first have to dismiss the current modal. But there is no current
         // modal you say? I know, it confuses me too. Without dismissing the current modal, if the user cancels out

--- a/src/pages/LogInWithShortLivedTokenPage.js
+++ b/src/pages/LogInWithShortLivedTokenPage.js
@@ -7,6 +7,7 @@ import ONYXKEYS from '../ONYXKEYS';
 import * as Session from '../libs/actions/Session';
 import FullScreenLoadingIndicator from '../components/FullscreenLoadingIndicator';
 import Navigation from '../libs/Navigation/Navigation';
+import CustomActions from '../libs/Navigation/CustomActions';
 
 const propTypes = {
     /** The parameters needed to authenticate with a short lived token are in the URL */
@@ -74,13 +75,10 @@ class LogInWithShortLivedTokenPage extends Component {
         // exitTo is URI encoded because it could contain a variable number of slashes (i.e. "workspace/new" vs "workspace/<ID>/card")
         const exitTo = decodeURIComponent(lodashGet(this.props.route.params, 'exitTo', ''));
 
-        // In order to navigate to a modal, we first have to dismiss the current modal. But there is no current
-        // modal you say? I know, it confuses me too. Without dismissing the current modal, if the user cancels out
-        // of the workspace modal, then they will be routed back to
-        // /transition/<accountID>/<email>/<authToken>/workspace/<policyID>/card and we don't want that. We want them to go back to `/`
-        // and by calling dismissModal(), the /transition/... route is removed from history so the user will get taken to `/`
-        // if they cancel out of the new workspace modal.
-        Navigation.dismissModal();
+        // We have two routes, "/" and "transition". We want to dismiss the trasition route, remove it rom the history
+        // or else a user could be routed back to `/transition` when they close the modal.
+        // Or in some cases, the home screen gets stuck in `/transition` and there is an endless spinner in the background
+        CustomActions.navigateBackToRootDrawer();
 
         // New workspace creation is handled in AuthScreens which creates a workspace and navigates to it
         // We do not need to navigate to /workspace/new

--- a/src/pages/LogInWithShortLivedTokenPage.js
+++ b/src/pages/LogInWithShortLivedTokenPage.js
@@ -7,7 +7,6 @@ import ONYXKEYS from '../ONYXKEYS';
 import * as Session from '../libs/actions/Session';
 import FullScreenLoadingIndicator from '../components/FullscreenLoadingIndicator';
 import Navigation from '../libs/Navigation/Navigation';
-import CustomActions from '../libs/Navigation/CustomActions';
 
 const propTypes = {
     /** The parameters needed to authenticate with a short lived token are in the URL */
@@ -74,18 +73,18 @@ class LogInWithShortLivedTokenPage extends Component {
 
         // exitTo is URI encoded because it could contain a variable number of slashes (i.e. "workspace/new" vs "workspace/<ID>/card")
         const exitTo = decodeURIComponent(lodashGet(this.props.route.params, 'exitTo', ''));
-
-        // We have two routes in our history, "/" and "transition". We want to dismiss the trasition route, remove it from the history
-        // or else a user could be routed back to `/transition` when they close the modal.
-        // Or in some cases, the home screen gets stuck in `/transition` and there is an endless spinner in the background
-        CustomActions.navigateBackToRootDrawer();
-
-        // New workspace creation is handled in AuthScreens which creates a workspace and navigates to it
-        // We do not need to navigate to /workspace/new
         if (exitTo === ROUTES.WORKSPACE_NEW) {
+            // New workspace creation is handled in AuthScreens, not in its own screen
             return;
         }
 
+        // In order to navigate to a modal, we first have to dismiss the current modal. But there is no current
+        // modal you say? I know, it confuses me too. Without dismissing the current modal, if the user cancels out
+        // of the workspace modal, then they will be routed back to
+        // /transition/<accountID>/<email>/<authToken>/workspace/<policyID>/card and we don't want that. We want them to go back to `/`
+        // and by calling dismissModal(), the /transition/... route is removed from history so the user will get taken to `/`
+        // if they cancel out of the new workspace modal.
+        Navigation.dismissModal();
         Navigation.navigate(exitTo);
     }
 

--- a/src/pages/LogInWithShortLivedTokenPage.js
+++ b/src/pages/LogInWithShortLivedTokenPage.js
@@ -75,7 +75,7 @@ class LogInWithShortLivedTokenPage extends Component {
         // exitTo is URI encoded because it could contain a variable number of slashes (i.e. "workspace/new" vs "workspace/<ID>/card")
         const exitTo = decodeURIComponent(lodashGet(this.props.route.params, 'exitTo', ''));
 
-        // We have two routes, "/" and "transition". We want to dismiss the trasition route, remove it rom the history
+        // We have two routes in our history, "/" and "transition". We want to dismiss the trasition route, remove it from the history
         // or else a user could be routed back to `/transition` when they close the modal.
         // Or in some cases, the home screen gets stuck in `/transition` and there is an endless spinner in the background
         CustomActions.navigateBackToRootDrawer();

--- a/src/pages/LogInWithShortLivedTokenPage.js
+++ b/src/pages/LogInWithShortLivedTokenPage.js
@@ -2,6 +2,7 @@ import React, {Component} from 'react';
 import lodashGet from 'lodash/get';
 import PropTypes from 'prop-types';
 import {withOnyx} from 'react-native-onyx';
+import ROUTES from '../ROUTES';
 import ONYXKEYS from '../ONYXKEYS';
 import * as Session from '../libs/actions/Session';
 import FullScreenLoadingIndicator from '../components/FullscreenLoadingIndicator';
@@ -80,6 +81,13 @@ class LogInWithShortLivedTokenPage extends Component {
         // and by calling dismissModal(), the /transition/... route is removed from history so the user will get taken to `/`
         // if they cancel out of the new workspace modal.
         Navigation.dismissModal();
+
+        // New workspace creation is handled in AuthScreens which creates a workspace and navigates to it
+        // We do not need to navigate to /workspace/new
+        if (exitTo === ROUTES.WORKSPACE_NEW) {
+            return;
+        }
+
         Navigation.navigate(exitTo);
     }
 

--- a/src/pages/LogInWithShortLivedTokenPage.js
+++ b/src/pages/LogInWithShortLivedTokenPage.js
@@ -2,7 +2,6 @@ import React, {Component} from 'react';
 import lodashGet from 'lodash/get';
 import PropTypes from 'prop-types';
 import {withOnyx} from 'react-native-onyx';
-import ROUTES from '../ROUTES';
 import ONYXKEYS from '../ONYXKEYS';
 import * as Session from '../libs/actions/Session';
 import FullScreenLoadingIndicator from '../components/FullscreenLoadingIndicator';


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Whenever we use "transition", we use `dismissModal()` [here](https://github.com/Expensify/App/blob/d5ea6921054e31b3f8919fc61774c1bab318b19b/src/pages/LogInWithShortLivedTokenPage.js#L82) because `/transition` is in our route history. If our exitTo points to a modal like "bank-account". When the user closes the modal, we go back to our last route which is "transition". So we used `dismissModal()` **mainly** for this method `navigateBackToRootDrawer()` which points to the first route in our history. 

However, we don't want to navigate to `exitTo` for workspace/new. We create the policy in AuthScreens and navigate to the workspace from there. The issue is that we don't run `dismissModal()` and we return early. This means the home screen/ back ground is pointing to the last route which is "transition". 

So my fix is:
- Move dismissModal() to before our ealry return
- Replace dismissModal() with the actual thing we need, navigateBackToRootDrawer()

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/Expensify/issues/188048

### Tests/QA
For local tests, before you begin, you need ngrok running and new dot running locally (`npm run web`)

1. Create a new expensify account
2. Click "Get Started" on the first inbox task, which is the free plan
    ![image](https://user-images.githubusercontent.com/12980144/146260991-b0d86c7e-2c6c-40db-b204-1859ae0448a4.png)
3. Verify that the homescreen/default convo with concierge loads in the background correctly, and the modal properly displays the new works pace settings
    ![kFrPjS6KTu](https://user-images.githubusercontent.com/12980144/146261603-cbaa9c7d-2788-4cea-a859-f1e10e4b19b9.gif)

    

### QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
