### PR TITLE
Aligned header

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -29,7 +29,7 @@ const Header = props => (
             </Text>
             {/* If there's no subtitle then display a fragment to avoid an empty space which moves the main title */}
             {_.isString(props.subtitle)
-                ? <Text style={[styles.mutedTextLabel]}>{props.subtitle}</Text>
+                ? Boolean(props.subtitle) && <Text style={[styles.mutedTextLabel]}>{props.subtitle}</Text>
                 : props.subtitle}
         </View>
         {props.shouldShowEnvironmentBadge && (


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Style fix for settings subpages miss-aligned headers on IOS and Android
### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ [#7491](https://github.com/Expensify/App/issues/7491)

### Tests | QA Steps
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Login in New Dot
2. Go to Settings
3. Check header title is vertically centered on all pages where there is a header. E.g. Settings pages. 
4. Note: that it should not affect the header where the subtitle is also visible. e.g. Attachment modal.

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
Chrome:
![image](https://user-images.githubusercontent.com/56851391/152054513-bbdda34b-15a0-4f14-875e-13e362199b1d.png)
Safari:
![Captura de Tela 2022-02-01 às 18 39 43](https://user-images.githubusercontent.com/56851391/152055988-db4b0dad-3fcd-4af9-8592-8f0f36dd3b8b.png)

#### Mobile Web
Android chrome mWeb:
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
![image](https://user-images.githubusercontent.com/56851391/152054442-5207ecac-4908-411d-8273-2131c1968d7d.png)
IOS safari mWeb:
![Captura de Tela 2022-02-01 às 19 11 07](https://user-images.githubusercontent.com/56851391/152060226-e0674526-17ba-4779-abf1-16ec8f5ce826.png)

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
![Captura de Tela 2022-02-01 às 18 22 38](https://user-images.githubusercontent.com/56851391/152053609-d0221c7a-3baa-41e2-a4a8-73d66d1c6e14.png)

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
![Captura de Tela 2022-02-01 às 14 19 58](https://user-images.githubusercontent.com/56851391/152018097-36cadafe-7f46-4cfe-aa3a-bef88fc04602.png)
#### Android
<!-- Insert screenshots of your changes on the Android platform-->
![image](https://user-images.githubusercontent.com/56851391/151899097-a4a29fc2-f9dc-437e-9136-5e8d57088a9e.png)