### PR TITLE
change SubscriptAvatar mode prop to size

### DIFF
--- a/src/components/OptionRow.js
+++ b/src/components/OptionRow.js
@@ -169,7 +169,7 @@ const OptionRow = (props) => {
                                             secondaryAvatar={props.option.icons[1]}
                                             mainTooltip={props.option.ownerEmail}
                                             secondaryTooltip={props.option.subtitle}
-                                            mode={props.mode}
+                                            size={props.mode === CONST.OPTION_MODE.COMPACT ? CONST.AVATAR_SIZE.SMALL : CONST.AVATAR_SIZE.DEFAULT}
                                         />
                                     ) : (
                                         <MultipleAvatars

--- a/src/components/SubscriptAvatar.js
+++ b/src/components/SubscriptAvatar.js
@@ -23,31 +23,31 @@ const propTypes = {
     secondaryTooltip: PropTypes.string,
 
     /** Set the size of avatars */
-    mode: PropTypes.oneOf(_.values(CONST.OPTION_MODE)),
+    size: PropTypes.oneOf(_.values(CONST.AVATAR_SIZE)),
 };
 
 const defaultProps = {
     mainTooltip: '',
     secondaryTooltip: '',
-    mode: CONST.OPTION_MODE.DEFAULT,
+    size: CONST.AVATAR_SIZE.DEFAULT,
 };
 
 const SubscriptAvatar = props => (
-    <View style={props.mode === CONST.OPTION_MODE.COMPACT ? styles.emptyAvatarSmall : styles.emptyAvatar}>
+    <View style={props.size === CONST.AVATAR_SIZE.SMALL ? styles.emptyAvatarSmall : styles.emptyAvatar}>
         <Tooltip text={props.mainTooltip}>
             <Avatar
                 source={props.mainAvatar}
-                size={props.mode === CONST.OPTION_MODE.COMPACT ? CONST.AVATAR_SIZE.SMALL : CONST.AVATAR_SIZE.DEFAULT}
+                size={props.size === CONST.AVATAR_SIZE.SMALL ? CONST.AVATAR_SIZE.SMALL : CONST.AVATAR_SIZE.DEFAULT}
             />
         </Tooltip>
         <View style={[
-            props.mode === CONST.OPTION_MODE.COMPACT ? styles.secondAvatarSubscriptCompact : styles.secondAvatarSubscript,
+            props.size === CONST.AVATAR_SIZE.SMALL ? styles.secondAvatarSubscriptCompact : styles.secondAvatarSubscript,
             StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)]}
         >
             <Tooltip text={props.secondaryTooltip}>
                 <Avatar
                     source={props.secondaryAvatar}
-                    size={props.mode === CONST.OPTION_MODE.COMPACT ? CONST.AVATAR_SIZE.SMALL_SUBSCRIPT : CONST.AVATAR_SIZE.SUBSCRIPT}
+                    size={props.size === CONST.AVATAR_SIZE.SMALL ? CONST.AVATAR_SIZE.SMALL_SUBSCRIPT : CONST.AVATAR_SIZE.SUBSCRIPT}
                     fill={themeColors.iconSuccessFill}
                 />
             </Tooltip>

--- a/src/stories/SubscriptAvatar.stories.js
+++ b/src/stories/SubscriptAvatar.stories.js
@@ -32,8 +32,8 @@ const Default = Template.bind({});
 
 const AvatarURLStory = Template.bind({});
 AvatarURLStory.args = {
-    mainAvatar: 'https://d2k5nsl2zxldvw.cloudfront.net/images/avatars/avatar_1.png',
-    secondaryAvatar: 'https://d2k5nsl2zxldvw.cloudfront.net/images/avatars/avatar_3.png',
+    mainAvatar: `${CONST.CLOUDFRONT_URL}/images/avatars/avatar_1.png`,
+    secondaryAvatar: `${CONST.CLOUDFRONT_URL}/images/avatars/avatar_3.png`,
 };
 
 export {

--- a/src/stories/SubscriptAvatar.stories.js
+++ b/src/stories/SubscriptAvatar.stories.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import SubscriptAvatar from '../components/SubscriptAvatar';
+import * as Expensicons from '../components/Icon/Expensicons';
 
 /**
  * We use the Component Story Format for writing stories. Follow the docs here:
@@ -9,7 +10,10 @@ import SubscriptAvatar from '../components/SubscriptAvatar';
 export default {
     title: 'Components/SubscriptAvatar',
     component: SubscriptAvatar,
-    args: {},
+    args: {
+        mainAvatar: Expensicons.Profile,
+        secondaryAvatar: Expensicons.Workspace,
+    },
 };
 
 // eslint-disable-next-line react/jsx-props-no-spreading

--- a/src/stories/SubscriptAvatar.stories.js
+++ b/src/stories/SubscriptAvatar.stories.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import SubscriptAvatar from '../components/SubscriptAvatar';
+
+/**
+ * We use the Component Story Format for writing stories. Follow the docs here:
+ *
+ * https://storybook.js.org/docs/react/writing-stories/introduction#component-story-format
+ */
+export default {
+    title: 'Components/SubscriptAvatar',
+    component: SubscriptAvatar,
+    args: {},
+};
+
+// eslint-disable-next-line react/jsx-props-no-spreading
+const Template = args => <SubscriptAvatar {...args} />;
+
+// Arguments can be passed to the component by binding
+// See: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
+const Default = Template.bind({});
+
+export {
+    Default,
+};

--- a/src/stories/SubscriptAvatar.stories.js
+++ b/src/stories/SubscriptAvatar.stories.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import SubscriptAvatar from '../components/SubscriptAvatar';
 import * as Expensicons from '../components/Icon/Expensicons';
+import CONST from '../CONST';
 
 /**
  * We use the Component Story Format for writing stories. Follow the docs here:
@@ -13,6 +14,12 @@ export default {
     args: {
         mainAvatar: Expensicons.Profile,
         secondaryAvatar: Expensicons.Workspace,
+        size: CONST.AVATAR_SIZE.DEFAULT,
+    },
+    argTypes: {
+        size: {
+            options: [CONST.AVATAR_SIZE.SMALL, CONST.AVATAR_SIZE.DEFAULT], // SubscriptAvatar only supports these two sizes
+        },
     },
 };
 

--- a/src/stories/SubscriptAvatar.stories.js
+++ b/src/stories/SubscriptAvatar.stories.js
@@ -30,6 +30,13 @@ const Template = args => <SubscriptAvatar {...args} />;
 // See: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
 const Default = Template.bind({});
 
+const AvatarURLStory = Template.bind({});
+AvatarURLStory.args = {
+    mainAvatar: 'https://d2k5nsl2zxldvw.cloudfront.net/images/avatars/avatar_1.png',
+    secondaryAvatar: 'https://d2k5nsl2zxldvw.cloudfront.net/images/avatars/avatar_3.png',
+};
+
 export {
     Default,
+    AvatarURLStory,
 };


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This is a pending change from Workspace chats implementation, also includes Storybooks stories for SubscriptAvatar component cc @roryabraham 

<img width="900" alt="Screen Shot 2022-03-14 at 14 07 05" src="https://user-images.githubusercontent.com/6829422/158252584-da5831be-78db-4fb8-8fb2-6ae157e321cb.png">

<img width="900" alt="Screen Shot 2022-03-14 at 14 07 23" src="https://user-images.githubusercontent.com/6829422/158252555-43007b01-befb-4318-ab29-d6adbb069fc0.png">


### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):


Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
This is a follow-up PR of https://github.com/Expensify/App/pull/7852#discussion_r819174112 

### Tests / QA
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Pre-requisites:
  - Create or use an existing account which will be the admin
  - Add the admin account to `policyExpenseChat` beta
  - Create a Workspace and invite a few workspace members.
  - As admin send a message to one of the members through the workspace chat

Steps:
1. From the workspace chat mark a few messages as unread
2. Enable #focus mode on Settings -> Preferences
3. The SubscriptAvatar should be displayed in small size

- [ ] Verify that no errors appear in the JS console

### PR Review Checklist
<!--
This is a checklist for PR authors & reviewers. Please make sure to complete all tasks and check them off once you do, or else Expensify has the right not to merge your PR!
-->
#### Contributor (PR Author) Checklist
- [x] I verified the PR has a small number of commits behind `main`
- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I clearly indicated the environment tests should be run in (Staging vs Production)
- [x] I wrote testing steps that cover success & fail scenarios (if applicable)
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests & veryfy they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors related to changes in this PR
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I added comments when the code was not self explanatory
    - [ ] I put all copy / text shown in the product in all `src/languages/*` files (if applicable)
    - [ ] I followed proper naming convention for platform-specific files (if applicable)
    - [x] I followed style guidelines (in [`Styling.md`](https://github.com/Expensify/App/blob/main/STYLING.md)) for all style edits I made
    - [x] I followed the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs))
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I corroborated the UI performance was not affected (the performance is the same than `main` branch)
- [x] If I created a new component I verified that a similar component doesn't exist in the codebase

#### PR Reviewer Checklist
- [ ] I verified the PR has a small number of commits behind `main`
- [ ] I verified the correct issue is linked in the `### Fixed Issues` section above
- [ ] I verified testing steps are clear and they cover the changes made in this PR
    - [ ] I verified the testing environment is mentioned in the test steps
- [ ] I verified testing steps cover success & fail scenarios (if applicable)
- [ ] I checked that screenshots or videos are included for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I verified tests pass on **all platforms** & I tested again on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [ ] I verified there are no console errors related to changes in this PR
- [ ] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified comments were added when the code was not self explanatory
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files (if applicable)
    - [ ] I verified proper naming convention for platform-specific files was followed (if applicable)
    - [ ] I verified [style guidelines](https://github.com/Expensify/App/blob/main/STYLING.md) were followed
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs)) were followed
- [ ] I verified that this PR follows the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [ ] I verified other components are not impacted by changes in this PR (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] I verified the UI performance was not affected (the performance is the same than `main` branch)
- [ ] If a new component is created I verified that a similar component doesn't exist in the codebase

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
4. Upload an image via copy paste
5. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
<img width="900" alt="Screen Shot 2022-03-14 at 13 53 28" src="https://user-images.githubusercontent.com/6829422/158252001-e943485c-d000-4622-bba5-0d973a0f036f.png">

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
<img width="350" alt="Screen Shot 2022-03-14 at 14 14 25" src="https://user-images.githubusercontent.com/6829422/158253674-bc935847-8930-4e40-a61f-73cbedbfaeae.png">

<img width="350" alt="Screen Shot 2022-03-14 at 14 14 56" src="https://user-images.githubusercontent.com/6829422/158253780-7ef8e691-65e5-4de9-8133-2eae8aed3a39.png">

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
<img width="900" alt="Screen Shot 2022-03-14 at 14 06 29" src="https://user-images.githubusercontent.com/6829422/158252644-81619001-c84d-4373-9332-bdad419b6625.png">

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
<img width="325" alt="Screen Shot 2022-03-14 at 14 20 10" src="https://user-images.githubusercontent.com/6829422/158254514-d90d6c68-6716-4b16-97f8-19432314495d.png">

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
<img width="427" alt="Screen Shot 2022-03-14 at 14 12 56" src="https://user-images.githubusercontent.com/6829422/158253442-7fc688d3-8676-4b17-abba-df7e71a8fb8e.png">

