### PR TITLE
Do not reauthenticate Pusher if we failed for any reason other than expired session

### DIFF
--- a/src/libs/actions/Session/index.js
+++ b/src/libs/actions/Session/index.js
@@ -508,6 +508,11 @@ function authenticatePusher(socketID, channelName, callback) {
                 return;
             }
 
+            if (data.jsonCode !== 200) {
+                Log.hmmm('[PusherConnectionManager] Unable to authenticate Pusher for some reason other than expired session');
+                return;
+            }
+
             Log.info(
                 '[PusherConnectionManager] Pusher authenticated successfully',
                 false,


### PR DESCRIPTION
### Details

Users get logged out of NewDot when the site goes down.

This happens because we treat anything that is not a `407` as a "success" when trying to authenticate Pusher via `Push_Authenticate`. But in reality, what happens is a generic `data` payload gets passed to the custom authorizer callback which emits an "error" event that get's handled in this switch here:

https://github.com/Expensify/App/blob/53a9891cec8734c59d1a15539f29eb74e85006d8/src/libs/PusherConnectionManager.js#L26-L29

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/168965

### Tests
1. Log into NewDot web locally
2. Apply this diff to Web Expensify

```diff
diff --git a/api.php b/api.php
index 301c9891036..52942056db4 100755
--- a/api.php
+++ b/api.php
@@ -92,6 +93,8 @@ try {
         Request::requireCSRFToken();
     }

+    throw new Expensify\Bedrock\Exceptions\BedrockError('derp');
+
     if ($command == '') {
         // Didn't set a command
         echo 'Missing command';
```

3. Do something in NewDot
4. Verify you are **not logged out** and see the log hmmm "Unable to authenticate Pusher for some reason other than expired session"

### QA Steps

QA is not possible for this PR. Simply test "realtime features" for any regressions.

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
