### PR TITLE
Update semver logic: one patch version per checklist

### DIFF
--- a/.github/actions/awaitStagingDeploys/action.yml
+++ b/.github/actions/awaitStagingDeploys/action.yml
@@ -1,0 +1,9 @@
+name: 'Await staging deploys'
+description: 'Waits for any active staging deploys to finish'
+inputs:
+  GITHUB_TOKEN:
+    description: Auth token for New Expensify Github
+    required: true
+runs:
+  using: 'node12'
+  main: './index.js'

--- a/.github/actions/awaitStagingDeploys/awaitStagingDeploys.js
+++ b/.github/actions/awaitStagingDeploys/awaitStagingDeploys.js
@@ -1,0 +1,18 @@
+const _ = require('underscore');
+const GitHubUtils = require('../../libs/GithubUtils');
+const {promiseDoWhile} = require('../../libs/promiseWhile');
+
+let currentStagingDeploys = [];
+promiseDoWhile(
+    () => !_.isEmpty(currentStagingDeploys),
+    _.throttle(
+        () => GitHubUtils.octokit.actions.listWorkflowRuns({
+            owner: GitHubUtils.GITHUB_OWNER,
+            repo: GitHubUtils.APP_REPO,
+            workflow_id: 'platformDeploy.yml',
+            event: 'push',
+        })
+            .then(response => currentStagingDeploys = _.filter(response.data.workflow_runs, workflowRun => workflowRun.status !== 'completed')),
+        GitHubUtils.POLL_RATE,
+    ),
+);

--- a/.github/actions/awaitStagingDeploys/awaitStagingDeploys.js
+++ b/.github/actions/awaitStagingDeploys/awaitStagingDeploys.js
@@ -7,21 +7,36 @@ function run() {
     return promiseDoWhile(
         () => !_.isEmpty(currentStagingDeploys),
         _.throttle(
-            () => GitHubUtils.octokit.actions.listWorkflowRuns({
-                owner: GitHubUtils.GITHUB_OWNER,
-                repo: GitHubUtils.APP_REPO,
-                workflow_id: 'platformDeploy.yml',
-                event: 'push',
-            })
-                .then(response => currentStagingDeploys = _.filter(response.data.workflow_runs, workflowRun => workflowRun.status !== 'completed'))
+            () => Promise.all([
+                // These are active deploys
+                GitHubUtils.octokit.actions.listWorkflowRuns({
+                    owner: GitHubUtils.GITHUB_OWNER,
+                    repo: GitHubUtils.APP_REPO,
+                    workflow_id: 'platformDeploy.yml',
+                    event: 'push',
+                }),
+
+                // These have the potential to become active deploys, so we need to wait for them to finish as well
+                // In this context, we'll refer to unresolved preDeploy workflow runs as staging deploys as well
+                GitHubUtils.octokit.actions.listWorkflowRuns({
+                    owner: GitHubUtils.GITHUB_OWNER,
+                    repo: GitHubUtils.APP_REPO,
+                    workflow_id: 'preDeploy.yml',
+                }),
+            ])
+                .then(responses => [
+                    ...responses[0].data.workflow_runs,
+                    ...responses[1].data.workflow_runs,
+                ])
+                .then(workflowRuns => currentStagingDeploys = _.filter(workflowRuns, workflowRun => workflowRun.status !== 'completed'))
                 .then(() => console.log(
                     _.isEmpty(currentStagingDeploys)
                         ? 'No current staging deploys found'
                         : `Found ${currentStagingDeploys.length} staging deploy${currentStagingDeploys.length > 1 ? 's' : ''} still running...`,
                 )),
 
-            // Poll every 90 seconds instead of every 10 seconds
-            GitHubUtils.POLL_RATE * 9,
+            // Poll every 60 seconds instead of every 10 seconds
+            GitHubUtils.POLL_RATE * 6,
         ),
     );
 }

--- a/.github/actions/awaitStagingDeploys/awaitStagingDeploys.js
+++ b/.github/actions/awaitStagingDeploys/awaitStagingDeploys.js
@@ -2,17 +2,32 @@ const _ = require('underscore');
 const GitHubUtils = require('../../libs/GithubUtils');
 const {promiseDoWhile} = require('../../libs/promiseWhile');
 
-let currentStagingDeploys = [];
-promiseDoWhile(
-    () => !_.isEmpty(currentStagingDeploys),
-    _.throttle(
-        () => GitHubUtils.octokit.actions.listWorkflowRuns({
-            owner: GitHubUtils.GITHUB_OWNER,
-            repo: GitHubUtils.APP_REPO,
-            workflow_id: 'platformDeploy.yml',
-            event: 'push',
-        })
-            .then(response => currentStagingDeploys = _.filter(response.data.workflow_runs, workflowRun => workflowRun.status !== 'completed')),
-        GitHubUtils.POLL_RATE,
-    ),
-);
+function run() {
+    let currentStagingDeploys = [];
+    return promiseDoWhile(
+        () => !_.isEmpty(currentStagingDeploys),
+        _.throttle(
+            () => GitHubUtils.octokit.actions.listWorkflowRuns({
+                owner: GitHubUtils.GITHUB_OWNER,
+                repo: GitHubUtils.APP_REPO,
+                workflow_id: 'platformDeploy.yml',
+                event: 'push',
+            })
+                .then(response => currentStagingDeploys = _.filter(response.data.workflow_runs, workflowRun => workflowRun.status !== 'completed'))
+                .then(() => console.log(
+                    _.isEmpty(currentStagingDeploys)
+                        ? 'No current staging deploys found'
+                        : `Found ${currentStagingDeploys.length} staging deploy${currentStagingDeploys.length > 1 ? 's' : ''} still running...`,
+                )),
+
+            // Poll every 90 seconds instead of every 10 seconds
+            GitHubUtils.POLL_RATE * 9,
+        ),
+    );
+}
+
+if (require.main === module) {
+    run();
+}
+
+module.exports = run;

--- a/.github/actions/awaitStagingDeploys/index.js
+++ b/.github/actions/awaitStagingDeploys/index.js
@@ -17,21 +17,36 @@ function run() {
     return promiseDoWhile(
         () => !_.isEmpty(currentStagingDeploys),
         _.throttle(
-            () => GitHubUtils.octokit.actions.listWorkflowRuns({
-                owner: GitHubUtils.GITHUB_OWNER,
-                repo: GitHubUtils.APP_REPO,
-                workflow_id: 'platformDeploy.yml',
-                event: 'push',
-            })
-                .then(response => currentStagingDeploys = _.filter(response.data.workflow_runs, workflowRun => workflowRun.status !== 'completed'))
+            () => Promise.all([
+                // These are active deploys
+                GitHubUtils.octokit.actions.listWorkflowRuns({
+                    owner: GitHubUtils.GITHUB_OWNER,
+                    repo: GitHubUtils.APP_REPO,
+                    workflow_id: 'platformDeploy.yml',
+                    event: 'push',
+                }),
+
+                // These have the potential to become active deploys, so we need to wait for them to finish as well
+                // In this context, we'll refer to unresolved preDeploy workflow runs as staging deploys as well
+                GitHubUtils.octokit.actions.listWorkflowRuns({
+                    owner: GitHubUtils.GITHUB_OWNER,
+                    repo: GitHubUtils.APP_REPO,
+                    workflow_id: 'preDeploy.yml',
+                }),
+            ])
+                .then(responses => [
+                    ...responses[0].data.workflow_runs,
+                    ...responses[1].data.workflow_runs,
+                ])
+                .then(workflowRuns => currentStagingDeploys = _.filter(workflowRuns, workflowRun => workflowRun.status !== 'completed'))
                 .then(() => console.log(
                     _.isEmpty(currentStagingDeploys)
                         ? 'No current staging deploys found'
                         : `Found ${currentStagingDeploys.length} staging deploy${currentStagingDeploys.length > 1 ? 's' : ''} still running...`,
                 )),
 
-            // Poll every 90 seconds instead of every 10 seconds
-            GitHubUtils.POLL_RATE * 9,
+            // Poll every 60 seconds instead of every 10 seconds
+            GitHubUtils.POLL_RATE * 6,
         ),
     );
 }

--- a/.github/actions/awaitStagingDeploys/index.js
+++ b/.github/actions/awaitStagingDeploys/index.js
@@ -5,195 +5,27 @@ module.exports =
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 9908:
-/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+/***/ 1738:
+/***/ ((__unused_webpack_module, __unused_webpack_exports, __nccwpck_require__) => {
 
 const _ = __nccwpck_require__(3571);
-const core = __nccwpck_require__(2186);
-const ActionUtils = __nccwpck_require__(970);
-const GithubUtils = __nccwpck_require__(7999);
-const {promiseWhile} = __nccwpck_require__(4502);
+const GitHubUtils = __nccwpck_require__(7999);
+const {promiseDoWhile} = __nccwpck_require__(4502);
 
-/**
- * The maximum amount of time (in ms) we'll wait for a new workflow to start after sending the workflow_dispatch event.
- * It's two minutes :)
- * @type {number}
- */
-const NEW_WORKFLOW_TIMEOUT = 120000;
-
-/**
- * The maximum amount of time (in ms) we'll wait for a workflow to complete before giving up.
- * It's two hours :)
- * @type {number}
- */
-const WORKFLOW_COMPLETION_TIMEOUT = 7200000;
-
-/**
- * URL prefixed to a specific workflow run
- * @type {string}
- */
-const WORKFLOW_RUN_URL_PREFIX = 'https://github.com/Expensify/App/actions/runs/';
-
-const run = function () {
-    const workflow = core.getInput('WORKFLOW', {required: true});
-    const inputs = ActionUtils.getJSONInput('INPUTS', {required: false}, {});
-
-    console.log('This action has received the following inputs: ', {workflow, inputs});
-
-    if (_.keys(inputs).length > 10) {
-        const err = new Error('Inputs to the workflow_dispatch event cannot have more than 10 keys, or GitHub will 🤮');
-        console.error(err.message);
-        core.setFailed(err);
-        process.exit(1);
-    }
-
-    // GitHub's createWorkflowDispatch returns a 204 No Content, so we need to:
-    // 1) Get the last workflow run
-    // 2) Trigger a new workflow run
-    // 3) Poll the API until a new one appears
-    // 4) Then we can poll and wait for that new workflow run to conclude
-    let previousWorkflowRunID;
-    let newWorkflowRunID;
-    let newWorkflowRunURL;
-    let hasNewWorkflowStarted = false;
-    let workflowCompleted = false;
-    return GithubUtils.getLatestWorkflowRunID(workflow)
-        .then((lastWorkflowRunID) => {
-            console.log(`Latest ${workflow} workflow run has ID: ${lastWorkflowRunID}`);
-            previousWorkflowRunID = lastWorkflowRunID;
-
-            console.log(`Dispatching workflow: ${workflow}`);
-            return GithubUtils.octokit.actions.createWorkflowDispatch({
-                owner: GithubUtils.GITHUB_OWNER,
-                repo: GithubUtils.APP_REPO,
-                workflow_id: workflow,
-                ref: 'main',
-                inputs,
-            });
+let currentStagingDeploys = [];
+promiseDoWhile(
+    () => !_.isEmpty(currentStagingDeploys),
+    _.throttle(
+        () => GitHubUtils.octokit.actions.listWorkflowRuns({
+            owner: GitHubUtils.GITHUB_OWNER,
+            repo: GitHubUtils.APP_REPO,
+            workflow_id: 'platformDeploy.yml',
+            event: 'push',
         })
-
-        .catch((err) => {
-            console.error(`Failed to dispatch workflow ${workflow}`, err);
-            core.setFailed(err);
-            process.exit(1);
-        })
-
-        // Wait for the new workflow to start
-        .then(() => {
-            let waitTimer = -GithubUtils.POLL_RATE;
-            return promiseWhile(
-                () => !hasNewWorkflowStarted && waitTimer < NEW_WORKFLOW_TIMEOUT,
-                _.throttle(
-                    () => {
-                        console.log(`\n🤚 Waiting for a new ${workflow} workflow run to begin...`);
-                        return GithubUtils.getLatestWorkflowRunID(workflow)
-                            .then((lastWorkflowRunID) => {
-                                newWorkflowRunID = lastWorkflowRunID;
-                                newWorkflowRunURL = WORKFLOW_RUN_URL_PREFIX + newWorkflowRunID;
-                                hasNewWorkflowStarted = newWorkflowRunID !== previousWorkflowRunID;
-
-                                if (!hasNewWorkflowStarted) {
-                                    waitTimer += GithubUtils.POLL_RATE;
-                                    if (waitTimer < NEW_WORKFLOW_TIMEOUT) {
-                                        // eslint-disable-next-line max-len
-                                        console.log(`After ${waitTimer / 1000} seconds, there's still no new ${workflow} workflow run 🙁`);
-                                    } else {
-                                        // eslint-disable-next-line max-len
-                                        const err = new Error(`After ${NEW_WORKFLOW_TIMEOUT / 1000} seconds, the ${workflow} workflow did not start.`);
-                                        console.error(err);
-                                        core.setFailed(err);
-                                        process.exit(1);
-                                    }
-                                } else {
-                                    console.log(`\n🚀 New ${workflow} run ${newWorkflowRunURL} has started`);
-                                }
-                            })
-                            .catch((err) => {
-                                console.warn('Failed to fetch latest workflow run.', err);
-                            });
-                    },
-                    GithubUtils.POLL_RATE,
-                ),
-            );
-        })
-
-        // Wait for the new workflow run to finish
-        .then(() => {
-            let waitTimer = -GithubUtils.POLL_RATE;
-            return promiseWhile(
-                () => !workflowCompleted && waitTimer < WORKFLOW_COMPLETION_TIMEOUT,
-                _.throttle(
-                    () => {
-                        console.log(`\n⏳ Waiting for workflow run ${newWorkflowRunURL} to finish...`);
-                        return GithubUtils.octokit.actions.getWorkflowRun({
-                            owner: GithubUtils.GITHUB_OWNER,
-                            repo: GithubUtils.APP_REPO,
-                            run_id: newWorkflowRunID,
-                        })
-                            .then(({data}) => {
-                                workflowCompleted = data.status === 'completed' && data.conclusion !== null;
-                                waitTimer += GithubUtils.POLL_RATE;
-                                if (waitTimer > WORKFLOW_COMPLETION_TIMEOUT) {
-                                    // eslint-disable-next-line max-len
-                                    const err = new Error(`After ${WORKFLOW_COMPLETION_TIMEOUT / 1000 / 60 / 60} hours, workflow ${newWorkflowRunURL} did not complete.`);
-                                    console.error(err);
-                                    core.setFailed(err);
-                                    process.exit(1);
-                                }
-                                if (workflowCompleted) {
-                                    if (data.conclusion === 'success') {
-                                        // eslint-disable-next-line max-len
-                                        console.log(`\n🎉 ${workflow} run ${newWorkflowRunURL} completed successfully! 🎉`);
-                                    } else {
-                                        // eslint-disable-next-line max-len
-                                        const err = new Error(`🙅‍ ${workflow} run ${newWorkflowRunURL} finished with conclusion ${data.conclusion}`);
-                                        console.error(err.message);
-                                        core.setFailed(err);
-                                        process.exit(1);
-                                    }
-                                }
-                            });
-                    },
-                    GithubUtils.POLL_RATE,
-                ),
-            );
-        });
-};
-
-if (require.main === require.cache[eval('__filename')]) {
-    run();
-}
-
-module.exports = run;
-
-
-/***/ }),
-
-/***/ 970:
-/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-const core = __nccwpck_require__(2186);
-
-/**
- * Safely parse a JSON input to a GitHub Action.
- *
- * @param {String} name - The name of the input.
- * @param {Object} options - Options to pass to core.getInput
- * @param {*} [defaultValue] - A default value to provide for the input.
- *                             Not required if the {required: true} option is given in the second arg to this function.
- * @returns {any}
- */
-function getJSONInput(name, options, defaultValue = undefined) {
-    const input = core.getInput(name, options);
-    if (input) {
-        return JSON.parse(input);
-    }
-    return defaultValue;
-}
-
-module.exports = {
-    getJSONInput,
-};
+            .then(response => currentStagingDeploys = _.filter(response.data.workflow_runs, workflowRun => workflowRun.status !== 'completed')),
+        GitHubUtils.POLL_RATE,
+    ),
+);
 
 
 /***/ }),
@@ -12272,6 +12104,6 @@ module.exports = require("zlib");;
 /******/ 	// module exports must be returned from runtime so entry inlining is disabled
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
-/******/ 	return __nccwpck_require__(9908);
+/******/ 	return __nccwpck_require__(1738);
 /******/ })()
 ;

--- a/.github/actions/checkDeployBlockers/checkDeployBlockers.js
+++ b/.github/actions/checkDeployBlockers/checkDeployBlockers.js
@@ -9,7 +9,7 @@ const run = function () {
 
     return GithubUtils.octokit.issues.get({
         owner: GithubUtils.GITHUB_OWNER,
-        repo: GithubUtils.EXPENSIFY_CASH_REPO,
+        repo: GithubUtils.APP_REPO,
         issue_number: issueNumber,
     })
         .then(({data}) => {
@@ -25,7 +25,7 @@ const run = function () {
 
             return GithubUtils.octokit.issues.listComments({
                 owner: GithubUtils.GITHUB_OWNER,
-                repo: GithubUtils.EXPENSIFY_CASH_REPO,
+                repo: GithubUtils.APP_REPO,
                 issue_number: issueNumber,
                 per_page: 100,
             });

--- a/.github/actions/checkDeployBlockers/index.js
+++ b/.github/actions/checkDeployBlockers/index.js
@@ -19,7 +19,7 @@ const run = function () {
 
     return GithubUtils.octokit.issues.get({
         owner: GithubUtils.GITHUB_OWNER,
-        repo: GithubUtils.EXPENSIFY_CASH_REPO,
+        repo: GithubUtils.APP_REPO,
         issue_number: issueNumber,
     })
         .then(({data}) => {
@@ -35,7 +35,7 @@ const run = function () {
 
             return GithubUtils.octokit.issues.listComments({
                 owner: GithubUtils.GITHUB_OWNER,
-                repo: GithubUtils.EXPENSIFY_CASH_REPO,
+                repo: GithubUtils.APP_REPO,
                 issue_number: issueNumber,
                 per_page: 100,
             });
@@ -92,8 +92,8 @@ const {GitHub, getOctokitOptions} = __nccwpck_require__(3030);
 const {throttling} = __nccwpck_require__(9968);
 
 const GITHUB_OWNER = 'Expensify';
-const EXPENSIFY_CASH_REPO = 'App';
-const EXPENSIFY_CASH_URL = 'https://github.com/Expensify/App';
+const APP_REPO = 'App';
+const APP_REPO_URL = 'https://github.com/Expensify/App';
 
 const GITHUB_BASE_URL_REGEX = new RegExp('https?://(?:github\\.com|api\\.github\\.com)');
 const PULL_REQUEST_REGEX = new RegExp(`${GITHUB_BASE_URL_REGEX.source}/.*/.*/pull/([0-9]+).*`);
@@ -104,6 +104,13 @@ const APPLAUSE_BOT = 'applausebot';
 const STAGING_DEPLOY_CASH_LABEL = 'StagingDeployCash';
 const DEPLOY_BLOCKER_CASH_LABEL = 'DeployBlockerCash';
 const INTERNAL_QA_LABEL = 'InternalQA';
+
+/**
+ * The standard rate in ms at which we'll poll the GitHub API to check for status changes.
+ * It's 10 seconds :)
+ * @type {number}
+ */
+const POLL_RATE = 10000;
 
 class GithubUtils {
     /**
@@ -152,7 +159,7 @@ class GithubUtils {
     static getStagingDeployCash() {
         return this.octokit.issues.listForRepo({
             owner: GITHUB_OWNER,
-            repo: EXPENSIFY_CASH_REPO,
+            repo: APP_REPO,
             labels: STAGING_DEPLOY_CASH_LABEL,
             state: 'open',
         })
@@ -360,7 +367,7 @@ class GithubUtils {
         const oldestPR = _.first(_.sortBy(pullRequestNumbers));
         return this.octokit.paginate(this.octokit.pulls.list, {
             owner: GITHUB_OWNER,
-            repo: EXPENSIFY_CASH_REPO,
+            repo: APP_REPO,
             state: 'all',
             sort: 'created',
             direction: 'desc',
@@ -403,7 +410,7 @@ class GithubUtils {
         console.log(`Fetching New Expensify workflow runs for ${workflow}...`);
         return this.octokit.actions.listWorkflowRuns({
             owner: GITHUB_OWNER,
-            repo: EXPENSIFY_CASH_REPO,
+            repo: APP_REPO,
             workflow_id: workflow,
         })
             .then(response => lodashGet(response, 'data.workflow_runs[0].id'));
@@ -429,7 +436,7 @@ class GithubUtils {
      * @returns {String}
      */
     static getPullRequestURLFromNumber(number) {
-        return `${EXPENSIFY_CASH_URL}/pull/${number}`;
+        return `${APP_REPO_URL}/pull/${number}`;
     }
 
     /**
@@ -496,7 +503,7 @@ class GithubUtils {
     static getActorWhoClosedIssue(issueNumber) {
         return this.octokit.paginate(this.octokit.issues.listEvents, {
             owner: GITHUB_OWNER,
-            repo: EXPENSIFY_CASH_REPO,
+            repo: APP_REPO,
             issue_number: issueNumber,
             per_page: 100,
         })
@@ -507,11 +514,12 @@ class GithubUtils {
 
 module.exports = GithubUtils;
 module.exports.GITHUB_OWNER = GITHUB_OWNER;
-module.exports.EXPENSIFY_CASH_REPO = EXPENSIFY_CASH_REPO;
+module.exports.APP_REPO = APP_REPO;
 module.exports.STAGING_DEPLOY_CASH_LABEL = STAGING_DEPLOY_CASH_LABEL;
 module.exports.DEPLOY_BLOCKER_CASH_LABEL = DEPLOY_BLOCKER_CASH_LABEL;
 module.exports.APPLAUSE_BOT = APPLAUSE_BOT;
 module.exports.ISSUE_OR_PULL_REQUEST_REGEX = ISSUE_OR_PULL_REQUEST_REGEX;
+module.exports.POLL_RATE = POLL_RATE;
 
 
 /***/ }),

--- a/.github/actions/createOrUpdateStagingDeploy/createOrUpdateStagingDeploy.js
+++ b/.github/actions/createOrUpdateStagingDeploy/createOrUpdateStagingDeploy.js
@@ -16,14 +16,14 @@ const run = function () {
         GithubUtils.octokit.issues.listForRepo({
             log: console,
             owner: GithubUtils.GITHUB_OWNER,
-            repo: GithubUtils.EXPENSIFY_CASH_REPO,
+            repo: GithubUtils.APP_REPO,
             labels: GithubUtils.STAGING_DEPLOY_CASH_LABEL,
             state: 'all',
         }),
         GithubUtils.octokit.issues.listForRepo({
             log: console,
             owner: GithubUtils.GITHUB_OWNER,
-            repo: GithubUtils.EXPENSIFY_CASH_REPO,
+            repo: GithubUtils.APP_REPO,
             labels: GithubUtils.DEPLOY_BLOCKER_CASH_LABEL,
         }),
     ])
@@ -133,7 +133,7 @@ const run = function () {
         .then((body) => {
             const defaultPayload = {
                 owner: GithubUtils.GITHUB_OWNER,
-                repo: GithubUtils.EXPENSIFY_CASH_REPO,
+                repo: GithubUtils.APP_REPO,
                 body,
             };
 

--- a/.github/actions/createOrUpdateStagingDeploy/index.js
+++ b/.github/actions/createOrUpdateStagingDeploy/index.js
@@ -26,14 +26,14 @@ const run = function () {
         GithubUtils.octokit.issues.listForRepo({
             log: console,
             owner: GithubUtils.GITHUB_OWNER,
-            repo: GithubUtils.EXPENSIFY_CASH_REPO,
+            repo: GithubUtils.APP_REPO,
             labels: GithubUtils.STAGING_DEPLOY_CASH_LABEL,
             state: 'all',
         }),
         GithubUtils.octokit.issues.listForRepo({
             log: console,
             owner: GithubUtils.GITHUB_OWNER,
-            repo: GithubUtils.EXPENSIFY_CASH_REPO,
+            repo: GithubUtils.APP_REPO,
             labels: GithubUtils.DEPLOY_BLOCKER_CASH_LABEL,
         }),
     ])
@@ -143,7 +143,7 @@ const run = function () {
         .then((body) => {
             const defaultPayload = {
                 owner: GithubUtils.GITHUB_OWNER,
-                repo: GithubUtils.EXPENSIFY_CASH_REPO,
+                repo: GithubUtils.APP_REPO,
                 body,
             };
 
@@ -282,8 +282,8 @@ const {GitHub, getOctokitOptions} = __nccwpck_require__(3030);
 const {throttling} = __nccwpck_require__(9968);
 
 const GITHUB_OWNER = 'Expensify';
-const EXPENSIFY_CASH_REPO = 'App';
-const EXPENSIFY_CASH_URL = 'https://github.com/Expensify/App';
+const APP_REPO = 'App';
+const APP_REPO_URL = 'https://github.com/Expensify/App';
 
 const GITHUB_BASE_URL_REGEX = new RegExp('https?://(?:github\\.com|api\\.github\\.com)');
 const PULL_REQUEST_REGEX = new RegExp(`${GITHUB_BASE_URL_REGEX.source}/.*/.*/pull/([0-9]+).*`);
@@ -294,6 +294,13 @@ const APPLAUSE_BOT = 'applausebot';
 const STAGING_DEPLOY_CASH_LABEL = 'StagingDeployCash';
 const DEPLOY_BLOCKER_CASH_LABEL = 'DeployBlockerCash';
 const INTERNAL_QA_LABEL = 'InternalQA';
+
+/**
+ * The standard rate in ms at which we'll poll the GitHub API to check for status changes.
+ * It's 10 seconds :)
+ * @type {number}
+ */
+const POLL_RATE = 10000;
 
 class GithubUtils {
     /**
@@ -342,7 +349,7 @@ class GithubUtils {
     static getStagingDeployCash() {
         return this.octokit.issues.listForRepo({
             owner: GITHUB_OWNER,
-            repo: EXPENSIFY_CASH_REPO,
+            repo: APP_REPO,
             labels: STAGING_DEPLOY_CASH_LABEL,
             state: 'open',
         })
@@ -550,7 +557,7 @@ class GithubUtils {
         const oldestPR = _.first(_.sortBy(pullRequestNumbers));
         return this.octokit.paginate(this.octokit.pulls.list, {
             owner: GITHUB_OWNER,
-            repo: EXPENSIFY_CASH_REPO,
+            repo: APP_REPO,
             state: 'all',
             sort: 'created',
             direction: 'desc',
@@ -593,7 +600,7 @@ class GithubUtils {
         console.log(`Fetching New Expensify workflow runs for ${workflow}...`);
         return this.octokit.actions.listWorkflowRuns({
             owner: GITHUB_OWNER,
-            repo: EXPENSIFY_CASH_REPO,
+            repo: APP_REPO,
             workflow_id: workflow,
         })
             .then(response => lodashGet(response, 'data.workflow_runs[0].id'));
@@ -619,7 +626,7 @@ class GithubUtils {
      * @returns {String}
      */
     static getPullRequestURLFromNumber(number) {
-        return `${EXPENSIFY_CASH_URL}/pull/${number}`;
+        return `${APP_REPO_URL}/pull/${number}`;
     }
 
     /**
@@ -686,7 +693,7 @@ class GithubUtils {
     static getActorWhoClosedIssue(issueNumber) {
         return this.octokit.paginate(this.octokit.issues.listEvents, {
             owner: GITHUB_OWNER,
-            repo: EXPENSIFY_CASH_REPO,
+            repo: APP_REPO,
             issue_number: issueNumber,
             per_page: 100,
         })
@@ -697,11 +704,12 @@ class GithubUtils {
 
 module.exports = GithubUtils;
 module.exports.GITHUB_OWNER = GITHUB_OWNER;
-module.exports.EXPENSIFY_CASH_REPO = EXPENSIFY_CASH_REPO;
+module.exports.APP_REPO = APP_REPO;
 module.exports.STAGING_DEPLOY_CASH_LABEL = STAGING_DEPLOY_CASH_LABEL;
 module.exports.DEPLOY_BLOCKER_CASH_LABEL = DEPLOY_BLOCKER_CASH_LABEL;
 module.exports.APPLAUSE_BOT = APPLAUSE_BOT;
 module.exports.ISSUE_OR_PULL_REQUEST_REGEX = ISSUE_OR_PULL_REQUEST_REGEX;
+module.exports.POLL_RATE = POLL_RATE;
 
 
 /***/ }),

--- a/.github/actions/getPullRequestDetails/getPullRequestDetails.js
+++ b/.github/actions/getPullRequestDetails/getPullRequestDetails.js
@@ -5,7 +5,7 @@ const GithubUtils = require('../../libs/GithubUtils');
 
 const DEFAULT_PAYLOAD = {
     owner: GithubUtils.GITHUB_OWNER,
-    repo: GithubUtils.EXPENSIFY_CASH_REPO,
+    repo: GithubUtils.APP_REPO,
 };
 
 const pullRequestNumber = ActionUtils.getJSONInput('PULL_REQUEST_NUMBER', {required: false}, null);

--- a/.github/actions/getPullRequestDetails/index.js
+++ b/.github/actions/getPullRequestDetails/index.js
@@ -15,7 +15,7 @@ const GithubUtils = __nccwpck_require__(7999);
 
 const DEFAULT_PAYLOAD = {
     owner: GithubUtils.GITHUB_OWNER,
-    repo: GithubUtils.EXPENSIFY_CASH_REPO,
+    repo: GithubUtils.APP_REPO,
 };
 
 const pullRequestNumber = ActionUtils.getJSONInput('PULL_REQUEST_NUMBER', {required: false}, null);
@@ -146,8 +146,8 @@ const {GitHub, getOctokitOptions} = __nccwpck_require__(3030);
 const {throttling} = __nccwpck_require__(9968);
 
 const GITHUB_OWNER = 'Expensify';
-const EXPENSIFY_CASH_REPO = 'App';
-const EXPENSIFY_CASH_URL = 'https://github.com/Expensify/App';
+const APP_REPO = 'App';
+const APP_REPO_URL = 'https://github.com/Expensify/App';
 
 const GITHUB_BASE_URL_REGEX = new RegExp('https?://(?:github\\.com|api\\.github\\.com)');
 const PULL_REQUEST_REGEX = new RegExp(`${GITHUB_BASE_URL_REGEX.source}/.*/.*/pull/([0-9]+).*`);
@@ -158,6 +158,13 @@ const APPLAUSE_BOT = 'applausebot';
 const STAGING_DEPLOY_CASH_LABEL = 'StagingDeployCash';
 const DEPLOY_BLOCKER_CASH_LABEL = 'DeployBlockerCash';
 const INTERNAL_QA_LABEL = 'InternalQA';
+
+/**
+ * The standard rate in ms at which we'll poll the GitHub API to check for status changes.
+ * It's 10 seconds :)
+ * @type {number}
+ */
+const POLL_RATE = 10000;
 
 class GithubUtils {
     /**
@@ -206,7 +213,7 @@ class GithubUtils {
     static getStagingDeployCash() {
         return this.octokit.issues.listForRepo({
             owner: GITHUB_OWNER,
-            repo: EXPENSIFY_CASH_REPO,
+            repo: APP_REPO,
             labels: STAGING_DEPLOY_CASH_LABEL,
             state: 'open',
         })
@@ -414,7 +421,7 @@ class GithubUtils {
         const oldestPR = _.first(_.sortBy(pullRequestNumbers));
         return this.octokit.paginate(this.octokit.pulls.list, {
             owner: GITHUB_OWNER,
-            repo: EXPENSIFY_CASH_REPO,
+            repo: APP_REPO,
             state: 'all',
             sort: 'created',
             direction: 'desc',
@@ -457,7 +464,7 @@ class GithubUtils {
         console.log(`Fetching New Expensify workflow runs for ${workflow}...`);
         return this.octokit.actions.listWorkflowRuns({
             owner: GITHUB_OWNER,
-            repo: EXPENSIFY_CASH_REPO,
+            repo: APP_REPO,
             workflow_id: workflow,
         })
             .then(response => lodashGet(response, 'data.workflow_runs[0].id'));
@@ -483,7 +490,7 @@ class GithubUtils {
      * @returns {String}
      */
     static getPullRequestURLFromNumber(number) {
-        return `${EXPENSIFY_CASH_URL}/pull/${number}`;
+        return `${APP_REPO_URL}/pull/${number}`;
     }
 
     /**
@@ -550,7 +557,7 @@ class GithubUtils {
     static getActorWhoClosedIssue(issueNumber) {
         return this.octokit.paginate(this.octokit.issues.listEvents, {
             owner: GITHUB_OWNER,
-            repo: EXPENSIFY_CASH_REPO,
+            repo: APP_REPO,
             issue_number: issueNumber,
             per_page: 100,
         })
@@ -561,11 +568,12 @@ class GithubUtils {
 
 module.exports = GithubUtils;
 module.exports.GITHUB_OWNER = GITHUB_OWNER;
-module.exports.EXPENSIFY_CASH_REPO = EXPENSIFY_CASH_REPO;
+module.exports.APP_REPO = APP_REPO;
 module.exports.STAGING_DEPLOY_CASH_LABEL = STAGING_DEPLOY_CASH_LABEL;
 module.exports.DEPLOY_BLOCKER_CASH_LABEL = DEPLOY_BLOCKER_CASH_LABEL;
 module.exports.APPLAUSE_BOT = APPLAUSE_BOT;
 module.exports.ISSUE_OR_PULL_REQUEST_REGEX = ISSUE_OR_PULL_REQUEST_REGEX;
+module.exports.POLL_RATE = POLL_RATE;
 
 
 /***/ }),

--- a/.github/actions/getReleaseBody/index.js
+++ b/.github/actions/getReleaseBody/index.js
@@ -64,8 +64,8 @@ const {GitHub, getOctokitOptions} = __nccwpck_require__(3030);
 const {throttling} = __nccwpck_require__(9968);
 
 const GITHUB_OWNER = 'Expensify';
-const EXPENSIFY_CASH_REPO = 'App';
-const EXPENSIFY_CASH_URL = 'https://github.com/Expensify/App';
+const APP_REPO = 'App';
+const APP_REPO_URL = 'https://github.com/Expensify/App';
 
 const GITHUB_BASE_URL_REGEX = new RegExp('https?://(?:github\\.com|api\\.github\\.com)');
 const PULL_REQUEST_REGEX = new RegExp(`${GITHUB_BASE_URL_REGEX.source}/.*/.*/pull/([0-9]+).*`);
@@ -76,6 +76,13 @@ const APPLAUSE_BOT = 'applausebot';
 const STAGING_DEPLOY_CASH_LABEL = 'StagingDeployCash';
 const DEPLOY_BLOCKER_CASH_LABEL = 'DeployBlockerCash';
 const INTERNAL_QA_LABEL = 'InternalQA';
+
+/**
+ * The standard rate in ms at which we'll poll the GitHub API to check for status changes.
+ * It's 10 seconds :)
+ * @type {number}
+ */
+const POLL_RATE = 10000;
 
 class GithubUtils {
     /**
@@ -124,7 +131,7 @@ class GithubUtils {
     static getStagingDeployCash() {
         return this.octokit.issues.listForRepo({
             owner: GITHUB_OWNER,
-            repo: EXPENSIFY_CASH_REPO,
+            repo: APP_REPO,
             labels: STAGING_DEPLOY_CASH_LABEL,
             state: 'open',
         })
@@ -332,7 +339,7 @@ class GithubUtils {
         const oldestPR = _.first(_.sortBy(pullRequestNumbers));
         return this.octokit.paginate(this.octokit.pulls.list, {
             owner: GITHUB_OWNER,
-            repo: EXPENSIFY_CASH_REPO,
+            repo: APP_REPO,
             state: 'all',
             sort: 'created',
             direction: 'desc',
@@ -375,7 +382,7 @@ class GithubUtils {
         console.log(`Fetching New Expensify workflow runs for ${workflow}...`);
         return this.octokit.actions.listWorkflowRuns({
             owner: GITHUB_OWNER,
-            repo: EXPENSIFY_CASH_REPO,
+            repo: APP_REPO,
             workflow_id: workflow,
         })
             .then(response => lodashGet(response, 'data.workflow_runs[0].id'));
@@ -401,7 +408,7 @@ class GithubUtils {
      * @returns {String}
      */
     static getPullRequestURLFromNumber(number) {
-        return `${EXPENSIFY_CASH_URL}/pull/${number}`;
+        return `${APP_REPO_URL}/pull/${number}`;
     }
 
     /**
@@ -468,7 +475,7 @@ class GithubUtils {
     static getActorWhoClosedIssue(issueNumber) {
         return this.octokit.paginate(this.octokit.issues.listEvents, {
             owner: GITHUB_OWNER,
-            repo: EXPENSIFY_CASH_REPO,
+            repo: APP_REPO,
             issue_number: issueNumber,
             per_page: 100,
         })
@@ -479,11 +486,12 @@ class GithubUtils {
 
 module.exports = GithubUtils;
 module.exports.GITHUB_OWNER = GITHUB_OWNER;
-module.exports.EXPENSIFY_CASH_REPO = EXPENSIFY_CASH_REPO;
+module.exports.APP_REPO = APP_REPO;
 module.exports.STAGING_DEPLOY_CASH_LABEL = STAGING_DEPLOY_CASH_LABEL;
 module.exports.DEPLOY_BLOCKER_CASH_LABEL = DEPLOY_BLOCKER_CASH_LABEL;
 module.exports.APPLAUSE_BOT = APPLAUSE_BOT;
 module.exports.ISSUE_OR_PULL_REQUEST_REGEX = ISSUE_OR_PULL_REQUEST_REGEX;
+module.exports.POLL_RATE = POLL_RATE;
 
 
 /***/ }),

--- a/.github/actions/isPullRequestMergeable/index.js
+++ b/.github/actions/isPullRequestMergeable/index.js
@@ -27,7 +27,7 @@ const run = function () {
         () => !mergeabilityResolved && retryCount < MAX_RETRIES,
         _.throttle(() => GithubUtils.octokit.pulls.get({
             owner: GithubUtils.GITHUB_OWNER,
-            repo: GithubUtils.EXPENSIFY_CASH_REPO,
+            repo: GithubUtils.APP_REPO,
             pull_number: pullRequestNumber,
         })
             .then(({data}) => {
@@ -82,8 +82,8 @@ const {GitHub, getOctokitOptions} = __nccwpck_require__(3030);
 const {throttling} = __nccwpck_require__(9968);
 
 const GITHUB_OWNER = 'Expensify';
-const EXPENSIFY_CASH_REPO = 'App';
-const EXPENSIFY_CASH_URL = 'https://github.com/Expensify/App';
+const APP_REPO = 'App';
+const APP_REPO_URL = 'https://github.com/Expensify/App';
 
 const GITHUB_BASE_URL_REGEX = new RegExp('https?://(?:github\\.com|api\\.github\\.com)');
 const PULL_REQUEST_REGEX = new RegExp(`${GITHUB_BASE_URL_REGEX.source}/.*/.*/pull/([0-9]+).*`);
@@ -94,6 +94,13 @@ const APPLAUSE_BOT = 'applausebot';
 const STAGING_DEPLOY_CASH_LABEL = 'StagingDeployCash';
 const DEPLOY_BLOCKER_CASH_LABEL = 'DeployBlockerCash';
 const INTERNAL_QA_LABEL = 'InternalQA';
+
+/**
+ * The standard rate in ms at which we'll poll the GitHub API to check for status changes.
+ * It's 10 seconds :)
+ * @type {number}
+ */
+const POLL_RATE = 10000;
 
 class GithubUtils {
     /**
@@ -142,7 +149,7 @@ class GithubUtils {
     static getStagingDeployCash() {
         return this.octokit.issues.listForRepo({
             owner: GITHUB_OWNER,
-            repo: EXPENSIFY_CASH_REPO,
+            repo: APP_REPO,
             labels: STAGING_DEPLOY_CASH_LABEL,
             state: 'open',
         })
@@ -350,7 +357,7 @@ class GithubUtils {
         const oldestPR = _.first(_.sortBy(pullRequestNumbers));
         return this.octokit.paginate(this.octokit.pulls.list, {
             owner: GITHUB_OWNER,
-            repo: EXPENSIFY_CASH_REPO,
+            repo: APP_REPO,
             state: 'all',
             sort: 'created',
             direction: 'desc',
@@ -393,7 +400,7 @@ class GithubUtils {
         console.log(`Fetching New Expensify workflow runs for ${workflow}...`);
         return this.octokit.actions.listWorkflowRuns({
             owner: GITHUB_OWNER,
-            repo: EXPENSIFY_CASH_REPO,
+            repo: APP_REPO,
             workflow_id: workflow,
         })
             .then(response => lodashGet(response, 'data.workflow_runs[0].id'));
@@ -419,7 +426,7 @@ class GithubUtils {
      * @returns {String}
      */
     static getPullRequestURLFromNumber(number) {
-        return `${EXPENSIFY_CASH_URL}/pull/${number}`;
+        return `${APP_REPO_URL}/pull/${number}`;
     }
 
     /**
@@ -486,7 +493,7 @@ class GithubUtils {
     static getActorWhoClosedIssue(issueNumber) {
         return this.octokit.paginate(this.octokit.issues.listEvents, {
             owner: GITHUB_OWNER,
-            repo: EXPENSIFY_CASH_REPO,
+            repo: APP_REPO,
             issue_number: issueNumber,
             per_page: 100,
         })
@@ -497,11 +504,12 @@ class GithubUtils {
 
 module.exports = GithubUtils;
 module.exports.GITHUB_OWNER = GITHUB_OWNER;
-module.exports.EXPENSIFY_CASH_REPO = EXPENSIFY_CASH_REPO;
+module.exports.APP_REPO = APP_REPO;
 module.exports.STAGING_DEPLOY_CASH_LABEL = STAGING_DEPLOY_CASH_LABEL;
 module.exports.DEPLOY_BLOCKER_CASH_LABEL = DEPLOY_BLOCKER_CASH_LABEL;
 module.exports.APPLAUSE_BOT = APPLAUSE_BOT;
 module.exports.ISSUE_OR_PULL_REQUEST_REGEX = ISSUE_OR_PULL_REQUEST_REGEX;
+module.exports.POLL_RATE = POLL_RATE;
 
 
 /***/ }),
@@ -531,7 +539,26 @@ function promiseWhile(condition, action) {
     });
 }
 
-module.exports = promiseWhile;
+/**
+ * Simulates a do-while loop where the condition is determined by the result of a Promise.
+ *
+ * @param {Function} condition
+ * @param {Function} action
+ * @returns {Promise}
+ */
+function promiseDoWhile(condition, action) {
+    return new Promise((resolve, reject) => {
+        action()
+            .then(() => promiseWhile(condition, action))
+            .then(() => resolve())
+            .catch(reject);
+    });
+}
+
+module.exports = {
+    promiseWhile,
+    promiseDoWhile,
+};
 
 
 /***/ }),

--- a/.github/actions/isPullRequestMergeable/index.js
+++ b/.github/actions/isPullRequestMergeable/index.js
@@ -11,7 +11,7 @@ module.exports =
 const _ = __nccwpck_require__(3571);
 const core = __nccwpck_require__(2186);
 const GithubUtils = __nccwpck_require__(7999);
-const promiseWhile = __nccwpck_require__(4502);
+const {promiseWhile} = __nccwpck_require__(4502);
 
 const MAX_RETRIES = 30;
 const THROTTLE_DURATION = process.env.NODE_ENV === 'test' ? 5 : 5000;

--- a/.github/actions/isPullRequestMergeable/isPullRequestMergeable.js
+++ b/.github/actions/isPullRequestMergeable/isPullRequestMergeable.js
@@ -1,7 +1,7 @@
 const _ = require('underscore');
 const core = require('@actions/core');
 const GithubUtils = require('../../libs/GithubUtils');
-const promiseWhile = require('../../libs/promiseWhile');
+const {promiseWhile} = require('../../libs/promiseWhile');
 
 const MAX_RETRIES = 30;
 const THROTTLE_DURATION = process.env.NODE_ENV === 'test' ? 5 : 5000;

--- a/.github/actions/isPullRequestMergeable/isPullRequestMergeable.js
+++ b/.github/actions/isPullRequestMergeable/isPullRequestMergeable.js
@@ -17,7 +17,7 @@ const run = function () {
         () => !mergeabilityResolved && retryCount < MAX_RETRIES,
         _.throttle(() => GithubUtils.octokit.pulls.get({
             owner: GithubUtils.GITHUB_OWNER,
-            repo: GithubUtils.EXPENSIFY_CASH_REPO,
+            repo: GithubUtils.APP_REPO,
             pull_number: pullRequestNumber,
         })
             .then(({data}) => {

--- a/.github/actions/isStagingDeployLocked/index.js
+++ b/.github/actions/isStagingDeployLocked/index.js
@@ -45,8 +45,8 @@ const {GitHub, getOctokitOptions} = __nccwpck_require__(3030);
 const {throttling} = __nccwpck_require__(9968);
 
 const GITHUB_OWNER = 'Expensify';
-const EXPENSIFY_CASH_REPO = 'App';
-const EXPENSIFY_CASH_URL = 'https://github.com/Expensify/App';
+const APP_REPO = 'App';
+const APP_REPO_URL = 'https://github.com/Expensify/App';
 
 const GITHUB_BASE_URL_REGEX = new RegExp('https?://(?:github\\.com|api\\.github\\.com)');
 const PULL_REQUEST_REGEX = new RegExp(`${GITHUB_BASE_URL_REGEX.source}/.*/.*/pull/([0-9]+).*`);
@@ -57,6 +57,13 @@ const APPLAUSE_BOT = 'applausebot';
 const STAGING_DEPLOY_CASH_LABEL = 'StagingDeployCash';
 const DEPLOY_BLOCKER_CASH_LABEL = 'DeployBlockerCash';
 const INTERNAL_QA_LABEL = 'InternalQA';
+
+/**
+ * The standard rate in ms at which we'll poll the GitHub API to check for status changes.
+ * It's 10 seconds :)
+ * @type {number}
+ */
+const POLL_RATE = 10000;
 
 class GithubUtils {
     /**
@@ -105,7 +112,7 @@ class GithubUtils {
     static getStagingDeployCash() {
         return this.octokit.issues.listForRepo({
             owner: GITHUB_OWNER,
-            repo: EXPENSIFY_CASH_REPO,
+            repo: APP_REPO,
             labels: STAGING_DEPLOY_CASH_LABEL,
             state: 'open',
         })
@@ -313,7 +320,7 @@ class GithubUtils {
         const oldestPR = _.first(_.sortBy(pullRequestNumbers));
         return this.octokit.paginate(this.octokit.pulls.list, {
             owner: GITHUB_OWNER,
-            repo: EXPENSIFY_CASH_REPO,
+            repo: APP_REPO,
             state: 'all',
             sort: 'created',
             direction: 'desc',
@@ -356,7 +363,7 @@ class GithubUtils {
         console.log(`Fetching New Expensify workflow runs for ${workflow}...`);
         return this.octokit.actions.listWorkflowRuns({
             owner: GITHUB_OWNER,
-            repo: EXPENSIFY_CASH_REPO,
+            repo: APP_REPO,
             workflow_id: workflow,
         })
             .then(response => lodashGet(response, 'data.workflow_runs[0].id'));
@@ -382,7 +389,7 @@ class GithubUtils {
      * @returns {String}
      */
     static getPullRequestURLFromNumber(number) {
-        return `${EXPENSIFY_CASH_URL}/pull/${number}`;
+        return `${APP_REPO_URL}/pull/${number}`;
     }
 
     /**
@@ -449,7 +456,7 @@ class GithubUtils {
     static getActorWhoClosedIssue(issueNumber) {
         return this.octokit.paginate(this.octokit.issues.listEvents, {
             owner: GITHUB_OWNER,
-            repo: EXPENSIFY_CASH_REPO,
+            repo: APP_REPO,
             issue_number: issueNumber,
             per_page: 100,
         })
@@ -460,11 +467,12 @@ class GithubUtils {
 
 module.exports = GithubUtils;
 module.exports.GITHUB_OWNER = GITHUB_OWNER;
-module.exports.EXPENSIFY_CASH_REPO = EXPENSIFY_CASH_REPO;
+module.exports.APP_REPO = APP_REPO;
 module.exports.STAGING_DEPLOY_CASH_LABEL = STAGING_DEPLOY_CASH_LABEL;
 module.exports.DEPLOY_BLOCKER_CASH_LABEL = DEPLOY_BLOCKER_CASH_LABEL;
 module.exports.APPLAUSE_BOT = APPLAUSE_BOT;
 module.exports.ISSUE_OR_PULL_REQUEST_REGEX = ISSUE_OR_PULL_REQUEST_REGEX;
+module.exports.POLL_RATE = POLL_RATE;
 
 
 /***/ }),

--- a/.github/actions/markPullRequestsAsDeployed/index.js
+++ b/.github/actions/markPullRequestsAsDeployed/index.js
@@ -88,7 +88,7 @@ const run = function () {
         // First find the deployer (who closed the last deploy checklist)?
         return GithubUtils.octokit.issues.listForRepo({
             owner: GithubUtils.GITHUB_OWNER,
-            repo: GithubUtils.EXPENSIFY_CASH_REPO,
+            repo: GithubUtils.APP_REPO,
             labels: GithubUtils.STAGING_DEPLOY_CASH_LABEL,
             state: 'closed',
         })
@@ -104,14 +104,14 @@ const run = function () {
     // First find out if this is a normal staging deploy or a CP by looking at the commit message on the tag
     return GithubUtils.octokit.repos.listTags({
         owner: GithubUtils.GITHUB_OWNER,
-        repo: GithubUtils.EXPENSIFY_CASH_REPO,
+        repo: GithubUtils.APP_REPO,
         per_page: 100,
     })
         .then(({data}) => {
             const tagSHA = _.find(data, tag => tag.name === version).commit.sha;
             return GithubUtils.octokit.git.getCommit({
                 owner: GithubUtils.GITHUB_OWNER,
-                repo: GithubUtils.EXPENSIFY_CASH_REPO,
+                repo: GithubUtils.APP_REPO,
                 commit_sha: tagSHA,
             });
         })
@@ -122,7 +122,7 @@ const run = function () {
                 // Then, for each PR, find out who merged it and determine the deployer
                 .then(() => GithubUtils.octokit.pulls.get({
                     owner: GithubUtils.GITHUB_OWNER,
-                    repo: GithubUtils.EXPENSIFY_CASH_REPO,
+                    repo: GithubUtils.APP_REPO,
                     pull_number: PR,
                 }))
                 .then((response) => {
@@ -197,8 +197,8 @@ const {GitHub, getOctokitOptions} = __nccwpck_require__(3030);
 const {throttling} = __nccwpck_require__(9968);
 
 const GITHUB_OWNER = 'Expensify';
-const EXPENSIFY_CASH_REPO = 'App';
-const EXPENSIFY_CASH_URL = 'https://github.com/Expensify/App';
+const APP_REPO = 'App';
+const APP_REPO_URL = 'https://github.com/Expensify/App';
 
 const GITHUB_BASE_URL_REGEX = new RegExp('https?://(?:github\\.com|api\\.github\\.com)');
 const PULL_REQUEST_REGEX = new RegExp(`${GITHUB_BASE_URL_REGEX.source}/.*/.*/pull/([0-9]+).*`);
@@ -209,6 +209,13 @@ const APPLAUSE_BOT = 'applausebot';
 const STAGING_DEPLOY_CASH_LABEL = 'StagingDeployCash';
 const DEPLOY_BLOCKER_CASH_LABEL = 'DeployBlockerCash';
 const INTERNAL_QA_LABEL = 'InternalQA';
+
+/**
+ * The standard rate in ms at which we'll poll the GitHub API to check for status changes.
+ * It's 10 seconds :)
+ * @type {number}
+ */
+const POLL_RATE = 10000;
 
 class GithubUtils {
     /**
@@ -257,7 +264,7 @@ class GithubUtils {
     static getStagingDeployCash() {
         return this.octokit.issues.listForRepo({
             owner: GITHUB_OWNER,
-            repo: EXPENSIFY_CASH_REPO,
+            repo: APP_REPO,
             labels: STAGING_DEPLOY_CASH_LABEL,
             state: 'open',
         })
@@ -465,7 +472,7 @@ class GithubUtils {
         const oldestPR = _.first(_.sortBy(pullRequestNumbers));
         return this.octokit.paginate(this.octokit.pulls.list, {
             owner: GITHUB_OWNER,
-            repo: EXPENSIFY_CASH_REPO,
+            repo: APP_REPO,
             state: 'all',
             sort: 'created',
             direction: 'desc',
@@ -508,7 +515,7 @@ class GithubUtils {
         console.log(`Fetching New Expensify workflow runs for ${workflow}...`);
         return this.octokit.actions.listWorkflowRuns({
             owner: GITHUB_OWNER,
-            repo: EXPENSIFY_CASH_REPO,
+            repo: APP_REPO,
             workflow_id: workflow,
         })
             .then(response => lodashGet(response, 'data.workflow_runs[0].id'));
@@ -534,7 +541,7 @@ class GithubUtils {
      * @returns {String}
      */
     static getPullRequestURLFromNumber(number) {
-        return `${EXPENSIFY_CASH_URL}/pull/${number}`;
+        return `${APP_REPO_URL}/pull/${number}`;
     }
 
     /**
@@ -601,7 +608,7 @@ class GithubUtils {
     static getActorWhoClosedIssue(issueNumber) {
         return this.octokit.paginate(this.octokit.issues.listEvents, {
             owner: GITHUB_OWNER,
-            repo: EXPENSIFY_CASH_REPO,
+            repo: APP_REPO,
             issue_number: issueNumber,
             per_page: 100,
         })
@@ -612,11 +619,12 @@ class GithubUtils {
 
 module.exports = GithubUtils;
 module.exports.GITHUB_OWNER = GITHUB_OWNER;
-module.exports.EXPENSIFY_CASH_REPO = EXPENSIFY_CASH_REPO;
+module.exports.APP_REPO = APP_REPO;
 module.exports.STAGING_DEPLOY_CASH_LABEL = STAGING_DEPLOY_CASH_LABEL;
 module.exports.DEPLOY_BLOCKER_CASH_LABEL = DEPLOY_BLOCKER_CASH_LABEL;
 module.exports.APPLAUSE_BOT = APPLAUSE_BOT;
 module.exports.ISSUE_OR_PULL_REQUEST_REGEX = ISSUE_OR_PULL_REQUEST_REGEX;
+module.exports.POLL_RATE = POLL_RATE;
 
 
 /***/ }),

--- a/.github/actions/markPullRequestsAsDeployed/markPullRequestsAsDeployed.js
+++ b/.github/actions/markPullRequestsAsDeployed/markPullRequestsAsDeployed.js
@@ -78,7 +78,7 @@ const run = function () {
         // First find the deployer (who closed the last deploy checklist)?
         return GithubUtils.octokit.issues.listForRepo({
             owner: GithubUtils.GITHUB_OWNER,
-            repo: GithubUtils.EXPENSIFY_CASH_REPO,
+            repo: GithubUtils.APP_REPO,
             labels: GithubUtils.STAGING_DEPLOY_CASH_LABEL,
             state: 'closed',
         })
@@ -94,14 +94,14 @@ const run = function () {
     // First find out if this is a normal staging deploy or a CP by looking at the commit message on the tag
     return GithubUtils.octokit.repos.listTags({
         owner: GithubUtils.GITHUB_OWNER,
-        repo: GithubUtils.EXPENSIFY_CASH_REPO,
+        repo: GithubUtils.APP_REPO,
         per_page: 100,
     })
         .then(({data}) => {
             const tagSHA = _.find(data, tag => tag.name === version).commit.sha;
             return GithubUtils.octokit.git.getCommit({
                 owner: GithubUtils.GITHUB_OWNER,
-                repo: GithubUtils.EXPENSIFY_CASH_REPO,
+                repo: GithubUtils.APP_REPO,
                 commit_sha: tagSHA,
             });
         })
@@ -112,7 +112,7 @@ const run = function () {
                 // Then, for each PR, find out who merged it and determine the deployer
                 .then(() => GithubUtils.octokit.pulls.get({
                     owner: GithubUtils.GITHUB_OWNER,
-                    repo: GithubUtils.EXPENSIFY_CASH_REPO,
+                    repo: GithubUtils.APP_REPO,
                     pull_number: PR,
                 }))
                 .then((response) => {

--- a/.github/actions/reopenIssueWithComment/index.js
+++ b/.github/actions/reopenIssueWithComment/index.js
@@ -18,7 +18,7 @@ function reopenIssueWithComment() {
     console.log(`Reopening issue #${issueNumber}`);
     return GithubUtils.octokit.issues.update({
         owner: GithubUtils.GITHUB_OWNER,
-        repo: GithubUtils.EXPENSIFY_CASH_REPO,
+        repo: GithubUtils.APP_REPO,
         issue_number: issueNumber,
         state: 'open',
     })
@@ -26,7 +26,7 @@ function reopenIssueWithComment() {
             console.log(`Commenting on issue #${issueNumber}`);
             return GithubUtils.octokit.issues.createComment({
                 owner: GithubUtils.GITHUB_OWNER,
-                repo: GithubUtils.EXPENSIFY_CASH_REPO,
+                repo: GithubUtils.APP_REPO,
                 issue_number: issueNumber,
                 body: comment,
             });
@@ -56,8 +56,8 @@ const {GitHub, getOctokitOptions} = __nccwpck_require__(3030);
 const {throttling} = __nccwpck_require__(9968);
 
 const GITHUB_OWNER = 'Expensify';
-const EXPENSIFY_CASH_REPO = 'App';
-const EXPENSIFY_CASH_URL = 'https://github.com/Expensify/App';
+const APP_REPO = 'App';
+const APP_REPO_URL = 'https://github.com/Expensify/App';
 
 const GITHUB_BASE_URL_REGEX = new RegExp('https?://(?:github\\.com|api\\.github\\.com)');
 const PULL_REQUEST_REGEX = new RegExp(`${GITHUB_BASE_URL_REGEX.source}/.*/.*/pull/([0-9]+).*`);
@@ -68,6 +68,13 @@ const APPLAUSE_BOT = 'applausebot';
 const STAGING_DEPLOY_CASH_LABEL = 'StagingDeployCash';
 const DEPLOY_BLOCKER_CASH_LABEL = 'DeployBlockerCash';
 const INTERNAL_QA_LABEL = 'InternalQA';
+
+/**
+ * The standard rate in ms at which we'll poll the GitHub API to check for status changes.
+ * It's 10 seconds :)
+ * @type {number}
+ */
+const POLL_RATE = 10000;
 
 class GithubUtils {
     /**
@@ -116,7 +123,7 @@ class GithubUtils {
     static getStagingDeployCash() {
         return this.octokit.issues.listForRepo({
             owner: GITHUB_OWNER,
-            repo: EXPENSIFY_CASH_REPO,
+            repo: APP_REPO,
             labels: STAGING_DEPLOY_CASH_LABEL,
             state: 'open',
         })
@@ -324,7 +331,7 @@ class GithubUtils {
         const oldestPR = _.first(_.sortBy(pullRequestNumbers));
         return this.octokit.paginate(this.octokit.pulls.list, {
             owner: GITHUB_OWNER,
-            repo: EXPENSIFY_CASH_REPO,
+            repo: APP_REPO,
             state: 'all',
             sort: 'created',
             direction: 'desc',
@@ -367,7 +374,7 @@ class GithubUtils {
         console.log(`Fetching New Expensify workflow runs for ${workflow}...`);
         return this.octokit.actions.listWorkflowRuns({
             owner: GITHUB_OWNER,
-            repo: EXPENSIFY_CASH_REPO,
+            repo: APP_REPO,
             workflow_id: workflow,
         })
             .then(response => lodashGet(response, 'data.workflow_runs[0].id'));
@@ -393,7 +400,7 @@ class GithubUtils {
      * @returns {String}
      */
     static getPullRequestURLFromNumber(number) {
-        return `${EXPENSIFY_CASH_URL}/pull/${number}`;
+        return `${APP_REPO_URL}/pull/${number}`;
     }
 
     /**
@@ -460,7 +467,7 @@ class GithubUtils {
     static getActorWhoClosedIssue(issueNumber) {
         return this.octokit.paginate(this.octokit.issues.listEvents, {
             owner: GITHUB_OWNER,
-            repo: EXPENSIFY_CASH_REPO,
+            repo: APP_REPO,
             issue_number: issueNumber,
             per_page: 100,
         })
@@ -471,11 +478,12 @@ class GithubUtils {
 
 module.exports = GithubUtils;
 module.exports.GITHUB_OWNER = GITHUB_OWNER;
-module.exports.EXPENSIFY_CASH_REPO = EXPENSIFY_CASH_REPO;
+module.exports.APP_REPO = APP_REPO;
 module.exports.STAGING_DEPLOY_CASH_LABEL = STAGING_DEPLOY_CASH_LABEL;
 module.exports.DEPLOY_BLOCKER_CASH_LABEL = DEPLOY_BLOCKER_CASH_LABEL;
 module.exports.APPLAUSE_BOT = APPLAUSE_BOT;
 module.exports.ISSUE_OR_PULL_REQUEST_REGEX = ISSUE_OR_PULL_REQUEST_REGEX;
+module.exports.POLL_RATE = POLL_RATE;
 
 
 /***/ }),

--- a/.github/actions/reopenIssueWithComment/reopenIssueWithComment.js
+++ b/.github/actions/reopenIssueWithComment/reopenIssueWithComment.js
@@ -8,7 +8,7 @@ function reopenIssueWithComment() {
     console.log(`Reopening issue #${issueNumber}`);
     return GithubUtils.octokit.issues.update({
         owner: GithubUtils.GITHUB_OWNER,
-        repo: GithubUtils.EXPENSIFY_CASH_REPO,
+        repo: GithubUtils.APP_REPO,
         issue_number: issueNumber,
         state: 'open',
     })
@@ -16,7 +16,7 @@ function reopenIssueWithComment() {
             console.log(`Commenting on issue #${issueNumber}`);
             return GithubUtils.octokit.issues.createComment({
                 owner: GithubUtils.GITHUB_OWNER,
-                repo: GithubUtils.EXPENSIFY_CASH_REPO,
+                repo: GithubUtils.APP_REPO,
                 issue_number: issueNumber,
                 body: comment,
             });

--- a/.github/libs/GithubUtils.js
+++ b/.github/libs/GithubUtils.js
@@ -5,8 +5,8 @@ const {GitHub, getOctokitOptions} = require('@actions/github/lib/utils');
 const {throttling} = require('@octokit/plugin-throttling');
 
 const GITHUB_OWNER = 'Expensify';
-const EXPENSIFY_CASH_REPO = 'App';
-const EXPENSIFY_CASH_URL = 'https://github.com/Expensify/App';
+const APP_REPO = 'App';
+const APP_REPO_URL = 'https://github.com/Expensify/App';
 
 const GITHUB_BASE_URL_REGEX = new RegExp('https?://(?:github\\.com|api\\.github\\.com)');
 const PULL_REQUEST_REGEX = new RegExp(`${GITHUB_BASE_URL_REGEX.source}/.*/.*/pull/([0-9]+).*`);
@@ -17,6 +17,13 @@ const APPLAUSE_BOT = 'applausebot';
 const STAGING_DEPLOY_CASH_LABEL = 'StagingDeployCash';
 const DEPLOY_BLOCKER_CASH_LABEL = 'DeployBlockerCash';
 const INTERNAL_QA_LABEL = 'InternalQA';
+
+/**
+ * The standard rate in ms at which we'll poll the GitHub API to check for status changes.
+ * It's 10 seconds :)
+ * @type {number}
+ */
+const POLL_RATE = 10000;
 
 class GithubUtils {
     /**
@@ -65,7 +72,7 @@ class GithubUtils {
     static getStagingDeployCash() {
         return this.octokit.issues.listForRepo({
             owner: GITHUB_OWNER,
-            repo: EXPENSIFY_CASH_REPO,
+            repo: APP_REPO,
             labels: STAGING_DEPLOY_CASH_LABEL,
             state: 'open',
         })
@@ -273,7 +280,7 @@ class GithubUtils {
         const oldestPR = _.first(_.sortBy(pullRequestNumbers));
         return this.octokit.paginate(this.octokit.pulls.list, {
             owner: GITHUB_OWNER,
-            repo: EXPENSIFY_CASH_REPO,
+            repo: APP_REPO,
             state: 'all',
             sort: 'created',
             direction: 'desc',
@@ -316,7 +323,7 @@ class GithubUtils {
         console.log(`Fetching New Expensify workflow runs for ${workflow}...`);
         return this.octokit.actions.listWorkflowRuns({
             owner: GITHUB_OWNER,
-            repo: EXPENSIFY_CASH_REPO,
+            repo: APP_REPO,
             workflow_id: workflow,
         })
             .then(response => lodashGet(response, 'data.workflow_runs[0].id'));
@@ -342,7 +349,7 @@ class GithubUtils {
      * @returns {String}
      */
     static getPullRequestURLFromNumber(number) {
-        return `${EXPENSIFY_CASH_URL}/pull/${number}`;
+        return `${APP_REPO_URL}/pull/${number}`;
     }
 
     /**
@@ -409,7 +416,7 @@ class GithubUtils {
     static getActorWhoClosedIssue(issueNumber) {
         return this.octokit.paginate(this.octokit.issues.listEvents, {
             owner: GITHUB_OWNER,
-            repo: EXPENSIFY_CASH_REPO,
+            repo: APP_REPO,
             issue_number: issueNumber,
             per_page: 100,
         })
@@ -420,8 +427,9 @@ class GithubUtils {
 
 module.exports = GithubUtils;
 module.exports.GITHUB_OWNER = GITHUB_OWNER;
-module.exports.EXPENSIFY_CASH_REPO = EXPENSIFY_CASH_REPO;
+module.exports.APP_REPO = APP_REPO;
 module.exports.STAGING_DEPLOY_CASH_LABEL = STAGING_DEPLOY_CASH_LABEL;
 module.exports.DEPLOY_BLOCKER_CASH_LABEL = DEPLOY_BLOCKER_CASH_LABEL;
 module.exports.APPLAUSE_BOT = APPLAUSE_BOT;
 module.exports.ISSUE_OR_PULL_REQUEST_REGEX = ISSUE_OR_PULL_REQUEST_REGEX;
+module.exports.POLL_RATE = POLL_RATE;

--- a/.github/libs/promiseWhile.js
+++ b/.github/libs/promiseWhile.js
@@ -20,4 +20,23 @@ function promiseWhile(condition, action) {
     });
 }
 
-module.exports = promiseWhile;
+/**
+ * Simulates a do-while loop where the condition is determined by the result of a Promise.
+ *
+ * @param {Function} condition
+ * @param {Function} action
+ * @returns {Promise}
+ */
+function promiseDoWhile(condition, action) {
+    return new Promise((resolve, reject) => {
+        action()
+            .then(() => promiseWhile(condition, action))
+            .then(() => resolve())
+            .catch(reject);
+    });
+}
+
+module.exports = {
+    promiseWhile,
+    promiseDoWhile,
+};

--- a/.github/scripts/buildActions.sh
+++ b/.github/scripts/buildActions.sh
@@ -9,6 +9,7 @@ ACTIONS_DIR="$(dirname "$(dirname "$0")")/actions"
 
 # List of paths to all JS files that implement our GH Actions
 declare -r GITHUB_ACTIONS=(
+    "$ACTIONS_DIR/awaitStagingDeploys/awaitStagingDeploys.js"
     "$ACTIONS_DIR/bumpVersion/bumpVersion.js"
     "$ACTIONS_DIR/checkBundleVersionStringMatch/checkBundleVersionStringMatch.js"
     "$ACTIONS_DIR/checkDeployBlockers/checkDeployBlockers.js"

--- a/.github/workflows/finishReleaseCycle.yml
+++ b/.github/workflows/finishReleaseCycle.yml
@@ -87,12 +87,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create new BUILD version
+      - name: Create new PATCH version
         uses: Expensify/App/.github/actions/triggerWorkflowAndWait@main
         with:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
           WORKFLOW: createNewVersion.yml
-          INPUTS: '{ "SEMVER_LEVEL": "BUILD" }'
+          INPUTS: '{ "SEMVER_LEVEL": "PATCH" }'
 
       - name: Update staging branch to trigger staging deploy
         uses: Expensify/App/.github/actions/triggerWorkflowAndWait@main

--- a/.github/workflows/lockDeploys.yml
+++ b/.github/workflows/lockDeploys.yml
@@ -16,45 +16,21 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.OS_BOTIFY_TOKEN }}
 
-      - uses: softprops/turnstyle@8db075d65b19bf94e6e8687b504db69938dc3c65
-        with:
-          poll-interval-seconds: 10
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create new PATCH version
-        uses: Expensify/App/.github/actions/triggerWorkflowAndWait@main
+      - name: Wait for staging deploys to finish
+        uses: Expensify/App/.github/actions/awaitStagingDeploys@main
         with:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
-          WORKFLOW: createNewVersion.yml
-          INPUTS: '{ "SEMVER_LEVEL": "PATCH" }'
 
-      - name: Update staging branch
-        uses: Expensify/App/.github/actions/triggerWorkflowAndWait@main
-        with:
-          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
-          WORKFLOW: updateProtectedBranch.yml
-          INPUTS: '{ "TARGET_BRANCH": "staging" }'
+      - name: Checkout staging branch
+        run: git checkout staging
 
-      - name: Pull staging to get the new version
+      - name: Comment in StagingDeployCash to give Applause the 🟢 to begin QA
         run: |
-          git checkout staging
-          git pull origin staging
-          echo "NEW_VERSION=$(npm run print-version --silent)" >> $GITHUB_ENV
-          echo "New version is ${{ env.NEW_VERSION }}"
-
-        # Create a local git tag on staging so that GitUtils.getPullRequestsMergedBetween can use `git log` to generate a
-        # list of pull requests that were merged between this version tag and another.
-        # NOTE: This tag is only used locally and shouldn't be pushed to the remote.
-        # If it was pushed, that would trigger the staging deploy which is handled in a separate workflow (deploy.yml)
-      - name: Tag version
-        run: git tag ${{ env.NEW_VERSION }}
-
-      - name: Update StagingDeployCash
-        uses: Expensify/App/.github/actions/createOrUpdateStagingDeploy@main
-        with:
+          gh issue comment \
+          $(gh issue list --label StagingDeployCash --json number --jq '.[0].number') \
+          --body ':rocket: All staging deploys are complete, @Expensify/applauseleads please begin QA on version https://github.com/Expensify/App/releases/tag/$(< package.json jq -r .version) :rocket:'
+        env:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
-          NPM_VERSION: ${{ env.NEW_VERSION }}
 
       # This Slack step is duplicated in all workflows, if you make a change to this step, make sure to update all
       # the other workflows with the same change

--- a/.github/workflows/lockDeploys.yml
+++ b/.github/workflows/lockDeploys.yml
@@ -21,9 +21,6 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 
-      - name: Checkout staging branch
-        run: git checkout staging
-
       - name: Comment in StagingDeployCash to give Applause the 🟢 to begin QA
         run: |
           gh issue comment \

--- a/README.md
+++ b/README.md
@@ -385,10 +385,10 @@ The [`deploy` workflow](https://github.com/Expensify/App/blob/main/.github/workf
 The [`platformDeploy` workflow](https://github.com/Expensify/App/blob/main/.github/workflows/platformDeploy.yml) is what actually runs the deployment on all four platforms (iOS, Android, Web, macOS Desktop). It runs a staging deploy whenever a new tag is pushed to GitHub, and runs a production deploy whenever a new release is created.
 
 ### lockDeploys
-The [`lockDeploys` workflow](https://github.com/Expensify/App/blob/main/.github/workflows/lockDeploys.yml) executes when the `StagingDeployCash` is locked, and it prepares the staging branch for a production release by creating a new `PATCH` version (i.e: `1.0.57-5` -> `1.0.58.0`).
+The [`lockDeploys` workflow](https://github.com/Expensify/App/blob/main/.github/workflows/lockDeploys.yml) executes when the `StagingDeployCash` is locked, and it waits for any currently running staging deploys to finish, then gives Applause the :green_circle: to begin QA by commenting in the `StagingDeployCash` checklist.
 
 ### finishReleaseCycle
-The [`finishReleaseCycle` workflow](https://github.com/Expensify/App/blob/main/.github/workflows/finishReleaseCycle.yml) executes when the `StagingDeployCash` is closed. It updates the `production` branch from `staging` (triggering a production deploy), deploys `main` to staging, and creates a new `StagingDeployCash` deploy checklist.
+The [`finishReleaseCycle` workflow](https://github.com/Expensify/App/blob/main/.github/workflows/finishReleaseCycle.yml) executes when the `StagingDeployCash` is closed. It updates the `production` branch from `staging` (triggering a production deploy), deploys `main` to staging (with a new `PATCH` version), and creates a new `StagingDeployCash` deploy checklist.
 
 ## Local production builds
 Sometimes it might be beneficial to generate a local production version instead of testing on production. Follow the steps below for each client:

--- a/tests/unit/awaitStagingDeploysTest.js
+++ b/tests/unit/awaitStagingDeploysTest.js
@@ -1,6 +1,7 @@
 /**
  * @jest-environment node
  */
+const _ = require('underscore');
 const run = require('../../.github/actions/awaitStagingDeploys/awaitStagingDeploys');
 const GitHubUtils = require('../../.github/libs/GithubUtils');
 
@@ -9,7 +10,25 @@ const TEST_POLL_RATE = 1;
 const COMPLETED_WORKFLOW = {status: 'completed'};
 const INCOMPLETE_WORKFLOW = {status: 'in_progress'};
 
-const mockListWorkflowRuns = jest.fn();
+const mockListPlatformDeploys = jest.fn();
+const mockListPreDeploys = jest.fn();
+const mockListWorkflowRuns = jest.fn().mockImplementation((args) => {
+    const defaultReturn = Promise.resolve({data: {workflow_runs: []}});
+
+    if (!_.has(args, 'workflow_id')) {
+        return defaultReturn;
+    }
+
+    if (args.workflow_id === 'platformDeploy.yml') {
+        return mockListPlatformDeploys();
+    }
+
+    if (args.workflow_id === 'preDeploy.yml') {
+        return mockListPreDeploys();
+    }
+
+    return defaultReturn;
+});
 
 beforeAll(() => {
     // Mock octokit module
@@ -24,7 +43,7 @@ beforeAll(() => {
 
 describe('awaitStagingDeploys', () => {
     test('Should wait for all running staging deploys to finish', () => {
-        mockListWorkflowRuns.mockResolvedValueOnce({
+        mockListPlatformDeploys.mockResolvedValueOnce({
             data: {
                 workflow_runs: [
                     COMPLETED_WORKFLOW,
@@ -33,7 +52,12 @@ describe('awaitStagingDeploys', () => {
                 ],
             },
         });
-        mockListWorkflowRuns.mockResolvedValueOnce({
+        mockListPreDeploys.mockResolvedValueOnce({
+            data: {
+                workflow_runs: [],
+            },
+        });
+        mockListPlatformDeploys.mockResolvedValueOnce({
             data: {
                 workflow_runs: [
                     COMPLETED_WORKFLOW,
@@ -42,11 +66,39 @@ describe('awaitStagingDeploys', () => {
                 ],
             },
         });
-        mockListWorkflowRuns.mockResolvedValueOnce({
+        mockListPreDeploys.mockResolvedValueOnce({
+            data: {
+                workflow_runs: [],
+            },
+        });
+        mockListPlatformDeploys.mockResolvedValueOnce({
             data: {
                 workflow_runs: [
                     COMPLETED_WORKFLOW,
                     COMPLETED_WORKFLOW,
+                    COMPLETED_WORKFLOW,
+                ],
+            },
+        });
+        mockListPreDeploys.mockResolvedValueOnce({
+            data: {
+                workflow_runs: [
+                    INCOMPLETE_WORKFLOW,
+                ],
+            },
+        });
+        mockListPlatformDeploys.mockResolvedValueOnce({
+            data: {
+                workflow_runs: [
+                    COMPLETED_WORKFLOW,
+                    COMPLETED_WORKFLOW,
+                    COMPLETED_WORKFLOW,
+                ],
+            },
+        });
+        mockListPreDeploys.mockResolvedValueOnce({
+            data: {
+                workflow_runs: [
                     COMPLETED_WORKFLOW,
                 ],
             },
@@ -55,9 +107,10 @@ describe('awaitStagingDeploys', () => {
         const consoleSpy = jest.spyOn(console, 'log');
         return run()
             .then(() => {
-                expect(consoleSpy).toHaveBeenCalledTimes(3);
+                expect(consoleSpy).toHaveBeenCalledTimes(4);
                 expect(consoleSpy).toHaveBeenNthCalledWith(1, 'Found 2 staging deploys still running...');
                 expect(consoleSpy).toHaveBeenNthCalledWith(2, 'Found 1 staging deploy still running...');
+                expect(consoleSpy).toHaveBeenNthCalledWith(3, 'Found 1 staging deploy still running...');
                 expect(consoleSpy).toHaveBeenLastCalledWith('No current staging deploys found');
             });
     });

--- a/tests/unit/awaitStagingDeploysTest.js
+++ b/tests/unit/awaitStagingDeploysTest.js
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment node
+ */
+const run = require('../../.github/actions/awaitStagingDeploys/awaitStagingDeploys');
+const GitHubUtils = require('../../.github/libs/GithubUtils');
+
+// Lower poll rate to speed up tests
+const TEST_POLL_RATE = 1;
+const COMPLETED_WORKFLOW = {status: 'completed'};
+const INCOMPLETE_WORKFLOW = {status: 'in_progress'};
+
+const mockListWorkflowRuns = jest.fn();
+
+beforeAll(() => {
+    // Mock octokit module
+    const mocktokit = {
+        actions: {
+            listWorkflowRuns: mockListWorkflowRuns,
+        },
+    };
+    GitHubUtils.octokitInternal = mocktokit;
+    GitHubUtils.POLL_RATE = TEST_POLL_RATE;
+});
+
+describe('awaitStagingDeploys', () => {
+    test('Should wait for all running staging deploys to finish', () => {
+        mockListWorkflowRuns.mockResolvedValueOnce({
+            data: {
+                workflow_runs: [
+                    COMPLETED_WORKFLOW,
+                    INCOMPLETE_WORKFLOW,
+                    INCOMPLETE_WORKFLOW,
+                ],
+            },
+        });
+        mockListWorkflowRuns.mockResolvedValueOnce({
+            data: {
+                workflow_runs: [
+                    COMPLETED_WORKFLOW,
+                    COMPLETED_WORKFLOW,
+                    INCOMPLETE_WORKFLOW,
+                ],
+            },
+        });
+        mockListWorkflowRuns.mockResolvedValueOnce({
+            data: {
+                workflow_runs: [
+                    COMPLETED_WORKFLOW,
+                    COMPLETED_WORKFLOW,
+                    COMPLETED_WORKFLOW,
+                ],
+            },
+        });
+
+        const consoleSpy = jest.spyOn(console, 'log');
+        return run()
+            .then(() => {
+                expect(consoleSpy).toHaveBeenCalledTimes(3);
+                expect(consoleSpy).toHaveBeenNthCalledWith(1, 'Found 2 staging deploys still running...');
+                expect(consoleSpy).toHaveBeenNthCalledWith(2, 'Found 1 staging deploy still running...');
+                expect(consoleSpy).toHaveBeenLastCalledWith('No current staging deploys found');
+            });
+    });
+});

--- a/tests/unit/createOrUpdateStagingDeployTest.js
+++ b/tests/unit/createOrUpdateStagingDeployTest.js
@@ -160,7 +160,7 @@ describe('createOrUpdateStagingDeployCash', () => {
         return run().then((result) => {
             expect(result).toStrictEqual({
                 owner: GithubUtils.GITHUB_OWNER,
-                repo: GithubUtils.EXPENSIFY_CASH_REPO,
+                repo: GithubUtils.APP_REPO,
                 title: `Deploy Checklist: New Expensify ${moment().format('YYYY-MM-DD')}`,
                 labels: [GithubUtils.STAGING_DEPLOY_CASH_LABEL],
                 html_url: 'https://github.com/Expensify/App/issues/29',
@@ -268,7 +268,7 @@ describe('createOrUpdateStagingDeployCash', () => {
             return run().then((result) => {
                 expect(result).toStrictEqual({
                     owner: GithubUtils.GITHUB_OWNER,
-                    repo: GithubUtils.EXPENSIFY_CASH_REPO,
+                    repo: GithubUtils.APP_REPO,
                     issue_number: openStagingDeployCashBefore.number,
                     // eslint-disable-next-line max-len
                     html_url: `https://github.com/Expensify/App/issues/${openStagingDeployCashBefore.number}`,
@@ -330,7 +330,7 @@ describe('createOrUpdateStagingDeployCash', () => {
             return run().then((result) => {
                 expect(result).toStrictEqual({
                     owner: GithubUtils.GITHUB_OWNER,
-                    repo: GithubUtils.EXPENSIFY_CASH_REPO,
+                    repo: GithubUtils.APP_REPO,
                     issue_number: openStagingDeployCashBefore.number,
                     // eslint-disable-next-line max-len
                     html_url: `https://github.com/Expensify/App/issues/${openStagingDeployCashBefore.number}`,

--- a/tests/unit/getPullRequestsMergedBetweenTest.sh
+++ b/tests/unit/getPullRequestsMergedBetweenTest.sh
@@ -138,106 +138,61 @@ assert_equal "$output" "[ '1' ]"
 success "Scenario #1 completed successfully!"
 
 
-title "Scenario #2: Locking the deploy checklist"
+title "Scenario #2: Merge a pull request with the checklist locked, but don't CP it"
 
-# Bump the version to 1.1.0 on main
-info "Bumping the version to 1.1.0 on main..."
+info "Creating PR #4 and merging it into main..."
 git checkout main
-git checkout -b version-bump
-npm --no-git-tag-version version 1.1.0 -m "Update version to 1.1.0"
-git add package.json package-lock.json
-git commit -m "Update version to $(print_version)"
+git checkout -b pr-4
+echo "Changes from PR #4" >> PR4.txt
+git add PR4.txt
+git commit -m "Changes from PR #4"
 git checkout main
-git merge version-bump --no-ff -m "Merge pull request #4 from Expensify/version-bump"
-info "Merged PR #4 to main"
-git branch -d version-bump
-success "Version bumped to $(print_version) on main!"
-
-# Merge main into staging
-info "Merging main into staging..."
-git checkout staging
-git checkout -b update-staging-from-main
-git merge --no-edit -Xtheirs main
-git checkout staging
-git merge update-staging-from-main --no-ff -m "Merge pull request #5 from Expensify/update-staging-from-main"
-info "Merged PR #5 into main"
-git branch -d update-staging-from-main
-success "Merged main into staging!"
-
-# Tag the new version on staging
-info "Tagging the new version on staging..."
-git checkout staging
-git tag "$(print_version)"
-success "Successfully created tag $(print_version)"
-
-# Verify output for checklist
-info "Checking output of getPullRequestsMergedBetween 1.0.1 1.1.0"
-output=$(node "$getPullRequestsMergedBetween" '1.0.1' '1.1.0')
-assert_equal "$output" "[ '1' ]"
-
-# Verify output for deploy comment
-info "Checking output of getPullRequestsMergedBetween 1.0.2 1.1.0"
-output=$(node "$getPullRequestsMergedBetween" '1.0.2' '1.1.0')
-assert_equal "$output" "[]"
+git merge pr-4 --no-ff -m "Merge pull request #4 from Expensify/pr-4"
+info "Merged PR #4 into main"
+git branch -d pr-4
+success "Created PR #4 and merged it to main!"
 
 success "Scenario #2 completed successfully!"
 
 
-title "Scenario #3: Merge a pull request with the checklist locked, but don't CP it"
+title "Scenario #3: Merge a pull request with the checklist locked and CP it to staging"
 
-info "Creating PR #6 and merging it into main..."
+info "Creating PR #5 and merging it into main..."
 git checkout main
-git checkout -b pr-6
-echo "Changes from PR #6" >> PR6.txt
-git add PR6.txt
-git commit -m "Changes from PR #6"
+git checkout -b pr-5
+echo "Changes from PR #5" >> PR5.txt
+git add PR5.txt
+git commit -m "Changes from PR #5"
 git checkout main
-git merge pr-6 --no-ff -m "Merge pull request #6 from Expensify/pr-6"
-info "Merged PR #6 into main"
-git branch -d pr-6
-success "Created PR #6 and merged it to main!"
+git merge pr-5 --no-ff -m "Merge pull request #5 from Expensify/pr-5"
+PR_5_MERGE_COMMIT="$(git log -1 --format='%H')"
+info "Merged PR #5 into main"
+git branch -d pr-5
+success "Created PR #5 and merged it to main!"
 
-success "Scenario #3 completed successfully!"
-
-
-title "Scenario #4: Merge a pull request with the checklist locked and CP it to staging"
-
-info "Creating PR #7 and merging it into main..."
-git checkout main
-git checkout -b pr-7
-echo "Changes from PR #7" >> PR7.txt
-git add PR7.txt
-git commit -m "Changes from PR #7"
-git checkout main
-git merge pr-7 --no-ff -m "Merge pull request #7 from Expensify/pr-7"
-PR_7_MERGE_COMMIT="$(git log -1 --format='%H')"
-info "Merged PR #7 into main"
-git branch -d pr-7
-success "Created PR #7 and merged it to main!"
-
-info "Bumping version to 1.1.1 on main..."
+info "Bumping version to 1.0.3 on main..."
 git checkout main
 git checkout -b version-bump
-npm --no-git-tag-version version 1.1.1 -m "Update version to 1.1.1"
+npm --no-git-tag-version version 1.0.3 -m "Update version to 1.0.3"
 git add package.json package-lock.json
 git commit -m "Update version to $(print_version)"
 git checkout main
-git merge version-bump --no-ff -m "Merge pull request #8 from Expensify/version-bump"
+git merge version-bump --no-ff -m "Merge pull request #6 from Expensify/version-bump"
 VERSION_BUMP_MERGE_COMMIT="$(git log -1 --format='%H')"
-info "Merged PR #8 into main"
+info "Merged PR #6 into main"
 git branch -d version-bump
-success "Bumped version to 1.1.1 on main!"
+success "Bumped version to 1.0.3 on main!"
 
-info "Cherry picking PR #7 and the version bump to staging..."
+info "Cherry picking PR #5 and the version bump to staging..."
 git checkout staging
-git checkout -b cherry-pick-staging-7
-git cherry-pick -x --mainline 1 --strategy=recursive -Xtheirs "$PR_7_MERGE_COMMIT"
+git checkout -b cherry-pick-staging-5
+git cherry-pick -x --mainline 1 --strategy=recursive -Xtheirs "$PR_5_MERGE_COMMIT"
 git cherry-pick -x --mainline 1 "$VERSION_BUMP_MERGE_COMMIT"
 git checkout staging
-git merge cherry-pick-staging-7 --no-ff -m "Merge pull request #9 from Expensify/cherry-pick-staging-7"
-git branch -d cherry-pick-staging-7
-info "Merged PR #9 into staging"
-success "Successfully cherry-picked PR #7 to staging!"
+git merge cherry-pick-staging-5 --no-ff -m "Merge pull request #7 from Expensify/cherry-pick-staging-5"
+git branch -d cherry-pick-staging-5
+info "Merged PR #7 into staging"
+success "Successfully cherry-picked PR #5 to staging!"
 
 info "Tagging the new version on staging..."
 git checkout staging
@@ -245,59 +200,59 @@ git tag "$(print_version)"
 success "Created tag $(print_version)"
 
 # Verify output for checklist
-info "Checking output of getPullRequestsMergedBetween 1.0.1 1.1.1"
-output=$(node "$getPullRequestsMergedBetween" '1.0.1' '1.1.1')
-assert_equal "$output" "[ '9', '7', '1' ]"
+info "Checking output of getPullRequestsMergedBetween 1.0.1 1.0.3"
+output=$(node "$getPullRequestsMergedBetween" '1.0.1' '1.0.3')
+assert_equal "$output" "[ '7', '5', '1' ]"
 
 # Verify output for deploy comment
-info "Checking output of getPullRequestsMergedBetween 1.1.0 1.1.1"
-output=$(node "$getPullRequestsMergedBetween" '1.1.0' '1.1.1')
-assert_equal "$output" "[ '9', '7' ]"
+info "Checking output of getPullRequestsMergedBetween 1.0.2 1.0.3"
+output=$(node "$getPullRequestsMergedBetween" '1.0.2' '1.0.3')
+assert_equal "$output" "[ '7', '5' ]"
 
-success "Scenario #4 completed successfully!"
+success "Scenario #3 completed successfully!"
 
 
-title "Scenario #5: Close the checklist"
-title "Scenario #5A: Run the production deploy"
+title "Scenario #4: Close the checklist"
+title "Scenario #4A: Run the production deploy"
 
 info "Updating production from staging..."
 git checkout production
 git checkout -b update-production-from-staging
 git merge --no-edit -Xtheirs staging
 git checkout production
-git merge update-production-from-staging --no-ff -m "Merge pull request #10 from Expensify/update-production-from-staging"
-info "Merged PR #10 into production"
+git merge update-production-from-staging --no-ff -m "Merge pull request #8 from Expensify/update-production-from-staging"
+info "Merged PR #8 into production"
 git branch -d update-production-from-staging
 success "Updated production from staging!"
 
 # Verify output for release body and production deploy comments
-info "Checking output of getPullRequestsMergedBetween 1.0.1 1.1.1"
-output=$(node "$getPullRequestsMergedBetween" '1.0.1' '1.1.1')
-assert_equal "$output" "[ '9', '7', '1' ]"
+info "Checking output of getPullRequestsMergedBetween 1.0.1 1.0.3"
+output=$(node "$getPullRequestsMergedBetween" '1.0.1' '1.0.3')
+assert_equal "$output" "[ '7', '5', '1' ]"
 
-success "Scenario #5A completed successfully!"
+success "Scenario #4A completed successfully!"
 
-title "Scenario #5B: Run the staging deploy and create a new checklist"
+title "Scenario #4B: Run the staging deploy and create a new checklist"
 
-info "Bumping version to 1.1.2 on main..."
+info "Bumping version to 1.1.0 on main..."
 git checkout main
 git checkout -b version-bump
-npm --no-git-tag-version version 1.1.2 -m "Update version to 1.1.2"
+npm --no-git-tag-version version 1.1.0 -m "Update version to 1.1.0"
 git add package.json package-lock.json
 git commit -m "Update version to $(print_version)"
 git checkout main
-git merge version-bump --no-ff -m "Merge pull request #11 from Expensify/version-bump"
-info "Merged PR #11 into main"
+git merge version-bump --no-ff -m "Merge pull request #9 from Expensify/version-bump"
+info "Merged PR #9 into main"
 git branch -d version-bump
-success "Successfully updated version to 1.1.2 on main!"
+success "Successfully updated version to 1.1.0 on main!"
 
 info "Updating staging from main..."
 git checkout staging
 git checkout -b update-staging-from-main
 git merge --no-edit -Xtheirs main
 git checkout staging
-git merge update-staging-from-main --no-ff -m "Merge pull request #12 from Expensify/update-staging-from-main"
-info "Merged PR #12 into staging"
+git merge update-staging-from-main --no-ff -m "Merge pull request #10 from Expensify/update-staging-from-main"
+info "Merged PR #10 into staging"
 git branch -d update-staging-from-main
 success "Successfully updated staging from main!"
 
@@ -307,46 +262,46 @@ git tag "$(print_version)"
 success "Successfully tagged version $(print_version) on staging"
 
 # Verify output for new checklist and staging deploy comments
-info "Checking output of getPullRequestsMergedBetween 1.1.1 1.1.2"
-output=$(node "$getPullRequestsMergedBetween" '1.1.1' '1.1.2')
-assert_equal "$output" "[ '6' ]"
+info "Checking output of getPullRequestsMergedBetween 1.0.3 1.1.0"
+output=$(node "$getPullRequestsMergedBetween" '1.0.3' '1.1.0')
+assert_equal "$output" "[ '4' ]"
 
-success "Scenario #5B completed successfully!"
+success "Scenario #4B completed successfully!"
 
 
-title "Scenario #6: Merging another pull request when the checklist is unlocked"
+title "Scenario #5: Merging another pull request when the checklist is unlocked"
 
-info "Creating PR #13 and merging it to main..."
+info "Creating PR #11 and merging it to main..."
 git checkout main
-git checkout -b pr-13
-echo "Changes from PR #13" >> PR13.txt
-git add PR13.txt
-git commit -m "Changes from PR #13"
+git checkout -b pr-11
+echo "Changes from PR #11" >> PR11.txt
+git add PR11.txt
+git commit -m "Changes from PR #11"
 git checkout main
-git merge pr-13 --no-ff -m "Merge pull request #13 from Expensify/pr-13"
-info "Merged PR #13 into main"
-git branch -d pr-13
-success "Created PR #13 and merged it into main!"
+git merge pr-11 --no-ff -m "Merge pull request #11 from Expensify/pr-11"
+info "Merged PR #11 into main"
+git branch -d pr-11
+success "Created PR #11 and merged it into main!"
 
-info "Bumping version to 1.1.3 on main..."
+info "Bumping version to 1.1.1 on main..."
 git checkout main
 git checkout -b version-bump
-npm --no-git-tag-version version 1.1.3 -m "Update version to 1.1.3"
+npm --no-git-tag-version version 1.1.1 -m "Update version to 1.1.1"
 git add package.json package-lock.json
 git commit -m "Update version to $(cat package.json | jq -r .version)"
 git checkout main
-git merge version-bump --no-ff -m "Merge pull request #14 from Expensify/version-bump"
-info "Merged PR #14 into main"
+git merge version-bump --no-ff -m "Merge pull request #12 from Expensify/version-bump"
+info "Merged PR #12 into main"
 git branch -d version-bump
-success "Bumped version to 1.1.3 on main!"
+success "Bumped version to 1.1.1 on main!"
 
 info "Merging main into staging..."
 git checkout staging
 git checkout -b update-staging-from-main
 git merge --no-edit -Xtheirs main
 git checkout staging
-git merge update-staging-from-main --no-ff -m "Merge pull request #15 from Expensify/update-staging-from-main"
-info "Merged PR #15 into staging"
+git merge update-staging-from-main --no-ff -m "Merge pull request #13 from Expensify/update-staging-from-main"
+info "Merged PR #13 into staging"
 git branch -d update-staging-from-main
 success "Merged main into staging!"
 
@@ -356,14 +311,14 @@ git tag "$(print_version)"
 success "Successfully tagged version $(print_version) on staging"
 
 # Verify output for checklist
-info "Checking output of getPullRequestsMergedBetween 1.1.1 1.1.3"
-output=$(node "$getPullRequestsMergedBetween" '1.1.1' '1.1.3')
-assert_equal "$output" "[ '13', '6' ]"
+info "Checking output of getPullRequestsMergedBetween 1.0.3 1.1.1"
+output=$(node "$getPullRequestsMergedBetween" '1.0.3' '1.1.1')
+assert_equal "$output" "[ '11', '4' ]"
 
 # Verify output for deploy comment
-info "Checking output of getPullRequestsMergedBetween 1.1.2 1.1.3"
-output=$(node "$getPullRequestsMergedBetween" '1.1.2' '1.1.3')
-assert_equal "$output" "[ '13' ]"
+info "Checking output of getPullRequestsMergedBetween 1.1.0 1.1.1"
+output=$(node "$getPullRequestsMergedBetween" '1.1.0' '1.1.1')
+assert_equal "$output" "[ '11' ]"
 
 success "Scenario #6 completed successfully!"
 


### PR DESCRIPTION
### Details
This changes the deploy paradigm so that we no longer bump the `PATCH` version or run a staging deploy when a checklist is locked. Instead, we bump the `PATCH` version when the checklist is first created.

### Fixed Issues
$ https://github.com/Expensify/App/issues/7166

### Tests
I tested commands locally and added automated unit tests where possible.

- [x] Verify that no errors appear in the JS console

### QA Steps
1. Close the deploy checklist.
1. The app should have it's `PATCH` version bumped, and a staging deploy should occur./
1. The new checklist should be created with the new `PATCH` version.
1. Lock the checklist when there is no staging deploy running.
1. The `awaitStagingDeploys` action should complete quickly, and `OSBotify` should comment on the deploy checklist:

    :rocket: All staging deploys are complete, @Expensify/applauseleads please begin QA on version https://github.com/Expensify/App/releases/tag/new-build-version :rocket:
    
1. Unlock the checklist and merge another PR.
1. While the staging deploy for the other PR is running, lock the checklist again.
1. The `awaitStagingDeploys` action should poll the GH API every 90 seconds until the staging deploy completes.
1. Once the staging deploy completes, the action should complete and `OSBotify` should comment on the deploy checklist with the name comment as above, using the new build version.

- [x] Verify that no errors appear in the JS console
