### PR TITLE
[NO-QA]Add Workflow run URL to `triggerWorkflowAndWait`

### DIFF
--- a/.github/actions/triggerWorkflowAndWait/index.js
+++ b/.github/actions/triggerWorkflowAndWait/index.js
@@ -35,6 +35,12 @@ const WORKFLOW_COMPLETION_TIMEOUT = 7200000;
  */
 const POLL_RATE = 10000;
 
+/**
+ * URL prefixed to a specific workflow run
+ * @type {string}
+ */
+const WORKFLOW_RUN_URL_PREFIX = 'https://github.com/Expensify/App/actions/runs/';
+
 const run = function () {
     const workflow = core.getInput('WORKFLOW', {required: true});
     const inputs = ActionUtils.getJSONInput('INPUTS', {required: false}, {});
@@ -55,6 +61,7 @@ const run = function () {
     // 4) Then we can poll and wait for that new workflow run to conclude
     let previousWorkflowRunID;
     let newWorkflowRunID;
+    let newWorkflowRunURL;
     let hasNewWorkflowStarted = false;
     let workflowCompleted = false;
     return GithubUtils.getLatestWorkflowRunID(workflow)
@@ -89,6 +96,7 @@ const run = function () {
                         return GithubUtils.getLatestWorkflowRunID(workflow)
                             .then((lastWorkflowRunID) => {
                                 newWorkflowRunID = lastWorkflowRunID;
+                                newWorkflowRunURL = WORKFLOW_RUN_URL_PREFIX + newWorkflowRunID;
                                 hasNewWorkflowStarted = newWorkflowRunID !== previousWorkflowRunID;
 
                                 if (!hasNewWorkflowStarted) {
@@ -104,7 +112,7 @@ const run = function () {
                                         process.exit(1);
                                     }
                                 } else {
-                                    console.log(`\n🚀 New ${workflow} run with ID ${newWorkflowRunID} has started`);
+                                    console.log(`\n🚀 New ${workflow} run ${newWorkflowRunURL} has started`);
                                 }
                             })
                             .catch((err) => {
@@ -123,7 +131,7 @@ const run = function () {
                 () => !workflowCompleted && waitTimer < WORKFLOW_COMPLETION_TIMEOUT,
                 _.throttle(
                     () => {
-                        console.log(`\n⏳ Waiting for workflow run ${newWorkflowRunID} to finish...`);
+                        console.log(`\n⏳ Waiting for workflow run ${newWorkflowRunURL} to finish...`);
                         return GithubUtils.octokit.actions.getWorkflowRun({
                             owner: GithubUtils.GITHUB_OWNER,
                             repo: GithubUtils.EXPENSIFY_CASH_REPO,
@@ -134,7 +142,7 @@ const run = function () {
                                 waitTimer += POLL_RATE;
                                 if (waitTimer > WORKFLOW_COMPLETION_TIMEOUT) {
                                     // eslint-disable-next-line max-len
-                                    const err = new Error(`After ${WORKFLOW_COMPLETION_TIMEOUT / 1000 / 60 / 60} hours, workflow ${newWorkflowRunID} did not complete.`);
+                                    const err = new Error(`After ${WORKFLOW_COMPLETION_TIMEOUT / 1000 / 60 / 60} hours, workflow ${newWorkflowRunURL} did not complete.`);
                                     console.error(err);
                                     core.setFailed(err);
                                     process.exit(1);
@@ -142,10 +150,10 @@ const run = function () {
                                 if (workflowCompleted) {
                                     if (data.conclusion === 'success') {
                                         // eslint-disable-next-line max-len
-                                        console.log(`\n🎉 ${workflow} run ${newWorkflowRunID} completed successfully! 🎉`);
+                                        console.log(`\n🎉 ${workflow} run ${newWorkflowRunURL} completed successfully! 🎉`);
                                     } else {
                                         // eslint-disable-next-line max-len
-                                        const err = new Error(`🙅‍ ${workflow} run ${newWorkflowRunID} finished with conclusion ${data.conclusion}`);
+                                        const err = new Error(`🙅‍ ${workflow} run ${newWorkflowRunURL} finished with conclusion ${data.conclusion}`);
                                         console.error(err.message);
                                         core.setFailed(err);
                                         process.exit(1);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Adds the workflow run URL to `triggerWorkflowAndWait`, which will be a small QOL improvement for us when viewing logs.

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/7239

### Tests
Since this code is deep in the weeds, it seems very hard to test this specific code without running some production code, therefore I would suggest:
1. Merge this PR 
2. I will watch logs for the deploys and verify the URL appears correctly when we deploy, lock a checklist, or any other workflow that uses `triggerWorkflowAndWait`