### PR TITLE
Simplify profile avatar setting logic

### DIFF
--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -326,15 +326,15 @@ function setAvatar(file) {
 }
 
 /**
- * Deletes the user's avatar image
+ * Replaces the user's avatar image with a default avatar
  *
- * @param {String} login
+ * @param {String} defaultAvatarURL
  */
-function deleteAvatar(login) {
+function deleteAvatar(defaultAvatarURL) {
     // We don't want to save the default avatar URL in the backend since we don't want to allow
     // users the option of removing the default avatar, instead we'll save an empty string
     API.PersonalDetails_Update({details: JSON.stringify({avatar: ''})});
-    mergeLocalPersonalDetails({avatar: OptionsListUtils.getDefaultAvatar(login)});
+    mergeLocalPersonalDetails({avatar: defaultAvatarURL});
 }
 
 // When the app reconnects from being offline, fetch all of the personal details

--- a/src/pages/settings/Profile/ProfilePage.js
+++ b/src/pages/settings/Profile/ProfilePage.js
@@ -171,7 +171,7 @@ class ProfilePage extends Component {
 
         // Check if the user has modified their avatar
         if ((this.props.myPersonalDetails.avatar !== this.state.avatar.uri) && this.state.isAvatarChanged) {
-            // If the user removed their profile photo, replace it accoridngly with the default avatar
+            // If the user removed their profile photo, replace it accordingly with the default avatar
             if (this.state.avatar.uri.includes('/images/avatars/avatar')) {
                 PersonalDetails.deleteAvatar(this.state.avatar.uri);
             } else {

--- a/src/pages/settings/Profile/ProfilePage.js
+++ b/src/pages/settings/Profile/ProfilePage.js
@@ -167,7 +167,7 @@ class ProfilePage extends Component {
         }
 
         // Check if the user has updated their avatar
-        if (this.props.myPersonalDetails.avatar !== this.state.avatar.uri) {
+        if ((this.props.myPersonalDetails.avatar !== this.state.avatar.uri) && this.state.isAvatarChanged) {
             // If user removed their avatar, update it accoridngly with the default image
             if (this.state.avatar.uri.includes('/images/avatars/avatar')) {
                 PersonalDetails.deleteAvatar(this.state.avatar.uri);
@@ -215,7 +215,7 @@ class ProfilePage extends Component {
             && (this.props.myPersonalDetails.timezone.selected === this.state.selectedTimezone)
             && (this.props.myPersonalDetails.timezone.automatic === this.state.isAutomaticTimezone)
             && (this.props.myPersonalDetails.pronouns === this.state.pronouns.trim())
-            && (!this.state.isAvatarChanged || this.props.myPersonalDetails.avatarUploading)
+            && (!this.state.isAvatarChanged || this.props.myPersonalDetails.avatarUploading);
 
         const pronounsPickerValue = this.state.hasSelfSelectedPronouns ? CONST.PRONOUNS.SELF_SELECT : this.state.pronouns;
 

--- a/src/pages/settings/Profile/ProfilePage.js
+++ b/src/pages/settings/Profile/ProfilePage.js
@@ -169,9 +169,9 @@ class ProfilePage extends Component {
             return;
         }
 
-        // Check if the user has updated their avatar
+        // Check if the user has modified their avatar
         if ((this.props.myPersonalDetails.avatar !== this.state.avatar.uri) && this.state.isAvatarChanged) {
-            // If user removed their avatar, update it accoridngly with the default image
+            // If the user removed their profile photo, replace it accoridngly with the default avatar
             if (this.state.avatar.uri.includes('/images/avatars/avatar')) {
                 PersonalDetails.deleteAvatar(this.state.avatar.uri);
             } else {


### PR DESCRIPTION
### Details
Update to the logic introduced in https://github.com/Expensify/App/pull/7366 and https://github.com/Expensify/App/pull/7785. Simplifies things a bit. 

Note that inconsistent `Save` button coloring on web and desktop appears to be an [existing regression](https://github.com/Expensify/App/issues/7784#issuecomment-1042377952)

cc: @mananjadhav 

### Fixed Issues

N/A found while looking at this regression https://github.com/Expensify/App/issues/7784

### Tests
1. Log into a new account on New Expensify and navigate to the profile settings 
2. Click on the profile picture and upload a photo
3. Confirm the photo preview  updates immediately  
4. Click the save button and confirm the photo saves as expected 
5. Modify your user's first and last name and click save
6. Confirm the name is updated and that your profile photo is maintained 
7. Click on the profile picture and remove the photo 
8. Confirm the photo preview updates immediately to a default avatar
9. Click save and confirm your profile photo is successfully updated 

### QA Steps
Same as tests 

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web

https://user-images.githubusercontent.com/16747822/154382682-701ffaf9-b4dd-41fc-bf3a-88c729693473.mov

#### Mobile Web

https://user-images.githubusercontent.com/16747822/154388783-ee674b00-7de0-4814-8ae9-e32d02b3c6d0.mov

#### Desktop

https://user-images.githubusercontent.com/16747822/154388797-0fd43b32-a2bd-4c0d-beb7-4c8cab1f3dcf.mov

#### iOS

https://user-images.githubusercontent.com/16747822/154386363-d942022d-6562-44e0-85bd-56a7f2e6cec0.mov

#### Android

Android device is super slow, will work on getting a video tomorrow