### PR TITLE
[No QA] Demote "splash screen still visible" alert to hmmm

### DIFF
--- a/src/Expensify.js
+++ b/src/Expensify.js
@@ -170,7 +170,7 @@ class Expensify extends PureComponent {
                 if (status === 'visible') {
                     const props = _.omit(this.props, ['children', 'session']);
                     props.isAuthenticated = this.isAuthenticated();
-                    Log.alert('[BootSplash] splash screen is still visible', {props}, false);
+                    Log.hmmm('[BootSplash] splash screen is still visible', {props}, false);
                 }
             });
     }

--- a/src/Expensify.js
+++ b/src/Expensify.js
@@ -170,7 +170,7 @@ class Expensify extends PureComponent {
                 if (status === 'visible') {
                     const props = _.omit(this.props, ['children', 'session']);
                     props.isAuthenticated = this.isAuthenticated();
-                    Log.hmmm('[BootSplash] splash screen is still visible', {props}, false);
+                    Log.hmmm('[BootSplash] splash screen is still visible', {props});
                 }
             });
     }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

With the resolution of https://github.com/Expensify/App/issues/5620 we are no longer experiencing the persistent splash screen iOS issue that caused us to add this log line to begin with. All current instances of the alert popping up are either from android devices that don't seem to be experiencing the issue or from iOS devices on versions prior to  1.1.31.2 (which is the version the fix was deployed on).

While it's interesting that we're logging this for android users despite the fact that they don't seem to be seeing the persistent splash screen, we don't need to be alerting every time it happens. This log line might be useful in the future, so let's not remove it completely but demote it to a `hmmm` instead. 

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/Expensify/issues/188977

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

N/A there's no logic change here, we're just demoting an existing `alrt `to a `hmmm`

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
N/A

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
