### PR TITLE
Clean up Picker and expose setNativeProps

### DIFF
--- a/src/components/Picker/BasePicker/index.js
+++ b/src/components/Picker/BasePicker/index.js
@@ -10,17 +10,20 @@ class BasePicker extends React.Component {
     constructor(props) {
         super(props);
 
-        this.state = {
-            selectedValue: this.props.defaultValue,
-        };
+        this.pickerValue = this.props.defaultValue;
 
         this.updateSelectedValueAndExecuteOnChange = this.updateSelectedValueAndExecuteOnChange.bind(this);
         this.executeOnCloseAndOnBlur = this.executeOnCloseAndOnBlur.bind(this);
+        this.setNativeProps = this.setNativeProps.bind(this);
+    }
+
+    setNativeProps({value}) {
+        this.pickerValue = value;
     }
 
     updateSelectedValueAndExecuteOnChange(value) {
         this.props.onInputChange(value);
-        this.setState({selectedValue: value});
+        this.pickerValue = value;
     }
 
     executeOnCloseAndOnBlur() {
@@ -38,7 +41,7 @@ class BasePicker extends React.Component {
                 style={this.props.size === 'normal' ? basePickerStyles(this.props.disabled, hasError, this.props.focused) : styles.pickerSmall}
                 useNativeAndroidPickerStyle={false}
                 placeholder={this.props.placeholder}
-                value={this.props.value || this.state.selectedValue}
+                value={this.props.value || this.pickerValue}
                 Icon={() => this.props.icon(this.props.size)}
                 disabled={this.props.disabled}
                 fixAndroidTouchableBug
@@ -47,7 +50,16 @@ class BasePicker extends React.Component {
                 pickerProps={{
                     onFocus: this.props.onOpen,
                     onBlur: this.executeOnCloseAndOnBlur,
-                    ref: this.props.innerRef,
+                }}
+                ref={(node) => {
+                    if (!node || !_.isFunction(this.props.innerRef)) {
+                        return;
+                    }
+
+                    this.props.innerRef(node);
+
+                    // eslint-disable-next-line no-param-reassign
+                    node.setNativeProps = this.setNativeProps;
                 }}
             />
         );

--- a/src/components/Picker/BasePicker/index.js
+++ b/src/components/Picker/BasePicker/index.js
@@ -17,6 +17,12 @@ class BasePicker extends React.Component {
         this.setNativeProps = this.setNativeProps.bind(this);
     }
 
+    /**
+     * This method mimicks RN's setNativeProps method. It's exposed to Picker's ref and can be used by other components 
+     * to directly manipulate Picker's value when Picker is used as an uncontrolled input.
+     *
+     * @param {*} value 
+     */
     setNativeProps({value}) {
         this.pickerValue = value;
     }

--- a/src/components/Picker/BasePicker/index.js
+++ b/src/components/Picker/BasePicker/index.js
@@ -18,10 +18,10 @@ class BasePicker extends React.Component {
     }
 
     /**
-     * This method mimicks RN's setNativeProps method. It's exposed to Picker's ref and can be used by other components 
+     * This method mimicks RN's setNativeProps method. It's exposed to Picker's ref and can be used by other components
      * to directly manipulate Picker's value when Picker is used as an uncontrolled input.
      *
-     * @param {*} value 
+     * @param {*} value
      */
     setNativeProps({value}) {
         this.pickerValue = value;

--- a/src/components/StatePicker.js
+++ b/src/components/StatePicker.js
@@ -55,7 +55,8 @@ const StatePicker = forwardRef((props, ref) => (
         placeholder={{value: '', label: '-'}}
         items={STATES}
         onInputChange={props.onInputChange}
-        value={props.value ? props.value : props.defaultValue}
+        value={props.value}
+        defaultValue={props.defaultValue}
         label={props.label || props.translate('common.state')}
         errorText={props.errorText}
         onBlur={props.onBlur}


### PR DESCRIPTION
### Details
1. Removes Picker state to enable it as an uncontrolled input
2. Correctly pass defaultProps from StatePicker
3. Correctly pass ref to picker input instead of the `TextInput` it wraps
4. Expose `setNativeProps` to picker ref

### Fixed Issues
$ https://github.com/Expensify/App/issues/9117

### Tests
1. Run `npm run storybook` and test picker functionalities. Make sure that we can edit the input and all values are updated accordinly.
2. Test ALL usages of Picker (any dropdown select input) in the app. Set new value, update value and verify error states (when applicable). Pre-requisite: account with Workspace and policy rooms

    - Login page > Select locale (below terms and conditions)
    - Settings > Profile > Preferred pronouns
    - Settings > Profile > Timezone
    - Settings > Preferences > Priority mode
    - Settings > Preferences > Language
    - Settings > Payments > Add payment method > Add debit card > Select state
    - Workspace > General settings > Default currency
    - Workspace > Reimburse expenses > Unit
    - Global create > New room > Workspace
    - Global create > New room > Visibility
    - Workspace > Connect bank account (Company step) > Address state
    - Workspace > Connect bank account (Company step) > Company type
    - Workspace > Connect bank account (Company step) > Corporation state
    - Workspace > Connect bank account (Personal information) > State
    - Workspace > Connect bank account (Additional information) > State
    - Policy room (#announce) > Settings > Notify me about new messages
 
- [x] Verify that no errors appear in the JS console

### PR Review Checklist
#### Contributor (PR Author) Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there’s a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained “why” the code was doing something instead of only explaining “what” the code was doing.
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named “index.js”. All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] Any functional components have the `displayName` property
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose and it is
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn’t already exist
    - [ ] The style can’t be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.


<details>
<summary><h4>PR Reviewer Checklist</h4></summary>

- [ ] I verified the correct issue is linked in the `### Fixed Issues` section above
- [ ] I verified testing steps are clear and they cover the changes made in this PR
    - [ ] I verified the steps for local testing are in the `Tests` section
    - [ ] I verified the steps for Staging and/or Production testing are in the `QA steps` section
    - [ ] I verified the steps cover any possible failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [ ] I checked that screenshots or videos are included for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I verified tests pass on **all platforms** & I tested again on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [ ] I verified there are no console errors (if there’s a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`).
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained “why” the code was doing something instead of only explaining “what” the code was doing.
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [ ] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named “index.js”. All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I verified that this PR follows the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] Any functional components have the `displayName` property
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose and it is broken down into smaller components in order to separate concerns and functions
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn’t already exist
    - [ ] The style can’t be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.

</details>

### QA Steps
Step 2 from the Test section.

- [ ] Verify that no errors appear in the JS console

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web

https://user-images.githubusercontent.com/22219519/169620728-1295db0a-f740-4f70-99e1-ba1a71810255.mov

#### Mobile Web

https://user-images.githubusercontent.com/22219519/169620876-7b74400d-f210-438f-b579-31d5808307e0.mov

#### Desktop

https://user-images.githubusercontent.com/22219519/169620746-91c06c85-f8a2-4f28-a8ac-3612db221a4f.mov

#### iOS

https://user-images.githubusercontent.com/22219519/169620764-e0197e7b-6125-4b26-8aec-9ff8d28f27ff.mov

#### Android

https://user-images.githubusercontent.com/22219519/169621170-8c34b285-8c24-4da6-90ed-9bd45c11bde1.mov
