### PR TITLE
Update Wallet Agreement link on Terms Page

### DIFF
--- a/src/pages/EnablePayments/TermsStep.js
+++ b/src/pages/EnablePayments/TermsStep.js
@@ -95,7 +95,7 @@ class TermsStep extends React.Component {
 
                                 <ExpensifyText>{`${this.props.translate('common.and')} `}</ExpensifyText>
 
-                                <TextLink href="https://use.expensify.com/personalpaymentsterms">
+                                <TextLink href="https://use.expensify.com/walletagreement">
                                     {`${this.props.translate('termsStep.walletAgreement')}.`}
                                 </TextLink>
                             </>

--- a/src/pages/EnablePayments/TermsStep.js
+++ b/src/pages/EnablePayments/TermsStep.js
@@ -71,8 +71,7 @@ class TermsStep extends React.Component {
                         onPress={this.toggleDisclosure}
                         LabelComponent={() => (
                             <ExpensifyText>
-                                {`${this.props.translate('termsStep.haveReadAndAgree')} `}
-
+                                {`${this.props.translate('termsStep.haveReadAndAgree')}`}
                                 <TextLink href="https://use.expensify.com/fees">
                                     {`${this.props.translate('termsStep.electronicDisclosures')}.`}
                                 </TextLink>

--- a/src/pages/EnablePayments/TermsStep.js
+++ b/src/pages/EnablePayments/TermsStep.js
@@ -72,7 +72,7 @@ class TermsStep extends React.Component {
                         LabelComponent={() => (
                             <ExpensifyText>
                                 {`${this.props.translate('termsStep.haveReadAndAgree')}`}
-                                <TextLink href="https://use.expensify.com/fees">
+                                <TextLink href="https://use.expensify.com/esignagreement">
                                     {`${this.props.translate('termsStep.electronicDisclosures')}.`}
                                 </TextLink>
                             </ExpensifyText>


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Per https://github.com/Expensify/Expensify/issues/167278#issuecomment-998296255, this updates a link on the Terms page of the VBA flow. This also fixes a spacing bug for the `electronic disclosures` link.

### Fixed Issues
Related to https://github.com/Expensify/Expensify/issues/167278

### Tests
1. Go to the Terms step of the VBA flow, confirm that the `Wallet agreement` link points to https://use.expensify.com/walletagreement
2. Confirm that there is no extra spacing on the `electronic disclosures` link.

### QA Steps
No QA

### Tested On
- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

| Web | Mobile |
|---|---|
| ![image](https://user-images.githubusercontent.com/3981102/146839962-34c103fc-acc3-4097-b77f-a7c2d45bcc10.png) | ![image](https://user-images.githubusercontent.com/3981102/146839975-630bd462-c972-4185-a20d-fb5790bb6077.png) |


