### PR TITLE
fix password input hint stylings

### DIFF
--- a/src/pages/settings/NewPasswordForm.js
+++ b/src/pages/settings/NewPasswordForm.js
@@ -81,8 +81,8 @@ class NewPasswordForm extends React.Component {
                 />
                 <Text
                     style={[
-                        styles.textLabelSupporting,
                         styles.passwordTextHint,
+                        styles.mt1,
                         this.isInvalidPassword() && styles.formError,
                     ]}
                 >

--- a/src/pages/settings/NewPasswordForm.js
+++ b/src/pages/settings/NewPasswordForm.js
@@ -81,7 +81,7 @@ class NewPasswordForm extends React.Component {
                 />
                 <Text
                     style={[
-                        styles.passwordTextHint,
+                        styles.formHelp,
                         styles.mt1,
                         this.isInvalidPassword() && styles.formError,
                     ]}

--- a/src/pages/settings/NewPasswordForm.js
+++ b/src/pages/settings/NewPasswordForm.js
@@ -82,7 +82,7 @@ class NewPasswordForm extends React.Component {
                 <Text
                     style={[
                         styles.textLabelSupporting,
-                        styles.mt1,
+                        styles.passwordTextHint,
                         this.isInvalidPassword() && styles.formError,
                     ]}
                 >

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -2340,7 +2340,7 @@ const styles = {
         backgroundColor: colors.black,
         flex: 1,
     },
-    passwordTextHint: {
+    formHelp: {
         color: themeColors.textSupporting,
         fontSize: variables.fontSizeLabel,
         lineHeight: 18,

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -783,6 +783,13 @@ const styles = {
         marginBottom: 8,
     },
 
+    formHelp: {
+        color: themeColors.textSupporting,
+        fontSize: variables.fontSizeLabel,
+        lineHeight: 18,
+        marginBottom: 4,
+    },
+
     formError: {
         color: themeColors.textError,
         fontSize: variables.fontSizeLabel,
@@ -2339,12 +2346,6 @@ const styles = {
     iPhoneXSafeArea: {
         backgroundColor: colors.black,
         flex: 1,
-    },
-    formHelp: {
-        color: themeColors.textSupporting,
-        fontSize: variables.fontSizeLabel,
-        lineHeight: 18,
-        marginBottom: 4,
     },
 };
 

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -2341,9 +2341,10 @@ const styles = {
         flex: 1,
     },
     passwordTextHint: {
+        color: themeColors.textSupporting,
+        fontSize: variables.fontSizeLabel,
         lineHeight: 18,
         marginBottom: 4,
-        marginTop: 4,
     },
 };
 

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -2340,6 +2340,11 @@ const styles = {
         backgroundColor: colors.black,
         flex: 1,
     },
+    passwordTextHint: {
+        lineHeight: 18,
+        marginBottom: 4,
+        marginTop: 4,
+    },
 };
 
 export default styles;


### PR DESCRIPTION
### Details
Harmonises stylings of hint text when in neutral and error state 

### Fixed Issues
$ https://github.com/Expensify/App/issues/6825

### QA Steps

1. Create a new account
2. Click link in email
3. Enter asdfasdF
4. Remove focus from input
5. See hint text changes to red and shows an error
6. Click back into the password input and enter 1
7. See hint text changes back to grey stylings, but it doesn't shift

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web
https://user-images.githubusercontent.com/47184118/147495533-b04cccff-e35d-4ddc-a1bb-6288bff6527e.mp4

#### Mobile Web
https://user-images.githubusercontent.com/47184118/147495951-6dd4cc1e-8400-4dbc-84dc-da16f39f8d64.mp4

#### Desktop
https://user-images.githubusercontent.com/47184118/147496396-d9f08183-c67c-4580-84ba-9f1553b3b48a.mov

#### iOS
https://user-images.githubusercontent.com/47184118/147772828-2ca959d8-28cd-4172-b572-7121b712649b.mov

#### Android

https://user-images.githubusercontent.com/47184118/147614695-11868036-d8ae-4b73-9e4b-5a0777ba659f.mov
