### PR TITLE
Fix:: Account details stuck in RHN when switching chats

### DIFF
--- a/src/libs/Navigation/CustomActions.js
+++ b/src/libs/Navigation/CustomActions.js
@@ -21,8 +21,9 @@ function getActiveState() {
 function navigateBackToRootDrawer() {
     const activeState = getActiveState();
 
-    //Dispatch "popToTop" action takes you back to the first screen in the stack at the same time 
-    //it will prevent bubbling of action and limit it to activeState by specifing target.
+    // To navigate to the main drawer Route, pop to the first route on the Root Stack Navigator as the main drawer is always the first route that is activated.
+    // It will pop all fullscreen and RHN modals that are over the main drawer. 
+    // It won't work when the main drawer is not the first route of the Root Stack Navigator which is not the case ATM.
     navigationRef.current.dispatch({
         ...StackActions.popToTop(),
         target: activeState.key,
@@ -54,14 +55,6 @@ function getParamsFromState(state) {
  */
 function getScreenNameFromState(state) {
     return getRouteFromState(state).name || '';
-}
-
-/**
- * @returns {Object}
- */
-function getActiveState() {
-    // We use our RootState as the dispatch's state is relative to the active navigator and might not contain our active screen.
-    return navigationRef.current.getRootState();
 }
 
 /**

--- a/src/libs/Navigation/CustomActions.js
+++ b/src/libs/Navigation/CustomActions.js
@@ -7,39 +7,23 @@ import linkingConfig from './linkingConfig';
 import navigationRef from './navigationRef';
 
 /**
+ * @returns {Object}
+ */
+function getActiveState() {
+    // We use our RootState as the dispatch's state is relative to the active navigator and might not contain our active screen.
+    return navigationRef.current.getRootState();
+}
+
+/**
  * Go back to the Main Drawer
  * @param {Object} navigationRef
  */
 function navigateBackToRootDrawer() {
-    let isLeavingNestedDrawerNavigator = false;
-
-    // This should take us to the first view of the modal's stack navigator
-    navigationRef.current.dispatch((state) => {
-        // If this is a nested drawer navigator then we pop the screen and
-        // prevent calling goBack() as it's default behavior is to toggle open the active drawer
-        if (state.type === 'drawer') {
-            isLeavingNestedDrawerNavigator = true;
-            return StackActions.pop();
-        }
-
-        // If there are multiple routes then we can pop back to the first route
-        if (state.routes.length > 1) {
-            return StackActions.popToTop();
-        }
-
-        // Otherwise, we are already on the last page of a modal so just do nothing here as goBack() will navigate us
-        // back to the screen we were on before we opened the modal.
-        return StackActions.pop(0);
+    const activeState = getActiveState();
+    navigationRef.current.dispatch({
+        ...StackActions.popToTop(),
+        target: activeState.key,
     });
-
-    if (isLeavingNestedDrawerNavigator) {
-        return;
-    }
-
-    // Navigate back to where we were before we launched the modal
-    if (navigationRef.current.canGoBack()) {
-        navigationRef.current.goBack();
-    }
 }
 
 /**

--- a/src/libs/Navigation/CustomActions.js
+++ b/src/libs/Navigation/CustomActions.js
@@ -22,7 +22,7 @@ function navigateBackToRootDrawer() {
     const activeState = getActiveState();
 
     // To navigate to the main drawer Route, pop to the first route on the Root Stack Navigator as the main drawer is always the first route that is activated.
-    // It will pop all fullscreen and RHN modals that are over the main drawer. 
+    // It will pop all fullscreen and RHN modals that are over the main drawer.
     // It won't work when the main drawer is not the first route of the Root Stack Navigator which is not the case ATM.
     navigationRef.current.dispatch({
         ...StackActions.popToTop(),

--- a/src/libs/Navigation/CustomActions.js
+++ b/src/libs/Navigation/CustomActions.js
@@ -20,6 +20,9 @@ function getActiveState() {
  */
 function navigateBackToRootDrawer() {
     const activeState = getActiveState();
+
+    //Dispatch "popToTop" action takes you back to the first screen in the stack at the same time 
+    //it will prevent bubbling of action and limit it to activeState by specifing target.
     navigationRef.current.dispatch({
         ...StackActions.popToTop(),
         target: activeState.key,


### PR DESCRIPTION
@chiragsalian @parasharrajat 

### Details
Re-written navigateBackToRootDrawer method to resolve #6720 and related issues if any. 

### Fixed Issues
$ https://github.com/Expensify/App/issues/6720

### Tests
By far I have checked following routes and they worked as expected.
bank-account - working
settings - working
settings/profile - working
settings/preferences - working
settings/security - working
settings/security/closeAccount - working
settings/security/password - working
settings/about - working
settings/about/app-download-links - working
settings/payments - working
settings/payments/add-paypal-me - working
settings/payments/add-debit-card - working
settings/payments/add-bank-account - working
settings/payments/transfer-balance - working
settings/payments/choose-transfer-account - working
new/group - working
new/chat - working
r/:reportID - working
iou/request - working
iou/request/:reportID - working
iou/split - working
iou/split/:reportID - working
iou/send - working
iou/split/currency - working
iou/split/currency/:reportID - working
iou/send/currency - working
iou/send/add-bank-account - working
iou/send/add-debit-card - working
iou/send/enable-payments - working
iou/details/add-bank-account - working
iou/details/add-debit-card - working
iou/details/enable-payments - working
iou/details/${chatReportID}/${iouReportID} - working
search - working
details?login=${encodeURIComponent(login)} - working
r/:reportID/participants - working
r/${reportID}/participants/details?login=${encodeURIComponent(login)} - working
r/:reportID/details - working
r/:reportID/settings - working
iou/send/currency/:reportID - working

### QA Steps
Here are many of the routes which I checked with following steps

1. Home -> go to any report -> click on header -> open detail -> ctrl+K -> search -> select any report

2. Home -> ctrl+k -> search -> select any report

3. Home -> click on search icon -> search -> select any report

4. Home -> click on groupReport -> click on header -> open group detail -> click on any member of group profile -> detail open -> ctl+k -> search -> select any report  

5. Home -> click on profile -> setting -> ctrl + k -> search -> select any report

6. Home -> click on plus icon -> start new chart -> ctrl + k -> search -> select any report

7. Home -> click on plus icon -> split bill -> enter amount -> select user -> split

8. Home -> setting -> change password -> update password

9. Home -> setting -> Profile -> update Profile

10. Home -> setting -> workspace -> general setting -> click on header (?) -> get assistance -> chat with concierge

11. Home -> setting -> workspace -> click on more(3 dot) on header -> delete workspace

### Tested On
- [x] Web
- [x] Android
- [x] iOS
- [x] Desktop

### Screenshots

#### Web

https://user-images.githubusercontent.com/5493716/153891589-76c4c283-5599-4b12-9660-c28b1e643c6d.mp4


#### Android

https://user-images.githubusercontent.com/5493716/153885773-ce22cc50-aed3-4924-8462-c7a3b4ab99db.mp4


#### iOS

https://user-images.githubusercontent.com/5493716/154075299-50d2343f-e285-470c-9c59-9c3ab6113c6d.mov



#### Desktop

https://user-images.githubusercontent.com/5493716/154000446-59482ada-f3ac-491a-8965-739bc6617856.mp4


