### PR TITLE
Fix min hight constant typo

### DIFF
--- a/src/pages/signin/SignInPageLayout/index.js
+++ b/src/pages/signin/SignInPageLayout/index.js
@@ -62,7 +62,7 @@ const SignInPageLayout = (props) => {
         return content;
     }
 
-    if (props.isMediumScreenWidth && props.windowHeight >= variables.minHeigthToShowGraphics) {
+    if (props.isMediumScreenWidth && props.windowHeight >= variables.minHeightToShowGraphics) {
         return (
             <View style={[styles.dFlex, styles.signInPageInner, styles.flexColumnReverse, styles.justifyContentBetween]}>
                 {graphicLayout}

--- a/src/styles/variables.js
+++ b/src/styles/variables.js
@@ -46,5 +46,5 @@ export default {
     tooltipzIndex: 10050,
     gutterWidth: 16,
     popoverMenuShadow: '0px 4px 12px 0px rgba(0, 0, 0, 0.06)',
-    minHeightToShowGraphics: 854, // below this height UI was broken on login form layout as there isn't enough height to show forma and graphics.
+    minHeightToShowGraphics: 854, // Login form layout breaks below this height due to insufficient space to show the form and graphics
 };


### PR DESCRIPTION
### Details

Fixes a small issue with [this PR](https://github.com/Expensify/App/pull/8752)

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/9128

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

### QA Steps

**For ipad/tablets***
- Open Expensify app on iPad/tablet (Signed out state).
- Verify that the login-form-layout is updated as per https://github.com/Expensify/App/issues/8122#issuecomment-1066971554.

**For other platforms**
- Open Expensify app
Verify that due to these changes https://github.com/Expensify/App/issues/8122#issuecomment-1066971554 is not effected for other platforms.
- Verify that no errors appear in the JS console

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

As this was a hotfix to [this PR](https://github.com/Expensify/App/pull/8752) I only built to web and iPad (the platform which was broken)

#### Web
1) ![Screenshot 2022-05-23 at 17 07 12](https://user-images.githubusercontent.com/10736861/169866983-3b42d62f-140c-45c9-aaa3-888e29987a3b.png)
2) ![Screenshot 2022-05-23 at 17 07 05](https://user-images.githubusercontent.com/10736861/169867008-44046dea-00aa-4f90-bdac-99a4f16e1923.png)


#### iOS
![Simulator Screen Shot - iPad Pro (12 9-inch) (5th generation) - 2022-05-23 at 17 31 07](https://user-images.githubusercontent.com/10736861/169866931-b0aa86a4-6f41-4970-8d3d-ddac3387a91e.png)

