### PR TITLE
remove focus from disabled buttons

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -247,7 +247,7 @@ class Button extends Component {
                 onPressOut={this.props.onPressOut}
                 disabled={this.props.isLoading || this.props.isDisabled}
                 style={[
-                    this.props.isDisabled ? styles.cursorDisabled : {},
+                    this.props.isDisabled ? {...styles.cursorDisabled, ...styles.noSelect} : {},
                     ...this.additionalStyles,
                 ]}
             >

--- a/src/components/ConfirmContent.js
+++ b/src/components/ConfirmContent.js
@@ -76,7 +76,7 @@ const ConfirmContent = props => (
         />
         {props.shouldShowCancelButton && (
             <Button
-                style={[styles.mt3]}
+                style={[styles.mt3, styles.noSelect]}
                 onPress={props.onCancel}
                 text={props.cancelText || props.translate('common.no')}
             />

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -2188,6 +2188,8 @@ const styles = {
 
     cursorDisabled: {
         cursor: 'not-allowed',
+        boxShadow: 'none',
+        outline: 'none',
     },
 
     cursorPointer: {

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -2188,6 +2188,9 @@ const styles = {
 
     cursorDisabled: {
         cursor: 'not-allowed',
+    },
+
+    noSelect: {
         boxShadow: 'none',
         outline: 'none',
     },


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #8934
--->
$https://github.com/Expensify/App/issues/8934

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

#### Test 1
1. Go to settings
2. Open any workspace
3. Click Manage members
4. Check Select all checkbox
5. Click on the Remove button
6. Press enter/return key on the remove popup

#### Test 2
1. Go to Settings
2. Go to Payments
3. Click on the Paypal payment method
4. Click on the delete button
5. Observe that the focus is on the cancel button by default is not longer there like. Verify from the screenshots below


<details>
<summary><h4>PR Reviewer Checklist</h4></summary>

- [ ] I verified the correct issue is linked in the `### Fixed Issues` section above
- [ ] I verified testing steps are clear and they cover the changes made in this PR
    - [ ] I verified the steps for local testing are in the `Tests` section
    - [ ] I verified the steps for Staging and/or Production testing are in the `QA steps` section
    - [ ] I verified the steps cover any possible failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [ ] I checked that screenshots or videos are included for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I verified tests pass on **all platforms** & I tested again on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [ ] I verified there are no console errors (if there’s a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`).
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained “why” the code was doing something instead of only explaining “what” the code was doing.
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [ ] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named “index.js”. All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I verified that this PR follows the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] Any functional components have the `displayName` property
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose and it is broken down into smaller components in order to separate concerns and functions
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn’t already exist
    - [ ] The style can’t be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.

</details>

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
3. Upload an image via copy paste
4. Verify a modal appears displaying a preview of that image
--->

#### Test 1
1. Go to settings
2. Open any workspace
3. Click Manage members
4. Check Select all checkbox
5. Click on the Remove button
6. Press enter/return key on the remove popup

#### Test 2
1. Go to Settings
2. Go to Payments
3. Click on the Paypal payment method
4. Click on the delete button
5. Observe that the focus is on the cancel button by default is not longer there like. Verify from the screenshots below

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
https://user-images.githubusercontent.com/26106822/169309289-fd7674ae-2a01-473b-9545-93bbc40b9859.mp4

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
https://user-images.githubusercontent.com/26106822/169309339-6e882bca-29c0-4373-9741-55b52964a087.mp4

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
https://user-images.githubusercontent.com/26106822/169309442-d5078b50-8eb6-4864-b65f-f5aa225b031f.mp4




#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
https://user-images.githubusercontent.com/26106822/169310454-89ed3058-2e40-4890-94b9-f3169d5fd77d.mp4


#### Android
<!-- Insert screenshots of your changes on the Android platform-->
https://user-images.githubusercontent.com/26106822/169310587-d70d858d-a540-46ac-85aa-d59c97131c87.mp4
