### PR TITLE
[No QA] Remove unnecessary checks for InlineErrorText

### DIFF
--- a/src/components/CheckboxWithLabel.js
+++ b/src/components/CheckboxWithLabel.js
@@ -102,11 +102,9 @@ const CheckboxWithLabel = React.forwardRef((props, ref) => {
                     {LabelComponent && (<LabelComponent />)}
                 </TouchableOpacity>
             </View>
-            {!_.isEmpty(props.errorText) && (
-                <InlineErrorText styles={[styles.ml8]}>
-                    {props.errorText}
-                </InlineErrorText>
-            )}
+            <InlineErrorText styles={[styles.ml8]}>
+                {props.errorText}
+            </InlineErrorText>
         </>
     );
 });

--- a/src/components/Picker/index.js
+++ b/src/components/Picker/index.js
@@ -63,11 +63,9 @@ class Picker extends PureComponent {
                         {...pickerProps}
                     />
                 </View>
-                {!_.isEmpty(this.props.errorText) && (
-                    <InlineErrorText>
-                        {this.props.errorText}
-                    </InlineErrorText>
-                )}
+                <InlineErrorText>
+                    {this.props.errorText}
+                </InlineErrorText>
             </>
         );
     }

--- a/src/components/RadioButtonWithLabel.js
+++ b/src/components/RadioButtonWithLabel.js
@@ -75,11 +75,9 @@ const RadioButtonWithLabel = (props) => {
                     {LabelComponent && (<LabelComponent />)}
                 </TouchableOpacity>
             </View>
-            {!_.isEmpty(props.errorText) && (
-                <InlineErrorText>
-                    {props.errorText}
-                </InlineErrorText>
-            )}
+            <InlineErrorText>
+                {props.errorText}
+            </InlineErrorText>
         </>
     );
 };


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

Follow up to PR https://github.com/Expensify/App/pull/8145#issuecomment-1068421110.

When using `InlineErrorText`, we're checking if `errorText` is empty.
But this isn't required because `InlineErrorText` already handles this for us, and returns `null` if no error text in passed to it.

https://github.com/Expensify/App/blob/7919e24c808dea9dedfe4a2d513365cf092cc1e1/src/components/InlineErrorText.js#L20-L23

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/8044 (cleanup PR)

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Regression tests only.
1. Navigate to Settings -> Any workspace -> Connect bank account -> Connect manually
2. Enter routing number: 041215032
3. Enter account number: 1234
4. Click save and continue
6. In company information page, verify that spacing has not changed.
7. Click save and continue
8. Verify that the errors have same spacing as before.
- [x] Verify that no errors appear in the JS console

### PR Review Checklist
<!--
This is a checklist for PR authors & reviewers. Please make sure to complete all tasks and check them off once you do, or else Expensify has the right not to merge your PR!
-->
#### Contributor (PR Author) Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (if applicable, i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I added steps to cover offline scenarios (if applicable, i.e. verify the default avatar icon is displayed if app is offline)
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors related to changes in this PR
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I added comments when the code was not self explanatory
    - [x] I put all copy / text shown in the product in all `src/languages/*` files (if applicable)
    - [x] I followed proper naming convention for platform-specific files (if applicable)
    - [x] I followed style guidelines (in [`Styling.md`](https://github.com/Expensify/App/blob/main/STYLING.md)) for all style edits I made
    - [x] I followed the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs))
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] Has the `displayName` property if it’s a Functional Component
    - [x] Has Storybook stories (optional)
    - [x] Has Unit tests (optional)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn’t already exist
    - [x] The style can’t be created with a [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function
(i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)



#### PR Reviewer Checklist
- [x] I verified the correct issue is linked in the `### Fixed Issues` section above
- [ ] I verified testing steps are clear and they cover the changes made in this PR
    - [ ] I verified the steps for local testing are in the `Tests` section
    - [ ] I verified the steps for Staging and/or Production testing are in the `QA steps` section
    - [ ] I verified the steps cover failure scenarios (if applicable, i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I verified steps cover offline scenarios (if applicable, i.e. verify the default avatar icon is displayed if app is offline)
- [x] I checked that screenshots or videos are included for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I verified tests pass on **all platforms** & I tested again on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [x] I verified there are no console errors related to changes in this PR
- [ ] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified comments were added when the code was not self explanatory
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files (if applicable)
    - [ ] I verified proper naming convention for platform-specific files was followed (if applicable)
    - [ ] I verified [style guidelines](https://github.com/Expensify/App/blob/main/STYLING.md) were followed
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs)) were followed
- [x] I verified that this PR follows the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [x] I verified other components are not impacted by changes in this PR (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] Has the `displayName` property if it’s a Functional Component
    - [ ] Has Storybook stories (optional)
    - [ ] Has Unit tests (optional)
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn’t already exist
    - [ ] The style can’t be created with a [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function
(i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)


- [ ] Verify that no errors appear in the JS console

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
<img width="711" alt="Screen Shot 2022-03-16 at 11 43 28 PM" src="https://user-images.githubusercontent.com/29673073/158712507-d4ecfd46-9d3a-489e-b9e2-d6e076670fe8.png">
<img width="715" alt="Screen Shot 2022-03-16 at 11 43 39 PM" src="https://user-images.githubusercontent.com/29673073/158712518-98fab65f-b7dc-4d5b-a8ce-e60b7a4f9641.png">

#### Mobile Web


<img width="379" alt="Screen Shot 2022-03-16 at 11 47 41 PM" src="https://user-images.githubusercontent.com/29673073/158712553-80b87a79-a021-4727-b606-e12f0048e119.png">
<img width="358" alt="Screen Shot 2022-03-16 at 11 48 05 PM" src="https://user-images.githubusercontent.com/29673073/158712559-1ad9288d-af1e-4371-a5d5-26b29fe20ef8.png">
#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
<img width="601" alt="Screen Shot 2022-03-16 at 11 52 11 PM" src="https://user-images.githubusercontent.com/29673073/158712591-8c4d666f-3dba-4903-97b4-9b121a703a9b.png">
<img width="600" alt="Screen Shot 2022-03-16 at 11 52 20 PM" src="https://user-images.githubusercontent.com/29673073/158712596-4f564c33-6d63-47f5-9c60-852ef440ec66.png">

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
<img width="321" alt="Screen Shot 2022-03-16 at 11 30 47 PM" src="https://user-images.githubusercontent.com/29673073/158712472-8cd50faf-622f-4a3a-8daf-7c653e84317f.png">
<img width="351" alt="Screen Shot 2022-03-16 at 11 31 09 PM" src="https://user-images.githubusercontent.com/29673073/158712475-64531ad5-5e88-49c9-8064-bb09fe787022.png">

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
![Screenshot_20220317-012632](https://user-images.githubusercontent.com/29673073/158712639-f5641aec-129b-47c9-93f1-cc52ddbfe393.jpg)
![Screenshot_20220317-012635](https://user-images.githubusercontent.com/29673073/158712652-b234852f-bad9-487b-9fca-253ad6ba0c70.jpg)

