### PR TITLE
[No QA] Show Workspace Chat first instead of opening Global Create

### DIFF
--- a/src/libs/actions/WelcomeActions.js
+++ b/src/libs/actions/WelcomeActions.js
@@ -48,34 +48,34 @@ Onyx.connect({
  * @param {Function} params.toggleCreateMenu
  */
 function show({routes, toggleCreateMenu}) {
-    if (!isFirstTimeNewExpensifyUser) {
-        return;
-    }
+    // NOTE: This setTimeout is required due to a bug in react-navigation where modals do not display properly in a drawerContent
+    // This is a short-term workaround, see this issue for updates on a long-term solution: https://github.com/Expensify/App/issues/5296
+    setTimeout(() => {
+        if (!isFirstTimeNewExpensifyUser) {
+            return;
+        }
 
-    // Set the NVP back to false so we don't automatically run welcome actions again
-    NameValuePair.set(CONST.NVP.IS_FIRST_TIME_NEW_EXPENSIFY_USER, false, ONYXKEYS.NVP_IS_FIRST_TIME_NEW_EXPENSIFY_USER);
+        // Set the NVP back to false so we don't automatically run welcome actions again
+        NameValuePair.set(CONST.NVP.IS_FIRST_TIME_NEW_EXPENSIFY_USER, false, ONYXKEYS.NVP_IS_FIRST_TIME_NEW_EXPENSIFY_USER);
 
-    // We want to display the Workspace chat first since that means a user is already in a Workspace and doesn't need to create another one
-    const workspaceChatReport = _.find(allReports, report => ReportUtils.isPolicyExpenseChat(report));
-    if (workspaceChatReport) {
-        Navigation.navigate(ROUTES.getReportRoute(workspaceChatReport.reportID));
-        return;
-    }
+        // We want to display the Workspace chat first since that means a user is already in a Workspace and doesn't need to create another one
+        const workspaceChatReport = _.find(allReports, report => ReportUtils.isPolicyExpenseChat(report));
+        if (workspaceChatReport) {
+            Navigation.navigate(ROUTES.getReportRoute(workspaceChatReport.reportID));
+            return;
+        }
 
-    // If we are rendering the SidebarScreen at the same time as a workspace route that means we've already created a workspace via workspace/new and should not open the global
-    // create menu right now.
-    const topRouteName = lodashGet(_.last(routes), 'name', '');
-    const isDisplayingWorkspaceRoute = topRouteName.toLowerCase().includes('workspace');
+        // If we are rendering the SidebarScreen at the same time as a workspace route that means we've already created a workspace via workspace/new and should not open the global
+        // create menu right now.
+        const topRouteName = lodashGet(_.last(routes), 'name', '');
+        const isDisplayingWorkspaceRoute = topRouteName.toLowerCase().includes('workspace');
 
-    // It's also possible that we already have a workspace policy. In either case we will not toggle the menu but do still want to set the NVP in this case
-    // since the user does not need to create a workspace.
-    if (!Policy.isAdminOfFreePolicy(allPolicies) && !isDisplayingWorkspaceRoute) {
-        // NOTE: This setTimeout is required due to a bug in react-navigation where modals do not display properly in a drawerContent
-        // This is a short-term workaround, see this issue for updates on a long-term solution: https://github.com/Expensify/App/issues/5296
-        setTimeout(() => {
+        // It's also possible that we already have a workspace policy. In either case we will not toggle the menu but do still want to set the NVP in this case
+        // since the user does not need to create a workspace.
+        if (!Policy.isAdminOfFreePolicy(allPolicies) && !isDisplayingWorkspaceRoute) {
             toggleCreateMenu();
-        }, 1500);
-    }
+        }
+    }, 1500);
 }
 
 export {

--- a/src/libs/actions/WelcomeActions.js
+++ b/src/libs/actions/WelcomeActions.js
@@ -1,0 +1,71 @@
+import Onyx from 'react-native-onyx';
+import _ from 'underscore';
+import Navigation from '../Navigation/Navigation';
+import * as ReportUtils from '../reportUtils';
+import ROUTES from '../../ROUTES';
+import * as Policy from './Policy';
+import ONYXKEYS from '../../ONYXKEYS';
+import NameValuePair from './NameValuePair';
+import CONST from '../../CONST';
+
+let isFirstTimeNewExpensifyUser = false;
+Onyx.connect({
+    key: ONYXKEYS.NVP_IS_FIRST_TIME_NEW_EXPENSIFY_USER,
+    callback: val => isFirstTimeNewExpensifyUser = val,
+});
+
+const allReports = {};
+Onyx.connect({
+    key: ONYXKEYS.COLLECTION.REPORT,
+    callback: (val, key) => {
+        if (!val || !key) {
+            return;
+        }
+
+        allReports[key] = {...allReports[key], ...val};
+    },
+});
+
+const allPolicies = {};
+Onyx.connect({
+    key: ONYXKEYS.COLLECTION.REPORT,
+    callback: (val, key) => {
+        if (!val || !key) {
+            return;
+        }
+
+        allPolicies[key] = {...allPolicies[key], ...val};
+    },
+});
+
+function show({isDisplayingWorkspaceRoute, toggleCreateMenu}) {
+    if (!isFirstTimeNewExpensifyUser) {
+        return;
+    }
+
+    // Set the NVP back to false so we don't automatically run welcome actions again
+    NameValuePair.set(CONST.NVP.IS_FIRST_TIME_NEW_EXPENSIFY_USER, false, ONYXKEYS.NVP_IS_FIRST_TIME_NEW_EXPENSIFY_USER);
+
+    // If the user is a member of workspace chat we want to display that chat instead of toggling the global create menu
+    const workspaceChatReport = _.find(allReports, report => ReportUtils.isPolicyExpenseChat(report));
+    if (workspaceChatReport) {
+        Navigation.navigate(ROUTES.getReportRoute(workspaceChatReport.reportID));
+        return;
+    }
+
+    // If we are rendering the SidebarScreen at the same time as a workspace route that means we've already created a workspace via workspace/new and should not open the global
+    // create menu right now. It's also possible that we already have a workspace policy. In either case we will not toggle the menu but do still want to set the NVP in this case
+    // since the user does not need to create a workspace.
+    if (!Policy.isAdminOfFreePolicy(allPolicies) && !isDisplayingWorkspaceRoute) {
+        // NOTE: This setTimeout is required due to a bug in react-navigation where modals do not display properly in a drawerContent
+        // This is a short-term workaround, see this issue for updates on a long-term solution: https://github.com/Expensify/App/issues/5296
+        setTimeout(() => {
+            toggleCreateMenu();
+        }, 1500);
+    }
+}
+
+export {
+    // eslint-disable-next-line import/prefer-default-export
+    show,
+};

--- a/src/libs/actions/WelcomeActions.js
+++ b/src/libs/actions/WelcomeActions.js
@@ -40,7 +40,15 @@ Onyx.connect({
     },
 });
 
+/**
+ * Shows a welcome action on first login
+ *
+ * @param {Object} params
+ * @param {Object} params.routes
+ * @param {Function} params.toggleCreateMenu
+ */
 function show({routes, toggleCreateMenu}) {
+    console.log(isFirstTimeNewExpensifyUser)
     if (!isFirstTimeNewExpensifyUser) {
         return;
     }
@@ -48,7 +56,7 @@ function show({routes, toggleCreateMenu}) {
     // Set the NVP back to false so we don't automatically run welcome actions again
     NameValuePair.set(CONST.NVP.IS_FIRST_TIME_NEW_EXPENSIFY_USER, false, ONYXKEYS.NVP_IS_FIRST_TIME_NEW_EXPENSIFY_USER);
 
-    // If the user is a member of workspace chat we want to display that chat instead of toggling the global create menu
+    // We want to display the Workspace chat first since that means a user is already in a Workspace and doesn't need to create another one
     const workspaceChatReport = _.find(allReports, report => ReportUtils.isPolicyExpenseChat(report));
     if (workspaceChatReport) {
         Navigation.navigate(ROUTES.getReportRoute(workspaceChatReport.reportID));
@@ -56,11 +64,12 @@ function show({routes, toggleCreateMenu}) {
     }
 
     // If we are rendering the SidebarScreen at the same time as a workspace route that means we've already created a workspace via workspace/new and should not open the global
-    // create menu right now. It's also possible that we already have a workspace policy. In either case we will not toggle the menu but do still want to set the NVP in this case
-    // since the user does not need to create a workspace.
+    // create menu right now.
     const topRouteName = lodashGet(_.last(routes), 'name', '');
     const isDisplayingWorkspaceRoute = topRouteName.toLowerCase().includes('workspace');
 
+    // It's also possible that we already have a workspace policy. In either case we will not toggle the menu but do still want to set the NVP in this case
+    // since the user does not need to create a workspace.
     if (!Policy.isAdminOfFreePolicy(allPolicies) && !isDisplayingWorkspaceRoute) {
         // NOTE: This setTimeout is required due to a bug in react-navigation where modals do not display properly in a drawerContent
         // This is a short-term workaround, see this issue for updates on a long-term solution: https://github.com/Expensify/App/issues/5296

--- a/src/libs/actions/WelcomeActions.js
+++ b/src/libs/actions/WelcomeActions.js
@@ -1,5 +1,6 @@
 import Onyx from 'react-native-onyx';
 import _ from 'underscore';
+import lodashGet from 'lodash/get';
 import Navigation from '../Navigation/Navigation';
 import * as ReportUtils from '../reportUtils';
 import ROUTES from '../../ROUTES';
@@ -8,6 +9,7 @@ import ONYXKEYS from '../../ONYXKEYS';
 import NameValuePair from './NameValuePair';
 import CONST from '../../CONST';
 
+/* Flag for new users used to show welcome actions on first load */
 let isFirstTimeNewExpensifyUser = false;
 Onyx.connect({
     key: ONYXKEYS.NVP_IS_FIRST_TIME_NEW_EXPENSIFY_USER,
@@ -38,7 +40,7 @@ Onyx.connect({
     },
 });
 
-function show({isDisplayingWorkspaceRoute, toggleCreateMenu}) {
+function show({routes, toggleCreateMenu}) {
     if (!isFirstTimeNewExpensifyUser) {
         return;
     }
@@ -56,6 +58,9 @@ function show({isDisplayingWorkspaceRoute, toggleCreateMenu}) {
     // If we are rendering the SidebarScreen at the same time as a workspace route that means we've already created a workspace via workspace/new and should not open the global
     // create menu right now. It's also possible that we already have a workspace policy. In either case we will not toggle the menu but do still want to set the NVP in this case
     // since the user does not need to create a workspace.
+    const topRouteName = lodashGet(_.last(routes), 'name', '');
+    const isDisplayingWorkspaceRoute = topRouteName.toLowerCase().includes('workspace');
+
     if (!Policy.isAdminOfFreePolicy(allPolicies) && !isDisplayingWorkspaceRoute) {
         // NOTE: This setTimeout is required due to a bug in react-navigation where modals do not display properly in a drawerContent
         // This is a short-term workaround, see this issue for updates on a long-term solution: https://github.com/Expensify/App/issues/5296

--- a/src/libs/actions/WelcomeActions.js
+++ b/src/libs/actions/WelcomeActions.js
@@ -48,7 +48,6 @@ Onyx.connect({
  * @param {Function} params.toggleCreateMenu
  */
 function show({routes, toggleCreateMenu}) {
-    console.log(isFirstTimeNewExpensifyUser)
     if (!isFirstTimeNewExpensifyUser) {
         return;
     }

--- a/src/pages/home/HeaderView.js
+++ b/src/pages/home/HeaderView.js
@@ -113,7 +113,7 @@ const HeaderView = (props) => {
                         </Pressable>
                     </Tooltip>
                 )}
-                {props.report && props.report.reportName && (
+                {Boolean(props.report && props.report.reportName) && (
                     <View
                         style={[
                             styles.flex1,

--- a/src/pages/home/sidebar/SidebarScreen.js
+++ b/src/pages/home/sidebar/SidebarScreen.js
@@ -1,4 +1,3 @@
-import _ from 'underscore';
 import lodashGet from 'lodash/get';
 import React, {Component} from 'react';
 import {View} from 'react-native';
@@ -22,15 +21,11 @@ import Permissions from '../../../libs/Permissions';
 import ONYXKEYS from '../../../ONYXKEYS';
 import * as Policy from '../../../libs/actions/Policy';
 import Performance from '../../../libs/Performance';
-import NameValuePair from '../../../libs/actions/NameValuePair';
-import * as ReportUtils from '../../../libs/reportUtils';
+import * as WelcomeAction from '../../../libs/actions/WelcomeActions';
 
 const propTypes = {
     /* Beta features list */
     betas: PropTypes.arrayOf(PropTypes.string).isRequired,
-
-    /* Flag for new users used to open the Global Create menu on first load */
-    isFirstTimeNewExpensifyUser: PropTypes.bool,
 
     /* Is workspace is being created by the user? */
     isCreatingWorkspace: PropTypes.bool,
@@ -40,7 +35,6 @@ const propTypes = {
     ...withLocalizePropTypes,
 };
 const defaultProps = {
-    isFirstTimeNewExpensifyUser: false,
     isCreatingWorkspace: false,
 };
 
@@ -62,35 +56,8 @@ class SidebarScreen extends Component {
         Performance.markStart(CONST.TIMING.SIDEBAR_LOADED);
         Timing.start(CONST.TIMING.SIDEBAR_LOADED, true);
 
-        // NOTE: This setTimeout is required due to a bug in react-navigation where modals do not display properly in a drawerContent
-        // This is a short-term workaround, see this issue for updates on a long-term solution: https://github.com/Expensify/App/issues/5296
-        setTimeout(() => {
-            if (!this.props.isFirstTimeNewExpensifyUser) {
-                return;
-            }
-
-            // We want to show the Workspace chat if the user is a member of one or open the global create menu instead
-            const workspaceChatReport = _.find(this.props.allReports, report => ReportUtils.isPolicyExpenseChat(report));
-            if (workspaceChatReport) {
-                Navigation.navigate(ROUTES.getReportRoute(workspaceChatReport.reportID));
-            } else {
-                // If we are rendering the SidebarScreen at the same time as a workspace route that means we've already created a workspace via workspace/new and should not open the global
-                // create menu right now.
-                const routes = lodashGet(this.props.navigation.getState(), 'routes', []);
-                const topRouteName = lodashGet(_.last(routes), 'name', '');
-                const isDisplayingWorkspaceRoute = topRouteName.toLowerCase().includes('workspace');
-
-                // It's also possible that we already have a workspace policy. In either case we will not toggle the menu but do still want to set the NVP in this case since the user does
-                // not need to create a workspace.
-                if (!Policy.isAdminOfFreePolicy(this.props.allPolicies) && !isDisplayingWorkspaceRoute) {
-                    this.toggleCreateMenu();
-                }
-            }
-
-            // Set the NVP back to false so we don't automatically run welcome actions again
-            // Note: this may need to be moved if this NVP is used for anything else later
-            NameValuePair.set(CONST.NVP.IS_FIRST_TIME_NEW_EXPENSIFY_USER, false, ONYXKEYS.NVP_IS_FIRST_TIME_NEW_EXPENSIFY_USER);
-        }, 1500);
+        const routes = lodashGet(this.props.navigation.getState(), 'routes', []);
+        WelcomeAction.show({routes, toggleCreateMenu: this.toggleCreateMenu});
     }
 
     /**
@@ -225,14 +192,8 @@ export default compose(
         allPolicies: {
             key: ONYXKEYS.COLLECTION.POLICY,
         },
-        allReports: {
-            key: ONYXKEYS.COLLECTION.REPORT,
-        },
         betas: {
             key: ONYXKEYS.BETAS,
-        },
-        isFirstTimeNewExpensifyUser: {
-            key: ONYXKEYS.NVP_IS_FIRST_TIME_NEW_EXPENSIFY_USER,
         },
         isCreatingWorkspace: {
             key: ONYXKEYS.IS_CREATING_WORKSPACE,

--- a/src/pages/home/sidebar/SidebarScreen.js
+++ b/src/pages/home/sidebar/SidebarScreen.js
@@ -69,25 +69,25 @@ class SidebarScreen extends Component {
                 return;
             }
 
+            // We want to show the Workspace chat if the user is a member of one or open the global create menu instead
             const report = _.find(this.props.allReports, report => ReportUtils.isPolicyExpenseChat(report));
             if (report) {
                 Navigation.navigate(ROUTES.getReportRoute(report.reportID));
-                return;
+            } else {
+                // If we are rendering the SidebarScreen at the same time as a workspace route that means we've already created a workspace via workspace/new and should not open the global
+                // create menu right now.
+                const routes = lodashGet(this.props.navigation.getState(), 'routes', []);
+                const topRouteName = lodashGet(_.last(routes), 'name', '');
+                const isDisplayingWorkspaceRoute = topRouteName.toLowerCase().includes('workspace');
+    
+                // It's also possible that we already have a workspace policy. In either case we will not toggle the menu but do still want to set the NVP in this case since the user does
+                // not need to create a workspace.
+                if (!Policy.isAdminOfFreePolicy(this.props.allPolicies) && !isDisplayingWorkspaceRoute) {
+                    this.toggleCreateMenu();
+                }
             }
 
-            // If we are rendering the SidebarScreen at the same time as a workspace route that means we've already created a workspace via workspace/new and should not open the global
-            // create menu right now.
-            const routes = lodashGet(this.props.navigation.getState(), 'routes', []);
-            const topRouteName = lodashGet(_.last(routes), 'name', '');
-            const isDisplayingWorkspaceRoute = topRouteName.toLowerCase().includes('workspace');
-
-            // It's also possible that we already have a workspace policy. In either case we will not toggle the menu but do still want to set the NVP in this case since the user does
-            // not need to create a workspace.
-            if (!Policy.isAdminOfFreePolicy(this.props.allPolicies) && !isDisplayingWorkspaceRoute) {
-                this.toggleCreateMenu();
-            }
-
-            // Set the NVP back to false so we don't automatically open the menu again
+            // Set the NVP back to false so we don't automatically run welcome actions again
             // Note: this may need to be moved if this NVP is used for anything else later
             NameValuePair.set(CONST.NVP.IS_FIRST_TIME_NEW_EXPENSIFY_USER, false, ONYXKEYS.NVP_IS_FIRST_TIME_NEW_EXPENSIFY_USER);
         }, 1500);

--- a/src/pages/home/sidebar/SidebarScreen.js
+++ b/src/pages/home/sidebar/SidebarScreen.js
@@ -70,16 +70,16 @@ class SidebarScreen extends Component {
             }
 
             // We want to show the Workspace chat if the user is a member of one or open the global create menu instead
-            const report = _.find(this.props.allReports, report => ReportUtils.isPolicyExpenseChat(report));
-            if (report) {
-                Navigation.navigate(ROUTES.getReportRoute(report.reportID));
+            const workspaceChatReport = _.find(this.props.allReports, report => ReportUtils.isPolicyExpenseChat(report));
+            if (workspaceChatReport) {
+                Navigation.navigate(ROUTES.getReportRoute(workspaceChatReport.reportID));
             } else {
                 // If we are rendering the SidebarScreen at the same time as a workspace route that means we've already created a workspace via workspace/new and should not open the global
                 // create menu right now.
                 const routes = lodashGet(this.props.navigation.getState(), 'routes', []);
                 const topRouteName = lodashGet(_.last(routes), 'name', '');
                 const isDisplayingWorkspaceRoute = topRouteName.toLowerCase().includes('workspace');
-    
+
                 // It's also possible that we already have a workspace policy. In either case we will not toggle the menu but do still want to set the NVP in this case since the user does
                 // not need to create a workspace.
                 if (!Policy.isAdminOfFreePolicy(this.props.allPolicies) && !isDisplayingWorkspaceRoute) {

--- a/src/pages/home/sidebar/SidebarScreen.js
+++ b/src/pages/home/sidebar/SidebarScreen.js
@@ -23,6 +23,7 @@ import ONYXKEYS from '../../../ONYXKEYS';
 import * as Policy from '../../../libs/actions/Policy';
 import Performance from '../../../libs/Performance';
 import NameValuePair from '../../../libs/actions/NameValuePair';
+import * as ReportUtils from '../../../libs/reportUtils';
 
 const propTypes = {
     /* Beta features list */
@@ -65,6 +66,12 @@ class SidebarScreen extends Component {
         // This is a short-term workaround, see this issue for updates on a long-term solution: https://github.com/Expensify/App/issues/5296
         setTimeout(() => {
             if (!this.props.isFirstTimeNewExpensifyUser) {
+                return;
+            }
+
+            const report = _.find(this.props.allReports, report => ReportUtils.isPolicyExpenseChat(report));
+            if (report) {
+                Navigation.navigate(ROUTES.getReportRoute(report.reportID));
                 return;
             }
 
@@ -217,6 +224,9 @@ export default compose(
     withOnyx({
         allPolicies: {
             key: ONYXKEYS.COLLECTION.POLICY,
+        },
+        allReports: {
+            key: ONYXKEYS.COLLECTION.REPORT,
         },
         betas: {
             key: ONYXKEYS.BETAS,


### PR DESCRIPTION
### Details
Updates the welcome actions to show the Workspace chat first instead of opening the global create.

cc @TomatoToaster 

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/195473

### Tests
1. Get the `accountID` and `reportID` for an existing account and chat.
2. Update the `chatType` of that chat to `policyExpenseChat` by running the following query: `UPDATE reportNameValuePairs SET value = 'policyExpenseChat' WHERE name = 'chatType' AND reportID = <reportID>;`
3. Update the `isFirstTimeNewExpensifyUser` for that user to true by running the following query `UPDATE nameValuePairs SET value = true WHERE name = 'isFirstTimeNewExpensifyUser' AND accountID = <accountID>;`
4. Clear browser data
5. Log into that account and notice that the chat switches to the `reportID` chat.
6. Create a new account by running `./script/clitools.sh generator:account`
7. Login and notice that the global create menu opens.

- [X] Verify that no errors appear in the JS console

### QA Steps
None, as Workspace chats are not available yet.

- [ ] Verify that no errors appear in the JS console

### Tested On

- [X] Web
- [x] Mobile Web
- [x] Desktop
- [x] iOS
- [x] Android

### Screenshots

#### Web

https://user-images.githubusercontent.com/22219519/155311082-a232b022-ccf2-461c-a76b-b56b7ae34b70.mov

#### Mobile Web

https://user-images.githubusercontent.com/22219519/155311114-e2d54dca-45a6-4ccf-bbaa-bddfbff95c40.mov

#### Desktop

https://user-images.githubusercontent.com/22219519/155311129-7550fd5c-9cf4-47ef-ba84-f1742a700d85.mov

#### iOS

https://user-images.githubusercontent.com/22219519/155311165-8202bf6c-ba0a-4c1e-87b4-7adbdee650a6.mov

#### Android

https://user-images.githubusercontent.com/22219519/155311187-d8edfb74-cf14-4f17-bd28-12e39048da62.mov
