### PR TITLE
Add SelectCircle replace usage in OptionsRow and makes MenuItem selectable

### DIFF
--- a/src/components/MenuItem.js
+++ b/src/components/MenuItem.js
@@ -13,6 +13,7 @@ import Avatar from './Avatar';
 import Badge from './Badge';
 import CONST from '../CONST';
 import menuItemPropTypes from './menuItemPropTypes';
+import SelectCircle from './SelectCircle';
 
 const propTypes = {
     ...menuItemPropTypes,
@@ -21,6 +22,7 @@ const propTypes = {
 const defaultProps = {
     badgeText: undefined,
     shouldShowRightIcon: false,
+    shouldShowSelectedState: false,
     wrapperStyle: [],
     success: false,
     icon: undefined,
@@ -32,6 +34,7 @@ const defaultProps = {
     iconFill: undefined,
     focused: false,
     disabled: false,
+    isSelected: false,
     subtitle: undefined,
     iconType: 'icon',
     onPress: () => {},
@@ -124,6 +127,7 @@ const MenuItem = props => (
                             />
                         </View>
                     )}
+                    {props.shouldShowSelectedState && <SelectCircle isChecked={props.isSelected} />}
                 </View>
             </>
         )}

--- a/src/components/SelectCircle.js
+++ b/src/components/SelectCircle.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import {View} from 'react-native';
+import PropTypes from 'prop-types';
+import styles from '../styles/styles';
+import Icon from './Icon';
+import * as Expensicons from './Icon/Expensicons';
+import themeColors from '../styles/themes/default';
+
+const propTypes = {
+    /** Should we show the checkmark inside the circle */
+    isChecked: PropTypes.bool,
+};
+
+const defaultProps = {
+    isChecked: false,
+};
+
+const SelectCircle = props => (
+    <View style={[styles.selectCircle, styles.alignSelfCenter]}>
+        {props.isChecked && (
+            <Icon src={Expensicons.Checkmark} fill={themeColors.iconSuccessFill} />
+        )}
+    </View>
+);
+
+SelectCircle.propTypes = propTypes;
+SelectCircle.defaultProps = defaultProps;
+SelectCircle.displayName = 'SelectCircle';
+
+export default SelectCircle;

--- a/src/components/SelectCircle.js
+++ b/src/components/SelectCircle.js
@@ -16,7 +16,7 @@ const defaultProps = {
 };
 
 const SelectCircle = props => (
-    <View style={[styles.selectCircle, styles.alignSelfCenter]}>
+    <View style={[styles.selectCircle]}>
         {props.isChecked && (
             <Icon src={Expensicons.Checkmark} fill={themeColors.iconSuccessFill} />
         )}

--- a/src/components/SelectCircle.js
+++ b/src/components/SelectCircle.js
@@ -16,7 +16,7 @@ const defaultProps = {
 };
 
 const SelectCircle = props => (
-    <View style={[styles.selectCircle]}>
+    <View style={[styles.selectCircle, styles.alignSelfCenter]}>
         {props.isChecked && (
             <Icon src={Expensicons.Checkmark} fill={themeColors.iconSuccessFill} />
         )}

--- a/src/components/menuItemPropTypes.js
+++ b/src/components/menuItemPropTypes.js
@@ -28,6 +28,12 @@ const propTypes = {
     /** Boolean whether to display the right icon */
     shouldShowRightIcon: PropTypes.bool,
 
+    /** Should we make this selectable with a checkbox */
+    shouldShowSelectedState: PropTypes.bool,
+
+    /** Whether this item is selected */
+    isSelected: PropTypes.bool,
+
     /** A boolean flag that gives the icon a green fill if true */
     success: PropTypes.bool,
 

--- a/src/pages/home/sidebar/OptionRow.js
+++ b/src/pages/home/sidebar/OptionRow.js
@@ -14,13 +14,13 @@ import {optionPropTypes} from './optionPropTypes';
 import Icon from '../../../components/Icon';
 import * as Expensicons from '../../../components/Icon/Expensicons';
 import MultipleAvatars from '../../../components/MultipleAvatars';
-import themeColors from '../../../styles/themes/default';
 import Hoverable from '../../../components/Hoverable';
 import DisplayNames from '../../../components/DisplayNames';
 import IOUBadge from '../../../components/IOUBadge';
 import colors from '../../../styles/colors';
 import withLocalize, {withLocalizePropTypes} from '../../../components/withLocalize';
 import ExpensifyText from '../../../components/ExpensifyText';
+import SelectCircle from '../../../components/SelectCircle';
 
 const propTypes = {
     /** Background Color of the Option Row */
@@ -203,13 +203,7 @@ const OptionRow = (props) => {
                                     </ExpensifyText>
                                 </View>
                             ) : null}
-                            {props.showSelectedState && (
-                                <View style={[styles.selectCircle]}>
-                                    {props.isSelected && (
-                                        <Icon src={Expensicons.Checkmark} fill={themeColors.iconSuccessFill} />
-                                    )}
-                                </View>
-                            )}
+                            {props.showSelectedState && <SelectCircle isChecked={props.isSelected} />}
                         </View>
                     </View>
                     {!props.hideAdditionalOptionStates && (

--- a/src/stories/MenuItem.stories.js
+++ b/src/stories/MenuItem.stories.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import MenuItem from '../components/MenuItem';
+import Chase from '../../assets/images/bankicons/chase.svg';
+import variables from '../styles/variables';
+
+/**
+ * We use the Component Story Format for writing stories. Follow the docs here:
+ *
+ * https://storybook.js.org/docs/react/writing-stories/introduction#component-story-format
+ */
+const story = {
+    title: 'Components/MenuItem',
+    component: MenuItem,
+};
+
+// eslint-disable-next-line react/jsx-props-no-spreading
+const Template = args => <MenuItem {...args} />;
+
+// Arguments can be passed to the component by binding
+// See: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
+const Default = Template.bind({});
+Default.args = {
+    title: 'Alberta Bobbeth Charleson',
+    description: 'Account ending in 1111',
+    shouldShowSelectedState: true,
+    isSelected: true,
+    icon: Chase,
+    iconHeight: variables.iconSizeExtraLarge,
+    iconWidth: variables.iconSizeExtraLarge,
+};
+
+export default story;
+export {
+    Default,
+};


### PR DESCRIPTION
### Details
cc @parasharrajat Just adds SelectCircle. Small PR moved out of your other PR to help minimize changes.

### Fixed Issues
No Issue

### Tests / QA Steps
1. Navigate to `/new/group`
2. Select a user
3. Verify the check mark looks normal
4. De-select verify the check mark disappears

![2021-12-15_14-33-48](https://user-images.githubusercontent.com/32969087/146286547-7b8bb34a-e0c4-4010-a59a-be9f46fd345b.png)

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
