### PR TITLE
Fix ellipsis in DisplayNames - 2

### DIFF
--- a/src/components/DisplayNames/index.js
+++ b/src/components/DisplayNames/index.js
@@ -84,7 +84,7 @@ class DisplayNames extends PureComponent {
 
             // Tokenization of string only support 1 numberOfLines on Web
             <Text
-                style={[...this.props.textStyles, styles.pRelative]}
+                style={[...this.props.textStyles, styles.pRelative, {display: 'inline-block'}, styles.noWrap]}
                 onLayout={this.setContainerLayout}
                 numberOfLines={1}
                 ref={el => this.containerRef = el}

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1100,7 +1100,6 @@ const styles = {
         fontFamily: fontFamily.GTA,
         height: 20,
         lineHeight: 20,
-        ...whiteSpace.noWrap,
     },
 
     optionDisplayNameCompact: {


### PR DESCRIPTION
### Details

Add `display: inline-block` in web to make ellipsis work.

### Fixed Issues

$ https://github.com/Expensify/App/issues/6913

### Tests | QA Steps

1. Open app
2. Create a group with multiple contacts
3. Check LHN for the group with multiple contacts, it should show an ellipsis if the names don't fit
4. Create a contact with a long email to check it also shows an ellipsis at the end
5. Check in the search page the same behavior as LHN 

Expected result: You should see the ellipsis for all cases above.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web

![image](https://user-images.githubusercontent.com/47149004/147839371-48fda310-0f68-41df-821c-5d9c52c1c533.png)

#### Mobile Web
Chrome Android 

<img width="453" alt="Screen Shot 2022-01-03 at 7 18 09 PM" src="https://user-images.githubusercontent.com/47149004/147986723-6739b27d-894e-4e89-a7a9-84195fd45a1a.png">
<img width="453" alt="Screen Shot 2022-01-03 at 7 17 52 PM" src="https://user-images.githubusercontent.com/47149004/147986728-f0595060-1d4e-4fd4-a581-4395d431a20d.png">
<img width="453" alt="Screen Shot 2022-01-03 at 7 17 30 PM" src="https://user-images.githubusercontent.com/47149004/147986730-b13c1f38-0cbe-4c25-bda7-93ef4d213b68.png">

Safari IOS

<img width="439" alt="Screen Shot 2022-01-03 at 7 47 52 PM" src="https://user-images.githubusercontent.com/47149004/147988732-512c68bb-657e-4413-bcc4-c3979359be1e.png">
<img width="439" alt="Screen Shot 2022-01-03 at 7 47 46 PM" src="https://user-images.githubusercontent.com/47149004/147988735-94190b1b-904e-4ea9-a42c-74f124b1ea7a.png">
<img width="439" alt="Screen Shot 2022-01-03 at 7 47 42 PM" src="https://user-images.githubusercontent.com/47149004/147988737-bee0ff6b-40ce-40b1-bd62-e06e91385d82.png">


#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
<img width="1207" alt="Screen Shot 2022-01-03 at 7 30 23 PM" src="https://user-images.githubusercontent.com/47149004/147987423-13c5e5dd-d033-43bd-b196-0b32869bbce5.png">
<img width="1207" alt="Screen Shot 2022-01-03 at 7 30 17 PM" src="https://user-images.githubusercontent.com/47149004/147987426-6879b300-c576-4d93-aa5f-320f286ab262.png">
<img width="1207" alt="Screen Shot 2022-01-03 at 7 30 11 PM" src="https://user-images.githubusercontent.com/47149004/147987428-0218c1b2-e5e3-4cd7-bdaa-efb27e9c1335.png">


#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
<img width="439" alt="Screen Shot 2022-01-03 at 7 45 21 PM" src="https://user-images.githubusercontent.com/47149004/147988523-38ff8228-f94e-425f-95f8-9112ca6d63e9.png">
<img width="439" alt="Screen Shot 2022-01-03 at 7 45 14 PM" src="https://user-images.githubusercontent.com/47149004/147988530-8374671d-ded7-4638-a261-cf64aa1f5ce6.png">
<img width="439" alt="Screen Shot 2022-01-03 at 7 45 08 PM" src="https://user-images.githubusercontent.com/47149004/147988533-d3fe6143-7188-48d4-9569-c9bb4125e2a5.png">


#### Android
<!-- Insert screenshots of your changes on the Android platform-->
![Screenshot_20220103-193913](https://user-images.githubusercontent.com/47149004/147988158-bb92fc16-2535-424d-86f4-33482a9032ca.png)
![Screenshot_20220103-193922](https://user-images.githubusercontent.com/47149004/147988160-5778b2ea-846b-4e43-bad5-228f6aa3f015.png)
![Screenshot_20220103-193931](https://user-images.githubusercontent.com/47149004/147988161-60cd52b2-702b-45a2-9b2a-689eae14d080.png)
