### PR TITLE
Disable save button after saving self-select pronoun with a sapce

### DIFF
--- a/src/pages/settings/Profile/ProfilePage.js
+++ b/src/pages/settings/Profile/ProfilePage.js
@@ -161,7 +161,7 @@ class ProfilePage extends Component {
     }
 
     validateInputs() {
-        const [hasFirstNameError, hasLastNameError, hasPronounError] = ValidationUtils.doesFailCharacterLimit(50, [this.state.firstName, this.state.lastName, this.state.pronouns]);
+        const [hasFirstNameError, hasLastNameError, hasPronounError] = ValidationUtils.doesFailCharacterLimit(50, [this.state.firstName.trim(), this.state.lastName.trim(), this.state.pronouns.trim()]);
         this.setState({
             hasFirstNameError,
             hasLastNameError,

--- a/src/pages/settings/Profile/ProfilePage.js
+++ b/src/pages/settings/Profile/ProfilePage.js
@@ -161,7 +161,10 @@ class ProfilePage extends Component {
     }
 
     validateInputs() {
-        const [hasFirstNameError, hasLastNameError, hasPronounError] = ValidationUtils.doesFailCharacterLimit(50, [this.state.firstName.trim(), this.state.lastName.trim(), this.state.pronouns.trim()]);
+        const [hasFirstNameError, hasLastNameError, hasPronounError] = ValidationUtils.doesFailCharacterLimit(
+            50,
+            [this.state.firstName.trim(), this.state.lastName.trim(), this.state.pronouns.trim()],
+        );
         this.setState({
             hasFirstNameError,
             hasLastNameError,

--- a/src/pages/settings/Profile/ProfilePage.js
+++ b/src/pages/settings/Profile/ProfilePage.js
@@ -177,7 +177,7 @@ class ProfilePage extends Component {
         }));
 
         // Determines if the pronouns/selected pronouns have changed
-        const arePronounsUnchanged = this.props.myPersonalDetails.pronouns === this.state.pronouns;
+        const arePronounsUnchanged = this.props.myPersonalDetails.pronouns === this.state.pronouns.trim();
 
         // Disables button if none of the form values have changed
         const isButtonDisabled = (this.props.myPersonalDetails.firstName === this.state.firstName.trim())


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
After saving self-select pronoun with space, the Save button was not disabled. The issue is fixed by making proper change in the variable that determines whether the button should be disabled or not.
### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/7147

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Go to Profile
- [ ] Select "Self-select" in Preferred pronouns field.
- [ ] Enter preferred pronoun with space at the end.
- [ ] Click Save button.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Go to Profile
- [ ] Select "Self-select" in Preferred pronouns field.
- [ ] Enter preferred pronoun with space at the end.
- [ ] Click Save button.

### Tested On

- [x] Web
- [x] Mobile Web
- [ ] Desktop
- [ ] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
![Screenshot from 2022-01-14 13-55-03](https://user-images.githubusercontent.com/25876548/149473490-3427b6a0-02a4-47a2-be36-bb0f3e7980d6.png)

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
![Screenshot_20220114-140753_Chrome](https://user-images.githubusercontent.com/25876548/149475416-a0eb7b65-a70a-42c9-973e-08fd0d7a9802.jpg)

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
![Screenshot_20220114-135917_New Expensify](https://user-images.githubusercontent.com/25876548/149474321-eaa7fa3e-8734-475a-8814-45f3b2c41433.jpg)

