### PR TITLE
Don't set default badge when only one defaultable payment method is available

### DIFF
--- a/src/pages/settings/Payments/PaymentMethodList.js
+++ b/src/pages/settings/Payments/PaymentMethodList.js
@@ -97,11 +97,26 @@ class PaymentMethodList extends Component {
     }
 
     /**
-     * Take all of the different payment methods and create a list that can be easily digested by renderItem
-     *
+     * @param {Boolean} isDefault
+     * @returns {*}
+     */
+    getDefaultBadgeText(isDefault = false) {
+        if (!isDefault) {
+            return null;
+        }
+
+        const paymentMethods = this.getFilteredPaymentMethods();
+        if (paymentMethods.length <= 1) {
+            return null;
+        }
+
+        return this.props.translate('paymentMethodList.defaultPaymentMethod');
+    }
+
+    /**
      * @returns {Array}
      */
-    createPaymentMethodList() {
+    getFilteredPaymentMethods() {
         let combinedPaymentMethods = PaymentUtils.formatPaymentMethods(this.props.bankAccountList, this.props.cardList, this.props.payPalMeUsername, this.props.userWallet);
 
         if (!_.isEmpty(this.props.filterType)) {
@@ -115,6 +130,17 @@ class PaymentMethodList extends Component {
             iconFill: this.isPaymentMethodActive(paymentMethod) ? StyleUtils.getIconFillColor(CONST.BUTTON_STATES.PRESSED) : null,
             wrapperStyle: this.isPaymentMethodActive(paymentMethod) ? [StyleUtils.getButtonBackgroundColorStyle(CONST.BUTTON_STATES.PRESSED)] : null,
         }));
+
+        return combinedPaymentMethods;
+    }
+
+    /**
+     * Take all of the different payment methods and create a list that can be easily digested by renderItem
+     *
+     * @returns {Array}
+     */
+    createPaymentMethodList() {
+        const combinedPaymentMethods = this.getFilteredPaymentMethods();
 
         // If we have not added any payment methods, show a default empty state
         if (_.isEmpty(combinedPaymentMethods)) {
@@ -172,7 +198,7 @@ class PaymentMethodList extends Component {
                     iconFill={item.iconFill}
                     iconHeight={item.iconSize}
                     iconWidth={item.iconSize}
-                    badgeText={item.isDefault ? this.props.translate('paymentMethodList.defaultPaymentMethod') : null}
+                    badgeText={this.getDefaultBadgeText(item.isDefault)}
                     wrapperStyle={item.wrapperStyle}
                     shouldShowSelectedState={this.props.shouldShowSelectedState}
                     isSelected={this.props.selectedMethodID === item.methodID}

--- a/src/pages/settings/Payments/PaymentMethodList.js
+++ b/src/pages/settings/Payments/PaymentMethodList.js
@@ -105,8 +105,12 @@ class PaymentMethodList extends Component {
             return null;
         }
 
-        const paymentMethods = this.getFilteredPaymentMethods();
-        if (paymentMethods.length <= 1) {
+        const defaultablePaymentMethodCount = _.reduce(this.getFilteredPaymentMethods(), (count, method) => (
+            (method.accountType === CONST.PAYMENT_METHODS.BANK_ACCOUNT || method.accountType === CONST.PAYMENT_METHODS.DEBIT_CARD)
+                ? count + 1
+                : count
+        ), 0);
+        if (defaultablePaymentMethodCount <= 1) {
             return null;
         }
 


### PR DESCRIPTION
### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/7613

### Tests
1. Add a payment method and verify there is no "Default" badge
![2022-02-15_15-02-36](https://user-images.githubusercontent.com/32969087/154176471-529df954-4b2a-4b89-bcaf-765513a188e1.png)
1. Add paypal.me and verify there is no "Default" badge
![2022-02-15_15-02-18](https://user-images.githubusercontent.com/32969087/154176533-584c532a-adcc-4bd1-8196-4598caa27fcb.png)
1. Add another payment method and verify there is now a "Default" badge 
![2022-02-15_15-01-58](https://user-images.githubusercontent.com/32969087/154176547-40aa5ed0-47ee-4e02-aded-dd1109792c76.png)

- [ ] Verify that no errors appear in the JS console

### QA Steps (Internal)

1. Run above test steps

- [ ] Verify that no errors appear in the JS console

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
