### PR TITLE
Security -> Change password menu icon updated to key

### DIFF
--- a/assets/images/key.svg
+++ b/assets/images/key.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 24.3.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 20 20" style="enable-background:new 0 0 20 20;" xml:space="preserve">
+<path d="M17.5,2.5c-1.8-1.6-4.5-1.6-6.2,0L10,3.9c-0.5,0.5-0.5,1.2,0,1.8l0.9,0.9l-5,5l-4.4,4.4c-0.1,0.1-0.2,0.2-0.2,0.5v1.1h2.2
+	c0.1,0,0.4-0.1,0.5-0.1l1-1.1h1.2L7.5,15v-1.2l1.2-1.2H10l1.2-1.2l1.2-1.2l1-0.9l0.9,0.9c0.5,0.5,1.2,0.5,1.8,0l1.4-1.2
+	C19.1,7,19.1,4.2,17.5,2.5z M17.4,5.2L17,5.6L14.4,3l0.4-0.4c0.2-0.2,0.8-0.2,1.1,0l1.5,1.5C17.6,4.5,17.6,5,17.4,5.2z"/>
+</svg>

--- a/src/components/Icon/Expensicons.js
+++ b/src/components/Icon/Expensicons.js
@@ -31,6 +31,7 @@ import Gear from '../../../assets/images/gear.svg';
 import Hashtag from '../../../assets/images/hashtag.svg';
 import Info from '../../../assets/images/info.svg';
 import Invoice from '../../../assets/images/invoice.svg';
+import Key from '../../../assets/images/key.svg';
 import Keyboard from '../../../assets/images/keyboard.svg';
 import Link from '../../../assets/images/link.svg';
 import LinkCopy from '../../../assets/images/link-copy.svg';
@@ -104,6 +105,7 @@ export {
     Hashtag,
     Info,
     Invoice,
+    Key,
     Keyboard,
     Link,
     LinkCopy,

--- a/src/pages/settings/Security/SecuritySettingsPage.js
+++ b/src/pages/settings/Security/SecuritySettingsPage.js
@@ -18,7 +18,7 @@ const SecuritySettingsPage = (props) => {
     const menuItems = [
         {
             translationKey: 'passwordPage.changePassword',
-            icon: Expensicons.Lock,
+            icon: Expensicons.Key,
             action: () => {
                 Navigation.navigate(ROUTES.SETTINGS_PASSWORD);
             },


### PR DESCRIPTION
@rushatgabhane @Beamanator PR is ready for review.

### Details
For Settings > Security screen **Change password** menu item **icon changed to key** (previously it was lock).

### Fixed Issues
$ https://github.com/Expensify/App/issues/7704

### Tests | QA Steps
1. Run app
2. Go to Settings > Security
3. Verify that Change password menu item **shows key icon** (previously it was lock)

- [ ] Verify that no errors appear in the JS console
_This is visual changes so no need to verify error in JS console._


### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web
<img width="1040" alt="Web" src="https://user-images.githubusercontent.com/7823358/153879350-70834b84-df1c-435d-ad3d-bac6ee3dad8a.png">

#### Mobile Web
<img width="469" alt="MobileWeb" src="https://user-images.githubusercontent.com/7823358/153879396-af69a387-423f-4bc4-9efb-5c9bd5fa13f2.png">

#### Desktop
<img width="1042" alt="Desktop" src="https://user-images.githubusercontent.com/7823358/153879476-e76b9c30-0859-4c43-9e4a-b3f279392943.png">

#### iOS
<img width="471" alt="iOS" src="https://user-images.githubusercontent.com/7823358/153879593-7f86ab45-7380-48c8-81b9-42456890bc10.png">

#### Android
<img width="554" alt="Android" src="https://user-images.githubusercontent.com/7823358/153879657-e0d1de08-463d-487e-84a9-65d38fc6e5e9.png">
