### PR TITLE
Corrected - IOU Cursor is set to pointer in IOU preview

### DIFF
--- a/src/components/ReportActionItem/IOUAction.js
+++ b/src/components/ReportActionItem/IOUAction.js
@@ -7,6 +7,7 @@ import reportActionPropTypes from '../../pages/home/report/reportActionPropTypes
 import IOUPreview from './IOUPreview';
 import Navigation from '../../libs/Navigation/Navigation';
 import ROUTES from '../../ROUTES';
+import styles from '../../styles/styles';
 
 const propTypes = {
     /** All the data of the action */
@@ -50,6 +51,7 @@ const IOUAction = (props) => {
                         chatReportID={props.chatReportID}
                         onPayButtonPressed={launchDetailsModal}
                         onPreviewPressed={launchDetailsModal}
+                        containerStyles={[styles.cursorPointer]}
                     />
             )}
         </>

--- a/src/components/ReportActionItem/IOUPreview.js
+++ b/src/components/ReportActionItem/IOUPreview.js
@@ -35,6 +35,12 @@ const propTypes = {
     /** The associated chatReport */
     chatReportID: PropTypes.number.isRequired,
 
+    /** Callback for the preview pressed */
+    onPreviewPressed: PropTypes.func,
+
+    /** Extra styles to pass to View wrapper */
+    containerStyles: PropTypes.arrayOf(PropTypes.object),
+
     /* Onyx Props */
 
     /** Active IOU Report for current report */
@@ -72,6 +78,8 @@ const defaultProps = {
     iouReport: {},
     shouldHidePayButton: false,
     onPayButtonPressed: null,
+    onPreviewPressed: null,
+    containerStyles: [],
 };
 
 const IOUPreview = (props) => {
@@ -103,7 +111,7 @@ const IOUPreview = (props) => {
     const cachedTotal = props.iouReport.cachedTotal ? props.iouReport.cachedTotal.replace(/[()]/g, '') : '';
     return (
         <TouchableWithoutFeedback onPress={props.onPreviewPressed}>
-            <View style={styles.iouPreviewBox}>
+            <View style={[styles.iouPreviewBox, ...props.containerStyles]}>
                 {reportIsLoading
                     ? <ActivityIndicator style={styles.iouPreviewBoxLoading} color={themeColors.text} />
                     : (

--- a/src/components/ReportActionItem/IOUPreview.js
+++ b/src/components/ReportActionItem/IOUPreview.js
@@ -78,7 +78,7 @@ const defaultProps = {
     iouReport: {},
     shouldHidePayButton: false,
     onPayButtonPressed: null,
-    onPreviewPressed: null,
+    onPreviewPressed: () => {},
     containerStyles: [],
 };
 

--- a/src/pages/iou/IOUDetailsModal.js
+++ b/src/pages/iou/IOUDetailsModal.js
@@ -115,6 +115,7 @@ class IOUDetailsModal extends Component {
                                 chatReportID={Number(this.props.route.params.chatReportID)}
                                 iouReportID={Number(this.props.route.params.iouReportID)}
                                 shouldHidePayButton
+                                containerStyles={[styles.cursorDefault]}
                             />
                             <IOUTransactions
                                 chatReportID={Number(this.props.route.params.chatReportID)}

--- a/src/pages/iou/IOUDetailsModal.js
+++ b/src/pages/iou/IOUDetailsModal.js
@@ -115,7 +115,6 @@ class IOUDetailsModal extends Component {
                                 chatReportID={Number(this.props.route.params.chatReportID)}
                                 iouReportID={Number(this.props.route.params.iouReportID)}
                                 shouldHidePayButton
-                                containerStyles={[styles.cursorDefault]}
                             />
                             <IOUTransactions
                                 chatReportID={Number(this.props.route.params.chatReportID)}

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -2049,6 +2049,10 @@ const styles = {
         marginVertical: 4,
     },
 
+    cursorDefault: {
+        cursor: 'default',
+    },
+
     cursorDisabled: {
         cursor: 'not-allowed',
     },

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1914,7 +1914,6 @@ const styles = {
         marginTop: 16,
         maxWidth: variables.sideBarWidth,
         width: '100%',
-        cursor: 'pointer',
     },
 
     iouPreviewBoxLoading: {
@@ -2047,10 +2046,6 @@ const styles = {
         borderLeftWidth: 4,
         paddingLeft: 12,
         marginVertical: 4,
-    },
-
-    cursorDefault: {
-        cursor: 'default',
     },
 
     cursorDisabled: {


### PR DESCRIPTION
@parasharrajat  @mallenexpensify  PR is ready for review.

### Details
User can see pointer when mouse over on IOU Preview in details modal at RHN, but there is no action occurring when clicking on it. So in this PR corrected cursor behaviour. i.e. Now it will show default cursor when mouse over on IOU Preview.  This cursor behaviour is visible on Web and Desktop version. 
Proposal: https://github.com/Expensify/App/issues/6693#issuecomment-995889708

### Fixed Issues
$ https://github.com/Expensify/App/issues/6693

### Tests | QA Steps

1. Login
2. Request money from someone.
3. From chat list click on IOU Preview 
4. It will open details window in RHN
5. Hover cursor over IOU Preview shows in RHN (amount and user details box)

**QA Check:**  Within Web and Desktop it will show default cursor because it is not clickable. (previously it was showing pointer).


### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web
https://user-images.githubusercontent.com/7823358/146630610-00db8fd3-daf3-488e-a395-7d44f3d9a8c2.mov

#### Mobile Web
https://user-images.githubusercontent.com/7823358/146630624-bdbc79c6-78a3-454b-85f3-ec8dcf8e7430.mov

#### Desktop
https://user-images.githubusercontent.com/7823358/146630630-fea27592-ae6c-4c81-b708-21a586b9a056.mov

#### iOS
https://user-images.githubusercontent.com/7823358/146630640-df6374cb-1da8-4e7f-b4bc-541f23f539be.mov

#### Android
https://user-images.githubusercontent.com/7823358/146630652-9234dd5e-dfd0-407c-ada1-933f00f48382.mov
