### PR TITLE
Make About footer links accessible

### DIFF
--- a/src/pages/settings/AboutPage/index.js
+++ b/src/pages/settings/AboutPage/index.js
@@ -116,8 +116,9 @@ const AboutPage = (props) => {
                         )}
                         {' '}
                         <Text
+                            accessibilityRole="link"
                             style={[styles.textMicroSupporting, styles.link]}
-                            href={CONST.TERMS_URL}
+                            onPress={() => Link.openExternalLink(CONST.TERMS_URL)}
                         >
                             {props.translate(
                                 'initialSettingsPage.readTheTermsAndPrivacyPolicy.phrase2',
@@ -129,8 +130,9 @@ const AboutPage = (props) => {
                         )}
                         {' '}
                         <Text
+                            accessibilityRole="link"
                             style={[styles.textMicroSupporting, styles.link]}
-                            href={CONST.PRIVACY_URL}
+                            onPress={() => Link.openExternalLink(CONST.PRIVACY_URL)}
                         >
                             {props.translate(
                                 'initialSettingsPage.readTheTermsAndPrivacyPolicy.phrase4',

--- a/src/pages/settings/AboutPage/index.js
+++ b/src/pages/settings/AboutPage/index.js
@@ -116,8 +116,8 @@ const AboutPage = (props) => {
                         )}
                         {' '}
                         <Text
-                            style={[styles.chatItemMessageHeaderTimestamp, styles.link]}
-                            onPress={() => Link.openExternalLink(CONST.TERMS_URL)}
+                            style={[styles.textMicroSupporting, styles.link]}
+                            href={CONST.TERMS_URL}
                         >
                             {props.translate(
                                 'initialSettingsPage.readTheTermsAndPrivacyPolicy.phrase2',
@@ -129,8 +129,8 @@ const AboutPage = (props) => {
                         )}
                         {' '}
                         <Text
-                            style={[styles.chatItemMessageHeaderTimestamp, styles.link]}
-                            onPress={() => Link.openExternalLink(CONST.PRIVACY_URL)}
+                            style={[styles.textMicroSupporting, styles.link]}
+                            href={CONST.PRIVACY_URL}
                         >
                             {props.translate(
                                 'initialSettingsPage.readTheTermsAndPrivacyPolicy.phrase4',


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Opened in place of a [previous PR](https://github.com/Expensify/App/pull/5173) for code-signing purposes

### Fixed Issues
$ https://github.com/Expensify/App/issues/5082

### Tests
1. Open Settings screen
2. Click 'About'
2. Tab through About options
3. Verify footer links (Terms of Service, Privacy Policy) focus when tabbed

### QA Steps
1. Open Settings screen
2. Click 'About'
2. Tab through About options
3. Verify footer links (Terms of Service, Privacy Policy) focus when tabbed

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
https://user-images.githubusercontent.com/39444813/133006494-164ff4ea-5873-417f-95f7-3e0eb1e6bef5.mov

#### Mobile Web
https://user-images.githubusercontent.com/39444813/133087857-dc7b5ed6-1d4d-4fe0-981d-366a834ec25c.mov

#### Desktop
https://user-images.githubusercontent.com/39444813/133006503-1a4aed52-b706-43f7-a410-1d0dce0e983b.mov

#### iOS
https://user-images.githubusercontent.com/39444813/133006505-edaaa8b5-8558-40bd-8acf-0720947fbc35.mov

#### Android
https://user-images.githubusercontent.com/39444813/146185863-313c3413-0156-46a6-b1e8-e193ae8ff3af.mov
