### PR TITLE
login form layout for ipad

### DIFF
--- a/config/webpack/webpack.dev.js
+++ b/config/webpack/webpack.dev.js
@@ -27,6 +27,7 @@ module.exports = (env = {}) => {
         devServer: {
             contentBase: path.join(__dirname, '../../dist'),
             hot: true,
+            host: '0.0.0.0',
             ...proxySettings,
             historyApiFallback: true,
         },

--- a/config/webpack/webpack.dev.js
+++ b/config/webpack/webpack.dev.js
@@ -27,7 +27,6 @@ module.exports = (env = {}) => {
         devServer: {
             contentBase: path.join(__dirname, '../../dist'),
             hot: true,
-            host: '0.0.0.0',
             ...proxySettings,
             historyApiFallback: true,
         },

--- a/src/pages/signin/SignInPageLayout/SignInPageContent.js
+++ b/src/pages/signin/SignInPageLayout/SignInPageContent.js
@@ -55,7 +55,7 @@ const SignInPageContent = props => (
             <LoginKeyboardAvoidingView
                 behavior="position"
                 contentContainerStyle={[
-                    props.isSmallScreenWidth && styles.signInPageNarrowContentMargin,
+                    props.isSmallScreenWidth ? styles.signInPageNarrowContentMargin : {},
                     !props.isMediumScreenWidth && styles.signInPageWideLeftContentMargin,
                     styles.mb3,
                     StyleUtils.getModalPaddingStyles({

--- a/src/pages/signin/SignInPageLayout/SignInPageContent.js
+++ b/src/pages/signin/SignInPageLayout/SignInPageContent.js
@@ -55,7 +55,8 @@ const SignInPageContent = props => (
             <LoginKeyboardAvoidingView
                 behavior="position"
                 contentContainerStyle={[
-                    props.isSmallScreenWidth ? styles.signInPageNarrowContentMargin : styles.signInPageWideLeftContentMargin,
+                    props.isSmallScreenWidth && styles.signInPageNarrowContentMargin,
+                    !props.isMediumScreenWidth && styles.signInPageWideLeftContentMargin,
                     styles.mb3,
                     StyleUtils.getModalPaddingStyles({
                         shouldAddBottomSafeAreaPadding: true,

--- a/src/pages/signin/SignInPageLayout/SignInPageContent.js
+++ b/src/pages/signin/SignInPageLayout/SignInPageContent.js
@@ -56,7 +56,7 @@ const SignInPageContent = props => (
                 behavior="position"
                 contentContainerStyle={[
                     props.isSmallScreenWidth ? styles.signInPageNarrowContentMargin : {},
-                    !props.isMediumScreenWidth && styles.signInPageWideLeftContentMargin,
+                    !props.isMediumScreenWidth ? styles.signInPageWideLeftContentMargin : {},
                     styles.mb3,
                     StyleUtils.getModalPaddingStyles({
                         shouldAddBottomSafeAreaPadding: true,

--- a/src/pages/signin/SignInPageLayout/index.js
+++ b/src/pages/signin/SignInPageLayout/index.js
@@ -8,6 +8,7 @@ import SVGImage from '../../../components/SVGImage';
 import styles from '../../../styles/styles';
 import * as StyleUtils from '../../../styles/StyleUtils';
 import * as Link from '../../../libs/actions/Link';
+import variables from '../../../styles/variables'; 
 
 const propTypes = {
     /** The children to show inside the layout */
@@ -64,7 +65,7 @@ const SignInPageLayout = (props) => {
     if (props.isMediumScreenWidth) {
         return (
             <View style={[styles.dFlex, styles.signInPageInner, styles.flexColumnReverse, styles.justifyContentBetween]}>
-                {props.windowHeight >= 854 && graphicLayout}
+                {props.windowHeight >= variables.minHeigthToShowGraphics && graphicLayout}
                 <View style={styles.flex1}>
                     {content}
                 </View>

--- a/src/pages/signin/SignInPageLayout/index.js
+++ b/src/pages/signin/SignInPageLayout/index.js
@@ -64,7 +64,7 @@ const SignInPageLayout = (props) => {
     if (props.isMediumScreenWidth) {
         return (
             <View style={[styles.dFlex, styles.signInPageInner, styles.flexColumnReverse, styles.justifyContentBetween]}>
-                {graphicLayout}
+                {props.windowHeight >= 854 && graphicLayout}
                 <View style={styles.flex1}>
                     {content}
                 </View>

--- a/src/pages/signin/SignInPageLayout/index.js
+++ b/src/pages/signin/SignInPageLayout/index.js
@@ -35,34 +35,48 @@ const SignInPageLayout = (props) => {
         </SignInPageContent>
     );
 
+    const hasRedirect = !_.isEmpty(backgroundStyle.redirectUri);
+
+    const graphicLayout = () => (
+        <Pressable
+            style={[
+                styles.flex1,
+                StyleUtils.getBackgroundColorStyle(backgroundStyle.backgroundColor),
+            ]}
+            onPress={() => {
+                Link.openExternalLink(backgroundStyle.redirectUri);
+            }}
+            disabled={!hasRedirect}
+        >
+            <SVGImage
+                width="100%"
+                height="100%"
+                src={backgroundStyle.backgroundImageUri}
+                resizeMode={props.isMediumScreenWidth ? 'contain' : 'cover'}
+            />
+        </Pressable>
+    );
+
     if (props.isSmallScreenWidth) {
         return content;
     }
 
-    const hasRedirect = !_.isEmpty(backgroundStyle.redirectUri);
+    if (props.isMediumScreenWidth) {
+        return (
+            <View style={[styles.dFlex, styles.signInPageInner, styles.flexColumnReverse, styles.justifyContentBetween]}>
+                {graphicLayout(props.isMediumScreenWidth)}
+                <View style={styles.flex1}>
+                    {content}
+                </View>
+            </View>
+        );
+    }
 
     return (
         <View style={[styles.flex1, styles.signInPageInner]}>
             <View style={[styles.flex1, styles.flexRow, styles.flexGrow1]}>
                 {content}
-                <Pressable
-                    style={[
-                        styles.flexGrow1,
-                        StyleUtils.getBackgroundColorStyle(backgroundStyle.backgroundColor),
-                        props.isMediumScreenWidth && styles.alignItemsCenter,
-                    ]}
-                    onPress={() => {
-                        Link.openExternalLink(backgroundStyle.redirectUri);
-                    }}
-                    disabled={!hasRedirect}
-                >
-                    <SVGImage
-                        width="100%"
-                        height="100%"
-                        src={backgroundStyle.backgroundImageUri}
-                        resizeMode={props.isMediumScreenWidth ? 'contain' : 'cover'}
-                    />
-                </Pressable>
+                {graphicLayout(props.isMediumScreenWidth)}
             </View>
         </View>
     );

--- a/src/pages/signin/SignInPageLayout/index.js
+++ b/src/pages/signin/SignInPageLayout/index.js
@@ -62,10 +62,10 @@ const SignInPageLayout = (props) => {
         return content;
     }
 
-    if (props.isMediumScreenWidth) {
+    if (props.isMediumScreenWidth && props.windowHeight >= variables.minHeigthToShowGraphics) {
         return (
             <View style={[styles.dFlex, styles.signInPageInner, styles.flexColumnReverse, styles.justifyContentBetween]}>
-                {props.windowHeight >= variables.minHeigthToShowGraphics && graphicLayout}
+                {graphicLayout}
                 <View style={styles.flex1}>
                     {content}
                 </View>

--- a/src/pages/signin/SignInPageLayout/index.js
+++ b/src/pages/signin/SignInPageLayout/index.js
@@ -37,7 +37,7 @@ const SignInPageLayout = (props) => {
 
     const hasRedirect = !_.isEmpty(backgroundStyle.redirectUri);
 
-    const graphicLayout = () => (
+    const graphicLayout = (
         <Pressable
             style={[
                 styles.flex1,
@@ -64,7 +64,7 @@ const SignInPageLayout = (props) => {
     if (props.isMediumScreenWidth) {
         return (
             <View style={[styles.dFlex, styles.signInPageInner, styles.flexColumnReverse, styles.justifyContentBetween]}>
-                {graphicLayout(props.isMediumScreenWidth)}
+                {graphicLayout}
                 <View style={styles.flex1}>
                     {content}
                 </View>
@@ -76,7 +76,7 @@ const SignInPageLayout = (props) => {
         <View style={[styles.flex1, styles.signInPageInner]}>
             <View style={[styles.flex1, styles.flexRow, styles.flexGrow1]}>
                 {content}
-                {graphicLayout(props.isMediumScreenWidth)}
+                {graphicLayout}
             </View>
         </View>
     );

--- a/src/pages/signin/SignInPageLayout/index.js
+++ b/src/pages/signin/SignInPageLayout/index.js
@@ -8,7 +8,7 @@ import SVGImage from '../../../components/SVGImage';
 import styles from '../../../styles/styles';
 import * as StyleUtils from '../../../styles/StyleUtils';
 import * as Link from '../../../libs/actions/Link';
-import variables from '../../../styles/variables'; 
+import variables from '../../../styles/variables';
 
 const propTypes = {
     /** The children to show inside the layout */

--- a/src/styles/variables.js
+++ b/src/styles/variables.js
@@ -44,5 +44,5 @@ export default {
     tooltipzIndex: 10050,
     gutterWidth: 16,
     popoverMenuShadow: '0px 4px 12px 0px rgba(0, 0, 0, 0.06)',
-    minHeightToShowGraphics: 854,
+    minHeightToShowGraphics: 854, // below this height UI was broken on login form layout as there isn't enough height to show forma and graphics.
 };

--- a/src/styles/variables.js
+++ b/src/styles/variables.js
@@ -44,4 +44,5 @@ export default {
     tooltipzIndex: 10050,
     gutterWidth: 16,
     popoverMenuShadow: '0px 4px 12px 0px rgba(0, 0, 0, 0.06)',
+    minHeigthToShowGraphics: 854
 };

--- a/src/styles/variables.js
+++ b/src/styles/variables.js
@@ -44,5 +44,5 @@ export default {
     tooltipzIndex: 10050,
     gutterWidth: 16,
     popoverMenuShadow: '0px 4px 12px 0px rgba(0, 0, 0, 0.06)',
-    minHeigthToShowGraphics: 854
+    minHeightToShowGraphics: 854,
 };


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
https://github.com/Expensify/App/issues/8122

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
**For ipad/tablets**
1. Open Expensify app on iPad/tablet (Signed out state).
2. Verify that the login-form-layout is updated as per [design]( https://github.com/Expensify/App/issues/8122#issuecomment-1066971554).

**For other platforms**
1.  Open Expensify app 
2. Verify that due to these changes design is not effected for other platforms.

- [x] Verify that no errors appear in the JS console

### PR Review Checklist
<!--
This is a checklist for PR authors & reviewers. Please make sure to complete all tasks and check them off once you do, or else Expensify has the right not to merge your PR!
-->
#### Contributor (PR Author) Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there’s a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained “why” the code was doing something instead of only explaining “what” the code was doing.
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [ ] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named “index.js”. All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] Any functional components have the `displayName` property
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose and it is
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn’t already exist
    - [ ] The style can’t be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.


<details>
<summary><h4>PR Reviewer Checklist</h4></summary>

- [ ] I verified the correct issue is linked in the `### Fixed Issues` section above
- [ ] I verified testing steps are clear and they cover the changes made in this PR
    - [ ] I verified the steps for local testing are in the `Tests` section
    - [ ] I verified the steps for Staging and/or Production testing are in the `QA steps` section
    - [ ] I verified the steps cover any possible failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [ ] I checked that screenshots or videos are included for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I verified tests pass on **all platforms** & I tested again on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [ ] I verified there are no console errors (if there’s a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`).
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained “why” the code was doing something instead of only explaining “what” the code was doing.
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [ ] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named “index.js”. All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I verified that this PR follows the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] Any functional components have the `displayName` property
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose and it is broken down into smaller components in order to separate concerns and functions
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn’t already exist
    - [ ] The style can’t be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.

</details>

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
3. Upload an image via copy paste
4. Verify a modal appears displaying a preview of that image
--->

*For ipad/tablets**
1. Open Expensify app on iPad/tablet (Signed out state).
2. Verify that the login-form-layout is updated as per [design]( https://github.com/Expensify/App/issues/8122#issuecomment-1066971554).

**For other platforms**
1.  Open Expensify app 
2. Verify that due to these changes [design]( https://github.com/Expensify/App/issues/8122#issuecomment-1066971554) is not effected for other platforms.

- [x] Verify that no errors appear in the JS console


### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<img width="1678" alt="Screen Shot 2022-04-22 at 11 55 09 PM" src="https://user-images.githubusercontent.com/36359331/164780965-db3e501a-fe14-4b09-86be-ad13191b5310.png">

#### Desktop
<img width="1196" alt="Screen Shot 2022-04-23 at 12 13 38 AM" src="https://user-images.githubusercontent.com/36359331/164781015-6a1acca5-f548-4ef0-9ce2-6b23a2334b66.png">

#### IOS
<img width="431" alt="Screen Shot 2022-04-23 at 12 15 58 AM" src="https://user-images.githubusercontent.com/36359331/164781075-b8acab54-d406-4bb8-9c5e-84e45bd3c0a8.png">

#### Android
![Android](https://user-images.githubusercontent.com/36359331/164781450-3a5665ed-0909-4604-923f-24302b06bb1a.jpeg)


#### Mweb
![Mweb](https://user-images.githubusercontent.com/36359331/164781333-2c6f41bc-c60e-49cd-8834-a31442de67da.jpeg)


#### IPad
<img width="717" alt="Screen Shot 2022-04-22 at 10 55 02 PM" src="https://user-images.githubusercontent.com/36359331/164773912-4076a53f-7846-4b61-bb29-b29cdfd21e35.png">

####
