### PR TITLE
Hide debit card behind wallet beta

### DIFF
--- a/src/components/AddPaymentMethodMenu.js
+++ b/src/components/AddPaymentMethodMenu.js
@@ -9,6 +9,7 @@ import styles from '../styles/styles';
 import compose from '../libs/compose';
 import ONYXKEYS from '../ONYXKEYS';
 import CONST from '../CONST';
+import Permissions from "../libs/Permissions";
 
 const propTypes = {
     isVisible: PropTypes.bool.isRequired,
@@ -23,6 +24,9 @@ const propTypes = {
 
     /** Should we show the Paypal option */
     shouldShowPaypal: PropTypes.bool,
+
+    /** List of betas available to current user */
+    betas: PropTypes.arrayOf(PropTypes.string),
 
     ...withLocalizePropTypes,
 };
@@ -45,12 +49,14 @@ const AddPaymentMethodMenu = props => (
             onPress={() => props.onItemSelected(CONST.PAYMENT_METHODS.BANK_ACCOUNT)}
             wrapperStyle={styles.pr15}
         />
-        <MenuItem
-            title={props.translate('common.debitCard')}
-            icon={Expensicons.CreditCard}
-            onPress={() => props.onItemSelected(CONST.PAYMENT_METHODS.DEBIT_CARD)}
-            wrapperStyle={styles.pr15}
-        />
+        {Permissions.canUseWallet(props.betas) && (
+            <MenuItem
+                title={props.translate('common.debitCard')}
+                icon={Expensicons.CreditCard}
+                onPress={() => props.onItemSelected(CONST.PAYMENT_METHODS.DEBIT_CARD)}
+                wrapperStyle={styles.pr15}
+            />
+        )}
         {props.shouldShowPaypal && !props.payPalMeUsername && (
             <MenuItem
                 title={props.translate('common.payPalMe')}
@@ -70,6 +76,9 @@ export default compose(
     withOnyx({
         payPalMeUsername: {
             key: ONYXKEYS.NVP_PAYPAL_ME_ADDRESS,
+        },
+        betas: {
+            key: ONYXKEYS.BETAS,
         },
     }),
 )(AddPaymentMethodMenu);

--- a/src/components/AddPaymentMethodMenu.js
+++ b/src/components/AddPaymentMethodMenu.js
@@ -9,7 +9,7 @@ import styles from '../styles/styles';
 import compose from '../libs/compose';
 import ONYXKEYS from '../ONYXKEYS';
 import CONST from '../CONST';
-import Permissions from "../libs/Permissions";
+import Permissions from '../libs/Permissions';
 
 const propTypes = {
     isVisible: PropTypes.bool.isRequired,
@@ -35,6 +35,7 @@ const defaultProps = {
     anchorPosition: {},
     payPalMeUsername: '',
     shouldShowPaypal: true,
+    betas: [],
 };
 
 const AddPaymentMethodMenu = props => (


### PR DESCRIPTION
### Details
We only want people on the wallet beta to be able to add debit cards.

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #7212
--->
$ https://github.com/Expensify/App/issues/7212

### Tests
1. Change [this line](https://github.com/Expensify/App/blob/50ebc74b906bc9ae01b9f52d301d672b53e29cbd/src/libs/Permissions.js#L77) to always return false
2. Log into an account
3. Go to Settings -> Payments
4. Click "Add Payment Methods"
5. Make sure you don't see the debit card option

### QA Steps
2. Log into an account not in the wallet beta
3. Go to Settings -> Payments
4. Click "Add Payment Methods"
5. Make sure you don't see the debit card option

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<img width="374" alt="2022-01-13_14-41-54" src="https://user-images.githubusercontent.com/42391420/149414303-6c448264-d47e-4d21-b3f0-683156fe59b3.png">

