### PR TITLE
Remove console error

### DIFF
--- a/src/components/Avatar.js
+++ b/src/components/Avatar.js
@@ -45,7 +45,7 @@ class Avatar extends PureComponent {
             this.props.size === 'small' ? styles.avatarSmall : styles.avatarNormal,
 
             // Background color isn't added for room avatar because it changes it's shape to a square
-            !this.props.isChatRoom && {backgroundColor: themeColors.icon},
+            this.props.isChatRoom ? {} : {backgroundColor: themeColors.icon},
             ...this.props.imageStyles,
         ];
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Remove the console error "Warning: Failed prop type: Invalid prop `avatarStyle[1]` of type `boolean` supplied to `RoomAvatar`, expected `object`."
Complementary to https://github.com/Expensify/App/pull/7742
### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/7494

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- Go to search page
- Check loading avatar (For testing purpose, to check loading avatar, I have set uri to '' in https://github.com/Expensify/App/blob/5e37ec71184956ca5bd7c6d471cf45054e09d503/src/components/Avatar.js#L51
- Default background color should be displayed

- [x] Verify that no errors appear in the JS console

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
- Go to search page
- Check loading avatar
- Default background color should be displayed

- [x] Verify that no errors appear in the JS console

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
<img width="1440" alt="Screen Shot 2022-02-20 at 13 37 19" src="https://user-images.githubusercontent.com/25876548/154834251-392a01bb-a64c-4df8-83f7-59012bdfe456.png">

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
<img src="https://user-images.githubusercontent.com/25876548/154834292-84893b5c-08ca-4367-b567-c518e40a77ff.png" alt="" width="350">

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
<img width="1440" alt="Screen Shot 2022-02-18 at 21 50 45" src="https://user-images.githubusercontent.com/25876548/154834325-25339261-1c03-4859-84a9-d2d9aca1698f.png">

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
<img src="https://user-images.githubusercontent.com/25876548/154834366-2419bdc1-afa9-47f4-b68c-e9c4f8598e10.png" alt="" width="350" >

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
<img src="https://user-images.githubusercontent.com/25876548/154834335-28e19a03-51e4-4533-af69-abd4d55b5f85.png" alt="" width="350" >
