### PR TITLE
fix: Move extension field to the next line

### DIFF
--- a/src/pages/RequestCallPage.js
+++ b/src/pages/RequestCallPage.js
@@ -317,31 +317,29 @@ class RequestCallPage extends Component {
                                 onChangeLastName={lastName => this.setState({lastName})}
                                 style={[styles.mv4]}
                             />
-                            <View style={[styles.mt4, styles.flexRow]}>
-                                <View style={styles.flex1}>
-                                    <TextInput
-                                        label={this.props.translate('common.phoneNumber')}
-                                        autoCompleteType="off"
-                                        autoCorrect={false}
-                                        value={this.state.phoneNumber}
-                                        placeholder="2109400803"
-                                        errorText={this.state.phoneNumberError}
-                                        onBlur={this.validatePhoneInput}
-                                        onChangeText={phoneNumber => this.setState({phoneNumber})}
-                                    />
-                                </View>
-                                <View style={[styles.flex1, styles.ml2]}>
-                                    <TextInput
-                                        label={this.props.translate('requestCallPage.extension')}
-                                        autoCompleteType="off"
-                                        autoCorrect={false}
-                                        value={this.state.phoneExtension}
-                                        placeholder="100"
-                                        errorText={this.state.phoneExtensionError}
-                                        onBlur={this.validatePhoneExtensionInput}
-                                        onChangeText={phoneExtension => this.setState({phoneExtension})}
-                                    />
-                                </View>
+                            <View style={[styles.flex1]}>
+                                <TextInput
+                                    label={this.props.translate('common.phoneNumber')}
+                                    autoCompleteType="off"
+                                    autoCorrect={false}
+                                    value={this.state.phoneNumber}
+                                    placeholder="2109400803"
+                                    errorText={this.state.phoneNumberError}
+                                    onBlur={this.validatePhoneInput}
+                                    onChangeText={phoneNumber => this.setState({phoneNumber})}
+                                />
+                            </View>
+                            <View style={[styles.mt4, styles.flex1]}>
+                                <TextInput
+                                    label={this.props.translate('requestCallPage.extension')}
+                                    autoCompleteType="off"
+                                    autoCorrect={false}
+                                    value={this.state.phoneExtension}
+                                    placeholder="100"
+                                    errorText={this.state.phoneExtensionError}
+                                    onBlur={this.validatePhoneExtensionInput}
+                                    onChangeText={phoneExtension => this.setState({phoneExtension})}
+                                />
                             </View>
                             <Text style={[styles.textMicroSupporting, styles.mt4]}>{this.getWaitTimeMessage()}</Text>
                         </Section>

--- a/src/pages/RequestCallPage.js
+++ b/src/pages/RequestCallPage.js
@@ -317,30 +317,27 @@ class RequestCallPage extends Component {
                                 onChangeLastName={lastName => this.setState({lastName})}
                                 style={[styles.mv4]}
                             />
-                            <View style={[styles.flex1]}>
-                                <TextInput
-                                    label={this.props.translate('common.phoneNumber')}
-                                    autoCompleteType="off"
-                                    autoCorrect={false}
-                                    value={this.state.phoneNumber}
-                                    placeholder="2109400803"
-                                    errorText={this.state.phoneNumberError}
-                                    onBlur={this.validatePhoneInput}
-                                    onChangeText={phoneNumber => this.setState({phoneNumber})}
-                                />
-                            </View>
-                            <View style={[styles.mt4, styles.flex1]}>
-                                <TextInput
-                                    label={this.props.translate('requestCallPage.extension')}
-                                    autoCompleteType="off"
-                                    autoCorrect={false}
-                                    value={this.state.phoneExtension}
-                                    placeholder="100"
-                                    errorText={this.state.phoneExtensionError}
-                                    onBlur={this.validatePhoneExtensionInput}
-                                    onChangeText={phoneExtension => this.setState({phoneExtension})}
-                                />
-                            </View>
+                            <TextInput
+                                label={this.props.translate('common.phoneNumber')}
+                                autoCompleteType="off"
+                                autoCorrect={false}
+                                value={this.state.phoneNumber}
+                                placeholder="2109400803"
+                                errorText={this.state.phoneNumberError}
+                                onBlur={this.validatePhoneInput}
+                                onChangeText={phoneNumber => this.setState({phoneNumber})}
+                            />
+                            <TextInput
+                                label={this.props.translate('requestCallPage.extension')}
+                                autoCompleteType="off"
+                                autoCorrect={false}
+                                value={this.state.phoneExtension}
+                                placeholder="100"
+                                errorText={this.state.phoneExtensionError}
+                                onBlur={this.validatePhoneExtensionInput}
+                                onChangeText={phoneExtension => this.setState({phoneExtension})}
+                                containerStyles={[styles.mt4]}
+                            />
                             <Text style={[styles.textMicroSupporting, styles.mt4]}>{this.getWaitTimeMessage()}</Text>
                         </Section>
                     </ScrollView>


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
- Extension field label "Extension (Optional)" was overlapping with the text for smaller screen devices. 

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/7645

### Tests
1. Tested the field in all the platforms
2. Tested the label in small screen device.

<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### QA Steps
1. Open app
2. Navigate to Concierge chat > Click on Request a call
3. Check “extension” field. The label shouldn't overlap with the text. Ensure to check with a small screen device.

<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
<img width="385" alt="web-optional-label-extension" src="https://user-images.githubusercontent.com/3069065/154791702-eea5cf84-8914-45d5-b6df-64605f9a7d62.png">

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
<img width="307" alt="mweb-small-optional-label-extension-field" src="https://user-images.githubusercontent.com/3069065/154791727-d7911fe6-d63f-45ad-bb62-405a6268cb4e.png">
<img width="394" alt="mweb-optional-label-extension-field" src="https://user-images.githubusercontent.com/3069065/154791729-a93c4c58-60b9-4be1-ba86-059d3bd2ee34.png">


#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
<img width="427" alt="Screenshot 2022-02-19 at 1 36 43 PM" src="https://user-images.githubusercontent.com/3069065/154792618-4dbd34fa-d74a-49b7-85b6-8235c3da191e.png">

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
<img width="370" alt="Screenshot 2022-02-19 at 1 36 01 PM" src="https://user-images.githubusercontent.com/3069065/154792624-72b3c43b-9612-4614-ba4d-7a5f29a53d1d.png">


#### Android
<!-- Insert screenshots of your changes on the Android platform-->
<img width="133" alt="Screenshot 2022-02-19 at 1 39 54 PM" src="https://user-images.githubusercontent.com/3069065/154792704-185b9141-a227-4258-b18f-157759a523cc.png">

