### PR TITLE
Resolve issue with focus being lost on search box after selecting a user

### DIFF
--- a/src/components/OptionsSelector.js
+++ b/src/components/OptionsSelector.js
@@ -1,7 +1,7 @@
 import _ from 'underscore';
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import {View} from 'react-native';
+import {View, findNodeHandle} from 'react-native';
 import OptionsList from './OptionsList';
 import CONST from '../CONST';
 import styles from '../styles/styles';
@@ -92,6 +92,7 @@ class OptionsSelector extends Component {
         this.handleKeyPress = this.handleKeyPress.bind(this);
         this.selectRow = this.selectRow.bind(this);
         this.viewableItems = [];
+        this.relatedTarget = null;
 
         this.state = {
             focusedIndex: 0,
@@ -191,12 +192,17 @@ class OptionsSelector extends Component {
      * Completes the follow up actions after a row is selected
      *
      * @param {Object} option
+     * @param {Object} ref
      */
-    selectRow(option) {
+    selectRow(option, ref) {
         if (this.props.shouldFocusOnSelectRow) {
             this.textInput.focus();
         }
+        if (this.relatedTarget && ref === findNodeHandle(this.relatedTarget)) {
+            this.textInput.focus();
+        }
         this.props.onSelectRow(option);
+        this.relatedTarget = null;
     }
 
     render() {
@@ -210,6 +216,8 @@ class OptionsSelector extends Component {
                         onKeyPress={this.handleKeyPress}
                         placeholder={this.props.placeholderText
                             || this.props.translate('optionsSelector.nameEmailOrPhoneNumber')}
+                        onBlur={e => this.relatedTarget = e.relatedTarget}
+                        onFocus={() => this.relatedTarget = null}
                     />
                 </View>
                 <OptionsList

--- a/src/components/OptionsSelector.js
+++ b/src/components/OptionsSelector.js
@@ -218,6 +218,7 @@ class OptionsSelector extends Component {
                             || this.props.translate('optionsSelector.nameEmailOrPhoneNumber')}
                         onBlur={e => this.relatedTarget = e.relatedTarget}
                         onFocus={() => this.relatedTarget = null}
+                        selectTextOnFocus
                     />
                 </View>
                 <OptionsList

--- a/src/pages/NewChatPage.js
+++ b/src/pages/NewChatPage.js
@@ -185,7 +185,7 @@ class NewChatPage extends Component {
                 recentReports,
                 personalDetails,
                 userToInvite,
-                searchValue: isOptionInList ? prevState.searchValue : '',
+                searchValue: prevState.searchValue,
             };
         });
     }

--- a/src/pages/home/sidebar/OptionRow.js
+++ b/src/pages/home/sidebar/OptionRow.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 import lodashGet from 'lodash/get';
-import React, {memo} from 'react';
+import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {
     TouchableOpacity,
@@ -81,204 +81,211 @@ const defaultProps = {
     disableRowInteractivity: false,
 };
 
-const OptionRow = (props) => {
-    const textStyle = props.optionIsFocused
-        ? styles.sidebarLinkActiveText
-        : styles.sidebarLinkText;
-    const textUnreadStyle = (props.option.isUnread || props.forceTextUnreadStyle)
-        ? [textStyle, styles.sidebarLinkTextUnread] : [textStyle];
-    const displayNameStyle = props.mode === 'compact'
-        ? [styles.optionDisplayName, ...textUnreadStyle, styles.optionDisplayNameCompact, styles.mr2]
-        : [styles.optionDisplayName, ...textUnreadStyle];
-    const alternateTextStyle = props.mode === 'compact'
-        ? [textStyle, styles.optionAlternateText, styles.textLabelSupporting, styles.optionAlternateTextCompact]
-        : [textStyle, styles.optionAlternateText, styles.textLabelSupporting];
-    const contentContainerStyles = props.mode === 'compact'
-        ? [styles.flex1, styles.flexRow, styles.overflowHidden, styles.alignItemsCenter]
-        : [styles.flex1];
-    const sidebarInnerRowStyle = StyleSheet.flatten(props.mode === 'compact' ? [
-        styles.chatLinkRowPressable,
-        styles.flexGrow1,
-        styles.optionItemAvatarNameWrapper,
-        styles.sidebarInnerRowSmall,
-        styles.justifyContentCenter,
-    ] : [
-        styles.chatLinkRowPressable,
-        styles.flexGrow1,
-        styles.optionItemAvatarNameWrapper,
-        styles.sidebarInnerRow,
-        styles.justifyContentCenter,
-    ]);
-    const hoveredBackgroundColor = props.hoverStyle && props.hoverStyle.backgroundColor
-        ? props.hoverStyle.backgroundColor
-        : props.backgroundColor;
-    const focusedBackgroundColor = styles.sidebarLinkActive.backgroundColor;
-    const isMultipleParticipant = lodashGet(props.option, 'participantsList.length', 0) > 1;
-    const displayNamesWithTooltips = _.map(
+class OptionRow extends Component {
+    constructor(props) {
+        super(props);
+    }
 
-        // We only create tooltips for the first 10 users or so since some reports have hundreds of users causing
-        // performance to degrade.
-        (props.option.participantsList || []).slice(0, 10),
-        ({displayName, firstName, login}) => {
-            const displayNameTrimmed = Str.isSMSLogin(login) ? props.toLocalPhone(displayName) : displayName;
+    shouldComponentUpdate(nextProps) {
+        if (this.props.optionIsFocused !== nextProps.optionIsFocused) {
+            return false;
+        }
+    
+        if (this.props.isSelected !== nextProps.isSelected) {
+            return false;
+        }
+    
+        if (this.props.mode !== nextProps.mode) {
+            return false;
+        }
+    
+        if (this.props.option.isUnread !== nextProps.option.isUnread) {
+            return false;
+        }
+    
+        if (this.props.option.alternateText !== nextProps.option.alternateText) {
+            return false;
+        }
+    
+        if (this.props.option.descriptiveText !== nextProps.option.descriptiveText) {
+            return false;
+        }
+    
+        if (this.props.option.hasDraftComment !== nextProps.option.hasDraftComment) {
+            return false;
+        }
+    
+        if (this.props.option.isPinned !== nextProps.option.isPinned) {
+            return false;
+        }
+    
+        if (this.props.option.hasOutstandingIOU !== nextProps.option.hasOutstandingIOU) {
+            return false;
+        }
+    
+        if (!_.isEqual(this.props.option.icons, nextProps.option.icons)) {
+            return false;
+        }
+    
+        // Re-render when the text changes
+        if (this.props.option.text !== nextProps.option.text) {
+            return false;
+        }
+    
+        return true;
+    }
 
-            return {
-                displayName: (isMultipleParticipant ? firstName : displayNameTrimmed) || Str.removeSMSDomain(login),
-                tooltip: Str.removeSMSDomain(login),
-            };
-        },
-    );
+    render() {
+        const textStyle = this.props.optionIsFocused
+            ? styles.sidebarLinkActiveText
+            : styles.sidebarLinkText;
+        const textUnreadStyle = (this.props.option.isUnread || this.props.forceTextUnreadStyle)
+            ? [textStyle, styles.sidebarLinkTextUnread] : [textStyle];
+        const displayNameStyle = this.props.mode === 'compact'
+            ? [styles.optionDisplayName, ...textUnreadStyle, styles.optionDisplayNameCompact, styles.mr2]
+            : [styles.optionDisplayName, ...textUnreadStyle];
+        const alternateTextStyle = this.props.mode === 'compact'
+            ? [textStyle, styles.optionAlternateText, styles.textLabelSupporting, styles.optionAlternateTextCompact]
+            : [textStyle, styles.optionAlternateText, styles.textLabelSupporting];
+        const contentContainerStyles = this.props.mode === 'compact'
+            ? [styles.flex1, styles.flexRow, styles.overflowHidden, styles.alignItemsCenter]
+            : [styles.flex1];
+        const sidebarInnerRowStyle = StyleSheet.flatten(this.props.mode === 'compact' ? [
+            styles.chatLinkRowPressable,
+            styles.flexGrow1,
+            styles.optionItemAvatarNameWrapper,
+            styles.sidebarInnerRowSmall,
+            styles.justifyContentCenter,
+        ] : [
+            styles.chatLinkRowPressable,
+            styles.flexGrow1,
+            styles.optionItemAvatarNameWrapper,
+            styles.sidebarInnerRow,
+            styles.justifyContentCenter,
+        ]);
+        const hoveredBackgroundColor = this.props.hoverStyle && this.props.hoverStyle.backgroundColor
+            ? this.props.hoverStyle.backgroundColor
+            : this.props.backgroundColor;
+        const focusedBackgroundColor = styles.sidebarLinkActive.backgroundColor;
+        const isMultipleParticipant = lodashGet(this.props.option, 'participantsList.length', 0) > 1;
+        const displayNamesWithTooltips = _.map(
 
-    return (
-        <Hoverable>
-            {hovered => (
-                <TouchableOpacity
-                    onPress={(e) => {
-                        e.preventDefault();
-                        props.onSelectRow(props.option);
-                    }}
-                    disabled={props.disableRowInteractivity}
-                    activeOpacity={0.8}
-                    style={[
-                        styles.flexRow,
-                        styles.alignItemsCenter,
-                        styles.justifyContentBetween,
-                        styles.sidebarLink,
-                        styles.sidebarLinkInner,
-                        StyleUtils.getBackgroundColorStyle(props.backgroundColor),
-                        props.optionIsFocused ? styles.sidebarLinkActive : null,
-                        hovered && !props.optionIsFocused ? props.hoverStyle : null,
-                        props.isDisabled && styles.cursorDisabled,
-                    ]}
-                >
-                    <View style={sidebarInnerRowStyle}>
-                        <View
-                            style={[
-                                styles.flexRow,
-                                styles.alignItemsCenter,
-                            ]}
-                        >
-                            {
-                                !_.isEmpty(props.option.icons)
-                                && (
-                                    <MultipleAvatars
-                                        avatarImageURLs={props.option.icons}
-                                        size={props.mode === 'compact' ? 'small' : 'default'}
-                                        secondAvatarStyle={[
-                                            StyleUtils.getBackgroundAndBorderStyle(props.backgroundColor),
-                                            props.optionIsFocused
-                                                ? StyleUtils.getBackgroundAndBorderStyle(focusedBackgroundColor)
-                                                : undefined,
-                                            hovered && !props.optionIsFocused
-                                                ? StyleUtils.getBackgroundAndBorderStyle(hoveredBackgroundColor)
-                                                : undefined,
-                                        ]}
-                                        isChatRoom={props.option.isChatRoom}
-                                        isArchivedRoom={props.option.isArchivedRoom}
-                                    />
-                                )
-                            }
-                            <View style={contentContainerStyles}>
-                                <DisplayNames
-                                    fullTitle={props.option.text}
-                                    displayNamesWithTooltips={displayNamesWithTooltips}
-                                    tooltipEnabled={props.showTitleTooltip}
-                                    numberOfLines={1}
-                                    textStyles={displayNameStyle}
-                                    shouldUseFullTitle={props.option.isChatRoom}
-                                />
-                                {props.option.alternateText ? (
-                                    <Text
-                                        style={alternateTextStyle}
+            // We only create tooltips for the first 10 users or so since some reports have hundreds of users causing
+            // performance to degrade.
+            (this.props.option.participantsList || []).slice(0, 10),
+            ({displayName, firstName, login}) => {
+                const displayNameTrimmed = Str.isSMSLogin(login) ? this.props.toLocalPhone(displayName) : displayName;
+
+                return {
+                    displayName: (isMultipleParticipant ? firstName : displayNameTrimmed) || Str.removeSMSDomain(login),
+                    tooltip: Str.removeSMSDomain(login),
+                };
+            },
+        );
+
+        return (
+            <Hoverable>
+                {hovered => (
+                    <TouchableOpacity
+                        onPress={(e) => {
+                            e.preventDefault();
+                            this.props.onSelectRow(this.props.option);
+                        }}
+                        disabled={this.props.disableRowInteractivity}
+                        activeOpacity={0.8}
+                        style={[
+                            styles.flexRow,
+                            styles.alignItemsCenter,
+                            styles.justifyContentBetween,
+                            styles.sidebarLink,
+                            styles.sidebarLinkInner,
+                            StyleUtils.getBackgroundColorStyle(this.props.backgroundColor),
+                            this.props.optionIsFocused ? styles.sidebarLinkActive : null,
+                            hovered && !this.props.optionIsFocused ? this.props.hoverStyle : null,
+                            this.props.isDisabled && styles.cursorDisabled,
+                        ]}
+                    >
+                        <View style={sidebarInnerRowStyle}>
+                            <View
+                                style={[
+                                    styles.flexRow,
+                                    styles.alignItemsCenter,
+                                ]}
+                            >
+                                {
+                                    !_.isEmpty(this.props.option.icons)
+                                    && (
+                                        <MultipleAvatars
+                                            avatarImageURLs={this.props.option.icons}
+                                            size={this.props.mode === 'compact' ? 'small' : 'default'}
+                                            secondAvatarStyle={[
+                                                StyleUtils.getBackgroundAndBorderStyle(this.props.backgroundColor),
+                                                this.props.optionIsFocused
+                                                    ? StyleUtils.getBackgroundAndBorderStyle(focusedBackgroundColor)
+                                                    : undefined,
+                                                hovered && !this.props.optionIsFocused
+                                                    ? StyleUtils.getBackgroundAndBorderStyle(hoveredBackgroundColor)
+                                                    : undefined,
+                                            ]}
+                                            isChatRoom={this.props.option.isChatRoom}
+                                            isArchivedRoom={this.props.option.isArchivedRoom}
+                                        />
+                                    )
+                                }
+                                <View style={contentContainerStyles}>
+                                    <DisplayNames
+                                        fullTitle={this.props.option.text}
+                                        displayNamesWithTooltips={displayNamesWithTooltips}
+                                        tooltipEnabled={this.props.showTitleTooltip}
                                         numberOfLines={1}
-                                    >
-                                        {props.option.alternateText}
-                                    </Text>
+                                        textStyles={displayNameStyle}
+                                        shouldUseFullTitle={this.props.option.isChatRoom}
+                                    />
+                                    {this.props.option.alternateText ? (
+                                        <Text
+                                            style={alternateTextStyle}
+                                            numberOfLines={1}
+                                        >
+                                            {this.props.option.alternateText}
+                                        </Text>
+                                    ) : null}
+                                </View>
+                                {this.props.option.descriptiveText ? (
+                                    <View style={[styles.flexWrap]}>
+                                        <Text style={[styles.textLabel]}>
+                                            {this.props.option.descriptiveText}
+                                        </Text>
+                                    </View>
                                 ) : null}
+                                {this.props.showSelectedState && <SelectCircle isChecked={this.props.isSelected} />}
                             </View>
-                            {props.option.descriptiveText ? (
-                                <View style={[styles.flexWrap]}>
-                                    <Text style={[styles.textLabel]}>
-                                        {props.option.descriptiveText}
-                                    </Text>
-                                </View>
-                            ) : null}
-                            {props.showSelectedState && <SelectCircle isChecked={props.isSelected} />}
                         </View>
-                    </View>
-                    {!props.hideAdditionalOptionStates && (
-                        <View style={[styles.flexRow, styles.alignItemsCenter]}>
-                            {props.option.hasDraftComment && (
-                                <View style={styles.ml2}>
-                                    <Icon src={Expensicons.Pencil} height={16} width={16} />
-                                </View>
-                            )}
-                            {props.option.hasOutstandingIOU && (
-                                <IOUBadge iouReportID={props.option.iouReportID} />
-                            )}
-                            {props.option.isPinned && (
-                                <View style={styles.ml2}>
-                                    <Icon src={Expensicons.Pin} height={16} width={16} />
-                                </View>
-                            )}
-                        </View>
-                    )}
-                </TouchableOpacity>
-            )}
-        </Hoverable>
-    );
-};
+                        {!this.props.hideAdditionalOptionStates && (
+                            <View style={[styles.flexRow, styles.alignItemsCenter]}>
+                                {this.props.option.hasDraftComment && (
+                                    <View style={styles.ml2}>
+                                        <Icon src={Expensicons.Pencil} height={16} width={16} />
+                                    </View>
+                                )}
+                                {this.props.option.hasOutstandingIOU && (
+                                    <IOUBadge iouReportID={this.props.option.iouReportID} />
+                                )}
+                                {this.props.option.isPinned && (
+                                    <View style={styles.ml2}>
+                                        <Icon src={Expensicons.Pin} height={16} width={16} />
+                                    </View>
+                                )}
+                            </View>
+                        )}
+                    </TouchableOpacity>
+                )}
+            </Hoverable>
+        );
+    }
+}
 
 OptionRow.propTypes = propTypes;
 OptionRow.defaultProps = defaultProps;
 OptionRow.displayName = 'OptionRow';
 
-// It it very important to use React.memo here so SectionList items will not unnecessarily re-render
-export default withLocalize(memo(OptionRow, (prevProps, nextProps) => {
-    if (prevProps.optionIsFocused !== nextProps.optionIsFocused) {
-        return false;
-    }
-
-    if (prevProps.isSelected !== nextProps.isSelected) {
-        return false;
-    }
-
-    if (prevProps.mode !== nextProps.mode) {
-        return false;
-    }
-
-    if (prevProps.option.isUnread !== nextProps.option.isUnread) {
-        return false;
-    }
-
-    if (prevProps.option.alternateText !== nextProps.option.alternateText) {
-        return false;
-    }
-
-    if (prevProps.option.descriptiveText !== nextProps.option.descriptiveText) {
-        return false;
-    }
-
-    if (prevProps.option.hasDraftComment !== nextProps.option.hasDraftComment) {
-        return false;
-    }
-
-    if (prevProps.option.isPinned !== nextProps.option.isPinned) {
-        return false;
-    }
-
-    if (prevProps.option.hasOutstandingIOU !== nextProps.option.hasOutstandingIOU) {
-        return false;
-    }
-
-    if (!_.isEqual(prevProps.option.icons, nextProps.option.icons)) {
-        return false;
-    }
-
-    // Re-render when the text changes
-    if (prevProps.option.text !== nextProps.option.text) {
-        return false;
-    }
-
-    return true;
-}));
+export default withLocalize(OptionRow);

--- a/src/pages/home/sidebar/OptionRow.js
+++ b/src/pages/home/sidebar/OptionRow.js
@@ -91,48 +91,48 @@ class OptionRow extends Component {
         if (this.props.optionIsFocused !== nextProps.optionIsFocused) {
             return false;
         }
-    
+
         if (this.props.isSelected !== nextProps.isSelected) {
             return false;
         }
-    
+
         if (this.props.mode !== nextProps.mode) {
             return false;
         }
-    
+
         if (this.props.option.isUnread !== nextProps.option.isUnread) {
             return false;
         }
-    
+
         if (this.props.option.alternateText !== nextProps.option.alternateText) {
             return false;
         }
-    
+
         if (this.props.option.descriptiveText !== nextProps.option.descriptiveText) {
             return false;
         }
-    
+
         if (this.props.option.hasDraftComment !== nextProps.option.hasDraftComment) {
             return false;
         }
-    
+
         if (this.props.option.isPinned !== nextProps.option.isPinned) {
             return false;
         }
-    
+
         if (this.props.option.hasOutstandingIOU !== nextProps.option.hasOutstandingIOU) {
             return false;
         }
-    
+
         if (!_.isEqual(this.props.option.icons, nextProps.option.icons)) {
             return false;
         }
-    
+
         // Re-render when the text changes
         if (this.props.option.text !== nextProps.option.text) {
             return false;
         }
-    
+
         return true;
     }
 

--- a/src/pages/home/sidebar/OptionRow.js
+++ b/src/pages/home/sidebar/OptionRow.js
@@ -84,6 +84,7 @@ const defaultProps = {
 class OptionRow extends Component {
     constructor(props) {
         super(props);
+        this.ref = null;
     }
 
     shouldComponentUpdate(nextProps) {
@@ -189,9 +190,10 @@ class OptionRow extends Component {
                     <TouchableOpacity
                         onPress={(e) => {
                             e.preventDefault();
-                            this.props.onSelectRow(this.props.option);
+                            this.props.onSelectRow(this.props.option, this.ref);
                         }}
                         disabled={this.props.disableRowInteractivity}
+                        ref={ref => this.ref = ref}
                         activeOpacity={0.8}
                         style={[
                             styles.flexRow,


### PR DESCRIPTION
### Details
[Expected behavior](https://github.com/Expensify/App/issues/6470#issuecomment-998120843):
1. Open the New Group page
2. Start typing the name of a user, and then select from the list of results.
3. Then if the search input was focused before the option was selected from the list, then the search input should retain focus, and the previous input value should be highlighted.
4. If the search input was not focused before the option was selected from the list, then the search input should not regain focus. Clicking on the search input should highlight the previous value, not clear it.

### Fixed Issues
https://github.com/Expensify/App/issues/6470

### Tests
1. Open the New Group page
2. Start typing the name of a user, and then select from the list of results.
3. If the search input was focused before the option was selected from the list, verify that it retains focus and the input value is highlighted.
4. If the search input was not focused before the option was selected from the list, click on it and verify that the input value is highlighted.


### QA Steps
1. Open the New Group page
2. Start typing the name of a user, and then select from the list of results.
3. If the search input was focused before the option was selected from the list, verify that it retains focus and the input value is highlighted.
4. If the search input was not focused before the option was selected from the list, click on it and verify that the input value is highlighted.

### Tested On

- [x] Web
- [x] Mobile Web
- [ ] Desktop

The problem is present on Web and Desktop, but i have no way of testing the macOS desktop app

### Screenshots
https://user-images.githubusercontent.com/9059945/147157544-0b512212-bfb7-43ed-808f-2ff3a5d3541a.mp4
