### PR TITLE
[HOLD] Fix notifcation count on initial load

### DIFF
--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -169,19 +169,19 @@ function getChatReportName(fullReport, chatType) {
 }
 
 /**
- * Returns number of optimisticReportActionIDs exist in reportActions
+ * Returns the number of optimisticReportActionIDs in reportActions
  *
- * @param {String} reportID
+ * @param {Number} reportID
  * @returns {Number}
  */
 function getNumberOfOptimisticActions(reportID) {
     const optimisticActionIds = lodashGet(allReports, [reportID, 'optimisticReportActionIDs'], []);
-    return _.filter(optimisticActionIds, actionId => ReportActions.isOptimisticReportActionExist(reportID, actionId)).length;
+    return _.filter(optimisticActionIds, actionId => ReportActions.doesOptimisticReportActionExist(reportID, actionId)).length;
 }
 
 /**
  * If onyx local report data is newer than fetched report then return updated version of simplifiedReport
- * Local report data could be newer than fetched report because pusher new comment event coming while fetch report request isn't completed yet
+ * Local report data could be newer than the fetched report because of a pusher new comment event coming while the fetching report request hasn't been completed yet
  *
  * @param {Object} simplifiedReport, simplifiedReport of Report Data
  * @returns {Object}
@@ -651,11 +651,10 @@ function updateReportWithNewAction(
 
         // Use updated lastReadSequenceNumber, value may have been modified by setLocalLastRead
         // Here deletedComments count does not include the new action being added. We can safely assume that newly received action is not deleted.
-        // If lastReadSequenceNumbers[reportID] is undefined (fetchAllReports isn't completed yet), fallback to local unreadActionCount
+        // If lastReadSequenceNumbers[reportID] is undefined (fetchAllReports isn't completed yet),
+        // fallback to local unreadActionCount and increment it by one each time a pusher event with a new comment arrives.
         unreadActionCount: lastReadSequenceNumbers[reportID]
             ? newMaxSequenceNumber - lastReadSequenceNumbers[reportID] - ReportActions.getDeletedCommentsCount(reportID, lastReadSequenceNumbers[reportID])
-
-            // If lastReadSequenceNumbers[reportID] isn't ready, use local/onyx unreadActionCount and increment it by one each time pusher new comment event arrived
             : lodashGet(allReports, [reportID, 'unreadActionCount'], 0) + 1,
         maxSequenceNumber: reportAction.sequenceNumber,
     };

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -185,7 +185,7 @@ function getNumberOfOptimisticActions(reportID) {
  * @returns {Object}
  */
 function checkAndUpdateSimplifiedReport(simplifiedReport) {
-    const currentReport = lodashGet(allReports, simplifiedReport.reportID, 0);
+    const currentReport = lodashGet(allReports, simplifiedReport.reportID, null);
     if (!currentReport) {
         return simplifiedReport;
     }

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -169,8 +169,6 @@ function getChatReportName(fullReport, chatType) {
 }
 
 /**
- * Returns the number of optimisticReportActionIDs in reportActions
- *
  * @param {Number} reportID
  * @returns {Number}
  */

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -204,7 +204,7 @@ function checkAndUpdateSimplifiedReport(simplifiedReport) {
 
     // Update some fields that are set by updateReportWithNewAction, the handler of pusher new comment event.
     const updatedSimplifiedReport = _.clone(simplifiedReport);
-    updatedSimplifiedReport.maxSequenceNumber = currentReport.MaxSeqNumber;
+    updatedSimplifiedReport.maxSequenceNumber = currentReport.maxSequenceNumber;
     updatedSimplifiedReport.unreadActionCount = unreadActionCount;
     updatedSimplifiedReport.lastMessageTimestamp = currentReport.lastMessageTimestamp;
     updatedSimplifiedReport.lastMessageText = currentReport.lastMessageText;

--- a/src/libs/actions/ReportActions.js
+++ b/src/libs/actions/ReportActions.js
@@ -112,7 +112,7 @@ function getLastVisibleMessageText(reportID) {
 }
 
 /**
- * Returns check result wheter optimisticActionId exist in reportActions
+ * Whether optimistic action exists in report actions.
  * @param {Number|String} reportID
  * @param {Number|String} optimisticActionId
  * @returns {Boolean}

--- a/src/libs/actions/ReportActions.js
+++ b/src/libs/actions/ReportActions.js
@@ -111,9 +111,20 @@ function getLastVisibleMessageText(reportID) {
     );
 }
 
+/**
+ * Returns check result wheter optimisticActionId exist in reportActions
+ * @param {Number|String} reportID
+ * @param {Number|String} optimisticActionId
+ * @returns {Boolean}
+ */
+function isOptimisticReportActionExist(reportID, optimisticActionId) {
+    return _.has(reportActions[reportID], optimisticActionId);
+}
+
 export {
     isReportMissingActions,
     dangerouslyGetReportActionsMaxSequenceNumber,
     getDeletedCommentsCount,
     getLastVisibleMessageText,
+    isOptimisticReportActionExist,
 };

--- a/src/libs/actions/ReportActions.js
+++ b/src/libs/actions/ReportActions.js
@@ -117,7 +117,7 @@ function getLastVisibleMessageText(reportID) {
  * @param {Number|String} optimisticActionId
  * @returns {Boolean}
  */
-function isOptimisticReportActionExist(reportID, optimisticActionId) {
+function doesOptimisticReportActionExist(reportID, optimisticActionId) {
     return _.has(reportActions[reportID], optimisticActionId);
 }
 
@@ -126,5 +126,5 @@ export {
     dangerouslyGetReportActionsMaxSequenceNumber,
     getDeletedCommentsCount,
     getLastVisibleMessageText,
-    isOptimisticReportActionExist,
+    doesOptimisticReportActionExist,
 };


### PR DESCRIPTION
### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/6591
$ https://github.com/Expensify/App/issues/7914

### Tests
For web:

1. Need firefox/chrome developer tools for doing testing on the web platform.
2. Open any chat room.
3. In-network tab of developers tools, configure throttling speed to be 20kbps.
4. Refresh browser tab.
5. In developer tools > network tab, observe push_authentication request and wait until it is completed
6. Right after the push_authenticate is completed, send a message to a room (other than active/currently visited room) from another device.
7. Verify that unread count notification is not a big number and correctly indicates the unread count.

For IOS:
1. On device A, sign out if already signed in.
2. Sign in again on device A with user A.
3. Right after sign in immediately go to the home screen (i.e. background the application)
4. From another user (User B) from device B, send a message to user A.
5. On device A, verify that the application icon badge count (unread count) on the iOS apps screen doesn't display a big number and display the unread count properly.


- [x] Verify that no errors appear in the JS console

### PR Review Checklist
<!--
This is a checklist for PR authors & reviewers. Please make sure to complete all tasks and check them off once you do, or else Expensify has the right not to merge your PR!
-->
#### Contributor (PR Author) Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] iOS / native
    - [ ] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there’s a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. “toggleReport” and not “onIconClick”)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct english, and explained “why” the code was doing something instead of only explaining “what” the code was doing.
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [x] I verified any copy / text that was added to the app is correct english and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named “index.js”. All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY
- [x] I verified any variables that can be defined as constants (ie. in CONST.js) are defined as such
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] Any functional components have the `displayName` property
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] Any internal methods are bound to “this” properly so there are no scoping issues
    - [x] Any internal methods bound to “this” are necessary to be bound
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose and it is
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn’t already exist
    - [x] The style can’t be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function
(i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)


#### PR Reviewer Checklist
- [ ] I verified the correct issue is linked in the `### Fixed Issues` section above
- [ ] I verified testing steps are clear and they cover the changes made in this PR
    - [ ] I verified the steps for local testing are in the `Tests` section
    - [ ] I verified the steps for Staging and/or Production testing are in the `QA steps` section
    - [ ] I verified the steps cover any possible failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [ ] I checked that screenshots or videos are included for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I verified tests pass on **all platforms** & I tested again on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [ ] I verified there are no console errors (if there’s a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. “toggleReport” and not “onIconClick”).
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct english, and explained “why” the code was doing something instead of only explaining “what” the code was doing.
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [ ] I verified any copy / text that was added to the app is correct english and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named “index.js”. All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I verified that this PR follows the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [ ] I verified other components are not impacted by changes in this PR (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] I verified all code is DRY
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js) are defined as such
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] Any functional components have the `displayName` property
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] Any internal methods are bound to “this” properly so there are no scoping issues
    - [ ] Any internal methods bound to “this” are necessary to be bound
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose and it is broken down into smaller components in order to separate concerns and functions
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn’t already exist
    - [ ] The style can’t be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function
(i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)

### QA Steps
For Web: 
Here is a video showing how the QA steps:

https://user-images.githubusercontent.com/1313124/158122505-99d3ebe4-14d6-4576-bc47-2f8ad21da802.mp4

<ol dir="auto">
<li>Need Chrome developer tools to do the test, doing the test in web platform</li>
<li>Open chrome then open expensify and press shortcut <code>Control + Shift + J</code></li>
<li>Open any chat room</li>
<li>In network tab of developers tools, configure throttling speed to be 65kbps for download and 50kbps for upload.</li>
<li>Go to network tabs, In <code>No Throttling</code> option select <code>add</code> -&gt; <code>Add custom profile</code> -&gt; fill profile name , download speed to be 65kbps and upload speed to be 50 kbps. Then press <code>add</code> -&gt; select that profile in throtlle.</li>
<li>In network tab of delveloper tools, select <code>fetch/xhr</code> and fill <code>filter</code> with push</li>
<li>Refresh Expensify tab</li>
<li>After refresh there will be two <code>push_authenticate</code> request, wait until both request completed</li>
<li>Right after the push_authenticate completed, send message to a room (other than active/currently visited room) from other device</li>
<li>Verify unread count notification is not a big number</li>
</ol>

For iOS:

<ol dir="auto">
<li>User A Sign out if he is already sign in</li>
<li>Sign in</li>
<li>Right after sign in immediately go to home screen/background the application</li>
<li>From other user (User B) send a message to user A</li>
<li>In IOS of User A: Verify application icon badge count (unread count) in home screen of IOS doesn't display big number and display the unread count properly.</li>
</ol>

- [ ] Verify that no errors appear in the JS console

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

  <details>
<summary>Before</summary>

https://user-images.githubusercontent.com/1313124/152940360-079fbaa4-2a7e-4911-abee-48aac8ea62fe.mp4

</details>
<details open>
<summary>After</summary>

https://user-images.githubusercontent.com/1313124/152937601-50ac7b20-bf6a-4056-8a72-1595bb4e07b7.mp4

</details>



#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

  <details>
<summary>Before</summary>

https://user-images.githubusercontent.com/1313124/154592731-1fde61ac-f879-446c-9bcd-35c3b7f2c1ea.mp4
</details>
<details open>
<summary>After</summary>

https://user-images.githubusercontent.com/1313124/154592339-9d320431-735b-47eb-aa63-cb2c80b9a748.mp4
</details>


#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
I wasn't able to test notifications. 

#### Android
<!-- Insert screenshots of your changes on the Android platform-->

I wasn't able to test notifications. 