### PR TITLE
Fetch policy chats after deleting a member so that the room updates correctly

### DIFF
--- a/src/libs/actions/Policy.js
+++ b/src/libs/actions/Policy.js
@@ -294,6 +294,9 @@ function removeMembers(members, policyID) {
     })
         .then((data) => {
             if (data.jsonCode === 200) {
+                if (!_.isEmpty(data.policyExpenseChatIDs)) {
+                    Report.fetchChatReportsByIDs(data.policyExpenseChatIDs);
+                }
                 return;
             }
             const policyDataWithMembersRemoved = _.clone(allPolicies[key]);


### PR DESCRIPTION


### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/Expensify/issues/204497

### Tests/QA Steps
1. Create a new workspace from an account that's on the `policyExpenseChat` beta (e.g @expensifail.com)
2. Add a new member to the workspace via Manage Members > Invite
3. Log-in as the member and send a couple of messages in the member's workspace chat
4. Log back in again to the admin account and remove the member from the workspace via Manage Members > Remove
5. Navigate to the removed member's workspace chat, the archived reason textbox should appear and the chat in the LHN should have the trashcan icon:

<img width="1128" alt="Screen Shot 2022-04-01 at 2 45 36 PM" src="https://user-images.githubusercontent.com/19366280/161266367-f0a06390-7e99-4f7d-80fc-8798cfb1df1a.png">
<img width="290" alt="Screen Shot 2022-04-01 at 2 45 42 PM" src="https://user-images.githubusercontent.com/19366280/161266384-f08d4758-be68-4fe5-af6a-485a83c429bc.png">

