### PR TITLE
Fix reportDetails icons for chatrooms

### DIFF
--- a/src/pages/ReportDetailsPage.js
+++ b/src/pages/ReportDetailsPage.js
@@ -5,7 +5,7 @@ import Str from 'expensify-common/lib/str';
 import _ from 'underscore';
 import {View, ScrollView} from 'react-native';
 import lodashGet from 'lodash/get';
-import Avatar from '../components/Avatar';
+import RoomHeaderAvatars from '../components/RoomHeaderAvatars';
 import compose from '../libs/compose';
 import withLocalize, {withLocalizePropTypes} from '../components/withLocalize';
 import ONYXKEYS from '../ONYXKEYS';
@@ -131,11 +131,12 @@ class ReportDetailsPage extends Component {
                         <View
                             style={styles.reportDetailsTitleContainer}
                         >
-                            <Avatar
-                                containerStyles={[styles.singleAvatarLarge, styles.mb4]}
-                                imageStyles={[styles.singleAvatarLarge]}
-                                source={_.first(OptionsListUtils.getAvatarSources(this.props.report))}
-                            />
+                            <View style={styles.mb4} >
+                                <RoomHeaderAvatars
+                                    avatarIcons={OptionsListUtils.getAvatarSources(this.props.report)}
+                                    shouldShowLargeAvatars={isPolicyExpenseChat}
+                                />
+                            </View>
                             <View style={[styles.reportDetailsRoomInfo, styles.mw100]}>
                                 <View style={[styles.alignSelfCenter, styles.w100]}>
                                     <DisplayNames

--- a/src/pages/ReportDetailsPage.js
+++ b/src/pages/ReportDetailsPage.js
@@ -103,6 +103,7 @@ class ReportDetailsPage extends Component {
     }
 
     render() {
+        const isPolicyExpenseChat = ReportUtils.isPolicyExpenseChat(this.props.report);
         const isChatRoom = ReportUtils.isChatRoom(this.props.report);
         const chatRoomSubtitle = ReportUtils.getChatRoomSubtitle(this.props.report, this.props.policies);
         const participants = lodashGet(this.props.report, 'participants', []);
@@ -131,7 +132,7 @@ class ReportDetailsPage extends Component {
                         <View
                             style={styles.reportDetailsTitleContainer}
                         >
-                            <View style={styles.mb4} >
+                            <View style={styles.mb4}>
                                 <RoomHeaderAvatars
                                     avatarIcons={OptionsListUtils.getAvatarSources(this.props.report)}
                                     shouldShowLargeAvatars={isPolicyExpenseChat}

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1503,14 +1503,6 @@ const styles = {
         borderRadius: 18,
     },
 
-    singleAvatarLarge: {
-        height: 64,
-        width: 64,
-        backgroundColor: themeColors.icon,
-        borderRadius: 64,
-        overflow: 'hidden',
-    },
-
     secondAvatar: {
         position: 'absolute',
         right: -18,

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1789,7 +1789,7 @@ const styles = {
         ...flex.flexColumn,
         ...flex.alignItemsCenter,
         ...spacing.mt4,
-        height: 150,
+        height: 170,
     },
 
     reportDetailsRoomInfo: {


### PR DESCRIPTION
@danieldoglas, please review when you have the chance.
CC: @marcochavezf @marcaaron @roryabraham 

### Details
Fixes regression found here: https://github.com/Expensify/App/pull/7852#issuecomment-1058941319

### Fixed Issues
related to PR: https://github.com/Expensify/App/pull/7852

### Tests / QA
1. Open a chatRoom (can be a #announce, #admin, or any policy room) and click on the header to open the report details
2. Verify the avatar looks like this:
<img width="195" alt="image" src="https://user-images.githubusercontent.com/19364431/156801966-b81cf3ad-6631-483d-969d-0a5bbc812a4b.png">


instead of this:
![image](https://user-images.githubusercontent.com/19364431/156800808-48276399-5cfa-48d3-8d63-f229c66d7c34.png)

- [x] Verify that no errors appear in the JS console
