### PR TITLE
Dismiss keyboard when transitioning to ResendValidationForm page

### DIFF
--- a/src/pages/signin/LoginForm.js
+++ b/src/pages/signin/LoginForm.js
@@ -20,6 +20,9 @@ import LoginUtil from '../../libs/LoginUtil';
 import withToggleVisibilityView, {toggleVisibilityViewPropTypes} from '../../components/withToggleVisibilityView';
 
 const propTypes = {
+    /** Should we dismiss the keyboard when transitioning away from the page? */
+    blurOnSubmit: PropTypes.bool,
+
     /* Onyx Props */
 
     /** The details about the account that the user is signing in with */
@@ -43,6 +46,7 @@ const propTypes = {
 
 const defaultProps = {
     account: {},
+    blurOnSubmit: false,
 };
 
 class LoginForm extends React.Component {
@@ -65,6 +69,9 @@ class LoginForm extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
+        if (!prevProps.blurOnSubmit && this.props.blurOnSubmit) {
+            this.input.blur();
+        }
         if (prevProps.isVisible || !this.props.isVisible) {
             return;
         }

--- a/src/pages/signin/SignInPage.js
+++ b/src/pages/signin/SignInPage.js
@@ -94,7 +94,7 @@ class SignInPage extends Component {
                 >
                     {/* LoginForm and PasswordForm must use the isVisible prop. This keeps them mounted, but visually hidden
                     so that password managers can access the values. Conditionally rendering these components will break this feature. */}
-                    <LoginForm isVisible={showLoginForm} />
+                    <LoginForm isVisible={showLoginForm} blurOnSubmit={shouldShowResendValidationLinkForm} />
                     <PasswordForm isVisible={showPasswordForm} />
                     {shouldShowResendValidationLinkForm && <ResendValidationForm />}
                 </SignInPageLayout>


### PR DESCRIPTION
### Details
Dismisses the keyboard when transitioning to `ResendValidationForm` page.

**Note:** mobile Safari seems to behave differently as inputs are not focused on render and because of that, I did not include testing for mWeb.

### Fixed Issues
$ https://github.com/Expensify/App/issues/7199

### Tests
1. On the login page, type an existing account email and tap `Continue`.
2. Verify that the keyboard is NOT dismissed and you are focused on the password input.
3. Tap `Go back`
4. Enter another email, this time for an inexistent account.
5. Verify that the keyboard is dismissed when transitioning to the `ResendValidationForm` page.

- [X] Verify that no errors appear in the JS console

### QA Steps
Steps above.

- [ ] Verify that no errors appear in the JS console

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [X] iOS
- [X] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS

https://user-images.githubusercontent.com/22219519/152845792-d6f6a8b9-e5cf-43c6-8b22-87f724313307.mov

#### Android

https://user-images.githubusercontent.com/22219519/152845807-ebd29516-e1b8-4d71-804e-44336381b997.mov
