### PR TITLE
Give buttons more space in the preferences page

### DIFF
--- a/src/components/TestToolRow.js
+++ b/src/components/TestToolRow.js
@@ -14,7 +14,7 @@ const propTypes = {
 
 const TestToolRow = props => (
     <View style={[styles.flexRow, styles.mb6, styles.justifyContentBetween, styles.alignItemsCenter]}>
-        <View style={styles.flex4}>
+        <View style={styles.flex3}>
             <Text>
                 {props.title}
             </Text>


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
The buttons didn't quite have enough room to display full text

### Fixed Issues
$ https://github.com/Expensify/App/issues/8783

### Tests
1. For testing locally, you must modify [this code](https://github.com/Expensify/App/blob/d99919292f9acde9af4b5f9c494e736a2e81006c/src/pages/settings/PreferencesPage.js#L104) to get access to the options. Change it to DEV (or delete the logic)
2. Go to User settings > Preferences
3. Verify the full buttons can be seen for "Invalidate"

### QA Steps
2. Go to User settings > Preferences
3. Verify the full buttons can be seen for "Invalidate"
- [ ] Verify that no errors appear in the JS console

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
#### Mobile Web
![image](https://user-images.githubusercontent.com/1228807/165391642-f19cc392-6bdd-485b-bcb3-bb845c158447.png)


#### Desktop
![image](https://user-images.githubusercontent.com/1228807/165391909-fff0fedb-9e43-49ee-8f36-37b93c076333.png)


#### iOS
![image](https://user-images.githubusercontent.com/1228807/165391620-1b1bde04-9517-4352-bc24-682e79ece2f4.png)


#### Android
I am having troubles getting my emulator to launch
