### PR TITLE
Check for non-blocked status when determining isMergeable

### DIFF
--- a/.github/actions/isPullRequestMergeable/index.js
+++ b/.github/actions/isPullRequestMergeable/index.js
@@ -37,15 +37,15 @@ const run = function () {
                     return;
                 }
 
-                if (_.isNull(data.mergeable_state)) {
+                if (_.isEmpty(data.mergeable_state)) {
                     console.log('Pull request mergeable_state is not yet resolved...');
                     retryCount++;
                     return;
                 }
 
                 mergeabilityResolved = true;
-                console.log(`Merge information for #${pullRequestNumber} - mergeable: ${data.mergeable}, mergeable_state ${data.mergeable_state}`);
-                isMergeable = data.mergeable && data.mergeable_state !== 'BLOCKED';
+                console.log(`Merge information for #${pullRequestNumber} - mergeable: ${data.mergeable}, mergeable_state: ${data.mergeable_state}`);
+                isMergeable = data.mergeable && data.mergeable_state.toUpperCase() !== 'BLOCKED';
             })
             .catch((githubError) => {
                 mergeabilityResolved = true;

--- a/.github/actions/isPullRequestMergeable/index.js
+++ b/.github/actions/isPullRequestMergeable/index.js
@@ -45,7 +45,7 @@ const run = function () {
 
                 mergeabilityResolved = true;
                 console.log(`Merge information for #${pullRequestNumber} - mergeable: ${data.mergeable}, mergeable_state ${data.mergeable_state}`);
-                isMergeable = data.mergeable && data.mergeable_state === 'CLEAN';
+                isMergeable = data.mergeable && data.mergeable_state !== 'BLOCKED';
             })
             .catch((githubError) => {
                 mergeabilityResolved = true;

--- a/.github/actions/isPullRequestMergeable/index.js
+++ b/.github/actions/isPullRequestMergeable/index.js
@@ -37,8 +37,15 @@ const run = function () {
                     return;
                 }
 
+                if (_.isNull(data.mergeable_state)) {
+                    console.log('Pull request mergeable_state is not yet resolved...');
+                    retryCount++;
+                    return;
+                }
+
                 mergeabilityResolved = true;
-                isMergeable = data.mergeable;
+                console.log(`Merge information for #${pullRequestNumber} - mergeable: ${data.mergeable}, mergeable_state ${data.mergeable_state}`);
+                isMergeable = data.mergeable && data.mergeable_state === 'CLEAN';
             })
             .catch((githubError) => {
                 mergeabilityResolved = true;

--- a/.github/actions/isPullRequestMergeable/isPullRequestMergeable.js
+++ b/.github/actions/isPullRequestMergeable/isPullRequestMergeable.js
@@ -35,7 +35,7 @@ const run = function () {
 
                 mergeabilityResolved = true;
                 console.log(`Merge information for #${pullRequestNumber} - mergeable: ${data.mergeable}, mergeable_state ${data.mergeable_state}`);
-                isMergeable = data.mergeable && data.mergeable_state === 'CLEAN';
+                isMergeable = data.mergeable && data.mergeable_state !== 'BLOCKED';
             })
             .catch((githubError) => {
                 mergeabilityResolved = true;

--- a/.github/actions/isPullRequestMergeable/isPullRequestMergeable.js
+++ b/.github/actions/isPullRequestMergeable/isPullRequestMergeable.js
@@ -27,8 +27,15 @@ const run = function () {
                     return;
                 }
 
+                if (_.isNull(data.mergeable_state)) {
+                    console.log('Pull request mergeable_state is not yet resolved...');
+                    retryCount++;
+                    return;
+                }
+
                 mergeabilityResolved = true;
-                isMergeable = data.mergeable;
+                console.log(`Merge information for #${pullRequestNumber} - mergeable: ${data.mergeable}, mergeable_state ${data.mergeable_state}`);
+                isMergeable = data.mergeable && data.mergeable_state === 'CLEAN';
             })
             .catch((githubError) => {
                 mergeabilityResolved = true;

--- a/.github/actions/isPullRequestMergeable/isPullRequestMergeable.js
+++ b/.github/actions/isPullRequestMergeable/isPullRequestMergeable.js
@@ -27,7 +27,7 @@ const run = function () {
                     return;
                 }
 
-                if (_.isNull(data.mergeable_state)) {
+                if (_.isEmpty(data.mergeable_state)) {
                     console.log('Pull request mergeable_state is not yet resolved...');
                     retryCount++;
                     return;

--- a/.github/actions/isPullRequestMergeable/isPullRequestMergeable.js
+++ b/.github/actions/isPullRequestMergeable/isPullRequestMergeable.js
@@ -35,7 +35,7 @@ const run = function () {
 
                 mergeabilityResolved = true;
                 console.log(`Merge information for #${pullRequestNumber} - mergeable: ${data.mergeable}, mergeable_state ${data.mergeable_state}`);
-                isMergeable = data.mergeable && data.mergeable_state !== 'BLOCKED';
+                isMergeable = data.mergeable && data.mergeable_state.toUpperCase() !== 'BLOCKED';
             })
             .catch((githubError) => {
                 mergeabilityResolved = true;

--- a/.github/actions/isPullRequestMergeable/isPullRequestMergeable.js
+++ b/.github/actions/isPullRequestMergeable/isPullRequestMergeable.js
@@ -34,7 +34,7 @@ const run = function () {
                 }
 
                 mergeabilityResolved = true;
-                console.log(`Merge information for #${pullRequestNumber} - mergeable: ${data.mergeable}, mergeable_state ${data.mergeable_state}`);
+                console.log(`Merge information for #${pullRequestNumber} - mergeable: ${data.mergeable}, mergeable_state: ${data.mergeable_state}`);
                 isMergeable = data.mergeable && data.mergeable_state.toUpperCase() !== 'BLOCKED';
             })
             .catch((githubError) => {

--- a/tests/unit/isPullRequestMergeableTest.js
+++ b/tests/unit/isPullRequestMergeableTest.js
@@ -46,14 +46,14 @@ afterAll(() => {
 
 describe('isPullRequestMergeable', () => {
     test('Pull request immediately mergeable', () => {
-        mockGetPullRequest.mockResolvedValue({data: {mergeable: true}});
+        mockGetPullRequest.mockResolvedValue({data: {mergeable: true, mergeable_state: 'CLEAN'}});
         return run().then(() => {
             expect(mockSetOutput).toHaveBeenCalledWith('IS_MERGEABLE', true);
         });
     });
 
     test('Pull request immediately not mergeable', () => {
-        mockGetPullRequest.mockResolvedValue({data: {mergeable: false}});
+        mockGetPullRequest.mockResolvedValue({data: {mergeable: false, mergeable_state: 'BLOCKED'}});
         return run().then(() => {
             expect(mockSetOutput).toHaveBeenCalledWith('IS_MERGEABLE', false);
         });
@@ -61,7 +61,7 @@ describe('isPullRequestMergeable', () => {
 
     test('Pull request mergeable after delay', () => {
         mockGetPullRequest
-            .mockResolvedValue({data: {mergeable: true}})
+            .mockResolvedValue({data: {mergeable: true, mergeable_state: 'CLEAN'}})
             .mockResolvedValueOnce({data: {mergeable: null}})
             .mockResolvedValueOnce({data: {mergeable: null}});
         return run().then(() => {
@@ -72,7 +72,7 @@ describe('isPullRequestMergeable', () => {
 
     test('Pull request not mergeable after delay', () => {
         mockGetPullRequest
-            .mockResolvedValue({data: {mergeable: false}})
+            .mockResolvedValue({data: {mergeable: false, mergeable_state: 'BLOCKED'}})
             .mockResolvedValueOnce({data: {mergeable: null}})
             .mockResolvedValueOnce({data: {mergeable: null}});
         return run().then(() => {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Adds a check for the `mergeable_state` of a PR to make sure it is not `BLOCKED`. This is the state that a PR can get in with unverified commits, messing up the deploy process.

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/Expensify/issues/190589

### Tests
1. I verified that PRs that are not able to be auto-merged if they are not in the [`mergeable_state` of `"clean", "has_hooks", "unknown", "unstable"`](https://github.com/pascalgn/automerge-action/blob/main/lib/merge.js#L5), so this will prevent auto-merge from silently failing in the `BLOCKED` state

![](https://user-images.githubusercontent.com/2838819/147990557-7ec27d01-87b2-41d5-abcb-1a15fdc81da5.png)

### QA Steps
N/A