### PR TITLE
Remove extra white space on attachment modal [iPad]

### DIFF
--- a/src/components/AttachmentModal.js
+++ b/src/components/AttachmentModal.js
@@ -139,7 +139,7 @@ class AttachmentModal extends PureComponent {
             ? addEncryptedAuthTokenToURL(this.state.sourceURL)
             : this.state.sourceURL;
 
-        const attachmentViewStyles = this.props.isSmallScreenWidth
+        const attachmentViewStyles = this.props.isSmallScreenWidth || this.props.isMediumScreenWidth
             ? [styles.imageModalImageCenterContainer]
             : [styles.imageModalImageCenterContainer, styles.p5];
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Removed extra white space from attachment modal on iPad

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/7590

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Go to any chat
2. Open any attachment
3. Verify there's no extra white space on attachment view on iPad
- [x] Verify that no errors appear in the JS console

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### iPad
| Before | After |
|--------|-------|
|![Screen Shot 2022-02-07 at 7 45 44 PM](https://user-images.githubusercontent.com/11542415/152811109-7bb48704-8766-4fbd-87dc-2fea9017894f.png)|![Screen Shot 2022-02-07 at 7 45 51 PM](https://user-images.githubusercontent.com/11542415/152810904-d845920d-af72-4f74-8705-1d60ebb08bec.png)|

#### Web
<img width="1552" alt="Screen Shot 2022-02-12 at 2 38 08 PM" src="https://user-images.githubusercontent.com/11542415/153706036-83099261-ad86-4b6a-9fe5-edd00405accf.png">

#### Mobile Web
<img width="892" alt="Screen Shot 2022-02-12 at 2 39 01 PM" src="https://user-images.githubusercontent.com/11542415/153706078-3a3b3f96-35f6-4d8f-bb71-de5b141baae8.png">

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<img width="516" alt="Screen Shot 2022-02-12 at 2 41 02 PM" src="https://user-images.githubusercontent.com/11542415/153706128-de995532-1ba7-4937-be98-e6c7e7673e2c.png">

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
![Screen Shot 2022-02-14 at 11 13 08 AM](https://user-images.githubusercontent.com/11542415/153809915-e26857ef-287b-45b7-9bf0-1fc19d9b9c18.png)

