### PR TITLE
Show permission error dialog only when storage permission is denied or missing

### DIFF
--- a/src/libs/fileDownload/index.native.js
+++ b/src/libs/fileDownload/index.native.js
@@ -138,9 +138,9 @@ export default function fileDownload(url, fileName) {
             hasAndroidPermission().then((hasPermission) => {
                 if (hasPermission) {
                     handleDownload(url, fileName).then(() => resolve());
+                } else {
+                    showAlert(permissionError);
                 }
-
-                showAlert(permissionError);
                 return resolve();
             }).catch(() => {
                 showAlert(permissionError);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

Fixes a bug on android devices where permission error dialog was shown even when storage permission is allowed by the user. 

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/6613

### Tests
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

1. Open app in an Android device.
2. Open a conversation with an attachment in it.
3. Tap on the attachment to view it in Attachment view
4. Tap on download icon to download the attachment.
5. Download success message should be shown.
6. Now kill the app, remove storage permission for New Expensify from settings.
7. Repeat steps 2-4.
8. Tap on Deny when os dialog for file permission is shown.
9. Tap on deny button to deny permission.
10. Permission error dialog should be shown to user. 

### QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->

https://user-images.githubusercontent.com/6880914/146823424-f76f6c3e-f0cc-4817-9843-0ccd0501179d.mp4


