### PR TITLE
[NO-QA]Use renamed git repo for change step

### DIFF
--- a/.github/workflows/updateProtectedBranch.yml
+++ b/.github/workflows/updateProtectedBranch.yml
@@ -95,7 +95,7 @@ jobs:
         if: ${{ github.event.inputs.TARGET_BRANCH == 'main' }}
         id: changedFiles
         # Version: 3.3.0
-        uses: futuratrepadeira/changed-files@1d252c611c64289d35243fc37ece7323ea5e93e1
+        uses: umani/changed-files@1d252c611c64289d35243fc37ece7323ea5e93e1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           pr-number: ${{ steps.createPullRequest.outputs.pr_number }}


### PR DESCRIPTION
### Details
`futuratrepadeira/changed-files` was renamed to `umani/changed-files`, I'm not sure it's causing errors in this repo, but it was in a different one, so let's just update to the renamed repo just in case.

### Tests
1. Merge this PR
2. Verify that `updateProtectedBranch.yml` continues to check for the correct files changed