### PR TITLE
Return exact search matches at the top of the search list

### DIFF
--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -598,7 +598,12 @@ function getOptions(reports, personalDetails, activeReportID, {
             if (!option.login) {
                 return 2;
             }
-            return 1;
+            if (option.login !== searchValue) {
+                return 1;
+            }
+
+            // When option.login is an exact match with the search value, returning 0 puts it at the top of the option list
+            return 0;
         }], ['asc']);
     }
 

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -598,7 +598,7 @@ function getOptions(reports, personalDetails, activeReportID, {
             if (!option.login) {
                 return 2;
             }
-            if (option.login !== searchValue) {
+            if (option.login.toLowerCase() !== searchValue.toLowerCase()) {
                 return 1;
             }
 


### PR DESCRIPTION
### Fixed Issues
$ https://github.com/Expensify/App/issues/8763

### Tests and QA
Create two additional users with similar usernames:
- user@expensify.com (any domain will work)
- newuser@expensify.com (any domain will work, but be sure the prefix (ie "user") exists as part of the email)

1. Start a chat with `newuser` and send a message
2. Now go to search chats and type "user@"
3. Verify that `newuser@expensify.com` is shown at the top of the list (because of the recent message you sent them)
4. Now keep typing the full email address for "user@expensify.com"
5. Verify that now `user@expensify.com` is shown at the top of the list once it's a perfect match with the search term

- [ ] Verify that no errors appear in the JS console

### QA Steps
Same as tests

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

https://user-images.githubusercontent.com/1228807/165814050-b4616257-b5e7-4d5a-b74b-a8385cd9c7aa.mp4


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->


https://user-images.githubusercontent.com/1228807/165813814-db3dfd47-7769-4061-b3c9-6d7985a3c906.mp4


#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

https://user-images.githubusercontent.com/1228807/165814468-c9259dfa-534e-48eb-b94d-013f2a62b36c.mp4


#### iOS


https://user-images.githubusercontent.com/1228807/165832511-309d5106-ced2-4f54-abb7-e1a0ebe13ae9.mp4


#### Android

https://user-images.githubusercontent.com/1228807/165832094-9f07ba78-4983-4fc4-8bf0-1015ee19e520.mp4


