### PR TITLE
fix: Fixed profile image removed if personal info changed

### DIFF
--- a/src/pages/settings/Profile/ProfilePage.js
+++ b/src/pages/settings/Profile/ProfilePage.js
@@ -70,6 +70,9 @@ const timezones = _.map(moment.tz.names(), timezone => ({
 class ProfilePage extends Component {
     constructor(props) {
         super(props);
+
+        this.defaultAvatar = OptionsListUtils.getDefaultAvatar(this.props.myPersonalDetails.login);
+
         this.state = {
             firstName: props.myPersonalDetails.firstName,
             hasFirstNameError: false,
@@ -82,7 +85,7 @@ class ProfilePage extends Component {
             isAutomaticTimezone: lodashGet(props.myPersonalDetails.timezone, 'automatic', CONST.DEFAULT_TIME_ZONE.automatic),
             logins: this.getLogins(props.user.loginList),
             avatarImage: null,
-            avatarPreviewURL: lodashGet(this.props.myPersonalDetails, 'avatar', OptionsListUtils.getDefaultAvatar(this.props.myPersonalDetails.login)),
+            avatarPreviewURL: lodashGet(this.props.myPersonalDetails, 'avatar', this.defaultAvatar),
             isAvatarUpdated: false,
         };
 
@@ -169,7 +172,7 @@ class ProfilePage extends Component {
      */
     removeAvatar() {
         this.setState({
-            avatarPreviewURL: OptionsListUtils.getDefaultAvatar(this.props.myPersonalDetails.login),
+            avatarPreviewURL: this.defaultAvatar,
             avatarImage: null,
             isAvatarUpdated: false,
         });
@@ -189,7 +192,7 @@ class ProfilePage extends Component {
 
         // Checks if the user already has an avatar and removePhoto is triggered
         // Avatar having `/images/avatars/avatar` in URL means a profile picture exists for the user
-        if (!this.props.myPersonalDetails.avatar.includes('/images/avatars/avatar') && !this.state.avatarImage) {
+        if (!this.props.myPersonalDetails.avatar.includes('/images/avatars/avatar') && this.state.avatarPreviewURL === this.defaultAvatar) {
             PersonalDetails.deleteAvatar(this.props.myPersonalDetails.login);
         }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
https://github.com/Expensify/App/pull/7366 caused a bug that if any of the personal details are updated and saved then the profile image was getting removed.  This PR compares that if the previewURL is default URL and the existing avatar is not a default avatar then it'll call the `deleteAvatar` API


### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/7784

### Tests
1. Tested the cases from https://github.com/Expensify/App/pull/7366
2. Tested editing any personal information and clicking on Save
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### QA Steps
1. Go to profile page.
2. Change or add firstName or lastName
3. Click on Save Button and ensure that the profile image is not removed
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
https://user-images.githubusercontent.com/3069065/154350727-df3060b1-c4b0-4cf0-b762-6adee65a2cf6.mov

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
https://user-images.githubusercontent.com/3069065/154350829-ecf4e1ed-94ee-4ae6-a638-472232f2bb66.mov

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
https://user-images.githubusercontent.com/3069065/154357004-239c437c-ef3c-4b4e-ae21-38c666ad47b9.mov

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
https://user-images.githubusercontent.com/3069065/154356629-c40c173d-9334-4f26-b6a3-9060e8eb25e0.mp4

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
https://user-images.githubusercontent.com/3069065/154353106-026c1268-b6ce-4aa2-845f-2987be2ab3fb.mov

