### PR TITLE
[CP Staging] Fix document upload on Android

### DIFF
--- a/src/components/AttachmentPicker/index.native.js
+++ b/src/components/AttachmentPicker/index.native.js
@@ -71,6 +71,13 @@ function getDataForUpload(fileData) {
         size: fileData.fileSize || fileData.size,
     };
 
+    // When the URI is lacking uri scheme - file upload would fail
+    // Prefixing the uri with `file://` fixes attachment upload on Android
+    const hasScheme = /^.+:\/\//.test(fileResult.uri);
+    if (!hasScheme) {
+        fileResult.uri = `file://${fileResult.uri}`;
+    }
+
     if (fileResult.size) {
         return Promise.resolve(fileResult);
     }
@@ -198,7 +205,6 @@ class AttachmentPicker extends Component {
                     return reject(new Error(`Error during attachment selection: ${response.errorMessage}`));
                 }
 
-                // Resolve with the first (and only) selected file
                 return resolve(response.assets);
             });
         });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
@mountiny 

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Add `file://` scheme prefix to attachment files (when it's missing)
Related to: https://github.com/Expensify/App/pull/4908#issuecomment-1013968846

RN Document picker does not add a URI scheme for the file uri on Android. This seems to work ok for showing the document in previews, but instantly fails File upload when `file://` is missing

Checked on iOS and there we do have a `file://` prefix
So the logic that adds the prefix is conditional
Maybe we should try to address this on RN document picker's repo - this PR would remove the deploy blocker in the meantime

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/7267

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console
- [ ] Add a Document attachment in Android (verify it gets uploaded)
- [ ] Add a Document attachment in iOS (verify it gets uploaded)
- [ ] Add a Document attachment on other platforms (verify it gets uploaded)

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

Same as above

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

https://user-images.githubusercontent.com/12156624/149757142-b7beb8de-c4dc-46bb-b3e3-65a072cdfc3d.mp4

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

https://user-images.githubusercontent.com/12156624/149758955-0ddcf6ff-d9f0-46c0-8c2d-c7661667adec.mov

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

https://user-images.githubusercontent.com/12156624/149758544-e45cee5b-2582-4987-bde3-b2823ceef7cf.mov

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

https://user-images.githubusercontent.com/12156624/149754955-b9012998-e7b1-4ce8-be58-f9e0c327c04d.mov

#### Android
<!-- Insert screenshots of your changes on the Android platform-->

https://user-images.githubusercontent.com/12156624/149754871-620c812c-38ca-4307-8d4b-9883c1f70935.mp4


