### PR TITLE
Allow App to Navigate to Last Visited Room On visiting with HOME url

### DIFF
--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -1267,11 +1267,6 @@ function updateLastReadActionID(reportID, sequenceNumber) {
     // (sequenceNumber - 1) || reportMaxSequenceNumbers[reportID] because the first expression results in 0 which is falsy.
     const lastReadSequenceNumber = _.isNumber(sequenceNumber) ? (sequenceNumber - 1) : reportMaxSequenceNumbers[reportID];
 
-    // We call this method in many cases where there's nothing to update because we already updated it, so we avoid
-    // doing an unnecessary server call if the last read is the same one we had already
-    if (lastReadSequenceNumbers[reportID] === lastReadSequenceNumber) {
-        return;
-    }
     setLocalLastRead(reportID, lastReadSequenceNumber);
 
     // Mark the report as not having any unread items

--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -140,7 +140,7 @@ class ReportActionsView extends React.Component {
             if (!ReportActionComposeFocusManager.isFocused()) {
                 return;
             }
-            ReportScrollManager.scrollToBottom()
+            ReportScrollManager.scrollToBottom();
         });
 
         this.updateUnreadIndicatorPosition(this.props.report.unreadActionCount);
@@ -210,7 +210,7 @@ class ReportActionsView extends React.Component {
             // leave the user positioned where they are now in the list.
             const lastAction = CollectionUtils.lastItem(this.props.reportActions);
             if (lastAction && (lastAction.actorEmail === this.props.session.email)) {
-                ReportScrollManager.scrollToBottom()
+                ReportScrollManager.scrollToBottom();
             }
 
             if (lodashGet(lastAction, 'actorEmail', '') !== lodashGet(this.props.session, 'email', '')) {

--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -310,7 +310,6 @@ class ReportActionsView extends React.Component {
         return Math.ceil(availableHeight / minimumReportActionHeight);
     }
 
-
     /**
      * Updates and sorts the report actions by sequence number
      *
@@ -379,7 +378,7 @@ class ReportActionsView extends React.Component {
      * items have been rendered. If the number of actions has changed since it was last rendered, then
      * scroll the list to the end. As a report can contain non-message actions, we should confirm that list data exists.
      */
-    scrollToBottomAndUpdateLastRead(){
+    scrollToBottomAndUpdateLastRead() {
         ReportScrollManager.scrollToBottom();
         Report.updateLastReadActionID(this.props.reportID);
     }
@@ -395,7 +394,6 @@ class ReportActionsView extends React.Component {
         const oldestUnreadSequenceNumber = unreadActionCount === 0 ? 0 : Report.getLastReadSequenceNumber(this.props.report.reportID) + 1;
         Report.setNewMarkerPosition(this.props.reportID, oldestUnreadSequenceNumber);
     }
-
 
     /**
      * Show/hide the new MarkerBadge when user is scrolling back/forth in the history of messages.

--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -101,7 +101,7 @@ class ReportActionsView extends React.Component {
 
         this.renderItem = this.renderItem.bind(this);
         this.renderCell = this.renderCell.bind(this);
-        this.scrollToListBottom = this.scrollToListBottom.bind(this);
+        this.scrollToBottomAndUpdateLastRead = this.scrollToBottomAndUpdateLastRead.bind(this);
         this.onVisibilityChange = this.onVisibilityChange.bind(this);
         this.recordTimeToMeasureItemLayout = this.recordTimeToMeasureItemLayout.bind(this);
         this.loadMoreChats = this.loadMoreChats.bind(this);
@@ -140,8 +140,7 @@ class ReportActionsView extends React.Component {
             if (!ReportActionComposeFocusManager.isFocused()) {
                 return;
             }
-
-            this.scrollToListBottom();
+            ReportScrollManager.scrollToBottom()
         });
 
         this.updateUnreadIndicatorPosition(this.props.report.unreadActionCount);
@@ -211,7 +210,7 @@ class ReportActionsView extends React.Component {
             // leave the user positioned where they are now in the list.
             const lastAction = CollectionUtils.lastItem(this.props.reportActions);
             if (lastAction && (lastAction.actorEmail === this.props.session.email)) {
-                this.scrollToListBottom();
+                ReportScrollManager.scrollToBottom()
             }
 
             if (lodashGet(lastAction, 'actorEmail', '') !== lodashGet(this.props.session, 'email', '')) {
@@ -380,7 +379,7 @@ class ReportActionsView extends React.Component {
      * items have been rendered. If the number of actions has changed since it was last rendered, then
      * scroll the list to the end. As a report can contain non-message actions, we should confirm that list data exists.
      */
-    scrollToListBottom() {
+    scrollToBottomAndUpdateLastRead(){
         ReportScrollManager.scrollToBottom();
         Report.updateLastReadActionID(this.props.reportID);
     }
@@ -557,7 +556,7 @@ class ReportActionsView extends React.Component {
                 <MarkerBadge
                     active={this.state.isMarkerActive}
                     count={this.state.localUnreadActionCount}
-                    onClick={this.scrollToListBottom}
+                    onClick={this.scrollToBottomAndUpdateLastRead}
                     onClose={this.hideMarker}
                 />
                 <InvertedFlatList


### PR DESCRIPTION
Fixing navigate to last visited room feature when user access App using HOME url
If onyx local data is exist, App will navigate to last visited room on that device.
If onyx is not exist in the device, App will use server data, hence will open last visited room by other device.

<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
1. Revert change on https://github.com/Expensify/App/pull/4078 because this feature (navigate to last visited room)  depend on `lastVisitedTimestamp` and it is set by `updateLastReadActionID`. [Instructed]
2. Remove unnecessary `updateLastReadActionID` on create new message [Instructed]
3. Remove `updateLastReadActionID` on `keyboardDidShow` ( not instructed. I have tested it on android: `updateLastReadActionID` is being called each time user open keyboard. if user open a room `updateLastReadActionID` is called automatically. When he is on top scroll (for example reading old message) then new message coming, `updateLastReadActionID` is also called (If `updateLastReadActionID` not called here, then `updateLastReadActionID` is necessary when he open keyboard). So this `updateLastReadActionID` when keyboard open up is unnecessary.



### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/6474

### Tests
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->
1. Open web new expensify
2. Navigate between rooms. Remember last time visited room.
3. Close tab
4. Open web new expensify on new tab with HOME url
5. App should navigate tor last visited room
############
6. Create new  message
7. When creating new message, API `Report_UpdateLastRead` is called only twice. (on developer tools)
############
8. On android When keyboard show up on report action view, `Report_UpdateLastRead` is not called unnecesarrily.


### QA Steps
<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

1. Open web new expensify
2. Navigate between rooms. Remember last time visited room.
3. Close tab
4. Open web new expensify on new tab with HOME url
5. App should navigate tor last visited room
###############
6.  All scenarios should be tested when messages are marked read. When we switch between reports, When we resize the window on Desktop from mobile to Web, etc...
 ############
7. Create new  message
8. When creating new message, API `Report_UpdateLastRead` is called only twice. (on developer tools)
############
9. On android When keyboard show up on report action view, `Report_UpdateLastRead` is not called unnecessarily.

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

https://user-images.githubusercontent.com/1313124/147898891-5c10e9df-3f67-434b-a1dc-7bbdfb41f82a.mp4


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
