### PR TITLE
Use `OS_BOTIFY_TOKEN` instead of `GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,6 @@ name: Lint JavaScript
 
 on:
   workflow_dispatch:
-    branches-ignore: [staging, production]
   pull_request:
     types: [opened, synchronize]
     branches-ignore: [staging, production]

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -14,14 +14,14 @@ jobs:
         uses: Expensify/App/.github/actions/triggerWorkflowAndWait@main
         with:
           WORKFLOW: lint.yml
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 
       - name: Run tests
         id: tests
         uses: Expensify/App/.github/actions/triggerWorkflowAndWait@main
         with:
           WORKFLOW: test.yml
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 
       # This Slack step is duplicated in all workflows, if you make a change to this step, make sure to update all
       # the other workflows with the same change

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,6 @@ name: Jest Unit Tests
 
 on:
   workflow_dispatch:
-    branches-ignore: [staging, production]
   pull_request:
     types: [opened, synchronize]
     branches-ignore: [staging, production]


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
In https://github.com/Expensify/App/runs/5149725235?check_suite_focus=true we saw that the token wasn't able to start the `lint` job, this upgraded token will allow the lint job to start.

### Fixed Issues
Broken deploy: https://github.com/Expensify/App/runs/5149725235?check_suite_focus=true

### Tests
1. Merge this PR
2. Verify `confirmPassingBuild` runs correctly