### PR TITLE
Deprecate `requiresTwoFactorAuth` property

### DIFF
--- a/src/libs/actions/Session/index.js
+++ b/src/libs/actions/Session/index.js
@@ -136,7 +136,6 @@ function fetchAccountDetails(login) {
                 });
                 Onyx.merge(ONYXKEYS.ACCOUNT, {
                     accountExists: response.accountExists,
-                    requiresTwoFactorAuth: response.requiresTwoFactorAuth,
                     validated: response.validated,
                     closed: response.isClosed,
                     forgotPassword: false,
@@ -250,6 +249,10 @@ function signIn(password, twoFactorAuthCode) {
             createTemporaryLogin(authToken, email);
         })
         .catch((error) => {
+            if (error.message === 'passwordForm.error.twoFactorAuthenticationEnabled') {
+                Onyx.merge(ONYXKEYS.ACCOUNT, {requiresTwoFactorAuth: true, loading: false});
+                return;
+            }
             Onyx.merge(ONYXKEYS.ACCOUNT, {error: Localize.translateLocal(error.message), loading: false});
         });
 }


### PR DESCRIPTION
### Details
Remove usage of the `requiresTwoFactorAuth` property from the response of `GetAccountStatus` request. This will be removed from the API. Related Web PR: https://github.com/Expensify/Web-Expensify/pull/33141

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/Expensify/issues/193728

### Tests
Tested with https://github.com/Expensify/Web-Expensify/pull/33141
Account set up with 2FA
1. Login with email and password
2. After entering the password and clicking signin, verify the 2FA input box is displayed 
3. Enter 2FA code and verify that the user can log in

Account not set up with 2FA
1. Login in with email and password
2. Verify the 2FA input box is not displayed
3. Verify the user can log in normally

### QA Steps
Account set up with 2FA
1. Login with email and password
2. After entering the password and clicking signin, verify the 2FA input box is displayed. Verify that leaving either or both password or 2FA empty results in a validation error.
3. Enter 2FA code and verify that the user can log in

Account not set up with 2FA
1. Login in with email and password
2. Verify the 2FA input box is not displayed
3. Verify the user can log in normally

### Tested On

- [x] Web
- [ ] Mobile Web
- [x] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web

![Screen Shot 2022-02-22 at 6 24 24 PM](https://user-images.githubusercontent.com/12268372/155153161-6ae6ab17-aae3-402d-866d-914d0f4509b8.png)

<!-- #### Mobile Web
Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop

![Screen Shot 2022-02-22 at 6 34 12 PM](https://user-images.githubusercontent.com/12268372/155153599-04485e84-166e-4026-9adf-3965105c6ccd.png)

![Screen Shot 2022-02-22 at 6 44 15 PM](https://user-images.githubusercontent.com/12268372/155155584-b369e25c-115c-4a67-b377-e59faf1db599.png)

![Screen Shot 2022-02-22 at 6 44 28 PM](https://user-images.githubusercontent.com/12268372/155155576-d53db7ab-faa4-466d-bab7-5be6bd7a25ca.png)

<!-- #### iOS
Insert screenshots of your changes on the iOS platform-->

<!-- #### Android
Insert screenshots of your changes on the Android platform-->
