### PR TITLE
Add stories for TextInput

### DIFF
--- a/src/components/TextInput/baseTextInputPropTypes.js
+++ b/src/components/TextInput/baseTextInputPropTypes.js
@@ -28,6 +28,7 @@ const propTypes = {
     /** input style */
     inputStyle: PropTypes.arrayOf(PropTypes.object),
 
+    /** If present, this prop forces the label to remain in a position where it will not collide with input text */
     forceActiveLabel: PropTypes.bool,
 
     /** Should the input auto focus? */

--- a/src/stories/TextInput.stories.js
+++ b/src/stories/TextInput.stories.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import TextInput from '../components/TextInput';
+
+/**
+ * We use the Component Story Format for writing stories. Follow the docs here:
+ *
+ * https://storybook.js.org/docs/react/writing-stories/introduction#component-story-format
+ */
+const story = {
+    title: 'Components/TextInput',
+    component: TextInput,
+};
+
+// eslint-disable-next-line react/jsx-props-no-spreading
+const Template = args => <TextInput {...args} />;
+
+// Arguments can be passed to the component by binding
+// See: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
+
+const AutoFocus = Template.bind({});
+AutoFocus.args = {
+    label: 'Auto-focused text input',
+    name: 'AutoFocus',
+    autoFocus: true,
+};
+
+const Default = Template.bind({});
+Default.args = {
+    label: 'Default text input',
+    name: 'Default',
+};
+
+const DefaultValue = Template.bind({});
+DefaultValue.args = {
+    label: 'Input with default value',
+    name: 'DefaultValue',
+    defaultValue: 'My default value',
+};
+
+const ErrorStory = Template.bind({});
+ErrorStory.args = {
+    label: 'Input with error',
+    name: 'InputWithError',
+    errorText: 'This field has an error.',
+};
+
+const ForceActiveLabel = Template.bind({});
+ForceActiveLabel.args = {
+    label: 'Forced active label',
+    forceActiveLabel: true,
+};
+
+const Placeholder = Template.bind({});
+Placeholder.args = {
+    label: 'Input with placeholder',
+    name: 'Placeholder',
+    placeholder: 'My placeholder text',
+};
+
+export default story;
+export {
+    AutoFocus,
+    Default,
+    DefaultValue,
+    ErrorStory,
+    ForceActiveLabel,
+    Placeholder,
+};


### PR DESCRIPTION
### Details
Adds stories for the `TextInput` component. Using this as a dummy PR for testing https://github.com/Expensify/App/pull/6906

### Fixed Issues
n/a

### Tests
1. Run `npm run storybook`
1. Look at the new stories and verify they work correctly!

- [x] Verify that no errors appear in the JS console

### QA Steps
1. Go to https://new.expensify.com/docs/index.html
1. Verify that you see the `TextInput` stories are available.
1. Play with them a bit and see that they work 🙂 

- [x] Verify that no errors appear in the JS console

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
#### Web
![image](https://user-images.githubusercontent.com/47436092/149075388-493a8aed-d170-4a28-87f5-1757422a01e8.png)
