### PR TITLE
Disable autofocus on Workspace Invite member page

### DIFF
--- a/src/components/OptionsSelector.js
+++ b/src/components/OptionsSelector.js
@@ -68,7 +68,7 @@ const propTypes = {
     shouldFocusOnSelectRow: PropTypes.bool,
 
     /** Whether to autofocus the search input on mount */
-    autofocus: PropTypes.bool,
+    autoFocus: PropTypes.bool,
 
     ...withLocalizePropTypes,
 };
@@ -86,7 +86,7 @@ const defaultProps = {
     forceTextUnreadStyle: false,
     showTitleTooltip: false,
     shouldFocusOnSelectRow: false,
-    autofocus: true,
+    autoFocus: true,
 };
 
 class OptionsSelector extends Component {
@@ -103,7 +103,7 @@ class OptionsSelector extends Component {
     }
 
     componentDidMount() {
-        if (!this.props.autofocus) {
+        if (!this.props.autoFocus) {
             return;
         }
 

--- a/src/components/OptionsSelector.js
+++ b/src/components/OptionsSelector.js
@@ -67,6 +67,9 @@ const propTypes = {
     /** Whether to focus the textinput after an option is selected */
     shouldFocusOnSelectRow: PropTypes.bool,
 
+    /** Whether to autofocus the search input on mount */
+    autofocus: PropTypes.bool,
+
     ...withLocalizePropTypes,
 };
 
@@ -83,6 +86,7 @@ const defaultProps = {
     forceTextUnreadStyle: false,
     showTitleTooltip: false,
     shouldFocusOnSelectRow: false,
+    autofocus: true,
 };
 
 class OptionsSelector extends Component {
@@ -99,6 +103,10 @@ class OptionsSelector extends Component {
     }
 
     componentDidMount() {
+        if (!this.props.autofocus) {
+            return;
+        }
+
         if (this.props.shouldDelayFocus) {
             setTimeout(() => this.textInput.focus(), CONST.ANIMATED_TRANSITION);
         } else {

--- a/src/pages/workspace/WorkspaceInvitePage.js
+++ b/src/pages/workspace/WorkspaceInvitePage.js
@@ -257,6 +257,7 @@ class WorkspaceInvitePage extends React.Component {
                             <FullScreenLoadingIndicator visible={!didScreenTransitionEnd} />
                             {didScreenTransitionEnd && (
                                 <OptionsSelector
+                                    autoFocus={false}
                                     canSelectMultipleOptions
                                     sections={sections}
                                     selectedOptions={this.state.selectedOptions}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/7675

### Tests | QA Steps
1. Launch the app and log in with any account
2. Go to Setting
3. Tap on any Workspace you have in your account
4. Go to Manage Members
 5. Tap the Invite button. 
 6. Confirm that no focus is applied to the search field automatically.


- [x] Verify that no errors appear in the JS console

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web | Desktop
<!-- Insert screenshots of your changes on the web platform-->
![image](https://user-images.githubusercontent.com/24370807/154480523-5ec1b261-f3b6-4ffa-8839-2b9dd0a9a901.png)

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
![image](https://user-images.githubusercontent.com/24370807/155620157-de94dc00-5042-4931-895b-94a3682be3c9.png)


#### iOS
![image](https://user-images.githubusercontent.com/24370807/155619826-e81b9ee6-60c2-4b19-be3c-fc8cda15b3fd.png)

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
![image](https://user-images.githubusercontent.com/24370807/155619667-36cb813f-7694-4de7-a8f3-3d4f070f2de9.png)
