### PR TITLE
Fix button padding on IOU Details page

### DIFF
--- a/src/pages/iou/IOUDetailsModal.js
+++ b/src/pages/iou/IOUDetailsModal.js
@@ -19,6 +19,7 @@ import compose from '../../libs/compose';
 import CONST from '../../CONST';
 import SettlementButton from '../../components/SettlementButton';
 import ROUTES from '../../ROUTES';
+import FixedFooter from '../../components/FixedFooter';
 
 const propTypes = {
     /** URL Route params */
@@ -126,7 +127,7 @@ class IOUDetailsModal extends Component {
                         </ScrollView>
                         {(this.props.iouReport.hasOutstandingIOU
                             && this.props.iouReport.managerEmail === sessionEmail && (
-                            <View style={styles.p5}>
+                            <FixedFooter>
                                 <SettlementButton
                                     isLoading={this.props.iou.loading}
                                     onPress={paymentMethodType => this.performIOUPayment(paymentMethodType)}
@@ -137,7 +138,7 @@ class IOUDetailsModal extends Component {
                                     addBankAccountRoute={ROUTES.IOU_DETAILS_ADD_BANK_ACCOUNT}
                                     addDebitCardRoute={ROUTES.IOU_DETAILS_ADD_DEBIT_CARD}
                                 />
-                            </View>
+                            </FixedFooter>
                         ))}
                     </View>
                 )}


### PR DESCRIPTION
Use `FixedFooter` component instead of `View` with custom style

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/7441

### Tests

1. Request money multiple times from a user
2. Make sure Payment button has no padding at the top

- [x] Verify that no errors appear in the JS console

### QA Steps

1. Requested money multiple times from a user
2. Make sure Payment button has no padding at the top

- [x] Verify that no errors appear in the JS console

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web


https://user-images.githubusercontent.com/32012005/151349467-0d611702-4e9b-4cab-ba5e-277b0769b1f9.mov


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
![Simulator Screen Shot - iPhone 12 - 2022-01-27 at 21 03 25](https://user-images.githubusercontent.com/32012005/151390818-f80908a6-2752-4a39-bc8c-14a620526055.png)

#### Android
![Screenshot_1643295386](https://user-images.githubusercontent.com/32012005/151383939-e8a428a9-f6ac-44e1-8e8e-fea5d9346c08.png)

