### PR TITLE
Add createOnReadyTask. Fix broken growls triggered before init.

### DIFF
--- a/src/components/GrowlNotification/index.js
+++ b/src/components/GrowlNotification/index.js
@@ -12,6 +12,7 @@ import * as Expensicons from '../Icon/Expensicons';
 import styles from '../../styles/styles';
 import GrowlNotificationContainer from './GrowlNotificationContainer';
 import CONST from '../../CONST';
+import * as Growl from '../../libs/Growl';
 
 const types = {
     [CONST.GROWL.SUCCESS]: {
@@ -31,8 +32,8 @@ const types = {
 const INACTIVE_POSITION_Y = -255;
 
 class GrowlNotification extends Component {
-    constructor() {
-        super();
+    constructor(props) {
+        super(props);
 
         this.state = {
             bodyText: '',
@@ -42,6 +43,10 @@ class GrowlNotification extends Component {
 
         this.show = this.show.bind(this);
         this.fling = this.fling.bind(this);
+    }
+
+    componentDidMount() {
+        Growl.setIsGrowlReady();
     }
 
     /**

--- a/src/components/GrowlNotification/index.js
+++ b/src/components/GrowlNotification/index.js
@@ -46,7 +46,7 @@ class GrowlNotification extends Component {
     }
 
     componentDidMount() {
-        Growl.setIsGrowlReady();
+        Growl.setIsReady();
     }
 
     /**

--- a/src/libs/ActiveClientManager/index.js
+++ b/src/libs/ActiveClientManager/index.js
@@ -3,18 +3,16 @@ import Onyx from 'react-native-onyx';
 import Str from 'expensify-common/lib/str';
 import ONYXKEYS from '../../ONYXKEYS';
 import * as ActiveClients from '../actions/ActiveClients';
+import createOnReadyTask from '../createOnReadyTask';
 
 const clientID = Str.guid();
 const maxClients = 20;
 
 let activeClients;
-let isInitialized;
 
 // Keeps track of the ActiveClientManager's readiness in one place
 // so that multiple calls of isReady resolve the same promise
-const isInitializedPromise = new Promise((resolve) => {
-    isInitialized = resolve;
-});
+const [isReady, setIsReady] = createOnReadyTask();
 
 Onyx.connect({
     key: ONYXKEYS.ACTIVE_CLIENTS,
@@ -32,11 +30,7 @@ Onyx.connect({
  */
 function init() {
     ActiveClients.addClient(clientID)
-        .then(isInitialized);
-}
-
-function isReady() {
-    return isInitializedPromise;
+        .then(setIsReady);
 }
 
 /**

--- a/src/libs/Growl.js
+++ b/src/libs/Growl.js
@@ -3,7 +3,7 @@ import CONST from '../CONST';
 import createOnReadyTask from './createOnReadyTask';
 
 const growlRef = React.createRef();
-const [isGrowlReady, setIsGrowlReady] = createOnReadyTask();
+const [isGrowlReady, setIsReady] = createOnReadyTask();
 
 /**
  * Show the growl notification
@@ -44,5 +44,5 @@ export default {
 
 export {
     growlRef,
-    setIsGrowlReady,
+    setIsReady,
 };

--- a/src/libs/Growl.js
+++ b/src/libs/Growl.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import CONST from '../CONST';
+import createOnReadyTask from './createOnReadyTask';
 
 const growlRef = React.createRef();
+const [isGrowlReady, setIsGrowlReady] = createOnReadyTask();
 
 /**
  * Show the growl notification
@@ -11,7 +13,7 @@ const growlRef = React.createRef();
  * @param {Number} [duration]
 */
 function show(bodyText, type, duration = CONST.GROWL.DURATION) {
-    growlRef.current.show(bodyText, type, duration);
+    isGrowlReady().then(() => growlRef.current.show(bodyText, type, duration));
 }
 
 /**
@@ -42,4 +44,5 @@ export default {
 
 export {
     growlRef,
+    setIsGrowlReady,
 };

--- a/src/libs/createOnReadyTask.js
+++ b/src/libs/createOnReadyTask.js
@@ -14,5 +14,5 @@ export default function createOnReadyTask() {
     const isReadyPromise = (new Promise((resolve) => {
         resolveIsReadyPromise = resolve;
     }));
-    return [isReadyPromise, resolveIsReadyPromise];
+    return [() => isReadyPromise, resolveIsReadyPromise];
 }

--- a/src/libs/createOnReadyTask.js
+++ b/src/libs/createOnReadyTask.js
@@ -1,0 +1,18 @@
+/**
+ * Helper method to create a task to track the "readiness" of something and defer any actions until after something is "ready".
+ *
+ * @example
+ *
+ *     const [isSomethingReady, setIsReady] = createOnReadyTask();
+ *     isSomethingReady().then(() => doIt());
+ *     setIsReady(); // -> doIt() will now execute
+ *
+ * @returns {Array<Promise, Function>}
+ */
+export default function createOnReadyTask() {
+    let resolveIsReadyPromise;
+    const isReadyPromise = (new Promise((resolve) => {
+        resolveIsReadyPromise = resolve;
+    }));
+    return [isReadyPromise, resolveIsReadyPromise];
+}


### PR DESCRIPTION
### Details

Sometimes Growls can be triggered before init.

### Fixed Issues
Related to https://github.com/Expensify/Expensify/issues/201705

### Tests
1. Place a call to `Growl.success()` in the constructor of Expensify.js
```diff
diff --git a/src/components/GrowlNotification/index.js b/src/components/GrowlNotification/index.js
index e3a16b600..b8d5855b7 100644
--- a/src/components/GrowlNotification/index.js
+++ b/src/components/GrowlNotification/index.js
@@ -12,6 +12,7 @@ import * as Expensicons from '../Icon/Expensicons';
 import styles from '../../styles/styles';
 import GrowlNotificationContainer from './GrowlNotificationContainer';
 import CONST from '../../CONST';
+import Growler from '../../libs/Growl';
 import * as Growl from '../../libs/Growl';

 const types = {
@@ -43,6 +44,8 @@ class GrowlNotification extends Component {

         this.show = this.show.bind(this);
         this.fling = this.fling.bind(this);
+
+        Growler.success('derpy derp pants');
     }

     componentDidMount() {
```
2. Verify it will run once the Growl component mounts

Only other specific QA we need to do here that I can think of is to test the `ActiveClientManager` logic to make sure it is still functioning as intended. I just logged out that this code executed:

https://github.com/Expensify/App/blob/9beba91bef9019f25d9bc256069198d290fe88ee/src/libs/Network.js#L272-L276

- [ ] Verify that no errors appear in the JS console

### QA Steps

Test offline report comments feature for regressions

1. Go offline
2. Add a comment
3. Close page
4. Come back online
5. Reopen New Expensify
6. Verify queued comments post to chat.

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
