### PR TITLE
[No QA] Include error in ErrorBoundary alert log to create more unique tickets

### DIFF
--- a/src/components/ErrorBoundary/index.js
+++ b/src/components/ErrorBoundary/index.js
@@ -3,6 +3,6 @@ import Log from '../../libs/Log';
 
 BaseErrorBoundary.defaultProps.logError = (errorMessage, error, errorInfo) => {
     // Log the error to the server
-    Log.alert(errorMessage, {error: error.message, errorInfo}, false);
+    Log.alert(`${errorMessage} - ${error.message}`, {errorInfo}, false);
 };
 export default BaseErrorBoundary;

--- a/src/components/ErrorBoundary/index.native.js
+++ b/src/components/ErrorBoundary/index.native.js
@@ -5,7 +5,7 @@ import Log from '../../libs/Log';
 
 BaseErrorBoundary.defaultProps.logError = (errorMessage, error, errorInfo) => {
     // Log the error to the server
-    Log.alert(errorMessage, {error: error.message, errorInfo}, false);
+    Log.alert(`${errorMessage} - ${error.message}`, {errorInfo}, false);
 
     /* On native we also log the error to crashlytics
     * Since the error was handled we need to manually tell crashlytics about it */


### PR DESCRIPTION
cc @AndrewGable 

Coming from https://expensify.slack.com/archives/C03TQ48KC/p1648671342026159

### Details

We are logging alerts when the error boundary is hit - but BugBot creates one huge issue with all the different crashes which is unreasonable for one person to assign themselves to (I tried and ran away) :D

<img width="1126" alt="2022-03-31_07-13-19" src="https://user-images.githubusercontent.com/32969087/161113559-0d3860cd-7426-4cf2-8388-3edb08dc81bf.png">

### Fixed Issues

No Issue, but full context in the Slack thread mentioned above.

### Tests
1. Applied this diff
```diff
diff --git a/src/libs/Navigation/AppNavigator/AuthScreens.js b/src/libs/Navigation/AppNavigator/AuthScreens.js
index 944dcfa52..acb1752c9 100644
--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -127,6 +127,8 @@ class AuthScreens extends React.Component {
         BankAccounts.fetchFreePlanVerifiedBankAccount();
         BankAccounts.fetchUserWallet();

+        throw new Error('derp');
+
         // Load policies, maybe creating a new policy first.
         Linking.getInitialURL()
             .then((url) => {
```
2. Verify that a more specific log line appears in logs
```
2022-03-31T18:57:01.574318+00:00 expensidev2004 php-fpm: jbDJLy /api.php marc@expensifail.com !ecash! ?api? [alrt] [alXt] NewExpensify crash caught by error boundary - derp ~~ errorInfo: '{"componentStack":"\n...
```

- [ ] Verify that no errors appear in the JS console

### QA Steps
❌ 