### PR TITLE
Update react-native-bootsplash to 3.2.7

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -506,7 +506,7 @@ PODS:
     - React-perflogger (= 0.64.1)
   - rn-fetch-blob (0.12.0):
     - React-Core
-  - RNBootSplash (3.2.6):
+  - RNBootSplash (3.2.7):
     - React-Core
   - RNCAsyncStorage (1.15.5):
     - React-Core
@@ -850,7 +850,7 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 7b423f9e248eae65987838148c36eec1dbfe0b53
-  FBReactNativeSpec: 9f813f735901d719751da82f0365b5c506c28f14
+  FBReactNativeSpec: f5187ed83c38ec2fb4634140a81c0019adcd9cb3
   Firebase: 54cdc8bc9c9b3de54f43dab86e62f5a76b47034f
   FirebaseABTesting: c3e48ebf5e7e5c674c5a131c68e941d7921d83dc
   FirebaseAnalytics: 4751d6a49598a2b58da678cc07df696bcd809ab9
@@ -920,7 +920,7 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: ff951a0c241bfaefc4940a3f1f1a229e7cb32fa6
   ReactCommon: bedc99ed4dae329c4fcf128d0c31b9115e5365ca
   rn-fetch-blob: f065bb7ab7fb48dd002629f8bdcb0336602d3cba
-  RNBootSplash: 00f99e3c05fb44af3613e6088406de4be0a8eca3
+  RNBootSplash: b82ee16a943903ea612edb15233ea4f247155ef9
   RNCAsyncStorage: 8324611026e8dc3706f829953aa6e3899f581589
   RNCClipboard: 5e299c6df8e0c98f3d7416b86ae563d3a9f768a3
   RNCMaskedView: 138134c4d8a9421b4f2bf39055a79aa05c2d47b1

--- a/package-lock.json
+++ b/package-lock.json
@@ -36593,9 +36593,9 @@
       }
     },
     "react-native-bootsplash": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/react-native-bootsplash/-/react-native-bootsplash-3.2.6.tgz",
-      "integrity": "sha512-zNEXIe2K1A06J45QOAg+OBo3wIyId9lZXOwITUcwNR2bQEg/3CO6uvcRB7MLuy2ct54R1PlbADHDZK/Ozt7mfA==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/react-native-bootsplash/-/react-native-bootsplash-3.2.7.tgz",
+      "integrity": "sha512-jc46lBuKeZerdUndY0yJw2mIbvX0kMHpkKsayxqJfjCiMorklSPZt0dyvaM9KyebCVop54udMJAySbnZVCEvIQ==",
       "requires": {
         "chalk": "^4.1.2",
         "fs-extra": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "react-collapse": "^5.1.0",
     "react-dom": "^17.0.2",
     "react-native": "0.64.1",
-    "react-native-bootsplash": "^3.2.6",
+    "react-native-bootsplash": "^3.2.7",
     "react-native-collapsible": "^1.6.0",
     "react-native-config": "^1.4.0",
     "react-native-document-picker": "^5.1.0",


### PR DESCRIPTION
Following https://github.com/Expensify/App/issues/5620

### Details

Update `react-native-bootsplash` module to `3.2.7` in order to apply these changes: https://github.com/Expensify/App/issues/5620#issuecomment-1002556568
This update doesn't affect Android (no changes).

### Fixed Issues

https://github.com/Expensify/App/issues/5620 (maybe? reproduction steps are not known)

### Tests

### QA Steps

- Starts the app on iOS, check if the splash screen is visible then disappear
- Retry by starting the app using a push notification
- Retry by putting the app on background before the app init, then put the app on foreground again

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [x] iOS
- [ ] Android

### Screenshots

#### iOS

<img src="https://user-images.githubusercontent.com/1902323/143475115-36c7bb6a-7fa3-47c5-b105-545680b9d71f.png" width="400" />