### PR TITLE
Fullscreen loader logging

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -305,6 +305,7 @@ const CONST = {
         COLD: 'cold',
         REPORT_ACTION_ITEM_LAYOUT_DEBOUNCE_TIME: 1500,
         TOOLTIP_SENSE: 1000,
+        SPINNER_TIMEOUT: 15 * 1000,
     },
     PRIORITY_MODE: {
         GSD: 'gsd',

--- a/src/components/FullscreenLoadingIndicator.js
+++ b/src/components/FullscreenLoadingIndicator.js
@@ -5,17 +5,22 @@ import {ActivityIndicator, StyleSheet, View} from 'react-native';
 import styles from '../styles/styles';
 import themeColors from '../styles/themes/default';
 import stylePropTypes from '../styles/stylePropTypes';
+import Log from '../libs/Log';
 
 const propTypes = {
-    /** Controls whether the loader is mounted and displayed */
-    visible: PropTypes.bool,
+    /** Name used in the logs if the loader is displayed for too long time */
+    name: PropTypes.string,
+
+    /** Optional duration (ms) after which a message would be logged if the loader is still covering the screen */
+    timeout: PropTypes.number,
 
     /** Additional style props */
     style: stylePropTypes,
 };
 
 const defaultProps = {
-    visible: true,
+    timeout: 0,
+    name: '',
     style: [],
 };
 
@@ -25,18 +30,38 @@ const defaultProps = {
  * @param {Object} props
  * @returns {JSX.Element}
  */
-const FullScreenLoadingIndicator = (props) => {
-    if (!props.visible) {
-        return null;
+class FullScreenLoadingIndicator extends React.Component {
+    componentDidMount() {
+        if (!this.props.name || !this.props.timeout) {
+            return;
+        }
+
+        Log.info(`[LoadingIndicator] "${this.props.name}" became visible`);
+
+        this.timeoutId = setTimeout(
+            () => Log.alert(`[LoadingIndicator] "${this.props.name}" is still visible after ${this.props.timeout} ms`),
+            this.props.timeout,
+        );
     }
 
-    const additionalStyles = _.isArray(props.style) ? props.style : [props.style];
-    return (
-        <View style={[StyleSheet.absoluteFillObject, styles.fullScreenLoading, ...additionalStyles]}>
-            <ActivityIndicator color={themeColors.spinner} size="large" />
-        </View>
-    );
-};
+    componentWillUnmount() {
+        if (!this.timeoutId) {
+            return;
+        }
+
+        clearTimeout(this.timeoutId);
+        Log.info(`[LoadingIndicator] "${this.props.name}" disappeared`);
+    }
+
+    render() {
+        const additionalStyles = _.isArray(this.props.style) ? this.props.style : [this.props.style];
+        return (
+            <View style={[StyleSheet.absoluteFillObject, styles.fullScreenLoading, ...additionalStyles]}>
+                <ActivityIndicator color={themeColors.spinner} size="large" />
+            </View>
+        );
+    }
+}
 
 FullScreenLoadingIndicator.propTypes = propTypes;
 FullScreenLoadingIndicator.defaultProps = defaultProps;

--- a/src/components/FullscreenLoadingIndicator.js
+++ b/src/components/FullscreenLoadingIndicator.js
@@ -27,12 +27,6 @@ const defaultProps = {
     logDetail: null,
 };
 
-/**
- * Loading indication component intended to cover the whole page, while the page prepares for initial render
- *
- * @param {Object} props
- * @returns {JSX.Element}
- */
 class FullScreenLoadingIndicator extends React.Component {
     componentDidMount() {
         if (!this.props.logDetail) {
@@ -40,7 +34,7 @@ class FullScreenLoadingIndicator extends React.Component {
         }
 
         if (!this.props.logDetail.name) {
-            throw new Error('A name should be set to distinct logged messages. Please check the `logDetails` prop');
+            throw new Error('A name should be set to distinct logged messages. Please check the `logDetails` prop.');
         }
 
         Log.info('[LoadingIndicator] Became visible', false, this.props.logDetail);

--- a/src/components/FullscreenLoadingIndicator.js
+++ b/src/components/FullscreenLoadingIndicator.js
@@ -39,7 +39,11 @@ class FullScreenLoadingIndicator extends React.Component {
         Log.info(`[LoadingIndicator] "${this.props.name}" became visible`);
 
         this.timeoutId = setTimeout(
-            () => Log.alert(`[LoadingIndicator] "${this.props.name}" is still visible after ${this.props.timeout} ms`),
+            () => Log.alert(
+                `[LoadingIndicator] "${this.props.name}" is still visible after ${this.props.timeout} ms`,
+                '',
+                false,
+            ),
             this.props.timeout,
         );
     }

--- a/src/components/WalletStatementModal/index.js
+++ b/src/components/WalletStatementModal/index.js
@@ -41,9 +41,7 @@ class WalletStatementModal extends React.Component {
         const authToken = lodashGet(this.props, 'session.authToken', null);
         return (
             <>
-                <FullScreenLoadingIndicator
-                    visible={this.state.isLoading}
-                />
+                {this.state.isLoading && <FullScreenLoadingIndicator />}
                 <View style={[styles.flex1]}>
                     <iframe
                         src={`${this.props.statementPageURL}&authToken=${authToken}`}

--- a/src/libs/Navigation/AppNavigator/MainDrawerNavigator.js
+++ b/src/libs/Navigation/AppNavigator/MainDrawerNavigator.js
@@ -49,7 +49,7 @@ const MainDrawerNavigator = (props) => {
 
     // Wait until reports are fetched and there is a reportID in initialParams
     if (!initialParams.reportID) {
-        return <FullScreenLoadingIndicator />;
+        return <FullScreenLoadingIndicator name="Main Drawer Loader" timeout={15 * 1000} />;
     }
 
     // After the app initializes and reports are available the home navigation is mounted

--- a/src/libs/Navigation/AppNavigator/MainDrawerNavigator.js
+++ b/src/libs/Navigation/AppNavigator/MainDrawerNavigator.js
@@ -49,7 +49,7 @@ const MainDrawerNavigator = (props) => {
 
     // Wait until reports are fetched and there is a reportID in initialParams
     if (!initialParams.reportID) {
-        return <FullScreenLoadingIndicator name="Main Drawer Loader" timeout={15 * 1000} />;
+        return <FullScreenLoadingIndicator logDetail={{name: 'Main Drawer Loader', initialParams}} />;
     }
 
     // After the app initializes and reports are available the home navigation is mounted

--- a/src/libs/Navigation/NavigationRoot.js
+++ b/src/libs/Navigation/NavigationRoot.js
@@ -59,8 +59,7 @@ class NavigationRoot extends Component {
             <NavigationContainer
                 fallback={(
                     <FullScreenLoadingIndicator
-                        name="Navigation Fallback Loader"
-                        timeout={15 * 1000}
+                        logDetail={{name: 'Navigation Fallback Loader', authenticated: this.props.authenticated}}
                         style={styles.navigatorFullScreenLoading}
                     />
                 )}

--- a/src/libs/Navigation/NavigationRoot.js
+++ b/src/libs/Navigation/NavigationRoot.js
@@ -57,7 +57,13 @@ class NavigationRoot extends Component {
     render() {
         return (
             <NavigationContainer
-                fallback={<FullScreenLoadingIndicator style={styles.navigatorFullScreenLoading} />}
+                fallback={(
+                    <FullScreenLoadingIndicator
+                        name="Navigation Fallback Loader"
+                        timeout={15 * 1000}
+                        style={styles.navigatorFullScreenLoading}
+                    />
+                )}
                 onStateChange={this.parseAndStoreRoute}
                 onReady={this.props.onReady}
                 theme={navigationTheme}

--- a/src/pages/NewChatPage.js
+++ b/src/pages/NewChatPage.js
@@ -235,7 +235,7 @@ class NewChatPage extends Component {
                             onCloseButtonPress={() => Navigation.dismissModal(true)}
                         />
                         <View style={[styles.flex1, styles.w100, styles.pRelative]}>
-                            <FullScreenLoadingIndicator visible={!didScreenTransitionEnd} />
+                            {!didScreenTransitionEnd && <FullScreenLoadingIndicator />}
                             {didScreenTransitionEnd && (
                                 <>
                                     <OptionsSelector

--- a/src/pages/SearchPage.js
+++ b/src/pages/SearchPage.js
@@ -173,7 +173,7 @@ class SearchPage extends Component {
                             onCloseButtonPress={() => Navigation.dismissModal(true)}
                         />
                         <View style={[styles.flex1, styles.w100, styles.pRelative]}>
-                            <FullScreenLoadingIndicator visible={!didScreenTransitionEnd} />
+                            {!didScreenTransitionEnd && <FullScreenLoadingIndicator />}
                             {didScreenTransitionEnd && (
                                 <OptionsSelector
                                     sections={sections}

--- a/src/pages/home/ReportScreen.js
+++ b/src/pages/home/ReportScreen.js
@@ -183,7 +183,7 @@ class ReportScreen extends React.Component {
                     nativeID={CONST.REPORT.DROP_NATIVE_ID}
                     style={[styles.flex1, styles.justifyContentEnd, styles.overflowHidden]}
                 >
-                    <FullScreenLoadingIndicator visible={this.shouldShowLoader()} />
+                    {this.shouldShowLoader() && <FullScreenLoadingIndicator />}
                     {!this.shouldShowLoader() && (
                         <ReportActionsView
                             reportID={reportID}

--- a/src/pages/iou/IOUModal.js
+++ b/src/pages/iou/IOUModal.js
@@ -387,9 +387,7 @@ class IOUModal extends Component {
                             </View>
                         </View>
                         <View style={[styles.pRelative, styles.flex1]}>
-                            <FullScreenLoadingIndicator
-                                visible={!didScreenTransitionEnd}
-                            />
+                            {!didScreenTransitionEnd && <FullScreenLoadingIndicator />}
                             {didScreenTransitionEnd && (
                                 <>
                                     {currentStep === Steps.IOUAmount && (

--- a/src/pages/workspace/WorkspaceInvitePage.js
+++ b/src/pages/workspace/WorkspaceInvitePage.js
@@ -262,7 +262,7 @@ class WorkspaceInvitePage extends React.Component {
                             onBackButtonPress={() => Navigation.goBack()}
                         />
                         <View style={[styles.flex1]}>
-                            <FullScreenLoadingIndicator visible={!didScreenTransitionEnd} />
+                            {!didScreenTransitionEnd && <FullScreenLoadingIndicator />}
                             {didScreenTransitionEnd && (
                                 <OptionsSelector
                                     autoFocus={false}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
As per the ticket requirement we're adding logging to Fullscreen loaders in order to capture a loader never being removed from the screen
When `name` and `timeout` props are used on the loader, it would log a message when it mounts/unmounts or stays longer than the specified timeout
In order to have simpler component did mount / will unmount logic, the `visible` prop was removed and existing usages refactored. `FullScreenLoadingIndicator` is used uniformly across the app by conditional rendering: 
```jsx
{this.state.isLoading && <FullScreenLoadingIndicator />}
```


### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/7424

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify `[LoadingIndicator] "${this.props.name}" became visible` is logged when loader is visible
    - logged for NavigationRoot when launching App (on ios/android)
    - logged for MainDrawerNavigation after login (on all platforms)
- [ ] Verify `[LoadingIndicator] "${this.props.name}" disappeared` is logged when loader hides
     - logged for NavigationRoot  when launching App (on ios/android)
     - logged for MainDrawerNavigation after login (on all platforms)
- [ ] Verify `[LoadingIndicator] "${this.props.name}" is still visible after ${this.props.timeout} ms` is logged when loader is displayed for longer than `timeout` duration
- [ ] There should be no regressions on places that use the `FullscreenLoadingIndicator`

I was able to test the `timeout` message (3rd bullet) when I forced the MainDrawerLoader to never hide. It also happened once (on dev) because loading was too slow and took longer than 15 sec. (after signing in)

#### Sample logging output
![image](https://user-images.githubusercontent.com/12156624/160834930-8c177d39-9a2d-4514-939c-2e345a4a0fe7.png)
note: _Since "Disappeared" is logged on unmount, the component didn't received the new props and logs whatever `logDetail` it last had, hence `reportID` is still `""` in the log_

### PR Review Checklist
<!--
This is a checklist for PR authors & reviewers. Please make sure to complete all tasks and check them off once you do, or else Expensify has the right not to merge your PR!
-->
#### Contributor (PR Author) Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there’s a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained “why” the code was doing something instead of only explaining “what” the code was doing.
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named “index.js”. All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] Any functional components have the `displayName` property
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose and it is
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn’t already exist
    - [ ] The style can’t be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.


<details>
<summary><h4>PR Reviewer Checklist</h4></summary>

- [ ] I verified the correct issue is linked in the `### Fixed Issues` section above
- [ ] I verified testing steps are clear and they cover the changes made in this PR
    - [ ] I verified the steps for local testing are in the `Tests` section
    - [ ] I verified the steps for Staging and/or Production testing are in the `QA steps` section
    - [ ] I verified the steps cover any possible failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [ ] I checked that screenshots or videos are included for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I verified tests pass on **all platforms** & I tested again on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [ ] I verified there are no console errors (if there’s a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`).
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained “why” the code was doing something instead of only explaining “what” the code was doing.
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [ ] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named “index.js”. All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I verified that this PR follows the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] Any functional components have the `displayName` property
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose and it is broken down into smaller components in order to separate concerns and functions
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn’t already exist
    - [ ] The style can’t be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.

</details>

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

No feature or bug to be tested. 
We're testing against any regressions around fullscreen loading indicators. 
A fullscreen loading indicator is a small rotating circle in the middle of the page with semi-transparent (white/gray) background

On all platforms, verify loading circle still appears:
- [ ] briefly after sign in
- [ ] on Wallet statement modal, while statement is loading
- [ ] after selecting "New chat" and search/users load
- [ ] after selecting "Search" and search/users load
- [ ] when you select a chat in LHN and it's loaded in the main view
- [ ] on the IOU modal while it loads
- [ ] on the Workspace / Manage Members / Invite page, while search/users load

_(These are the pages that had the `visible` prop which was removed from the loader)_

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
![image](https://user-images.githubusercontent.com/12156624/160684233-40219b63-85e7-4e0f-ba0a-69c83d75d64f.png)

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
![image](https://user-images.githubusercontent.com/12156624/160686914-feb8d211-cf86-4c77-9de2-99bdb82879d5.png)

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
![image](https://user-images.githubusercontent.com/12156624/160684487-389c71c5-3d94-454b-b2d2-ad9ad72dfdae.png)

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
![image](https://user-images.githubusercontent.com/12156624/160685380-7d224510-ec9a-4e89-aa71-47dd70d5b145.png)

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
https://user-images.githubusercontent.com/12156624/160691993-8224b64a-2661-4a21-9517-b90d5a9ed43b.mp4


