### PR TITLE
[No QA] Fix Android deploy failures

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -106,8 +106,6 @@ PODS:
     - OpenSSL-Universal (= 1.1.180)
   - Flipper-Glog (0.3.6)
   - Flipper-PeerTalk (0.0.4)
-  - flipper-plugin-react-native-performance (0.6.0):
-    - React
   - Flipper-RSocket (1.4.3):
     - Flipper-Folly (~> 2.6)
   - FlipperKit (0.99.0):
@@ -623,7 +621,6 @@ DEPENDENCIES:
   - Flipper-Folly (= 2.6.7)
   - Flipper-Glog (= 0.3.6)
   - Flipper-PeerTalk (= 0.0.4)
-  - flipper-plugin-react-native-performance (from `../node_modules/flipper-plugin-react-native-performance/ios`)
   - Flipper-RSocket (= 1.4.3)
   - FlipperKit (= 0.99.0)
   - FlipperKit/Core (= 0.99.0)
@@ -753,8 +750,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/Libraries/FBLazyVector"
   FBReactNativeSpec:
     :path: "../node_modules/react-native/React/FBReactNativeSpec"
-  flipper-plugin-react-native-performance:
-    :path: "../node_modules/flipper-plugin-react-native-performance/ios"
   glog:
     :podspec: "../node_modules/react-native/third-party-podspecs/glog.podspec"
   onfido-react-native-sdk:
@@ -901,7 +896,6 @@ SPEC CHECKSUMS:
   Flipper-Folly: 83af37379faa69497529e414bd43fbfc7cae259a
   Flipper-Glog: 1dfd6abf1e922806c52ceb8701a3599a79a200a6
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
-  flipper-plugin-react-native-performance: 82e0d9bf8f330d2e256ff018978e2a19b86fec17
   Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
   FlipperKit: d8d346844eca5d9120c17d441a2f38596e8ed2b9
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9

--- a/package-lock.json
+++ b/package-lock.json
@@ -25312,12 +25312,6 @@
       "integrity": "sha512-KdJcKbgnFfkdhQ8+dOLQtpeeQDFkLjKC21fM20iZ1lpZg+XJ5EHRZWhqzwJMgt0pDFLA7Ws2itmZESYtjyyvKA==",
       "dev": true
     },
-    "flipper-plugin-react-native-performance": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/flipper-plugin-react-native-performance/-/flipper-plugin-react-native-performance-0.6.0.tgz",
-      "integrity": "sha512-2l1oFYYyloyg2AtsaY7rGaolsgvbF1xrbdBfJFuP3581hM8tz/GxziymzUOR6OuFu6wRJy0nxUVKx2D5UCV6vA==",
-      "dev": true
-    },
     "flow-parser": {
       "version": "0.121.0",
       "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.121.0.tgz",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,6 @@
     "eslint-plugin-detox": "^1.0.0",
     "eslint-plugin-jest": "^24.1.0",
     "flipper-plugin-bridgespy-client": "^0.1.9",
-    "flipper-plugin-react-native-performance": "^0.6.0",
     "html-webpack-plugin": "^4.3.0",
     "jest": "^26.5.2",
     "jest-circus": "^26.5.2",


### PR DESCRIPTION
### Details
This PR removes a deprecated package that is causing Android deploy failures. More context in https://github.com/Expensify/App/issues/7111#issuecomment-1009350159.

### Fixed Issues
$ https://github.com/Expensify/App/issues/7111

### Tests
1. Run the tests from https://github.com/Expensify/App/pull/4760, confirm you can still see the performance options (see screenshots)
2. Confirm you can run the app on all platforms
3. From the App directory, run `npm run build-android` and confirm there is no error for `Could not find com.facebook.flipper:flipper-noop:0.66.0.`

- [x] Verify that no errors appear in the JS console

### QA Steps
None, I'll confirm CPing this change results in a successful Android build

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
![image](https://user-images.githubusercontent.com/3981102/148845739-1108102d-1eec-41b6-9cb3-ff13cb37116b.png)
![image](https://user-images.githubusercontent.com/3981102/148845744-1d9fbe70-0ff3-4043-a5fc-7d40d64972c5.png)
