### PR TITLE
remove emoji picker menu from tablets

### DIFF
--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -44,6 +44,7 @@ import * as User from '../../../libs/actions/User';
 import Tooltip from '../../../components/Tooltip';
 import EmojiPickerButton from '../../../components/EmojiPicker/EmojiPickerButton';
 import VirtualKeyboard from '../../../libs/VirtualKeyboard';
+import canUseTouchScreen from '../../../libs/canUseTouchscreen';
 
 const propTypes = {
     /** Beta features list */
@@ -565,11 +566,13 @@ class ReportActionCompose extends React.Component {
                             </>
                         )}
                     </AttachmentModal>
-                    <EmojiPickerButton
-                        isDisabled={isBlockedFromConcierge || isArchivedChatRoom}
-                        onModalHide={() => this.focus(true)}
-                        onEmojiSelected={this.addEmojiToTextBox}
-                    />
+                    {canUseTouchScreen() && !this.props.isSmallScreenWidth ? null : (
+                        <EmojiPickerButton
+                            isDisabled={isBlockedFromConcierge || isArchivedChatRoom}
+                            onModalHide={() => this.focus(true)}
+                            onEmojiSelected={this.addEmojiToTextBox}
+                        />
+                    )}
                     <View style={[styles.justifyContentEnd]}>
                         <Tooltip text={this.props.translate('common.send')}>
                             <TouchableOpacity


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Removed the emoji picker menu option from tablets.

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/7585

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Open app on Tablet
2. Navigate to any chat
3. Verify no emoji picker option is there on tablet (when the LHN is visible)
- [x] Verify that no errors appear in the JS console

### Tested On

- [x] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
<img width="1440" alt="Screenshot 2022-02-22 at 1 10 18 AM" src="https://user-images.githubusercontent.com/83179295/155018602-edafa6bb-6a38-448e-9b61-f978e49ea60a.png">

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
<img width="855" alt="Screenshot 2022-02-22 at 12 35 00 AM" src="https://user-images.githubusercontent.com/83179295/155018755-a9564663-6730-4eb6-b883-ac58d5063473.png">

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
<img width="1199" alt="Screenshot 2022-02-22 at 1 08 27 AM" src="https://user-images.githubusercontent.com/83179295/155018610-774d7ccf-8b54-4bda-ba2d-cfd6205d04ec.png">

#### iOS

<img width="855" alt="Screenshot 2022-02-22 at 12 53 11 AM" src="https://user-images.githubusercontent.com/83179295/155018634-bb5f1b4f-a4c1-48f8-b180-32548d877221.png">


#### Android
<!-- Insert screenshots of your changes on the Android platform-->
<img width="1143" alt="Screenshot 2022-02-22 at 12 28 33 AM" src="https://user-images.githubusercontent.com/83179295/155018677-c6e7ef7d-ef2c-4e8c-8765-b9ae5283cd40.png">

https://user-images.githubusercontent.com/83179295/155143513-19cc2335-5e4b-4708-9c75-ed1c3da3739e.mov


