### PR TITLE
Highlight the  💳 Payment Method on the PaymentMethod list when its menu is active

### DIFF
--- a/src/pages/settings/Payments/PaymentMethodList.js
+++ b/src/pages/settings/Payments/PaymentMethodList.js
@@ -143,7 +143,7 @@ class PaymentMethodList extends Component {
      * @return {Boolean}
      */
     isPaymentMethodActive(paymentMethod) {
-        return paymentMethod.type === this.props.actionPaymentMethodType && paymentMethod.methodID === this.props.activePaymentMethodID;
+        return paymentMethod.accountType === this.props.actionPaymentMethodType && paymentMethod.methodID === this.props.activePaymentMethodID;
     }
 
     /**

--- a/src/pages/settings/Payments/PaymentMethodList.js
+++ b/src/pages/settings/Payments/PaymentMethodList.js
@@ -108,6 +108,8 @@ class PaymentMethodList extends Component {
             ...paymentMethod,
             type: MENU_ITEM,
             onPress: e => this.props.onPress(e, paymentMethod.accountType, paymentMethod.accountData),
+            iconFill: this.isPaymentMethodActive(paymentMethod) ? StyleUtils.getIconFillColor(CONST.BUTTON_STATES.PRESSED) : null,
+            wrapperStyle: this.isPaymentMethodActive(paymentMethod) ? [StyleUtils.getButtonBackgroundColorStyle(CONST.BUTTON_STATES.PRESSED)] : null,
         }));
 
         // If we have not added any payment methods, show a default empty state
@@ -134,6 +136,14 @@ class PaymentMethodList extends Component {
         });
 
         return combinedPaymentMethods;
+    }
+
+    /**
+     * @param {*} paymentMethod
+     * @return {Boolean}
+     */
+    isPaymentMethodActive(paymentMethod) {
+        return paymentMethod.type === this.props.actionPaymentMethodType && paymentMethod.methodID === this.props.activePaymentMethodID;
     }
 
     /**

--- a/src/pages/settings/Payments/PaymentMethodList.js
+++ b/src/pages/settings/Payments/PaymentMethodList.js
@@ -60,6 +60,12 @@ const propTypes = {
         walletLinkedAccountType: PropTypes.string,
     }),
 
+    /** Type of active/highlighted payment method */
+    actionPaymentMethodType: PropTypes.oneOf([CONST.PAYMENT_METHODS.DEBIT_CARD, CONST.PAYMENT_METHODS.BANK_ACCOUNT, '']),
+
+    /** ID of active/highlighted payment method */
+    activePaymentMethodID: PropTypes.number,
+
     ...withLocalizePropTypes,
 };
 
@@ -75,6 +81,8 @@ const defaultProps = {
     isAddPaymentMenuActive: false,
     shouldShowAddPaymentMethodButton: true,
     filterType: '',
+    actionPaymentMethodType: '',
+    activePaymentMethodID: NaN,
 };
 
 class PaymentMethodList extends Component {

--- a/src/pages/settings/Payments/PaymentMethodList.js
+++ b/src/pages/settings/Payments/PaymentMethodList.js
@@ -61,7 +61,7 @@ const propTypes = {
     }),
 
     /** Type of active/highlighted payment method */
-    actionPaymentMethodType: PropTypes.oneOf([CONST.PAYMENT_METHODS.DEBIT_CARD, CONST.PAYMENT_METHODS.BANK_ACCOUNT, '']),
+    actionPaymentMethodType: PropTypes.oneOf([..._.values(CONST.PAYMENT_METHODS), '']),
 
     /** ID of active/highlighted payment method */
     activePaymentMethodID: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),

--- a/src/pages/settings/Payments/PaymentMethodList.js
+++ b/src/pages/settings/Payments/PaymentMethodList.js
@@ -64,7 +64,7 @@ const propTypes = {
     actionPaymentMethodType: PropTypes.oneOf([CONST.PAYMENT_METHODS.DEBIT_CARD, CONST.PAYMENT_METHODS.BANK_ACCOUNT, '']),
 
     /** ID of active/highlighted payment method */
-    activePaymentMethodID: PropTypes.number,
+    activePaymentMethodID: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
     /** ID of selected payment method */
     selectedMethodID: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
@@ -85,7 +85,7 @@ const defaultProps = {
     shouldShowAddPaymentMethodButton: true,
     filterType: '',
     actionPaymentMethodType: '',
-    activePaymentMethodID: NaN,
+    activePaymentMethodID: '',
     selectedMethodID: '',
 };
 
@@ -143,7 +143,9 @@ class PaymentMethodList extends Component {
     }
 
     /**
-     * @param {*} paymentMethod
+     * @param {Object} paymentMethod
+     * @param {String|Number} paymentMethod.methodID
+     * @param {String} paymentMethod.accountType
      * @return {Boolean}
      */
     isPaymentMethodActive(paymentMethod) {

--- a/src/pages/settings/Payments/PaymentsPage.js
+++ b/src/pages/settings/Payments/PaymentsPage.js
@@ -82,6 +82,18 @@ class PaymentsPage extends React.Component {
         PaymentMethods.getPaymentMethods();
     }
 
+    getSelectedPaymentMethodID() {
+        if (this.state.selectedPaymentMethodType === CONST.PAYMENT_METHODS.PAYPAL) {
+            return CONST.PAYMENT_METHODS.PAYPAL;
+        }
+        if (this.state.selectedPaymentMethodType === CONST.PAYMENT_METHODS.BANK_ACCOUNT) {
+            return this.state.selectedPaymentMethod.bankAccountID;
+        }
+        if (this.state.selectedPaymentMethodType === CONST.PAYMENT_METHODS.DEBIT_CARD) {
+            return this.state.selectedPaymentMethod.fundID;
+        }
+    }
+
     /**
      * Display the delete/default menu, or the add payment method menu
      *
@@ -247,6 +259,16 @@ class PaymentsPage extends React.Component {
                             style={[styles.flex4]}
                             isLoadingPayments={this.props.isLoadingPaymentMethods}
                             isAddPaymentMenuActive={this.state.shouldShowAddPaymentMenu}
+                            actionPaymentMethodType={
+                                this.state.shouldShowDefaultDeleteMenu
+                                    ? this.state.selectedPaymentMethodType
+                                    : ''
+                            }
+                            activePaymentMethodID={
+                                this.state.shouldShowDefaultDeleteMenu
+                                    ? this.getSelectedPaymentMethodID()
+                                    : ''
+                            }
                         />
                     </View>
                     <AddPaymentMethodMenu

--- a/src/pages/settings/Payments/PaymentsPage.js
+++ b/src/pages/settings/Payments/PaymentsPage.js
@@ -259,16 +259,12 @@ class PaymentsPage extends React.Component {
                             style={[styles.flex4]}
                             isLoadingPayments={this.props.isLoadingPaymentMethods}
                             isAddPaymentMenuActive={this.state.shouldShowAddPaymentMenu}
-                            actionPaymentMethodType={
-                                this.state.shouldShowDefaultDeleteMenu
-                                    ? this.state.selectedPaymentMethodType
-                                    : ''
-                            }
-                            activePaymentMethodID={
-                                this.state.shouldShowDefaultDeleteMenu
-                                    ? this.getSelectedPaymentMethodID()
-                                    : ''
-                            }
+                            actionPaymentMethodType={this.state.shouldShowDefaultDeleteMenu || this.state.shouldShowPasswordPrompt || this.state.shouldShowConfirmPopover
+                                ? this.state.selectedPaymentMethodType
+                                : ''}
+                            activePaymentMethodID={this.state.shouldShowDefaultDeleteMenu || this.state.shouldShowPasswordPrompt || this.state.shouldShowConfirmPopover
+                                ? this.getSelectedPaymentMethodID()
+                                : ''}
                         />
                     </View>
                     <AddPaymentMethodMenu


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/7353

### Tests | QA Steps
1. Open PaymentsPage .
2. Click any payment method.
3. It should be highlighted when menu is open for it.

- [x] Verify that no errors appear in the JS console

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web | Desktop | Mobile Web
<!-- Insert screenshots of your changes on the web platform-->
![image](https://user-images.githubusercontent.com/24370807/150895889-72520acc-4e97-4b94-a936-41d0aefb9fa9.png)

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
![image](https://user-images.githubusercontent.com/24370807/150896953-4185e14d-2524-49ad-81a8-11c4865ac895.png)
