### PR TITLE
fix: views overlap on auth screen

### DIFF
--- a/src/pages/signin/SignInPageLayout/SignInPageContent.js
+++ b/src/pages/signin/SignInPageLayout/SignInPageContent.js
@@ -11,7 +11,6 @@ import TermsAndLicenses from '../TermsAndLicenses';
 import withLocalize, {withLocalizePropTypes} from '../../../components/withLocalize';
 import Form from '../../../components/Form';
 import compose from '../../../libs/compose';
-import scrollViewContentContainerStyles from './signInPageStyles';
 import LoginKeyboardAvoidingView from './LoginKeyboardAvoidingView';
 import withKeyboardState from '../../../components/withKeyboardState';
 import withWindowDimensions, {windowDimensionsPropTypes} from '../../../components/withWindowDimensions';
@@ -41,7 +40,7 @@ const SignInPageContent = props => (
             !props.isSmallScreenWidth && styles.signInPageWideLeftContainer,
         ]}
         contentContainerStyle={[
-            scrollViewContentContainerStyles,
+            styles.mnh100,
             !props.isSmallScreenWidth && styles.ph6,
         ]}
     >

--- a/src/pages/signin/SignInPageLayout/signInPageStyles/index.ios.js
+++ b/src/pages/signin/SignInPageLayout/signInPageStyles/index.ios.js
@@ -1,5 +1,0 @@
-import styles from '../../../../styles/styles';
-
-const scrollViewContentContainerStyles = styles.flex1;
-
-export default scrollViewContentContainerStyles;

--- a/src/pages/signin/SignInPageLayout/signInPageStyles/index.js
+++ b/src/pages/signin/SignInPageLayout/signInPageStyles/index.js
@@ -1,5 +1,0 @@
-import styles from '../../../../styles/styles';
-
-const scrollViewContentContainerStyles = styles.mnh100;
-
-export default scrollViewContentContainerStyles;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

There was a custom styling set on iOS to set the height to a fixed ```flex: 1```, changes are made to make it's ```min height 100%```.

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/7122

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Goto login page enter a registered email.
2. Enter a wrong password, so that an error appears.
3. Verify that terms copy text to the bottom does not overlap.
- [x] Verify that no errors appear in the JS console

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Same as test steps.
- [x] Verify that no errors appear in the JS console

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
![Simulator Screen Shot - iPod touch (7th generation) - 2022-01-12 at 11 06 33](https://user-images.githubusercontent.com/77761491/149070103-a7cbfda3-5896-4f53-913b-3b87ad63a06a.png)

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
