### PR TITLE
Allow hitting production web-secure from staging

### DIFF
--- a/.env.staging
+++ b/.env.staging
@@ -1,5 +1,5 @@
 EXPENSIFY_URL_CASH=https://staging.new.expensify.com/
-EXPENSIFY_URL_SECURE=https://staging-secure.expensify.com/
+EXPENSIFY_URL_SECURE=https://secure.expensify.com/
 EXPENSIFY_URL_COM=https://www.expensify.com/
 EXPENSIFY_PARTNER_NAME=chat-expensify-com
 EXPENSIFY_PARTNER_PASSWORD=e21965746fd75f82bb66


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/7371

### Tests
There's no way to test this on dev really.

### QA Steps

1. Ensure the user preference for the staging secure server toggle is off
2. Try to log in with the Chase credentials 
3. Verify it doesn't work (because we are not on staging secure)
4. Toggle to staging secure server
5. Try to log in with the Chase credentials
6. Verify we can do so now since we are in the sandbox

- [ ] Verify that no errors appear in the JS console

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
