### PR TITLE
Fixes IOU - Unable to paste the amount copied from Notes on MacOS Safari

### DIFF
--- a/src/components/TextInputAutoWidthWithoutKeyboard/BaseTextInputAutoWidthWithoutKeyboard.js
+++ b/src/components/TextInputAutoWidthWithoutKeyboard/BaseTextInputAutoWidthWithoutKeyboard.js
@@ -3,11 +3,13 @@ import {
     View,
     AppState,
     Keyboard,
+
     // eslint-disable-next-line no-restricted-imports
     TextInput as RNTextInput,
 } from 'react-native';
 import _ from 'underscore';
 import styles from '../../styles/styles';
+import themeColors from '../../styles/themes/default';
 import * as StyleUtils from '../../styles/StyleUtils';
 import Text from '../Text';
 import * as baseTextInputAutoWidthWithoutKeyboardPropTypes from './baseTextInputAutoWidthWithoutKeyboardPropTypes';
@@ -49,6 +51,7 @@ class BaseTextInputAutoWidthWithoutKeyboard extends React.Component {
             <>
                 <View>
                     <RNTextInput
+                        placeholderTextColor={themeColors.placeholderText}
                         style={[this.props.inputStyle, StyleUtils.getAutoGrowTextInputStyle(this.state.textInputWidth)]}
                         ref={this.props.forwardedRef}
                         showSoftInputOnFocus={false}

--- a/src/components/TextInputAutoWidthWithoutKeyboard/BaseTextInputAutoWidthWithoutKeyboard.js
+++ b/src/components/TextInputAutoWidthWithoutKeyboard/BaseTextInputAutoWidthWithoutKeyboard.js
@@ -3,12 +3,13 @@ import {
     View,
     AppState,
     Keyboard,
+    // eslint-disable-next-line no-restricted-imports
+    TextInput,
 } from 'react-native';
 import _ from 'underscore';
 import styles from '../../styles/styles';
 import * as StyleUtils from '../../styles/StyleUtils';
 import Text from '../Text';
-import TextInputFocusable from '../TextInputFocusable';
 import * as baseTextInputAutoWidthWithoutKeyboardPropTypes from './baseTextInputAutoWidthWithoutKeyboardPropTypes';
 
 class BaseTextInputAutoWidthWithoutKeyboard extends React.Component {
@@ -47,7 +48,7 @@ class BaseTextInputAutoWidthWithoutKeyboard extends React.Component {
         return (
             <>
                 <View>
-                    <TextInputFocusable
+                    <TextInput
                         style={[this.props.inputStyle, StyleUtils.getAutoGrowTextInputStyle(this.state.textInputWidth)]}
                         ref={this.props.forwardedRef}
                         showSoftInputOnFocus={false}

--- a/src/components/TextInputAutoWidthWithoutKeyboard/BaseTextInputAutoWidthWithoutKeyboard.js
+++ b/src/components/TextInputAutoWidthWithoutKeyboard/BaseTextInputAutoWidthWithoutKeyboard.js
@@ -4,7 +4,7 @@ import {
     AppState,
     Keyboard,
     // eslint-disable-next-line no-restricted-imports
-    TextInput,
+    TextInput as RNTextInput,
 } from 'react-native';
 import _ from 'underscore';
 import styles from '../../styles/styles';
@@ -48,7 +48,7 @@ class BaseTextInputAutoWidthWithoutKeyboard extends React.Component {
         return (
             <>
                 <View>
-                    <TextInput
+                    <RNTextInput
                         style={[this.props.inputStyle, StyleUtils.getAutoGrowTextInputStyle(this.state.textInputWidth)]}
                         ref={this.props.forwardedRef}
                         showSoftInputOnFocus={false}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Use `TextInput` directly imported from React Native in `TextInputAutoWidthWithoutKeyboard`. Because `TextInputFocusable` will transform styled text into markdown format when pasting. That's not what we want. See also: https://github.com/Expensify/App/issues/6931#issuecomment-1008097420

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/6931

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Copy a piece of bold text of amount number format. Some examples is in the following step 2:
2. **12.50** or **1,234.8** or **0.5**
3. Verify they can be pasted into the amount input.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Same as above.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
<img width="1122" alt="web" src="https://user-images.githubusercontent.com/19236594/149488326-fe8d1db4-0ff8-4dca-8d97-cb835ebe4fd5.png">

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
<img width="353" alt="mobile-web" src="https://user-images.githubusercontent.com/19236594/149488349-3c27d079-5820-4f2f-bec3-b96feece0e59.png">

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
<img width="1074" alt="desktop" src="https://user-images.githubusercontent.com/19236594/149488405-fe453ef5-151c-4007-a351-51f34b69b6dd.png">

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
<img width="353" alt="ios" src="https://user-images.githubusercontent.com/19236594/149488432-82b76b27-9f05-4de4-9da1-35eaec94f88b.png">

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
<img width="353" alt="ios" src="https://user-images.githubusercontent.com/19236594/149488602-60cfc8bc-1309-4029-b911-83ba0f118d01.jpg">


