### PR TITLE
Add policy rooms to its own beta, and restrict this beta on dev

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -103,6 +103,7 @@ const CONST = {
         BETA_EXPENSIFY_WALLET: 'expensifyWallet',
         INTERNATIONALIZATION: 'internationalization',
         IOU_SEND: 'sendMoney',
+        POLICY_ROOMS: 'policyRooms',
     },
     BUTTON_STATES: {
         DEFAULT: 'default',

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -415,6 +415,10 @@ function getOptions(reports, personalDetails, activeReportID, {
             return;
         }
 
+        if (ReportUtils.isUserCreatedPolicyRoom(report) && !Permissions.canUsePolicyRooms(betas)) {
+            return;
+        }
+
         const reportPersonalDetails = getPersonalDetailsForLogins(logins, personalDetails);
 
         // Save the report in the map if this is a single participant so we can associate the reportID with the

--- a/src/libs/Permissions.js
+++ b/src/libs/Permissions.js
@@ -77,6 +77,18 @@ function canUseWallet(betas) {
     return _.contains(betas, CONST.BETAS.BETA_EXPENSIFY_WALLET) || canUseAllBetas(betas);
 }
 
+/**
+ * We're requiring you to be added to the policy rooms beta on dev,
+ * since contributors have been reporting a number of false issues related to the feature being under development.
+ * See https://expensify.slack.com/archives/C01GTK53T8Q/p1641921996319400?thread_ts=1641598356.166900&cid=C01GTK53T8Q
+ * @param {Array<String>} betas
+ * @returns {Boolean}
+ */
+
+function canUsePolicyRooms(betas) {
+    return _.contains(betas, CONST.BETAS.POLICY_ROOMS) || _.contains(betas, CONST.BETAS.ALL);
+}
+
 export default {
     canUseChronos,
     canUseIOU,
@@ -86,4 +98,5 @@ export default {
     canUseInternationalization,
     canUseIOUSend,
     canUseWallet,
+    canUsePolicyRooms,
 };

--- a/src/libs/Permissions.js
+++ b/src/libs/Permissions.js
@@ -86,7 +86,7 @@ function canUseWallet(betas) {
  */
 
 function canUsePolicyRooms(betas) {
-    return _.contains(betas, CONST.BETAS.POLICY_ROOMS) || _.contains(betas, CONST.BETAS.ALL);
+    return _.contains(betas, CONST.BETAS.POLICY_ROOMS);
 }
 
 export default {

--- a/src/libs/Permissions.js
+++ b/src/libs/Permissions.js
@@ -86,7 +86,7 @@ function canUseWallet(betas) {
  */
 
 function canUsePolicyRooms(betas) {
-    return _.contains(betas, CONST.BETAS.POLICY_ROOMS);
+    return _.contains(betas, CONST.BETAS.POLICY_ROOMS) || _.contains(betas, CONST.BETAS.ALL);
 }
 
 export default {

--- a/src/pages/home/sidebar/SidebarScreen.js
+++ b/src/pages/home/sidebar/SidebarScreen.js
@@ -160,7 +160,7 @@ class SidebarScreen extends Component {
                                     text: this.props.translate('sidebarScreen.newGroup'),
                                     onSelected: () => Navigation.navigate(ROUTES.NEW_GROUP),
                                 },
-                                ...(Permissions.canUseDefaultRooms(this.props.betas) ? [
+                                ...(Permissions.canUsePolicyRooms(this.props.betas) ? [
                                     {
                                         icon: Expensicons.Hashtag,
                                         text: this.props.translate('sidebarScreen.newRoom'),


### PR DESCRIPTION
### Details
This restricts the usage of policy rooms to those behind the beta on dev. This includes creating policy rooms via the global create menu, and accessing them in the LHN.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/191754

### Tests/QA
N/A

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
