### PR TITLE
Disable guides calling if user is blocked from concierge

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -854,6 +854,7 @@ export default {
         growlMessageEmptyName: 'Please provide both a first and last name so our guides know how to address you!',
         callButton: 'Call',
         callButtonTooltip: 'Get live help from our team',
+        blockedFromConcierge: 'Due to previous interactions with our staff, call cannot be scheduled at this time.',
         waitTime: {
             calculating: 'Calculating wait time...',
             fiveHoursPlus: 'The current wait time is longer than 5 hours.',

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -854,7 +854,7 @@ export default {
         growlMessageEmptyName: 'Please provide both a first and last name so our guides know how to address you!',
         callButton: 'Call',
         callButtonTooltip: 'Get live help from our team',
-        blockedFromConcierge: 'Due to previous interactions with our staff, call cannot be scheduled at this time.',
+        blockedFromConcierge: 'Due to previous interactions with our staff, a call cannot be scheduled at this time.',
         waitTime: {
             calculating: 'Calculating wait time...',
             fiveHoursPlus: 'The current wait time is longer than 5 hours.',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -856,7 +856,7 @@ export default {
         growlMessageEmptyName: 'Por favor ingresa tu nombre completo',
         callButton: 'Llamar',
         callButtonTooltip: 'Recibe ayuda telefónica de nuestro equipo',
-        blockedFromConcierge: 'Debido a sus interacciones pasadas con nuestro equipo, la llamada no puede ser programada en este momento.',
+        blockedFromConcierge: 'Debido a sus interacciones pasadas con nuestro equipo, la llamada no puede ser agendada en este momento.',
         waitTime: {
             calculating: 'Calculando el tiempo de espera...',
             fiveHoursPlus: 'El tiempo de espera actual es superior a 5 horas.',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -856,6 +856,7 @@ export default {
         growlMessageEmptyName: 'Por favor ingresa tu nombre completo',
         callButton: 'Llamar',
         callButtonTooltip: 'Recibe ayuda telefónica de nuestro equipo',
+        blockedFromConcierge: 'Debido a sus interacciones pasadas con nuestro equipo, la llamada no puede ser programada en este momento.',
         waitTime: {
             calculating: 'Calculando el tiempo de espera...',
             fiveHoursPlus: 'El tiempo de espera actual es superior a 5 horas.',

--- a/src/libs/actions/Inbox.js
+++ b/src/libs/actions/Inbox.js
@@ -4,6 +4,7 @@ import * as API from '../API';
 import Growl from '../Growl';
 import * as Localize from '../Localize';
 import Navigation from '../Navigation/Navigation';
+import * as User from './User';
 
 /**
  * @param {Object} params
@@ -30,6 +31,11 @@ function requestInboxCall({
                 Growl.success(Localize.translateLocal('requestCallPage.growlMessageOnSave'));
                 Navigation.goBack();
                 return;
+            }
+
+            if (result.jsonCode === 666) {
+                // The fact that the API is returning this error means the BLOCKED_FROM_CONCIERGE nvp in the user details has changed since the last time we checked, so let's update
+                User.getUserDetails();
             }
 
             // Phone number validation is handled by the API

--- a/src/pages/RequestCallPage.js
+++ b/src/pages/RequestCallPage.js
@@ -8,6 +8,7 @@ import Str from 'expensify-common/lib/str';
 import HeaderWithCloseButton from '../components/HeaderWithCloseButton';
 import Navigation from '../libs/Navigation/Navigation';
 import styles from '../styles/styles';
+import colors from '../styles/colors';
 import ScreenWrapper from '../components/ScreenWrapper';
 import withLocalize, {withLocalizePropTypes} from '../components/withLocalize';
 import ONYXKEYS from '../ONYXKEYS';
@@ -344,7 +345,7 @@ class RequestCallPage extends Component {
                     <FixedFooter>
                         {isBlockedFromConcierge && (
                             <View style={[styles.flexRow, styles.alignItemsCenter, styles.mb3]}>
-                                <Icon src={Expensicons.Exclamation} />
+                                <Icon src={Expensicons.Exclamation} fill={colors.yellow} />
                                 <Text style={[styles.mutedTextLabel, styles.ml2]}>{this.props.translate('requestCallPage.blockedFromConcierge')}</Text>
                             </View>
                         )}

--- a/src/pages/RequestCallPage.js
+++ b/src/pages/RequestCallPage.js
@@ -27,6 +27,7 @@ import * as Illustrations from '../components/Icon/Illustrations';
 import LoginUtil from '../libs/LoginUtil';
 import * as ValidationUtils from '../libs/ValidationUtils';
 import * as PersonalDetails from '../libs/actions/PersonalDetails';
+import * as User from '../libs/actions/User';
 
 const propTypes = {
     ...withLocalizePropTypes,
@@ -71,6 +72,12 @@ const propTypes = {
 
     /** The policyID of the last workspace whose settings the user accessed */
     lastAccessedWorkspacePolicyID: PropTypes.string,
+
+    // The NVP describing a user's block status
+    blockedFromConcierge: PropTypes.shape({
+        // The date that the user will be unblocked
+        expiresAt: PropTypes.string,
+    }),
 };
 
 const defaultProps = {
@@ -79,6 +86,7 @@ const defaultProps = {
     },
     inboxCallUserWaitTime: null,
     lastAccessedWorkspacePolicyID: '',
+    blockedFromConcierge: {},
 };
 
 class RequestCallPage extends Component {
@@ -274,6 +282,8 @@ class RequestCallPage extends Component {
     }
 
     render() {
+        const isBlockedFromConcierge = !_.isEmpty(this.props.blockedFromConcierge) && User.isBlockedFromConcierge(this.props.blockedFromConcierge.expiresAt);
+
         return (
             <ScreenWrapper>
                 <KeyboardAvoidingView>
@@ -336,6 +346,7 @@ class RequestCallPage extends Component {
                             style={[styles.w100]}
                             text={this.props.translate('requestCallPage.callMe')}
                             isLoading={this.props.requestCallForm.loading}
+                            isDisabled={isBlockedFromConcierge}
                         />
                     </FixedFooter>
                 </KeyboardAvoidingView>
@@ -369,6 +380,9 @@ export default compose(
         },
         lastAccessedWorkspacePolicyID: {
             key: ONYXKEYS.LAST_ACCESSED_WORKSPACE_POLICY_ID,
+        },
+        blockedFromConcierge: {
+            key: ONYXKEYS.NVP_BLOCKED_FROM_CONCIERGE,
         },
     }),
 )(RequestCallPage);

--- a/src/pages/RequestCallPage.js
+++ b/src/pages/RequestCallPage.js
@@ -345,7 +345,7 @@ class RequestCallPage extends Component {
                         {isBlockedFromConcierge && (
                             <View style={[styles.flexRow, styles.alignItemsCenter, styles.mb3]}>
                                 <Icon src={Expensicons.Exclamation} />
-                                <Text style={[styles.mutedTextLabel, styles.ml2]}>{'Due to previous interactions with our staff, call cannot be scheduled at this time.'}</Text>
+                                <Text style={[styles.mutedTextLabel, styles.ml2]}>{this.props.translate('requestCallPage.blockedFromConcierge')}</Text>
                             </View>
                         )}
                         <Button

--- a/src/pages/RequestCallPage.js
+++ b/src/pages/RequestCallPage.js
@@ -15,6 +15,7 @@ import compose from '../libs/compose';
 import FullNameInputRow from '../components/FullNameInputRow';
 import Button from '../components/Button';
 import FixedFooter from '../components/FixedFooter';
+import Icon from '../components/Icon';
 import CONST from '../CONST';
 import Growl from '../libs/Growl';
 import * as Inbox from '../libs/actions/Inbox';
@@ -24,6 +25,7 @@ import Text from '../components/Text';
 import Section from '../components/Section';
 import KeyboardAvoidingView from '../components/KeyboardAvoidingView';
 import * as Illustrations from '../components/Icon/Illustrations';
+import * as Expensicons from '../components/Icon/Expensicons';
 import LoginUtil from '../libs/LoginUtil';
 import * as ValidationUtils from '../libs/ValidationUtils';
 import * as PersonalDetails from '../libs/actions/PersonalDetails';
@@ -340,6 +342,12 @@ class RequestCallPage extends Component {
                         </Section>
                     </ScrollView>
                     <FixedFooter>
+                        {isBlockedFromConcierge && (
+                            <View style={[styles.flexRow, styles.alignItemsCenter, styles.mb3]}>
+                                <Icon src={Expensicons.Exclamation} />
+                                <Text style={[styles.mutedTextLabel, styles.ml2]}>{'Due to previous interactions with our staff, call cannot be scheduled at this time.'}</Text>
+                            </View>
+                        )}
                         <Button
                             success
                             onPress={this.onSubmit}

--- a/src/pages/RequestCallPage.js
+++ b/src/pages/RequestCallPage.js
@@ -346,7 +346,7 @@ class RequestCallPage extends Component {
                         {isBlockedFromConcierge && (
                             <View style={[styles.flexRow, styles.alignItemsCenter, styles.mb3]}>
                                 <Icon src={Expensicons.Exclamation} fill={colors.yellow} />
-                                <Text style={[styles.mutedTextLabel, styles.ml2]}>{this.props.translate('requestCallPage.blockedFromConcierge')}</Text>
+                                <Text style={[styles.mutedTextLabel, styles.ml2, styles.flex1]}>{this.props.translate('requestCallPage.blockedFromConcierge')}</Text>
                             </View>
                         )}
                         <Button


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR makes it so that if a user is blocked from talking to Concierge they are also blocked from starting a Guides call. cc @stitesExpensify 

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/7499


https://user-images.githubusercontent.com/1371996/152244179-a4fd7808-0bc6-4690-90e3-eddcab14c1e7.mov

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

1. Sign into an account in New Dot and navigate to your Concierge chat 
2. Message Concierge
2. Go to `https://www.expensify.com.dev/concierge/#/tools/ChatSearchByUser` and find the chat with your user
3. Click `User Info` and block the user
4. Go back to New Dot and try to start a call 
5. You should see a growl saying that calling is blocked
6. The call button should become disabled with a warning message above explaining why 
7. Close the call modal, refresh the page, and open the call modal again 
8. You should still see the call button as disabled with the message above it

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

1. Sign into an account in New Dot and navigate to your Concierge chat 
2. Message Concierge
2. Go to `https://www.expensify.com/concierge/#/tools/ChatSearchByUser` and find the chat with your user
3. Click `User Info` and block the user
4. Go back to New Dot and try to start a call 
5. You should see a growl saying that calling is blocked
6. The call button should become disabled with a warning message above explaining why 
7. Close the call modal, refresh the page, and open the call modal again 
8. You should still see the call button as disabled with the message above it

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
<img width="1365" alt="Screen Shot 2022-02-02 at 5 02 58 PM" src="https://user-images.githubusercontent.com/1371996/152245010-f23cf50e-1ca7-4a59-b8bf-62479dce92dc.png">

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
<img width="352" alt="Screen Shot 2022-02-02 at 5 12 14 PM" src="https://user-images.githubusercontent.com/1371996/152246235-96ff935f-3e72-4687-aa5e-5d34e1b123f6.png">

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
<img width="1194" alt="Screen Shot 2022-02-02 at 5 15 19 PM" src="https://user-images.githubusercontent.com/1371996/152246618-29da635b-32cc-4961-8562-5187f5aceb54.png">

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
<img width="355" alt="Screen Shot 2022-02-02 at 5 10 23 PM" src="https://user-images.githubusercontent.com/1371996/152246207-c60a23c4-2f06-4bd8-b706-7ce1bdbf3ad5.png">


#### Android
<!-- Insert screenshots of your changes on the Android platform-->
<img width="327" alt="Screen Shot 2022-02-02 at 5 35 20 PM" src="https://user-images.githubusercontent.com/1371996/152249121-df9e615f-eb82-4456-adee-37a718b3abc9.png">

