### PR TITLE
Fix NewRoomPage visibility dropdown

### DIFF
--- a/src/pages/workspace/WorkspaceNewRoomPage.js
+++ b/src/pages/workspace/WorkspaceNewRoomPage.js
@@ -161,7 +161,7 @@ class WorkspaceNewRoomPage extends React.Component {
                         />
                     </View>
                     <ExpensiPicker
-                        value={CONST.REPORT.VISIBILITY.RESTRICTED}
+                        value={this.state.visibility}
                         label={this.props.translate('newRoomPage.visibility')}
                         items={visibilityOptions}
                         onChange={visibility => this.setState({visibility})}


### PR DESCRIPTION
No idea how this got past review but the `value` prop for the dropdown in the `WorkspaceNewRoomPage` was being hard-coded to `CONST.REPORT.VISIBILITY.RESTRICTED` preventing the dropdown from updating with the selected value.

### Fixed Issues
$ https://github.com/Expensify/App/issues/6757

### Tests/QA
1. Select "New Room" from the global create menu.
2. Attempt to change the Visibility dropdown (it should start with "Restricted"). Verify it works correctly.

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
