### PR TITLE
Remove import to fix lint error

### DIFF
--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -26,7 +26,6 @@ import Timers from '../Timers';
 import * as ReportActions from './ReportActions';
 import Growl from '../Growl';
 import * as Localize from '../Localize';
-import * as OptionsListUtils from '../OptionsListUtils';
 
 let currentUserEmail;
 let currentUserAccountID;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Fix lint error:

```
andrew ➜ (main) App npm run lint

> new.expensify@1.1.33-0 lint /Users/andrew/Expensidev/App
> eslint . --max-warnings=0


Error while parsing /Users/andrew/Expensidev/App/src/libs/actions/Report.js
Line 29, column 13: Line 29: Identifier 'OptionsListUtils' has already been declared

  27 | import Growl from '../Growl';
  28 | import * as Localize from '../Localize';
> 29 | import * as OptionsListUtils from '../OptionsListUtils';
     |             ^
  30 |
  31 | let currentUserEmail;
  32 | let currentUserAccountID;
`parseForESLint` from parser `/Users/andrew/Expensidev/App/node_modules/babel-eslint/lib/index.js` is invalid and will just be ignored

/Users/andrew/Expensidev/App/src/libs/actions/Report.js
  29:13  error  Parsing error: Identifier 'OptionsListUtils' has already been declared

  1 Remove import to fix lint error
  27 | import Growl from '../Growl';
  28 | import * as Localize from '../Localize';
> 29 | import * as OptionsListUtils from '../OptionsListUtils';
     |             ^
  30 |
  31 | let currentUserEmail;
  32 | let currentUserAccountID;

✖ 1 problem (1 error, 0 warnings)

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! new.expensify@1.1.33-0 lint: `eslint . --max-warnings=0`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the new.expensify@1.1.33-0 lint script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/andrew/.npm/_logs/2022-01-25T23_23_36_924Z-debug.log
```

### Tests
1. Run `npm lint` or check the lint action