### PR TITLE
Fix gsd mode pinned room not on the top

### DIFF
--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -686,6 +686,7 @@ function getSidebarOptions(
     };
     if (priorityMode === CONST.PRIORITY_MODE.GSD) {
         sideBarOptions = {
+            prioritizePinnedReports: true,
             hideReadReports: true,
             sortByAlphaAsc: true,
         };

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -680,13 +680,11 @@ function getSidebarOptions(
     betas,
 ) {
     let sideBarOptions = {
-        prioritizePinnedReports: true,
         prioritizeIOUDebts: true,
         prioritizeReportsWithDraftComments: true,
     };
     if (priorityMode === CONST.PRIORITY_MODE.GSD) {
         sideBarOptions = {
-            prioritizePinnedReports: true,
             hideReadReports: true,
             sortByAlphaAsc: true,
         };
@@ -699,6 +697,7 @@ function getSidebarOptions(
         maxRecentReportsToShow: 0, // Unlimited
         sortByLastMessageTimestamp: true,
         showChatPreviewLine: true,
+        prioritizePinnedReports: true,
         ...sideBarOptions,
     });
 }

--- a/tests/unit/OptionsListUtilsTest.js
+++ b/tests/unit/OptionsListUtilsTest.js
@@ -188,7 +188,7 @@ describe('OptionsListUtils', () => {
             unreadActionCount: 1,
         },
     };
-    
+
     const REPORTS_WITH_MORE_PINS = {
         ...REPORTS,
         13: {
@@ -516,7 +516,6 @@ describe('OptionsListUtils', () => {
             ]),
         );
 
-
         // Test by excluding Chronos from the results
         results = OptionsListUtils.getNewChatOptions(
             REPORTS_WITH_CHRONOS,
@@ -629,29 +628,29 @@ describe('OptionsListUtils', () => {
                 expect(results.personalDetails.length).toBe(0);
 
                 // Pinned reports are always on the top in alphabetical order regardless of whether they are unread or have IOU debt.
-                // D report name (Alphabetically first among pinned reports)  
+                // D report name (Alphabetically first among pinned reports)
                 expect(results.recentReports[0].login).toBe('d_email@email.com');
-        
-                // Mister Fantastic report name (Alphabetically second among pinned reports) 
+
+                // Mister Fantastic report name (Alphabetically second among pinned reports)
                 expect(results.recentReports[1].login).toBe('reedrichards@expensify.com');
 
-                // Z report name (Alphabetically third among pinned reports) 
+                // Z report name (Alphabetically third among pinned reports)
                 expect(results.recentReports[2].login).toBe('z_email@email.com');
 
                 // Unpinned report name ordered alphabetically after pinned reports
-                //Black Panther report name has unread message
+                // Black Panther report name has unread message
                 expect(results.recentReports[3].login).toBe('tchalla@expensify.com');
 
-                //Captain America report name has unread message
+                // Captain America report name has unread message
                 expect(results.recentReports[4].login).toBe('steverogers@expensify.com');
 
-                //Invisible woman report name has unread message
+                // Invisible woman report name has unread message
                 expect(results.recentReports[5].login).toBe('suestorm@expensify.com');
-        
-                //Mister Sinister report name has IOU debt
+
+                // Mister Sinister report name has IOU debt
                 expect(results.recentReports[7].login).toBe('mistersinister@marauders.com');
 
-                //Spider-Man report name is last report and has unread message
+                // Spider-Man report name is last report and has unread message
                 expect(results.recentReports[8].login).toBe('peterparker@expensify.com');
             }));
 });

--- a/tests/unit/OptionsListUtilsTest.js
+++ b/tests/unit/OptionsListUtilsTest.js
@@ -188,6 +188,28 @@ describe('OptionsListUtils', () => {
             unreadActionCount: 1,
         },
     };
+    
+    const REPORTS_WITH_MORE_PINS = {
+        ...REPORTS,
+        10: {
+            lastVisitedTimestamp: 1610666739302,
+            lastMessageTimestamp: 1,
+            isPinned: true,
+            reportID: 10,
+            participants: ['d_email@email.com'],
+            reportName: 'D report name',
+            unreadActionCount: 0,
+        },
+        11: {
+            lastVisitedTimestamp: 1610666732302,
+            lastMessageTimestamp: 1,
+            isPinned: true,
+            reportID: 11,
+            participants: ['z_email@email.com'],
+            reportName: 'Z Report Name',
+            unreadActionCount: 0,
+        },
+    };
 
     const PERSONAL_DETAILS_WITH_CONCIERGE = {
         ...PERSONAL_DETAILS,
@@ -597,23 +619,42 @@ describe('OptionsListUtils', () => {
         () => Report.setReportWithDraft(1, true)
             .then(() => {
                 // When we call getSidebarOptions() with no search value
-                const results = OptionsListUtils.getSidebarOptions(REPORTS, PERSONAL_DETAILS, 0, CONST.PRIORITY_MODE.GSD);
+                const results = OptionsListUtils.getSidebarOptions(REPORTS_WITH_MORE_PINS, PERSONAL_DETAILS_WITH_MORE_PINS, 0, CONST.PRIORITY_MODE.GSD);
+                //const results = OptionsListUtils.getSidebarOptions(REPORTS_WITH_MORE_PINNED, PERSONAL_DETAILS, 0, CONST.PRIORITY_MODE.GSD);
 
                 // Then expect all of the reports to be shown both multiple and single participant except the
                 // report that has no lastMessageTimestamp and the chat with Thor who's message is read
-                expect(results.recentReports.length).toBe(_.size(REPORTS) - 2);
+                expect(results.recentReports.length).toBe(_.size(REPORTS_WITH_MORE_PINS) - 2);
 
                 // That no personalDetails are shown
                 expect(results.personalDetails.length).toBe(0);
 
-                // And Mister Fantastic is alphabetically the fourth report and has an unread message
-                // despite being pinned
-                expect(results.recentReports[4].login).toBe('reedrichards@expensify.com');
 
-                // And Black Panther is alphabetically the first report and has an unread message
-                expect(results.recentReports[0].login).toBe('tchalla@expensify.com');
+                //------------------- Pinned report---------
+                // Pinned reports always on top regardless of having unread message or not  
+                // and regardless having IOU debt or not
+                // ordered by alphabetical order. 
+                // D report name (Alphabetically first among pinned tabs) 
+                expect(results.recentReports[0].login).toBe('d_email@email');
+        
+                // Mister Fantastic report name (Alphabetically second among pinned tabs) 
+                expect(results.recentReports[1].login).toBe('reedrichards@expensify.com');
 
-                // And Mister Sinister is alphabetically the fifth report and has an IOU debt despite not being pinned
-                expect(results.recentReports[5].login).toBe('mistersinister@marauders.com');
+                // Z report name (Alphabetically third among pinned tabs) 
+                expect(results.recentReports[2].login).toBe('z_email@email');
+
+                //------------ Unpinned reports ------------
+                // Unpinned report name ordered alphabetically after pinned report
+                //Black Panther report name
+                expect(results.recentReports[3].login).toBe('tchalla@expensify.com');
+
+                //Captain America report name
+                expect(results.recentReports[4].login).toBe('steverogers@expensify.com');
+
+                //Invisible woman report name. Has an IOU debt.
+                expect(results.recentReports[5].login).toBe('suestorm@expensify.com');
+
+                //Spider-Man report name is last report
+                expect(results.recentReports[8].login).toBe('peterparker@expensify.com');
             }));
 });

--- a/tests/unit/OptionsListUtilsTest.js
+++ b/tests/unit/OptionsListUtilsTest.js
@@ -191,20 +191,20 @@ describe('OptionsListUtils', () => {
     
     const REPORTS_WITH_MORE_PINS = {
         ...REPORTS,
-        10: {
+        13: {
             lastVisitedTimestamp: 1610666739302,
             lastMessageTimestamp: 1,
             isPinned: true,
-            reportID: 10,
+            reportID: 13,
             participants: ['d_email@email.com'],
             reportName: 'D report name',
             unreadActionCount: 0,
         },
-        11: {
+        14: {
             lastVisitedTimestamp: 1610666732302,
             lastMessageTimestamp: 1,
             isPinned: true,
-            reportID: 11,
+            reportID: 14,
             participants: ['z_email@email.com'],
             reportName: 'Z Report Name',
             unreadActionCount: 0,
@@ -630,30 +630,31 @@ describe('OptionsListUtils', () => {
 
 
                 //------------------- Pinned report---------
-                // Pinned reports always on top regardless of having unread message or not  
-                // and regardless having IOU debt or not
-                // ordered by alphabetical order. 
-                // D report name (Alphabetically first among pinned tabs) 
+                // Pinned reports are always on the top in alphabetical order regardless of whether they are unread or have IOU debt.
+                // D report name (Alphabetically first among pinned reports)  
                 expect(results.recentReports[0].login).toBe('d_email@email.com');
         
-                // Mister Fantastic report name (Alphabetically second among pinned tabs) 
+                // Mister Fantastic report name (Alphabetically second among pinned reports) 
                 expect(results.recentReports[1].login).toBe('reedrichards@expensify.com');
 
-                // Z report name (Alphabetically third among pinned tabs) 
+                // Z report name (Alphabetically third among pinned reports) 
                 expect(results.recentReports[2].login).toBe('z_email@email.com');
 
                 //------------ Unpinned reports ------------
-                // Unpinned report name ordered alphabetically after pinned report
-                //Black Panther report name
+                // Unpinned report name ordered alphabetically after pinned reports
+                //Black Panther report name has unread message
                 expect(results.recentReports[3].login).toBe('tchalla@expensify.com');
 
-                //Captain America report name
+                //Captain America report name has unread message
                 expect(results.recentReports[4].login).toBe('steverogers@expensify.com');
 
-                //Invisible woman report name. Has an IOU debt.
+                //Invisible woman report name has unread message
                 expect(results.recentReports[5].login).toBe('suestorm@expensify.com');
+        
+                //Mister Sinister report name has IOU debt
+                expect(results.recentReports[7].login).toBe('mistersinister@marauders.com');
 
-                //Spider-Man report name is last report
+                //Spider-Man report name is last report and has unread message
                 expect(results.recentReports[8].login).toBe('peterparker@expensify.com');
             }));
 });

--- a/tests/unit/OptionsListUtilsTest.js
+++ b/tests/unit/OptionsListUtilsTest.js
@@ -640,7 +640,6 @@ describe('OptionsListUtils', () => {
                 // Z report name (Alphabetically third among pinned reports) 
                 expect(results.recentReports[2].login).toBe('z_email@email.com');
 
-                //------------ Unpinned reports ------------
                 // Unpinned report name ordered alphabetically after pinned reports
                 //Black Panther report name has unread message
                 expect(results.recentReports[3].login).toBe('tchalla@expensify.com');

--- a/tests/unit/OptionsListUtilsTest.js
+++ b/tests/unit/OptionsListUtilsTest.js
@@ -634,13 +634,13 @@ describe('OptionsListUtils', () => {
                 // and regardless having IOU debt or not
                 // ordered by alphabetical order. 
                 // D report name (Alphabetically first among pinned tabs) 
-                expect(results.recentReports[0].login).toBe('d_email@email');
+                expect(results.recentReports[0].login).toBe('d_email@email.com');
         
                 // Mister Fantastic report name (Alphabetically second among pinned tabs) 
                 expect(results.recentReports[1].login).toBe('reedrichards@expensify.com');
 
                 // Z report name (Alphabetically third among pinned tabs) 
-                expect(results.recentReports[2].login).toBe('z_email@email');
+                expect(results.recentReports[2].login).toBe('z_email@email.com');
 
                 //------------ Unpinned reports ------------
                 // Unpinned report name ordered alphabetically after pinned report

--- a/tests/unit/OptionsListUtilsTest.js
+++ b/tests/unit/OptionsListUtilsTest.js
@@ -628,8 +628,6 @@ describe('OptionsListUtils', () => {
                 // That no personalDetails are shown
                 expect(results.personalDetails.length).toBe(0);
 
-
-                //------------------- Pinned report---------
                 // Pinned reports are always on the top in alphabetical order regardless of whether they are unread or have IOU debt.
                 // D report name (Alphabetically first among pinned reports)  
                 expect(results.recentReports[0].login).toBe('d_email@email.com');

--- a/tests/unit/OptionsListUtilsTest.js
+++ b/tests/unit/OptionsListUtilsTest.js
@@ -619,8 +619,7 @@ describe('OptionsListUtils', () => {
         () => Report.setReportWithDraft(1, true)
             .then(() => {
                 // When we call getSidebarOptions() with no search value
-                const results = OptionsListUtils.getSidebarOptions(REPORTS_WITH_MORE_PINS, PERSONAL_DETAILS_WITH_MORE_PINS, 0, CONST.PRIORITY_MODE.GSD);
-                //const results = OptionsListUtils.getSidebarOptions(REPORTS_WITH_MORE_PINNED, PERSONAL_DETAILS, 0, CONST.PRIORITY_MODE.GSD);
+                const results = OptionsListUtils.getSidebarOptions(REPORTS_WITH_MORE_PINS, PERSONAL_DETAILS, 0, CONST.PRIORITY_MODE.GSD);
 
                 // Then expect all of the reports to be shown both multiple and single participant except the
                 // report that has no lastMessageTimestamp and the chat with Thor who's message is read


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/6563

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$  https://github.com/Expensify/App/issues/6563

### Tests
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->
1. On LHN there must be two or more pinned reports
2. On LHN there must be one or more unpinned unread reports or have outstanding IOU
3. The unread reports name should be between or before the pinned reports ordered alphabetically  
4. Change LHN  mode to focus mode
5. The pinned reports must be on top, alphabetically ordered
6. The unpinned reports that have unread  or outstanding IOU must be bellow pinned reports ordered alphabetically

### QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->
1. On LHN there should be two or more pinned reports
2. On LHN there must be one or more unpinned unread reports or have outstanding IOU
3. The unread report names should be between or before the pinned reports ordered alphabetically  
4. Change LHN  mode to focus mode
5. The pinned reports must be on top, ordered alphabetically
6. The unpinned reports that have unread  or outstanding IOU must be bellow pinned reports ordered alphabetically
### Tested On

- [v] Web
- [v] Mobile Web
- [ ] Desktop
- [ ] iOS
- [v] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->
#### Before
![focus_before](https://user-images.githubusercontent.com/1313124/147111962-76072441-5e2d-4900-8775-d2a43cf2cefd.png)

<br />

### After

#### Web
<!-- Insert screenshots of your changes on the web platform-->
![focus_web](https://user-images.githubusercontent.com/1313124/147111835-20ab0820-7e30-4408-bd1a-211a740cb46e.png)

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
![focus_mobile_web](https://user-images.githubusercontent.com/1313124/147111815-3125f132-f020-4509-aaad-46cd08173f14.png)

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
![focus_anroid_2](https://user-images.githubusercontent.com/1313124/147111738-0b0ec293-6c0c-45c8-bcc3-83c0e9ddd02e.jpg)
