### PR TITLE
Fix Terms And Licenses text styles

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -419,9 +419,8 @@ export default {
         phrase2: 'terms of service',
         phrase3: 'and',
         phrase4: 'privacy policy',
-        phrase5: 'Money transmission is provided by Expensify Payments LLC (NMLS',
-        phrase6: 'ID:2017010) pursuant to its',
-        phrase7: 'licenses',
+        phrase5: 'Money transmission is provided by Expensify Payments LLC (NMLS ID:2017010) pursuant to its',
+        phrase6: 'licenses',
     },
     passwordForm: {
         pleaseFillOutAllFields: 'Please fill out all fields',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -419,9 +419,8 @@ export default {
         phrase2: 'términos de servicio',
         phrase3: 'y',
         phrase4: 'política de privacidad',
-        phrase5: 'El envío de dinero es brindado por Expensify Payments LLC (NMLS',
-        phrase6: 'ID:2017010) de conformidad con sus',
-        phrase7: 'licencias',
+        phrase5: 'El envío de dinero es brindado por Expensify Payments LLC (NMLS ID:2017010) de conformidad con sus',
+        phrase6: 'licencias',
     },
     passwordForm: {
         pleaseFillOutAllFields: 'Por favor completa todos los campos',

--- a/src/pages/signin/TermsAndLicenses.js
+++ b/src/pages/signin/TermsAndLicenses.js
@@ -11,9 +11,7 @@ import LocalePicker from '../../components/LocalePicker';
 const TermsAndLicenses = props => (
     <>
         <Text style={[styles.textExtraSmallSupporting]}>
-            <Text style={[styles.textExtraSmallSupporting]}>
                 {props.translate('termsOfUse.phrase1')}
-            </Text>
             <TextLink
                 style={[styles.textExtraSmallSupporting, styles.link]}
                 href={CONST.TERMS_URL}
@@ -22,9 +20,7 @@ const TermsAndLicenses = props => (
                 {props.translate('termsOfUse.phrase2')}
                 {' '}
             </TextLink>
-            <Text style={[styles.textExtraSmallSupporting]}>
                 {props.translate('termsOfUse.phrase3')}
-            </Text>
             <TextLink
                 style={[styles.textExtraSmallSupporting, styles.link]}
                 href={CONST.PRIVACY_URL}
@@ -32,14 +28,10 @@ const TermsAndLicenses = props => (
                 {' '}
                 {props.translate('termsOfUse.phrase4')}
             </TextLink>
-            <Text style={[styles.textExtraSmallSupporting]}>{'. '}</Text>
-            <Text style={[styles.textExtraSmallSupporting]}>
+            {'. '}
                 {props.translate('termsOfUse.phrase5')}
                 {' '}
-            </Text>
-            <Text style={[styles.textExtraSmallSupporting]}>
                 {props.translate('termsOfUse.phrase6')}
-            </Text>
             <TextLink
                 style={[styles.textExtraSmallSupporting, styles.link]}
                 href={CONST.LICENSES_URL}
@@ -47,7 +39,7 @@ const TermsAndLicenses = props => (
                 {' '}
                 {props.translate('termsOfUse.phrase7')}
             </TextLink>
-            <Text style={[styles.textExtraSmallSupporting]}>.</Text>
+            {'.'}
         </Text>
         <View style={[styles.mt4, styles.alignItemsCenter, styles.mb2, styles.flexRow, styles.justifyContentBetween]}>
             <LogoWordmark height={30} width={80} />

--- a/src/pages/signin/TermsAndLicenses.js
+++ b/src/pages/signin/TermsAndLicenses.js
@@ -10,16 +10,8 @@ import LocalePicker from '../../components/LocalePicker';
 
 const TermsAndLicenses = props => (
     <>
-        <View
-            style={[
-                styles.dFlex,
-                styles.flexRow,
-                styles.flexWrap,
-                styles.textAlignCenter,
-                styles.alignItemsCenter,
-            ]}
-        >
-            <Text style={[styles.textAlignCenter, styles.textExtraSmallSupporting]}>
+        <Text style={[styles.textExtraSmallSupporting]}>
+            <Text style={[styles.textExtraSmallSupporting]}>
                 {props.translate('termsOfUse.phrase1')}
             </Text>
             <TextLink
@@ -30,7 +22,7 @@ const TermsAndLicenses = props => (
                 {props.translate('termsOfUse.phrase2')}
                 {' '}
             </TextLink>
-            <Text style={[styles.textAlignCenter, styles.textExtraSmallSupporting]}>
+            <Text style={[styles.textExtraSmallSupporting]}>
                 {props.translate('termsOfUse.phrase3')}
             </Text>
             <TextLink
@@ -40,12 +32,12 @@ const TermsAndLicenses = props => (
                 {' '}
                 {props.translate('termsOfUse.phrase4')}
             </TextLink>
-            <Text style={[styles.textAlignCenter, styles.textExtraSmallSupporting]}>.</Text>
-            <Text style={[styles.textAlignCenter, styles.textExtraSmallSupporting]}>
+            <Text style={[styles.textExtraSmallSupporting]}>{'. '}</Text>
+            <Text style={[styles.textExtraSmallSupporting]}>
                 {props.translate('termsOfUse.phrase5')}
                 {' '}
             </Text>
-            <Text style={[styles.textAlignCenter, styles.textExtraSmallSupporting]}>
+            <Text style={[styles.textExtraSmallSupporting]}>
                 {props.translate('termsOfUse.phrase6')}
             </Text>
             <TextLink
@@ -55,8 +47,8 @@ const TermsAndLicenses = props => (
                 {' '}
                 {props.translate('termsOfUse.phrase7')}
             </TextLink>
-            <Text style={[styles.textAlignCenter, styles.textExtraSmallSupporting]}>.</Text>
-        </View>
+            <Text style={[styles.textExtraSmallSupporting]}>.</Text>
+        </Text>
         <View style={[styles.mt4, styles.alignItemsCenter, styles.mb2, styles.flexRow, styles.justifyContentBetween]}>
             <LogoWordmark height={30} width={80} />
             <LocalePicker size="small" />

--- a/src/pages/signin/TermsAndLicenses.js
+++ b/src/pages/signin/TermsAndLicenses.js
@@ -24,11 +24,9 @@ const TermsAndLicenses = props => (
             </TextLink>
             {'. '}
             {props.translate('termsOfUse.phrase5')}
-            {' '}
-            {props.translate('termsOfUse.phrase6')}
             <TextLink style={[styles.textExtraSmallSupporting, styles.link]} href={CONST.LICENSES_URL}>
                 {' '}
-                {props.translate('termsOfUse.phrase7')}
+                {props.translate('termsOfUse.phrase6')}
             </TextLink>
             .
         </Text>

--- a/src/pages/signin/TermsAndLicenses.js
+++ b/src/pages/signin/TermsAndLicenses.js
@@ -11,35 +11,26 @@ import LocalePicker from '../../components/LocalePicker';
 const TermsAndLicenses = props => (
     <>
         <Text style={[styles.textExtraSmallSupporting]}>
-                {props.translate('termsOfUse.phrase1')}
-            <TextLink
-                style={[styles.textExtraSmallSupporting, styles.link]}
-                href={CONST.TERMS_URL}
-            >
+            {props.translate('termsOfUse.phrase1')}
+            <TextLink style={[styles.textExtraSmallSupporting, styles.link]} href={CONST.TERMS_URL}>
                 {' '}
                 {props.translate('termsOfUse.phrase2')}
                 {' '}
             </TextLink>
-                {props.translate('termsOfUse.phrase3')}
-            <TextLink
-                style={[styles.textExtraSmallSupporting, styles.link]}
-                href={CONST.PRIVACY_URL}
-            >
+            {props.translate('termsOfUse.phrase3')}
+            <TextLink style={[styles.textExtraSmallSupporting, styles.link]} href={CONST.PRIVACY_URL}>
                 {' '}
                 {props.translate('termsOfUse.phrase4')}
             </TextLink>
             {'. '}
-                {props.translate('termsOfUse.phrase5')}
-                {' '}
-                {props.translate('termsOfUse.phrase6')}
-            <TextLink
-                style={[styles.textExtraSmallSupporting, styles.link]}
-                href={CONST.LICENSES_URL}
-            >
+            {props.translate('termsOfUse.phrase5')}
+            {' '}
+            {props.translate('termsOfUse.phrase6')}
+            <TextLink style={[styles.textExtraSmallSupporting, styles.link]} href={CONST.LICENSES_URL}>
                 {' '}
                 {props.translate('termsOfUse.phrase7')}
             </TextLink>
-            {'.'}
+            .
         </Text>
         <View style={[styles.mt4, styles.alignItemsCenter, styles.mb2, styles.flexRow, styles.justifyContentBetween]}>
             <LogoWordmark height={30} width={80} />


### PR DESCRIPTION
Use <Text> parent element so text wrapping occurs "naturally"

<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/7437

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- On the login screen
- verify text line wrapping looks ok in English and Spanish
    -  _"El envío de dinero es brindado por Expensify..."_ should not be starting on a new line
- using browser zoom does not cause weird text wrapping (e.g. spacing word centering, see comparison screenshot below)
     
### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

Same as above

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
#### No diff for English (staging vs local)
![image](https://user-images.githubusercontent.com/12156624/151810523-db611db5-2d89-4319-8104-39505c756888.png)

#### Spanish wrapping fixed
![image](https://user-images.githubusercontent.com/12156624/151810659-7be1bd21-ac02-4fb0-98c5-eefbe876adc2.png)

#### 150% zoom (staging vs local)
![image](https://user-images.githubusercontent.com/12156624/151810800-b2abc2c6-7f5c-4828-a796-fd0fb2fb9ee2.png)

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
![image](https://user-images.githubusercontent.com/12156624/151814840-148d5b21-6e1c-4925-935d-02feb242d743.png)

![image](https://user-images.githubusercontent.com/12156624/151814888-a5601446-d1e6-4b7b-ae40-25d46b0fbaab.png)

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
![image](https://user-images.githubusercontent.com/12156624/151814999-1eb44a39-42e7-46bc-b896-627585fc45dd.png)

![image](https://user-images.githubusercontent.com/12156624/151815035-6e94d730-a9be-4410-878d-d14163befa25.png)

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

![image](https://user-images.githubusercontent.com/12156624/151814642-5645b69a-f8d6-4c97-928f-9682b080d004.png)

![image](https://user-images.githubusercontent.com/12156624/151814706-d8cce971-2346-4300-8e5c-a6954fb447e0.png)

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
![image](https://user-images.githubusercontent.com/12156624/151809198-7c3e8f96-68df-4ed1-b10d-e42424986d8f.png)

![image](https://user-images.githubusercontent.com/12156624/151809240-abedc2e7-413e-429c-b6cc-58fadd5c4814.png)
