### PR TITLE
Make sure we round properly wallet transfer fee and balance for display

### DIFF
--- a/src/libs/PaymentUtils.js
+++ b/src/libs/PaymentUtils.js
@@ -94,15 +94,15 @@ function formatPaymentMethods(bankAccountList, cardList, payPalMeUsername = '', 
 }
 
 /**
- * @param {Number} currentBalance
+ * @param {Number} currentBalance, in cents
  * @param {String} methodType
- * @returns {Number}
+ * @returns {Number} the fee, in cents
  */
 function calculateWalletTransferBalanceFee(currentBalance, methodType) {
     const transferMethodTypeFeeStructure = methodType === CONST.WALLET.TRANSFER_METHOD_TYPE.INSTANT
         ? CONST.WALLET.TRANSFER_METHOD_TYPE_FEE.INSTANT
         : CONST.WALLET.TRANSFER_METHOD_TYPE_FEE.ACH;
-    const calculateFee = (currentBalance * transferMethodTypeFeeStructure.RATE) / 100;
+    const calculateFee = Math.ceil(currentBalance * (transferMethodTypeFeeStructure.RATE / 100));
     return Math.max(calculateFee, transferMethodTypeFeeStructure.MINIMUM_FEE);
 }
 

--- a/tests/unit/PaymentUtilsTest.js
+++ b/tests/unit/PaymentUtilsTest.js
@@ -1,0 +1,9 @@
+import CONST from '../../src/CONST';
+
+const paymentUtils = require('../../src/libs/PaymentUtils');
+
+describe('PaymentUtils', () => {
+    it('Test rounding wallet transfer instant fee', () => {
+        expect(paymentUtils.calculateWalletTransferBalanceFee(2100, CONST.WALLET.TRANSFER_METHOD_TYPE.INSTANT)).toBe(32);
+    });
+});


### PR DESCRIPTION
### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/195670

### Tests
Added unit test.

### QA Steps
None

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots

#### Web
To test the display locally, I hardcoded the wallet balance, and made sure the transfer was displayed as $20.68 instead of $20.69.
![image](https://user-images.githubusercontent.com/2463975/153445278-cb60e038-f644-4955-8ca5-f0bc9a988cff.png)
