### PR TITLE
fix alignment for tablets

### DIFF
--- a/src/pages/ErrorPage/GenericErrorPage.js
+++ b/src/pages/ErrorPage/GenericErrorPage.js
@@ -48,7 +48,7 @@ const GenericErrorPage = props => (
                         </TextLink>
                     </Text>
                 </View>
-                <View style={[styles.dFlex, styles.flexRow]}>
+                <View style={[styles.flexRow]}>
                     <View style={[styles.flex1, styles.flexRow]}>
                         <Button
                             success

--- a/src/pages/ErrorPage/GenericErrorPage.js
+++ b/src/pages/ErrorPage/GenericErrorPage.js
@@ -25,7 +25,7 @@ const propTypes = {
 const GenericErrorPage = props => (
     <View style={[styles.flex1, styles.pv10, styles.ph5, styles.errorPageContainer]}>
         <View style={[styles.flex1, styles.alignItemsCenter, styles.justifyContentCenter]}>
-            <View style={styles.alignItemsStart}>
+            <View>
                 <View style={styles.mb5}>
                     <Icon
                         src={Expensicons.Bug}
@@ -48,7 +48,7 @@ const GenericErrorPage = props => (
                         </TextLink>
                     </Text>
                 </View>
-                <View style={[styles.dFlex, styles.flexRow, styles.w100]}>
+                <View style={[styles.dFlex, styles.flexRow]}>
                     <View style={[styles.flex1, styles.flexRow]}>
                         <Button
                             success


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/7969

### Tests/QA Steps
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Open app on tablet
2. Make any current trigger to see the error page (e.g. https://github.com/Expensify/App/issues/8033 if still repro) or just add `!` before `this.state.hasError` https://github.com/Expensify/App/blob/e404117c3666c57306b14915b0ae855b9e9e002b/src/components/ErrorBoundary/BaseErrorBoundary.js#L50-L53
4. Verify that error page content is in center
- [x] Verify that no errors appear in the JS console

### PR Review Checklist
<!--
This is a checklist for PR authors & reviewers. Please make sure to complete all tasks and check them off once you do, or else Expensify has the right not to merge your PR!
-->
#### Contributor (PR Author) Checklist
- [x] I verified the PR has a small number of commits behind `main`
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I clearly indicated the environment tests should be run in (Staging vs Production)
- [ ] I wrote testing steps that cover success & fail scenarios (if applicable)
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests & veryfy they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors related to changes in this PR
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I added comments when the code was not self explanatory
    - [ ] I put all copy / text shown in the product in all `src/languages/*` files (if applicable)
    - [ ] I followed proper naming convention for platform-specific files (if applicable)
    - [x] I followed style guidelines (in [`Styling.md`](https://github.com/Expensify/App/blob/main/STYLING.md)) for all style edits I made
    - [x] I followed the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs))
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I corroborated the UI performance was not affected (the performance is the same than `main` branch)
- [ ] If I created a new component I verified that a similar component doesn't exist in the codebase

#### PR Reviewer Checklist
- [ ] I verified the PR has a small number of commits behind `main`
- [ ] I verified the correct issue is linked in the `### Fixed Issues` section above
- [ ] I verified testing steps are clear and they cover the changes made in this PR
    - [ ] I verified the testing environment is mentioned in the test steps
- [ ] I verified testing steps cover success & fail scenarios (if applicable)
- [ ] I checked that screenshots or videos are included for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I verified tests pass on **all platforms** & I tested again on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [ ] I verified there are no console errors related to changes in this PR
- [ ] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified comments were added when the code was not self explanatory
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files (if applicable)
    - [ ] I verified proper naming convention for platform-specific files was followed (if applicable)
    - [ ] I verified [style guidelines](https://github.com/Expensify/App/blob/main/STYLING.md) were followed
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs)) were followed
- [ ] I verified that this PR follows the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [ ] I verified other components are not impacted by changes in this PR (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] I verified the UI performance was not affected (the performance is the same than `main` branch)
- [ ] If a new component is created I verified that a similar component doesn't exist in the codebase

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
<img width="1440" alt="Screenshot 2022-03-12 at 6 48 04 PM" src="https://user-images.githubusercontent.com/83179295/158020666-34342782-c06c-4850-b97b-defa0b5cb1f0.png">


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
<img width="1027" alt="Screenshot 2022-03-12 at 7 04 31 PM" src="https://user-images.githubusercontent.com/83179295/158020672-f8c75b69-18f5-4d99-9758-64b7acede7a7.png">
<img width="521" alt="Screenshot 2022-03-12 at 10 19 28 PM" src="https://user-images.githubusercontent.com/83179295/158026976-9aa222c9-b3b7-4c92-900d-ad7a6ae81a40.png">
<img width="521" alt="Screenshot 2022-03-12 at 10 10 44 PM" src="https://user-images.githubusercontent.com/83179295/158026991-19cd8365-f087-42c8-b2d6-7142e2123286.png">


#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

<img width="1200" alt="Screenshot 2022-03-12 at 6 36 41 PM" src="https://user-images.githubusercontent.com/83179295/158020674-64a53e40-df89-4fdd-8c68-405cce2875d2.png">


#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
<img width="880" alt="Screenshot 2022-03-12 at 2 45 10 PM" src="https://user-images.githubusercontent.com/83179295/158020680-a69803c6-c543-40fc-9d07-e9527e9b4d90.png">
<img width="521" alt="Screenshot 2022-03-12 at 10 17 21 PM" src="https://user-images.githubusercontent.com/83179295/158026980-1655e158-3df1-4395-8488-b730f726956c.png">



#### Android
<!-- Insert screenshots of your changes on the Android platform-->
<img width="1027" alt="Screenshot 2022-03-12 at 6 56 15 PM" src="https://user-images.githubusercontent.com/83179295/158020671-cd20955e-7d7b-4400-9b3c-a48a3170ef58.png">
<img width="521" alt="Screenshot 2022-03-12 at 10 07 19 PM" src="https://user-images.githubusercontent.com/83179295/158027003-c95b76c8-2234-4ebe-856f-3239cc4ab3fb.png">
