### PR TITLE
Workspace general settings form Save button behaviour corrected.

### DIFF
--- a/src/pages/workspace/WorkspaceSettingsPage.js
+++ b/src/pages/workspace/WorkspaceSettingsPage.js
@@ -118,6 +118,11 @@ class WorkspaceSettingsPage extends React.Component {
             return <FullScreenLoadingIndicator />;
         }
 
+        // Disables button if none of the form values have changed or workspace name empty
+        const isButtonDisabled = (this.state.name.trim() === ''
+            || (this.props.policy.name === this.state.name.trim()
+            && this.props.policy.outputCurrency === this.state.currency));
+
         return (
             <WorkspacePageWithSections
                 headerText={this.props.translate('workspace.common.settings')}
@@ -126,6 +131,7 @@ class WorkspaceSettingsPage extends React.Component {
                     <FixedFooter style={[styles.w100]}>
                         <Button
                             success
+                            isDisabled={isButtonDisabled}
                             isLoading={this.props.policy.isPolicyUpdating}
                             text={this.props.translate('workspace.editor.save')}
                             onPress={this.submit}

--- a/src/pages/workspace/WorkspaceSettingsPage.js
+++ b/src/pages/workspace/WorkspaceSettingsPage.js
@@ -119,9 +119,9 @@ class WorkspaceSettingsPage extends React.Component {
         }
 
         // Disables button if none of the form values have changed or workspace name empty
-        const isButtonDisabled = (this.state.name.trim() === ''
+        const isButtonDisabled = this.state.name.trim() === ''
             || (this.props.policy.name === this.state.name.trim()
-            && this.props.policy.outputCurrency === this.state.currency));
+            && this.props.policy.outputCurrency === this.state.currency);
 
         return (
             <WorkspacePageWithSections


### PR DESCRIPTION
@johnmlee101  @parasharrajat @roryabraham PR Is ready for review

### Details
Save button on Workspace General Settings remain enabled although any information not changed within form. So in this pr we corrected Save button behaviour. So now If user change some information within form, it will enable Save button, otherwise Save button remain disabled.

### Fixed Issues

$ https://github.com/Expensify/App/issues/6717

### Tests | QA Steps
1. Run app on any platform
2. Click on Profile >> Select Workspace
3. Click General Settings
4. Change any information within workspace form.
4. Observe behaviour of Save button

**QA Check:**   If user change some information within form, it will enable Save button. i.e. If any information not changed within form it will keep Save button Disabled.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web
https://user-images.githubusercontent.com/7823358/146629505-ebfe759d-ef1b-46bd-889c-080cf6e324d6.mov

#### Mobile Web
https://user-images.githubusercontent.com/7823358/146629528-9fd46e5b-ae23-4a6e-b4c9-0070600272bf.mov

#### Desktop
https://user-images.githubusercontent.com/7823358/146629550-5e8be3d1-ae05-4941-b217-11be81926add.mov

#### iOS
https://user-images.githubusercontent.com/7823358/146629607-33219059-d653-436b-b7d4-98c5e868dd5c.mov

#### Android
https://user-images.githubusercontent.com/7823358/146629634-b7a94113-628f-4989-a0f0-e4612dcd348b.mov

