### PR TITLE
remove personal message placeholder

### DIFF
--- a/src/pages/workspace/WorkspaceInvitePage.js
+++ b/src/pages/workspace/WorkspaceInvitePage.js
@@ -299,7 +299,6 @@ class WorkspaceInvitePage extends React.Component {
                                     multiline
                                     containerStyles={[styles.workspaceInviteWelcome]}
                                     value={this.state.welcomeNote}
-                                    placeholder={this.getWelcomeNotePlaceholder()}
                                     onChangeText={text => this.setState({welcomeNote: text})}
                                 />
                             </View>

--- a/src/pages/workspace/WorkspaceInvitePage.js
+++ b/src/pages/workspace/WorkspaceInvitePage.js
@@ -81,7 +81,7 @@ class WorkspaceInvitePage extends React.Component {
             personalDetails,
             selectedOptions: [],
             userToInvite,
-            welcomeNote: this.getWelcomeNotePlaceholder(),
+            welcomeNote: this.getWelcomeNote(),
         };
     }
 
@@ -99,7 +99,7 @@ class WorkspaceInvitePage extends React.Component {
      *
      * @returns {Object}
      */
-    getWelcomeNotePlaceholder() {
+    getWelcomeNote() {
         return this.props.translate('workspace.invite.welcomeNote', {
             workspaceName: this.props.policy.name,
         });
@@ -215,7 +215,7 @@ class WorkspaceInvitePage extends React.Component {
 
         const logins = _.map(this.state.selectedOptions, option => option.login);
         const filteredLogins = _.uniq(_.compact(_.map(logins, login => login.toLowerCase().trim())));
-        Policy.invite(filteredLogins, this.state.welcomeNote || this.getWelcomeNotePlaceholder(), this.props.route.params.policyID);
+        Policy.invite(filteredLogins, this.state.welcomeNote || this.getWelcomeNote(), this.props.route.params.policyID);
     }
 
     /**

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -2205,7 +2205,7 @@ const styles = {
     },
 
     workspaceInviteWelcome: {
-        minHeight: 100,
+        minHeight: 115,
     },
 
     peopleRow: {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Removed placeholder of personal message textinput and increased height of textinput in Invite new members page

### Fixed Issues
$ [#7354](https://github.com/Expensify/App/issues/7354)

### Tests | QA Steps
1. Go to a workspace
2. Go to manage members screen
3. Tap on the Invite button
4. Clear the text in Add a personal message input field
5. The placeholder should not be there

- [x] Verify that no errors appear in the JS console

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web

https://user-images.githubusercontent.com/13783842/152170838-e2dbcdcd-64d3-4004-bb53-e7f0488aa758.mov



#### Mobile Web

https://user-images.githubusercontent.com/13783842/152170992-b2edbafd-2745-4949-b015-3fc7d0fb1d5a.mp4



#### Desktop

https://user-images.githubusercontent.com/13783842/152171128-c4361f77-d32c-4d6a-898a-b7d9cbe102ec.mov



#### iOS

https://user-images.githubusercontent.com/13783842/152171165-afce2b2b-3ed8-426c-9fb5-c26b647daa31.mp4



#### Android

https://user-images.githubusercontent.com/13783842/152171233-cb8ad917-2f84-4120-a21f-68967fc850b0.mov


