### PR TITLE
fix: Remove duplicate emojis from search

### DIFF
--- a/src/pages/home/report/EmojiPickerMenu/index.js
+++ b/src/pages/home/report/EmojiPickerMenu/index.js
@@ -343,7 +343,7 @@ class EmojiPickerMenu extends Component {
             return;
         }
 
-        // Skip "Frequently Used" emojis to avoid duplicate results. 
+        // Skip "Frequently Used" emojis to avoid duplicate results.
         // Frequently used emojis are on the 0th index category. Hence, slice the array from the 1st index category onwards.
         const uniqueEmojis = _.isEmpty(this.props.frequentlyUsedEmojis) ? this.emojis : this.emojis.slice(this.unfilteredHeaderIndices[1] * this.numColumns);
         const newFilteredEmojiList = _.filter(uniqueEmojis, emoji => (

--- a/src/pages/home/report/EmojiPickerMenu/index.js
+++ b/src/pages/home/report/EmojiPickerMenu/index.js
@@ -343,8 +343,8 @@ class EmojiPickerMenu extends Component {
             return;
         }
 
-        // We're skipping "Frequently Used" emojis to avoid duplicate results. Frequently Usd Emoji is the 0th index category.
-        // Hence, we slice the array from the 1st index category onwards
+        // Skip "Frequently Used" emojis to avoid duplicate results. 
+        // Frequently used emojis are on the 0th index category. Hence, slice the array from the 1st index category onwards.
         const uniqueEmojis = _.isEmpty(this.props.frequentlyUsedEmojis) ? this.emojis : this.emojis.slice(this.unfilteredHeaderIndices[1] * this.numColumns);
         const newFilteredEmojiList = _.filter(uniqueEmojis, emoji => (
             !emoji.header

--- a/src/pages/home/report/EmojiPickerMenu/index.js
+++ b/src/pages/home/report/EmojiPickerMenu/index.js
@@ -343,7 +343,9 @@ class EmojiPickerMenu extends Component {
             return;
         }
 
-        const newFilteredEmojiList = _.filter(this.emojis, emoji => (
+        // We're skipping "Frequently Used" emojis to avoid duplicate results. Frequently Usd Emoji is the 0th index category,.
+        // Hence, we slice the array from the 1st index category onwards
+        const newFilteredEmojiList = _.filter(this.emojis.slice(this.unfilteredHeaderIndices[1] * this.numColumns), emoji => (
             !emoji.header
             && emoji.code !== CONST.EMOJI_SPACER
             && _.find(emoji.keywords, keyword => keyword.includes(normalizedSearchTerm))

--- a/src/pages/home/report/EmojiPickerMenu/index.js
+++ b/src/pages/home/report/EmojiPickerMenu/index.js
@@ -242,7 +242,7 @@ class EmojiPickerMenu extends Component {
             }
 
             // Move in the prescribed direction until we reach an element that isn't a header
-            const isHeader = e => e.header || e.code === CONST.EMOJI_SPACER;
+            const isHeader = e => e.header || e.spacer;
             do {
                 newIndex += steps;
             } while (isHeader(this.state.filteredEmojis[newIndex]));
@@ -347,7 +347,7 @@ class EmojiPickerMenu extends Component {
         // Hence, we slice the array from the 1st index category onwards
         const newFilteredEmojiList = _.filter(this.emojis.slice(this.unfilteredHeaderIndices[1] * this.numColumns), emoji => (
             !emoji.header
-            && emoji.code !== CONST.EMOJI_SPACER
+            && !emoji.spacer
             && _.find(emoji.keywords, keyword => keyword.includes(normalizedSearchTerm))
         ));
 

--- a/src/pages/home/report/EmojiPickerMenu/index.js
+++ b/src/pages/home/report/EmojiPickerMenu/index.js
@@ -343,7 +343,7 @@ class EmojiPickerMenu extends Component {
             return;
         }
 
-        // We're skipping "Frequently Used" emojis to avoid duplicate results. Frequently Usd Emoji is the 0th index category,.
+        // We're skipping "Frequently Used" emojis to avoid duplicate results. Frequently Usd Emoji is the 0th index category.
         // Hence, we slice the array from the 1st index category onwards
         const uniqueEmojis = _.isEmpty(this.props.frequentlyUsedEmojis) ? this.emojis : this.emojis.slice(this.unfilteredHeaderIndices[1] * this.numColumns);
         const newFilteredEmojiList = _.filter(uniqueEmojis, emoji => (

--- a/src/pages/home/report/EmojiPickerMenu/index.js
+++ b/src/pages/home/report/EmojiPickerMenu/index.js
@@ -345,7 +345,8 @@ class EmojiPickerMenu extends Component {
 
         // We're skipping "Frequently Used" emojis to avoid duplicate results. Frequently Usd Emoji is the 0th index category,.
         // Hence, we slice the array from the 1st index category onwards
-        const newFilteredEmojiList = _.filter(this.emojis.slice(this.unfilteredHeaderIndices[1] * this.numColumns), emoji => (
+        const uniqueEmojis = _.isEmpty(this.props.frequentlyUsedEmojis) ? this.emojis : this.emojis.slice(this.unfilteredHeaderIndices[1] * this.numColumns);
+        const newFilteredEmojiList = _.filter(uniqueEmojis, emoji => (
             !emoji.header
             && !emoji.spacer
             && _.find(emoji.keywords, keyword => keyword.includes(normalizedSearchTerm))

--- a/tests/unit/EmojiRegexTest.js
+++ b/tests/unit/EmojiRegexTest.js
@@ -1,13 +1,12 @@
 import _ from 'underscore';
 import Emoji from '../../assets/emojis';
-import CONST from '../../src/CONST';
 import * as EmojiUtils from '../../src/libs/EmojiUtils';
 
 describe('EmojiRegexTest', () => {
     it('matches all the emojis in the list', () => {
         // Given the set of Emojis available in the application
         const emojiMatched = _.every(Emoji, (emoji) => {
-            if (emoji.header === true || emoji.code === CONST.EMOJI_SPACER) {
+            if (emoji.header === true || emoji.spacer) {
                 return true;
             }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
- Emojis when searched were picked twice - once from "frequently used" and the other relevant category. This PR ignores the emojis from "frequently used" and search only in the original data categories.

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/7273

### Tests
1. Test by filtering the text
2. Test when the emoji exists in original category as well as frequently used category, then the search result should be one of them only
3. Tested without frequently used
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Launch any chat
2. Click on EmojiPicker action
3. If Frequenly Used emojis don't exist then add a few emojis in the chat, if it exists then go to step 4
4. In the search menu, filter the emoji say "smile", "laugh", etc.
5. It should show each emoji only once. 

- [x] Verify that no errors appear in the JS console

### Tested On

- [x] Web
- [ ] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
<img width="404" alt="frequently-used-emojis-reference" src="https://user-images.githubusercontent.com/3069065/150168600-e065c9f4-08b1-4a6f-bbd7-57572bd56cf6.png">

<img width="397" alt="web-remove-duplicate-emojis-in-search" src="https://user-images.githubusercontent.com/3069065/150168631-0058fd14-0675-415c-8e8b-0869f478aa79.png">

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
NA

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
<img width="508" alt="desktop-remove-duplicate-emojis-in-search" src="https://user-images.githubusercontent.com/3069065/150170887-94f96995-be98-449e-9d17-efaed15aec66.png">


#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
NA

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
NA