### PR TITLE
[NO QA] Use set instead of merge

### DIFF
--- a/src/libs/actions/App.js
+++ b/src/libs/actions/App.js
@@ -80,7 +80,7 @@ AppState.addEventListener('change', (nextAppState) => {
 });
 
 function triggerUpdateAvailable() {
-    Onyx.merge(ONYXKEYS.UPDATE_AVAILABLE, true);
+    Onyx.set(ONYXKEYS.UPDATE_AVAILABLE, true);
 }
 
 export {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
We should be using `.set` instead of `.merge` since we're only storing a bool in `ONYXKEYS.UPDATE_AVAILABLE`

### Fixed Issues
none

### Tests
None, tiny change