### PR TITLE
Fix/disable new room non workspace members

### DIFF
--- a/src/pages/home/sidebar/SidebarScreen.js
+++ b/src/pages/home/sidebar/SidebarScreen.js
@@ -122,6 +122,7 @@ class SidebarScreen extends Component {
     }
 
     render() {
+        const workspaces = _.filter(this.props.allPolicies, policy => policy && policy.type === CONST.POLICY.TYPE.FREE);
         return (
             <ScreenWrapper
                 includePaddingBottom={false}
@@ -160,7 +161,7 @@ class SidebarScreen extends Component {
                                     text: this.props.translate('sidebarScreen.newGroup'),
                                     onSelected: () => Navigation.navigate(ROUTES.NEW_GROUP),
                                 },
-                                ...(Permissions.canUsePolicyRooms(this.props.betas) && this.props.allPolicies.length > 0 ? [
+                                ...(Permissions.canUsePolicyRooms(this.props.betas) && workspaces.length > 0 ? [
                                     {
                                         icon: Expensicons.Hashtag,
                                         text: this.props.translate('sidebarScreen.newRoom'),

--- a/src/pages/home/sidebar/SidebarScreen.js
+++ b/src/pages/home/sidebar/SidebarScreen.js
@@ -122,6 +122,7 @@ class SidebarScreen extends Component {
     }
 
     render() {
+        // Workspaces are policies with type === 'free'
         const workspaces = _.filter(this.props.allPolicies, policy => policy && policy.type === CONST.POLICY.TYPE.FREE);
         return (
             <ScreenWrapper

--- a/src/pages/home/sidebar/SidebarScreen.js
+++ b/src/pages/home/sidebar/SidebarScreen.js
@@ -160,7 +160,7 @@ class SidebarScreen extends Component {
                                     text: this.props.translate('sidebarScreen.newGroup'),
                                     onSelected: () => Navigation.navigate(ROUTES.NEW_GROUP),
                                 },
-                                ...(Permissions.canUsePolicyRooms(this.props.betas) ? [
+                                ...(Permissions.canUsePolicyRooms(this.props.betas) && this.props.allPolicies.length > 0 ? [
                                     {
                                         icon: Expensicons.Hashtag,
                                         text: this.props.translate('sidebarScreen.newRoom'),

--- a/src/pages/home/sidebar/SidebarScreen.js
+++ b/src/pages/home/sidebar/SidebarScreen.js
@@ -162,7 +162,7 @@ class SidebarScreen extends Component {
                                     text: this.props.translate('sidebarScreen.newGroup'),
                                     onSelected: () => Navigation.navigate(ROUTES.NEW_GROUP),
                                 },
-                                ...(Permissions.canUsePolicyRooms(this.props.betas) && workspaces.length > 0 ? [
+                                ...(Permissions.canUsePolicyRooms(this.props.betas) && workspaces.length ? [
                                     {
                                         icon: Expensicons.Hashtag,
                                         text: this.props.translate('sidebarScreen.newRoom'),


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
- New Room by default requires Workspace Selection in the dropdown. Hence, if the user doesn't have any workspace created then we remove the "New Room" menu from the Action Menu.

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/7668

### Tests
1. Tested with workspace to see the new room
2. Tested without workspace to check "New Room" doesn't show up.
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### QA Steps

As an account that is not a member of any workspace:

1. Click the "+" global create icon
2. Check that "New Room" doesn't show up

<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
<img width="371" alt="web-new-room-enabled" src="https://user-images.githubusercontent.com/3069065/154813133-ccba06f1-0229-4af3-b907-89a77187363a.png">
<img width="425" alt="web-new-room-disabled" src="https://user-images.githubusercontent.com/3069065/154813136-f49a68a6-b92e-48ff-9df0-c1a177dc836c.png">

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
<img width="348" alt="mweb-new-room-disabled" src="https://user-images.githubusercontent.com/3069065/154813141-17893f13-1184-4e53-8ab7-302fbbfe1221.png">

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
<img width="391" alt="desktop-new-room-disabled" src="https://user-images.githubusercontent.com/3069065/154813152-0ea92107-65fa-418c-8667-d303ad8f3baf.png">

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
<img width="369" alt="ios-new-room-disabled" src="https://user-images.githubusercontent.com/3069065/154813170-438d1051-5b56-4aa7-b867-731e32ab2bf5.png">

#### Android
<!-- Insert screenshots of your changes on the Android platform-->

<img width="318" alt="android-new-room-disabled" src="https://user-images.githubusercontent.com/3069065/154813182-84d5ba26-433c-4db7-b869-7b65d1f1eb57.png">

