### PR TITLE
[No QA] Differentiate workspace chats for admins and members

### DIFF
--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -144,8 +144,8 @@ function getChatReportName(fullReport, chatType) {
             : '')}`;
     }
 
-    // For a basic policy room, return its original name
-    if (ReportUtils.isUserCreatedPolicyRoom({chatType})) {
+    // For a basic policy room or a Policy Expense chat, return its original name
+    if (ReportUtils.isUserCreatedPolicyRoom({chatType}) || ReportUtils.isPolicyExpenseChat({chatType})) {
         return fullReport.reportName;
     }
 

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -224,6 +224,7 @@ function getSimplifiedReportObject(report) {
         statusNum: report.status,
         oldPolicyName,
         visibility,
+        isOwnPolicyExpenseChat: lodashGet(report, ['isOwnPolicyExpenseChat'], false),
     };
 }
 

--- a/src/libs/reportUtils.js
+++ b/src/libs/reportUtils.js
@@ -103,6 +103,16 @@ function isUserCreatedPolicyRoom(report) {
 }
 
 /**
+ * Whether the provided report is a Policy Expense chat.
+ * @param {Object} report
+ * @param {String} report.chatType
+ * @returns {Boolean}
+ */
+ function isPolicyExpenseChat(report) {
+    return lodashGet(report, ['chatType'], '') === CONST.REPORT.CHAT_TYPE.POLICY_EXPENSE_CHAT;
+}
+
+/**
  * Whether the provided report is a chat room
  * @param {Object} report
  * @param {String} report.chatType
@@ -257,4 +267,5 @@ export {
     canShowReportRecipientLocalTime,
     formatReportLastMessageText,
     chatIncludesConcierge,
+    isPolicyExpenseChat,
 };

--- a/src/libs/reportUtils.js
+++ b/src/libs/reportUtils.js
@@ -108,7 +108,7 @@ function isUserCreatedPolicyRoom(report) {
  * @param {String} report.chatType
  * @returns {Boolean}
  */
- function isPolicyExpenseChat(report) {
+function isPolicyExpenseChat(report) {
     return lodashGet(report, ['chatType'], '') === CONST.REPORT.CHAT_TYPE.POLICY_EXPENSE_CHAT;
 }
 


### PR DESCRIPTION
### Details
Adds an utility method and some setup for Policy Expense chats functionality.

cc @TomatoToaster 

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/195470

### Tests
This functionality is still being built and we will test it once Policy Expense Chats can be created. For now, I just checked that we set it in the report object as follows:

1. Reload the app
2. Open the browser console and in the application tab > IndexedDB search for `report_`
3. Verify that `isOwnPolicyExpenseChat` is set in the report object.

**Note:** you might need to refresh IndexedDB to see the changes.

- [X] Verify that no errors appear in the JS console

### QA Steps
None

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
