### PR TITLE
[Transfer Balance] Don't force account selection when there is only one option

### DIFF
--- a/src/pages/settings/Payments/TransferBalancePage.js
+++ b/src/pages/settings/Payments/TransferBalancePage.js
@@ -160,9 +160,7 @@ class TransferBalancePage extends React.Component {
             const account = _.first(filteredMethods);
             PaymentMethods.saveWalletTransferAccountTypeAndID(
                 filterPaymentMethodType,
-                filterPaymentMethodType === CONST.PAYMENT_METHODS.BANK_ACCOUNT
-                    ? account.bankAccountID
-                    : account.fundID,
+                account.methodID,
             );
             return;
         }

--- a/src/pages/settings/Payments/TransferBalancePage.js
+++ b/src/pages/settings/Payments/TransferBalancePage.js
@@ -146,6 +146,27 @@ class TransferBalancePage extends React.Component {
      */
     navigateToChooseTransferAccount(filterPaymentMethodType) {
         PaymentMethods.saveWalletTransferMethodType(filterPaymentMethodType);
+
+        // If we only have a single option for the given paymentMethodType do not force the user to make a selection
+        const combinedPaymentMethods = PaymentUtils.formatPaymentMethods(
+            this.props.bankAccountList,
+            this.props.cardList,
+            this.props.payPalMeUsername,
+            this.props.userWallet,
+        );
+
+        const filteredMethods = _.filter(combinedPaymentMethods, paymentMethod => paymentMethod.accountType === filterPaymentMethodType);
+        if (filteredMethods.length === 1) {
+            const account = _.first(filteredMethods);
+            PaymentMethods.saveWalletTransferAccountTypeAndID(
+                filterPaymentMethodType,
+                filterPaymentMethodType === CONST.PAYMENT_METHODS.BANK_ACCOUNT
+                    ? account.bankAccountID
+                    : account.fundID,
+            );
+            return;
+        }
+
         Navigation.navigate(ROUTES.SETTINGS_PAYMENTS_CHOOSE_TRANSFER_ACCOUNT);
     }
 
@@ -272,6 +293,9 @@ export default compose(
         },
         bankAccountList: {
             key: ONYXKEYS.BANK_ACCOUNT_LIST,
+        },
+        payPalMeUsername: {
+            key: ONYXKEYS.NVP_PAYPAL_ME_ADDRESS,
         },
         cardList: {
             key: ONYXKEYS.CARD_LIST,

--- a/src/pages/settings/Payments/TransferBalancePage.js
+++ b/src/pages/settings/Payments/TransferBalancePage.js
@@ -151,7 +151,7 @@ class TransferBalancePage extends React.Component {
         const combinedPaymentMethods = PaymentUtils.formatPaymentMethods(
             this.props.bankAccountList,
             this.props.cardList,
-            this.props.payPalMeUsername,
+            '',
             this.props.userWallet,
         );
 
@@ -291,9 +291,6 @@ export default compose(
         },
         bankAccountList: {
             key: ONYXKEYS.BANK_ACCOUNT_LIST,
-        },
-        payPalMeUsername: {
-            key: ONYXKEYS.NVP_PAYPAL_ME_ADDRESS,
         },
         cardList: {
             key: ONYXKEYS.CARD_LIST,


### PR DESCRIPTION
### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues (Related to)
https://github.com/Expensify/App/issues/7613

### Tests
1. Add a valid bank account AND debit card payment method via New Dot
2. Make sure there are only one of each
3. Navigate to the Transfer Balance page and toggle back and forth between debit and bank options
4. Verify the selection screen does not appear because it is not necessary
5. Add another payment method (fund) and verify that the selection screen pops up when there's more than one debit card
6. Add another payment method (bank) and verify that the selection screen pops up when there's more than one bank account
https://user-images.githubusercontent.com/32969087/152886420-b16b96f6-a6d8-4be3-8cd2-7164bf185262.mp4

- [x] Verify that no errors appear in the JS console

### QA Steps
Same as tests

- [ ] Verify that no errors appear in the JS console

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
