### PR TITLE
Invite lowercase emails to workspaces

### DIFF
--- a/src/pages/workspace/WorkspaceInvitePage.js
+++ b/src/pages/workspace/WorkspaceInvitePage.js
@@ -214,7 +214,8 @@ class WorkspaceInvitePage extends React.Component {
         }
 
         const logins = _.map(this.state.selectedOptions, option => option.login);
-        Policy.invite(logins, this.state.welcomeNote || this.getWelcomeNotePlaceholder(), this.props.route.params.policyID);
+        const filteredLogins = _.uniq(_.compact(_.map(logins, login => login.toLowerCase().trim())));
+        Policy.invite(filteredLogins, this.state.welcomeNote || this.getWelcomeNotePlaceholder(), this.props.route.params.policyID);
     }
 
     /**


### PR DESCRIPTION
### Details
We couldn't delete emails added with an uppercase, because then, when deleting, php side was trying to retrieve the email by key comparing it with lowercase. Let's just always add emails in lowercase

### Fixed Issues
$ https://github.com/Expensify/App/issues/7431

### Tests
Invite an email with an uppercase letter to the workspace.
Make sure it's added with only lowercase letters.
Try to remove it. It should work

### QA Steps
Invite an email with an uppercase letter to the workspace.
Make sure it's added with only lowercase letters.
Try to remove it. It should work

- [ ] Verify that no errors appear in the JS console

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots

#### Web
![image](https://user-images.githubusercontent.com/2463975/151338678-c982c0f1-ce83-4d56-9a28-faf91815f660.png)

![image](https://user-images.githubusercontent.com/2463975/151338739-62fc562f-ca7e-4c57-8167-06ad52a80a22.png)

![image](https://user-images.githubusercontent.com/2463975/151338769-90e1c9c1-6b45-4827-b6f8-da100c84e41d.png)

