### PR TITLE
fix: Add trim to searchValue in OptionsUtils

### DIFF
--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -583,7 +583,7 @@ function getSearchOptions(
 ) {
     return getOptions(reports, personalDetails, 0, {
         betas,
-        searchValue,
+        searchValue: searchValue.trim(),
         includeRecentReports: true,
         includeMultipleParticipantReports: true,
         maxRecentReportsToShow: 0, // Unlimited
@@ -652,7 +652,7 @@ function getNewChatOptions(
 ) {
     return getOptions(reports, personalDetails, 0, {
         betas,
-        searchValue,
+        searchValue: searchValue.trim(),
         selectedOptions,
         excludeDefaultRooms: true,
         includeRecentReports: true,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
- Added `trim()` for `OptionsUtils` so that leading/trailing spaces can be ignored when making the search calls.

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/6907

### Tests
1. Tested the search with leading/trailing spaces for the input
2. Ensured the input doesn't change automatically

<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### QA Steps
1. Click the Profile image to open settings
2. Navigate to any Workspaces
3. Go to Members >Manage Members
4. Invite any email with leading/trailing spaces
5. Ensure the search shows the result.

<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
<img width="393" alt="web-options-space-trim" src="https://user-images.githubusercontent.com/3069065/147981870-94d06dd0-06df-448a-b917-410c402f8e64.png">

**New Email Search**
<img width="400" alt="web-new-email-options-search" src="https://user-images.githubusercontent.com/3069065/147983989-45dfd645-72f6-4784-bf41-7125542a5b0d.png">


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
<img width="339" alt="mweb-options-space-trim" src="https://user-images.githubusercontent.com/3069065/147981888-9e8c93a4-973b-4d92-a3f6-20d57ad4ae25.png">

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
<img width="389" alt="desktop-options-space-trim" src="https://user-images.githubusercontent.com/3069065/147981906-a3e81f6f-97b9-49e1-8df8-4d00523f5047.png">

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
<img width="349" alt="ios-options-space-trim" src="https://user-images.githubusercontent.com/3069065/147982863-9c9d8156-ee92-4f14-8811-953069d59efd.png">

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
<img width="317" alt="android-options-space-trim" src="https://user-images.githubusercontent.com/3069065/147982877-4a39f244-817c-4574-80a0-ad264f066104.png">

