### PR TITLE
[No QA] Don't rely on non-portable realpath

### DIFF
--- a/tests/unit/getPullRequestsMergedBetweenTest.sh
+++ b/tests/unit/getPullRequestsMergedBetweenTest.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-TEST_DIR=$(dirname "$(dirname "$(realpath "$0")")")
+TEST_DIR=$(dirname "$(dirname "$(cd "$(dirname "$0")" || exit 1;pwd)/$(basename "$0")")")
 DUMMY_DIR="$HOME/DumDumRepo"
 getPullRequestsMergedBetween="$TEST_DIR/utils/getPullRequestsMergedBetween.js"
 


### PR DESCRIPTION
### Details
As explained in [this comment](https://github.com/Expensify/Expensify/issues/191675#issuecomment-1010368217), `realpath` is not completely portable. This PR implements a workaround to find the absolute path of the script without using `realpath`.

### Fixed Issues
n/a

### Tests
Run the test, verify it passes.

### QA Steps
None.