### PR TITLE
Fix /transition route for already signed in users

### DIFF
--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -195,8 +195,12 @@ class AuthScreens extends React.Component {
         }
 
         const path = new URL(url).pathname;
-        const exitTo = new URLSearchParams(url).get('exitTo');
-        return Str.startsWith(path, Str.normalizeUrl(ROUTES.LOGIN_WITH_SHORT_LIVED_TOKEN))
+        const params = new URLSearchParams(url);
+        const exitTo = params.get('exitTo');
+        const email = params.get('email');
+        const isLoggingInAsNewUser = !_.isNull(this.props.session.email) && (email !== this.props.session.email);
+        return !isLoggingInAsNewUser
+            && Str.startsWith(path, Str.normalizeUrl(ROUTES.LOGIN_WITH_SHORT_LIVED_TOKEN))
             && exitTo === ROUTES.WORKSPACE_NEW;
     }
 
@@ -365,6 +369,9 @@ export default compose(
     withOnyx({
         network: {
             key: ONYXKEYS.NETWORK,
+        },
+        session: {
+            key: ONYXKEYS.SESSION,
         },
     }),
 )(AuthScreens);

--- a/src/libs/actions/Session/index.js
+++ b/src/libs/actions/Session/index.js
@@ -86,6 +86,10 @@ function signOut() {
     Onyx.set(ONYXKEYS.SESSION, null);
     Onyx.set(ONYXKEYS.CREDENTIALS, null);
     Timing.clearData();
+}
+
+function signOutAndRedirectToSignIn() {
+    signOut();
     redirectToSignIn();
     Log.info('Redirecting to Sign In because signOut() was called');
 }
@@ -256,6 +260,7 @@ function signIn(password, twoFactorAuthCode) {
  * @param {String} accountID
  * @param {String} email
  * @param {String} shortLivedToken
+ * @param {String} exitTo
  */
 function signInWithShortLivedToken(accountID, email, shortLivedToken) {
     Onyx.merge(ONYXKEYS.ACCOUNT, {...CONST.DEFAULT_ACCOUNT_DATA, loading: true});
@@ -531,6 +536,7 @@ export {
     signIn,
     signInWithShortLivedToken,
     signOut,
+    signOutAndRedirectToSignIn,
     reopenAccount,
     resendValidationLink,
     resetPassword,

--- a/src/pages/GenericErrorPage/index.js
+++ b/src/pages/GenericErrorPage/index.js
@@ -60,7 +60,7 @@ const GenericErrorPage = props => (
                         <Button
                             medium
                             onPress={() => {
-                                Session.signOut();
+                                Session.signOutAndRedirectToSignIn();
                                 props.onRefresh();
                             }}
                             text={props.translate('initialSettingsPage.signOut')}

--- a/src/pages/settings/InitialSettingsPage.js
+++ b/src/pages/settings/InitialSettingsPage.js
@@ -116,7 +116,7 @@ const defaultMenuItems = [
     {
         translationKey: 'initialSettingsPage.signOut',
         icon: Expensicons.Exit,
-        action: Session.signOut,
+        action: Session.signOutAndRedirectToSignIn,
     },
 ];
 


### PR DESCRIPTION
### Details

There are a few ways a user can transition from OldDot to NewDot none of them work particularly well when the user is already signed into an existing account that is different from the one they are logging in as.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/193842
$ https://github.com/Expensify/Expensify/issues/193843

### Tests / QA Steps

**Test new account that does not have a policy yet**

1. Open an incognito window and go to expensify.com
1. Sign in to expensify.com as a brand new user (User A)
1. Click "Get Started" on WelcomeFree
1. Verify and note that User A is now logged into NewDot
1. Navigate back to expensify.com and sign out
1. Sign in to expensify.com as a brand new user (User B)
1. Click "Get Started" on WelcomeFree
1. Verify User A is logged out, User B is logged in, only one workspace is created, and User B is brought to the Workspace settings view

**Test creating a new free policy for account that already has one while logged in as another user**
1. Open an incognito window and sign into new.expensify.com as a new User A
2. Sign into expensify.com as a different user (User B) that has a Free Policy
3. Navigate to Policies > New Policy > Free
4. Verify that User A is logged out of NewDot and User B is logged in and brought to the workspace settings. Verify this user has 2 workspaces now. Verify User B does not have any additional workspaces.

**Test transition when logged in as another user and tapping inbox task as a workspace user in setup**
1. Open an incognito window and sign into new.expensify.com as a new User A
1. Sign in to expensify.com as a different user (User B) that has a Free Policy / Workspace but not VBA
1. Click "Continue Setup"
1. Verify that User A is logged out of NewDot and User B is logged in and brought to the bank account setup screen to finish setup

**Test transition when logged in as another user and tapping inbox task as a workspace user with valid VBA**
1. Open an incognito window and sign into new.expensify.com as User A
1. Sign in to expensify.com as a different user (User B) that has a Free Policy / Workspace and completely set up VBA
1. Navigate to `expensify.com/admin_policies` and select the Workspace
1. Verify that User A is logged out of NewDot and User B is logged in and brought to the bank account setup screen to finish setup

- [ ] Verify that no errors appear in the JS console

**Note:** Also test that the mainline case of no users logged into NewDot or OldDot and a user signing up for the first time works fine.

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
