### PR TITLE
Anthony  remove second secure inputs

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -290,10 +290,8 @@ export default {
         currentPassword: 'Current password',
         newPassword: 'New password',
         newPasswordPrompt: 'New password must be different than your old password, have at least 8 characters,\n1 capital letter, 1 lowercase letter, and 1 number.',
-        confirmNewPassword: 'Confirm new password',
         errors: {
             currentPassword: 'Current password is required',
-            confirmNewPassword: 'Confirm password is required',
             newPasswordSameAsOld: 'New password must be different than your old password',
             newPassword: 'Your password must have at least 8 characters,\n1 capital letter, 1 lowercase letter, and 1 number.',
         },
@@ -424,9 +422,7 @@ export default {
     },
     setPasswordPage: {
         enterPassword: 'Enter a password',
-        confirmNewPassword: 'Confirm the password',
         setPassword: 'Set password',
-        passwordsDontMatch: 'Passwords must match',
         newPasswordPrompt: 'Your password must have at least 8 characters,\n1 capital letter, 1 lowercase letter, and 1 number.',
         passwordFormTitle: 'Welcome back to the New Expensify! Please set your password.',
         passwordNotSet: 'We were unable to set your new password correctly.',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -290,10 +290,8 @@ export default {
         currentPassword: 'Contraseña actual',
         newPassword: 'Nueva contraseña',
         newPasswordPrompt: 'La nueva contraseña debe ser diferente de la antigua, tener al menos 8 caracteres,\n1 letra mayúscula, 1 letra minúscula y 1 número.',
-        confirmNewPassword: 'Confirma la nueva contraseña',
         errors: {
             currentPassword: 'Contraseña actual es requerido',
-            confirmNewPassword: 'Confirma la nueva contraseña es requerido',
             newPasswordSameAsOld: 'La nueva contraseña tiene que ser diferente de la antigua',
             newPassword: 'Su contraseña debe tener al menos 8 caracteres, \n1 letra mayúscula, 1 letra minúscula y 1 número.',
         },
@@ -424,9 +422,7 @@ export default {
     },
     setPasswordPage: {
         enterPassword: 'Escribe una contraseña',
-        confirmNewPassword: 'Confirma la contraseña',
         setPassword: 'Configura tu contraseña',
-        passwordsDontMatch: 'Las contraseñas deben coincidir',
         newPasswordPrompt: 'La contraseña debe tener al menos 8 caracteres, \n1 letra mayúscula, 1 letra minúscula y 1 número.',
         passwordFormTitle: '¡Bienvenido de vuelta al Nuevo Expensify! Por favor, elige una contraseña.',
         passwordNotSet: 'No pudimos establecer to contaseña correctamente.',

--- a/src/pages/settings/NewPasswordForm.js
+++ b/src/pages/settings/NewPasswordForm.js
@@ -8,7 +8,6 @@ import withLocalize, {
 import CONST from '../../CONST';
 import styles from '../../styles/styles';
 import ExpensiTextInput from '../../components/ExpensiTextInput';
-import InlineErrorText from '../../components/InlineErrorText';
 
 const propTypes = {
     /** String to control the first password box in the form */
@@ -30,16 +29,13 @@ class NewPasswordForm extends React.Component {
         super(props);
 
         this.state = {
-            confirmNewPassword: '',
             passwordHintError: false,
-            shouldShowPasswordConfirmError: false,
         };
     }
 
-    componentDidUpdate(prevProps, prevState) {
-        const eitherPasswordChanged = (this.props.password !== prevProps.password)
-        || this.state.confirmNewPassword !== prevState.confirmNewPassword;
-        if (eitherPasswordChanged) {
+    componentDidUpdate(prevProps) {
+        const passwordChanged = (this.props.password !== prevProps.password);
+        if (passwordChanged) {
             this.props.updateIsFormValid(this.isValidForm());
         }
     }
@@ -50,15 +46,6 @@ class NewPasswordForm extends React.Component {
         }
         if (this.props.password && !this.isValidPassword()) {
             this.setState({passwordHintError: true});
-        }
-    }
-
-    onBlurConfirmPassword() {
-        if (this.state.shouldShowPasswordConfirmError) {
-            return;
-        }
-        if (this.state.confirmNewPassword && !this.doPasswordsMatch()) {
-            this.setState({shouldShowPasswordConfirmError: true});
         }
     }
 
@@ -74,63 +61,34 @@ class NewPasswordForm extends React.Component {
         return this.state.passwordHintError && this.props.password && !this.isValidPassword();
     }
 
-    doPasswordsMatch() {
-        return this.props.password === this.state.confirmNewPassword;
-    }
-
     isValidForm() {
-        return this.isValidPassword() && this.doPasswordsMatch();
+        return this.isValidPassword();
     }
 
-    showPasswordMatchError() {
-        return Boolean(
-            !this.doPasswordsMatch()
-            && this.state.shouldShowPasswordConfirmError
-            && this.state.confirmNewPassword,
-        );
-    }
 
     render() {
         return (
-            <>
-                <View style={styles.mb6}>
-                    <ExpensiTextInput
-                        label={`${this.props.translate('setPasswordPage.enterPassword')}`}
-                        secureTextEntry
-                        autoCompleteType="password"
-                        textContentType="password"
-                        value={this.props.password}
-                        onChangeText={password => this.props.updatePassword(password)}
-                        onBlur={() => this.onBlurNewPassword()}
-                    />
-                    <ExpensifyText
-                        style={[
-                            styles.textLabelSupporting,
-                            styles.mt1,
-                            this.isInvalidPassword() && styles.formError,
-                        ]}
-                    >
-                        {this.props.translate('setPasswordPage.newPasswordPrompt')}
-                    </ExpensifyText>
-                </View>
-                <View style={styles.mb6}>
-                    <ExpensiTextInput
-                        label={`${this.props.translate('setPasswordPage.confirmNewPassword')}*`}
-                        secureTextEntry
-                        autoCompleteType="password"
-                        textContentType="password"
-                        value={this.state.confirmNewPassword}
-                        onChangeText={confirmNewPassword => this.setState({confirmNewPassword})}
-                        onSubmitEditing={() => this.props.onSubmitEditing()}
-                        onBlur={() => this.onBlurConfirmPassword()}
-                    />
-                    {this.showPasswordMatchError() && (
-                        <InlineErrorText>
-                            {this.props.translate('setPasswordPage.passwordsDontMatch')}
-                        </InlineErrorText>
-                    )}
-                </View>
-            </>
+            <View style={styles.mb6}>
+                <ExpensiTextInput
+                    label={`${this.props.translate('setPasswordPage.enterPassword')}`}
+                    secureTextEntry
+                    autoCompleteType="password"
+                    textContentType="password"
+                    value={this.props.password}
+                    onChangeText={password => this.props.updatePassword(password)}
+                    onBlur={() => this.onBlurNewPassword()}
+                    onSubmitEditing={() => this.props.onSubmitEditing()}
+                />
+                <ExpensifyText
+                    style={[
+                        styles.textLabelSupporting,
+                        styles.mt1,
+                        this.isInvalidPassword() && styles.formError,
+                    ]}
+                >
+                    {this.props.translate('setPasswordPage.newPasswordPrompt')}
+                </ExpensifyText>
+            </View>
         );
     }
 }

--- a/src/pages/settings/PasswordPage.js
+++ b/src/pages/settings/PasswordPage.js
@@ -52,7 +52,6 @@ class PasswordPage extends Component {
             errors: {
                 currentPassword: false,
                 newPassword: false,
-                confirmNewPassword: false,
                 newPasswordSameAsOld: false,
             },
         };
@@ -65,7 +64,6 @@ class PasswordPage extends Component {
 
         this.errorKeysMap = {
             currentPassword: 'passwordPage.errors.currentPassword',
-            confirmNewPassword: 'passwordPage.errors.confirmNewPassword',
             newPasswordSameAsOld: 'passwordPage.errors.newPasswordSameAsOld',
             newPassword: 'passwordPage.errors.newPassword',
         };

--- a/src/pages/settings/PasswordPage.js
+++ b/src/pages/settings/PasswordPage.js
@@ -49,12 +49,10 @@ class PasswordPage extends Component {
         this.state = {
             currentPassword: '',
             newPassword: '',
-            confirmNewPassword: '',
             errors: {
                 currentPassword: false,
                 newPassword: false,
                 confirmNewPassword: false,
-                confirmPasswordMatch: false,
                 newPasswordSameAsOld: false,
             },
         };
@@ -69,7 +67,6 @@ class PasswordPage extends Component {
             currentPassword: 'passwordPage.errors.currentPassword',
             confirmNewPassword: 'passwordPage.errors.confirmNewPassword',
             newPasswordSameAsOld: 'passwordPage.errors.newPasswordSameAsOld',
-            confirmPasswordMatch: 'setPasswordPage.passwordsDontMatch',
             newPassword: 'passwordPage.errors.newPassword',
         };
     }
@@ -125,16 +122,8 @@ class PasswordPage extends Component {
             errors.newPassword = true;
         }
 
-        if (!this.state.confirmNewPassword) {
-            errors.confirmNewPassword = true;
-        }
-
         if (this.state.currentPassword && this.state.newPassword && _.isEqual(this.state.currentPassword, this.state.newPassword)) {
             errors.newPasswordSameAsOld = true;
-        }
-
-        if (ValidationUtils.isValidPassword(this.state.newPassword) && this.state.confirmNewPassword && !_.isEqual(this.state.newPassword, this.state.confirmNewPassword)) {
-            errors.confirmPasswordMatch = true;
         }
 
         this.setState({errors});
@@ -199,6 +188,7 @@ class PasswordPage extends Component {
                                     ? this.getErrorText('newPasswordSameAsOld')
                                     : this.getErrorText('newPassword')}
                                 onChangeText={text => this.clearErrorAndSetValue('newPassword', text, ['newPasswordSameAsOld'])}
+                                onSubmitEditing={this.submit}
                             />
                             {
 
@@ -213,19 +203,6 @@ class PasswordPage extends Component {
                                 </ExpensifyText>
                                 )
                             }
-                        </View>
-                        <View style={styles.mb6}>
-                            <ExpensiTextInput
-                                label={`${this.props.translate('passwordPage.confirmNewPassword')}*`}
-                                secureTextEntry
-                                autoCompleteType="password"
-                                textContentType="password"
-                                value={this.state.confirmNewPassword}
-                                onChangeText={text => this.clearErrorAndSetValue('confirmNewPassword', text, ['confirmPasswordMatch'])}
-                                hasError={this.state.errors.confirmNewPassword || this.state.errors.confirmPasswordMatch}
-                                errorText={this.getErrorText(this.state.errors.confirmNewPassword ? 'confirmNewPassword' : 'confirmPasswordMatch')}
-                                onSubmitEditing={this.validateAndSubmitForm}
-                            />
                         </View>
                         {_.every(this.state.errors, error => !error) && !_.isEmpty(this.props.account.error) && (
                             <ExpensifyText style={styles.formError}>

--- a/src/pages/settings/PasswordPage.js
+++ b/src/pages/settings/PasswordPage.js
@@ -32,7 +32,7 @@ const propTypes = {
         /** Success message to display when necessary */
         success: PropTypes.string,
 
-        /** Whether or not a sign on form is loading (being submitted) */
+        /** Whether a sign on form is loading (being submitted) */
         loading: PropTypes.bool,
     }),
 


### PR DESCRIPTION
### Details

### Fixed Issues
$ https://github.com/Expensify/App/issues/6565
$ https://github.com/Expensify/App/issues/6823


### QA Steps
1. Create a new account
2. Click the link in the email
3. Verify the password form works (including some invalid password states)
4. Submit the form and verify it allows you to set the password with a valid password

1. Given being logged in
2. Navigate to the change password setting
3. Verify the password form works (including some invalid password states)
4. Submit the form and verify it allows you to change with a valid password

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
![image](https://user-images.githubusercontent.com/47184118/146436230-dc9f906c-fdc4-40c8-a274-7035652aac82.png)

#### Mobile Web
![image](https://user-images.githubusercontent.com/47184118/146437501-24442dbb-5183-41d4-bb9f-db8d38f58d12.png)


#### Desktop
![image](https://user-images.githubusercontent.com/47184118/146440918-8c16bb5a-4685-4335-977b-21f7b93350ac.png)

#### iOS
![image](https://user-images.githubusercontent.com/47184118/146445837-42929dbf-3e2b-4b0d-b17e-0da93fefdfb3.png)

#### Android
![image](https://user-images.githubusercontent.com/47184118/146825283-a24132a8-c65a-4197-8159-616fdef33401.png)

