### PR TITLE
Wait for Onyx to clear before signing in the transitioning user

### DIFF
--- a/src/ONYXKEYS.js
+++ b/src/ONYXKEYS.js
@@ -25,6 +25,9 @@ export default {
     // Boolean flag set when workspace is being created
     IS_CREATING_WORKSPACE: 'isCreatingWorkspace',
 
+    // Boolean flag set when Onyx finishes clearing
+    IS_ONYX_DONE_CLEARING: 'isOnyxDoneClearing',
+
     // Note: These are Persisted Requests - not all requests in the main queue as the key name might lead one to believe
     PERSISTED_REQUESTS: 'networkRequestQueue',
 

--- a/src/libs/actions/App.js
+++ b/src/libs/actions/App.js
@@ -83,10 +83,15 @@ function triggerUpdateAvailable() {
     Onyx.set(ONYXKEYS.UPDATE_AVAILABLE, true);
 }
 
+function setOnyxDoneClearing() {
+    Onyx.set(ONYXKEYS.IS_ONYX_DONE_CLEARING, true);
+}
+
 export {
     setCurrentURL,
     setLocale,
     setSidebarLoaded,
     getLocale,
     triggerUpdateAvailable,
+    setOnyxDoneClearing,
 };

--- a/src/libs/actions/SignInRedirect.js
+++ b/src/libs/actions/SignInRedirect.js
@@ -35,6 +35,7 @@ function clearStorageAndRedirect(errorMessage) {
 
             // `Onyx.clear` reinitialize the Onyx instance with initial values so use `Onyx.merge` instead of `Onyx.set`.
             Onyx.merge(ONYXKEYS.SESSION, {error: errorMessage});
+            Onyx.set(ONYXKEYS.IS_ONYX_DONE_CLEARING, true);
         });
 }
 

--- a/src/pages/LogInWithShortLivedTokenPage.js
+++ b/src/pages/LogInWithShortLivedTokenPage.js
@@ -58,6 +58,14 @@ const defaultProps = {
 
 class LogInWithShortLivedTokenPage extends Component {
     componentDidMount() {
+        // We need to wait for Onyx to finish clearing before signing in because
+        // it will re-initialize with the initialKeyStates, which can notify
+        // subscribers with an out of date value causing the user to be signed
+        // out again. See https://github.com/Expensify/react-native-onyx/issues/125
+        if (!this.props.isOnyxDoneClearing) {
+            return;
+        }
+
         if (this.signInIfNeeded()) {
             return;
         }
@@ -71,10 +79,6 @@ class LogInWithShortLivedTokenPage extends Component {
     }
 
     componentDidUpdate() {
-        // We need to wait for Onyx to finish clearing before signing in because
-        // it will re-initialize with the initialKeyStates, which can notify
-        // subscribers with an out of date value causing the user to be signed
-        // out again. See https://github.com/Expensify/react-native-onyx/issues/125
         if (!this.props.isOnyxDoneClearing) {
             return;
         }

--- a/src/pages/LogInWithShortLivedTokenPage.js
+++ b/src/pages/LogInWithShortLivedTokenPage.js
@@ -57,6 +57,13 @@ const defaultProps = {
 };
 
 class LogInWithShortLivedTokenPage extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            isSigningIn: false,
+        };
+    }
+
     componentDidMount() {
         // We need to wait for Onyx to finish clearing before signing in because
         // it will re-initialize with the initialKeyStates, which can notify
@@ -65,11 +72,9 @@ class LogInWithShortLivedTokenPage extends Component {
         if (!this.props.isOnyxDoneClearing) {
             return;
         }
-
         if (this.signInIfNeeded()) {
             return;
         }
-
         if (this.signOutIfNeeded()) {
             return;
         }
@@ -80,6 +85,9 @@ class LogInWithShortLivedTokenPage extends Component {
 
     componentDidUpdate() {
         if (!this.props.isOnyxDoneClearing) {
+            return;
+        }
+        if (this.state.isSigningIn) {
             return;
         }
         if (this.signInIfNeeded()) {
@@ -122,6 +130,7 @@ class LogInWithShortLivedTokenPage extends Component {
             return false;
         }
         Log.info('[LoginWithShortLivedTokenPage] User not signed in - signing in with short lived token');
+        this.setState({isSigningIn: true});
         Session.signInWithShortLivedToken(email, shortLivedToken);
         return true;
     }

--- a/src/pages/LogInWithShortLivedTokenPage.js
+++ b/src/pages/LogInWithShortLivedTokenPage.js
@@ -69,7 +69,14 @@ class LogInWithShortLivedTokenPage extends Component {
         }
 
         Log.info('[LoginWithShortLivedTokenPage] User is signed in');
+        this.navigateToExitRoute();
+    }
 
+    componentDidUpdate() {
+        this.navigateToExitRoute();
+    }
+
+    navigateToExitRoute() {
         // exitTo is URI encoded because it could contain a variable number of slashes (i.e. "workspace/new" vs "workspace/<ID>/card")
         const exitTo = decodeURIComponent(lodashGet(this.props.route.params, 'exitTo', ''));
         if (exitTo === ROUTES.WORKSPACE_NEW) {

--- a/src/pages/LogInWithShortLivedTokenPage.js
+++ b/src/pages/LogInWithShortLivedTokenPage.js
@@ -77,21 +77,6 @@ class LogInWithShortLivedTokenPage extends Component {
     }
 
     navigateToExitRoute() {
-        // exitTo is URI encoded because it could contain a variable number of slashes (i.e. "workspace/new" vs "workspace/<ID>/card")
-        const exitTo = decodeURIComponent(lodashGet(this.props.route.params, 'exitTo', ''));
-        if (exitTo === ROUTES.WORKSPACE_NEW) {
-            // New workspace creation is handled in AuthScreens, not in its own screen
-            Log.info('[LoginWithShortLivedTokenPage] exitTo is workspace/new - handling new workspace creation in AuthScreens');
-            return;
-        }
-        this.navigateToExitRoute();
-    }
-
-    componentDidUpdate() {
-        this.navigateToExitRoute();
-    }
-
-    navigateToExitRoute() {
         if (!this.props.betas) {
             // Wait to navigate until the betas are loaded. Some pages like ReimbursementAccountPage require betas, so keep loading until they are available.
             return;
@@ -99,6 +84,11 @@ class LogInWithShortLivedTokenPage extends Component {
 
         // exitTo is URI encoded because it could contain a variable number of slashes (i.e. "workspace/new" vs "workspace/<ID>/card")
         const exitTo = decodeURIComponent(lodashGet(this.props.route.params, 'exitTo', ''));
+        if (exitTo === ROUTES.WORKSPACE_NEW) {
+            // New workspace creation is handled in AuthScreens, not in its own screen
+            Log.info('[LoginWithShortLivedTokenPage] exitTo is workspace/new - handling new workspace creation in AuthScreens');
+            return;
+        }
 
         // In order to navigate to a modal, we first have to dismiss the current modal. Without dismissing the current modal, if the user cancels out of the workspace modal,
         // then they will be routed back to /transition/<accountID>/<email>/<authToken>/workspace/<policyID>/card and we don't want that. We want them to go back to `/`

--- a/src/setup/index.js
+++ b/src/setup/index.js
@@ -4,6 +4,7 @@ import ONYXKEYS from '../ONYXKEYS';
 import CONST from '../CONST';
 import platformSetup from './platformSetup';
 import * as Metrics from '../libs/Metrics';
+import * as App from '../libs/actions/App';
 
 export default function () {
     /*
@@ -35,6 +36,10 @@ export default function () {
             [ONYXKEYS.IS_SIDEBAR_LOADED]: false,
         },
     });
+
+    // We need to set IS_ONYX_DONE_CLEARING outside of the initial key states, because
+    // initial key states are set within Onyx.clear.
+    App.setOnyxDoneClearing();
 
     // Force app layout to work left to right because our design does not currently support devices using this mode
     I18nManager.allowRTL(false);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
As an alternative to modifying how Onyx updates subscribers when initializing the default key states, wait for Onyx to finish clearing and initializing before signing in the transitioning user.

### Related Issue
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/8676

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Below are tests for all of the transition flows from Web-Expensify to NewDot. This PR specifically fixes flow C, but we should test all of them.

- [x] **A. Set up my company for free**

1. Make sure you are signed out of NewDot
2. Go to OldDot with a mobile screen size and sign up with a new account
3. Click join
4. Click "Set up my company for free".
5. You should be directed to NewDot and have a new workspace created.
6. Repeat steps 2-5 to test the case where you are signed in to a different account on NewDot

- [x] **B. Select a free workspace**

1. Make sure you are signed out of NewDot
2. Go to OldDot and sign in to an account if needed
3. Go to Settings > Policies > Group and click New Policy in the top right
4. Click select on the free plan
5. You should be directed to NewDot and have a new workspace created.
6. Repeat steps 2-5 to test the case where you are signed in to the same account on NewDot
8. Sign in to a different account on OldDot
9. Repeat steps 3-5 to test the case where you are signed in to a different account on NewDot

- [x] **C. Clicking on the name of a free policy**

1. Make sure you are signed out of NewDot
2. Go to OldDot and sign in (if needed) to an account that has a free workspace / group policy
3. Go to Settings > Policies > Group and click on the name of a free workspace
4. You should be directed to NewDot and the workspace settings should open
5. Repeat steps 2-4 to test the case where you are signed in to the same account on NewDot
6. Sign in to a different account on OldDot that has a free workspace / group policy
7. Repeat steps 3-4 to test the case where you are signed in to a different account on NewDot

- [x] **D. Get Started Inbox Task**

1. Make sure you are signed out of NewDot
2. Go to OldDot and sign up for a new account with an `@gmail.com` address
3. Click on the "Get started" on the inbox task that says "Would you like to get started with our free plan?".
4. You should be directed to NewDot and have a new workspace created, and the workspace settings should open.
5. Go back to OldDot and go to Settings > Policies > Group
6. Refresh the page and verify that 1 free workspace policy has been created
7. Repeat steps 2-6 to test the case where you are signed in to a different account on NewDot

- [x] **E. Pricing select free**

- [x] E.1 Creating a free policy

1. Make sure you are signed out of NewDot
2. Go to OldDot and sign in with any account
3. Go to Settings > Policies > Group, refresh the page, then delete any free group policies
4. Go to [expensify.com.dev/pricing](https://www.expensify.com.dev/pricing) and click "Select" on the free plan
5. You should be directed to NewDot and have a new workspace created, and the workspace settings should open.
6. Go back to OldDot and go to Settings > Policies > Group
7. Refresh the page and verify that 1 free workspace policy has been created
8. Repeat steps 3-7 to test the case where you are signed in to the same account
10. Go to OldDot and sign in with a different account
11. Repeat steps 3-7 to test the case where you are signed in to a different account.

- [x] E.2 Navigating to an existing free policy

1. Make sure you are signed out of NewDot
2. Go to OldDot and sign in with any account **with** free group policies
3. Go to [expensify.com.dev/pricing](https://www.expensify.com.dev/pricing) and click "Select" on the free plan
4. You should be directed to NewDot and the workspace settings should open for some workspace.
5. Repeat steps 3-4 to test the case where you are signed in to the same account
6. Go to OldDot and sign in with a different account **with** free group policies
7. Repeat steps 3-4 to test the case where you are signed in to a different account.

- [x] **F. Continue setup Inbox task**

1. Make sure you are signed out of NewDot
2. Go to OldDot and sign in with any account **with** free group policies and without a bank account set up
3. In the OldDot inbox click "Continue setup" on the inbox task that says "Finish setting up your bank account".
4. The Connect bank account page should open in the right sidebar
5. Repeat steps 3-4 to test the case where you are signed in to the same account
6. Go to OldDot and sign in with a different account **with** free group policies and without a bank account set up
7. Repeat steps 3-4 to test the case where you are signed in to a different account.

- [x] Verify that no errors appear in the JS console

### PR Review Checklist
<!--
This is a checklist for PR authors & reviewers. Please make sure to complete all tasks and check them off once you do, or else Expensify has the right not to merge your PR!
-->
#### Contributor (PR Author) Checklist
- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [ ] I verified there are no console errors (if there’s a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained “why” the code was doing something instead of only explaining “what” the code was doing.
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [ ] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named “index.js”. All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] Any functional components have the `displayName` property
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose and it is
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn’t already exist
    - [ ] The style can’t be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.


<details>
<summary><h4>PR Reviewer Checklist</h4></summary>

- [ ] I verified the correct issue is linked in the `### Fixed Issues` section above
- [ ] I verified testing steps are clear and they cover the changes made in this PR
    - [ ] I verified the steps for local testing are in the `Tests` section
    - [ ] I verified the steps for Staging and/or Production testing are in the `QA steps` section
    - [ ] I verified the steps cover any possible failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [ ] I checked that screenshots or videos are included for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I verified tests pass on **all platforms** & I tested again on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [ ] I verified there are no console errors (if there’s a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`).
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained “why” the code was doing something instead of only explaining “what” the code was doing.
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [ ] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named “index.js”. All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I verified that this PR follows the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] Any functional components have the `displayName` property
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose and it is broken down into smaller components in order to separate concerns and functions
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn’t already exist
    - [ ] The style can’t be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.

</details>

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
