### PR TITLE
[No QA] Upgrade expensify-common

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24123,8 +24123,8 @@
       }
     },
     "expensify-common": {
-      "version": "git+https://github.com/Expensify/expensify-common.git#2d0f8f2f3424fea79854ea10d050824b5bd0c27b",
-      "from": "git+https://github.com/Expensify/expensify-common.git#2d0f8f2f3424fea79854ea10d050824b5bd0c27b",
+      "version": "github:Expensify/expensify-common#f77bb4710c13d01153716df7fb087b637ba3b8bd",
+      "from": "github:Expensify/expensify-common#f77bb4710c13d01153716df7fb087b637ba3b8bd",
       "requires": {
         "classnames": "2.3.1",
         "clipboard": "2.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24123,8 +24123,8 @@
       }
     },
     "expensify-common": {
-      "version": "github:Expensify/expensify-common#f77bb4710c13d01153716df7fb087b637ba3b8bd",
-      "from": "github:Expensify/expensify-common#f77bb4710c13d01153716df7fb087b637ba3b8bd",
+      "version": "git+https://github.com/Expensify/expensify-common.git#f77bb4710c13d01153716df7fb087b637ba3b8bd",
+      "from": "git+https://github.com/Expensify/expensify-common.git#f77bb4710c13d01153716df7fb087b637ba3b8bd",
       "requires": {
         "classnames": "2.3.1",
         "clipboard": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "electron-log": "^4.3.5",
     "electron-serve": "^1.0.0",
     "electron-updater": "^4.3.4",
-    "expensify-common": "git+https://github.com/Expensify/expensify-common.git#2d0f8f2f3424fea79854ea10d050824b5bd0c27b",
+    "expensify-common": "github:Expensify/expensify-common#f77bb4710c13d01153716df7fb087b637ba3b8bd",
     "fbjs": "^3.0.2",
     "file-loader": "^6.0.0",
     "html-entities": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "electron-log": "^4.3.5",
     "electron-serve": "^1.0.0",
     "electron-updater": "^4.3.4",
-    "expensify-common": "github:Expensify/expensify-common#f77bb4710c13d01153716df7fb087b637ba3b8bd",
+    "expensify-common": "git+https://github.com/Expensify/expensify-common.git#f77bb4710c13d01153716df7fb087b637ba3b8bd",
     "fbjs": "^3.0.2",
     "file-loader": "^6.0.0",
     "html-entities": "^1.3.1",


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->


The following PRs were merged into `expensify-common` to fix issues in NewDot.

- https://github.com/Expensify/expensify-common/pull/433
- https://github.com/Expensify/expensify-common/pull/435

This PR just upgrades `expensify-common` to the latest commit (https://github.com/Expensify/expensify-common/commit/f77bb4710c13d01153716df7fb087b637ba3b8bd).

### Fixed Issues

$ https://github.com/Expensify/App/issues/7268
$ https://github.com/Expensify/App/issues/7496

### Tests / QA

Verify that the app doesn't crash

- [x] Verify that no errors appear in the JS console

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android
