### PR TITLE
remove extra margin below checkbox

### DIFF
--- a/src/pages/EnablePayments/TermsStep.js
+++ b/src/pages/EnablePayments/TermsStep.js
@@ -106,7 +106,7 @@ class TermsStep extends React.Component {
                     )}
                     <Button
                         success
-                        style={[styles.mb4, styles.mt4]}
+                        style={[styles.mv4]}
                         text={this.props.translate('termsStep.enablePayments')}
                         isLoading={this.props.walletTerms.loading}
                         onPress={() => {

--- a/src/pages/EnablePayments/TermsStep.js
+++ b/src/pages/EnablePayments/TermsStep.js
@@ -79,7 +79,6 @@ class TermsStep extends React.Component {
                         )}
                     />
                     <CheckboxWithLabel
-                        style={styles.mb4}
                         isChecked={this.state.hasAcceptedPrivacyPolicyAndWalletAgreement}
                         onPress={this.togglePrivacyPolicy}
                         LabelComponent={() => (
@@ -107,7 +106,7 @@ class TermsStep extends React.Component {
                     )}
                     <Button
                         success
-                        style={styles.mb4}
+                        style={[styles.mb4, styles.mt4]}
                         text={this.props.translate('termsStep.enablePayments')}
                         isLoading={this.props.walletTerms.loading}
                         onPress={() => {

--- a/src/pages/ReimbursementAccount/BankAccountStep.js
+++ b/src/pages/ReimbursementAccount/BankAccountStep.js
@@ -300,7 +300,7 @@ class BankAccountStep extends React.Component {
                             errorText={this.getErrorText('accountNumber')}
                         />
                         <CheckboxWithLabel
-                            style={styles.mt5}
+                            style={styles.mt4}
                             isChecked={this.state.hasAcceptedTerms}
                             onPress={this.toggleTerms}
                             LabelComponent={() => (

--- a/src/pages/ReimbursementAccount/BankAccountStep.js
+++ b/src/pages/ReimbursementAccount/BankAccountStep.js
@@ -300,7 +300,7 @@ class BankAccountStep extends React.Component {
                             errorText={this.getErrorText('accountNumber')}
                         />
                         <CheckboxWithLabel
-                            style={[styles.mb4, styles.mt5]}
+                            style={styles.mt5}
                             isChecked={this.state.hasAcceptedTerms}
                             onPress={this.toggleTerms}
                             LabelComponent={() => (

--- a/src/pages/settings/Payments/AddDebitCardPage.js
+++ b/src/pages/settings/Payments/AddDebitCardPage.js
@@ -304,7 +304,7 @@ class DebitCardPage extends Component {
                                         </TextLink>
                                     </>
                                 )}
-                                style={[styles.mt4, styles.mb4]}
+                                style={styles.mt4}
                                 errorText={this.getErrorText('acceptedTerms')}
                                 hasError={Boolean(this.state.errors.acceptedTerms)}
                             />


### PR DESCRIPTION
### Details
Remove the extra margin below the checkbox in `BankAccountStep`, `AddDebitCardPage` and `TermsStep` page

### Fixed Issues
$ #7838

### Tests
- [x] Verify that no errors appear in the JS console

### PR Review Checklist
<!--
This is a checklist for PR authors & reviewers. Please make sure to complete all tasks and check them off once you do, or else Expensify has the right not to merge your PR!
-->
#### Contributor (PR Author) Checklist
- [x] I verified the PR has a small number of commits behind `main`
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I clearly indicated the environment tests should be run in (Staging vs Production)
- [ ] I wrote testing steps that cover success & fail scenarios (if applicable)
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests & veryfy they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors related to changes in this PR
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I added comments when the code was not self explanatory
    - [ ] I put all copy / text shown in the product in all `src/languages/*` files (if applicable)
    - [ ] I followed proper naming convention for platform-specific files (if applicable)
    - [x] I followed style guidelines (in [`Styling.md`](https://github.com/Expensify/App/blob/main/STYLING.md)) for all style edits I made
    - [x] I followed the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs))
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I corroborated the UI performance was not affected (the performance is the same than `main` branch)
- [ ] If I created a new component I verified that a similar component doesn't exist in the codebase

#### PR Reviewer Checklist
- [ ] I verified the PR has a small number of commits behind `main`
- [ ] I verified the correct issue is linked in the `### Fixed Issues` section above
- [ ] I verified testing steps are clear and they cover the changes made in this PR
    - [ ] I verified the testing environment is mentioned in the test steps
- [ ] I verified testing steps cover success & fail scenarios (if applicable)
- [ ] I checked that screenshots or videos are included for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I verified tests pass on **all platforms** & I tested again on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [ ] I verified there are no console errors related to changes in this PR
- [ ] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified comments were added when the code was not self explanatory
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files (if applicable)
    - [ ] I verified proper naming convention for platform-specific files was followed (if applicable)
    - [ ] I verified [style guidelines](https://github.com/Expensify/App/blob/main/STYLING.md) were followed
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs)) were followed
- [ ] I verified that this PR follows the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [ ] I verified other components are not impacted by changes in this PR (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] I verified the UI performance was not affected (the performance is the same than `main` branch)
- [ ] If a new component is created I verified that a similar component doesn't exist in the codebase

### QA Steps
For `Add a debit card` page:
1. Navigate to Settings > Payments
2. Tap Add a payment method
3. Select Debit card
4. Press `Save` button without checking the terms checkbox
5. Observe the right margin between the checkbox and the error message

For `Connect bank account` page:
1. Navigate to Settings > Workspace > Connect bank account
2. Tap Connect manually
3. Press `Save & continue` button without checking the terms checkbox
4. Observe the right margin between the checkbox and the error message

For `Terms and fees` page:
1. Navigate to `/settings/payments/enable-payments` url
2. Press `Enable payments` button without checking the terms checkboxes
3. Observe the right margin between the checkbox and the error message

- [x] Verify that no errors appear in the JS console

### Screenshots

#### Web
<img width="1430" alt="web" src="https://user-images.githubusercontent.com/13783842/156872685-b041cc73-3940-47a5-a23e-a616fb9729f6.png">


#### Mobile Web
![mWeb](https://user-images.githubusercontent.com/13783842/156872691-34b155f6-144d-4cb7-9ed3-cff35b5f0780.png)


#### Desktop
<img width="1191" alt="desktop" src="https://user-images.githubusercontent.com/13783842/156872694-44ce75df-4c4a-4284-8822-f1519ea0329d.png">


#### iOS
![ios](https://user-images.githubusercontent.com/13783842/156872697-e1d2e91e-b27e-427d-88e5-bce634e05534.png)


#### Android
![android](https://user-images.githubusercontent.com/13783842/156872715-f51317de-ac7c-4294-9264-6baa09be5fbf.png)

