### PR TITLE
Fix Android text selection context menu (copy, paste)

### DIFF
--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -248,6 +248,10 @@ class ReportActionCompose extends React.Component {
 
         const caret = this.currentSelection.start + emoji.length;
 
+        InteractionManager.runAfterInteractions(() => {
+            this.textInput.setNativeProps({selection: {start: caret, end: caret}});
+        });
+
         if (this.textInput.setSelectionRange) {
             this.textInput.setSelectionRange(caret, caret);
         }

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -250,6 +250,7 @@ class ReportActionCompose extends React.Component {
 
         InteractionManager.runAfterInteractions(() => {
             this.textInput.setNativeProps({selection: {start: caret, end: caret}});
+            global.requestAnimationFrame(() => this.textInput.setNativeProps({selection: null}));
         });
 
         if (this.textInput.setSelectionRange) {

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -134,7 +134,7 @@ class ReportActionCompose extends React.Component {
             textInputShouldClear: false,
             isCommentEmpty: props.comment.length === 0,
             isMenuVisible: false,
-            selection: {
+            defaultSelection: {
                 start: props.comment.length,
                 end: props.comment.length,
             },
@@ -142,6 +142,8 @@ class ReportActionCompose extends React.Component {
     }
 
     componentDidMount() {
+        this.setState({defaultSelection: undefined});
+
         ReportActionComposeFocusManager.onComposerFocus(() => {
             if (!this.shouldFocusInputOnScreenFocus || !this.props.isFocused) {
                 return;
@@ -175,7 +177,7 @@ class ReportActionCompose extends React.Component {
     }
 
     onSelectionChange(e) {
-        this.setState({selection: e.nativeEvent.selection});
+        this.currentSelection = e.nativeEvent.selection;
     }
 
     /**
@@ -239,18 +241,16 @@ class ReportActionCompose extends React.Component {
      * @param {String} emoji
      */
     addEmojiToTextBox(emoji) {
-        const newComment = this.comment.slice(0, this.state.selection.start)
-            + emoji + this.comment.slice(this.state.selection.end, this.comment.length);
-        this.textInput.setNativeProps({
-            text: newComment,
-        });
-        this.setState(prevState => ({
-            selection: {
-                start: prevState.selection.start + emoji.length,
-                end: prevState.selection.start + emoji.length,
-            },
-        }));
+        const newComment = this.comment.slice(0, this.currentSelection.start)
+            + emoji + this.comment.slice(this.currentSelection.end, this.comment.length);
+
         this.updateComment(newComment);
+
+        const caret = this.currentSelection.start + emoji.length;
+
+        if (this.textInput.setSelectionRange) {
+            this.textInput.setSelectionRange(caret, caret);
+        }
     }
 
     /**
@@ -547,7 +547,7 @@ class ReportActionCompose extends React.Component {
                                     shouldClear={this.state.textInputShouldClear}
                                     onClear={() => this.setTextInputShouldClear(false)}
                                     isDisabled={isComposeDisabled || isBlockedFromConcierge}
-                                    selection={this.state.selection}
+                                    selection={this.state.defaultSelection}
                                     onSelectionChange={this.onSelectionChange}
                                 />
                             </>


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Related to slack thread: https://expensify.slack.com/archives/C01GTK53T8Q/p1645201764524639?thread_ts=1645191589.301989&cid=C01GTK53T8Q

Using controlled `selection` is not allowing the user to control the selection freely
Switching to uncontrolled `selection` addresses the issue and improves performance a bit

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/6876

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

### Tested On

- [x] Web
- [x] Mobile Web
- [ ] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
https://user-images.githubusercontent.com/12156624/159987317-c4af23b5-31d9-4866-b4bf-64d8ba9d3930.mov

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
https://user-images.githubusercontent.com/12156624/159987691-7a1552a9-9cbd-4db4-8f66-3918e66cd0c7.mov

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
https://user-images.githubusercontent.com/12156624/159985807-71d3f8a9-fa82-4479-8a38-f8b5100b8805.mov

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
https://user-images.githubusercontent.com/12156624/155128799-498584ca-1634-4e91-a51c-6b7f3dbe1b48.mp4
