### PR TITLE
Add a five second sleep before getting PR number

### DIFF
--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -148,6 +148,7 @@ jobs:
             --body "🍒 Cherry pick https://github.com/Expensify/App/pull/${{ github.event.inputs.PULL_REQUEST_NUMBER }} to staging 🍒" \
             --label "automerge" \
             --base "staging"
+          sleep 5
           echo "::set-output name=PR_NUMBER::$(gh pr view --json 'number' --jq '.number')"
         env:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}

--- a/.github/workflows/updateProtectedBranch.yml
+++ b/.github/workflows/updateProtectedBranch.yml
@@ -86,6 +86,7 @@ jobs:
             --body "Update version to ${{ env.NEW_VERSION }}" \
             --label "automerge" \
             --base ${{ github.event.inputs.TARGET_BRANCH }}
+          sleep 5
           echo "::set-output name=PR_NUMBER::$(gh pr view --json 'number' --jq '.number')"
         env:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Adds a five second delay before trying to get the Pull Request number because it appears like it takes a bit of time for a pull request to be "ready".

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/9106

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/9106

### Tests
1. I will re-run the staging deploy and verify that this sleep gives us enough time to get the PR number and complete the deploy