### PR TITLE
Add story for InlineSystemMessage

### DIFF
--- a/src/components/InlineSystemMessage.js
+++ b/src/components/InlineSystemMessage.js
@@ -2,9 +2,9 @@ import React from 'react';
 import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import styles from '../styles/styles';
+import theme from '../styles/themes/default';
 import Text from './Text';
 import * as Expensicons from './Icon/Expensicons';
-import colors from '../styles/colors';
 import Icon from './Icon';
 
 const propTypes = {
@@ -18,7 +18,7 @@ const InlineSystemMessage = (props) => {
     }
     return (
         <View style={[styles.flexRow, styles.alignItemsCenter]}>
-            <Icon src={Expensicons.Exclamation} fill={colors.red} />
+            <Icon src={Expensicons.Exclamation} fill={theme.badgeDangerBG} />
             <Text style={[styles.inlineSystemMessage]}>{props.message}</Text>
         </View>
     );

--- a/src/stories/InlineSystemMessage.stories.js
+++ b/src/stories/InlineSystemMessage.stories.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import InlineSystemMessage from '../components/InlineSystemMessage';
+
+/**
+ * We use the Component Story Format for writing stories. Follow the docs here:
+ *
+ * https://storybook.js.org/docs/react/writing-stories/introduction#component-story-format
+ */
+const story = {
+    title: 'Components/InlineSystemMessage',
+    component: InlineSystemMessage,
+};
+
+// eslint-disable-next-line react/jsx-props-no-spreading
+const Template = args => <InlineSystemMessage {...args} />;
+
+// Arguments can be passed to the component by binding
+// See: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
+const Default = Template.bind({});
+Default.args = {
+    message: 'This is an error message',
+};
+
+export default story;
+export {
+    Default,
+};


### PR DESCRIPTION
@Gonals will you please review this?

### Details
This PR does two things:

- Uses `theme` instead of `color` for an icon color
- Adds a storybook story for the InlineSystemMessage component.

### Fixed Issues
$ n/a

### Tests
1. Run `npm run storybook`
1. Look at the new story:

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/47436092/170604062-c2e8b178-13cf-498e-b2fd-321e24ec8467.png">