### PR TITLE
Separate report name and icon configuration from personal details

### DIFF
--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -782,7 +782,7 @@ function getReportIcons(report, personalDetails) {
     }
     const sortedParticipants = _.map(report.participants, dmParticipant => ({
         firstName: lodashGet(personalDetails, [dmParticipant, 'firstName'], ''),
-        avatar: lodashGet(personalDetails, [dmParticipant, 'avatarThumbnail'], '')
+        avatar: lodashGet(personalDetails, [dmParticipant, 'avatar'], '')
             || getDefaultAvatar(dmParticipant),
     }))
         .sort((first, second) => first.firstName - second.firstName);

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -782,7 +782,7 @@ function getReportIcons(report, personalDetails) {
     }
     const sortedParticipants = _.map(report.participants, dmParticipant => ({
         firstName: lodashGet(personalDetails, [dmParticipant, 'firstName'], ''),
-        avatar: lodashGet(personalDetails, [dmParticipant, 'avatar'], '')
+        avatar: lodashGet(personalDetails, [dmParticipant, 'avatarThumbnail'], '')
             || getDefaultAvatar(dmParticipant),
     }))
         .sort((first, second) => first.firstName - second.firstName);

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -155,7 +155,7 @@ function getFromReportParticipants(reports) {
         .value();
 
     if (participantEmails.length === 0) {
-        return Promise.resolve([]);
+        return Promise.resolve({});
     }
 
     return API.PersonalDetails_GetForEmails({emailList: participantEmails.join(',')})

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -145,6 +145,7 @@ function fetchPersonalDetails() {
  * Get personal details from report participants.
  *
  * @param {Object} reports
+ * @returns {Promise}
  */
 function getFromReportParticipants(reports) {
     const participantEmails = _.chain(reports)
@@ -157,7 +158,7 @@ function getFromReportParticipants(reports) {
         return;
     }
 
-    API.PersonalDetails_GetForEmails({emailList: participantEmails.join(',')})
+    return API.PersonalDetails_GetForEmails({emailList: participantEmails.join(',')})
         .then((data) => {
             const existingDetails = _.pick(data, participantEmails);
 
@@ -172,6 +173,7 @@ function getFromReportParticipants(reports) {
 
             const formattedPersonalDetails = formatPersonalDetails(details);
             Onyx.merge(ONYXKEYS.PERSONAL_DETAILS, formattedPersonalDetails);
+            return details;
         });
 }
 

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -8,7 +8,6 @@ import CONST from '../../CONST';
 import NetworkConnection from '../NetworkConnection';
 import * as API from '../API';
 import NameValuePair from './NameValuePair';
-import * as ReportUtils from '../reportUtils';
 import * as OptionsListUtils from '../OptionsListUtils';
 import Growl from '../Growl';
 import * as Localize from '../Localize';
@@ -173,36 +172,6 @@ function getFromReportParticipants(reports) {
 
             const formattedPersonalDetails = formatPersonalDetails(details);
             Onyx.merge(ONYXKEYS.PERSONAL_DETAILS, formattedPersonalDetails);
-
-            // The personalDetails of the participants contain their avatar images. Here we'll go over each
-            // report and based on the participants we'll link up their avatars to report icons. This will
-            // skip over default rooms which aren't named by participants.
-            const reportsToUpdate = {};
-            _.each(reports, (report) => {
-                if (report.participants.length <= 0 && !ReportUtils.isChatRoom(report)) {
-                    return;
-                }
-
-                const avatars = OptionsListUtils.getReportIcons(report, details);
-                const reportName = ReportUtils.isChatRoom(report)
-                    ? report.reportName
-                    : _.chain(report.participants)
-                        .filter(participant => participant !== currentUserEmail)
-                        .map(participant => lodashGet(
-                            formattedPersonalDetails,
-                            [participant, 'displayName'],
-                            participant,
-                        ))
-                        .value()
-                        .join(', ');
-
-                reportsToUpdate[`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`] = {icons: avatars, reportName};
-            });
-
-            // We use mergeCollection such that it updates ONYXKEYS.COLLECTION.REPORT in one go.
-            // Any withOnyx subscribers to this key will also receive the complete updated props just once
-            // than updating props for each report and re-rendering had merge been used.
-            Onyx.mergeCollection(ONYXKEYS.COLLECTION.REPORT, reportsToUpdate);
         });
 }
 

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -155,7 +155,7 @@ function getFromReportParticipants(reports) {
         .value();
 
     if (participantEmails.length === 0) {
-        return;
+        return Promise.resolve([]);
     }
 
     return API.PersonalDetails_GetForEmails({emailList: participantEmails.join(',')})

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -320,42 +320,37 @@ function fetchIOUReportID(debtorEmail) {
     });
 }
 
-function configureReportNameAndIcon(reports) {
+function configureReportNameAndIcon(reports, details) {
     // The personalDetails of the participants contain their avatar images. Here we'll go over each
     // report and based on the participants we'll link up their avatars to report icons. This will
     // skip over default rooms which aren't named by participants.
 
-    Onyx.connect({
-        key: ONYXKEYS.PERSONAL_DETAILS,
-        callback: (formattedPersonalDetails) => {
-            const reportsToUpdate = {};
-            _.each(reports, (report) => {
-                if (report.participants.length <= 0 && !ReportUtils.isChatRoom(report)) {
-                    return;
-                }
+    const reportsToUpdate = {};
+    _.each(reports, (report) => {
+        if (report.participants.length <= 0 && !ReportUtils.isChatRoom(report)) {
+            return;
+        }
 
-                const avatars = ReportUtils.isChatRoom(report) ? (['']) : OptionsListUtils.getReportIcons(report, formattedPersonalDetails);
-                const reportName = ReportUtils.isChatRoom(report)
-                    ? report.reportName
-                    : _.chain(report.participants)
-                        .filter(participant => participant !== currentUserEmail)
-                        .map(participant => lodashGet(
-                            formattedPersonalDetails,
-                            [participant, 'displayName'],
-                            participant,
-                        ))
-                        .value()
-                        .join(', ');
+        const avatars = ReportUtils.isChatRoom(report) ? (['']) : OptionsListUtils.getReportIcons(report, details);
+        const reportName = ReportUtils.isChatRoom(report)
+            ? report.reportName
+            : _.chain(report.participants)
+                .filter(participant => participant !== currentUserEmail)
+                .map(participant => lodashGet(
+                    details,
+                    [participant, 'displayName'],
+                    participant,
+                ))
+                .value()
+                .join(', ');
 
-                reportsToUpdate[`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`] = {icons: avatars, reportName};
-            });
-
-            // We use mergeCollection such that it updates ONYXKEYS.COLLECTION.REPORT in one go.
-            // Any withOnyx subscribers to this key will also receive the complete updated props just once
-            // than updating props for each report and re-rendering had merge been used.
-            Onyx.mergeCollection(ONYXKEYS.COLLECTION.REPORT, reportsToUpdate);
-        },
+        reportsToUpdate[`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`] = {icons: avatars, reportName};
     });
+
+    // We use mergeCollection such that it updates ONYXKEYS.COLLECTION.REPORT in one go.
+    // Any withOnyx subscribers to this key will also receive the complete updated props just once
+    // than updating props for each report and re-rendering had merge been used.
+    Onyx.mergeCollection(ONYXKEYS.COLLECTION.REPORT, reportsToUpdate);
 }
 
 /**
@@ -439,10 +434,10 @@ function fetchChatReportsByIDs(chatList, shouldRedirectIfInaccessible = false) {
             Onyx.mergeCollection(ONYXKEYS.COLLECTION.REPORT, simplifiedReports);
 
             // Fetch the personal details if there are any
-            PersonalDetails.getFromReportParticipants(_.values(simplifiedReports));
+            Promise.resolve(PersonalDetails.getFromReportParticipants(_.values(simplifiedReports))).then(
+                details => configureReportNameAndIcon(_.values(simplifiedReports), details),
+            );
 
-            // Configure Report Name and Report Icon
-            configureReportNameAndIcon(_.values(simplifiedReports));
             return fetchedReports;
         })
         .catch((err) => {

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -433,10 +433,11 @@ function fetchChatReportsByIDs(chatList, shouldRedirectIfInaccessible = false) {
             Onyx.mergeCollection(ONYXKEYS.COLLECTION.REPORT_IOUS, reportIOUData);
             Onyx.mergeCollection(ONYXKEYS.COLLECTION.REPORT, simplifiedReports);
 
+            const simplifiedReportsList = _.values(simplifiedReports);
+
             // Fetch the personal details if there are any
-            Promise.resolve(PersonalDetails.getFromReportParticipants(_.values(simplifiedReports))).then(
-                details => configureReportNameAndIcon(_.values(simplifiedReports), details),
-            );
+            PersonalDetails.getFromReportParticipants(simplifiedReportsList)
+                .then(details => configureReportNameAndIcon(simplifiedReportsList, details));
 
             return fetchedReports;
         })


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Solve the issue of report names and icons.
### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/7261

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- Create New Room (Private) and check report name and icon
- Create New Room (Restricted) and check report name and icon
- Create New Group and check report name and icon
- Create New Chat and check report name and icon

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- Create New Room (Private) and check report name and icon
- Create New Room (Restricted) and check report name and icon
- Create New Group and check report name and icon
- Create New Chat and check report name and icon

### Tested On

- [x] Web
- [x] Mobile Web
- [ ] Desktop
- [ ] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
![Screenshot from 2022-01-24 10-14-52](https://user-images.githubusercontent.com/25876548/150739658-1fc7f7ca-d0b6-454a-bda9-b1e7f51a615e.png)
![Screenshot from 2022-01-24 10-13-23](https://user-images.githubusercontent.com/25876548/150739686-ae338317-973f-43ef-97b7-18c3cde1b87a.png)
![Screenshot from 2022-01-24 10-01-59](https://user-images.githubusercontent.com/25876548/150739716-40076b0a-d5ef-4ba6-bb2e-3f8665780699.png)

![Screenshot from 2022-01-24 09-53-28](https://user-images.githubusercontent.com/25876548/150739847-511d09c9-647b-4184-a9cd-c420a699f91d.png)

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
![Screenshot_20220124-101849_Chrome](https://user-images.githubusercontent.com/25876548/150740172-a42c7335-bc12-40a8-a62b-d6bf15f55af5.jpg)

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
![Screenshot_20220124-122600_New Expensify](https://user-images.githubusercontent.com/25876548/150740259-ee605e49-1ccc-4932-aa30-fd60b709263d.jpg)
![Screenshot_20220124-122502_New Expensify](https://user-images.githubusercontent.com/25876548/150740279-8d8ebc74-cc53-4e05-9516-07a7d188b173.jpg)