### PR TITLE
Use latest expensify-common

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23779,8 +23779,8 @@
       }
     },
     "expensify-common": {
-      "version": "git+https://github.com/Expensify/expensify-common.git#15237e012770048e8413dc08d4c36bc12304f3e8",
-      "from": "git+https://github.com/Expensify/expensify-common.git#15237e012770048e8413dc08d4c36bc12304f3e8",
+      "version": "git+https://github.com/Expensify/expensify-common.git#427295da130a4eacc184d38693664280d020dffd",
+      "from": "git+https://github.com/Expensify/expensify-common.git#427295da130a4eacc184d38693664280d020dffd",
       "requires": {
         "classnames": "2.3.1",
         "clipboard": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "dom-serializer": "^0.2.2",
     "domhandler": "^4.3.0",
     "dotenv": "^8.2.0",
-    "expensify-common": "git+https://github.com/Expensify/expensify-common.git#15237e012770048e8413dc08d4c36bc12304f3e8",
+    "expensify-common": "git+https://github.com/Expensify/expensify-common.git#427295da130a4eacc184d38693664280d020dffd",
     "fbjs": "^3.0.2",
     "file-loader": "^6.0.0",
     "html-entities": "^1.3.1",


### PR DESCRIPTION
Fixes issues with sending or editing messages with empty markdown tags. This was already more thoroughly detailed and tested in this PR: https://github.com/Expensify/expensify-common/pull/443

### Fixed Issues

$ https://github.com/Expensify/App/issues/8720

### Tests

- [x] Verify that no errors appear in the JS console

1. Log in
2. Start a chat conversation
3. Send a message with empty backticks (code block with no text in-between)
4. Verify empty backticks are sent and NOT an empty code block
5. Send a message with empty code fence backticks
6. Verify 2 code blocks with a back tick in each is sent and NOT an empty code fence
7. Send a message with a markdown link with no text
8. Verify the text is sent as is and an invisible link is NOT sent

### QA Steps

Same as Tests section