### PR TITLE
Include `GITHUB_TOKEN` in `confirmPassingBuild` steps

### DIFF
--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -14,12 +14,14 @@ jobs:
         uses: Expensify/App/.github/actions/triggerWorkflowAndWait@main
         with:
           WORKFLOW: lint.yml
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run tests
         id: tests
         uses: Expensify/App/.github/actions/triggerWorkflowAndWait@main
         with:
           WORKFLOW: test.yml
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # This Slack step is duplicated in all workflows, if you make a change to this step, make sure to update all
       # the other workflows with the same change


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
I forgot to include `GITHUB_TOKEN` in `confirmPassingBuild` steps, this adds them to allow the steps to run correctly.

### Fixed Issues
Broken build: https://expensify.slack.com/archives/C03V9A4TB/p1644537495625939

### Tests
1. Merge this PR
2. Verify the `confirmPassingBuild` job runs correctly