### PR TITLE
P2P KYC - Ask user to provide full SSN when LexisNexis cannot

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -426,6 +426,7 @@ const CONST = {
             },
         },
         ERROR: {
+            FULL_SSN_NOT_FOUND: 'Full SSN not found',
             IDENTITY_NOT_FOUND: 'Identity not found',
             INVALID_SSN: 'Invalid SSN',
             UNEXPECTED: 'Unexpected error',
@@ -570,6 +571,7 @@ const CONST = {
         ZIP_CODE: /[0-9]{5}(?:[- ][0-9]{4})?/,
         INDUSTRY_CODE: /^[0-9]{6}$/,
         SSN_LAST_FOUR: /^(?!0000)[0-9]{4}$/,
+        SSN_FULL_NINE: /^(?!0000)[0-9]{9}$/,
         NUMBER: /^[0-9]+$/,
         CARD_NUMBER: /^[0-9]{15,16}$/,
         CARD_SECURITY_CODE: /^[0-9]{3,4}$/,

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -51,6 +51,7 @@ export default {
         here: 'here',
         dob: 'Date of birth',
         ssnLast4: 'Last 4 digits of SSN',
+        ssnFull9: 'Full 9 digits of SSN',
         personalAddress: 'Personal address',
         companyAddress: 'Company address',
         noPO: 'PO boxes and mail drop addresses are not allowed',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -51,6 +51,7 @@ export default {
         here: 'aquí',
         dob: 'Fecha de Nacimiento',
         ssnLast4: 'Últimos 4 dígitos de su SSN',
+        ssnFull9: 'Los 9 dígitos del SSN',
         personalAddress: 'Dirección física personal',
         companyAddress: 'Dirección física de la empresa',
         noPO: 'No se aceptan apartados ni direcciones postales',

--- a/src/libs/ValidationUtils.js
+++ b/src/libs/ValidationUtils.js
@@ -176,6 +176,14 @@ function isValidSSNLastFour(ssnLast4) {
 }
 
 /**
+ * @param {String} ssnFull9
+ * @returns {Boolean}
+ */
+function isValidSSNFullNine(ssnFull9) {
+    return CONST.REGEX.SSN_FULL_NINE.test(ssnFull9);
+}
+
+/**
  *
  * @param {String} paypalUsername
  * @returns {Boolean}
@@ -370,6 +378,7 @@ export {
     isValidPaypalUsername,
     isValidRoutingNumber,
     isValidSSNLastFour,
+    isValidSSNFullNine,
     doesFailCharacterLimit,
     isReservedRoomName,
     isExistingRoomName,

--- a/src/pages/EnablePayments/AdditionalDetailsStep.js
+++ b/src/pages/EnablePayments/AdditionalDetailsStep.js
@@ -233,7 +233,6 @@ class AdditionalDetailsStep extends React.Component {
                                             });
                                         }}
                                         errorText={this.getErrorText('addressStreet')}
-                                        autoComplete="off"
                                     />
                                     <Text style={[styles.mutedTextLabel, styles.mt1]}>
                                         {this.props.translate('common.noPO')}

--- a/src/pages/EnablePayments/AdditionalDetailsStep.js
+++ b/src/pages/EnablePayments/AdditionalDetailsStep.js
@@ -44,7 +44,7 @@ const propTypes = {
 
 const defaultProps = {
     walletAdditionalDetails: {
-        errorFields: [],
+        errorFields: {},
         loading: false,
         additionalErrorMessage: '',
     },
@@ -78,6 +78,7 @@ class AdditionalDetailsStep extends React.Component {
             phoneNumber: 'common.phoneNumber',
             dob: 'common.dob',
             ssn: 'common.ssnLast4',
+            ssnFull9: 'common.ssnFull9',
         };
 
         this.state = {
@@ -141,7 +142,7 @@ class AdditionalDetailsStep extends React.Component {
             errors.addressStreet = true;
         }
 
-        if (!ValidationUtils.isValidSSNLastFour(this.state.ssn)) {
+        if (!ValidationUtils.isValidSSNLastFour(this.state.ssn) && !ValidationUtils.isValidSSNFullNine(this.state.ssn)) {
             errors.ssn = true;
         }
 
@@ -180,6 +181,8 @@ class AdditionalDetailsStep extends React.Component {
     render() {
         const isErrorVisible = _.size(this.getErrors()) > 0
             || lodashGet(this.props, 'walletAdditionalDetails.additionalErrorMessage', '').length > 0;
+        const shouldAskForFullSSN = this.props.walletAdditionalDetails.shouldAskForFullSSN;
+
         return (
             <ScreenWrapper>
                 <KeyboardAvoidingView style={[styles.flex1]} behavior="height">
@@ -230,6 +233,7 @@ class AdditionalDetailsStep extends React.Component {
                                             });
                                         }}
                                         errorText={this.getErrorText('addressStreet')}
+                                        autoComplete="off"
                                     />
                                     <Text style={[styles.mutedTextLabel, styles.mt1]}>
                                         {this.props.translate('common.noPO')}
@@ -253,11 +257,11 @@ class AdditionalDetailsStep extends React.Component {
                                 />
                                 <TextInput
                                     containerStyles={[styles.mt4]}
-                                    label={this.props.translate(this.fieldNameTranslationKeys.ssn)}
+                                    label={this.props.translate(this.fieldNameTranslationKeys[shouldAskForFullSSN ? 'ssnFull9' : 'ssn'])}
                                     onChangeText={val => this.clearErrorAndSetValue('ssn', val)}
                                     value={this.state.ssn}
                                     errorText={this.getErrorText('ssn')}
-                                    maxLength={4}
+                                    maxLength={shouldAskForFullSSN ? 9 : 4}
                                     keyboardType={CONST.KEYBOARD_TYPE.NUMBER_PAD}
                                 />
                             </View>


### PR DESCRIPTION
### Details
Ask for full 9 digit SSN when LexisNexis cannot find the first five after the user gives his last 4.

### Fixed Issues
Part of https://github.com/Expensify/Expensify/issues/193504

### Tests
Tested with the [secure PR](https://github.com/Expensify/Web-Secure/pull/2153) (but should be merged before the secure one) and these app fixes: https://github.com/Expensify/App/pull/7782 and https://github.com/Expensify/App/pull/7812

Try to transfer your wallet balance.
Fill up the Additional Details Step with random 4 digit SSN.
Submit the form.
Make sure you get an error, asking you to enter your full SSN.
Enter your full SSN and submit. You should then get another error (not SSN related).

### QA Steps
None, as it needs the [secure PR](https://github.com/Expensify/Web-Secure/pull/2153).

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots

#### Web

<table><tr>
<td><img src="https://user-images.githubusercontent.com/2463975/154665435-210c8ab4-4530-4d07-88b4-2c75b727dc72.png" /></td>
<td><img src="https://user-images.githubusercontent.com/2463975/154665495-0bfd5889-d9fe-4add-836d-2343a61ef453.png" /></td>
<td><img src="https://user-images.githubusercontent.com/2463975/154665550-e13ceba7-80f8-42c1-af38-9b0e86e6b06c.png" /></td>
<td><img src="https://user-images.githubusercontent.com/2463975/154666175-de3f96c5-70ff-4591-93de-052c86539568.png" /></td>
</tr></table>
