### PR TITLE
P2P KYC - Fix errors at field level

### DIFF
--- a/src/pages/EnablePayments/AdditionalDetailsStep.js
+++ b/src/pages/EnablePayments/AdditionalDetailsStep.js
@@ -100,6 +100,9 @@ class AdditionalDetailsStep extends React.Component {
         });
     }
 
+    /**
+     * @returns {Object}
+     */
     getErrors() {
         return this.formHelper.getErrors(this.props);
     }
@@ -116,8 +119,11 @@ class AdditionalDetailsStep extends React.Component {
         return `${this.props.translate(this.fieldNameTranslationKeys[fieldName])} ${this.props.translate('common.isRequiredField')}.`;
     }
 
+    /**
+     * @param {String} path
+     */
     clearError(path) {
-        return this.formHelper.clearError(this.props, path);
+        this.formHelper.clearError(this.props, path);
     }
 
     /**

--- a/src/pages/EnablePayments/AdditionalDetailsStep.js
+++ b/src/pages/EnablePayments/AdditionalDetailsStep.js
@@ -94,13 +94,14 @@ class AdditionalDetailsStep extends React.Component {
             ssn: lodashGet(props.walletAdditionalDetailsDraft, 'ssn', ''),
         };
 
-        const formHelper = new FormHelper({
+        this.formHelper = new FormHelper({
             errorPath: 'walletAdditionalDetails.errorFields',
             setErrors: Wallet.setAdditionalDetailsErrors,
         });
+    }
 
-        this.getErrors = () => formHelper.getErrors(props);
-        this.clearError = path => formHelper.clearError(props, path);
+    getErrors() {
+        return this.formHelper.getErrors(this.props);
     }
 
     /**
@@ -113,6 +114,10 @@ class AdditionalDetailsStep extends React.Component {
         }
 
         return `${this.props.translate(this.fieldNameTranslationKeys[fieldName])} ${this.props.translate('common.isRequiredField')}.`;
+    }
+
+    clearError(path) {
+        return this.formHelper.clearError(this.props, path);
     }
 
     /**


### PR DESCRIPTION

### Details
When there was an error at field level, the field didn't get red, and the corresponding error didn't show up.
It's because getErrors was always sending the original props, not the updated ones that were received after an Onyx change.
Now, I'm passing the right props.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/197281

### Tests / QA Steps
Try to transfer your wallet balance.
When asked for your personal additional details, submit the form with empty fields.
Required fields should get red and with a corresponding error message.

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
![image](https://user-images.githubusercontent.com/2463975/154660039-fc7e8798-cba6-495d-8743-55d477bb71f0.png)

#### Web
