### PR TITLE
Added check for blocking svg file upload and handling error for unsupported file type.

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -364,6 +364,8 @@ const CONST = {
         IMAGE: 'image',
     },
 
+    UNSUPPORTED_FILE_TYPES: ['image/svg+xml'],
+
     ADD_PAYMENT_MENU_POSITION_Y: 226,
     ADD_PAYMENT_MENU_POSITION_X: 356,
     EMOJI_PICKER_SIZE: {

--- a/src/CONST.js
+++ b/src/CONST.js
@@ -365,7 +365,6 @@ const CONST = {
     },
 
     UNSUPPORTED_FILE_TYPES: ['image/svg+xml'],
-
     ADD_PAYMENT_MENU_POSITION_Y: 226,
     ADD_PAYMENT_MENU_POSITION_X: 356,
     EMOJI_PICKER_SIZE: {

--- a/src/components/AttachmentModal.js
+++ b/src/components/AttachmentModal.js
@@ -153,7 +153,7 @@ class AttachmentModal extends PureComponent {
     /**
      * Checks whether file type is acceptable
      * @param {String} type
-     * @returns {boolean}
+     * @returns {Boolean}
      */
     isValidFileType(type) {
         return !_.includes(CONST.UNSUPPORTED_FILE_TYPES, type);

--- a/src/components/AttachmentModal.js
+++ b/src/components/AttachmentModal.js
@@ -77,6 +77,9 @@ class AttachmentModal extends PureComponent {
         this.submitAndClose = this.submitAndClose.bind(this);
         this.closeConfirmModal = this.closeConfirmModal.bind(this);
         this.isValidSize = this.isValidSize.bind(this);
+        this.isValidFileType = this.isValidFileType.bind(this);
+        this.openUnsupportedFileConfirmModal = this.openUnsupportedFileConfirmModal.bind(this);
+        this.openLargeAttachmentConfirmModal = this.openLargeAttachmentConfirmModal.bind(this);
     }
 
     /**
@@ -129,12 +132,34 @@ class AttachmentModal extends PureComponent {
     }
 
     /**
+     * Opens the confirm modal if the selected file type is unsupported.
+     */
+    openUnsupportedFileConfirmModal() {
+        this.setState({
+            isConfirmModalOpen: true,
+            confirmModalTitle: this.props.translate('attachmentPicker.attachmentError'),
+            confirmModalPrompt: this.props.translate('attachmentPicker.errorWhileSelectingUnsupportedFile'),
+        });
+    }
+
+    /**
+     * Opens the confirm modal if the selected file is too large.
+     */
+    openLargeAttachmentConfirmModal() {
+        this.setState({
+            isConfirmModalOpen: true,
+            confirmModalTitle: this.props.translate('attachmentPicker.attachmentTooLarge'),
+            confirmModalPrompt: this.props.translate('attachmentPicker.sizeExceeded'),
+        });
+    }
+
+    /**
      * Checks whether file type is acceptable
      * @param {String} type
      * @returns {boolean}
      */
     isValidFileType(type) {
-        return !CONST.UNSUPPORTED_FILE_TYPES.includes(type);
+        return !_.includes(CONST.UNSUPPORTED_FILE_TYPES, type);
     }
 
     /**
@@ -214,19 +239,11 @@ class AttachmentModal extends PureComponent {
                 {this.props.children({
                     displayFileInModal: ({file}) => {
                         if (!this.isValidFileType(file.type)) {
-                            this.setState({
-                                isConfirmModalOpen: true,
-                                confirmModalTitle: this.props.translate('attachmentPicker.attachmentError'),
-                                confirmModalPrompt: this.props.translate('attachmentPicker.errorWhileSelectingUnsupportedFile'),
-                            });
+                            this.openUnsupportedFileConfirmModal();
                             return;
                         }
                         if (!this.isValidSize(file)) {
-                            this.setState({
-                                isConfirmModalOpen: true,
-                                confirmModalTitle: this.props.translate('attachmentPicker.attachmentTooLarge'),
-                                confirmModalPrompt: this.props.translate('attachmentPicker.sizeExceeded'),
-                            });
+                            this.openLargeAttachmentConfirmModal();
                             return;
                         }
                         if (file instanceof File) {

--- a/src/components/AttachmentModal.js
+++ b/src/components/AttachmentModal.js
@@ -128,7 +128,7 @@ class AttachmentModal extends PureComponent {
      * Close the confirm modal.
      */
     closeConfirmModal() {
-        this.setState({isConfirmModalOpen: false});
+        this.setState({isConfirmModalOpen: false, confirmModalTitle: '', confirmModalPrompt: ''});
     }
 
     /**

--- a/src/components/AttachmentModal.js
+++ b/src/components/AttachmentModal.js
@@ -77,9 +77,6 @@ class AttachmentModal extends PureComponent {
         this.submitAndClose = this.submitAndClose.bind(this);
         this.closeConfirmModal = this.closeConfirmModal.bind(this);
         this.isValidSize = this.isValidSize.bind(this);
-        this.isValidFileType = this.isValidFileType.bind(this);
-        this.openUnsupportedFileConfirmModal = this.openUnsupportedFileConfirmModal.bind(this);
-        this.openLargeAttachmentConfirmModal = this.openLargeAttachmentConfirmModal.bind(this);
     }
 
     /**

--- a/src/components/AttachmentModal.js
+++ b/src/components/AttachmentModal.js
@@ -70,6 +70,8 @@ class AttachmentModal extends PureComponent {
             file: null,
             sourceURL: props.sourceURL,
             modalType: CONST.MODAL.MODAL_TYPE.CENTERED_UNSWIPEABLE,
+            confirmModalTitle: '',
+            confirmModalPrompt: '',
         };
 
         this.submitAndClose = this.submitAndClose.bind(this);
@@ -124,6 +126,15 @@ class AttachmentModal extends PureComponent {
      */
     closeConfirmModal() {
         this.setState({isConfirmModalOpen: false});
+    }
+
+    /**
+     * Checks whether file type is acceptable
+     * @param {String} type
+     * @returns {boolean}
+     */
+    isValidFileType(type) {
+        return !CONST.UNSUPPORTED_FILE_TYPES.includes(type);
     }
 
     /**
@@ -192,18 +203,30 @@ class AttachmentModal extends PureComponent {
                     )}
                 </Modal>
                 <ConfirmModal
-                    title={this.props.translate('attachmentPicker.attachmentTooLarge')}
+                    title={this.state.confirmModalTitle}
                     onConfirm={this.closeConfirmModal}
                     onCancel={this.closeConfirmModal}
                     isVisible={this.state.isConfirmModalOpen}
-                    prompt={this.props.translate('attachmentPicker.sizeExceeded')}
+                    prompt={this.state.confirmModalPrompt}
                     confirmText={this.props.translate('common.close')}
                     shouldShowCancelButton={false}
                 />
                 {this.props.children({
                     displayFileInModal: ({file}) => {
+                        if (!this.isValidFileType(file.type)) {
+                            this.setState({
+                                isConfirmModalOpen: true,
+                                confirmModalTitle: this.props.translate('attachmentPicker.attachmentError'),
+                                confirmModalPrompt: this.props.translate('attachmentPicker.errorWhileSelectingUnsupportedFile'),
+                            });
+                            return;
+                        }
                         if (!this.isValidSize(file)) {
-                            this.setState({isConfirmModalOpen: true});
+                            this.setState({
+                                isConfirmModalOpen: true,
+                                confirmModalTitle: this.props.translate('attachmentPicker.attachmentTooLarge'),
+                                confirmModalPrompt: this.props.translate('attachmentPicker.sizeExceeded'),
+                            });
                             return;
                         }
                         if (file instanceof File) {

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -104,6 +104,7 @@ export default {
         attachmentError: 'Attachment error',
         errorWhileSelectingAttachment: 'An error occurred while selecting an attachment, please try again',
         errorWhileSelectingCorruptedImage: 'An error occurred while selecting a corrupted attachment, please try another file',
+        errorWhileSelectingUnsupportedFile: 'The selected file type is unsupported.',
         takePhoto: 'Take photo',
         chooseFromGallery: 'Choose from gallery',
         chooseDocument: 'Choose document',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -104,6 +104,7 @@ export default {
         attachmentError: 'Error al adjuntar archivo',
         errorWhileSelectingAttachment: 'Ha ocurrido un error al seleccionar un adjunto, por favor inténtalo de nuevo',
         errorWhileSelectingCorruptedImage: 'Ha ocurrido un error al seleccionar un adjunto corrupto, por favor inténtalo con otro archivo',
+        errorWhileSelectingUnsupportedFile: '',
         takePhoto: 'Hacer una foto',
         chooseFromGallery: 'Elegir de la galería',
         chooseDocument: 'Elegir documento',

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -1171,7 +1171,7 @@ function addAction(reportID, text, file) {
         persist: true,
     })
         .then((response) => {
-            if (response.jsonCode === 408 || (response.jsonCode === 666 && isAttachment)) {
+            if (response.jsonCode === 408) {
                 Growl.error(Localize.translateLocal('reportActionCompose.fileUploadFailed'));
                 Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`, {
                     [optimisticReportActionID]: null,

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -1171,7 +1171,7 @@ function addAction(reportID, text, file) {
         persist: true,
     })
         .then((response) => {
-            if (response.jsonCode === 408 || (response.data && response.data.responseCode === 2001)) {
+            if (response.jsonCode === 408 || (response.jsonCode === 666 && isAttachment)) {
                 Growl.error(Localize.translateLocal('reportActionCompose.fileUploadFailed'));
                 Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`, {
                     [optimisticReportActionID]: null,

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -1171,7 +1171,7 @@ function addAction(reportID, text, file) {
         persist: true,
     })
         .then((response) => {
-            if (response.jsonCode === 408) {
+            if (response.jsonCode === 408 || (response.data && response.data.responseCode === 2001)) {
                 Growl.error(Localize.translateLocal('reportActionCompose.fileUploadFailed'));
                 Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`, {
                     [optimisticReportActionID]: null,


### PR DESCRIPTION
Blocked the upload of svg file and more file type can be blocked by adding on ``CONST.UNSUPPORTED_FILE_TYPES``

<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
AttachmentModal ``displayFileInModal`` renderProp has been extended to check for valid file type before uploading and inform with the confirm modal popup for invalid type (works for drag & drop as well as upload from attachment button).

### Testing
Testing was done using ``.svg`` file by blocking as well as allowing to upload it.  For native iOS, version 13.7 simulator was used as simulator version above that currently have reported issue with ``react-document-picker``(might be M1 issue).

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/7598

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### PR Review Checklist
<!--
This is a checklist for PR authors & reviewers. Please make sure to complete all tasks and check them off once you do, or else Expensify has the right not to merge your PR!
-->
#### Contributor (PR Author) Checklist
- [x] I verified the PR has a small number of commits behind `main`
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I clearly indicated the environment tests should be run in (Staging vs Production)
- [x] I wrote testing steps that cover success & fail scenarios (if applicable)
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests & veryfy they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors related to changes in this PR
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I added comments when the code was not self explanatory
    - [x] I put all copy / text shown in the product in all `src/languages/*` files (if applicable)
    - [ ] I followed proper naming convention for platform-specific files (if applicable)
    - [ ] I followed style guidelines (in [`Styling.md`](https://github.com/Expensify/App/blob/main/STYLING.md)) for all style edits I made
    - [x] I followed the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs))
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I corroborated the UI performance was not affected (the performance is the same than `main` branch)
- [x] If I created a new component I verified that a similar component doesn't exist in the codebase

#### PR Reviewer Checklist
- [ ] I verified the PR has a small number of commits behind `main`
- [ ] I verified the correct issue is linked in the `### Fixed Issues` section above
- [ ] I verified testing steps are clear and they cover the changes made in this PR
    - [ ] I verified the testing environment is mentioned in the test steps
- [ ] I verified testing steps cover success & fail scenarios (if applicable)
- [ ] I checked that screenshots or videos are included for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I verified tests pass on **all platforms** & I tested again on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [ ] I verified there are no console errors related to changes in this PR
- [ ] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified comments were added when the code was not self explanatory
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files (if applicable)
    - [ ] I verified proper naming convention for platform-specific files was followed (if applicable)
    - [ ] I verified [style guidelines](https://github.com/Expensify/App/blob/main/STYLING.md) were followed
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs)) were followed
- [ ] I verified that this PR follows the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [ ] I verified other components are not impacted by changes in this PR (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] I verified the UI performance was not affected (the performance is the same than `main` branch)
- [ ] If a new component is created I verified that a similar component doesn't exist in the codebase

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

#### All Platforms
- [ ] Pick svg image using the attachment button
- [ ] Verify a modal appears displaying error for unsupported file.
- [ ] Pick .psd(Photoshop) file using the attachment button.
- [ ] Send the file.
- [ ] Verify that an alert appears showing ``File type is not supported``(was already being handled).
- [ ] Verify that no errors appear in the JS console

#### Desktop (Web / Electron)
- [ ]  Drag and Drop the svg image.
- [ ] Verify a modal appears displaying error for unsupported file.

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
<img width="676" alt="Screen Shot 2022-03-09 at 6 37 35 PM" src="https://user-images.githubusercontent.com/18470532/157445861-42db4be7-a62e-4ae4-9d76-85d91a4d9b9d.png">
<img width="676" alt="Screen Shot 2022-03-09 at 6 37 45 PM" src="https://user-images.githubusercontent.com/18470532/157445880-ccdc4412-76b2-4325-96a1-b75a14cd3cd0.png">

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
![Simulator Screen Shot - iPhone 11 Pro - 2022-03-09 at 18 38 53](https://user-images.githubusercontent.com/18470532/157445898-75a01cfa-f545-4966-90d9-17ec4e90c49d.png)
![Simulator Screen Shot - iPhone 11 Pro - 2022-03-09 at 18 39 07](https://user-images.githubusercontent.com/18470532/157445905-e5306ebd-5cc0-495a-ad20-bc66000902f2.png)
![Screenshot_1646831547](https://user-images.githubusercontent.com/18470532/157448665-91cac240-232b-408f-a36a-e345a886903b.png)
![Screenshot_1646831564](https://user-images.githubusercontent.com/18470532/157448682-549bd60e-4fa7-4dba-b7c0-5371d5b9b453.png)

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
<img width="676" alt="Screen Shot 2022-03-09 at 6 43 55 PM" src="https://user-images.githubusercontent.com/18470532/157446730-b5830fa4-ba70-4d20-b43f-95281a25c696.png">
<img width="676" alt="Screen Shot 2022-03-09 at 6 44 05 PM" src="https://user-images.githubusercontent.com/18470532/157446747-78299a19-4ce6-414e-8f86-6b9d940e1043.png">

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
![Simulator Screen Shot - iPhone 11 Pro - 2022-03-09 at 18 32 48](https://user-images.githubusercontent.com/18470532/157445966-16e390a4-8184-468b-911b-80b934fcb01e.png)
![Simulator Screen Shot - iPhone 11 Pro - 2022-03-09 at 18 33 31](https://user-images.githubusercontent.com/18470532/157445987-bc4741c5-1348-4b6e-aba4-7f729fa01fcd.png)


#### Android
<!-- Insert screenshots of your changes on the Android platform-->
![Screenshot_1646833151](https://user-images.githubusercontent.com/18470532/157453678-6218fefd-03f4-48a3-a748-aba8a5664783.png)
![Screenshot_1646833386](https://user-images.githubusercontent.com/18470532/157453698-280e57f1-80b2-45cb-b0ec-d8c6cce1dfff.png)

