### PR TITLE
[No QA] Fix desktop for developers without .env file

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -183,7 +183,7 @@ const mainWindow = (() => {
                 const path = require('path');
                 const devEnvConfig = dotenv.config({path: path.resolve(__dirname, '../.env')}).parsed;
 
-                if (devEnvConfig.USE_WEB_PROXY === 'true') {
+                if (devEnvConfig.USE_WEB_PROXY !== 'false') {
                     browserWindow.webContents.session.webRequest.onHeadersReceived(validDestinationFilters, (details, callback) => {
                         // eslint-disable-next-line no-param-reassign
                         details.responseHeaders['access-control-allow-origin'] = ['http://localhost:8080'];


### PR DESCRIPTION
cc @kidroca

### Details
Following-up on https://github.com/Expensify/App/pull/7693#discussion_r805106089 – the Electron app is currently broken for developers not having a `.env` file. 

### Fixed Issues
$ n/a

### Tests
1. Comment out all lines on your `.env` or temporarily move it somewhere else.
1. Run `npm run desktop`
1. Verify that the app loads.

- [x] Verify that no _new_ errors appear in the JS console

### QA Steps
None (dev only)

### Tested On

- [ ] Web
- [ ] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
#### Desktop
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/47436092/153730834-a5d1a7af-e660-462b-940a-ef1c3f44176d.png">
