### PR TITLE
Refactor BankAccountSetup using nextStepValues to force Chase manual account numbers

### DIFF
--- a/src/components/AddPlaidBankAccount.js
+++ b/src/components/AddPlaidBankAccount.js
@@ -61,6 +61,9 @@ const propTypes = {
 
             /** Routing number for the account */
             routingNumber: PropTypes.string,
+
+            /** last 4 digits of the account number */
+            mask: PropTypes.string,
         })),
     }),
 

--- a/src/components/AddPlaidBankAccount.js
+++ b/src/components/AddPlaidBankAccount.js
@@ -192,7 +192,7 @@ class AddPlaidBankAccount extends React.Component {
         const accounts = this.getAccounts();
         const token = this.getPlaidLinkToken();
         const options = _.map(accounts, (account, index) => ({
-            value: index, label: `${account.addressName} ${account.accountNumber}`,
+            value: index, label: `${account.addressName} ${account.mask}`,
         }));
         const {icon, iconSize} = getBankIcon(this.state.institution.name);
 

--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -955,7 +955,7 @@ function BankAccount_SetupWithdrawal(parameters) {
         'currentStep', 'policyID', 'bankAccountID', 'useOnfido', 'errorAttemptsCount', 'enableCardAfterVerified',
 
         // data from bankAccount step:
-        'setupType', 'routingNumber', 'accountNumber', 'addressName', 'plaidAccountID', 'ownershipType', 'isSavings',
+        'setupType', 'routingNumber', 'accountNumber', 'addressName', 'plaidAccountID', 'mask', 'ownershipType', 'isSavings',
         'acceptTerms', 'bankName', 'plaidAccessToken', 'alternateRoutingNumber',
 
         // data from company step:

--- a/src/libs/actions/ReimbursementAccount/setupWithdrawalAccount.js
+++ b/src/libs/actions/ReimbursementAccount/setupWithdrawalAccount.js
@@ -103,10 +103,10 @@ function showSetupWithdrawalAccountErrors(response, verificationsError, updatedA
         errors.showBankAccountErrorModal(error, isErrorHTML);
     }
 
-    // Go to next step
-    navigation.goToWithdrawalAccountSetupStep(getNextStep(updatedACHData), {
+    const nextStep = response.jsonCode === 200 && !error ? getNextStep(updatedACHData) : updatedACHData.currentStep;
+    navigation.goToWithdrawalAccountSetupStep(nextStep, {
         ...responseACHData,
-        subStep: hasAccountOrRoutingError(response),
+        subStep: hasAccountOrRoutingError(response) ? CONST.BANK_ACCOUNT.SUBSTEP.MANUAL : responseACHData.subStep,
     });
     Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {loading: false});
 }

--- a/src/libs/actions/ReimbursementAccount/setupWithdrawalAccount.js
+++ b/src/libs/actions/ReimbursementAccount/setupWithdrawalAccount.js
@@ -232,7 +232,7 @@ function setupWithdrawalAccount(params) {
             if (_.has(responseACHData, 'nextStepValues')) {
                 navigation.goToWithdrawalAccountSetupStep(_.get(responseACHData.nextStepValues, 'currentStep') || nextStep, {
                     ...updatedACHData,
-                    ...responseACHData,
+                    ...(_.omit(responseACHData, 'nextStepValues')),
                     ...responseACHData.nextStepValues,
                 });
                 Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {loading: false});

--- a/src/libs/actions/ReimbursementAccount/setupWithdrawalAccount.js
+++ b/src/libs/actions/ReimbursementAccount/setupWithdrawalAccount.js
@@ -231,6 +231,7 @@ function setupWithdrawalAccount(params) {
             // Example 2: When on the requestor step, showing Onfido view after submitting the identity and retrieving the sdkToken
             if (_.has(responseACHData, 'nextStepValues')) {
                 navigation.goToWithdrawalAccountSetupStep(_.get(responseACHData.nextStepValues, 'currentStep') || nextStep, {
+                    ...updatedACHData,
                     ...responseACHData,
                     ...responseACHData.nextStepValues,
                 });
@@ -244,7 +245,8 @@ function setupWithdrawalAccount(params) {
             }
 
             // Go to next step
-            navigation.goToWithdrawalAccountSetupStep(nextStep, responseACHData);
+            // Note: php sometimes returns code 200 with no achData, just to indicate that we should keep whatever the JS values are.
+            navigation.goToWithdrawalAccountSetupStep(nextStep, {...updatedACHData, ...responseACHData});
             Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {loading: false});
         })
         .catch((response) => {

--- a/src/libs/actions/ReimbursementAccount/setupWithdrawalAccount.js
+++ b/src/libs/actions/ReimbursementAccount/setupWithdrawalAccount.js
@@ -1,6 +1,7 @@
 import _ from 'underscore';
 import Onyx from 'react-native-onyx';
 import lodashGet from 'lodash/get';
+import Log from '../../Log';
 import BankAccount from '../../models/BankAccount';
 import * as Plaid from '../Plaid';
 import CONST from '../../../CONST';
@@ -245,8 +246,12 @@ function setupWithdrawalAccount(params) {
             }
 
             // Go to next step
-            // Note: php sometimes returns code 200 with no achData, just to indicate that we should keep whatever the JS values are.
-            navigation.goToWithdrawalAccountSetupStep(nextStep, {...updatedACHData, ...responseACHData});
+            if (_.isEmpty(responseACHData)) {
+                Log.info('[SetupWithdrawalAccount] No achData in response. Navigating to next step based on currently stored values.', 0, {nextStep});
+                navigation.goToWithdrawalAccountSetupStep(nextStep, updatedACHData);
+            } else {
+                navigation.goToWithdrawalAccountSetupStep(nextStep, responseACHData);
+            }
             Onyx.merge(ONYXKEYS.REIMBURSEMENT_ACCOUNT, {loading: false});
         })
         .catch((response) => {

--- a/src/libs/actions/ReimbursementAccount/setupWithdrawalAccount.js
+++ b/src/libs/actions/ReimbursementAccount/setupWithdrawalAccount.js
@@ -226,7 +226,7 @@ function setupWithdrawalAccount(params) {
             const nextStep = getNextStep(updatedACHData);
 
             // Some steps require several substeps based on some data.
-            // This logic is done php side: when we need to display a specific step with specific data, php add them in the response in nextStepValues
+            // This logic is done php side: when we need to display a specific step with specific data, php adds them in the response in nextStepValues
             // Example 1: When forcing manual step after adding Chase bank account via Plaid, so we can ask for the real numbers instead of the plaid substitutes
             // Example 2: When on the requestor step, showing Onfido view after submitting the identity and retrieving the sdkToken
             if (_.has(responseACHData, 'nextStepValues')) {

--- a/src/pages/ReimbursementAccount/BankAccountStep.js
+++ b/src/pages/ReimbursementAccount/BankAccountStep.js
@@ -171,7 +171,7 @@ class BankAccountStep extends React.Component {
         // Disable bank account fields once they've been added in db so they can't be changed
         const isFromPlaid = this.props.achData.setupType === CONST.BANK_ACCOUNT.SETUP_TYPE.PLAID;
         const shouldDisableInputs = Boolean(this.props.achData.bankAccountID) || isFromPlaid;
-        const shouldReinitializePlaidLink = this.props.plaidLinkOAuthToken && this.props.receivedRedirectURI;
+        const shouldReinitializePlaidLink = this.props.plaidLinkOAuthToken && this.props.receivedRedirectURI && this.props.achData.subStep !== 'manual';
         const subStep = shouldReinitializePlaidLink ? CONST.BANK_ACCOUNT.SETUP_TYPE.PLAID : this.props.achData.subStep;
 
         return (

--- a/src/pages/ReimbursementAccount/BankAccountStep.js
+++ b/src/pages/ReimbursementAccount/BankAccountStep.js
@@ -159,6 +159,7 @@ class BankAccountStep extends React.Component {
             isSavings: params.account.isSavings,
             bankName: params.bankName,
             addressName: params.account.addressName,
+            mask: params.account.mask,
 
             // Note: These are hardcoded as we're not supporting AU bank accounts for the free plan
             country: CONST.COUNTRY.US,

--- a/src/pages/ReimbursementAccount/BankAccountStep.js
+++ b/src/pages/ReimbursementAccount/BankAccountStep.js
@@ -172,7 +172,7 @@ class BankAccountStep extends React.Component {
         // Disable bank account fields once they've been added in db so they can't be changed
         const isFromPlaid = this.props.achData.setupType === CONST.BANK_ACCOUNT.SETUP_TYPE.PLAID;
         const shouldDisableInputs = Boolean(this.props.achData.bankAccountID) || isFromPlaid;
-        const shouldReinitializePlaidLink = this.props.plaidLinkOAuthToken && this.props.receivedRedirectURI && this.props.achData.subStep !== 'manual';
+        const shouldReinitializePlaidLink = this.props.plaidLinkOAuthToken && this.props.receivedRedirectURI && this.props.achData.subStep !== CONST.BANK_ACCOUNT.SUBSTEP.MANUAL;
         const subStep = shouldReinitializePlaidLink ? CONST.BANK_ACCOUNT.SETUP_TYPE.PLAID : this.props.achData.subStep;
 
         return (


### PR DESCRIPTION
- [x] HOLD on https://github.com/Expensify/Web-Secure/pull/2121

### Details
Allow to show manual account numbers form after choosing Plaid Oauth Chase accounts, while refactoring using nextStepValues as all the logic moved php side in this PR: https://github.com/Expensify/Web-Secure/pull/2121/files

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/188463

### Tests
Made sure I could add a business bank account via Plaid OAuth Chase, entering account numbers manually.
To test it, pull the web-secure branch `nat-chaseoauth` and then follow https://docs.google.com/document/d/1_E2pxPGzp2UjVOPHqVHUj09dvWyzSYWbBOy8pbsMORc/edit# 

### QA Steps
Add a business bank account using Plaid Chase. Make sure that after you connect to Chase, you're still asked to add your account numbers manually. Make sure you can complete the rest of the flow.

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots

#### Web
![image](https://user-images.githubusercontent.com/2463975/146969932-96da27ab-64b6-43e3-bbdc-9700a5cd3fa0.png)

![image](https://user-images.githubusercontent.com/2463975/146969977-20fc7ded-01e7-465c-8edc-aded0ae0e970.png)
![image](https://user-images.githubusercontent.com/2463975/146970055-a0ffa2c8-299f-404b-8d1a-e7bd5f50c772.png)
![image](https://user-images.githubusercontent.com/2463975/146970098-2de5b835-75da-4d47-a1f2-503b2e90e3d4.png)

![image](https://user-images.githubusercontent.com/2463975/146973281-f04f8f4e-f982-43cb-a8b9-da26e90f8bd6.png)

![image](https://user-images.githubusercontent.com/2463975/147003326-1ebc83aa-79e3-4c35-b334-c78fc5cdc8c2.png)

If you enter a wrong account number (not ending with the mask), you'll see an error
![image](https://user-images.githubusercontent.com/2463975/147006003-b5a6dda0-df5f-459f-a53f-5309b7c1bc65.png)

Make sure you can finish the flow.
![image](https://user-images.githubusercontent.com/2463975/147097027-53f78d66-55e5-4a84-be78-7c4ece7deb05.png)
![image](https://user-images.githubusercontent.com/2463975/147097072-ae684409-aab3-49bc-83d3-255436bbe955.png)
