### PR TITLE
Make sure IOU preview amounts are positive

### DIFF
--- a/src/components/ReportActionItem/IOUPreview.js
+++ b/src/components/ReportActionItem/IOUPreview.js
@@ -113,7 +113,7 @@ const IOUPreview = (props) => {
     const ownerAvatar = lodashGet(props.personalDetails, [ownerEmail, 'avatar'], '');
     const cachedTotal = props.iouReport.total && props.iouReport.currency
         ? props.numberFormat(
-            props.iouReport.total / 100,
+            Math.abs(props.iouReport.total) / 100,
             {style: 'currency', currency: props.iouReport.currency},
         ) : '';
     return (


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
We localized the `amount` in this PR [here](https://github.com/Expensify/App/pull/7221/files) and switched from using `cachedTotal` to `total`.

However, `Send Money` totals are actually negative because the transaction is withdrawing money from the sender, so transactions were showing up as negative in the FE when they are supposed to always be positive.

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ [GH_LINK](https://github.com/Expensify/App/issues/7714)

### Tests / QA Steps
1. Send money from one GOLD wallet account to any account
2. Verify amount in preview shows up as positive

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<img width="475" alt="Screen Shot 2022-02-15 at 4 31 08 PM" src="https://user-images.githubusercontent.com/24466196/154175649-73db7da3-34b7-4908-a839-d31ac755102e.png">