### PR TITLE
[No QA] Disable recheck against local web API when local web API is in use

### DIFF
--- a/src/CONFIG.js
+++ b/src/CONFIG.js
@@ -50,6 +50,7 @@ export default {
         EXPENSIFY_CASH_REFERER: 'ecash',
     },
     IS_IN_PRODUCTION: Platform.OS === 'web' ? process.env.NODE_ENV === 'production' : !__DEV__,
+    IS_USING_LOCAL_WEB: useNgrok || expensifyURLRoot.includes('dev'),
     PUSHER: {
         APP_KEY: lodashGet(Config, 'PUSHER_APP_KEY', '268df511a204fbb60884'),
         CLUSTER: 'mt1',

--- a/src/libs/NetworkConnection.js
+++ b/src/libs/NetworkConnection.js
@@ -52,17 +52,21 @@ function setOfflineStatus(isCurrentlyOffline) {
  * `disconnected` event which takes about 10-15 seconds to emit.
  */
 function subscribeToNetInfo() {
-    // Calling NetInfo.configure (re)checks current state. We use it to force a recheck whenever we (re)subscribe
-    NetInfo.configure({
-        // By default, NetInfo uses `/` for `reachabilityUrl`
-        // When App is served locally (or from Electron) this address is always reachable - even offline
-        // Using the API url ensures reachability is tested over internet
-        reachabilityUrl: `${CONFIG.EXPENSIFY.URL_API_ROOT}api`,
-        reachabilityTest: response => Promise.resolve(response.status === 200),
+    // Note: We are disabling the configuration for NetInfo when using the local web API since requests can get stuck in a 'Pending' state and are not reliable indicators for "offline".
+    // If you need to test the "recheck" feature then switch to the production API proxy server.
+    if (!CONFIG.IS_USING_LOCAL_WEB) {
+        // Calling NetInfo.configure (re)checks current state. We use it to force a recheck whenever we (re)subscribe
+        NetInfo.configure({
+            // By default, NetInfo uses `/` for `reachabilityUrl`
+            // When App is served locally (or from Electron) this address is always reachable - even offline
+            // Using the API url ensures reachability is tested over internet
+            reachabilityUrl: `${CONFIG.EXPENSIFY.URL_API_ROOT}api`,
+            reachabilityTest: response => Promise.resolve(response.status === 200),
 
-        // If a check is taking longer than this time we're considered offline
-        reachabilityRequestTimeout: CONST.NETWORK.MAX_PENDING_TIME_MS,
-    });
+            // If a check is taking longer than this time we're considered offline
+            reachabilityRequestTimeout: CONST.NETWORK.MAX_PENDING_TIME_MS,
+        });
+    }
 
     // Subscribe to the state change event via NetInfo so we can update
     // whether a user has internet connectivity or not.


### PR DESCRIPTION
### Details

We are still having issues on dev related to https://github.com/Expensify/App/pull/7825

### Tests
1. Setup ngrok
2. Run web app
3. Verify that we are not seeing infinite loops of going offline/online and ngrok tunnel does not crash