### PR TITLE
Increase upload size for avatar image

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -9,7 +9,7 @@ const CONST = {
 
     // 50 megabytes in bytes
     API_MAX_ATTACHMENT_SIZE: 52428800,
-    AVATAR_MAX_ATTACHMENT_SIZE: 3145728,
+    AVATAR_MAX_ATTACHMENT_SIZE: 6291456,
     APP_DOWNLOAD_LINKS: {
         ANDROID: `https://play.google.com/store/apps/details?id=${ANDROID_PACKAGE_NAME}`,
         IOS: 'https://apps.apple.com/us/app/expensify-cash/id1530278510',


### PR DESCRIPTION
### Details
For iOS users, the minimum upload size for the avatar image is smaller than the size of the photo a user takes when selecting the `Take a Photo` option, so this PR updates the minimum upload size so users can use this functionality. Once https://github.com/Expensify/App/issues/6301#issuecomment-995173042 is implemented we can come back to this to see if a smaller file size should be required.

### Fixed Issues
$ https://github.com/Expensify/App/issues/6628

### Tests/QA
1. On an iPhone, sign into an account and tap the profile image in the top right
2. On the settings screen, tap the profile image again
3. On the profile screen, tap the profile photo and select `Upload photo` and then `Take photo`
4. Take a photo with the front camera, confirm that you do not get an error message that the photo is over 6MB

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [x] iOS
- [ ] Android

### Screenshots
N/A
