### PR TITLE
[NO QA] Fix desktop for web-proxy (again)

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -179,11 +179,8 @@ const mainWindow = (() => {
             }
 
             if (ELECTRON_ENVIRONMENT.isDev()) {
-                const dotenv = require('dotenv');
-                const path = require('path');
-                const devEnvConfig = dotenv.config({path: path.resolve(__dirname, '../.env')}).parsed;
-
-                if (devEnvConfig.USE_WEB_PROXY !== 'false') {
+                require('dotenv').config();
+                if (process.env.USE_WEB_PROXY !== 'false') {
                     browserWindow.webContents.session.webRequest.onHeadersReceived(validDestinationFilters, (details, callback) => {
                         // eslint-disable-next-line no-param-reassign
                         details.responseHeaders['access-control-allow-origin'] = ['http://localhost:8080'];


### PR DESCRIPTION
### Details
Follows-up on https://github.com/Expensify/App/pull/7719, which was a fault PR. I had committed this locally but forgot to push my changes after adding screenshots to the PR 😅 

### Fixed Issues
$ n/a

### Tests
1. Comment out all lines on your `.env` or temporarily move it somewhere else.
1. Run `npm run desktop`
1. Verify that the app loads.

- [x] Verify that no _new_ errors appear in the JS console
