### PR TITLE
Fix issue with google meet not opening on Android

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -188,6 +188,7 @@ const CONST = {
     USE_EXPENSIFY_URL,
     NEW_ZOOM_MEETING_URL: 'https://zoom.us/start/videomeeting',
     NEW_GOOGLE_MEET_MEETING_URL: 'https://meet.google.com/new',
+    GOOGLE_MEET_URL_ANDROID: 'https://meet.google.com',
     DEEPLINK_BASE_URL: 'new-expensify://',
     PDF_VIEWER_URL: '/pdf/web/viewer.html',
     EXPENSIFY_ICON_URL: `${CLOUDFRONT_URL}/images/favicon-2019.png`,

--- a/src/components/VideoChatButtonAndMenu/BaseVideoChatButtonAndMenu.js
+++ b/src/components/VideoChatButtonAndMenu/BaseVideoChatButtonAndMenu.js
@@ -3,34 +3,24 @@ import React, {Component} from 'react';
 import {
     View, Pressable, Dimensions, Linking,
 } from 'react-native';
-import PropTypes from 'prop-types';
-import Icon from './Icon';
-import * as Expensicons from './Icon/Expensicons';
-import Popover from './Popover';
-import MenuItem from './MenuItem';
-import ZoomIcon from '../../assets/images/zoom-icon.svg';
-import GoogleMeetIcon from '../../assets/images/google-meet.svg';
-import CONST from '../CONST';
-import styles from '../styles/styles';
-import themeColors from '../styles/themes/default';
-import withWindowDimensions, {windowDimensionsPropTypes} from './withWindowDimensions';
-import withLocalize, {withLocalizePropTypes} from './withLocalize';
-import compose from '../libs/compose';
-import Navigation from '../libs/Navigation/Navigation';
-import ROUTES from '../ROUTES';
-import Tooltip from './Tooltip';
+import Icon from '../Icon';
+import * as Expensicons from '../Icon/Expensicons';
+import Popover from '../Popover';
+import MenuItem from '../MenuItem';
+import ZoomIcon from '../../../assets/images/zoom-icon.svg';
+import GoogleMeetIcon from '../../../assets/images/google-meet.svg';
+import CONST from '../../CONST';
+import styles from '../../styles/styles';
+import themeColors from '../../styles/themes/default';
+import withWindowDimensions from '../withWindowDimensions';
+import withLocalize from '../withLocalize';
+import compose from '../../libs/compose';
+import Navigation from '../../libs/Navigation/Navigation';
+import ROUTES from '../../ROUTES';
+import Tooltip from '../Tooltip';
+import {propTypes, defaultProps} from './videoChatButtonAndMenuPropTypes';
 
-const propTypes = {
-    ...withLocalizePropTypes,
-    ...windowDimensionsPropTypes,
-    isConcierge: PropTypes.bool,
-};
-
-const defaultProps = {
-    isConcierge: false,
-};
-
-class VideoChatButtonAndMenu extends Component {
+class BaseVideoChatButtonAndMenu extends Component {
     constructor(props) {
         super(props);
 
@@ -53,7 +43,7 @@ class VideoChatButtonAndMenu extends Component {
                 text: props.translate('videoChatButtonAndMenu.googleMeet'),
                 onPress: () => {
                     this.toggleVideoChatMenu();
-                    Linking.openURL(CONST.NEW_GOOGLE_MEET_MEETING_URL);
+                    Linking.openURL(this.props.newGoogleMeetingUrl || CONST.NEW_GOOGLE_MEET_MEETING_URL);
                 },
             },
         ];
@@ -148,10 +138,10 @@ class VideoChatButtonAndMenu extends Component {
     }
 }
 
-VideoChatButtonAndMenu.propTypes = propTypes;
-VideoChatButtonAndMenu.defaultProps = defaultProps;
+BaseVideoChatButtonAndMenu.propTypes = propTypes;
+BaseVideoChatButtonAndMenu.defaultProps = defaultProps;
 
 export default compose(
     withWindowDimensions,
     withLocalize,
-)(VideoChatButtonAndMenu);
+)(BaseVideoChatButtonAndMenu);

--- a/src/components/VideoChatButtonAndMenu/BaseVideoChatButtonAndMenu.js
+++ b/src/components/VideoChatButtonAndMenu/BaseVideoChatButtonAndMenu.js
@@ -43,7 +43,7 @@ class BaseVideoChatButtonAndMenu extends Component {
                 text: props.translate('videoChatButtonAndMenu.googleMeet'),
                 onPress: () => {
                     this.toggleVideoChatMenu();
-                    Linking.openURL(this.props.newGoogleMeetingUrl || CONST.NEW_GOOGLE_MEET_MEETING_URL);
+                    Linking.openURL(this.props.googleMeetURL);
                 },
             },
         ];

--- a/src/components/VideoChatButtonAndMenu/index.android.js
+++ b/src/components/VideoChatButtonAndMenu/index.android.js
@@ -8,7 +8,7 @@ import BaseVideoChatButtonAndMenu from './BaseVideoChatButtonAndMenu';
 // https://github.com/Expensify/App/issues/8851#issuecomment-1120236904
 const VideoChatButtonAndMenu = props => (
     <BaseVideoChatButtonAndMenu
-        newGoogleMeetingUrl={CONST.GOOGLE_MEET_URL_ANDROID}
+        googleMeetURL={CONST.GOOGLE_MEET_URL_ANDROID}
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...props}
     />

--- a/src/components/VideoChatButtonAndMenu/index.android.js
+++ b/src/components/VideoChatButtonAndMenu/index.android.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import CONST from '../../CONST';
+import {propTypes, defaultProps} from './videoChatButtonAndMenuPropTypes';
+import BaseVideoChatButtonAndMenu from './BaseVideoChatButtonAndMenu';
+
+// On Android creating a new google meet meeting requires the CALL_PHONE permission in some cases
+// so we're just opening the google meet app instead, more details:
+// https://github.com/Expensify/App/issues/8851#issuecomment-1120236904
+const VideoChatButtonAndMenu = props => (
+    <BaseVideoChatButtonAndMenu
+        newGoogleMeetingUrl={CONST.GOOGLE_MEET_URL_ANDROID}
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...props}
+    />
+);
+
+VideoChatButtonAndMenu.propTypes = propTypes;
+VideoChatButtonAndMenu.defaultProps = defaultProps;
+VideoChatButtonAndMenu.displayName = 'VideoChatButtonAndMenu';
+export default VideoChatButtonAndMenu;

--- a/src/components/VideoChatButtonAndMenu/index.js
+++ b/src/components/VideoChatButtonAndMenu/index.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import {propTypes, defaultProps} from './videoChatButtonAndMenuPropTypes';
+import BaseVideoChatButtonAndMenu from './BaseVideoChatButtonAndMenu';
+
+const VideoChatButtonAndMenu = props => (
+    <BaseVideoChatButtonAndMenu
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...props}
+    />
+);
+
+VideoChatButtonAndMenu.propTypes = propTypes;
+VideoChatButtonAndMenu.defaultProps = defaultProps;
+VideoChatButtonAndMenu.displayName = 'VideoChatButtonAndMenu';
+export default VideoChatButtonAndMenu;

--- a/src/components/VideoChatButtonAndMenu/index.js
+++ b/src/components/VideoChatButtonAndMenu/index.js
@@ -1,9 +1,11 @@
 import React from 'react';
+import CONST from '../../CONST';
 import {propTypes, defaultProps} from './videoChatButtonAndMenuPropTypes';
 import BaseVideoChatButtonAndMenu from './BaseVideoChatButtonAndMenu';
 
 const VideoChatButtonAndMenu = props => (
     <BaseVideoChatButtonAndMenu
+        googleMeetURL={CONST.NEW_GOOGLE_MEET_MEETING_URL}
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...props}
     />

--- a/src/components/VideoChatButtonAndMenu/videoChatButtonAndMenuPropTypes.js
+++ b/src/components/VideoChatButtonAndMenu/videoChatButtonAndMenuPropTypes.js
@@ -7,7 +7,7 @@ const propTypes = {
     isConcierge: PropTypes.bool,
 
     /** Link to open when user wants to create a new google meet meeting */
-    newGoogleMeetingUrl: PropTypes.string,
+    googleMeetURL: PropTypes.string.isRequired,
 
     ...withLocalizePropTypes,
     ...windowDimensionsPropTypes,

--- a/src/components/VideoChatButtonAndMenu/videoChatButtonAndMenuPropTypes.js
+++ b/src/components/VideoChatButtonAndMenu/videoChatButtonAndMenuPropTypes.js
@@ -1,0 +1,20 @@
+import PropTypes from 'prop-types';
+import {windowDimensionsPropTypes} from '../withWindowDimensions';
+import {withLocalizePropTypes} from '../withLocalize';
+
+const propTypes = {
+    /** If this is the Concierge chat, we'll open the modal for requesting a setup call instead of showing popover menu */
+    isConcierge: PropTypes.bool,
+
+    /** Link to open when user wants to create a new google meet meeting */
+    newGoogleMeetingUrl: PropTypes.string,
+
+    ...withLocalizePropTypes,
+    ...windowDimensionsPropTypes,
+};
+
+const defaultProps = {
+    isConcierge: false,
+};
+
+export {propTypes, defaultProps};


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
On some Android devices (under some circumstances) creating new google meet meeting requires a `CALL_PHONE` permission. We can get around this by just opening google meet app `meet.google.com` instead of trying to create new meeting `meet.google.com/new`, since both of those links just open up the google meet app. 

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
https://github.com/Expensify/App/issues/8851

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Go to any chat
2. Press Start a call icon
3. Select Google Meet option
4. Verify that google meet app/site is opened

### PR Review Checklist
<!--
This is a checklist for PR authors & reviewers. Please make sure to complete all tasks and check them off once you do, or else Expensify has the right not to merge your PR!
-->
#### Contributor (PR Author) Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [ ] MacOS / Desktop
- [x] I verified there are no console errors (if there’s a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained “why” the code was doing something instead of only explaining “what” the code was doing.
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [ ] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named “index.js”. All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] Any functional components have the `displayName` property
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose and it is
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn’t already exist
    - [ ] The style can’t be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.


<details>
<summary><h4>PR Reviewer Checklist</h4></summary>

- [ ] I verified the correct issue is linked in the `### Fixed Issues` section above
- [ ] I verified testing steps are clear and they cover the changes made in this PR
    - [ ] I verified the steps for local testing are in the `Tests` section
    - [ ] I verified the steps for Staging and/or Production testing are in the `QA steps` section
    - [ ] I verified the steps cover any possible failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [ ] I checked that screenshots or videos are included for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I verified tests pass on **all platforms** & I tested again on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [ ] I verified there are no console errors (if there’s a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`).
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained “why” the code was doing something instead of only explaining “what” the code was doing.
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [ ] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named “index.js”. All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I verified that this PR follows the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] Any functional components have the `displayName` property
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose and it is broken down into smaller components in order to separate concerns and functions
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn’t already exist
    - [ ] The style can’t be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.

</details>

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Go to any chat
2. Press Start a call icon
3. Select Google Meet option
4. Verify that google meet app/site is opened

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

https://user-images.githubusercontent.com/9059945/170566092-3469c16b-cf73-492c-90d1-38894fefd659.mp4


#### Mobile Web

https://user-images.githubusercontent.com/9059945/170566133-6091bb54-2822-4fc5-a25e-29998ca52e88.mp4


#### Desktop
I'm unable to launch the desktop app due to #8888. It is not present if you downgrade to certain node and npm versions, but since I use MacinCloud, I'm unable to do so. So if someone with a mac could test it and upload a video, I would highly appreciate it.

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

https://user-images.githubusercontent.com/9059945/170566286-b038e7a0-08df-4b16-a74e-f8235bc0930a.mp4


#### Android
<!-- Insert screenshots of your changes on the Android platform-->

https://user-images.githubusercontent.com/9059945/170566207-88ea7ee6-859b-4abc-bc24-959d9a0fce74.mp4


