### PR TITLE
[No QA][CP Stg] Export ELECTRON_ENV to electronBuilder.config.js

### DIFF
--- a/scripts/build-desktop.sh
+++ b/scripts/build-desktop.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-ELECTRON_ENV=${1:-development}
+export ELECTRON_ENV=${1:-development}
 
 if [[ "$ELECTRON_ENV" == "staging" ]]; then
   ENV_FILE=".env.staging"


### PR DESCRIPTION
### Details
`npm run desktop-build-staging -- --publish always` (as executed [here](https://github.com/Expensify/App/blob/b09bd2af1212ad4278f3fc1ef0a3cba18e44f692/.github/workflows/platformDeploy.yml#L157)) is deploying the desktop app to production 😬 

More context [here](https://github.com/Expensify/App/issues/7987)

### Fixed Issues
$ https://github.com/Expensify/App/issues/7987

### Tests
No way to test locally. Merge this PR and the desktop app should deploy to the staging S3 bucket.

### QA Steps
None.
