### PR TITLE
Fix autofill for full name input row

### DIFF
--- a/src/components/FullNameInputRow.js
+++ b/src/components/FullNameInputRow.js
@@ -48,7 +48,7 @@ const FullNameInputRow = (props) => {
             <View style={styles.flex1}>
                 <TextInput
                     label={props.translate('common.firstName')}
-                    name='fname'
+                    name="fname"
                     value={props.firstName}
                     errorText={props.firstNameError}
                     onChangeText={props.onChangeFirstName}
@@ -58,7 +58,7 @@ const FullNameInputRow = (props) => {
             <View style={[styles.flex1, styles.ml2]}>
                 <TextInput
                     label={props.translate('common.lastName')}
-                    name='lname'
+                    name="lname"
                     value={props.lastName}
                     errorText={props.lastNameError}
                     onChangeText={props.onChangeLastName}

--- a/src/components/FullNameInputRow.js
+++ b/src/components/FullNameInputRow.js
@@ -47,7 +47,6 @@ const FullNameInputRow = (props) => {
         <View style={[styles.flexRow, ...additionalStyles]}>
             <View style={styles.flex1}>
                 <TextInput
-                    autoComplete='given-name'
                     label={props.translate('common.firstName')}
                     name='fname'
                     value={props.firstName}
@@ -58,7 +57,6 @@ const FullNameInputRow = (props) => {
             </View>
             <View style={[styles.flex1, styles.ml2]}>
                 <TextInput
-                    autoComplete='family-name'
                     label={props.translate('common.lastName')}
                     name='lname'
                     value={props.lastName}

--- a/src/components/FullNameInputRow.js
+++ b/src/components/FullNameInputRow.js
@@ -47,7 +47,9 @@ const FullNameInputRow = (props) => {
         <View style={[styles.flexRow, ...additionalStyles]}>
             <View style={styles.flex1}>
                 <TextInput
+                    autoComplete='given-name'
                     label={props.translate('common.firstName')}
+                    name='fname'
                     value={props.firstName}
                     errorText={props.firstNameError}
                     onChangeText={props.onChangeFirstName}
@@ -56,7 +58,9 @@ const FullNameInputRow = (props) => {
             </View>
             <View style={[styles.flex1, styles.ml2]}>
                 <TextInput
+                    autoComplete='family-name'
                     label={props.translate('common.lastName')}
+                    name='lname'
                     value={props.lastName}
                     errorText={props.lastNameError}
                     onChangeText={props.onChangeLastName}

--- a/src/pages/RequestCallPage.js
+++ b/src/pages/RequestCallPage.js
@@ -318,7 +318,6 @@ class RequestCallPage extends Component {
                                 style={[styles.mv4]}
                             />
                             <TextInput
-                                autoComplete='tel'
                                 label={this.props.translate('common.phoneNumber')}
                                 name='phone'
                                 autoCorrect={false}

--- a/src/pages/RequestCallPage.js
+++ b/src/pages/RequestCallPage.js
@@ -319,7 +319,7 @@ class RequestCallPage extends Component {
                             />
                             <TextInput
                                 label={this.props.translate('common.phoneNumber')}
-                                name='phone'
+                                name="phone"
                                 autoCorrect={false}
                                 value={this.state.phoneNumber}
                                 placeholder="2109400803"

--- a/src/pages/RequestCallPage.js
+++ b/src/pages/RequestCallPage.js
@@ -318,8 +318,9 @@ class RequestCallPage extends Component {
                                 style={[styles.mv4]}
                             />
                             <TextInput
+                                autoComplete='tel'
                                 label={this.props.translate('common.phoneNumber')}
-                                autoCompleteType="off"
+                                name='phone'
                                 autoCorrect={false}
                                 value={this.state.phoneNumber}
                                 placeholder="2109400803"


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
cc @luacmartins 
### Details
<!-- Explanation of the change or anything fishy that is going on -->
Fix autofill for first and last name on the profile page and the request a call modal. For some reason first and last name fill separately on the profile page and they fill simultaneously on the request a call modal. I'm not sure why that is, but I think any autofill is better than none.
### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/7529

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
First set up autofill:
 - For Chrome go to chrome://settings/addresses
 - For Mobile Web Safari go to Settings > Safari > Autofill and turn on 'Use Contact Info'

1. Add an address and enter a first and last name in the name field. Add a phone number including a country code (e.g, +1-945-881-9540).

Then test autofill on the profile page and the request a call modal.

1. Create a new account on new expensify.
2. Go to Settings > Profile.
3. Click into the first name field.
4. Make sure you see an autofill prompt like so:
<img width="200" alt="image" src="https://user-images.githubusercontent.com/26260477/155414520-63f159b6-98bb-4620-923e-9057eac3ffaf.png">

5. Click the autofill prompt and verify that the first name is entered.
6. Click into the last name field
7. Click the autofill prompt and verify that the last name is entered.
8. Click save and make sure it is successful.
9. Create a chat with concierge.
10. Click the call button in the upper right.
11. Click into the first name field and make sure you see an autofill prompt.
12. Click the autofill prompt and verify that the first name, last name, and phone number are entered.
13. Click 'Request a Call' and make sure that it is successful.

- [ ] Verify that no errors appear in the JS console

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Same as the test steps above.
- [ ] Verify that no errors appear in the JS console

### Tested On

- [x] Web
- [x] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

https://user-images.githubusercontent.com/26260477/155400538-6b9404c1-4e97-4f57-8b2e-23beacb0c1d2.mov


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

https://user-images.githubusercontent.com/26260477/155401074-ec51fa75-aca3-4778-b15a-cb6f0ee73107.mp4


#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
<img width="1312" alt="image" src="https://user-images.githubusercontent.com/26260477/155401471-bc8a16f1-4ba5-4b89-ac37-db155196ef3b.png">

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
<img width="200" alt="image" src="https://user-images.githubusercontent.com/26260477/155402450-cca24e35-dc8d-499f-80eb-5e80d41e424e.png">

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
<img width="200" alt="image" src="https://user-images.githubusercontent.com/26260477/155410447-9c29617d-8d00-4224-97c9-0f83547cfbc6.png">

