### PR TITLE
Revert "Remove create new workspace button from workspace settings"

### DIFF
--- a/src/pages/workspace/WorkspaceInitialPage.js
+++ b/src/pages/workspace/WorkspaceInitialPage.js
@@ -135,11 +135,17 @@ class WorkspaceInitialPage extends React.Component {
                     onBackButtonPress={() => Navigation.navigate(ROUTES.SETTINGS)}
                     onCloseButtonPress={() => Navigation.dismissModal()}
                     shouldShowThreeDotsButton
-                    threeDotsMenuItems={[{
-                        icon: Expensicons.Trashcan,
-                        text: this.props.translate('workspace.common.delete'),
-                        onSelected: () => this.setState({isDeleteModalOpen: true}),
-                    }]}
+                    threeDotsMenuItems={[
+                        {
+                            icon: Expensicons.Plus,
+                            text: this.props.translate('workspace.new.newWorkspace'),
+                            onSelected: () => PolicyActions.createAndNavigate(),
+                        }, {
+                            icon: Expensicons.Trashcan,
+                            text: this.props.translate('workspace.common.delete'),
+                            onSelected: () => this.setState({isDeleteModalOpen: true}),
+                        },
+                    ]}
                     threeDotsAnchorPosition={styles.threeDotsPopoverOffset}
                 />
                 <ScrollView
@@ -216,7 +222,6 @@ class WorkspaceInitialPage extends React.Component {
                     </View>
                 </ScrollView>
                 <ConfirmModal
-                    danger
                     title={this.props.translate('workspace.common.delete')}
                     isVisible={this.state.isDeleteModalOpen}
                     onConfirm={this.confirmDeleteAndHideModal}


### PR DESCRIPTION
Reverts Expensify/App#6827

The [reported issue](https://github.com/Expensify/App/issues/6818) is invalid since users should be able to create multiple Workspaces per account.