### PR TITLE
fix: Stories rendering issues

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,1 +1,29 @@
+import React from 'react';
+import Onyx from 'react-native-onyx';
 import '../assets/css/fonts.css';
+import ComposeProviders from '../src/components/ComposeProviders';
+import OnyxProvider from '../src/components/OnyxProvider';
+import {LocaleContextProvider} from '../src/components/withLocalize';
+import ONYXKEYS from '../src/ONYXKEYS';
+
+Onyx.init({
+    keys: ONYXKEYS,
+});
+
+const decorators = [
+    Story => (
+        <ComposeProviders
+            components={[
+                OnyxProvider,
+                LocaleContextProvider,
+            ]}
+        >
+            <Story />
+        </ComposeProviders>
+    ),
+];
+
+export {
+    // eslint-disable-next-line import/prefer-default-export
+    decorators,
+};


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/7187

### Tests | QA Steps
1. Go to staging.new.expensify.com/docs/index.html
    and verify that you can see the storybook docs with the themes matching the screenshots below.
2. Canvas / Header/ Default
3. Canvas / ButtonWithDropdwn/ Fefault
4. Canvas/ MenuItem/ Default
5. Repeat step 2-4 for Docs tab
 6. Go to HeaderWithCloseButton


- [x] Verify that no errors appear in the JS console

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
![image](https://user-images.githubusercontent.com/24370807/149544330-b2db2786-1c3e-4d62-bc02-9ca749361f04.png)508579.png)

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
