### PR TITLE
Output logs client-side in production as well as dev

### DIFF
--- a/src/libs/Log.js
+++ b/src/libs/Log.js
@@ -2,7 +2,6 @@
 // action would likely cause confusion about which one to use. But most other API methods should happen inside an action file.
 /* eslint-disable rulesdir/no-api-in-views */
 import Logger from 'expensify-common/lib/Logger';
-import CONFIG from '../CONFIG';
 import getPlatform from './getPlatform';
 import {version} from '../../package.json';
 import requireParameters from './requireParameters';
@@ -53,7 +52,7 @@ const Log = new Logger({
     clientLoggingCallback: (message) => {
         console.debug(message);
     },
-    isDebug: !CONFIG.IS_IN_PRODUCTION,
+    isDebug: true,
 });
 timeout = setTimeout(() => Log.info('Flushing logs older than 10 minutes', true, {}, true), 10 * 60 * 1000);
 


### PR DESCRIPTION
### Details
Makes sure logs are output in the client as well as being sent to the server, in both dev and production.

### Fixed Issues
Coming from https://expensify.slack.com/archives/C01SKUP7QR0/p1644262684236399

### Tests
No way to test this on dev.

- [ ] Verify that no errors appear in the JS console

### QA Steps
Verify that you see logs prefixed by `[info]` in the dev console.

- [ ] Verify that no errors appear in the JS console
