### PR TITLE
[Experiment] NetworkResponseManager

### DIFF
--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -12,6 +12,7 @@ import Log from './Log';
 import * as Network from './Network';
 import updateSessionAuthTokens from './actions/Session/updateSessionAuthTokens';
 import setSessionLoadingAndError from './actions/Session/setSessionLoadingAndError';
+import NetworkResponseManager from './NetworkResponseManager';
 
 let isAuthenticating;
 let credentials;
@@ -149,6 +150,8 @@ Network.registerRequestSkippedHandler((parameters) => {
 });
 
 Network.registerResponseHandler((queuedRequest, response) => {
+    NetworkResponseManager.publish(queuedRequest.command, {request: queuedRequest, response});
+
     if (queuedRequest.command !== 'Log') {
         Log.info('Finished API request', false, {
             command: queuedRequest.command,
@@ -597,7 +600,7 @@ function PersonalDetails_Update(parameters) {
     const commandName = 'PersonalDetails_Update';
     requireParameters(['details'],
         parameters, commandName);
-    return Network.post(commandName, parameters);
+    return Network.post(commandName, {...parameters, persist: true});
 }
 
 /**

--- a/src/libs/NetworkResponseManager.js
+++ b/src/libs/NetworkResponseManager.js
@@ -1,7 +1,7 @@
 import _ from 'underscore';
 
 function handleDefaultError(jsonCode, response) {
-
+    // @TODO do some default handling
 }
 
 const NetworkResponseManager = {

--- a/src/libs/NetworkResponseManager.js
+++ b/src/libs/NetworkResponseManager.js
@@ -2,25 +2,58 @@ import _ from 'underscore';
 
 const NetworkResponseManager = {
     commandHandlers: {},
-    subscribe(commandName, callback) {
+    subscribe(commandName) {
+        const connection = {
+            onSuccess: () => {},
+            onHandle: () => {},
+        };
+
         this.commandHandlers[commandName] = this.commandHandlers[commandName] || [];
-        this.commandHandlers[commandName].push(callback);
-        return () => {
+        this.commandHandlers[commandName].push(connection);
+
+        connection.done = (successCallback) => {
+            connection.onSuccess = successCallback;
+            return connection;
+        };
+
+        connection.handle = (jsonCodes, callback) => {
+            connection.onHandle = [jsonCodes, callback];
+            return connection;
+        };
+
+        connection.cancel = () => {
             for (let i = 0; i < this.commandHandlers[commandName].length; i++) {
-                if (this.commandHandlers[commandName][i] === callback) {
+                if (this.commandHandlers[commandName][i] === connection) {
                     this.commandHandlers[commandName].splice(i, 1);
                     break;
                 }
             }
         };
+
+        return connection;
     },
-    publish(commandName, response) {
+    publish(commandName, payload) {
         if (!this.commandHandlers[commandName]) {
             return;
         }
 
-        _.each(this.commandHandlers[commandName], (callback) => {
-            callback(response);
+        const {response} = payload;
+        _.each(this.commandHandlers[commandName], (connection) => {
+            if (response.jsonCode === 200 && connection.onSuccess) {
+                connection.onSuccess(payload);
+                return;
+            }
+
+            if (!connection.onHandle) {
+                return;
+            }
+
+            const [jsonCodes, callback] = connection.onHandle;
+            if (!_.contains(jsonCodes, response.jsonCode)) {
+                return;
+            }
+
+            callback(response.jsonCode, payload);
         });
     },
 };

--- a/src/libs/NetworkResponseManager.js
+++ b/src/libs/NetworkResponseManager.js
@@ -1,0 +1,28 @@
+import _ from 'underscore';
+
+const NetworkResponseManager = {
+    commandHandlers: {},
+    subscribe(commandName, callback) {
+        this.commandHandlers[commandName] = this.commandHandlers[commandName] || [];
+        this.commandHandlers[commandName].push(callback);
+        return () => {
+            for (let i = 0; i < this.commandHandlers[commandName].length; i++) {
+                if (this.commandHandlers[commandName][i] === callback) {
+                    this.commandHandlers[commandName].splice(i, 1);
+                    break;
+                }
+            }
+        };
+    },
+    publish(commandName, response) {
+        if (!this.commandHandlers[commandName]) {
+            return;
+        }
+
+        _.each(this.commandHandlers[commandName], (callback) => {
+            callback(response);
+        });
+    },
+};
+
+export default NetworkResponseManager;

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -334,7 +334,7 @@ function setAvatar(file) {
 function deleteAvatar(defaultAvatarURL) {
     // We don't want to save the default avatar URL in the backend since we don't want to allow
     // users the option of removing the default avatar, instead we'll save an empty string
-    API.PersonalDetails_Update({isDeletingAvatar: true, details: JSON.stringify({avatar: ''})});
+    API.PersonalDetails_Update({details: JSON.stringify({avatar: ''})});
     mergeLocalPersonalDetails({avatar: defaultAvatarURL});
 }
 

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -236,16 +236,14 @@ function mergeLocalPersonalDetails(details) {
  * Sets the personal details object for the current user
  *
  * @param {Object} details
+ * @param {Boolean} shouldGrowl
  */
-function setPersonalDetails(details) {
-    API.PersonalDetails_Update({details: JSON.stringify(details)});
+function setPersonalDetails(details, shouldGrowl) {
+    API.PersonalDetails_Update({details: JSON.stringify(details), shouldGrowl});
 }
 
 NetworkResponseManager.subscribe('PersonalDetails_Update', ({request, response}) => {
-    const {data: {details, isDeletingAvatar}} = request;
-    if (isDeletingAvatar) {
-        return;
-    }
+    const {data: {details, shouldGrowl}} = request;
 
     const parsedDetails = JSON.parse(details);
     if (response.jsonCode === 200) {
@@ -253,6 +251,10 @@ NetworkResponseManager.subscribe('PersonalDetails_Update', ({request, response})
             NameValuePair.set(CONST.NVP.TIMEZONE, parsedDetails.timezone);
         }
         mergeLocalPersonalDetails(parsedDetails);
+
+        if (shouldGrowl) {
+            Growl.show(Localize.translateLocal('profilePage.growlMessageOnSave'), CONST.GROWL.SUCCESS, 3000);
+        }
     } else if (response.jsonCode === 400) {
         Growl.error(Localize.translateLocal('personalDetails.error.firstNameLength'), 3000);
     } else if (response.jsonCode === 401) {

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -242,11 +242,11 @@ function setPersonalDetails(details, shouldGrowl) {
     API.PersonalDetails_Update({details: JSON.stringify(details), shouldGrowl});
 }
 
-NetworkResponseManager.subscribe('PersonalDetails_Update', ({request, response}) => {
-    const {data: {details, shouldGrowl}} = request;
+NetworkResponseManager.subscribe('PersonalDetails_Update')
+    .done(({request}) => {
+        const {data: {details, shouldGrowl}} = request;
+        const parsedDetails = JSON.parse(details);
 
-    const parsedDetails = JSON.parse(details);
-    if (response.jsonCode === 200) {
         if (parsedDetails.timezone) {
             NameValuePair.set(CONST.NVP.TIMEZONE, parsedDetails.timezone);
         }
@@ -255,12 +255,14 @@ NetworkResponseManager.subscribe('PersonalDetails_Update', ({request, response})
         if (shouldGrowl) {
             Growl.show(Localize.translateLocal('profilePage.growlMessageOnSave'), CONST.GROWL.SUCCESS, 3000);
         }
-    } else if (response.jsonCode === 400) {
-        Growl.error(Localize.translateLocal('personalDetails.error.firstNameLength'), 3000);
-    } else if (response.jsonCode === 401) {
-        Growl.error(Localize.translateLocal('personalDetails.error.lastNameLength'), 3000);
-    }
-});
+    })
+    .handle([400, 401], (code) => {
+        if (code === 400) {
+            Growl.error(Localize.translateLocal('personalDetails.error.firstNameLength'), 3000);
+        } else if (code === 401) {
+            Growl.error(Localize.translateLocal('personalDetails.error.lastNameLength'), 3000);
+        }
+    });
 
 /**
  * Sets the onyx with the currency list from the network

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -244,6 +244,10 @@ function setPersonalDetails(details, shouldGrowl) {
 
 NetworkResponseManager.subscribe('PersonalDetails_Update')
     .done(({request}) => {
+        if (request.caller === 'deleteAvatar') {
+            return;
+        }
+
         const {data: {details, shouldGrowl}} = request;
         const parsedDetails = JSON.parse(details);
 
@@ -256,7 +260,11 @@ NetworkResponseManager.subscribe('PersonalDetails_Update')
             Growl.show(Localize.translateLocal('profilePage.growlMessageOnSave'), CONST.GROWL.SUCCESS, 3000);
         }
     })
-    .handle([400, 401], (code) => {
+    .handle([400, 401], (code, {request}) => {
+        if (request.caller === 'deleteAvatar') {
+            return;
+        }
+
         if (code === 400) {
             Growl.error(Localize.translateLocal('personalDetails.error.firstNameLength'), 3000);
         } else if (code === 401) {
@@ -338,7 +346,7 @@ function setAvatar(file) {
 function deleteAvatar(defaultAvatarURL) {
     // We don't want to save the default avatar URL in the backend since we don't want to allow
     // users the option of removing the default avatar, instead we'll save an empty string
-    API.PersonalDetails_Update({details: JSON.stringify({avatar: ''})});
+    API.PersonalDetails_Update({caller: 'deleteAvatar', details: JSON.stringify({avatar: ''})});
     mergeLocalPersonalDetails({avatar: defaultAvatarURL});
 }
 


### PR DESCRIPTION
Related to: https://github.com/Expensify/App/issues/6820

### Details

cc @tgolen @iwiznia just a proof of concept that sets up a few things 

- Allows "registering" a callback for a command
- Borrows the `.done()` and `.handle()` pattern we are used to in Web-Expensify
- Tests it out on `PersonalDetails_Update` and makes that command "persistable"

Couple of interesting takeaways...

1. By decoupling the handling from the call to `API.PersonalDetails_Update()` we lost some context to things that the original caller had e.g. there was a `shouldGrowl` parameter getting passed to `setPersonalDetails()` and that parameter is not available to the subscriber. One solution I came up with was to just pass that to the "request" object so it can be stored there and then returned back in the success handler. In this case, that works fine, but wouldn't work with something like a callback function (but maybe we can just call that an "anti-pattern" if we adopt a similar system to this).

2. I picked `API.PersonalDetails_Update()` because there are two different usages, but only one of them has specific handling. That created an interesting problem because we might run into cases where we want completely different handling depending on the caller. I couldn't think of a clean way to solve that besides passing some kind of key to the request object to tell us that that particular request should have different handling. Not sure if this is really a problem or not, but if we have to do it it seems kind of ugly.