### PR TITLE
[No QA] Stringify errorInfo in ErrorBoundary so stack traces show in logs

### DIFF
--- a/src/components/ErrorBoundary/BaseErrorBoundary.js
+++ b/src/components/ErrorBoundary/BaseErrorBoundary.js
@@ -36,7 +36,7 @@ class BaseErrorBoundary extends React.Component {
     }
 
     componentDidCatch(error, errorInfo) {
-        this.props.logError(this.props.errorMessage, error, errorInfo);
+        this.props.logError(this.props.errorMessage, error, JSON.stringify(errorInfo));
 
         // We hide the splash screen since the error might happened during app init
         BootSplash.hide();

--- a/src/components/ErrorBoundary/index.native.js
+++ b/src/components/ErrorBoundary/index.native.js
@@ -9,7 +9,7 @@ BaseErrorBoundary.defaultProps.logError = (errorMessage, error, errorInfo) => {
 
     /* On native we also log the error to crashlytics
     * Since the error was handled we need to manually tell crashlytics about it */
-    crashlytics().log(`errorInfo: ${JSON.stringify(errorInfo)}`);
+    crashlytics().log(`errorInfo: ${errorInfo}`);
     crashlytics().recordError(error);
 };
 


### PR DESCRIPTION
### Details

Coming from https://github.com/Expensify/App/issues/7811#issuecomment-1045049530

### Fixed Issues
$ https://github.com/Expensify/App/issues/7818

### Tests
1. Add an error somewhere like the sidebar e.g.

```diff
diff --git a/src/pages/home/sidebar/SidebarLinks.js b/src/pages/home/sidebar/SidebarLinks.js
index d31e1f9d0..4aac47b99 100644
--- a/src/pages/home/sidebar/SidebarLinks.js
+++ b/src/pages/home/sidebar/SidebarLinks.js
@@ -185,6 +185,8 @@ class SidebarLinks extends React.Component {
     }

     render() {
+        throw new Error('Test');
+
         // Wait until the reports and personalDetails are actually loaded before displaying the LHN
         if (!this.props.initialReportDataLoaded || _.isEmpty(this.props.personalDetails)) {
             return null;
```
2. Run the app while tailing the logs and grep for `NewExpensify crash`
3. Verify the error appears and shows in the logs
4. Verify the entire stack trace is logged e.g.
```
2022-02-18T19:36:56.215763+00:00 expensidev2004 php-fpm: Gt8dvc /api.php marc@reporttest.com !ecash! ?api? [alrt] [alXt] NewExpensify crash caught by error boundary ~~ error: 'Testing a throw' trace: '{"componentStack":"\n    at SidebarScreen (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:372701:81)\n    at withOnyx (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:193097:85)\n    at WithWindowDimensions (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:339174:83)\n    at withLocalize(Component)\n    at WrappedComponent (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:40221:5)\n    at div\n    at http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:259811:25\n    at AnimatedComponent (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:201991:83)\n    at div\n    at http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:259811:25\n    at AnimatedComponent (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:201991:83)\n    at Dummy (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:45758:3)\n    at DrawerView (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:45925:5)\n    at DrawerViewBase (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:45508:3)\n    at div\n    at http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:259811:25\n    at div\n    at http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:259811:25\n    at SafeAreaProviderCompat (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:47757:3)\n    at DrawerView (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:45719:3)\n    at http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:42513:13\n    at DrawerNavigator (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:44834:3)\n    at BaseDrawerNavigator (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:345033:45)\n    at WithWindowDimensions (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:339174:83)\n    at MainDrawerNavigator (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:345193:58)\n    at withOnyx (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:193097:85)\n    at StaticContainer (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:41062:16)\n    at EnsureSingleNavigator (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:40715:5)\n    at SceneView (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:40952:5)\n    at div\n    at http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:259811:25\n    at div\n    at http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:259811:25\n    at div\n    at http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:259811:25\n    at CardSheet (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:53429:3)\n    at div\n    at http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:259811:25\n    at AnimatedComponent (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:269285:37)\n    at AnimatedComponentWrapper\n    at Dummy (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:52113:3)\n    at div\n    at http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:259811:25\n    at AnimatedComponent (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:269285:37)\n    at AnimatedComponentWrapper\n    at div\n    at http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:259811:25\n    at Card (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:52657:5)\n    at CardContainer (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:53151:3)\n    at div\n    at http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:259811:25\n    at NativeScreen (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:249770:1)\n    at AnimatedComponent (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:269285:37)\n    at AnimatedComponentWrapper\n    at MaybeScreen (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:52579:3)\n    at div\n    at http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:259811:25\n    at MaybeScreenContainer (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:52567:3)\n    at div\n    at http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:259811:25\n    at Background (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:46761:3)\n    at CardStack (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:53669:5)\n    at div\n    at http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:259811:25\n    at SafeAreaProviderCompat (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:47757:3)\n    at div\n    at http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:259811:25\n    at StackView (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:53996:5)\n    at CustomRootStackNavigator (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:345652:23)\n    at AuthScreens (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:344707:81)\n    at withOnyx (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:193097:85)\n    at WithWindowDimensions (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:339174:83)\n    at AppNavigator (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:345727:16)\n    at EnsureSingleNavigator (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:40715:5)\n    at BaseNavigationContainer (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:40369:5)\n    at ThemeProvider (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:48542:5)\n    at NavigationContainerInner (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:48165:5)\n    at NavigationRoot (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:346339:81)\n    at Expensify (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:317645:81)\n    at withOnyx (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:193097:85)\n    at withLocalize(Component)\n    at BaseErrorBoundary (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:324375:81)\n    at RenderersPropsProvider (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:225551:44)\n    at ListStyleSpecsProvider (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:225413:3)\n    at SharedPropsProvider (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:225655:48)\n    at RenderRegistryProvider (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:225479:3)\n    at RenderHTMLConfigProvider (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:224201:5)\n    at TRenderEngineProvider (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:225238:3)\n    at BaseHTMLEngineProvider (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:325395:13)\n    at HTMLEngineProvider (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:325882:18)\n    at WithWindowDimensions (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:339174:83)\n    at LocaleContextProvider (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:338885:81)\n    at withOnyx (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:193097:85)\n    at http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:334366:23\n    at div\n    at http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:259811:25\n    at NativeSafeAreaView (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:249280:3)\n    at SafeAreaProvider (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:249445:3)\n    at Provider (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:338323:19)\n    at withOnyx (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:193097:85)\n    at Provider (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:338323:19)\n    at withOnyx (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:193097:85)\n    at Provider (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a68.bundle.js:338323:19)\n    at withOnyx (http:\/\/localhost:8080\/app-25b9df5c3ff4632d1a
```

- [x] Verify that no errors appear in the JS console

### QA Steps
❌ 