### PR TITLE
[HOLD] Get Pusher dev suffix from `_config.local.php` file (Expensify employees only) & append to pusher channel names

### DIFF
--- a/config/webpack/webpack.common.js
+++ b/config/webpack/webpack.common.js
@@ -7,6 +7,7 @@ const CopyPlugin = require('copy-webpack-plugin');
 const dotenv = require('dotenv');
 const {BundleAnalyzerPlugin} = require('webpack-bundle-analyzer');
 const CustomVersionFilePlugin = require('./CustomVersionFilePlugin');
+const _ = require('underscore');
 
 const includeModules = [
     'react-native-animatable',
@@ -24,8 +25,8 @@ const includeModules = [
 
 // Try to read pusher suffix from local php file. If it doesn't exist, just save an empty string.
 const phpConfigFile = readFileSync('../Web-Expensify/_config.local.php', 'utf8');
-const pusherSuffixRow = phpConfigFile.split('\n').find(row => row.indexOf('PUSHER_DEV_SUFFIX') > -1);
-const pusherSuffix = pusherSuffixRow ? '-' + pusherSuffixRow.replace(/[';)]/g, '').split(' ')[1] : '';
+const pusherSuffixRow = _.find(phpConfigFile.split('\n'), row => row.indexOf('PUSHER_DEV_SUFFIX') > -1);
+const pusherSuffix = pusherSuffixRow ? `-${pusherSuffixRow.replace(/[';)]/g, '').split(' ')[1]}` : '';
 
 /**
  * Get a production grade config for web or desktop

--- a/config/webpack/webpack.common.js
+++ b/config/webpack/webpack.common.js
@@ -6,8 +6,8 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CopyPlugin = require('copy-webpack-plugin');
 const dotenv = require('dotenv');
 const {BundleAnalyzerPlugin} = require('webpack-bundle-analyzer');
-const CustomVersionFilePlugin = require('./CustomVersionFilePlugin');
 const _ = require('underscore');
+const CustomVersionFilePlugin = require('./CustomVersionFilePlugin');
 
 const includeModules = [
     'react-native-animatable',

--- a/src/CONFIG.js
+++ b/src/CONFIG.js
@@ -54,6 +54,7 @@ export default {
     PUSHER: {
         APP_KEY: lodashGet(Config, 'PUSHER_APP_KEY', '268df511a204fbb60884'),
         CLUSTER: 'mt1',
+        SUFFIX: lodashGet(Config, 'pusherSuffix'),
     },
     SITE_TITLE: 'New Expensify',
     FAVICON: {

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -18,6 +18,7 @@ import ROUTES from '../../ROUTES';
 import NetworkConnection from '../NetworkConnection';
 import Timing from './Timing';
 import * as API from '../API';
+import CONFIG from '../../CONFIG';
 import CONST from '../../CONST';
 import Log from '../Log';
 import * as LoginUtils from '../LoginUtils';
@@ -719,7 +720,7 @@ function updateReportPinnedState(reportID, isPinned) {
  * @returns {String}
  */
 function getReportChannelName(reportID) {
-    return `private-report-reportID-${reportID}`;
+    return `private-report-reportID-${reportID}${CONFIG.PUSHER.SUFFIX}`;
 }
 
 /**
@@ -730,7 +731,7 @@ function getReportChannelName(reportID) {
  * @param {Boolean} isChunked
  */
 function subscribeToPrivateUserChannelEvent(eventName, onEvent, isChunked = false) {
-    const pusherChannelName = `private-user-accountID-${currentUserAccountID}`;
+    const pusherChannelName = `private-user-accountID-${currentUserAccountID}${CONFIG.PUSHER.SUFFIX}`;
 
     /**
      * @param {Object} pushJSON
@@ -771,7 +772,7 @@ function subscribeToUserEvents() {
         return;
     }
 
-    const pusherChannelName = `private-user-accountID-${currentUserAccountID}`;
+    const pusherChannelName = `private-user-accountID-${currentUserAccountID}${CONFIG.PUSHER.SUFFIX}`;
     if (Pusher.isSubscribed(pusherChannelName) || Pusher.isAlreadySubscribing(pusherChannelName)) {
         return;
     }

--- a/src/libs/actions/User.js
+++ b/src/libs/actions/User.js
@@ -6,6 +6,7 @@ import {PUBLIC_DOMAINS as COMMON_PUBLIC_DOMAINS} from 'expensify-common/lib/CONS
 import moment from 'moment';
 import ONYXKEYS from '../../ONYXKEYS';
 import * as API from '../API';
+import CONFIG from '../../CONFIG';
 import CONST from '../../CONST';
 import Navigation from '../Navigation/Navigation';
 import ROUTES from '../../ROUTES';
@@ -295,7 +296,7 @@ function subscribeToUserEvents() {
         return;
     }
 
-    const pusherChannelName = `private-user-accountID-${currentUserAccountID}`;
+    const pusherChannelName = `private-user-accountID-${currentUserAccountID}${CONFIG.PUSHER.SUFFIX}`;
 
     // Live-update an user's preferred locale
     Pusher.subscribe(pusherChannelName, Pusher.TYPE.PREFERRED_LOCALE, (pushJSON) => {
@@ -329,7 +330,7 @@ function subscribeToExpensifyCardUpdates() {
         return;
     }
 
-    const pusherChannelName = `private-user-accountID-${currentUserAccountID}`;
+    const pusherChannelName = `private-user-accountID-${currentUserAccountID}${CONFIG.PUSHER.SUFFIX}`;
 
     // Handle Expensify Card approval flow updates
     Pusher.subscribe(pusherChannelName, Pusher.TYPE.EXPENSIFY_CARD_UPDATE, (pushJSON) => {

--- a/tests/actions/ReportTest.js
+++ b/tests/actions/ReportTest.js
@@ -42,7 +42,7 @@ describe('actions/Report', () => {
     afterEach(() => {
         // Unsubscribe from account channel after each test since we subscribe in the function
         // subscribeToUserEvents and we don't want duplicate event subscriptions.
-        Pusher.unsubscribe('private-user-accountID-1');
+        Pusher.unsubscribe(`private-user-accountID-1${CONFIG.PUSHER.SUFFIX}`);
     });
 
     it('should store a new report action in Onyx when reportComment event is handled via Pusher', () => {
@@ -103,7 +103,7 @@ describe('actions/Report', () => {
             .then(() => {
                 // We subscribed to the Pusher channel above and now we need to simulate a reportComment action
                 // Pusher event so we can verify that action was handled correctly and merged into the reportActions.
-                const channel = Pusher.getChannel('private-user-accountID-1');
+                const channel = Pusher.getChannel(`private-user-accountID-1${CONFIG.PUSHER.SUFFIX}`);
                 channel.emit(Pusher.TYPE.REPORT_COMMENT, {
                     reportID: REPORT_ID,
                     reportAction: {...REPORT_ACTION, clientID},
@@ -157,7 +157,7 @@ describe('actions/Report', () => {
             .then(() => {
                 // We subscribed to the Pusher channel above and now we need to simulate a reportTogglePinned
                 // Pusher event so we can verify that pinning was handled correctly and merged into the report.
-                const channel = Pusher.getChannel('private-user-accountID-1');
+                const channel = Pusher.getChannel(`private-user-accountID-1${CONFIG.PUSHER.SUFFIX}`);
                 channel.emit(Pusher.TYPE.REPORT_TOGGLE_PINNED, {
                     reportID: REPORT_ID,
                     isPinned: true,


### PR DESCRIPTION
~Holding on pusher suffix being generated in VMs here: https://github.com/Expensify/Expensify/issues/207388~

Needs to be tested in combination with Web-E changes I believe 🤔 

<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Part of bigger Offline First - Pusher Changes design doc.

The reason we need to start doing this is b/c in the near future Pusher will handle some API responses, and we don't want one response to take effect on multiple engineers' local environments. Hence we're appending a unique string (the pusher suffix) to the end of pusher channels to keep things from crossing over

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/207393

### Tests

- [x] Verify that no errors appear in the JS console

To prepare for testing these changes:
1. Open New Expensify in a normal web browser tab with account A & in an **incognito** tab with account B
2. Open a chat between the two accounts

There's 2 types of channels being modified. Here they are and here's how to test each:
- `private-user-accountID-${accountID}${CONFIG.PUSHER.SUFFIX}`
    - Send a message from account A to account B, make sure account B receives the message instantly, without needing to refresh the page
    - Verify this works visa versa too 👍 
- `public-report-reportID-${reportID}${CONFIG.PUSHER.SUFFIX}`
    - Start typing a message from account A to account B
    - In account B's screen, make sure you see "User is typing..." like this:

<img width="450" alt="Screen Shot 2022-04-25 at 4 37 56 PM" src="https://user-images.githubusercontent.com/3885503/165111972-f1b1cc94-76eb-4920-a9da-6b8266e93bea.png">

### PR Review Checklist
<!--
This is a checklist for PR authors & reviewers. Please make sure to complete all tasks and check them off once you do, or else Expensify has the right not to merge your PR!
-->
#### Contributor (PR Author) Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [x] I verified there are no console errors (if there’s a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained “why” the code was doing something instead of only explaining “what” the code was doing.
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [ ] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named “index.js”. All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] Any functional components have the `displayName` property
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose and it is
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn’t already exist
    - [ ] The style can’t be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.

### QA Steps

- [x] Verify that no errors appear in the JS console

Please follow the same steps as above