### PR TITLE
[No QA] fix: Fixed error with frequently used emojis not showing up

### DIFF
--- a/src/libs/EmojiUtils.js
+++ b/src/libs/EmojiUtils.js
@@ -140,8 +140,7 @@ function mergeEmojisWithFrequentlyUsedEmojis(emojis, frequentlyUsedEmojis = []) 
     }];
 
     allEmojis = allEmojis.concat(frequentlyUsedEmojis, emojis);
-    allEmojis = addSpacesToEmojiCategories(allEmojis);
-    return allEmojis;
+    return addSpacesToEmojiCategories(allEmojis);
 }
 
 /**

--- a/src/libs/EmojiUtils.js
+++ b/src/libs/EmojiUtils.js
@@ -140,7 +140,7 @@ function mergeEmojisWithFrequentlyUsedEmojis(emojis, frequentlyUsedEmojis = []) 
     }];
 
     allEmojis = allEmojis.concat(frequentlyUsedEmojis, emojis);
-    allEmojis = addSpacesToEmojiCategories(emojis);
+    allEmojis = addSpacesToEmojiCategories(allEmojis);
     return allEmojis;
 }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
- When working with #7125 we changed the logic for dynamic spacing. A bug was introduced where Frequently Used Emojis stopped showing up and this PR fixes it.

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/7074

### Tests
1. Tested frequently used emojis in the EmojiPicker
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
![image](https://user-images.githubusercontent.com/3069065/149608455-d5277e4d-d113-4852-9cf0-a265d6c4861e.png)


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
<img width="378" alt="Screenshot 2022-01-15 at 9 47 10 AM" src="https://user-images.githubusercontent.com/3069065/149608511-46ddc904-591c-473e-a13b-0f4671614f3d.png">

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
<img width="459" alt="Screenshot 2022-01-15 at 9 50 09 AM" src="https://user-images.githubusercontent.com/3069065/149608683-54e9db87-afa0-4e77-925d-44b31ddc0ff7.png">

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
![image](https://user-images.githubusercontent.com/3069065/149609162-c6bfac4c-79a7-4ac5-af38-fa0b78bc7623.png)


#### Android
<!-- Insert screenshots of your changes on the Android platform-->
<img width="365" alt="Screenshot 2022-01-15 at 10 03 50 AM" src="https://user-images.githubusercontent.com/3069065/149608959-28002cf2-2df6-449a-aea1-6fec43f94bae.png">

