### PR TITLE
Comment on deploy checklist when a pull request is CP'd

### DIFF
--- a/.github/actions/awaitStagingDeploys/action.yml
+++ b/.github/actions/awaitStagingDeploys/action.yml
@@ -4,6 +4,9 @@ inputs:
   GITHUB_TOKEN:
     description: Auth token for New Expensify Github
     required: true
+  TAG:
+    description: If provided, this action will only wait for a deploy matching this tag.
+    required: false
 runs:
   using: 'node12'
   main: './index.js'

--- a/.github/actions/awaitStagingDeploys/awaitStagingDeploys.js
+++ b/.github/actions/awaitStagingDeploys/awaitStagingDeploys.js
@@ -1,6 +1,9 @@
 const _ = require('underscore');
+const ActionUtils = require('../../libs/ActionUtils');
 const GitHubUtils = require('../../libs/GithubUtils');
 const {promiseDoWhile} = require('../../libs/promiseWhile');
+
+const tag = ActionUtils.getJSONInput('TAG', {required: false});
 
 function run() {
     let currentStagingDeploys = [];
@@ -14,20 +17,24 @@ function run() {
                     repo: GitHubUtils.APP_REPO,
                     workflow_id: 'platformDeploy.yml',
                     event: 'push',
+                    branch: tag,
                 }),
 
-                // These have the potential to become active deploys, so we need to wait for them to finish as well
+                // These have the potential to become active deploys, so we need to wait for them to finish as well (unless we're looking for a specific tag)
                 // In this context, we'll refer to unresolved preDeploy workflow runs as staging deploys as well
-                GitHubUtils.octokit.actions.listWorkflowRuns({
+                !tag && GitHubUtils.octokit.actions.listWorkflowRuns({
                     owner: GitHubUtils.GITHUB_OWNER,
                     repo: GitHubUtils.APP_REPO,
                     workflow_id: 'preDeploy.yml',
                 }),
             ])
-                .then(responses => [
-                    ...responses[0].data.workflow_runs,
-                    ...responses[1].data.workflow_runs,
-                ])
+                .then((responses) => {
+                    const workflowRuns = responses[0].data.workflow_runs;
+                    if (!tag) {
+                        workflowRuns.push(...responses[1].data.workflow_runs);
+                    }
+                    return workflowRuns;
+                })
                 .then(workflowRuns => currentStagingDeploys = _.filter(workflowRuns, workflowRun => workflowRun.status !== 'completed'))
                 .then(() => console.log(
                     _.isEmpty(currentStagingDeploys)

--- a/.github/actions/awaitStagingDeploys/awaitStagingDeploys.js
+++ b/.github/actions/awaitStagingDeploys/awaitStagingDeploys.js
@@ -3,9 +3,8 @@ const ActionUtils = require('../../libs/ActionUtils');
 const GitHubUtils = require('../../libs/GithubUtils');
 const {promiseDoWhile} = require('../../libs/promiseWhile');
 
-const tag = ActionUtils.getJSONInput('TAG', {required: false});
-
 function run() {
+    const tag = ActionUtils.getStringInput('TAG', {required: false});
     let currentStagingDeploys = [];
     return promiseDoWhile(
         () => !_.isEmpty(currentStagingDeploys),

--- a/.github/actions/awaitStagingDeploys/index.js
+++ b/.github/actions/awaitStagingDeploys/index.js
@@ -69,7 +69,6 @@ module.exports = run;
 /***/ 970:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const _ = __nccwpck_require__(3571);
 const core = __nccwpck_require__(2186);
 
 /**

--- a/.github/actions/awaitStagingDeploys/index.js
+++ b/.github/actions/awaitStagingDeploys/index.js
@@ -13,9 +13,8 @@ const ActionUtils = __nccwpck_require__(970);
 const GitHubUtils = __nccwpck_require__(7999);
 const {promiseDoWhile} = __nccwpck_require__(4502);
 
-const tag = ActionUtils.getJSONInput('TAG', {required: false});
-
 function run() {
+    const tag = ActionUtils.getStringInput('TAG', {required: false});
     let currentStagingDeploys = [];
     return promiseDoWhile(
         () => !_.isEmpty(currentStagingDeploys),
@@ -70,6 +69,7 @@ module.exports = run;
 /***/ 970:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
+const _ = __nccwpck_require__(3571);
 const core = __nccwpck_require__(2186);
 
 /**
@@ -89,8 +89,25 @@ function getJSONInput(name, options, defaultValue = undefined) {
     return defaultValue;
 }
 
+/**
+ * Safely access a string input to a GitHub Action, or fall back on a default if the string is empty.
+ *
+ * @param {String} name
+ * @param {Object} options
+ * @param {*} [defaultValue]
+ * @returns {string|undefined}
+ */
+function getStringInput(name, options, defaultValue = undefined) {
+    const input = core.getInput(name, options);
+    if (!input) {
+        return defaultValue;
+    }
+    return input;
+}
+
 module.exports = {
     getJSONInput,
+    getStringInput,
 };
 
 

--- a/.github/actions/awaitStagingDeploys/index.js
+++ b/.github/actions/awaitStagingDeploys/index.js
@@ -9,8 +9,11 @@ module.exports =
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 const _ = __nccwpck_require__(3571);
+const ActionUtils = __nccwpck_require__(970);
 const GitHubUtils = __nccwpck_require__(7999);
 const {promiseDoWhile} = __nccwpck_require__(4502);
+
+const tag = ActionUtils.getJSONInput('TAG', {required: false});
 
 function run() {
     let currentStagingDeploys = [];
@@ -24,20 +27,24 @@ function run() {
                     repo: GitHubUtils.APP_REPO,
                     workflow_id: 'platformDeploy.yml',
                     event: 'push',
+                    branch: tag,
                 }),
 
-                // These have the potential to become active deploys, so we need to wait for them to finish as well
+                // These have the potential to become active deploys, so we need to wait for them to finish as well (unless we're looking for a specific tag)
                 // In this context, we'll refer to unresolved preDeploy workflow runs as staging deploys as well
-                GitHubUtils.octokit.actions.listWorkflowRuns({
+                !tag && GitHubUtils.octokit.actions.listWorkflowRuns({
                     owner: GitHubUtils.GITHUB_OWNER,
                     repo: GitHubUtils.APP_REPO,
                     workflow_id: 'preDeploy.yml',
                 }),
             ])
-                .then(responses => [
-                    ...responses[0].data.workflow_runs,
-                    ...responses[1].data.workflow_runs,
-                ])
+                .then((responses) => {
+                    const workflowRuns = responses[0].data.workflow_runs;
+                    if (!tag) {
+                        workflowRuns.push(...responses[1].data.workflow_runs);
+                    }
+                    return workflowRuns;
+                })
                 .then(workflowRuns => currentStagingDeploys = _.filter(workflowRuns, workflowRun => workflowRun.status !== 'completed'))
                 .then(() => console.log(
                     _.isEmpty(currentStagingDeploys)
@@ -56,6 +63,35 @@ if (require.main === require.cache[eval('__filename')]) {
 }
 
 module.exports = run;
+
+
+/***/ }),
+
+/***/ 970:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+const core = __nccwpck_require__(2186);
+
+/**
+ * Safely parse a JSON input to a GitHub Action.
+ *
+ * @param {String} name - The name of the input.
+ * @param {Object} options - Options to pass to core.getInput
+ * @param {*} [defaultValue] - A default value to provide for the input.
+ *                             Not required if the {required: true} option is given in the second arg to this function.
+ * @returns {any}
+ */
+function getJSONInput(name, options, defaultValue = undefined) {
+    const input = core.getInput(name, options);
+    if (input) {
+        return JSON.parse(input);
+    }
+    return defaultValue;
+}
+
+module.exports = {
+    getJSONInput,
+};
 
 
 /***/ }),

--- a/.github/actions/getDeployPullRequestList/index.js
+++ b/.github/actions/getDeployPullRequestList/index.js
@@ -77,7 +77,6 @@ getTagsOrReleases(isProductionDeploy)
 /***/ 970:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const _ = __nccwpck_require__(3571);
 const core = __nccwpck_require__(2186);
 
 /**

--- a/.github/actions/getDeployPullRequestList/index.js
+++ b/.github/actions/getDeployPullRequestList/index.js
@@ -77,6 +77,7 @@ getTagsOrReleases(isProductionDeploy)
 /***/ 970:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
+const _ = __nccwpck_require__(3571);
 const core = __nccwpck_require__(2186);
 
 /**
@@ -96,8 +97,25 @@ function getJSONInput(name, options, defaultValue = undefined) {
     return defaultValue;
 }
 
+/**
+ * Safely access a string input to a GitHub Action, or fall back on a default if the string is empty.
+ *
+ * @param {String} name
+ * @param {Object} options
+ * @param {*} [defaultValue]
+ * @returns {string|undefined}
+ */
+function getStringInput(name, options, defaultValue = undefined) {
+    const input = core.getInput(name, options);
+    if (!input) {
+        return defaultValue;
+    }
+    return input;
+}
+
 module.exports = {
     getJSONInput,
+    getStringInput,
 };
 
 

--- a/.github/actions/getPullRequestDetails/index.js
+++ b/.github/actions/getPullRequestDetails/index.js
@@ -110,7 +110,6 @@ if (pullRequestNumber) {
 /***/ 970:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const _ = __nccwpck_require__(3571);
 const core = __nccwpck_require__(2186);
 
 /**

--- a/.github/actions/getPullRequestDetails/index.js
+++ b/.github/actions/getPullRequestDetails/index.js
@@ -110,6 +110,7 @@ if (pullRequestNumber) {
 /***/ 970:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
+const _ = __nccwpck_require__(3571);
 const core = __nccwpck_require__(2186);
 
 /**
@@ -129,8 +130,25 @@ function getJSONInput(name, options, defaultValue = undefined) {
     return defaultValue;
 }
 
+/**
+ * Safely access a string input to a GitHub Action, or fall back on a default if the string is empty.
+ *
+ * @param {String} name
+ * @param {Object} options
+ * @param {*} [defaultValue]
+ * @returns {string|undefined}
+ */
+function getStringInput(name, options, defaultValue = undefined) {
+    const input = core.getInput(name, options);
+    if (!input) {
+        return defaultValue;
+    }
+    return input;
+}
+
 module.exports = {
     getJSONInput,
+    getStringInput,
 };
 
 

--- a/.github/actions/getReleaseBody/index.js
+++ b/.github/actions/getReleaseBody/index.js
@@ -28,6 +28,7 @@ core.setOutput('RELEASE_BODY', releaseBody);
 /***/ 970:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
+const _ = __nccwpck_require__(3571);
 const core = __nccwpck_require__(2186);
 
 /**
@@ -47,8 +48,25 @@ function getJSONInput(name, options, defaultValue = undefined) {
     return defaultValue;
 }
 
+/**
+ * Safely access a string input to a GitHub Action, or fall back on a default if the string is empty.
+ *
+ * @param {String} name
+ * @param {Object} options
+ * @param {*} [defaultValue]
+ * @returns {string|undefined}
+ */
+function getStringInput(name, options, defaultValue = undefined) {
+    const input = core.getInput(name, options);
+    if (!input) {
+        return defaultValue;
+    }
+    return input;
+}
+
 module.exports = {
     getJSONInput,
+    getStringInput,
 };
 
 

--- a/.github/actions/getReleaseBody/index.js
+++ b/.github/actions/getReleaseBody/index.js
@@ -28,7 +28,6 @@ core.setOutput('RELEASE_BODY', releaseBody);
 /***/ 970:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const _ = __nccwpck_require__(3571);
 const core = __nccwpck_require__(2186);
 
 /**

--- a/.github/actions/markPullRequestsAsDeployed/index.js
+++ b/.github/actions/markPullRequestsAsDeployed/index.js
@@ -161,7 +161,6 @@ module.exports = run;
 /***/ 970:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const _ = __nccwpck_require__(3571);
 const core = __nccwpck_require__(2186);
 
 /**

--- a/.github/actions/markPullRequestsAsDeployed/index.js
+++ b/.github/actions/markPullRequestsAsDeployed/index.js
@@ -161,6 +161,7 @@ module.exports = run;
 /***/ 970:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
+const _ = __nccwpck_require__(3571);
 const core = __nccwpck_require__(2186);
 
 /**
@@ -180,8 +181,25 @@ function getJSONInput(name, options, defaultValue = undefined) {
     return defaultValue;
 }
 
+/**
+ * Safely access a string input to a GitHub Action, or fall back on a default if the string is empty.
+ *
+ * @param {String} name
+ * @param {Object} options
+ * @param {*} [defaultValue]
+ * @returns {string|undefined}
+ */
+function getStringInput(name, options, defaultValue = undefined) {
+    const input = core.getInput(name, options);
+    if (!input) {
+        return defaultValue;
+    }
+    return input;
+}
+
 module.exports = {
     getJSONInput,
+    getStringInput,
 };
 
 

--- a/.github/actions/triggerWorkflowAndWait/index.js
+++ b/.github/actions/triggerWorkflowAndWait/index.js
@@ -172,6 +172,7 @@ module.exports = run;
 /***/ 970:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
+const _ = __nccwpck_require__(3571);
 const core = __nccwpck_require__(2186);
 
 /**
@@ -191,8 +192,25 @@ function getJSONInput(name, options, defaultValue = undefined) {
     return defaultValue;
 }
 
+/**
+ * Safely access a string input to a GitHub Action, or fall back on a default if the string is empty.
+ *
+ * @param {String} name
+ * @param {Object} options
+ * @param {*} [defaultValue]
+ * @returns {string|undefined}
+ */
+function getStringInput(name, options, defaultValue = undefined) {
+    const input = core.getInput(name, options);
+    if (!input) {
+        return defaultValue;
+    }
+    return input;
+}
+
 module.exports = {
     getJSONInput,
+    getStringInput,
 };
 
 

--- a/.github/actions/triggerWorkflowAndWait/index.js
+++ b/.github/actions/triggerWorkflowAndWait/index.js
@@ -172,7 +172,6 @@ module.exports = run;
 /***/ 970:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const _ = __nccwpck_require__(3571);
 const core = __nccwpck_require__(2186);
 
 /**

--- a/.github/libs/ActionUtils.js
+++ b/.github/libs/ActionUtils.js
@@ -1,3 +1,4 @@
+const _ = require('underscore');
 const core = require('@actions/core');
 
 /**
@@ -17,6 +18,23 @@ function getJSONInput(name, options, defaultValue = undefined) {
     return defaultValue;
 }
 
+/**
+ * Safely access a string input to a GitHub Action, or fall back on a default if the string is empty.
+ *
+ * @param {String} name
+ * @param {Object} options
+ * @param {*} [defaultValue]
+ * @returns {string|undefined}
+ */
+function getStringInput(name, options, defaultValue = undefined) {
+    const input = core.getInput(name, options);
+    if (!input) {
+        return defaultValue;
+    }
+    return input;
+}
+
 module.exports = {
     getJSONInput,
+    getStringInput,
 };

--- a/.github/libs/ActionUtils.js
+++ b/.github/libs/ActionUtils.js
@@ -1,4 +1,3 @@
-const _ = require('underscore');
 const core = require('@actions/core');
 
 /**

--- a/.github/scripts/validateActionsAndWorkflows.sh
+++ b/.github/scripts/validateActionsAndWorkflows.sh
@@ -11,10 +11,10 @@ curl https://json.schemastore.org/github-action.json --output ./tempSchemas/gith
 curl https://json.schemastore.org/github-workflow.json --output ./tempSchemas/github-workflow.json --silent || exit 1
 
 # Validate the actions and workflows using the JSON schemas and ajv https://github.com/ajv-validator/ajv-cli
-find ./actions/ -type f -name "*.yml" -print0 | xargs -0 -I file ajv -s ./tempSchemas/github-action.json -d file --strict=false || EXIT_CODE=1
-find ./workflows/ -type f -name "*.yml" -print0 | xargs -0 -I file ajv -s ./tempSchemas/github-workflow.json -d file --strict=false || EXIT_CODE=1
+find ./actions -type f -name "*.yml" -print0 | xargs -0 -I file ajv -s ./tempSchemas/github-action.json -d file --strict=false || EXIT_CODE=1
+find ./workflows -type f -name "*.yml" -print0 | xargs -0 -I file ajv -s ./tempSchemas/github-workflow.json -d file --strict=false || EXIT_CODE=1
 
-if (( $EXIT_CODE != 0 )); then
+if (( "$EXIT_CODE" != 0 )); then
   exit $EXIT_CODE
 fi
 

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -164,9 +164,10 @@ jobs:
         if: ${{ env.DO_CHERRY_PICK }}
         run: |
           PR_URL=${{ https://github.com/Expensify/App/pull/${{ nneeds.chooseDeployActions.outputs.mergedPullRequest }}
+          printf -v COMMENT ':clap: Heads up @Expensify/applauseleads :clap:\nA [new pull request](%s) has been :cherries: cherry-picked :cherries: to staging, and will be deployed to staging in version `%s` :rocket:' "$PR_URL" ${{ env.NEW_VERSION }}
           gh issue comment \
           "$(gh issue list --label StagingDeployCash --json number --jq '.[0].number')" \
-          --body ":clap: Heads up @Expensify/applauseleads :clap:\nA [new pull request]($PR_URL) has been :cherries: cherry-picked :cherries: to staging, and will be deployed to staging in version `${{ env.NEW_VERSION }}` :rocket:"
+          --body "$COMMENT"
         env:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 
@@ -182,7 +183,7 @@ jobs:
         run: |
           gh issue comment \
           "$(gh issue list --label StagingDeployCash --json number --jq '.[0].number')" \
-          --body ":rocket: All set?…You bet! https://github.com/Expensify/App/releases/tag/${{ env.NEW_VERSION }} has been deployed to staging :rocket:"
+          --body ":tada: All set?…You bet! https://github.com/Expensify/App/releases/tag/${{ env.NEW_VERSION }} has been deployed to staging :tada:"
         env:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -163,9 +163,10 @@ jobs:
       - name: Comment in StagingDeployCash to alert Applause that a new pull request has been cherry-picked
         if: ${{ env.DO_CHERRY_PICK }}
         run: |
+          PR_URL=${{ https://github.com/Expensify/App/pull/${{ nneeds.chooseDeployActions.outputs.mergedPullRequest }}
           gh issue comment \
           "$(gh issue list --label StagingDeployCash --json number --jq '.[0].number')" \
-          --body ":clap: Heads up @Expensify/applauseleads :clap:\nA new pull request has been :cherries: cherry-picked :cherries: to staging, and will be deployed to staging in version `${{ env.NEW_VERSION }}` :rocket:"
+          --body ":clap: Heads up @Expensify/applauseleads :clap:\nA [new pull request]($PR_URL) has been :cherries: cherry-picked :cherries: to staging, and will be deployed to staging in version `${{ env.NEW_VERSION }}` :rocket:"
         env:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -163,7 +163,7 @@ jobs:
       - name: Comment in StagingDeployCash to alert Applause that a new pull request has been cherry-picked
         if: ${{ env.DO_CHERRY_PICK }}
         run: |
-          PR_URL=${{ https://github.com/Expensify/App/pull/${{ nneeds.chooseDeployActions.outputs.mergedPullRequest }}
+          PR_URL="https://github.com/Expensify/App/pull/${{ needs.chooseDeployActions.outputs.mergedPullRequest }}"
           printf -v COMMENT ':clap: Heads up @Expensify/applauseleads :clap:\nA [new pull request](%s) has been :cherries: cherry-picked :cherries: to staging, and will be deployed to staging in version `%s` :rocket:' "$PR_URL" ${{ env.NEW_VERSION }}
           gh issue comment \
           "$(gh issue list --label StagingDeployCash --json number --jq '.[0].number')" \

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -164,7 +164,7 @@ jobs:
         if: ${{ env.DO_CHERRY_PICK }}
         run: |
           PR_URL="https://github.com/Expensify/App/pull/${{ needs.chooseDeployActions.outputs.mergedPullRequest }}"
-          printf -v COMMENT ':clap: Heads up @Expensify/applauseleads :clap:\nA [new pull request](%s) has been :cherries: cherry-picked :cherries: to staging, and will be deployed to staging in version `%s` :rocket:' "$PR_URL" ${{ env.NEW_VERSION }}
+          printf -v COMMENT ":clap: Heads up @Expensify/applauseleads :clap:\nA [new pull request](%s) has been :cherries: cherry-picked :cherries: to staging, and will be deployed to staging in version \`%s\` :rocket:" "$PR_URL" ${{ env.NEW_VERSION }}
           gh issue comment \
           "$(gh issue list --label StagingDeployCash --json number --jq '.[0].number')" \
           --body "$COMMENT"

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -183,7 +183,7 @@ jobs:
         run: |
           gh issue comment \
           "$(gh issue list --label StagingDeployCash --json number --jq '.[0].number')" \
-          --body ":tada: All set?…You bet! https://github.com/Expensify/App/releases/tag/${{ env.NEW_VERSION }} has been deployed to staging :tada:"
+          --body ":tada: All set?…You bet! @Expensify/applauseleads https://github.com/Expensify/App/releases/tag/${{ env.NEW_VERSION }} has been deployed to staging :tada:"
         env:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -133,8 +133,11 @@ jobs:
           WORKFLOW: updateProtectedBranch.yml
           INPUTS: '{ "TARGET_BRANCH": "staging" }'
 
+      - name: Determine if this pull request will be cherry-picked
+        run: echo "DO_CHERRY_PICK=${{ fromJSON(needs.chooseDeployActions.outputs.isStagingDeployLocked) && fromJSON(needs.chooseDeployActions.outputs.shouldCherryPick) }}" >> "$GITHUB_ENV"
+
       - name: Cherry pick to staging
-        if: ${{ fromJSON(needs.chooseDeployActions.outputs.isStagingDeployLocked) && fromJSON(needs.chooseDeployActions.outputs.shouldCherryPick) }}
+        if: ${{ env.DO_CHERRY_PICK }}
         uses: Expensify/App/.github/actions/triggerWorkflowAndWait@main
         with:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
@@ -157,6 +160,31 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
           NPM_VERSION: ${{ env.NEW_VERSION }}
 
+      - name: Comment in StagingDeployCash to alert Applause that a new pull request has been cherry-picked
+        if: ${{ env.DO_CHERRY_PICK }}
+        run: |
+          gh issue comment \
+          "$(gh issue list --label StagingDeployCash --json number --jq '.[0].number')" \
+          --body ":clap: Heads up @Expensify/applauseleads :clap:\nA new pull request has been :cherries: cherry-picked :cherries: to staging, and will be deployed to staging in version `${{ env.NEW_VERSION }}` :rocket:"
+        env:
+          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+
+      - name: Wait for staging deploys to finish
+        if: ${{ env.DO_CHERRY_PICK }}
+        uses: Expensify/App/.github/actions/awaitStagingDeploys@main
+        with:
+          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+          TAG: ${{ env.NEW_VERSION }}
+
+      - name: Comment in StagingDeployCash to alert Applause that cherry-picked pull request has been deployed.
+        if: ${{ env.DO_CHERRY_PICK }}
+        run: |
+          gh issue comment \
+          "$(gh issue list --label StagingDeployCash --json number --jq '.[0].number')" \
+          --body ":rocket: https://github.com/Expensify/App/releases/tag/${{ env.NEW_VERSION }} has been deployed to staging :rocket:"
+        env:
+          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+
       # This Slack step is duplicated in all workflows, if you make a change to this step, make sure to update all
       # the other workflows with the same change
       - uses: 8398a7/action-slack@v3
@@ -178,7 +206,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
 
-  # Check if actor is member of Expensify organization by looking for expensify-expensify team
+  # Check if actor is member of Expensify organization by looking for expensify-expensify team
   isExpensifyEmployee:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -181,7 +181,7 @@ jobs:
         run: |
           gh issue comment \
           "$(gh issue list --label StagingDeployCash --json number --jq '.[0].number')" \
-          --body ":rocket: https://github.com/Expensify/App/releases/tag/${{ env.NEW_VERSION }} has been deployed to staging :rocket:"
+          --body ":rocket: All set?…You bet! https://github.com/Expensify/App/releases/tag/${{ env.NEW_VERSION }} has been deployed to staging :rocket:"
         env:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 


### PR DESCRIPTION
### Details
1. Comments on the deploy checklist like so when a pull request is CP'd:

	  ---
	  
	  :clap: Heads up @Expensify/applauseleads :clap:
	  
	  A [new pull request](https://github.com/Expensify/App/pull/7802) has been :cherries: cherry-picked :cherries: to staging, and will be deployed to staging in version `1.1.39-2` :rocket:
	  
	  ---

1. Then waits for the staging deploy for that version to complete

1. then comments again like so:

	  ---
	  
	  :rocket: _All set?…You bet!_ https://github.com/Expensify/App/releases/tag/1.1.39-2 has been deployed to staging :rocket:
	  
	  ---

### Fixed Issues
$ https://github.com/Expensify/App/issues/7178

### Tests
Unit tests added.

### QA Steps
1. Merge a PR with the `CP Staging` label with the checklist locked.
1. Verify that the first comment appears on the checklist and is correctly formatted.
1. Verify that the staging deploy completes, then the second comment appears on the checklist and is correctly formatted.
1. Merge another PR without the `CP Staging` label with the checklist locked.
1. Verify that no comments appear on the checklist.
1. Manually CP the PR.
1. Repeat steps 2 and 3.
