### PR TITLE
[No QA] Fix lock comment

### DIFF
--- a/.github/workflows/lockDeploys.yml
+++ b/.github/workflows/lockDeploys.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           gh issue comment \
           $(gh issue list --label StagingDeployCash --json number --jq '.[0].number') \
-          --body ':rocket: All staging deploys are complete, @Expensify/applauseleads please begin QA on version https://github.com/Expensify/App/releases/tag/$(< package.json jq -r .version) :rocket:'
+          --body ":rocket: All staging deploys are complete, @Expensify/applauseleads please begin QA on version https://github.com/Expensify/App/releases/tag/$(< package.json jq -r .version) :rocket:"
         env:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 


### PR DESCRIPTION
### Details
Fixes an oops. Need double-quotes for variable expansion in bash.

### Fixed Issues
$ n/a – see here:

[broken comment](https://github.com/Expensify/App/issues/7528#issuecomment-1028300194)
[fixed comment](https://github.com/Expensify/App/issues/7528#issuecomment-1028342405)

### Tests
You can test the bash command to verify that the fix works (need the GitHub CLI installed):

```bash
gh issue comment \
    $(gh issue list --label StagingDeployCash --json number --jq '.[0].number') \
    --body ":rocket: All staging deploys are complete, @Expensify/applauseleads please begin QA on version https://github.com/Expensify/App/releases/tag/$(< package.json jq -r .version) :rocket:"
```

- [x] Verify that no errors appear in the JS console

### Tested On

Bash/GitHub