### PR TITLE
Add styles for multiline input

### DIFF
--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -688,6 +688,8 @@ const styles = {
     },
 
     textInputAndIconContainer: {
+        flex: 1,
+        height: '100%',
         zIndex: -1,
         flexDirection: 'row',
     },


### PR DESCRIPTION
### Details
Makes multiline text input expand to the container height.

### Fixed Issues
$ https://github.com/Expensify/App/issues/7589

### Tests
1. Log into the app
2. Navigate to `Settings > Workspace > Manage members > Invite`
4. Start typing in the custom message field and verify that the text is aligned to the top.

- [X] Verify that no errors appear in the JS console

### QA Steps
Steps above.

- [ ] Verify that no errors appear in the JS console

### Tested On

- [X] Web
- [X] Mobile Web
- [X] Desktop
- [X] iOS
- [X] Android

### Screenshots

#### Web

https://user-images.githubusercontent.com/22219519/152875678-5680b942-a844-4ddc-9898-b97344bb0967.mov

#### Mobile Web

https://user-images.githubusercontent.com/22219519/152875704-3c0bfeeb-e82f-4ee1-aa20-509c5e0eeea3.mov

#### Desktop

https://user-images.githubusercontent.com/22219519/152875722-8cf09aa8-7bab-4963-a87c-825230175ff1.mov

#### iOS

https://user-images.githubusercontent.com/22219519/152875777-edce7f35-1579-4a20-aae6-1bf54e603e11.mov

#### Android

https://user-images.githubusercontent.com/22219519/152875803-d279a9c8-531b-473e-bac8-1cefc42c9d59.mov
