### PR TITLE
Remove create new workspace button from workspace settings

### DIFF
--- a/src/pages/workspace/WorkspaceInitialPage.js
+++ b/src/pages/workspace/WorkspaceInitialPage.js
@@ -135,17 +135,11 @@ class WorkspaceInitialPage extends React.Component {
                     onBackButtonPress={() => Navigation.navigate(ROUTES.SETTINGS)}
                     onCloseButtonPress={() => Navigation.dismissModal()}
                     shouldShowThreeDotsButton
-                    threeDotsMenuItems={[
-                        {
-                            icon: Expensicons.Plus,
-                            text: this.props.translate('workspace.new.newWorkspace'),
-                            onSelected: () => PolicyActions.createAndNavigate(),
-                        }, {
-                            icon: Expensicons.Trashcan,
-                            text: this.props.translate('workspace.common.delete'),
-                            onSelected: () => this.setState({isDeleteModalOpen: true}),
-                        },
-                    ]}
+                    threeDotsMenuItems={[{
+                        icon: Expensicons.Trashcan,
+                        text: this.props.translate('workspace.common.delete'),
+                        onSelected: () => this.setState({isDeleteModalOpen: true}),
+                    }]}
                     threeDotsAnchorPosition={styles.threeDotsPopoverOffset}
                 />
                 <ScrollView
@@ -222,6 +216,7 @@ class WorkspaceInitialPage extends React.Component {
                     </View>
                 </ScrollView>
                 <ConfirmModal
+                    danger
                     title={this.props.translate('workspace.common.delete')}
                     isVisible={this.state.isDeleteModalOpen}
                     onConfirm={this.confirmDeleteAndHideModal}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
We only allow users to have one Workspace. However, users are able to create multiple Workspaces by using the three dot menu on the Workspace Settings page. This PR removes that button since users that can navigate to the Workspace settings page already have a Workspace. 

I also updated the delete Workspace button color to red, instead of the current green.

### Fixed Issues
$ https://github.com/Expensify/App/issues/6818

### Tests
1. Log into the App.
2. Create a Workspace.
3. Click on `Profile > Select Workspace > Three dot menu`
4. Verify that the `New Workspace` button is no longer visible.

### QA Steps
Steps above.

### Tested On

- [X] Web
- [x] Mobile Web
- [X] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web

https://user-images.githubusercontent.com/22219519/146618165-2a980e98-02f4-4d0a-849e-c9d78e35b951.mov

#### Mobile Web

https://user-images.githubusercontent.com/22219519/146618218-895e2248-4317-4480-ba3d-d4eeb5122156.mov

#### Desktop

https://user-images.githubusercontent.com/22219519/146618233-0f3fe77e-6b83-4dbb-8c5a-f714f3cc505b.mov

#### iOS

https://user-images.githubusercontent.com/22219519/146618577-e76ff2bf-f404-4220-b113-c7dda3cfcf73.mov

#### Android

https://user-images.githubusercontent.com/22219519/146618484-8defeb95-6c53-4d84-95ca-bfebdfefa4a9.mov
