### PR TITLE
Remove whiteSpace rule for optionDisplayName

### DIFF
--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1100,7 +1100,6 @@ const styles = {
         fontFamily: fontFamily.GTA,
         height: 20,
         lineHeight: 20,
-        ...whiteSpace.noWrap,
     },
 
     optionDisplayNameCompact: {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
On the web, an ellipsis is not shown if the contacts do not fit.

### Fixed Issues

$ https://github.com/Expensify/App/issues/6913

### Tests | QA Steps

1. Open app
2. Create a group with multiple contacts
3. Check LHN for the group with multiple contacts, it should show an ellipsis if the names don't fit
4. Create a contact with a long email to check it also shows an ellipsis at the end
5. Check in the search page the same behavior as LHN 

Expected result: You should see the ellipsis for all cases above.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android

### Screenshots

#### Web
<img width="1792" alt="Screen Shot 2021-12-31 at 11 59 05 AM" src="https://user-images.githubusercontent.com/47149004/147829855-82a31c64-11c1-4e38-a3c2-ac62f17be26d.png">

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
