### PR TITLE
Always request version.json from network (no cache)

### DIFF
--- a/config/webpack/webpack.dev.js
+++ b/config/webpack/webpack.dev.js
@@ -25,7 +25,7 @@ module.exports = (env = {}) => {
         mode: 'development',
         devtool: 'inline-source-map',
         devServer: {
-            contentBase: path.join(__dirname, '../dist'),
+            contentBase: path.join(__dirname, '../../dist'),
             hot: true,
             ...proxySettings,
             historyApiFallback: true,

--- a/src/libs/HttpUtils.js
+++ b/src/libs/HttpUtils.js
@@ -59,23 +59,6 @@ function xhr(command, data, type = CONST.NETWORK.METHOD.POST, shouldUseSecure = 
     return processHTTPRequest(`${apiRoot}api?command=${command}`, type, formData, data.canCancel);
 }
 
-/**
- * Just download a file from the web server.
- *
- * @param {String} relativePath From the website root, NOT the API root. (no leading slash, ., or ..)
- * @returns {Promise}
- */
-function download(relativePath) {
-    const siteRoot = CONFIG.EXPENSIFY.NEW_EXPENSIFY_URL;
-
-    // Strip leading slashes and periods from relative path, if present
-    const strippedRelativePath = relativePath.charAt(0) === '/' || relativePath.charAt(0) === '.'
-        ? relativePath.slice(relativePath.indexOf('/') + 1)
-        : relativePath;
-
-    return processHTTPRequest(`${siteRoot}${strippedRelativePath}`);
-}
-
 function cancelPendingRequests() {
     cancellationController.abort();
 
@@ -85,7 +68,6 @@ function cancelPendingRequests() {
 }
 
 export default {
-    download,
     xhr,
     cancelPendingRequests,
 };

--- a/src/setup/platformSetup/index.website.js
+++ b/src/setup/platformSetup/index.website.js
@@ -5,7 +5,6 @@ import 'shim-keyboard-event-key';
 
 import checkForUpdates from '../../libs/checkForUpdates';
 import Config from '../../CONFIG';
-import HttpUtils from '../../libs/HttpUtils';
 import DateUtils from '../../libs/DateUtils';
 import {version as currentVersion} from '../../../package.json';
 import Visibility from '../../libs/Visibility';
@@ -15,7 +14,10 @@ import Visibility from '../../libs/Visibility';
  * then refresh. If the page is visibile, prompt the user to refresh.
  */
 function webUpdate() {
-    HttpUtils.download('version.json')
+    fetch(`${Config.EXPENSIFY.NEW_EXPENSIFY_URL}version.json`, {
+        cache: 'no-cache',
+    })
+        .then(response => response.json())
         .then(({version}) => {
             if (version === currentVersion) {
                 return;

--- a/src/setup/platformSetup/index.website.js
+++ b/src/setup/platformSetup/index.website.js
@@ -14,9 +14,7 @@ import Visibility from '../../libs/Visibility';
  * then refresh. If the page is visibile, prompt the user to refresh.
  */
 function webUpdate() {
-    fetch(`${Config.EXPENSIFY.NEW_EXPENSIFY_URL}version.json`, {
-        cache: 'no-cache',
-    })
+    fetch('/version.json', {cache: 'no-cache'})
         .then(response => response.json())
         .then(({version}) => {
             if (version === currentVersion) {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
As explained in the [issue comment](https://github.com/Expensify/App/issues/7856#issuecomment-1082409268) the only usage for `HttpUtils.download` was in the version check here
Instead of modifying existing code to make `HttpUtils.download` support a cache/no-cache options, we use `fetch` directly 
Since now `HttpUtils.download` has no more usages it can be deleted
A [problem with the webpack dev](https://expensify.slack.com/archives/C01GTK53T8Q/p1648595359709439) config was fixed so that the fix can be tested locally

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/7856

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

To test locally modify `src/setup/platformSetup/index.website.js` so that this 
https://github.com/Expensify/App/blob/1c4add7b7b691724edd2040110d2adc2b92e7b60/src/setup/platformSetup/index.website.js#L63-L66

becomes:
```js
    // When app loads, get current version (production only)
    checkForUpdates(webUpdater());
```

1. `dist/version.json` is created automatically by the webpack dev server - you should have this file after running `npm run web`
2. Background the app or switch to another tap
3. Switch back to App

- [ ] Verify that no errors appear in the JS console
- [ ] Verify a network request is being made to fetch `./version.json`
- [ ] Verify nothing happens since the fetched version is the same as the `currentVersion`

1. Modify `dist/version.json` to be a greater version than `currentVersion`
2. Background the app or switch to another tap
3. Switch back to App

- [ ] Verify that no errors appear in the JS console
- [ ] Verify a network request is being made to fetch `./version.json`
    - since we expect App to refresh, because a new version is available we should, toggle to preserve Network log between refreshes
    - alternatively you can put a breakpoint inside the code that receive the new version, and code should be paused there after you switch back to the tab. This would also help catch the "Update Available" prompt, since now App would be in the foreground
-  Depending on how fast you switch back and forth between tabs, App can either refresh on the background, or prompt you to confirm refreshing. See the videos under Web that showcase both cases
   - [ ] Switching between tabs fast should show you an "Update available prompt like this" 
    ![image](https://user-images.githubusercontent.com/12156624/160724236-1539a94e-3cb1-4f65-9788-68c84223076a.png)
   - [ ] Backgrounding the app and waiting for a few seconds should initiate a refresh in the background - you should be able to see a spinner briefly appearing on the collapsed tab

### PR Review Checklist
<!--
This is a checklist for PR authors & reviewers. Please make sure to complete all tasks and check them off once you do, or else Expensify has the right not to merge your PR!
-->
#### Contributor (PR Author) Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there’s a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained “why” the code was doing something instead of only explaining “what” the code was doing.
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [ ] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named “index.js”. All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] Any functional components have the `displayName` property
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose and it is
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn’t already exist
    - [ ] The style can’t be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.


<details>
<summary><h4>PR Reviewer Checklist</h4></summary>

- [ ] I verified the correct issue is linked in the `### Fixed Issues` section above
- [ ] I verified testing steps are clear and they cover the changes made in this PR
    - [ ] I verified the steps for local testing are in the `Tests` section
    - [ ] I verified the steps for Staging and/or Production testing are in the `QA steps` section
    - [ ] I verified the steps cover any possible failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [ ] I checked that screenshots or videos are included for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I verified tests pass on **all platforms** & I tested again on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [ ] I verified there are no console errors (if there’s a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`).
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained “why” the code was doing something instead of only explaining “what” the code was doing.
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [ ] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named “index.js”. All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I verified that this PR follows the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] Any functional components have the `displayName` property
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose and it is broken down into smaller components in order to separate concerns and functions
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn’t already exist
    - [ ] The style can’t be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.

</details>

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
4. Upload an image via copy paste
5. Verify a modal appears displaying a preview of that image
--->

I think this ticket can only be tested after deploying to staging, because we need to be on older version and a new version be released in the meantime

We're primarily verifying there are no regressions and the update check works as expected
All the scenarios below are existing flows and not introduced in the current PR
We're verifying they work as expected

On web/mobile-web

- [ ] Verify new version is detected during background the app
    1. Have App opened and foregrounded before an update is released
    3. Wait for update to be released and then background App - open a new tab
    4. Observer App's tab is refreshing (little spinning circle appears on the tab in Chrome)
    5. Switching back to App's tab you should be on the update version

- [ ] Verify new version is detected during foregrounding the app
    - _This happens only if you're background very quickly (see attached video)_
    1. Have App opened and in the **background** before an update is released
    2. Wait for update to be released and then foreground App
    3. You should see a prompt like this:
       ![image](https://user-images.githubusercontent.com/12156624/160724236-1539a94e-3cb1-4f65-9788-68c84223076a.png)
    4. Pressing "OK" should refresh the page
    6. You should now be on the updated version

- [ ] Verify new version is detected during foregrounding the app - alternative
   - _This happens only if you're background very quickly (see attached video)_
   - Do the 1,2,3 from above, but instead of pressing "OK" on the prompt press "Cancel"
   - The page should not refresh
   - If you background App now it should refresh in the background and the next time you bring it up it would have the updated version

- [ ] Verify problems due to cache are fixed (the bug in the linked ticket)
    1. Shortly (1-2 minutes, up to 30) after an update have been published (on staging or prod) open the web page
    2. Verify you're on the latest version
    3. Verify that opening a new tab or backgrounding the app, does not result in App refresh - app doesn't incorrectly think there's an update 
    4. Verify that opening a new tab or backgrounding the app, doesn't result in showing the "Update available prompt"

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
- _Note: I've setup my local environment to simulate there's always a new version_

##### New version refreshes in the background
https://user-images.githubusercontent.com/12156624/160727009-84a67faa-5505-41dd-b4fd-777652778998.mov

##### New version prompts to refresh page on the foreground
https://user-images.githubusercontent.com/12156624/160727058-e47da2ac-4a75-4ab8-a2a6-0ecb5d28840d.mov

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

##### New version available and refreshes App
https://user-images.githubusercontent.com/12156624/160727223-9dfe6454-f044-4f6b-b713-78014179a8d4.mov

##### No new version available - no page refresh
https://user-images.githubusercontent.com/12156624/160727253-0cd81de8-3cc4-46a3-9c33-b0219dea66e7.mov

##### Android Chrome
https://user-images.githubusercontent.com/12156624/160727885-b72f35c4-f784-439f-9c81-675953d436f6.mp4

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
![image](https://user-images.githubusercontent.com/12156624/160727659-09f377dd-9a4c-430f-9677-3daa4a10c1fb.png)

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
![image](https://user-images.githubusercontent.com/12156624/160727325-4a3e770a-34a1-444f-9ea5-aadacb7f638c.png)

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
![image](https://user-images.githubusercontent.com/12156624/160727941-6897998f-14e1-4ac2-8fdf-03ebb2a2e460.png)
