### PR TITLE
Fix - Uploading Mp4 Videos Removes 'Attachment' Tag 

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -379,6 +379,8 @@ const CONST = {
         DECIMAL_PAD: 'decimal-pad',
     },
 
+    ATTACHMENT_SOURCE_ATTRIBUTE : 'data-expensify-source',
+
     ATTACHMENT_PICKER_TYPE: {
         FILE: 'file',
         IMAGE: 'image',

--- a/src/CONST.js
+++ b/src/CONST.js
@@ -379,7 +379,7 @@ const CONST = {
         DECIMAL_PAD: 'decimal-pad',
     },
 
-    ATTACHMENT_SOURCE_ATTRIBUTE : 'data-expensify-source',
+    ATTACHMENT_SOURCE_ATTRIBUTE: 'data-expensify-source',
 
     ATTACHMENT_PICKER_TYPE: {
         FILE: 'file',

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -183,7 +183,7 @@ function getSimplifiedReportObject(report) {
     const createTimestamp = lodashGet(report, 'lastActionCreated', 0);
     const lastMessageTimestamp = moment.utc(createTimestamp).unix();
     const lastActionMessage = lodashGet(report, ['lastActionMessage', 'html'], '');
-    const isLastMessageAttachment = /<img|a\s[^>]*data-expensify-source\s*=\s*"[^"]*"[^>]*>/gi.test(lastActionMessage);
+    const isLastMessageAttachment =  new RegExp(`<img|a\\s[^>]*${CONST.ATTACHMENT_SOURCE_ATTRIBUTE}\\s*=\\s*"[^"]*"[^>]*>`,"gi").test(lastActionMessage);
     const chatType = lodashGet(report, ['reportNameValuePairs', 'chatType'], '');
 
     let lastMessageText = null;

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -183,7 +183,7 @@ function getSimplifiedReportObject(report) {
     const createTimestamp = lodashGet(report, 'lastActionCreated', 0);
     const lastMessageTimestamp = moment.utc(createTimestamp).unix();
     const lastActionMessage = lodashGet(report, ['lastActionMessage', 'html'], '');
-    const isLastMessageAttachment = /<img([^>]+)\/>/gi.test(lastActionMessage);
+    const isLastMessageAttachment = /<\/?(a|img|...)\b[^<>]*>/gi.test(lastActionMessage);
     const chatType = lodashGet(report, ['reportNameValuePairs', 'chatType'], '');
 
     let lastMessageText = null;

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -186,8 +186,6 @@ function getSimplifiedReportObject(report) {
     const isLastMessageAttachment = /<img|a\s[^>]*data-expensify-source\s*=\s*"[^"]*"[^>]*>/gi.test(lastActionMessage);
     const chatType = lodashGet(report, ['reportNameValuePairs', 'chatType'], '');
 
-    console.log("LastActionMessage",lastActionMessage);
-
     let lastMessageText = null;
     if (report.reportActionCount > 0) {
         // We are removing any html tags from the message html since we cannot access the text version of any comments as

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -183,8 +183,10 @@ function getSimplifiedReportObject(report) {
     const createTimestamp = lodashGet(report, 'lastActionCreated', 0);
     const lastMessageTimestamp = moment.utc(createTimestamp).unix();
     const lastActionMessage = lodashGet(report, ['lastActionMessage', 'html'], '');
-    const isLastMessageAttachment = /<\/?(a|img|...)\b[^<>]*>/gi.test(lastActionMessage);
+    const isLastMessageAttachment = /<img|a\s[^>]*data-expensify-source\s*=\s*"[^"]*"[^>]*>/gi.test(lastActionMessage);
     const chatType = lodashGet(report, ['reportNameValuePairs', 'chatType'], '');
+
+    console.log("LastActionMessage",lastActionMessage);
 
     let lastMessageText = null;
     if (report.reportActionCount > 0) {

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -183,7 +183,7 @@ function getSimplifiedReportObject(report) {
     const createTimestamp = lodashGet(report, 'lastActionCreated', 0);
     const lastMessageTimestamp = moment.utc(createTimestamp).unix();
     const lastActionMessage = lodashGet(report, ['lastActionMessage', 'html'], '');
-    const isLastMessageAttachment =  new RegExp(`<img|a\\s[^>]*${CONST.ATTACHMENT_SOURCE_ATTRIBUTE}\\s*=\\s*"[^"]*"[^>]*>`,"gi").test(lastActionMessage);
+    const isLastMessageAttachment = new RegExp(`<img|a\\s[^>]*${CONST.ATTACHMENT_SOURCE_ATTRIBUTE}\\s*=\\s*"[^"]*"[^>]*>`, 'gi').test(lastActionMessage);
     const chatType = lodashGet(report, ['reportNameValuePairs', 'chatType'], '');
 
     let lastMessageText = null;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/8331

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Open Expensify App and log in with any account
2. Click to add attachment
3. Select mp4 video and tap Send
4. Refresh the page

### PR Review Checklist
<!--
This is a checklist for PR authors & reviewers. Please make sure to complete all tasks and check them off once you do, or else Expensify has the right not to merge your PR!
-->
#### Contributor (PR Author) Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there’s a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained “why” the code was doing something instead of only explaining “what” the code was doing.
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named “index.js”. All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] Any functional components have the `displayName` property
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose and it is
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn’t already exist
    - [x] The style can’t be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.


<details>
<summary><h4>PR Reviewer Checklist</h4></summary>

- [ ] I verified the correct issue is linked in the `### Fixed Issues` section above
- [ ] I verified testing steps are clear and they cover the changes made in this PR
    - [ ] I verified the steps for local testing are in the `Tests` section
    - [ ] I verified the steps for Staging and/or Production testing are in the `QA steps` section
    - [ ] I verified the steps cover any possible failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [ ] I checked that screenshots or videos are included for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [] I verified tests pass on **all platforms** & I tested again on:
    - [] iOS / native
    - [] Android / native
    - [] iOS / Safari
    - [] Android / Chrome
    - [] MacOS / Chrome
    - [] MacOS / Desktop
- [] I verified there are no console errors (if there’s a console error not related to the PR, report it or open an issue for it to be fixed)
- [] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`).
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained “why” the code was doing something instead of only explaining “what” the code was doing.
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [ ] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named “index.js”. All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I verified that this PR follows the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] Any functional components have the `displayName` property
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose and it is broken down into smaller components in order to separate concerns and functions
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn’t already exist
    - [ ] The style can’t be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.

</details>

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
##Expected Result
- `[Attachment]` Tag should be shown for all attachment types. 
-  Links should not be shown as attachments 

LHN - Left Hand Navigation 

To test these changes on all platforms please follow these steps 

Testing File uploads (Images,PDF,Audio,Video) 

1. Open Expensify App and log in with any account
2. Click to add attachment
3. Select any to upload File e.g (Mp4 video) and tap Send 
4. This should show up on the LHN as `[Attachment]` instead of showing the filename
5. Refresh the page (on mobile go back to chats page)
6. Attachments should still show as `[Attachment]` on the LHN


Testing Links 

1. Open Expensify App and log in with any account
2. Navigate to any chat 
3. Copy paste/ Type in any link e.g https://google.com in the textbox and hit send
4. This should show up on the LHN as a link `https://google.com` and not as an Attachment
5. Refresh the page (on mobile go back to chats page)
6. Links should still show as links on the LHN

This should work on all platforms & for all attachments. 

- [ ] Verify that attachment tag is shown for all file uploads even after page refresh 
- [ ] Verify that links are not shown as attachments 
- [ ] Verify that no errors appear in the JS console

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

https://user-images.githubusercontent.com/4717301/161214022-7fdaac4f-7435-4c91-9c55-84ab164bb8bd.mov



#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

https://user-images.githubusercontent.com/4717301/161274783-9154781a-bc42-468f-87da-34a09e88e5bf.mov


#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

https://user-images.githubusercontent.com/4717301/161274917-d175d078-7913-4ef5-9309-0be428faf701.mov




#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->


https://user-images.githubusercontent.com/4717301/161274944-133a58c8-9fb0-4a64-ad86-5e769fd3fcae.mov




#### Android
<!-- Insert screenshots of your changes on the Android platform-->
https://user-images.githubusercontent.com/4717301/161275076-a1349eeb-d2d7-47e2-9d72-b9dea93476da.mov


