### PR TITLE
Remove GMT options from timezones

### DIFF
--- a/src/pages/settings/Profile/ProfilePage.js
+++ b/src/pages/settings/Profile/ProfilePage.js
@@ -56,10 +56,13 @@ const defaultProps = {
     loginList: [],
 };
 
-const timezones = _.map(moment.tz.names(), timezone => ({
-    value: timezone,
-    label: timezone,
-}));
+const timezones = _.chain(moment.tz.names())
+    .filter(timezone => !timezone.startsWith('Etc/GMT'))
+    .map(timezone => ({
+        value: timezone,
+        label: timezone,
+    }))
+    .value();
 
 class ProfilePage extends Component {
     constructor(props) {


### PR DESCRIPTION
Pullearbearing (@sketchydroide)

### Details
Remove the Etc/GMT timezones from the timezone options. See [this comment](https://github.com/Expensify/App/issues/8251#issuecomment-1103272479) for the explanation on why

### Fixed Issues
$ https://github.com/Expensify/App/issues/8251

### Tests/QA
1. Login to account “A”.
2. Go to settings -> Profile
3. Uncheck “Set my timezone automatically”
4. Make sure there are no timezones available to select that start with "Etc/GMT"

- [ ] Verify that no errors appear in the JS console

### Screenshots
<img width="592" alt="Screen Shot 2022-04-20 at 5 38 24 PM" src="https://user-images.githubusercontent.com/4741899/164347929-af550850-cf74-4863-8e9b-1d9e99872362.png">