### PR TITLE
fix: Hide Copy to clipboard for IOU comments

### DIFF
--- a/src/pages/home/report/ContextMenu/ContextMenuActions.js
+++ b/src/pages/home/report/ContextMenu/ContextMenuActions.js
@@ -7,6 +7,7 @@ import Clipboard from '../../../../libs/Clipboard';
 import * as ReportUtils from '../../../../libs/reportUtils';
 import ReportActionComposeFocusManager from '../../../../libs/ReportActionComposeFocusManager';
 import {hideContextMenu, showDeleteModal} from './ReportActionContextMenu';
+import CONST from '../../../../CONST';
 
 /**
  * Gets the HTML version of the message in an action.
@@ -41,7 +42,7 @@ export default [
         icon: Expensicons.Clipboard,
         successTextTranslateKey: 'reportActionContextMenu.copied',
         successIcon: Expensicons.Checkmark,
-        shouldShow: type => type === CONTEXT_MENU_TYPES.REPORT_ACTION,
+        shouldShow: (type, reportAction) => (type === CONTEXT_MENU_TYPES.REPORT_ACTION && reportAction.actionName !== CONST.REPORT.ACTIONS.TYPE.IOU),
 
         // If return value is true, we switch the `text` and `icon` on
         // `ContextMenuItem` with `successText` and `successIcon` which will fallback to


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
- Hide `Copy to clipboard` action for IOU transactions

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/7009

### Tests
1. Tested for all IOU transactions (self and the other party)
<!--- 
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### QA Steps
1. Go to any chat list with IOU transactions
2. Right-click on Web/Desktop (and long press on mobile) on any IOU transaction
3. Copy to clipboard shouldn't show up.

<!--- 
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image 
--->

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
<img width="1070" alt="web-iou-hide-copy-to-clipboard" src="https://user-images.githubusercontent.com/3069065/148294019-57478cf4-0aee-4c7b-b89c-4949ab86a6a1.png">

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
<img width="352" alt="mweb-iou-hide-copy-to-clipboard" src="https://user-images.githubusercontent.com/3069065/148294047-f7256b7f-6c16-471b-ae58-ab15593b9182.png">

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
<img width="909" alt="desktop-iou-hide-copy-to-clipboard" src="https://user-images.githubusercontent.com/3069065/148294061-3a6d92e1-f6cb-44d7-90d9-f06046ed0895.png">

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
<img width="349" alt="ios-iou-hide-copy-to-clipboard" src="https://user-images.githubusercontent.com/3069065/148294093-67b2e252-6912-442b-a1fd-dc00a3b4930c.png">

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
<img width="306" alt="android-iou-hide-copy-to-clipboard" src="https://user-images.githubusercontent.com/3069065/148294112-ecf16d25-7e01-4e9c-a351-03905d302924.png">

