### PR TITLE
Password sign in form has error msg

### DIFF
--- a/src/pages/signin/PasswordForm.js
+++ b/src/pages/signin/PasswordForm.js
@@ -67,6 +67,7 @@ class PasswordForm extends React.Component {
     componentDidUpdate(prevProps) {
         if (!prevProps.isVisible && this.props.isVisible) {
             this.inputPassword.focus();
+            this.clearFormError();
         }
         if (prevProps.isVisible && !this.props.isVisible && this.state.password) {
             this.clearPassword();
@@ -78,6 +79,10 @@ class PasswordForm extends React.Component {
      */
     clearPassword() {
         this.setState({password: ''}, this.inputPassword.clear);
+    }
+
+    clearFormError() {
+        this.setState({formError: false});
     }
 
     /**


### PR DESCRIPTION
Password  in sign-in form has error message when user triggers an error on his/her password and goes back to email sign-in form type his/her email continues to password form and then the error occurs from the previous password error.


https://user-images.githubusercontent.com/60424062/170525504-3f12c555-5616-45a2-994c-7fc6e0c5a619.mov

fixes applied are in PL
