### PR TITLE
Hide Keyboard shortcuts menu in Native Devices

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -123,6 +123,8 @@ const CONST = {
     PLATFORM: {
         IOS: 'ios',
         ANDROID: 'android',
+        WEB: 'web',
+        DESKTOP: 'desktop',
     },
     KEYBOARD_SHORTCUT_MODIFIERS: {
         CTRL: {

--- a/src/libs/getPlatform/index.desktop.js
+++ b/src/libs/getPlatform/index.desktop.js
@@ -1,3 +1,5 @@
+import CONST from '../../CONST';
+
 export default function getPlatform() {
-    return 'desktop';
+    return CONST.PLATFORM.DESKTOP;
 }

--- a/src/libs/getPlatform/index.website.js
+++ b/src/libs/getPlatform/index.website.js
@@ -1,3 +1,5 @@
+import CONST from '../../CONST';
+
 export default function getPlatform() {
-    return 'web';
+    return CONST.PLATFORM.WEB;
 }

--- a/src/pages/settings/AboutPage.js
+++ b/src/pages/settings/AboutPage.js
@@ -11,17 +11,23 @@ import CONST from '../../CONST';
 import * as Expensicons from '../../components/Icon/Expensicons';
 import ScreenWrapper from '../../components/ScreenWrapper';
 import withLocalize, {withLocalizePropTypes} from '../../components/withLocalize';
+import withWindowDimensions, {windowDimensionsPropTypes} from '../../components/withWindowDimensions';
 import MenuItem from '../../components/MenuItem';
 import Logo from '../../../assets/images/new-expensify.svg';
 import {version} from '../../../package.json';
 import * as Report from '../../libs/actions/Report';
 import * as Link from '../../libs/actions/Link';
+import getPlatform from '../../libs/getPlatform/index.website';
+import compose from '../../libs/compose';
 
 const propTypes = {
     ...withLocalizePropTypes,
+    ...windowDimensionsPropTypes,
 };
 
 const AboutPage = (props) => {
+    const shouldShowKeyboardShortcutsMenu = !props.isSmallScreenWidth && [CONST.PLATFORM.WEB, CONST.PLATFORM.DESKTOP].indexOf(getPlatform()) > -1;
+
     const menuItems = [
         {
             translationKey: 'initialSettingsPage.aboutPage.appDownloadLinks',
@@ -30,11 +36,13 @@ const AboutPage = (props) => {
                 Navigation.navigate(ROUTES.SETTINGS_APP_DOWNLOAD_LINKS);
             },
         },
-        {
-            translationKey: 'initialSettingsPage.aboutPage.viewKeyboardShortcuts',
-            icon: Expensicons.Keyboard,
-            action: KeyboardShortcuts.showKeyboardShortcutModal,
-        },
+        ...(shouldShowKeyboardShortcutsMenu ? [
+            {
+                translationKey: 'initialSettingsPage.aboutPage.viewKeyboardShortcuts',
+                icon: Expensicons.Keyboard,
+                action: KeyboardShortcuts.showKeyboardShortcutModal,
+            },
+        ] : []),
         {
             translationKey: 'initialSettingsPage.aboutPage.viewTheCode',
             icon: Expensicons.Eye,
@@ -146,4 +154,7 @@ const AboutPage = (props) => {
 AboutPage.propTypes = propTypes;
 AboutPage.displayName = 'AboutPage';
 
-export default withLocalize(AboutPage);
+export default compose(
+    withLocalize,
+    withWindowDimensions,
+)(AboutPage);

--- a/src/pages/settings/AboutPage/getPlatformSpecificMenuItems/index.js
+++ b/src/pages/settings/AboutPage/getPlatformSpecificMenuItems/index.js
@@ -1,0 +1,15 @@
+import * as KeyboardShortcuts from '../../../../libs/actions/KeyboardShortcuts';
+import * as Expensicons from '../../../../components/Icon/Expensicons';
+
+export default (isSmallScreenWidth) => {
+    if (isSmallScreenWidth) {
+        return [];
+    }
+    return [
+        {
+            translationKey: 'initialSettingsPage.aboutPage.viewKeyboardShortcuts',
+            icon: Expensicons.Keyboard,
+            action: KeyboardShortcuts.showKeyboardShortcutModal,
+        },
+    ];
+};

--- a/src/pages/settings/AboutPage/getPlatformSpecificMenuItems/index.native.js
+++ b/src/pages/settings/AboutPage/getPlatformSpecificMenuItems/index.native.js
@@ -1,0 +1,1 @@
+export default () => [];

--- a/src/pages/settings/AboutPage/index.js
+++ b/src/pages/settings/AboutPage/index.js
@@ -1,24 +1,23 @@
 import _ from 'underscore';
 import React from 'react';
 import {View, ScrollView} from 'react-native';
-import HeaderWithCloseButton from '../../components/HeaderWithCloseButton';
-import Navigation from '../../libs/Navigation/Navigation';
-import * as KeyboardShortcuts from '../../libs/actions/KeyboardShortcuts';
-import ROUTES from '../../ROUTES';
-import styles from '../../styles/styles';
-import ExpensifyText from '../../components/ExpensifyText';
-import CONST from '../../CONST';
-import * as Expensicons from '../../components/Icon/Expensicons';
-import ScreenWrapper from '../../components/ScreenWrapper';
-import withLocalize, {withLocalizePropTypes} from '../../components/withLocalize';
-import withWindowDimensions, {windowDimensionsPropTypes} from '../../components/withWindowDimensions';
-import MenuItem from '../../components/MenuItem';
-import Logo from '../../../assets/images/new-expensify.svg';
-import {version} from '../../../package.json';
-import * as Report from '../../libs/actions/Report';
-import * as Link from '../../libs/actions/Link';
-import getPlatform from '../../libs/getPlatform/index.website';
-import compose from '../../libs/compose';
+import HeaderWithCloseButton from '../../../components/HeaderWithCloseButton';
+import Navigation from '../../../libs/Navigation/Navigation';
+import ROUTES from '../../../ROUTES';
+import styles from '../../../styles/styles';
+import ExpensifyText from '../../../components/ExpensifyText';
+import CONST from '../../../CONST';
+import * as Expensicons from '../../../components/Icon/Expensicons';
+import ScreenWrapper from '../../../components/ScreenWrapper';
+import withLocalize, {withLocalizePropTypes} from '../../../components/withLocalize';
+import withWindowDimensions, {windowDimensionsPropTypes} from '../../../components/withWindowDimensions';
+import MenuItem from '../../../components/MenuItem';
+import Logo from '../../../../assets/images/new-expensify.svg';
+import {version} from '../../../../package.json';
+import * as Report from '../../../libs/actions/Report';
+import * as Link from '../../../libs/actions/Link';
+import getPlatformSpecificMenuItems from './getPlatformSpecificMenuItems';
+import compose from '../../../libs/compose';
 
 const propTypes = {
     ...withLocalizePropTypes,
@@ -26,7 +25,7 @@ const propTypes = {
 };
 
 const AboutPage = (props) => {
-    const shouldShowKeyboardShortcutsMenu = !props.isSmallScreenWidth && [CONST.PLATFORM.WEB, CONST.PLATFORM.DESKTOP].indexOf(getPlatform()) > -1;
+    const platformSpecificMenuItems = getPlatformSpecificMenuItems(props.isSmallScreenWidth);
 
     const menuItems = [
         {
@@ -36,13 +35,7 @@ const AboutPage = (props) => {
                 Navigation.navigate(ROUTES.SETTINGS_APP_DOWNLOAD_LINKS);
             },
         },
-        ...(shouldShowKeyboardShortcutsMenu ? [
-            {
-                translationKey: 'initialSettingsPage.aboutPage.viewKeyboardShortcuts',
-                icon: Expensicons.Keyboard,
-                action: KeyboardShortcuts.showKeyboardShortcutModal,
-            },
-        ] : []),
+        ...platformSpecificMenuItems,
         {
             translationKey: 'initialSettingsPage.aboutPage.viewTheCode',
             icon: Expensicons.Eye,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
- Hide Keyboard shortcuts menu in Native Devices
- Follow up PR to fix issues due to  https://github.com/Expensify/App/issues/6660

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/6879
$ https://github.com/Expensify/App/issues/6660

### Tests
1. Tested the menu visibility on all platforms.
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### QA Steps
1. Launch the app
2. Log in with any account
3. Go to Setting > About
4. You shouldn't see the View Keyboard Shortcuts menu on Mobile Web, iOS and Android App.'

<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
<img width="1204" alt="web-shortcuts-menu" src="https://user-images.githubusercontent.com/57435789/147148569-ca964aea-7f36-44df-aff2-8576634d7e68.png">

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
<img width="330" alt="mweb-shortcuts-menu" src="https://user-images.githubusercontent.com/57435789/147148389-7bf3d3e2-e178-4fff-b7b5-1295ddcdc8cf.png">

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
<img width="380" alt="desktop-shortcuts-menu" src="https://user-images.githubusercontent.com/57435789/147148334-022ea142-7acf-4fe0-aeee-2d6d17f0f92b.png">

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
<img width="336" alt="ios-shortcuts-menu" src="https://user-images.githubusercontent.com/57435789/147148285-082a928a-e8b6-481e-aa72-bdf075e7c047.png">


#### Android
<!-- Insert screenshots of your changes on the Android platform-->
<img width="316" alt="android-shortcuts-menu" src="https://user-images.githubusercontent.com/57435789/147148260-ae5f04ae-8f16-4fc5-a67d-c56c41c82926.png">
