### PR TITLE
Style and remove "Save" button for Default Room Settings

### DIFF
--- a/src/pages/ReportSettingsPage.js
+++ b/src/pages/ReportSettingsPage.js
@@ -20,7 +20,6 @@ import Picker from '../components/Picker';
 import withFullPolicy, {fullPolicyDefaultProps, fullPolicyPropTypes} from './workspace/withFullPolicy';
 import * as ValidationUtils from '../libs/ValidationUtils';
 import Growl from '../libs/Growl';
-import TextInput from '../components/TextInput';
 
 const propTypes = {
     /** Route params */
@@ -192,13 +191,13 @@ class ReportSettingsPage extends Component {
                                             onChangeText={newRoomName => this.clearErrorAndSetValue('newRoomName', newRoomName)}
                                             disabled={isDefaultOrArchivedRoom}
                                         />
-                                        )
+                                    )
                                         : (
                                             <View>
-                                                <Text style={[styles.textLabelSupporting]} numberOfLines={1}>
+                                                <Text style={[styles.textLabelSupporting, styles.lh16, styles.mb1]} numberOfLines={1}>
                                                     {this.props.translate('newRoomPage.roomName')}
                                                 </Text>
-                                                <Text numberOfLines={1} style={[styles.reportSettingsVisibilityText]}>
+                                                <Text numberOfLines={1} style={[styles.reportSettingsVisibilityText, styles.optionAlternateText]}>
                                                     {this.state.newRoomName}
                                                 </Text>
                                             </View>
@@ -223,17 +222,10 @@ class ReportSettingsPage extends Component {
                     {linkedWorkspace && (
                         <View style={[styles.mt4]}>
                             <View style={[styles.flex3]}>
-                                {/*<TextInput*/}
-                                {/*    disabled*/}
-                                {/*    label={this.props.translate('workspace.common.workspace')}*/}
-                                {/*    placeholder={this.props.translate('newRoomPage.social')}*/}
-                                {/*    value={linkedWorkspace.name}*/}
-                                {/*    autoCapitalize="none"*/}
-                                {/*/>*/}
-                                <Text style={[styles.textLabelSupporting]} numberOfLines={1}>
+                                <Text style={[styles.textLabelSupporting, styles.lh16, styles.mb1]} numberOfLines={1}>
                                     {this.props.translate('workspace.common.workspace')}
                                 </Text>
-                                <Text numberOfLines={1} style={[styles.reportSettingsVisibilityText]} autoCapitalize="none">
+                                <Text numberOfLines={1} style={[styles.reportSettingsVisibilityText, styles.optionAlternateText]}>
                                     {linkedWorkspace.name}
                                 </Text>
                             </View>

--- a/src/pages/ReportSettingsPage.js
+++ b/src/pages/ReportSettingsPage.js
@@ -152,7 +152,7 @@ class ReportSettingsPage extends Component {
 
     render() {
         const shouldShowRename = !ReportUtils.isPolicyExpenseChat(this.props.report);
-        const shouldDisableRename = ReportUtils.isDefaultRoom(this.props.report)
+        const isDefaultOrArchivedRoom = ReportUtils.isDefaultRoom(this.props.report)
             || ReportUtils.isArchivedRoom(this.props.report);
         const linkedWorkspace = _.find(this.props.policies, policy => policy.id === this.props.report.policyID);
 
@@ -184,25 +184,37 @@ class ReportSettingsPage extends Component {
                         <View style={styles.mt4}>
                             <View style={[styles.flexRow]}>
                                 <View style={[styles.flex3]}>
-                                    <RoomNameInput
-                                        initialValue={this.state.newRoomName}
-                                        policyID={linkedWorkspace && linkedWorkspace.id}
-                                        errorText={this.state.errors.newRoomName}
-                                        onChangeText={newRoomName => this.clearErrorAndSetValue('newRoomName', newRoomName)}
-                                        disabled={shouldDisableRename}
-                                    />
+                                    {!isDefaultOrArchivedRoom ? (
+                                        <RoomNameInput
+                                            initialValue={this.state.newRoomName}
+                                            policyID={linkedWorkspace && linkedWorkspace.id}
+                                            errorText={this.state.errors.newRoomName}
+                                            onChangeText={newRoomName => this.clearErrorAndSetValue('newRoomName', newRoomName)}
+                                            disabled={isDefaultOrArchivedRoom}
+                                        />
+                                        )
+                                        : (
+                                            <View>
+                                                <Text style={[styles.textLabelSupporting]} numberOfLines={1}>
+                                                    {this.props.translate('newRoomPage.roomName')}
+                                                </Text>
+                                                <Text numberOfLines={1} style={[styles.reportSettingsVisibilityText]}>
+                                                    {this.state.newRoomName}
+                                                </Text>
+                                            </View>
+                                        )}
                                 </View>
-                                {!shouldDisableRename && (
+                                {!isDefaultOrArchivedRoom && (
                                     <Button
                                         large
-                                        success={!shouldDisableRename}
+                                        success={!isDefaultOrArchivedRoom}
                                         text={this.props.translate('common.save')}
                                         onPress={this.validateAndRenameReport}
                                         style={[styles.ml2, styles.flex1]}
                                         textStyles={[styles.label]}
                                         innerStyles={[styles.ph5]}
                                         isLoading={this.props.isLoadingRenamePolicyRoom}
-                                        isDisabled={shouldDisableRename}
+                                        isDisabled={isDefaultOrArchivedRoom}
                                     />
                                 )}
                             </View>
@@ -211,13 +223,19 @@ class ReportSettingsPage extends Component {
                     {linkedWorkspace && (
                         <View style={[styles.mt4]}>
                             <View style={[styles.flex3]}>
-                                <TextInput
-                                    disabled
-                                    label={this.props.translate('workspace.common.workspace')}
-                                    placeholder={this.props.translate('newRoomPage.social')}
-                                    value={linkedWorkspace.name}
-                                    autoCapitalize="none"
-                                />
+                                {/*<TextInput*/}
+                                {/*    disabled*/}
+                                {/*    label={this.props.translate('workspace.common.workspace')}*/}
+                                {/*    placeholder={this.props.translate('newRoomPage.social')}*/}
+                                {/*    value={linkedWorkspace.name}*/}
+                                {/*    autoCapitalize="none"*/}
+                                {/*/>*/}
+                                <Text style={[styles.textLabelSupporting]} numberOfLines={1}>
+                                    {this.props.translate('workspace.common.workspace')}
+                                </Text>
+                                <Text numberOfLines={1} style={[styles.reportSettingsVisibilityText]} autoCapitalize="none">
+                                    {linkedWorkspace.name}
+                                </Text>
                             </View>
                         </View>
                     )}

--- a/src/pages/ReportSettingsPage.js
+++ b/src/pages/ReportSettingsPage.js
@@ -197,7 +197,7 @@ class ReportSettingsPage extends Component {
                                                 <Text style={[styles.textLabelSupporting, styles.lh16, styles.mb1]} numberOfLines={1}>
                                                     {this.props.translate('newRoomPage.roomName')}
                                                 </Text>
-                                                <Text numberOfLines={1} style={[styles.reportSettingsVisibilityText, styles.optionAlternateText]}>
+                                                <Text numberOfLines={1} style={[styles.optionAlternateText]}>
                                                     {this.state.newRoomName}
                                                 </Text>
                                             </View>
@@ -221,14 +221,12 @@ class ReportSettingsPage extends Component {
                     )}
                     {linkedWorkspace && (
                         <View style={[styles.mt4]}>
-                            <View style={[styles.flex3]}>
-                                <Text style={[styles.textLabelSupporting, styles.lh16, styles.mb1]} numberOfLines={1}>
-                                    {this.props.translate('workspace.common.workspace')}
-                                </Text>
-                                <Text numberOfLines={1} style={[styles.reportSettingsVisibilityText, styles.optionAlternateText]}>
-                                    {linkedWorkspace.name}
-                                </Text>
-                            </View>
+                            <Text style={[styles.textLabelSupporting, styles.lh16, styles.mb1]} numberOfLines={1}>
+                                {this.props.translate('workspace.common.workspace')}
+                            </Text>
+                            <Text numberOfLines={1} style={[styles.optionAlternateText]}>
+                                {linkedWorkspace.name}
+                            </Text>
                         </View>
                     )}
                     {this.props.report.visibility && (

--- a/src/pages/ReportSettingsPage.js
+++ b/src/pages/ReportSettingsPage.js
@@ -167,9 +167,6 @@ class ReportSettingsPage extends Component {
                 <ScrollView style={styles.flex1} contentContainerStyle={styles.p5}>
                     <View>
                         <View>
-                            <Text style={[styles.formLabel]} numberOfLines={1}>
-                                {this.props.translate('common.notifications')}
-                            </Text>
                         </View>
                         <View style={[styles.mb5, styles.mt2]}>
                             <Picker
@@ -187,9 +184,6 @@ class ReportSettingsPage extends Component {
                     </View>
                     {shouldShowRename && (
                         <View style={styles.mt4}>
-                            <Text style={[styles.formLabel]} numberOfLines={1}>
-                                {this.props.translate('newRoomPage.roomName')}
-                            </Text>
                             <View style={[styles.flexRow, styles.mb1]}>
                                 <View style={[styles.flex3]}>
                                     <RoomNameInput
@@ -218,7 +212,7 @@ class ReportSettingsPage extends Component {
                     )}
                     {linkedWorkspace && (
                         <View style={[styles.mt4]}>
-                            <Text style={[styles.formLabel]} numberOfLines={1}>
+                            <Text style={[styles.label]} numberOfLines={1}>
                                 {this.props.translate('workspace.common.workspace')}
                             </Text>
                             <Text numberOfLines={1}>

--- a/src/pages/ReportSettingsPage.js
+++ b/src/pages/ReportSettingsPage.js
@@ -20,6 +20,7 @@ import Picker from '../components/Picker';
 import withFullPolicy, {fullPolicyDefaultProps, fullPolicyPropTypes} from './workspace/withFullPolicy';
 import * as ValidationUtils from '../libs/ValidationUtils';
 import Growl from '../libs/Growl';
+import TextInput from '../components/TextInput';
 
 const propTypes = {
     /** Route params */
@@ -212,12 +213,15 @@ class ReportSettingsPage extends Component {
                     )}
                     {linkedWorkspace && (
                         <View style={[styles.mt4]}>
-                            <Text style={[styles.label]} numberOfLines={1}>
-                                {this.props.translate('workspace.common.workspace')}
-                            </Text>
-                            <Text numberOfLines={1}>
-                                {linkedWorkspace.name}
-                            </Text>
+                            <View style={[styles.flex3]}>
+                                <TextInput
+                                    disabled
+                                    label={this.props.translate('workspace.common.workspace')}
+                                    placeholder={this.props.translate('newRoomPage.social')}
+                                    value={linkedWorkspace.name}
+                                    autoCapitalize="none"
+                                />
+                            </View>
                         </View>
                     )}
                     {this.props.report.visibility && (

--- a/src/pages/ReportSettingsPage.js
+++ b/src/pages/ReportSettingsPage.js
@@ -153,6 +153,7 @@ class ReportSettingsPage extends Component {
         const shouldShowRename = !ReportUtils.isPolicyExpenseChat(this.props.report);
         const shouldDisableRename = ReportUtils.isDefaultRoom(this.props.report)
             || ReportUtils.isArchivedRoom(this.props.report);
+        console.log(shouldDisableRename);
         const linkedWorkspace = _.find(this.props.policies, policy => policy.id === this.props.report.policyID);
 
         return (
@@ -199,17 +200,19 @@ class ReportSettingsPage extends Component {
                                         disabled={shouldDisableRename}
                                     />
                                 </View>
-                                <Button
-                                    large
-                                    success={!shouldDisableRename}
-                                    text={this.props.translate('common.save')}
-                                    onPress={this.validateAndRenameReport}
-                                    style={[styles.ml2, styles.flex1]}
-                                    textStyles={[styles.label]}
-                                    innerStyles={[styles.ph5]}
-                                    isLoading={this.props.isLoadingRenamePolicyRoom}
-                                    isDisabled={shouldDisableRename}
-                                />
+                                {!shouldDisableRename && (
+                                    <Button
+                                        large
+                                        success={!shouldDisableRename}
+                                        text={this.props.translate('common.save')}
+                                        onPress={this.validateAndRenameReport}
+                                        style={[styles.ml2, styles.flex1]}
+                                        textStyles={[styles.label]}
+                                        innerStyles={[styles.ph5]}
+                                        isLoading={this.props.isLoadingRenamePolicyRoom}
+                                        isDisabled={shouldDisableRename}
+                                    />
+                                )}
                             </View>
                         </View>
                     )}

--- a/src/pages/ReportSettingsPage.js
+++ b/src/pages/ReportSettingsPage.js
@@ -166,7 +166,7 @@ class ReportSettingsPage extends Component {
                 />
                 <ScrollView style={styles.flex1} contentContainerStyle={styles.p5}>
                     <View>
-                        <View style={[styles.mb1, styles.mt2]}>
+                        <View style={[styles.mt2]}>
                             <Picker
                                 label={this.props.translate('notificationPreferences.label')}
                                 onChange={(notificationPreference) => {
@@ -181,8 +181,8 @@ class ReportSettingsPage extends Component {
                         </View>
                     </View>
                     {shouldShowRename && (
-                        <View style={styles.mt2}>
-                            <View style={[styles.flexRow, styles.mb1]}>
+                        <View style={styles.mt4}>
+                            <View style={[styles.flexRow]}>
                                 <View style={[styles.flex3]}>
                                     <RoomNameInput
                                         initialValue={this.state.newRoomName}

--- a/src/pages/ReportSettingsPage.js
+++ b/src/pages/ReportSettingsPage.js
@@ -231,7 +231,7 @@ class ReportSettingsPage extends Component {
                     )}
                     {this.props.report.visibility && (
                         <View style={[styles.mt4]}>
-                            <Text style={[styles.formLabel]} numberOfLines={1}>
+                            <Text style={[styles.textLabelSupporting, styles.lh16, styles.mb1]} numberOfLines={1}>
                                 {this.props.translate('newRoomPage.visibility')}
                             </Text>
                             <Text numberOfLines={1} style={[styles.reportSettingsVisibilityText]}>{this.props.report.visibility}</Text>

--- a/src/pages/ReportSettingsPage.js
+++ b/src/pages/ReportSettingsPage.js
@@ -150,8 +150,8 @@ class ReportSettingsPage extends Component {
     }
 
     render() {
-        const shouldShowRename = !ReportUtils.isPolicyExpenseChat(this.props.report);
-        const isDefaultOrArchivedRoom = ReportUtils.isDefaultRoom(this.props.report)
+        const shouldShowRoomName = !ReportUtils.isPolicyExpenseChat(this.props.report);
+        const shouldDisableRename = ReportUtils.isDefaultRoom(this.props.report)
             || ReportUtils.isArchivedRoom(this.props.report);
         const linkedWorkspace = _.find(this.props.policies, policy => policy.id === this.props.report.policyID);
 
@@ -179,41 +179,41 @@ class ReportSettingsPage extends Component {
                             />
                         </View>
                     </View>
-                    {shouldShowRename && (
+                    {shouldShowRoomName && (
                         <View style={styles.mt4}>
                             <View style={[styles.flexRow]}>
                                 <View style={[styles.flex3]}>
-                                    {!isDefaultOrArchivedRoom ? (
-                                        <RoomNameInput
-                                            initialValue={this.state.newRoomName}
-                                            policyID={linkedWorkspace && linkedWorkspace.id}
-                                            errorText={this.state.errors.newRoomName}
-                                            onChangeText={newRoomName => this.clearErrorAndSetValue('newRoomName', newRoomName)}
-                                            disabled={isDefaultOrArchivedRoom}
-                                        />
+                                    {shouldDisableRename ? (
+                                        <View>
+                                            <Text style={[styles.textLabelSupporting, styles.lh16, styles.mb1]} numberOfLines={1}>
+                                                {this.props.translate('newRoomPage.roomName')}
+                                            </Text>
+                                            <Text numberOfLines={1} style={[styles.optionAlternateText]}>
+                                                {this.state.newRoomName}
+                                            </Text>
+                                        </View>
                                     )
                                         : (
-                                            <View>
-                                                <Text style={[styles.textLabelSupporting, styles.lh16, styles.mb1]} numberOfLines={1}>
-                                                    {this.props.translate('newRoomPage.roomName')}
-                                                </Text>
-                                                <Text numberOfLines={1} style={[styles.optionAlternateText]}>
-                                                    {this.state.newRoomName}
-                                                </Text>
-                                            </View>
+                                            <RoomNameInput
+                                                initialValue={this.state.newRoomName}
+                                                policyID={linkedWorkspace && linkedWorkspace.id}
+                                                errorText={this.state.errors.newRoomName}
+                                                onChangeText={newRoomName => this.clearErrorAndSetValue('newRoomName', newRoomName)}
+                                                disabled={shouldDisableRename}
+                                            />
                                         )}
                                 </View>
-                                {!isDefaultOrArchivedRoom && (
+                                {!shouldDisableRename && (
                                     <Button
                                         large
-                                        success={!isDefaultOrArchivedRoom}
+                                        success={!shouldDisableRename}
                                         text={this.props.translate('common.save')}
                                         onPress={this.validateAndRenameReport}
                                         style={[styles.ml2, styles.flex1]}
                                         textStyles={[styles.label]}
                                         innerStyles={[styles.ph5]}
                                         isLoading={this.props.isLoadingRenamePolicyRoom}
-                                        isDisabled={isDefaultOrArchivedRoom}
+                                        isDisabled={shouldDisableRename}
                                     />
                                 )}
                             </View>

--- a/src/pages/ReportSettingsPage.js
+++ b/src/pages/ReportSettingsPage.js
@@ -154,7 +154,6 @@ class ReportSettingsPage extends Component {
         const shouldShowRename = !ReportUtils.isPolicyExpenseChat(this.props.report);
         const shouldDisableRename = ReportUtils.isDefaultRoom(this.props.report)
             || ReportUtils.isArchivedRoom(this.props.report);
-        console.log(shouldDisableRename);
         const linkedWorkspace = _.find(this.props.policies, policy => policy.id === this.props.report.policyID);
 
         return (
@@ -167,9 +166,7 @@ class ReportSettingsPage extends Component {
                 />
                 <ScrollView style={styles.flex1} contentContainerStyle={styles.p5}>
                     <View>
-                        <View>
-                        </View>
-                        <View style={[styles.mb5, styles.mt2]}>
+                        <View style={[styles.mb1, styles.mt2]}>
                             <Picker
                                 label={this.props.translate('notificationPreferences.label')}
                                 onChange={(notificationPreference) => {
@@ -184,7 +181,7 @@ class ReportSettingsPage extends Component {
                         </View>
                     </View>
                     {shouldShowRename && (
-                        <View style={styles.mt4}>
+                        <View style={styles.mt2}>
                             <View style={[styles.flexRow, styles.mb1]}>
                                 <View style={[styles.flex3]}>
                                     <RoomNameInput

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -293,6 +293,10 @@ const styles = {
         textTransform: 'uppercase',
     },
 
+    textLowercase: {
+        textTransform: 'lowercase',
+    },
+
     textNoWrap: {
         ...whiteSpace.noWrap,
     },

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -293,10 +293,6 @@ const styles = {
         textTransform: 'uppercase',
     },
 
-    textLowercase: {
-        textTransform: 'lowercase',
-    },
-
     textNoWrap: {
         ...whiteSpace.noWrap,
     },
@@ -811,6 +807,10 @@ const styles = {
         fontFamily: fontFamily.GTA,
         fontSize: variables.fontSizeLabel,
         color: themeColors.textSupporting,
+    },
+
+    lh16: {
+        lineHeight: 16,
     },
 
     formLabel: {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
"Save" button is hidden for default/archived rooms and updated the style.

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ [GH_LINK](https://github.com/Expensify/App/issues/8146)

### Tests / QA Steps
1. See default room - either #announce or #admins
1. Click room avatar
1. Click settings
2. Verify "Save" button is no longer visible and text inputs are just text.
3. Click "+" Global create, create a new room, add name and in the new room's settings, verify you can edit and save the name of the room but not the workspace.

### PR Review Checklist
<!--
This is a checklist for PR authors & reviewers. Please make sure to complete all tasks and check them off once you do, or else Expensify has the right not to merge your PR!
-->
#### Contributor (PR Author) Checklist
- [x] I verified the PR has a small number of commits behind `main`
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I clearly indicated the environment tests should be run in (Staging vs Production)
- [x] I wrote testing steps that cover success & fail scenarios (if applicable)
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors related to changes in this PR
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I added comments when the code was not self explanatory
    - [x] I put all copy / text shown in the product in all `src/languages/*` files (if applicable)
    - [x] I followed proper naming convention for platform-specific files (if applicable)
    - [x] I followed style guidelines (in [`Styling.md`](https://github.com/Expensify/App/blob/main/STYLING.md)) for all style edits I made
    - [x] I followed the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs))
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I corroborated the UI performance was not affected (the performance is the same than `main` branch)
- [x] If I created a new component I verified that a similar component doesn't exist in the codebase

#### PR Reviewer Checklist
- [x] I verified the PR has a small number of commits behind `main`
- [x] I verified the correct issue is linked in the `### Fixed Issues` section above
- [x] I verified testing steps are clear and they cover the changes made in this PR
    - [ ] I verified the testing environment is mentioned in the test steps
- [x] I verified testing steps cover success & fail scenarios (if applicable)
- [x] I checked that screenshots or videos are included for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I verified tests pass on **all platforms** & I tested again on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors related to changes in this PR
- [x] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified comments were added when the code was not self explanatory
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files (if applicable)
    - [x] I verified proper naming convention for platform-specific files was followed (if applicable)
    - [x] I verified [style guidelines](https://github.com/Expensify/App/blob/main/STYLING.md) were followed
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs)) were followed
- [x] I verified that this PR follows the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [x] I verified other components are not impacted by changes in this PR (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified the UI performance was not affected (the performance is the same than `main` branch)
- [ ] If a new component is created I verified that a similar component doesn't exist in the codebase

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
default room
<img width="383" alt="Screen Shot 2022-03-15 at 1 35 23 PM" src="https://user-images.githubusercontent.com/24466196/158468684-cdee8cb6-8361-4896-8cff-ac76b64c32f8.png">

new room
<img width="372" alt="Screen Shot 2022-03-16 at 3 25 02 PM" src="https://user-images.githubusercontent.com/24466196/158701507-57942675-ac57-4f30-9088-9f59459d48cd.png">

#### Mobile Web
![Screen Shot 2022-03-16 at 12 39 55 PM](https://user-images.githubusercontent.com/24466196/158676393-d0b314cd-2a18-4e49-8973-0602c2b8b399.png)
<img width="379" alt="Screen Shot 2022-03-16 at 12 55 20 PM" src="https://user-images.githubusercontent.com/24466196/158701217-f700ef72-5871-4a21-a061-48b82bd76f3f.png">

#### Desktop
<img width="372" alt="Screen Shot 2022-03-15 at 2 45 38 PM" src="https://user-images.githubusercontent.com/24466196/158480439-c8678c90-df68-43c8-8d54-dc93bbcf6b4f.png">
<img width="372" alt="Screen Shot 2022-03-16 at 3 25 02 PM" src="https://user-images.githubusercontent.com/24466196/158701523-977adfcc-4a62-4123-809c-62c0a966e5e3.png">

#### iOS
![Screen Shot 2022-03-16 at 12 20 25 PM](https://user-images.githubusercontent.com/24466196/158672245-d7d186ef-6009-475d-90d5-70f8c02296a7.png)
![Screen Shot 2022-03-16 at 3 10 41 PM](https://user-images.githubusercontent.com/24466196/158699734-b230825b-d5a6-47d5-9aeb-b8bb302886bf.png)

#### Android
<img width="426" alt="Screen Shot 2022-03-15 at 3 05 33 PM" src="https://user-images.githubusercontent.com/24466196/158480392-552bd2e4-3c5a-4046-af7c-00c4a8ba3bc5.png">
![Screen Shot 2022-03-16 at 4 11 15 PM](https://user-images.githubusercontent.com/24466196/158706139-46b14b7e-da89-46fd-8023-16470bbf4578.png)
