### PR TITLE
Add tooltip over copy icon in reimburse expenses page

### DIFF
--- a/src/components/CopyTextToClipboard.js
+++ b/src/components/CopyTextToClipboard.js
@@ -4,9 +4,11 @@ import Text from './Text';
 import * as Expensicons from './Icon/Expensicons';
 import Clipboard from '../libs/Clipboard';
 import Icon from './Icon';
+import Tooltip from './Tooltip';
 import styles from '../styles/styles';
 import themeColors from '../styles/themes/default';
 import variables from '../styles/variables';
+import withLocalize, {withLocalizePropTypes} from './withLocalize';
 
 const propTypes = {
     /** The text to display and copy to the clipboard */
@@ -14,6 +16,8 @@ const propTypes = {
 
     /** Styles to apply to the text */
     textStyles: PropTypes.arrayOf(PropTypes.object),
+
+    ...withLocalizePropTypes,
 };
 
 const defaultProps = {
@@ -53,13 +57,15 @@ class CopyTextToClipboard extends React.Component {
                 style={[styles.flexRow, styles.cursorPointer]}
             >
                 <Text style={this.props.textStyles}>{this.props.text}</Text>
-                <Icon
-                    src={this.state.showCheckmark ? Expensicons.Checkmark : Expensicons.Clipboard}
-                    fill={this.state.showCheckmark ? themeColors.iconSuccessFill : themeColors.icon}
-                    width={variables.iconSizeSmall}
-                    height={variables.iconSizeSmall}
-                    inline
-                />
+                <Tooltip text={this.props.translate('reportActionContextMenu.copyToClipboard')}>
+                    <Icon
+                        src={this.state.showCheckmark ? Expensicons.Checkmark : Expensicons.Clipboard}
+                        fill={this.state.showCheckmark ? themeColors.iconSuccessFill : themeColors.icon}
+                        width={variables.iconSizeSmall}
+                        height={variables.iconSizeSmall}
+                        inline
+                    />
+                </Tooltip>
             </Text>
         );
     }
@@ -68,4 +74,4 @@ class CopyTextToClipboard extends React.Component {
 CopyTextToClipboard.propTypes = propTypes;
 CopyTextToClipboard.defaultProps = defaultProps;
 
-export default CopyTextToClipboard;
+export default withLocalize(CopyTextToClipboard);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Added tooltip over copy icon in "Reimburse expenses" page. Issue is occurring in Web and Desktop App.

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/7466

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- Settings > Workspace > Reimburse expenses
- Hover over copy icon in Capture receipts section

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- Settings > Workspace > Reimburse expenses
- Hover over copy icon in Capture receipts section

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
![Screenshot from 2022-02-04 14-58-20](https://user-images.githubusercontent.com/25876548/152507583-2cfc8fd8-83ca-4244-be6c-5c3abbbf3647.png)

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
