### PR TITLE
[No QA] Use manual signing for provisioning profile

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,13 @@ jobs:
     if: github.actor != 'OSBotify'
     runs-on: ubuntu-latest
     steps:
+      - name: Check Provisioning Style
+        run: |
+          if grep -q 'ProvisioningStyle = Automatic;' ios/NewExpensify.xcodeproj/project.pbxproj; then
+            echo "Error: Automatic provisioning style is not allowed!"
+            exit 1
+          fi
+
       - uses: actions/checkout@v2
 
       - name: Use Node.js

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # If automatic signing is enabled, iOS builds will fail, so ensure we always have the proper profile specified
       - name: Check Provisioning Style
         run: |
-          if grep -q 'ProvisioningStyle = Automatic;' ios/NewExpensify.xcodeproj/project.pbxproj; then
+          if grep -q 'PROVISIONING_PROFILE_SPECIFIER = chat_expensify_appstore' ios/NewExpensify.xcodeproj/project.pbxproj; then
+            exit 0
+          else
             echo "Error: Automatic provisioning style is not allowed!"
             exit 1
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,14 +10,14 @@ jobs:
     if: github.actor != 'OSBotify'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
+
       - name: Check Provisioning Style
         run: |
           if grep -q 'ProvisioningStyle = Automatic;' ios/NewExpensify.xcodeproj/project.pbxproj; then
             echo "Error: Automatic provisioning style is not allowed!"
             exit 1
           fi
-
-      - uses: actions/checkout@v2
 
       - name: Use Node.js
         uses: actions/setup-node@v1

--- a/ios/NewExpensify.xcodeproj/project.pbxproj
+++ b/ios/NewExpensify.xcodeproj/project.pbxproj
@@ -287,7 +287,7 @@
 					13B07F861A680F5B00A75B9A = {
 						DevelopmentTeam = 368M544MTT;
 						LastSwiftMigration = 1230;
-						ProvisioningStyle = Automatic;
+						ProvisioningStyle = Manual;
 					};
 				};
 			};
@@ -849,10 +849,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = NewExpensify/Chat.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 3;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 368M544MTT;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				INFOPLIST_FILE = "$(SRCROOT)/NewExpensify/Info.plist";
@@ -866,7 +866,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.chat.expensify.chat;
 				PRODUCT_NAME = "New Expensify";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = chat_expensify_appstore;
 				SWIFT_OBJC_BRIDGING_HEADER = "ExpensifyCash-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -882,10 +882,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = NewExpensify/Chat.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 3;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 368M544MTT;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				INFOPLIST_FILE = NewExpensify/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
@@ -898,7 +898,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.chat.expensify.chat;
 				PRODUCT_NAME = "New Expensify";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = chat_expensify_appstore;
 				SWIFT_OBJC_BRIDGING_HEADER = "ExpensifyCash-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
cc @Julesssss 

### Details
In https://github.com/Expensify/App/pull/6773/files#diff-1b579b2c321f383fcd88594bcf7023d2154da98817b50ee7ec9bc523acb56f35R290 we accidentally changed the signing options (likely for local testing) which resulted in a deploy failure [here](https://expensify.slack.com/archives/C03V9A4TB/p1642190414341000). This PR reverts the automatic signing change to use our manual provisioning profile.

### Fixed Issues
Slack thread: https://expensify.slack.com/archives/C03V9A4TB/p1642190414341000

### Tests
1. Confirm the app builds and runs
2. Confirm that when this is CPd, the build is successful on staging

- [x] Verify that no errors appear in the JS console

### QA Steps
No QA

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [x] iOS
- [ ] Android

