### PR TITLE
Retry Cocoapod install in deploy

### DIFF
--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -210,7 +210,11 @@ jobs:
           command: npm ci
 
       - name: Install cocoapods
-        run: cd ios && pod install
+        uses: nick-invision/retry@7c68161adf97a48beb850a595b8784ec57a98cbb
+        with:
+          timeout_minutes: 10
+          max_attempts: 5
+          command: cd ios && pod install
 
       - name: Decrypt profile
         run: cd ios && gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output chat_expensify_appstore.mobileprovision chat_expensify_appstore.mobileprovision.gpg


### PR DESCRIPTION
### Details
Adds a retry step to the pod install step of the deploy. It failed today due to a flaky http issue, so this will add a retry and make the deploys a bit more stable.

### Fixed Issues
Fixed broken & flaky deploys
