### PR TITLE
Add avatar background color

### DIFF
--- a/src/components/Avatar.js
+++ b/src/components/Avatar.js
@@ -44,10 +44,16 @@ class Avatar extends PureComponent {
             this.props.size === 'small' ? styles.avatarSmall : styles.avatarNormal,
             ...this.props.imageStyles,
         ];
+
+        const roomAvatarStyle = [
+            this.props.size === 'small' ? styles.roomAvatarSmall : styles.roomAvatarNormal,
+            ...this.props.imageStyles,
+        ];
+
         return (
             <View pointerEvents="none" style={this.props.containerStyles}>
                 {this.props.isChatRoom
-                    ? <RoomAvatar avatarStyle={imageStyle} isArchived={this.props.isArchivedRoom} />
+                    ? <RoomAvatar avatarStyle={roomAvatarStyle} isArchived={this.props.isArchivedRoom} />
                     : <Image source={{uri: this.props.source}} style={imageStyle} />}
             </View>
         );

--- a/src/components/Avatar.js
+++ b/src/components/Avatar.js
@@ -43,7 +43,9 @@ class Avatar extends PureComponent {
 
         const imageStyle = [
             this.props.size === 'small' ? styles.avatarSmall : styles.avatarNormal,
-            !this.props.isChatRoom && {backgroundColor: themeColors.icon}, // Adding background to roomAvatar makes roomAvatar rectangular
+
+            // Adding background makes RoomAvatar rectangular so adding background only if not chatRoom
+            !this.props.isChatRoom && {backgroundColor: themeColors.icon},
             ...this.props.imageStyles,
         ];
 

--- a/src/components/Avatar.js
+++ b/src/components/Avatar.js
@@ -2,6 +2,7 @@ import React, {PureComponent} from 'react';
 import {Image, View} from 'react-native';
 import PropTypes from 'prop-types';
 import styles from '../styles/styles';
+import themeColors from '../styles/themes/default';
 import RoomAvatar from './RoomAvatar';
 import stylePropTypes from '../styles/stylePropTypes';
 
@@ -42,18 +43,14 @@ class Avatar extends PureComponent {
 
         const imageStyle = [
             this.props.size === 'small' ? styles.avatarSmall : styles.avatarNormal,
-            ...this.props.imageStyles,
-        ];
-
-        const roomAvatarStyle = [
-            this.props.size === 'small' ? styles.roomAvatarSmall : styles.roomAvatarNormal,
+            !this.props.isChatRoom && {backgroundColor: themeColors.icon}, // Adding background to roomAvatar makes roomAvatar rectangular
             ...this.props.imageStyles,
         ];
 
         return (
             <View pointerEvents="none" style={this.props.containerStyles}>
                 {this.props.isChatRoom
-                    ? <RoomAvatar avatarStyle={roomAvatarStyle} isArchived={this.props.isArchivedRoom} />
+                    ? <RoomAvatar avatarStyle={imageStyle} isArchived={this.props.isArchivedRoom} />
                     : <Image source={{uri: this.props.source}} style={imageStyle} />}
             </View>
         );

--- a/src/components/Avatar.js
+++ b/src/components/Avatar.js
@@ -44,7 +44,7 @@ class Avatar extends PureComponent {
         const imageStyle = [
             this.props.size === 'small' ? styles.avatarSmall : styles.avatarNormal,
 
-            // Adding background makes RoomAvatar rectangular so adding background only if not chatRoom
+            // Background color isn't added for room avatar because it changes it's shape to a square
             !this.props.isChatRoom && {backgroundColor: themeColors.icon},
             ...this.props.imageStyles,
         ];

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1531,9 +1531,23 @@ const styles = {
         height: variables.componentSizeNormal,
         width: variables.componentSizeNormal,
         borderRadius: variables.componentSizeNormal,
+        backgroundColor: themeColors.icon,
     },
 
     avatarSmall: {
+        height: variables.avatarSizeSmall,
+        width: variables.avatarSizeSmall,
+        borderRadius: variables.avatarSizeSmall,
+        backgroundColor: themeColors.icon,
+    },
+
+    roomAvatarNormal: {
+        height: variables.componentSizeNormal,
+        width: variables.componentSizeNormal,
+        borderRadius: variables.componentSizeNormal,
+    },
+
+    roomAvatarSmall: {
         height: variables.avatarSizeSmall,
         width: variables.avatarSizeSmall,
         borderRadius: variables.avatarSizeSmall,

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1531,23 +1531,9 @@ const styles = {
         height: variables.componentSizeNormal,
         width: variables.componentSizeNormal,
         borderRadius: variables.componentSizeNormal,
-        backgroundColor: themeColors.icon,
     },
 
     avatarSmall: {
-        height: variables.avatarSizeSmall,
-        width: variables.avatarSizeSmall,
-        borderRadius: variables.avatarSizeSmall,
-        backgroundColor: themeColors.icon,
-    },
-
-    roomAvatarNormal: {
-        height: variables.componentSizeNormal,
-        width: variables.componentSizeNormal,
-        borderRadius: variables.componentSizeNormal,
-    },
-
-    roomAvatarSmall: {
         height: variables.avatarSizeSmall,
         width: variables.avatarSizeSmall,
         borderRadius: variables.avatarSizeSmall,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

Solves the issue "Avatars no longer have a default background color behind them"
### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/7494

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- Go to search page
- Check loading avatar (For testing purpose, to check loading avatar, I have set uri to '' in https://github.com/Expensify/App/blob/5e37ec71184956ca5bd7c6d471cf45054e09d503/src/components/Avatar.js#L51
- Default background color should be displayed

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- Go to search page
- Check loading avatar
- Default background color should be displayed

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
<img width="903" alt="Screen Shot 2022-02-14 at 11 25 05" src="https://user-images.githubusercontent.com/25876548/153903568-208ebdbc-32d0-4561-8c27-c1753248752a.png">

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
<img width="350" alt="" src="https://user-images.githubusercontent.com/25876548/153903693-67aceb65-f32d-4383-b36f-6cc6b1f7cbef.png">

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
<img width="1440" alt="Screen Shot 2022-02-18 at 21 50 45" src="https://user-images.githubusercontent.com/25876548/154718804-a2ff4997-51d6-45ea-90ec-6bc60a777d56.png">


#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
<img width="350" alt="" src="https://user-images.githubusercontent.com/25876548/153905209-21f551b0-0c98-4f1c-9f22-d3c3b3cf635b.png">

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
<img width="350" alt="" src="https://user-images.githubusercontent.com/25876548/153904001-efa3e800-f84d-4851-b5b9-d725deda939c.png">
