### PR TITLE
Fix broken manual address on Additional Information page

### DIFF
--- a/src/pages/ReimbursementAccount/ACHContractStep.js
+++ b/src/pages/ReimbursementAccount/ACHContractStep.js
@@ -136,7 +136,9 @@ class ACHContractStep extends React.Component {
             const renamedInputKey = lodashGet(renamedFields, inputKey, inputKey);
             const beneficialOwners = [...prevState.beneficialOwners];
             beneficialOwners[ownerIndex] = {...beneficialOwners[ownerIndex], [renamedInputKey]: value};
-            BankAccounts.updateReimbursementAccountDraft({beneficialOwners});
+            if (inputKey !== 'manualAddress') {
+                BankAccounts.updateReimbursementAccountDraft({beneficialOwners});
+            }
             return {beneficialOwners};
         });
 

--- a/src/pages/ReimbursementAccount/ACHContractStep.js
+++ b/src/pages/ReimbursementAccount/ACHContractStep.js
@@ -243,6 +243,7 @@ class ACHContractStep extends React.Component {
                                             zipCode: owner.zipCode || '',
                                             dob: owner.dob || '',
                                             ssnLast4: owner.ssnLast4 || '',
+                                            manualAddress: owner.manualAddress,
                                         }}
                                         errors={lodashGet(this.getErrors(), `beneficialOwnersErrors[${index}]`, {})}
                                     />


### PR DESCRIPTION
### Details
Tracks the manualAddress state for beneficial owners in the Additional Information page.

### Fixed Issues
$ https://github.com/Expensify/App/issues/6793

### Tests
1. Log into the app
2. Select a Workspace and click on `Connect bank account`
3. Fill in the form to get to the `Additional Information` page
3. Select `Somebody else owns more than 25% of ...`
4. Under the address field, click on `Can't find your address? Enter it manually`
5. Verify that the fields for City, State and Zip code show up.

### QA Steps
Steps above.

### Tested On

- [X] Web
- [X] Mobile Web
- [X] Desktop
- [X] iOS
- [X] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web

https://user-images.githubusercontent.com/22219519/146419535-df09b751-975f-4cda-9960-faadc973c3ed.mov

#### Mobile Web

https://user-images.githubusercontent.com/22219519/146419555-88592cbb-33c9-42c3-806f-8b5349d482dc.mov

#### Desktop

https://user-images.githubusercontent.com/22219519/146419573-4ddfdf93-2913-4af4-b4b2-ef13aaf45d9a.mov

#### iOS

https://user-images.githubusercontent.com/22219519/146419592-4df4684a-450d-41d2-bdc5-d342e9ce5feb.mov

#### Android

https://user-images.githubusercontent.com/22219519/146419624-70ee3d7f-f5a0-49c1-8915-14162b8c2597.mov
