### PR TITLE
Fix maxLength data type

### DIFF
--- a/src/pages/settings/Payments/AddDebitCardPage.js
+++ b/src/pages/settings/Payments/AddDebitCardPage.js
@@ -211,7 +211,7 @@ class DebitCardPage extends Component {
                                         placeholder={this.props.translate('addDebitCardPage.expirationDate')}
                                         onChangeText={expirationDate => this.clearErrorAndSetValue('expirationDate', expirationDate)}
                                         value={this.state.expirationDate}
-                                        maxLength="7"
+                                        maxLength={7}
                                         errorText={this.getErrorText('expirationDate')}
                                         keyboardType={CONST.KEYBOARD_TYPE.PHONE_PAD}
                                     />
@@ -221,7 +221,7 @@ class DebitCardPage extends Component {
                                         label={this.props.translate('addDebitCardPage.cvv')}
                                         onChangeText={securityCode => this.clearErrorAndSetValue('securityCode', securityCode)}
                                         value={this.state.securityCode}
-                                        maxLength="4"
+                                        maxLength={4}
                                         errorText={this.getErrorText('securityCode')}
                                         keyboardType={CONST.KEYBOARD_TYPE.NUMBER_PAD}
                                     />


### PR DESCRIPTION
### Details
Introduced here https://github.com/Expensify/App/pull/6845 cc @marcochavezf 

Fixes data type for maxLength prop.

### Fixed Issues
$ https://github.com/Expensify/App/issues/7085

### Tests
1. On Android, navigate to `Settings > Payments > Add payment method > Debit card`
2. Verify there is no error thrown.
3. Verify that the cvv and expiration date fields do not allow more than 4 and 7 digits, respectively.

### QA Steps
Steps above.

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [X] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android

https://user-images.githubusercontent.com/22219519/148596038-2f91eefe-ac98-44a2-a75b-80ab04834ceb.mov
