### PR TITLE
bumping expensify-common hash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24156,8 +24156,8 @@
       }
     },
     "expensify-common": {
-      "version": "git+https://github.com/Expensify/expensify-common.git#fa190f6c844cf5646345f3e5e4862b62f1fa27bc",
-      "from": "git+https://github.com/Expensify/expensify-common.git#fa190f6c844cf5646345f3e5e4862b62f1fa27bc",
+      "version": "git+https://github.com/Expensify/expensify-common.git#9d7193bdad33754680a358b3acf9a8a0a2d89e98",
+      "from": "git+https://github.com/Expensify/expensify-common.git#9d7193bdad33754680a358b3acf9a8a0a2d89e98",
       "requires": {
         "classnames": "2.3.1",
         "clipboard": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "electron-log": "^4.3.5",
     "electron-serve": "^1.0.0",
     "electron-updater": "^4.3.4",
-    "expensify-common": "git+https://github.com/Expensify/expensify-common.git#fa190f6c844cf5646345f3e5e4862b62f1fa27bc",
+    "expensify-common": "git+https://github.com/Expensify/expensify-common.git#9d7193bdad33754680a358b3acf9a8a0a2d89e98",
     "fbjs": "^3.0.2",
     "file-loader": "^6.0.0",
     "html-entities": "^1.3.1",


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

I noticed we're a bit behind on the expensify-common hash when investigating[ this other issue](https://github.com/Expensify/Expensify/issues/191781). 
