### PR TITLE
[HOLD]load plaid in iframe in web and desktop

### DIFF
--- a/src/components/PlaidLink/index.js
+++ b/src/components/PlaidLink/index.js
@@ -8,21 +8,36 @@ const PlaidLink = (props) => {
         props.onSuccess({publicToken, metadata});
     }, []);
 
-    const {open, ready, error} = usePlaidLink({
-        token: props.token,
-        onSuccess,
-        onExit: (exitError, metadata) => {
-            Log.info('[PlaidLink] Exit: ', false, {exitError, metadata});
-            props.onExit();
-        },
-        onEvent: (event, metadata) => {
-            Log.info('[PlaidLink] Event: ', false, {event, metadata});
-        },
+    const {
+        open,
+        ready,
+        error,
+    } = usePlaidLink(
+        {
+            token: props.token,
+            onSuccess,
+            onExit: (exitError, metadata) => {
+                Log.info('[PlaidLink] Exit: ', false, {
+                    exitError,
+                    metadata,
+                });
+                props.onExit();
+            },
+            onEvent: (event, metadata) => {
+                Log.info('[PlaidLink] Event: ', false, {
+                    event,
+                    metadata,
+                });
+            },
 
-        // The redirect URI with an OAuth state ID. Needed to re-initialize the PlaidLink after directing the
-        // user to their respective bank platform
-        receivedRedirectUri: props.receivedRedirectURI,
-    });
+            // The redirect URI with an OAuth state ID. Needed to re-initialize the PlaidLink after directing the
+            // user to their respective bank platform
+            receivedRedirectUri: props.receivedRedirectURI,
+        },
+        {
+            forceMobile: true,
+        },
+    );
 
     useEffect(() => {
         if (error) {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #179297
--->
$ https://github.com/Expensify/Expensify/issues/179297

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Sign in to NewDot
- [ ] Click on your profile picture > Workspace > Pay Bills > Connect Bank Account
- [ ] Click on `Connect online with Plaid` Button
- [ ] Verify that plaid doesn't fill the entire screen and shows only in the modal in the screenshots below


<details>
<summary><h4>PR Reviewer Checklist</h4></summary>

- [ ] I verified the correct issue is linked in the `### Fixed Issues` section above
- [ ] I verified testing steps are clear and they cover the changes made in this PR
    - [ ] I verified the steps for local testing are in the `Tests` section
    - [ ] I verified the steps for Staging and/or Production testing are in the `QA steps` section
    - [ ] I verified the steps cover any possible failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [ ] I checked that screenshots or videos are included for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I verified tests pass on **all platforms** & I tested again on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [ ] I verified there are no console errors (if there’s a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`).
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained “why” the code was doing something instead of only explaining “what” the code was doing.
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [ ] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named “index.js”. All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I verified that this PR follows the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] Any functional components have the `displayName` property
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose and it is broken down into smaller components in order to separate concerns and functions
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn’t already exist
    - [ ] The style can’t be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.

</details>

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
<img width="1440" alt="Screenshot 2022-05-10 at 4 48 52 PM" src="https://user-images.githubusercontent.com/26106822/167698864-fda1c178-a290-481c-bdab-2b58d00dad8c.png">


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
<img width="394" alt="Screenshot 2022-05-10 at 6 44 45 PM" src="https://user-images.githubusercontent.com/26106822/167700228-e80f6e8d-f65f-4069-b2ff-0448dc7e97a9.png">


#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
<img width="1440" alt="Screenshot 2022-05-10 at 4 55 50 PM" src="https://user-images.githubusercontent.com/26106822/167698911-816a7bf5-2704-41c1-b229-57c86b38ac74.png">


#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
![61781](https://user-images.githubusercontent.com/26106822/167699189-7751c6ef-bf1d-461c-bdb8-673f528b20a1.jpg)


#### Android
<!-- Insert screenshots of your changes on the Android platform-->
