### PR TITLE
New welcome message for deleted #admins/#announce rooms 

### DIFF
--- a/src/components/ReportWelcomeText.js
+++ b/src/components/ReportWelcomeText.js
@@ -4,6 +4,8 @@ import lodashGet from 'lodash/get';
 import Str from 'expensify-common/lib/str';
 import {withOnyx} from 'react-native-onyx';
 import _ from 'underscore';
+import RenderHTML from 'react-native-render-html';
+import {View} from 'react-native';
 import styles from '../styles/styles';
 import Text from './Text';
 import withLocalize, {withLocalizePropTypes} from './withLocalize';
@@ -75,52 +77,46 @@ const ReportWelcomeText = (props) => {
         },
     );
     const isResctrictedRoom = lodashGet(props, 'report.visibility', '') === CONST.REPORT.VISIBILITY.RESTRICTED;
+    const owner = lodashGet(props.personalDetails, [props.report.ownerEmail, 'firstName']) || props.report.ownerEmail;
+    const policyName = lodashGet(props.policies, [`${ONYXKEYS.COLLECTION.POLICY}${props.report.policyID}`, 'name'], Localize.translateLocal('workspace.common.unavailable'));
 
     return (
-        <Text style={[styles.mt3, styles.mw100, styles.textAlignCenter]}>
+        <View style={[styles.mt3, styles.mw100]}>
             {isPolicyExpenseChat && (
-                <>
-                    {/* Add align center style individually because of limited style inheritance in React Native https://reactnative.dev/docs/text#limited-style-inheritance */}
-                    <Text style={styles.textAlignCenter}>
-                        {props.translate('reportActionsView.beginningOfChatHistoryPolicyExpenseChatPartOne')}
-                    </Text>
-                    <Text style={[styles.textStrong]}>
-                        {/* Use the policyExpenseChat owner's first name or their email if it's undefined or an empty string */}
-                        {lodashGet(props.personalDetails, [props.report.ownerEmail, 'firstName']) || props.report.ownerEmail}
-                    </Text>
-                    <Text>
-                        {props.translate('reportActionsView.beginningOfChatHistoryPolicyExpenseChatPartTwo')}
-                    </Text>
-                    <Text style={[styles.textStrong]}>
-                        {lodashGet(props.policies, [`${ONYXKEYS.COLLECTION.POLICY}${props.report.policyID}`, 'name'], Localize.translateLocal('workspace.common.unavailable'))}
-                    </Text>
-                    <Text>
-                        {props.translate('reportActionsView.beginningOfChatHistoryPolicyExpenseChatPartThree')}
-                    </Text>
-                </>
+            <RenderHTML
+                defaultTextProps={{
+                    style: styles.textAlignCenter,
+                }}
+                source={{
+                    html: props.translate('reportActionsView.beginningOfChatHistoryPolicyExpenseChat', {owner, policyName}),
+                }}
+            />
             )}
-            {isChatRoom && (
+            {isChatRoom
+            && (
                 <>
-                    {/* Add align center style individually because of limited style inheritance in React Native https://reactnative.dev/docs/text#limited-style-inheritance */}
-                    <Text style={styles.textAlignCenter}>
-                        {isResctrictedRoom
-                            ? `${props.translate('reportActionsView.beginningOfChatHistoryRestrictedPartOne')}`
-                            : `${props.translate('reportActionsView.beginningOfChatHistoryPrivatePartOne')}`}
-                    </Text>
-                    <Text style={[styles.textStrong]}>
-                        {props.report.reportName}
-                    </Text>
-                    <Text>
-                        {isResctrictedRoom
-                            ? `${props.translate('reportActionsView.beginningOfChatHistoryRestrictedPartTwo')}`
-                            : `${props.translate('reportActionsView.beginningOfChatHistoryPrivatePartTwo')}`}
-                    </Text>
+                    {isResctrictedRoom
+                        ? (
+                            <RenderHTML
+                                defaultTextProps={{
+                                    style: styles.textAlignCenter,
+                                }}
+                                source={{html: props.translate('reportActionsView.beginningOfChatHistoryRestricted', {reportName: props.report.reportName})}}
+                            />
+                        )
+                        : (
+                            <RenderHTML
+                                defaultTextProps={{
+                                    style: styles.textAlignCenter,
+                                }}
+                                source={{html: props.translate('reportActionsView.beginningOfChatHistoryPrivate', {reportName: props.report.reportName})}}
+                            />
+                        )}
                 </>
             )}
             {isDefault && (
-                <>
-                    {/* Add align center style individually because of limited style inheritance in React Native https://reactnative.dev/docs/text#limited-style-inheritance */}
-                    <Text style={styles.textAlignCenter}>
+                <Text style={styles.textAlignCenter}>
+                    <Text>
                         {props.translate('reportActionsView.beginningOfChatHistory')}
                     </Text>
                     {_.map(displayNamesWithTooltips, ({displayName, pronouns}, index) => (
@@ -134,9 +130,9 @@ const ReportWelcomeText = (props) => {
                             {(index < displayNamesWithTooltips.length - 2) && <Text>, </Text>}
                         </Text>
                     ))}
-                </>
+                </Text>
             )}
-        </Text>
+        </View>
     );
 };
 

--- a/src/components/ReportWelcomeText.js
+++ b/src/components/ReportWelcomeText.js
@@ -85,34 +85,35 @@ const ReportWelcomeText = (props) => {
     const policyName = lodashGet(props.policies, [`${ONYXKEYS.COLLECTION.POLICY}${props.report.policyID}`, 'name'], Localize.translateLocal('workspace.common.unavailable'));
 
     // Show different welcome messages depending on if the room is archived or not and its visiblity.
-    // eslint-disable-next-line no-nested-ternary
-    const chatRoomWelcomeText = () => (ReportUtils.isArchivedRoom(props.report)
-        ? (
-            <RenderHTML
-                defaultTextProps={{
-                    style: styles.textAlignCenter,
-                }}
-                source={{html: props.translate('reportActionsView.beginningOfChatHistoryDeleted', {reportName: props.report.reportName})}}
-            />
-        ) : (
-            isResctrictedRoom
-                ? (
-                    <RenderHTML
-                        defaultTextProps={{
-                            style: styles.textAlignCenter,
-                        }}
-                        source={{html: props.translate('reportActionsView.beginningOfChatHistoryRestricted', {reportName: props.report.reportName})}}
-                    />
-                ) : (
-                    <RenderHTML
-                        defaultTextProps={{
-                            style: styles.textAlignCenter,
-                        }}
-                        source={{html: props.translate('reportActionsView.beginningOfChatHistoryPrivate', {reportName: props.report.reportName})}}
-                    />
-                )
-        )
-    );
+    function chatRoomWelcomeText() {
+        // eslint-disable-next-line no-nested-ternary
+        return ReportUtils.isArchivedRoom(props.report)
+            ? (
+                <RenderHTML
+                    defaultTextProps={{
+                        style: styles.textAlignCenter,
+                    }}
+                    source={{html: props.translate('reportActionsView.beginningOfChatHistoryDeleted', {reportName: props.report.reportName})}}
+                />
+            ) : (
+                isResctrictedRoom
+                    ? (
+                        <RenderHTML
+                            defaultTextProps={{
+                                style: styles.textAlignCenter,
+                            }}
+                            source={{html: props.translate('reportActionsView.beginningOfChatHistoryRestricted', {reportName: props.report.reportName})}}
+                        />
+                    ) : (
+                        <RenderHTML
+                            defaultTextProps={{
+                                style: styles.textAlignCenter,
+                            }}
+                            source={{html: props.translate('reportActionsView.beginningOfChatHistoryPrivate', {reportName: props.report.reportName})}}
+                        />
+                    )
+            );
+    }
 
     return (
         <View style={[styles.mt3, styles.mw100]}>

--- a/src/components/ReportWelcomeText.js
+++ b/src/components/ReportWelcomeText.js
@@ -77,9 +77,14 @@ const ReportWelcomeText = (props) => {
         },
     );
     const isResctrictedRoom = lodashGet(props, 'report.visibility', '') === CONST.REPORT.VISIBILITY.RESTRICTED;
+
+    // Use the policyExpenseChat owner's first name or fall back to their email if it's unavailable.
     const owner = lodashGet(props.personalDetails, [props.report.ownerEmail, 'firstName']) || props.report.ownerEmail;
+
+    // Use the policyName or fallback to default text if it's unavailable.
     const policyName = lodashGet(props.policies, [`${ONYXKEYS.COLLECTION.POLICY}${props.report.policyID}`, 'name'], Localize.translateLocal('workspace.common.unavailable'));
 
+    // Show different welcome messages depending on if the room is archived or not and its visiblity.
     // eslint-disable-next-line no-nested-ternary
     const chatRoomWelcomeText = () => (ReportUtils.isArchivedRoom(props.report)
         ? (

--- a/src/components/ReportWelcomeText.js
+++ b/src/components/ReportWelcomeText.js
@@ -80,6 +80,35 @@ const ReportWelcomeText = (props) => {
     const owner = lodashGet(props.personalDetails, [props.report.ownerEmail, 'firstName']) || props.report.ownerEmail;
     const policyName = lodashGet(props.policies, [`${ONYXKEYS.COLLECTION.POLICY}${props.report.policyID}`, 'name'], Localize.translateLocal('workspace.common.unavailable'));
 
+    // eslint-disable-next-line no-nested-ternary
+    const chatRoomWelcomeText = () => (ReportUtils.isArchivedRoom(props.report)
+        ? (
+            <RenderHTML
+                defaultTextProps={{
+                    style: styles.textAlignCenter,
+                }}
+                source={{html: props.translate('reportActionsView.beginningOfChatHistoryDeleted', {reportName: props.report.reportName})}}
+            />
+        ) : (
+            isResctrictedRoom
+                ? (
+                    <RenderHTML
+                        defaultTextProps={{
+                            style: styles.textAlignCenter,
+                        }}
+                        source={{html: props.translate('reportActionsView.beginningOfChatHistoryRestricted', {reportName: props.report.reportName})}}
+                    />
+                ) : (
+                    <RenderHTML
+                        defaultTextProps={{
+                            style: styles.textAlignCenter,
+                        }}
+                        source={{html: props.translate('reportActionsView.beginningOfChatHistoryPrivate', {reportName: props.report.reportName})}}
+                    />
+                )
+        )
+    );
+
     return (
         <View style={[styles.mt3, styles.mw100]}>
             {isPolicyExpenseChat && (
@@ -92,28 +121,7 @@ const ReportWelcomeText = (props) => {
                 }}
             />
             )}
-            {isChatRoom
-            && (
-                <>
-                    {isResctrictedRoom
-                        ? (
-                            <RenderHTML
-                                defaultTextProps={{
-                                    style: styles.textAlignCenter,
-                                }}
-                                source={{html: props.translate('reportActionsView.beginningOfChatHistoryRestricted', {reportName: props.report.reportName})}}
-                            />
-                        )
-                        : (
-                            <RenderHTML
-                                defaultTextProps={{
-                                    style: styles.textAlignCenter,
-                                }}
-                                source={{html: props.translate('reportActionsView.beginningOfChatHistoryPrivate', {reportName: props.report.reportName})}}
-                            />
-                        )}
-                </>
-            )}
+            {isChatRoom && chatRoomWelcomeText() }
             {isDefault && (
                 <Text style={styles.textAlignCenter}>
                     <Text>

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -172,13 +172,10 @@ export default {
     },
     reportActionsView: {
         beginningOfChatHistory: 'This is the beginning of your chat history with ',
-        beginningOfChatHistoryPrivatePartOne: 'This is the beginning of the private ',
-        beginningOfChatHistoryRestrictedPartOne: 'This is the beginning of ',
-        beginningOfChatHistoryPrivatePartTwo: ' room, invite others by @mentioning them.',
-        beginningOfChatHistoryRestrictedPartTwo: ', invite others by @mentioning them.',
-        beginningOfChatHistoryPolicyExpenseChatPartOne: 'Collaboration between ',
-        beginningOfChatHistoryPolicyExpenseChatPartTwo: ' and ',
-        beginningOfChatHistoryPolicyExpenseChatPartThree: ' starts here! 🎉 This is the place to chat, request money and settle up.',
+        beginningOfChatHistoryPrivate: ({reportName}) => `This is the beginning of the private <strong>${reportName}</strong> room, invite others by @mentioning them.`,
+        beginningOfChatHistoryRestricted: ({reportName}) => `This is the beginning of <strong>${reportName}</strong>, invite others by @mentioning them.`,
+        beginningOfChatHistoryPolicyExpenseChat: ({owner, policyName}) => `Collaboration between <strong>${owner}</strong> and <strong>${policyName}</strong> starts here! 🎉 This is the place to chat, request money and settle up.`,
+
     },
     reportActionsViewMarkerBadge: {
         newMsg: ({count}) => `${count} new message${count > 1 ? 's' : ''}`,

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -175,7 +175,7 @@ export default {
         beginningOfChatHistoryPrivate: ({reportName}) => `This is the beginning of the private <strong>${reportName}</strong> room, invite others by @mentioning them.`,
         beginningOfChatHistoryRestricted: ({reportName}) => `This is the beginning of <strong>${reportName}</strong>, invite others by @mentioning them.`,
         beginningOfChatHistoryPolicyExpenseChat: ({owner, policyName}) => `Collaboration between <strong>${owner}</strong> and <strong>${policyName}</strong> starts here! 🎉 This is the place to chat, request money and settle up.`,
-
+        beginningOfChatHistoryDeleted: ({reportName}) => `This is the beginning of <strong>${reportName}</strong>, there's nothing to see here.`,
     },
     reportActionsViewMarkerBadge: {
         newMsg: ({count}) => `${count} new message${count > 1 ? 's' : ''}`,

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -175,7 +175,7 @@ export default {
         beginningOfChatHistoryPrivate: ({reportName}) => `This is the beginning of the private <strong>${reportName}</strong> room, invite others by @mentioning them.`,
         beginningOfChatHistoryRestricted: ({reportName}) => `This is the beginning of <strong>${reportName}</strong>, invite others by @mentioning them.`,
         beginningOfChatHistoryPolicyExpenseChat: ({owner, policyName}) => `Collaboration between <strong>${owner}</strong> and <strong>${policyName}</strong> starts here! 🎉 This is the place to chat, request money and settle up.`,
-        beginningOfChatHistoryDeleted: ({reportName}) => `This is the beginning of <strong>${reportName}</strong>, there's nothing to see here.`,
+        beginningOfChatHistoryDeleted: ({reportName}) => `You missed the party in <strong>${reportName}</strong>, there's nothing to see here.`,
     },
     reportActionsViewMarkerBadge: {
         newMsg: ({count}) => `${count} new message${count > 1 ? 's' : ''}`,

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -175,6 +175,7 @@ export default {
         beginningOfChatHistoryPrivate: ({reportName}) => `Este es el principio de la sala privada <strong>${reportName}</strong>, invita a otros @mencionándolos.`,
         beginningOfChatHistoryRestricted: ({reportName}) => `Este es el principio de <strong>${reportName}</strong>, invita a otros @mencionándolos.`,
         beginningOfChatHistoryPolicyExpenseChat: ({owner, policyName}) => `¡La colaboración entre <strong>${owner}</strong> y <strong>${policyName}</strong> empieza aquí! :tada: Este es el lugar donde chatear, pedir dinero y pagar.`,
+        beginningOfChatHistoryDeleted: ({reportName}) => `Este es el principio de <strong>${reportName}</strong>, no hay nada que ver aquí.`,
     },
     reportActionsViewMarkerBadge: {
         newMsg: ({count}) => `${count} mensaje${count > 1 ? 's' : ''} nuevo${count > 1 ? 's' : ''}`,

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -172,13 +172,9 @@ export default {
     },
     reportActionsView: {
         beginningOfChatHistory: 'Aquí comienza tu historial de conversaciones con ',
-        beginningOfChatHistoryPrivatePartOne: 'Este es el principio de la sala privada ',
-        beginningOfChatHistoryRestrictedPartOne: 'Este es el principio de ',
-        beginningOfChatHistoryPrivatePartTwo: ', invita a otros @mencionándolos.',
-        beginningOfChatHistoryRestrictedPartTwo: ', invita a otros @mencionándolos.',
-        beginningOfChatHistoryPolicyExpenseChatPartOne: '¡La colaboración entre ',
-        beginningOfChatHistoryPolicyExpenseChatPartTwo: ' y ',
-        beginningOfChatHistoryPolicyExpenseChatPartThree: ' empieza aquí! :tada: Este es el lugar donde chatear, pedir dinero y pagar.',
+        beginningOfChatHistoryPrivate: ({reportName}) => `Este es el principio de la sala privada <strong>${reportName}</strong>, invita a otros @mencionándolos.`,
+        beginningOfChatHistoryRestricted: ({reportName}) => `Este es el principio de <strong>${reportName}</strong>, invita a otros @mencionándolos.`,
+        beginningOfChatHistoryPolicyExpenseChat: ({owner, policyName}) => `¡La colaboración entre <strong>${owner}</strong> y <strong>${policyName}</strong> empieza aquí! :tada: Este es el lugar donde chatear, pedir dinero y pagar.`,
     },
     reportActionsViewMarkerBadge: {
         newMsg: ({count}) => `${count} mensaje${count > 1 ? 's' : ''} nuevo${count > 1 ? 's' : ''}`,

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -175,7 +175,7 @@ export default {
         beginningOfChatHistoryPrivate: ({reportName}) => `Este es el principio de la sala privada <strong>${reportName}</strong>, invita a otros @mencionándolos.`,
         beginningOfChatHistoryRestricted: ({reportName}) => `Este es el principio de <strong>${reportName}</strong>, invita a otros @mencionándolos.`,
         beginningOfChatHistoryPolicyExpenseChat: ({owner, policyName}) => `¡La colaboración entre <strong>${owner}</strong> y <strong>${policyName}</strong> empieza aquí! :tada: Este es el lugar donde chatear, pedir dinero y pagar.`,
-        beginningOfChatHistoryDeleted: ({reportName}) => `Este es el principio de <strong>${reportName}</strong>, no hay nada que ver aquí.`,
+        beginningOfChatHistoryDeleted: ({reportName}) => `Te perdiste la fiesta en <strong>${reportName}</strong>, no hay nada que ver aquí.`,
     },
     reportActionsViewMarkerBadge: {
         newMsg: ({count}) => `${count} mensaje${count > 1 ? 's' : ''} nuevo${count > 1 ? 's' : ''}`,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Used RenderHTML for little refactor and added a new welcome text for deleted #admins/#announce rooms 
### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/7625

### Tests | QA Steps
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Create a workspace
2. Delete that workspace
3. Search #announce or #admins 
4. Choose the #announce(deleted) or #admins (deleted)
5. Verify it says "You missed the party in **#annouce(deleted)**, there's nothing to see here."
- [x] Verify that no errors appear in the JS console

### PR Review Checklist
<!--
This is a checklist for PR authors & reviewers. Please make sure to complete all tasks and check them off once you do, or else Expensify has the right not to merge your PR!
-->
#### Contributor (PR Author) Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there’s a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. “toggleReport” and not “onIconClick”)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct english, and explained “why” the code was doing something instead of only explaining “what” the code was doing.
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [x] I verified any copy / text that was added to the app is correct english and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named “index.js”. All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY
- [x] I verified any variables that can be defined as constants (ie. in CONST.js) are defined as such
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] Any functional components have the `displayName` property
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] Any internal methods are bound to “this” properly so there are no scoping issues
    - [ ] Any internal methods bound to “this” are necessary to be bound
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose and it is
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn’t already exist
    - [ ] The style can’t be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function
(i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)



#### PR Reviewer Checklist
- [ ] I verified the correct issue is linked in the `### Fixed Issues` section above
- [ ] I verified testing steps are clear and they cover the changes made in this PR
    - [ ] I verified the steps for local testing are in the `Tests` section
    - [ ] I verified the steps for Staging and/or Production testing are in the `QA steps` section
    - [ ] I verified the steps cover any possible failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [ ] I checked that screenshots or videos are included for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I verified tests pass on **all platforms** & I tested again on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [ ] I verified there are no console errors (if there’s a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. “toggleReport” and not “onIconClick”).
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct english, and explained “why” the code was doing something instead of only explaining “what” the code was doing.
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [ ] I verified any copy / text that was added to the app is correct english and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named “index.js”. All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I verified that this PR follows the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [ ] I verified other components are not impacted by changes in this PR (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] I verified all code is DRY
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js) are defined as such
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] Any functional components have the `displayName` property
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] Any internal methods are bound to “this” properly so there are no scoping issues
    - [ ] Any internal methods bound to “this” are necessary to be bound
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose and it is broken down into smaller components in order to separate concerns and functions
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn’t already exist
    - [ ] The style can’t be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function
(i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)


### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
<img width="1067" alt="Screenshot 2022-03-22 at 7 02 24 PM" src="https://user-images.githubusercontent.com/83179295/159493494-a510acb7-06f3-4c82-a930-04cbbabd7e63.png">

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
<img width="419" alt="Screenshot 2022-03-22 at 7 01 48 PM" src="https://user-images.githubusercontent.com/83179295/159493488-f1959bdc-1ee4-4a1a-94aa-8d9bf0ec7f58.png">


#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
<img width="827" alt="Screenshot 2022-03-22 at 7 05 12 PM" src="https://user-images.githubusercontent.com/83179295/159493736-1ff6b281-34e5-42b4-b7b5-76df8026e604.png">

#### iOS
<img width="310" alt="Screenshot 2022-03-22 at 7 06 20 PM" src="https://user-images.githubusercontent.com/83179295/159493991-163d2958-26e1-4f1d-8790-5ab37191e403.png">


#### Android
<!-- Insert screenshots of your changes on the Android platform-->

<img width="419" alt="Screenshot 2022-03-22 at 7 00 57 PM" src="https://user-images.githubusercontent.com/83179295/159493463-67a17033-564d-49b0-b846-0938d74ef2f6.png">


