### PR TITLE
[CP Stg] Resolve getImageSize promise with an object instead of multiple values

### DIFF
--- a/src/components/ImageWithSizeCalculation.js
+++ b/src/components/ImageWithSizeCalculation.js
@@ -56,7 +56,7 @@ class ImageWithSizeCalculation extends PureComponent {
     getImageSize(url) {
         return new Promise((resolve, reject) => {
             Image.getSize(url, (width, height) => {
-                resolve(width, height);
+                resolve({width, height});
             }, (error) => {
                 reject(error);
             });
@@ -70,7 +70,7 @@ class ImageWithSizeCalculation extends PureComponent {
 
         this.getImageSizePromise = makeCancellablePromise(this.getImageSize(this.props.url));
         this.getImageSizePromise.promise
-            .then((width, height) => {
+            .then(({width, height}) => {
                 if (!width || !height) {
                     // Image didn't load properly
                     return;


### PR DESCRIPTION
### Details
Those pesky curly braces! The problem here was that `Promise.resolve` only takes a single argument, not multiple args. So we now pass width and height together in a single object.

### Fixed Issues
$ https://github.com/Expensify/App/issues/7407

### Tests / QA Steps
1. Send an image attachment that's not square.
1. Make sure it doesn't appear inscribed within the square thumbnail.

- [x] Verify that no new errors appear in the JS console (tests)
- [ ] Verify that no new errors appear in the JS console (QA)

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
#### Web
![image](https://user-images.githubusercontent.com/47436092/151083103-c73e1876-3031-4967-81bc-f4db79f5d8aa.png)

#### Mobile Web
<img src="https://user-images.githubusercontent.com/47436092/151083295-3f914249-b34b-4d22-a0b5-2db361eee978.png" width="350px" alt="" />

#### Desktop
![image](https://user-images.githubusercontent.com/47436092/151085071-8a683771-ee60-4d6d-9845-d187706d2cfc.png)

#### iOS
<img src="https://user-images.githubusercontent.com/47436092/151084139-396784f4-45c2-4c8c-a1f8-52648ac9732e.png" alt="" width="350px" />

#### Android
<img src="https://user-images.githubusercontent.com/47436092/151084822-57173213-0568-486a-add0-9a149121a269.png" alt="" width="350px" />
