### PR TITLE
fix: Added translation for room visibility dropdown 

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -808,6 +808,10 @@ export default {
         social: 'social',
         selectAWorkspace: 'Select a workspace',
         growlMessageOnError: 'Unable to create policy room, please check your connection and try again.',
+        visibilityOptions: {
+            restricted: 'Restricted',
+            private: 'Private',
+        },
     },
     keyboardShortcutModal: {
         title: 'Keyboard Shortcuts',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -810,6 +810,10 @@ export default {
         social: 'social',
         selectAWorkspace: 'Seleccionar un espacio de trabajo',
         growlMessageOnError: 'No ha sido posible crear el espacio de trabajo, por favor comprueba tu conexión e inténtalo de nuevo.',
+        visibilityOptions: {
+            restricted: 'Restringido',
+            private: 'Privado',
+        },
     },
     keyboardShortcutModal: {
         title: 'Atajos de teclado',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -811,8 +811,8 @@ export default {
         selectAWorkspace: 'Seleccionar un espacio de trabajo',
         growlMessageOnError: 'No ha sido posible crear el espacio de trabajo, por favor comprueba tu conexión e inténtalo de nuevo.',
         visibilityOptions: {
-            restricted: 'Restringido',
-            private: 'Privado',
+            restricted: 'Restringida',
+            private: 'Privada',
         },
     },
     keyboardShortcutModal: {

--- a/src/pages/workspace/WorkspaceNewRoomPage.js
+++ b/src/pages/workspace/WorkspaceNewRoomPage.js
@@ -130,8 +130,8 @@ class WorkspaceNewRoomPage extends React.Component {
         }
         const shouldDisableSubmit = Boolean(!this.state.roomName || !this.state.policyID || this.state.error);
 
-        const visibilityOptions = _.map(_.values(CONST.REPORT.VISIBILITY), v => ({
-            label: this.props.translate(`newRoomPage.visibilityOptions.${v}`),
+        const visibilityOptions = _.map(_.values(CONST.REPORT.VISIBILITY), visibilityOption => ({
+            label: this.props.translate(`newRoomPage.visibilityOptions.${visibilityOption}`),
             value: v,
         }));
 

--- a/src/pages/workspace/WorkspaceNewRoomPage.js
+++ b/src/pages/workspace/WorkspaceNewRoomPage.js
@@ -132,7 +132,7 @@ class WorkspaceNewRoomPage extends React.Component {
 
         const visibilityOptions = _.map(_.values(CONST.REPORT.VISIBILITY), visibilityOption => ({
             label: this.props.translate(`newRoomPage.visibilityOptions.${visibilityOption}`),
-            value: v,
+            value: visibilityOption,
         }));
 
         return (

--- a/src/pages/workspace/WorkspaceNewRoomPage.js
+++ b/src/pages/workspace/WorkspaceNewRoomPage.js
@@ -129,6 +129,12 @@ class WorkspaceNewRoomPage extends React.Component {
             return null;
         }
         const shouldDisableSubmit = Boolean(!this.state.roomName || !this.state.policyID || this.state.error);
+
+        const visibilityOptions = _.map(_.values(CONST.REPORT.VISIBILITY), v => ({
+            label: this.props.translate(`newRoomPage.visibilityOptions.${v}`),
+            value: v,
+        }));
+
         return (
             <ScreenWrapper>
                 <HeaderWithCloseButton
@@ -157,10 +163,7 @@ class WorkspaceNewRoomPage extends React.Component {
                     <ExpensiPicker
                         value={CONST.REPORT.VISIBILITY.RESTRICTED}
                         label={this.props.translate('newRoomPage.visibility')}
-                        items={[
-                            {label: 'Restricted', value: CONST.REPORT.VISIBILITY.RESTRICTED},
-                            {label: 'Private', value: CONST.REPORT.VISIBILITY.PRIVATE},
-                        ]}
+                        items={visibilityOptions}
                         onChange={visibility => this.setState({visibility})}
                     />
                 </View>


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
- Added translations for room visibility dropdown

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/6733

### Tests
1. Verified translations in English as well as Spanish
2. Verified Room creation visibility values being passed.
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### QA Steps
1. Go to Preferences -> change your language
2. On the home screen, click on the FAB and open the quick options menu
3. Click on New Room
4. Ensure that the visibility dropdown options are in the correct language translation
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
<img width="393" alt="web-room-visibility-translation" src="https://user-images.githubusercontent.com/3069065/146299041-8b012de2-9f61-45af-9750-7e0b082ee537.png">

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
<img width="339" alt="mweb-room-visibility-translation" src="https://user-images.githubusercontent.com/3069065/146299067-003ad7de-5958-476d-94bb-f7fab3efff23.png">


#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
<img width="399" alt="desktop-room-visibility-translation" src="https://user-images.githubusercontent.com/3069065/146299099-d61546ff-8558-4ffa-bf5e-3acd77aca3d6.png">

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
<img width="347" alt="ios-room-visibility-translation" src="https://user-images.githubusercontent.com/3069065/146301754-744f1c65-b472-43dc-98ad-2fdb38ebb9ff.png">


#### Android
<!-- Insert screenshots of your changes on the Android platform-->
<img width="315" alt="android-room-visibility-translation" src="https://user-images.githubusercontent.com/3069065/146299125-80aee038-ffa0-487d-a56d-1811677dfab4.png">

