### PR TITLE
Remove credentials and session from Onyx on sign out

### DIFF
--- a/src/libs/actions/Session/index.js
+++ b/src/libs/actions/Session/index.js
@@ -83,6 +83,8 @@ function signOut() {
         })
             .catch(error => Onyx.merge(ONYXKEYS.SESSION, {error: error.message}));
     }
+    Onyx.set(ONYXKEYS.SESSION, null);
+    Onyx.set(ONYXKEYS.CREDENTIALS, null);
     Timing.clearData();
     redirectToSignIn();
     Log.info('Redirecting to Sign In because signOut() was called');


### PR DESCRIPTION
### Details
Removes session and credentials from local storage after sign out.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/193459

### Tests
1. Login
2. Sign out
3. Refresh the page and verify that you still see the login page.

- [X] Verify that no errors appear in the JS console

### QA Steps
Steps above.

- [ ] Verify that no errors appear in the JS console

### Tested On

- [X] Web
- [ ] Mobile Web
- [X] Desktop
- [ ] iOS
- [ ] Android

### Screenshots

#### Web

https://user-images.githubusercontent.com/22219519/151057676-81afb72e-a709-4fc8-be65-e97f9667efd1.mov

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop

https://user-images.githubusercontent.com/22219519/151057913-d23bdfeb-bd39-4f0a-a5bc-42f4e0c051b7.mov

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
