### PR TITLE
Fix miss-aligned input with prefix

### DIFF
--- a/src/components/TextInputWithPrefix/index.android.js
+++ b/src/components/TextInputWithPrefix/index.android.js
@@ -34,17 +34,15 @@ const TextInputWithPrefix = props => (_.isEmpty(props.prefixCharacter)
         <View
                 style={[
                     styles.textInputWithPrefix.container,
-                    {paddingTop: 0},
                     props.disabled && styles.inputDisabled,
                     props.errorText && styles.errorOutline,
                 ]}
         >
-            <Text style={[styles.textInputWithPrefix.prefix, {paddingTop: 10}]}>{props.prefixCharacter}</Text>
+            <Text style={[styles.textInputWithPrefix.prefix]}>{props.prefixCharacter}</Text>
             <TextInput
                 style={[
                     styles.textInputWithPrefix.textInput,
                     styles.noOutline,
-                    {height: 40},
                 ]}
                 onChangeText={text => props.onChangeText(`${props.prefixCharacter}${text}`)}
                 // eslint-disable-next-line react/jsx-props-no-spreading

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1,3 +1,4 @@
+import {Platform} from 'react-native';
 import fontFamily from './fontFamily';
 import addOutlineWidth from './addOutlineWidth';
 import themeColors from './themes/default';
@@ -696,11 +697,13 @@ const styles = {
             textAlignVertical: 'center',
         },
         textInput: {
+            padding: 0,
             outlineStyle: 'none',
             color: themeColors.text,
             fontFamily: fontFamily.GTA,
             fontSize: variables.fontSizeNormal,
             textAlignVertical: 'center',
+            lineHeight: (Platform.OS === 'ios') ? 19 : 20,
             flex: 1,
         },
         prefix: {
@@ -709,6 +712,7 @@ const styles = {
             fontFamily: fontFamily.GTA,
             fontSize: variables.fontSizeNormal,
             textAlignVertical: 'center',
+            lineHeight: 20,
         },
     },
 


### PR DESCRIPTION

### Details

Fix input with prefix alignment

### Fixed Issues

$ https://github.com/Expensify/App/issues/6965

### Tests / QA

1. Open app
2. Click "+" and select New Room
3. Compare Room name alignment

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [x] iOS
- [x] Android

### Screenshots


#### Web

![image](https://user-images.githubusercontent.com/47149004/148489414-20df70ef-4668-4de0-a5a2-2207a8b3dc8d.png)

Prefix's padding-right removed to see better the alignment:
![Screen Shot 2022-01-07 at 12 45 06 AM](https://user-images.githubusercontent.com/47149004/148489070-4511df1b-c1ed-4115-87af-6e223f619021.png)

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
![image](https://user-images.githubusercontent.com/47149004/148489446-8bea57aa-85b2-427f-a295-e50aa35e1730.png)

Prefix's padding-right removed to see better the alignment:
![Screen Shot 2022-01-07 at 12 45 23 AM](https://user-images.githubusercontent.com/47149004/148489060-961b6d7c-adb9-4e28-a865-8bd112b10684.png)

#### Android
![image](https://user-images.githubusercontent.com/47149004/148489485-9591984b-9be4-47a4-86f7-4558aa0096da.png)

Prefix's padding-right removed to see better the alignment:
![image](https://user-images.githubusercontent.com/47149004/148489159-c04e393c-7a67-4961-b49b-d84c5e35ca97.png)
