### PR TITLE
[No QA] Temporarily remove getPullRequestsMergedBetween unit test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,19 +37,9 @@ jobs:
         env:
           CI: true
 
-      - name: Decrypt OSBotify GPG key
-        run: cd .github/workflows && gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output OSBotify-private-key.asc OSBotify-private-key.asc.gpg
-        env:
-          LARGE_SECRET_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
-
-      - name: Import OSBotify GPG Key
-        run: cd .github/workflows && gpg --import OSBotify-private-key.asc
-
       - name: Set up git for OSBotify
         run: |
           git config --global user.name OSBotify
           git config --global user.email infra+osbotify@expensify.com
-          git config --global user.signingkey 367811D53E34168C
-          git config --global commit.gpgsign true
 
       - run: tests/unit/getPullRequestsMergedBetweenTest.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,10 +36,3 @@ jobs:
       - run: npm run test
         env:
           CI: true
-
-      - name: Set up git for OSBotify
-        run: |
-          git config --global user.name OSBotify
-          git config --global user.email infra+osbotify@expensify.com
-
-      - run: tests/unit/getPullRequestsMergedBetweenTest.sh


### PR DESCRIPTION
### Details
Contributor PRs are failing unit tests because they do not have access to the repo secrets necessary for `OSBotify` to configure commit signing on the GitHub Actions runner. This PR should fix that temporarily removing the new failing test, pending a solution that doesn't require commit signing (or doesn't use actual GPG keys).

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/191675

### Tests
None - only PR checks.

### QA Steps
No QA.

### Tested On

- GitHub only
