### PR TITLE
Don't allow users to chat with Concierge when blocked

### DIFF
--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -1189,7 +1189,7 @@ function addAction(reportID, text, file) {
                     [optimisticReportActionID]: null,
                 });
 
-                // The fact that we're getting this error from the API means the BLOCKED_FROM_CONCIERGE nvp in the user details has changed since the last time we checked, so let's trigger an update
+                // The fact that the API is returning this error means the BLOCKED_FROM_CONCIERGE nvp in the user details has changed since the last time we checked, so let's update
                 User.getUserDetails();
                 return;
             }

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -10,6 +10,7 @@ import * as Pusher from '../Pusher/pusher';
 import LocalNotification from '../Notification/LocalNotification';
 import PushNotification from '../Notification/PushNotification';
 import * as PersonalDetails from './PersonalDetails';
+import * as User from './User';
 import Navigation from '../Navigation/Navigation';
 import * as ActiveClientManager from '../ActiveClientManager';
 import Visibility from '../Visibility';
@@ -1181,6 +1182,18 @@ function addAction(reportID, text, file) {
                 console.error(response.message);
                 return;
             }
+
+            if (response.jsonCode === 666 && reportID === conciergeChatReportID) {
+                Growl.error('You are blocked from chatting with Concierge.');
+                Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`, {
+                    [optimisticReportActionID]: null,
+                });
+
+                // The fact that we're getting this error from the API means the BLOCKED_FROM_CONCIERGE nvp in the user details has changed since the last time we checked, so let's trigger an update
+                User.getUserDetails();
+                return;
+            }
+
             updateReportWithNewAction(reportID, response.reportAction);
         });
 }

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -1184,7 +1184,7 @@ function addAction(reportID, text, file) {
             }
 
             if (response.jsonCode === 666 && reportID === conciergeChatReportID) {
-                Growl.error('You are blocked from chatting with Concierge.');
+                Growl.error(Localize.translateLocal('reportActionCompose.blockedFromConcierge'));
                 Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`, {
                     [optimisticReportActionID]: null,
                 });

--- a/src/libs/actions/User.js
+++ b/src/libs/actions/User.js
@@ -103,6 +103,7 @@ function getUserDetails() {
             CONST.NVP.PAYPAL_ME_ADDRESS,
             CONST.NVP.PREFERRED_EMOJI_SKIN_TONE,
             CONST.NVP.FREQUENTLY_USED_EMOJIS,
+            CONST.NVP.BLOCKED_FROM_CONCIERGE,
         ].join(','),
     })
         .then((response) => {

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -505,7 +505,7 @@ class ReportActionCompose extends React.Component {
                 {shouldShowReportRecipientLocalTime
                     && <ParticipantLocalTime participant={reportRecipient} />}
                 <View style={[
-                    (this.state.isFocused || this.state.isDraggingOver)
+                    (!isBlockedFromConcierge && (this.state.isFocused || this.state.isDraggingOver))
                         ? styles.chatItemComposeBoxFocusedColor
                         : styles.chatItemComposeBoxColor,
                     styles.chatItemComposeBox,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR makes a few changes/updates to the concierge blocking functionality. 
1. It fixes the bug where we weren't actually blocking the user from chatting with Concierge. This is because we weren't asking for the `isBlockedFromConcierge` NVP in the API call. This was broken at some point.
2. Makes it so that if a user does chat with Concierge while blocked, we handle the API response. This is possible because we only get the user details every 30 min. So if a user is in active conversation with Concierge and is blocked, they can still seemingly be able to keep chatting until the user details refresh. This PR catches that API response, throws a growl, and prevents them from sending further messages. 
3. Updates the style on the compose box so that it won't appear selected when the user is blocked from using it.  

https://user-images.githubusercontent.com/1371996/150432582-5d4f5946-fd25-44cb-b0be-c970519a0b95.mov

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/Expensify/issues/172842

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/Expensify/issues/172842

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console
1. sign into an account on new dot and go to your concierge chat 
2. send a message to concierge
3. open `expensify.com.dev/concierge/`
4. sign in with an @expensify.com email address
4. click `Tools`
5. use the find chats by user tool to find the chat with your user
6. click "user info" 
7. block your user
8. go back to new dot and try to chat with concierge again 
9. verify that you see the growl that you are barred from chatting
10. verify that your message that you just sent is removed from the chat history
11. verify that the input is disabled and you are no longer able to message concierge
12. verify that the blue highlight is no longer shown around the input

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

Will need to be tested by an Expensify employee on production. Steps are the same as above. 

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
Video above. 

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
<img width="352" alt="Screen Shot 2022-01-20 at 6 04 22 PM" src="https://user-images.githubusercontent.com/1371996/150436120-71440c1d-d8ba-4a76-a722-28361d46d7e8.png">

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
<img width="1194" alt="Screen Shot 2022-01-20 at 5 35 36 PM" src="https://user-images.githubusercontent.com/1371996/150433122-de2c6f86-a997-4daa-845a-f33055cc0b90.png">

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
<img width="354" alt="Screen Shot 2022-01-20 at 5 59 30 PM" src="https://user-images.githubusercontent.com/1371996/150435621-6e8df50e-c3e9-4cf3-9ab1-79433277cd1f.png">


#### Android
<!-- Insert screenshots of your changes on the Android platform-->
<img width="384" alt="Screen Shot 2022-01-20 at 6 24 54 PM" src="https://user-images.githubusercontent.com/1371996/150438103-18b31d73-9f55-4a3b-b188-b0b25ffb3b1f.png">

