### PR TITLE
[InternalQA] Make sure the first PR comment shows only for external contributors

### DIFF
--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -139,11 +139,11 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
 
   # Check if actor is member of Expensify organization
-  isTeamMember:
+  isOrganizationMember:
     runs-on: ubuntu-latest
 
     outputs:
-      isValid: ${{ fromJSON(steps.checkActor.outputs.isTeamMember) }}
+      isMember: ${{ fromJSON(steps.checkActor.outputs.isTeamMember) }}
 
     steps:
       - name: Check whether the actor is member of Expensify organization
@@ -155,7 +155,8 @@ jobs:
 
   newContributorWelcomeMessage:
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'OSBotify' }}
+    needs: isOrganizationMember
+    if: ${{ github.actor != 'OSBotify' && fromJSON(needs.isOrganizationMember.outputs.isMember) }}
     steps:
       # Version: 2.3.4
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -156,7 +156,7 @@ jobs:
   newContributorWelcomeMessage:
     runs-on: ubuntu-latest
     needs: isOrganizationMember
-    if: ${{ github.actor != 'OSBotify' && fromJSON(needs.isOrganizationMember.outputs.isMember) }}
+    if: ${{ github.actor != 'OSBotify' && !fromJSON(needs.isOrganizationMember.outputs.isMember) }}
     steps:
       # Version: 2.3.4
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -152,6 +152,7 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
           username: ${{ github.actor }}
+          organization: Expensify
 
   newContributorWelcomeMessage:
     runs-on: ubuntu-latest

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -139,14 +139,14 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
 
   # Check if actor is member of Expensify organization by looking for expensify-expensify team
-  isOrganizationMember:
+  isExpensifyEmployee:
     runs-on: ubuntu-latest
 
     outputs:
       isExpensifyEmployee: ${{ steps.checkActor.outputs.isTeamMember }}
 
     steps:
-      - name: Check whether the actor is member of Expensify organization
+      - name: Check whether the actor is member of expensify-expensify team
         id: checkActor
         uses: tspascoal/get-user-teams-membership@baf2e6adf4c3b897bd65a7e3184305c165aec872
         with:
@@ -157,8 +157,8 @@ jobs:
 
   newContributorWelcomeMessage:
     runs-on: ubuntu-latest
-    needs: isOrganizationMember
-    if: ${{ github.actor != 'OSBotify' && !fromJSON(needs.isOrganizationMember.outputs.isMember) }}
+    needs: isExpensifyEmployee
+    if: ${{ github.actor != 'OSBotify' && !fromJSON(needs.isExpensifyEmployee.outputs.isExpensifyEmployee) }}
     steps:
       # Version: 2.3.4
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -143,7 +143,7 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      isMember: ${{ fromJSON(steps.checkActor.outputs.isTeamMember) }}
+      isMember: ${{ contains(fromJSON(steps.checkActor.outputs.teams), 'expensify-expensify') }}
 
     steps:
       - name: Check whether the actor is member of Expensify organization

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -152,7 +152,6 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
           username: ${{ github.actor }}
-          organization: Expensify
           team: expensify-expensify
 
   newContributorWelcomeMessage:

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -138,12 +138,12 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
 
-  # Check if actor is member of Expensify organization
+  # Check if actor is member of Expensify organization by looking for expensify-expensify team
   isOrganizationMember:
     runs-on: ubuntu-latest
 
     outputs:
-      isMember: ${{ contains(fromJSON(steps.checkActor.outputs.teams), 'expensify-expensify') }}
+      isExpensifyEmployee: ${{ steps.checkActor.outputs.isTeamMember }}
 
     steps:
       - name: Check whether the actor is member of Expensify organization
@@ -153,6 +153,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
           username: ${{ github.actor }}
           organization: Expensify
+          team: expensify-expensify
 
   newContributorWelcomeMessage:
     runs-on: ubuntu-latest

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -138,6 +138,21 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
 
+  # Check if actor is member of Expensify organization
+  isTeamMember:
+    runs-on: ubuntu-latest
+
+    outputs:
+      isValid: ${{ fromJSON(steps.checkActor.outputs.isTeamMember) }}
+
+    steps:
+      - name: Check whether the actor is member of Expensify organization
+        id: checkActor
+        uses: tspascoal/get-user-teams-membership@baf2e6adf4c3b897bd65a7e3184305c165aec872
+        with:
+          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+          username: ${{ github.actor }}
+
   newContributorWelcomeMessage:
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'OSBotify' }}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

cc @roryabraham since you God of the GIthub actions.

### Details
<!-- Explanation of the change or anything fishy that is going on -->

There is a comment congratulation first-time contributors to our App repository for their job, however, we also show this comment to internal contributors. That is not intended behaviour so we need to add a check whether the author of the PR is part of the Expensify organization.

The comment is this one: https://github.com/Expensify/App/pull/5060#issuecomment-919438004

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/Expensify/issues/194440

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

I am not sure how these can be easily tested locally. I will ask if there is a way that does not involve recreating the entire structure of Organization, a couple of fake accounts as members, personal repository etc.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

I will keep an eye on QAing this.

- [x] Verify that no errors appear in the JS console

- [ ] Make sure that first time contributors who are external still get the comment
- [ ] Make sure that internal contributors do not get this comment on merge. The easiest would be to wait for @PauloGasparSv to make his first PR to App (or just create dummy one once this PR is deployed) and see if the comment appears
