### PR TITLE
Bump Onyx version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37125,8 +37125,8 @@
       }
     },
     "react-native-onyx": {
-      "version": "git+https://github.com/Expensify/react-native-onyx.git#40c5b14dcc77e1193d027ecc9dd5f2563516e148",
-      "from": "git+https://github.com/Expensify/react-native-onyx.git#40c5b14dcc77e1193d027ecc9dd5f2563516e148",
+      "version": "git+https://github.com/Expensify/react-native-onyx.git#793fce8f4c19f2ab1a0bf349123cf6a641d7f84a",
+      "from": "git+https://github.com/Expensify/react-native-onyx.git#793fce8f4c19f2ab1a0bf349123cf6a641d7f84a",
       "requires": {
         "ascii-table": "0.0.9",
         "expensify-common": "git+https://github.com/Expensify/expensify-common.git#2e5cff552cf132da90a3fb9756e6b4fb6ae7b40c",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37125,8 +37125,8 @@
       }
     },
     "react-native-onyx": {
-      "version": "git+https://github.com/Expensify/react-native-onyx.git#793fce8f4c19f2ab1a0bf349123cf6a641d7f84a",
-      "from": "git+https://github.com/Expensify/react-native-onyx.git#793fce8f4c19f2ab1a0bf349123cf6a641d7f84a",
+      "version": "git+https://github.com/Expensify/react-native-onyx.git#41c0ee3fae92f644463d3d95fd510eb0142f950c",
+      "from": "git+https://github.com/Expensify/react-native-onyx.git#41c0ee3fae92f644463d3d95fd510eb0142f950c",
       "requires": {
         "ascii-table": "0.0.9",
         "expensify-common": "git+https://github.com/Expensify/expensify-common.git#2e5cff552cf132da90a3fb9756e6b4fb6ae7b40c",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "react-native-image-size": "^1.1.3",
     "react-native-keyboard-spacer": "^0.4.1",
     "react-native-modal": "^11.10.0",
-    "react-native-onyx": "git+https://github.com/Expensify/react-native-onyx.git#40c5b14dcc77e1193d027ecc9dd5f2563516e148",
+    "react-native-onyx": "git+https://github.com/Expensify/react-native-onyx.git#793fce8f4c19f2ab1a0bf349123cf6a641d7f84a",
     "react-native-pdf": "^6.2.2",
     "react-native-performance": "^2.0.0",
     "react-native-permissions": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "react-native-image-size": "^1.1.3",
     "react-native-keyboard-spacer": "^0.4.1",
     "react-native-modal": "^11.10.0",
-    "react-native-onyx": "git+https://github.com/Expensify/react-native-onyx.git#793fce8f4c19f2ab1a0bf349123cf6a641d7f84a",
+    "react-native-onyx": "git+https://github.com/Expensify/react-native-onyx.git#41c0ee3fae92f644463d3d95fd510eb0142f950c",
     "react-native-pdf": "^6.2.2",
     "react-native-performance": "^2.0.0",
     "react-native-permissions": "^3.0.1",


### PR DESCRIPTION
### Details

IndexedDB errors are triggering storage eviction even when we are not running out of storage.

### Fixed Issues
$ https://github.com/Expensify/react-native-onyx/issues/115

### Tests
1. Expose Onyx as a global by putting `window.Onyx = Onyx` somewhere in the code
2. In the JS Console try to set something that should not be set as data e.g.

```js
Onyx.set('bad', {test: new FormData()});
```
3. Verify that there are no messages about storage eviction and instead you see errors about IndexedDB

![2022-01-20_13-10-39](https://user-images.githubusercontent.com/32969087/150436707-fe22deb5-04b2-4f39-ac87-75a2e6cdae27.png)

### QA Steps

No QA

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
