### PR TITLE
Do not show "Message <user>" button when seeing your own profile

### DIFF
--- a/src/pages/DetailsPage.js
+++ b/src/pages/DetailsPage.js
@@ -152,13 +152,15 @@ const DetailsPage = (props) => {
                                 </View>
                             ) : null}
                         </View>
-                        <MenuItem
-                            title={`${props.translate('common.message')}${details.displayName}`}
-                            icon={Expensicons.ChatBubble}
-                            onPress={() => Report.fetchOrCreateChatReport([props.session.email, details.login])}
-                            wrapperStyle={styles.breakAll}
-                            shouldShowRightIcon
-                        />
+                        {details.login !== props.session.email && (
+                            <MenuItem
+                                title={`${props.translate('common.message')}${details.displayName}`}
+                                icon={Expensicons.ChatBubble}
+                                onPress={() => Report.fetchOrCreateChatReport([props.session.email, details.login])}
+                                wrapperStyle={styles.breakAll}
+                                shouldShowRightIcon
+                            />
+                        )}
                     </ScrollView>
                 ) : null}
             </View>


### PR DESCRIPTION
### Details
Prevents showing the `Message <user>` button when trying to message yourself.

### Fixed Issues
$ https://github.com/Expensify/App/issues/7203

### Tests
1. Start a chat with a user.
2. Click on your avatar in the chat and verify that no `Message <user>` button is visible.
3. Now click on another user's avatar and verify that the `Message <user>` button is visible and clicking it opens the chat with that user.

- [X] Verify that no errors appear in the JS console

### QA Steps
Steps above.

- [X] Verify that no errors appear in the JS console

### Tested On

- [X] Web
- [X] Mobile Web
- [x] Desktop
- [X] iOS
- [x] Android

### Screenshots

#### Web

https://user-images.githubusercontent.com/22219519/149563994-174fa2a4-7daf-47d9-a8e8-9fc075038c85.mov

#### Mobile Web

https://user-images.githubusercontent.com/22219519/149564836-e37310d8-a1bc-49a7-8ba1-005da81cde61.mov

#### Desktop

https://user-images.githubusercontent.com/22219519/149564099-ed1d9409-13a2-4ef6-a8de-c15629e3d1ce.mov

#### iOS

https://user-images.githubusercontent.com/22219519/149564812-b33aae89-21b2-4b8d-8ca6-957f23a61353.mov

#### Android

https://user-images.githubusercontent.com/22219519/149565392-8708f5de-e3cf-49e6-b479-88b2a5c127ce.mov
