### PR TITLE
Remove unnecessary _.map in the code for video call menu items

### DIFF
--- a/src/components/VideoChatButtonAndMenu.js
+++ b/src/components/VideoChatButtonAndMenu.js
@@ -39,24 +39,24 @@ class VideoChatButtonAndMenu extends Component {
         this.toggleVideoChatMenu = this.toggleVideoChatMenu.bind(this);
         this.measureVideoChatIconPosition = this.measureVideoChatIconPosition.bind(this);
         this.videoChatIconWrapper = null;
-        this.menuItemData = _.map([
+        this.menuItemData = [
             {
                 icon: ZoomIcon,
                 text: props.translate('videoChatButtonAndMenu.zoom'),
-                onPress: () => Linking.openURL(CONST.NEW_ZOOM_MEETING_URL),
+                onPress: () => {
+                    this.toggleVideoChatMenu();
+                    Linking.openURL(CONST.NEW_ZOOM_MEETING_URL);
+                },
             },
             {
                 icon: GoogleMeetIcon,
                 text: props.translate('videoChatButtonAndMenu.googleMeet'),
-                onPress: () => Linking.openURL(CONST.NEW_GOOGLE_MEET_MEETING_URL),
+                onPress: () => {
+                    this.toggleVideoChatMenu();
+                    Linking.openURL(CONST.NEW_GOOGLE_MEET_MEETING_URL);
+                },
             },
-        ], item => ({
-            ...item,
-            onPress: () => {
-                item.onPress();
-                this.toggleVideoChatMenu();
-            },
-        }));
+        ];
 
         this.state = {
             isVideoChatMenuActive: false,


### PR DESCRIPTION
### Tests & QA
1. Open a chat
2. Click on the video chat icon
3. Click the google meet option
4. Go back to the app
5. Verify that the video chat menu went away

- [ ] Verify that no errors appear in the JS console

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

https://user-images.githubusercontent.com/1228807/166560700-31a3ba6a-c65c-4b66-bd1f-8d1f24fb64e4.mp4


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

https://user-images.githubusercontent.com/1228807/166560768-ac2c85a1-18cc-48e6-992e-c1dbea3d946a.mp4


#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

https://user-images.githubusercontent.com/1228807/166561066-1ca31c22-a5b0-4770-a380-d2e9accf7a51.mp4


#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

https://user-images.githubusercontent.com/1228807/166560436-d81387bd-47c1-4b39-9a8a-4c106e79af0a.mp4


#### Android
<!-- Insert screenshots of your changes on the Android platform-->

https://user-images.githubusercontent.com/1228807/166559694-d53d670e-4bde-407f-aea0-70e7baae9cde.mp4


