### PR TITLE
[No QA] Update copy on terms page

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -562,10 +562,10 @@ export default {
             sendingFundsTitle: 'Sending funds to another account holder',
             sendingFundsDetails: 'There is no fee to send funds to another account holder using your balance, '
                 + 'bank account, or debit card.',
-            electronicFundsStandardDetails: 'There is no fee to transfer funds from your Expensify Payments Account '
+            electronicFundsStandardDetails: 'There is no fee to transfer funds from your Expensify Wallet '
                 + 'to your bank account using the standard option. This transfer usually completes within 1-3 business'
                 + ' days.',
-            electronicFundsInstantDetails: 'There is a fee to transfer funds from your Expensify Payments Account to '
+            electronicFundsInstantDetails: 'There is a fee to transfer funds from your Expensify Wallet to '
                 + 'your linked debit card using the instant transfer option. This transfer usually completes within '
                 + 'several minutes. The fee is 1.5% of the transfer amount (with a minimum fee of $0.25).',
             fdicInsuranceBancorp: 'Your funds are eligible for FDIC insurance. Your funds will be held at or '

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -562,10 +562,10 @@ export default {
             sendingFundsTitle: 'Enviar fondos a otro titular de cuenta',
             sendingFundsDetails: 'No se aplica ningún cargo por enviar fondos a otro titular de cuenta utilizando su '
                 + 'saldo cuenta bancaria o tarjeta de débito',
-            electronicFundsStandardDetails: 'No hay cargo por transferir fondos desde su cuenta Expensify Payments'
+            electronicFundsStandardDetails: 'No hay cargo por transferir fondos desde su billetera Expensify '
                 + 'a su cuenta bancaria utilizando la opción estándar. Esta transferencia generalmente se completa en'
                 + '1-3 negocios días.',
-            electronicFundsInstantDetails: 'Hay una tarifa para transferir fondos desde su cuenta Expensify Payments a '
+            electronicFundsInstantDetails: 'Hay una tarifa para transferir fondos desde su billetera Expensify a '
                 + 'su tarjeta de débito vinculada utilizando la opción de transferencia instantánea. Esta transferencia '
                 + 'generalmente se completa dentro de varios minutos. La tarifa es el 1.5% del monto de la '
                 + 'transferencia (con una tarifa mínima de $ 0.25). ',


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This PR updates 2 copy sections for the terms page of the VBA flow, specifically the updates in [this comment](https://github.com/Expensify/Expensify/issues/167278#issuecomment-997055666). I've also added a screenshot to confirm that `expensify.cash` is not on the terms page and `new.expensify.com` is shown instead.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/167278

### Tests
Go through the VBA flow, confirm that the copy is updated.

### QA Steps
No QA

### Tested On
- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
|||
|---|---|
| ![image](https://user-images.githubusercontent.com/3981102/146622776-29fab558-73b8-468e-83c1-d562b89d68c4.png) | ![image](https://user-images.githubusercontent.com/3981102/146622782-d7763c92-76a2-4cca-a54e-9d8a10120c99.png) |


