### PR TITLE
Use `ROOT/api` to avoid ngrok problems

### DIFF
--- a/src/libs/NetworkConnection.js
+++ b/src/libs/NetworkConnection.js
@@ -53,18 +53,16 @@ function setOfflineStatus(isCurrentlyOffline) {
  */
 function subscribeToNetInfo() {
     // Calling NetInfo.configure (re)checks current state. We use it to force a recheck whenever we (re)subscribe
-    if (CONFIG.IS_IN_PRODUCTION) {
-        NetInfo.configure({
-            // By default, for web (including Electron) NetInfo uses `/` for `reachabilityUrl`
-            // When App is served locally or from Electron this would respond with OK even with no internet
-            // Using API url ensures reachability is tested over internet
-            reachabilityUrl: CONFIG.EXPENSIFY.URL_API_ROOT,
-            reachabilityTest: response => Promise.resolve(response.status === 200),
+    NetInfo.configure({
+        // By default, NetInfo uses `/` for `reachabilityUrl`
+        // When App is served locally (or from Electron) this address is always reachable - even offline
+        // Using the API url ensures reachability is tested over internet
+        reachabilityUrl: `${CONFIG.EXPENSIFY.URL_API_ROOT}api`,
+        reachabilityTest: response => Promise.resolve(response.status === 200),
 
-            // If a check is taking longer than this time we're considered offline
-            reachabilityRequestTimeout: CONST.NETWORK.MAX_PENDING_TIME_MS,
-        });
-    }
+        // If a check is taking longer than this time we're considered offline
+        reachabilityRequestTimeout: CONST.NETWORK.MAX_PENDING_TIME_MS,
+    });
 
     // Subscribe to the state change event via NetInfo so we can update
     // whether a user has internet connectivity or not.


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
@marcaaron
Would this change resolve the ngrok problem?

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Trying to keep the same NetInfo config for dev and prod so that offline mode is detected the same way on both

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/pull/8043#discussion_r822002437

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. verify internet reachability url is used and the request is receiving response (when online)
    1. open dev tools
    2. refresh page
    3. there should be a request triggered by `internetReachability.js`
    4. It should be using the URL in the NetInfo.configure `ROOT/api` 
    5. It should be completing successfully and the app should be considered online

2. using together with ngrok should work 
3. turning off network (airplane mode) should still correctly detect that you're offline 

### PR Review Checklist
<!--
This is a checklist for PR authors & reviewers. Please make sure to complete all tasks and check them off once you do, or else Expensify has the right not to merge your PR!
-->
#### Contributor (PR Author) Checklist
- [x] I verified the PR has a small number of commits behind `main`
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I clearly indicated the environment tests should be run in (Staging vs Production)
- [x] I wrote testing steps that cover success & fail scenarios (if applicable)
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests & verify they passed on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors related to changes in this PR
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I added comments when the code was not self explanatory
    - [x] I put all copy / text shown in the product in all `src/languages/*` files (if applicable)
    - [x] I followed proper naming convention for platform-specific files (if applicable)
    - [x] I followed style guidelines (in [`Styling.md`](https://github.com/Expensify/App/blob/main/STYLING.md)) for all style edits I made
    - [x] I followed the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs))
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I corroborated the UI performance was not affected (the performance is the same than `main` branch)
- [x] If I created a new component I verified that a similar component doesn't exist in the codebase

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
7. Upload an image via copy paste
8. Verify a modal appears displaying a preview of that image
--->

Try to simulate very poor or no network conditions

- [ ] Test network connection being correctly detected as offline
- [ ] Test network connection being correctly detected as online

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
<img width="1552" alt="Screenshot 2022-03-09 at 1 45 48" src="https://user-images.githubusercontent.com/12156624/157344905-73465fbe-9a04-4a15-a432-2891af545a54.png">

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
<img width="1403" alt="Screenshot 2022-03-09 at 3 04 34" src="https://user-images.githubusercontent.com/12156624/157352331-9df000a2-5f96-4dcc-8f15-bbd7267000e3.png">

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
