### PR TITLE
Remove duplication in Report.js

### DIFF
--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -711,10 +711,11 @@ function subscribeToPrivateUserChannelEvent(eventName) {
     let callback = () => {};
     const pusherChannelName = `private-user-accountID-${currentUserAccountID}`;
 
+    /**
+     * @param {Object} pushJSON
+     */
     function logPusherEvent(pushJSON) {
-        Log.info(
-            `[Report] Handled ${eventName} event sent by Pusher`, false, {reportID: pushJSON.reportID, reportActionID: pushJSON.reportActionID},
-        );
+        Log.info(`[Report] Handled ${eventName} event sent by Pusher`, false, {reportID: pushJSON.reportID, reportActionID: pushJSON.reportActionID});
     }
 
     function onPusherResubscribeToPrivateUserChannel() {
@@ -733,11 +734,7 @@ function subscribeToPrivateUserChannelEvent(eventName) {
      * @param {*} error
      */
     function onSubscriptionFailed(error) {
-        Log.info(
-            '[Report] Failed to subscribe to Pusher channel',
-            false,
-            {error, pusherChannelName, eventName},
-        );
+        Log.info('[Report] Failed to subscribe to Pusher channel', false, {error, pusherChannelName, eventName});
     }
 
     Pusher.subscribe(pusherChannelName, eventName, onEvent, false, onPusherResubscribeToPrivateUserChannel)

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -759,7 +759,11 @@ function subscribeToUserEvents() {
     subscribeToPrivateUserChannelEvent(Pusher.TYPE.REPORT_COMMENT, pushJSON => updateReportWithNewAction(pushJSON.reportID, pushJSON.reportAction, pushJSON.notificationPreference));
 
     // Live-update a report's actions when a 'chunked report comment' event is received.
-    subscribeToPrivateUserChannelEvent(Pusher.TYPE.REPORT_COMMENT_CHUNK, pushJSON => updateReportWithNewAction(pushJSON.reportID, pushJSON.reportAction, pushJSON.notificationPreference), true);
+    subscribeToPrivateUserChannelEvent(
+        Pusher.TYPE.REPORT_COMMENT_CHUNK,
+        pushJSON => updateReportWithNewAction(pushJSON.reportID, pushJSON.reportAction, pushJSON.notificationPreference),
+        true,
+    );
 
     // Live-update a report's actions when an 'edit comment' event is received.
     subscribeToPrivateUserChannelEvent(Pusher.TYPE.REPORT_COMMENT_EDIT, pushJSON => updateReportActionMessage(pushJSON.reportID, pushJSON.sequenceNumber, pushJSON.message));

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -702,6 +702,55 @@ function getReportChannelName(reportID) {
 }
 
 /**
+ * Abstraction around subscribing to private user channel events. Handles all logs and errors automatically.
+ *
+ * @param {String} eventName
+ * @returns {Promise}
+ */
+function subscribeToPrivateUserChannelEvent(eventName) {
+    let callback = () => {};
+    const pusherChannelName = `private-user-accountID-${currentUserAccountID}`;
+
+    function logPusherEvent(pushJSON) {
+        Log.info(
+            `[Report] Handled ${eventName} event sent by Pusher`, false, {reportID: pushJSON.reportID, reportActionID: pushJSON.reportActionID},
+        );
+    }
+
+    function onPusherResubscribeToPrivateUserChannel() {
+        NetworkConnection.triggerReconnectionCallbacks('Pusher re-subscribed to private user channel');
+    }
+
+    /**
+     * @param {*} pushJSON
+     */
+    function onEvent(pushJSON) {
+        logPusherEvent(pushJSON);
+        callback(pushJSON);
+    }
+
+    /**
+     * @param {*} error
+     */
+    function onSubscriptionFailed(error) {
+        Log.info(
+            '[Report] Failed to subscribe to Pusher channel',
+            false,
+            {error, pusherChannelName, eventName},
+        );
+    }
+
+    Pusher.subscribe(pusherChannelName, eventName, onEvent, false, onPusherResubscribeToPrivateUserChannel)
+        .catch(onSubscriptionFailed);
+
+    return {
+        onEvent(cb) {
+            callback = cb;
+        },
+    };
+}
+
+/**
  * Initialize our pusher subscriptions to listen for new report comments and pin toggles
  */
 function subscribeToUserEvents() {
@@ -716,100 +765,24 @@ function subscribeToUserEvents() {
     }
 
     // Live-update a report's actions when a 'report comment' event is received.
-    Pusher.subscribe(pusherChannelName, Pusher.TYPE.REPORT_COMMENT, (pushJSON) => {
-        Log.info(
-            `[Report] Handled ${Pusher.TYPE.REPORT_COMMENT} event sent by Pusher`, false, {reportID: pushJSON.reportID},
-        );
-        updateReportWithNewAction(pushJSON.reportID, pushJSON.reportAction, pushJSON.notificationPreference);
-    }, false,
-    () => {
-        NetworkConnection.triggerReconnectionCallbacks('pusher re-subscribed to private user channel');
-    })
-        .catch((error) => {
-            Log.info(
-                '[Report] Failed to subscribe to Pusher channel',
-                false,
-                {error, pusherChannelName, eventName: Pusher.TYPE.REPORT_COMMENT},
-            );
-        });
+    subscribeToPrivateUserChannelEvent(Pusher.TYPE.REPORT_COMMENT)
+        .onEvent(pushJSON => updateReportWithNewAction(pushJSON.reportID, pushJSON.reportAction, pushJSON.notificationPreference));
 
     // Live-update a report's actions when a 'chunked report comment' event is received.
-    Pusher.subscribe(pusherChannelName, Pusher.TYPE.REPORT_COMMENT_CHUNK, (pushJSON) => {
-        Log.info(
-            `[Report] Handled ${Pusher.TYPE.REPORT_COMMENT_CHUNK} event sent by Pusher`, false, {reportID: pushJSON.reportID},
-        );
-        updateReportWithNewAction(pushJSON.reportID, pushJSON.reportAction, pushJSON.notificationPreference);
-    }, true,
-    () => {
-        NetworkConnection.triggerReconnectionCallbacks('pusher re-subscribed to private user channel');
-    })
-        .catch((error) => {
-            Log.info(
-                '[Report] Failed to subscribe to Pusher channel',
-                false,
-                {error, pusherChannelName, eventName: Pusher.TYPE.REPORT_COMMENT_CHUNK},
-            );
-        });
+    subscribeToPrivateUserChannelEvent(Pusher.TYPE.REPORT_COMMENT_CHUNK)
+        .onEvent(pushJSON => updateReportWithNewAction(pushJSON.reportID, pushJSON.reportAction, pushJSON.notificationPreference));
 
     // Live-update a report's actions when an 'edit comment' event is received.
-    Pusher.subscribe(pusherChannelName, Pusher.TYPE.REPORT_COMMENT_EDIT, (pushJSON) => {
-        Log.info(
-            `[Report] Handled ${Pusher.TYPE.REPORT_COMMENT_EDIT} event sent by Pusher`, false, {
-                reportActionID: pushJSON.reportActionID,
-            },
-        );
-        updateReportActionMessage(pushJSON.reportID, pushJSON.sequenceNumber, pushJSON.message);
-    }, false,
-    () => {
-        NetworkConnection.triggerReconnectionCallbacks('pusher re-subscribed to private user channel');
-    })
-        .catch((error) => {
-            Log.info(
-                '[Report] Failed to subscribe to Pusher channel',
-                false,
-                {error, pusherChannelName, eventName: Pusher.TYPE.REPORT_COMMENT_EDIT},
-            );
-        });
+    subscribeToPrivateUserChannelEvent(Pusher.TYPE.REPORT_COMMENT_EDIT)
+        .onEvent(pushJSON => updateReportActionMessage(pushJSON.reportID, pushJSON.sequenceNumber, pushJSON.message));
 
     // Live-update a report's actions when an 'edit comment chunk' event is received.
-    Pusher.subscribe(pusherChannelName, Pusher.TYPE.REPORT_COMMENT_EDIT_CHUNK, (pushJSON) => {
-        Log.info(
-            `[Report] Handled ${Pusher.TYPE.REPORT_COMMENT_EDIT_CHUNK} event sent by Pusher`, false, {
-                reportActionID: pushJSON.reportActionID,
-            },
-        );
-        updateReportActionMessage(pushJSON.reportID, pushJSON.sequenceNumber, pushJSON.message);
-    }, true,
-    () => {
-        NetworkConnection.triggerReconnectionCallbacks('pusher re-subscribed to private user channel');
-    })
-        .catch((error) => {
-            Log.info(
-                '[Report] Failed to subscribe to Pusher channel',
-                false,
-                {error, pusherChannelName, eventName: Pusher.TYPE.REPORT_COMMENT_EDIT_CHUNK},
-            );
-        });
+    subscribeToPrivateUserChannelEvent(Pusher.TYPE.REPORT_COMMENT_EDIT_CHUNK)
+        .onEvent(pushJSON => updateReportActionMessage(pushJSON.reportID, pushJSON.sequenceNumber, pushJSON.message));
 
     // Live-update a report's pinned state when a 'report toggle pinned' event is received.
-    Pusher.subscribe(pusherChannelName, Pusher.TYPE.REPORT_TOGGLE_PINNED, (pushJSON) => {
-        Log.info(
-            `[Report] Handled ${Pusher.TYPE.REPORT_TOGGLE_PINNED} event sent by Pusher`,
-            false,
-            {reportID: pushJSON.reportID},
-        );
-        updateReportPinnedState(pushJSON.reportID, pushJSON.isPinned);
-    }, false,
-    () => {
-        NetworkConnection.triggerReconnectionCallbacks('pusher re-subscribed to private user channel');
-    })
-        .catch((error) => {
-            Log.info(
-                '[Report] Failed to subscribe to Pusher channel',
-                false,
-                {error, pusherChannelName, eventName: Pusher.TYPE.REPORT_TOGGLE_PINNED},
-            );
-        });
+    subscribeToPrivateUserChannelEvent(Pusher.TYPE.REPORT_TOGGLE_PINNED)
+        .onEvent(pushJSON => updateReportPinnedState(pushJSON.reportID, pushJSON.isPinned));
 }
 
 /**

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -705,7 +705,7 @@ function getReportChannelName(reportID) {
  * Abstraction around subscribing to private user channel events. Handles all logs and errors automatically.
  *
  * @param {String} eventName
- * @returns {Promise}
+ * @returns {Object}
  */
 function subscribeToPrivateUserChannelEvent(eventName) {
     let callback = () => {};

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -707,7 +707,6 @@ function getReportChannelName(reportID) {
  * @param {String} eventName
  * @param {Function} onEvent
  * @param {Boolean} isChunked
- * @returns {Object}
  */
 function subscribeToPrivateUserChannelEvent(eventName, onEvent, isChunked = false) {
     const pusherChannelName = `private-user-accountID-${currentUserAccountID}`;
@@ -740,6 +739,7 @@ function subscribeToPrivateUserChannelEvent(eventName, onEvent, isChunked = fals
 
     Pusher.subscribe(pusherChannelName, eventName, onEventPush, isChunked, onPusherResubscribeToPrivateUserChannel)
         .catch(onSubscriptionFailed);
+}
 
 /**
  * Initialize our pusher subscriptions to listen for new report comments and pin toggles

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -705,9 +705,10 @@ function getReportChannelName(reportID) {
  * Abstraction around subscribing to private user channel events. Handles all logs and errors automatically.
  *
  * @param {String} eventName
+ * @param {Boolean} isChunked
  * @returns {Object}
  */
-function subscribeToPrivateUserChannelEvent(eventName) {
+function subscribeToPrivateUserChannelEvent(eventName, isChunked = false) {
     let callback = () => {};
     const pusherChannelName = `private-user-accountID-${currentUserAccountID}`;
 
@@ -737,7 +738,7 @@ function subscribeToPrivateUserChannelEvent(eventName) {
         Log.info('[Report] Failed to subscribe to Pusher channel', false, {error, pusherChannelName, eventName});
     }
 
-    Pusher.subscribe(pusherChannelName, eventName, onEvent, false, onPusherResubscribeToPrivateUserChannel)
+    Pusher.subscribe(pusherChannelName, eventName, onEvent, isChunked, onPusherResubscribeToPrivateUserChannel)
         .catch(onSubscriptionFailed);
 
     return {
@@ -766,7 +767,7 @@ function subscribeToUserEvents() {
         .onEvent(pushJSON => updateReportWithNewAction(pushJSON.reportID, pushJSON.reportAction, pushJSON.notificationPreference));
 
     // Live-update a report's actions when a 'chunked report comment' event is received.
-    subscribeToPrivateUserChannelEvent(Pusher.TYPE.REPORT_COMMENT_CHUNK)
+    subscribeToPrivateUserChannelEvent(Pusher.TYPE.REPORT_COMMENT_CHUNK, true)
         .onEvent(pushJSON => updateReportWithNewAction(pushJSON.reportID, pushJSON.reportAction, pushJSON.notificationPreference));
 
     // Live-update a report's actions when an 'edit comment' event is received.
@@ -774,7 +775,7 @@ function subscribeToUserEvents() {
         .onEvent(pushJSON => updateReportActionMessage(pushJSON.reportID, pushJSON.sequenceNumber, pushJSON.message));
 
     // Live-update a report's actions when an 'edit comment chunk' event is received.
-    subscribeToPrivateUserChannelEvent(Pusher.TYPE.REPORT_COMMENT_EDIT_CHUNK)
+    subscribeToPrivateUserChannelEvent(Pusher.TYPE.REPORT_COMMENT_EDIT_CHUNK, true)
         .onEvent(pushJSON => updateReportActionMessage(pushJSON.reportID, pushJSON.sequenceNumber, pushJSON.message));
 
     // Live-update a report's pinned state when a 'report toggle pinned' event is received.


### PR DESCRIPTION
### Details

Pusher subscription logic in Report.js is pretty wild and lots of copy pasta is used. Cleaning this up a bit.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/201111

### Tests
1. Not much apart from regressions around various realtime features like report comments
2. Verify that you are subscribed to the Pusher channels here

![2022-03-11_07-50-12](https://user-images.githubusercontent.com/32969087/157922502-502851e3-3041-4fd4-95e6-09066a1cd04d.png)

- [x] Verify that no errors appear in the JS console

### QA Steps
1. None apart from regressions around various realtime features like report comments

- [ ] Verify that no errors appear in the JS console