### PR TITLE
Fix spacing in compose metadata

### DIFF
--- a/src/components/ExceededCommentLength.js
+++ b/src/components/ExceededCommentLength.js
@@ -1,12 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import _ from 'underscore';
 import CONST from '../CONST';
 import Text from './Text';
 import styles from '../styles/styles';
+import stylePropTypes from '../styles/stylePropTypes';
 
 const propTypes = {
     /** The current length of the comment */
     commentLength: PropTypes.number.isRequired,
+
+    /** Additional style props */
+    style: stylePropTypes,
+};
+
+const defaultProps = {
+    style: [],
 };
 
 const ExceededCommentLength = (props) => {
@@ -14,14 +23,17 @@ const ExceededCommentLength = (props) => {
         return null;
     }
 
+    const additionalStyles = _.isArray(props.style) ? props.style : [props.style];
+
     return (
-        <Text style={[styles.textMicro, styles.textDanger]}>
+        <Text style={[styles.textMicro, styles.textDanger, ...additionalStyles]}>
             {`${props.commentLength}/${CONST.MAX_COMMENT_LENGTH}`}
         </Text>
     );
 };
 
 ExceededCommentLength.propTypes = propTypes;
+ExceededCommentLength.defaultProps = defaultProps;
 ExceededCommentLength.displayName = 'ExceededCommentLength';
 
 export default ExceededCommentLength;

--- a/src/components/OfflineIndicator.js
+++ b/src/components/OfflineIndicator.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import {View} from 'react-native';
+import _ from 'underscore';
 import {withNetwork} from './OnyxProvider';
 import networkPropTypes from './networkPropTypes';
 import Icon from './Icon';
@@ -9,20 +10,31 @@ import Text from './Text';
 import styles from '../styles/styles';
 import compose from '../libs/compose';
 import withLocalize, {withLocalizePropTypes} from './withLocalize';
+import stylePropTypes from '../styles/stylePropTypes';
 
 const propTypes = {
     /** Information about the network */
     network: networkPropTypes.isRequired,
 
+    /** Additional style props */
+    style: stylePropTypes,
+
     ...withLocalizePropTypes,
+};
+
+const defaultProps = {
+    style: [],
 };
 
 const OfflineIndicator = (props) => {
     if (!props.network.isOffline) {
         return null;
     }
+
+    const additionalStyles = _.isArray(props.style) ? props.style : [props.style];
+
     return (
-        <View style={[styles.flexRow]}>
+        <View style={[styles.flexRow, ...additionalStyles]}>
             <Icon
                 src={Expensicons.Offline}
                 width={variables.iconSizeExtraSmall}
@@ -36,6 +48,7 @@ const OfflineIndicator = (props) => {
 };
 
 OfflineIndicator.propTypes = propTypes;
+OfflineIndicator.defaultProps = defaultProps;
 OfflineIndicator.displayName = 'OfflineIndicator';
 
 export default compose(

--- a/src/pages/home/report/ParticipantLocalTime.js
+++ b/src/pages/home/report/ParticipantLocalTime.js
@@ -1,6 +1,7 @@
 import React, {PureComponent} from 'react';
 import lodashGet from 'lodash/get';
 import Str from 'expensify-common/lib/str';
+import _ from 'underscore';
 import styles from '../../../styles/styles';
 import withLocalize, {withLocalizePropTypes} from '../../../components/withLocalize';
 import participantPropTypes from '../../../components/participantPropTypes';
@@ -8,12 +9,20 @@ import Text from '../../../components/Text';
 import Timers from '../../../libs/Timers';
 import CONST from '../../../CONST';
 import DateUtils from '../../../libs/DateUtils';
+import stylePropTypes from '../../../styles/stylePropTypes';
 
 const propTypes = {
     /** Personal details of the participant */
     participant: participantPropTypes.isRequired,
 
+    /** Additional style props */
+    style: stylePropTypes,
+
     ...withLocalizePropTypes,
+};
+
+const defaultProps = {
+    style: [],
 };
 
 class ParticipantLocalTime extends PureComponent {
@@ -51,6 +60,7 @@ class ParticipantLocalTime extends PureComponent {
     }
 
     render() {
+        const additionalStyles = _.isArray(this.props.style) ? this.props.style : [this.props.style];
         const reportRecipientDisplayName = this.props.participant.firstName
             || (Str.isSMSLogin(this.props.participant.login)
                 ? this.props.toLocalPhone(this.props.participant.displayName)
@@ -58,7 +68,7 @@ class ParticipantLocalTime extends PureComponent {
 
         return (
             <Text
-                style={[styles.chatItemComposeSecondaryRowSubText]}
+                style={[styles.chatItemComposeSecondaryRowSubText, ...additionalStyles]}
                 numberOfLines={1}
             >
                 {this.props.translate(
@@ -74,5 +84,5 @@ class ParticipantLocalTime extends PureComponent {
 }
 
 ParticipantLocalTime.propTypes = propTypes;
-
+ParticipantLocalTime.defaultProps = defaultProps;
 export default withLocalize(ParticipantLocalTime);

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -444,25 +444,13 @@ class ReportActionCompose extends React.Component {
 
         return (
             <View style={[styles.chatItemComposeWithFirstRow]}>
-                <View style={[styles.flexRow, styles.chatItemComposeSecondaryRow, styles.chatItemComposeSecondaryRowOffset, styles.flexWrap]}>
-                    {shouldShowReportRecipientLocalTime
-                        && (
-                            <View style={[styles.mr3]}>
-                                <ParticipantLocalTime participant={reportRecipient} />
-                            </View>
-                        )}
-
-                    <View style={[styles.mr3]}>
-                        <OfflineIndicator />
-                    </View>
-
-                    <View style={[styles.mr3]}>
-                        <ExceededCommentLength commentLength={this.comment.length} />
-                    </View>
-
-                    <View style={[styles.mr3]}>
-                        <ReportTypingIndicator reportID={this.props.reportID} />
-                    </View>
+                <View style={[styles.flexRow, styles.chatItemComposeSecondaryRow, styles.chatItemComposeSecondaryRowOffset, styles.flexWrap, styles.tester]}>
+                    {shouldShowReportRecipientLocalTime && (
+                        <ParticipantLocalTime participant={reportRecipient} style={[styles.mr3]} />
+                    )}
+                    <OfflineIndicator style={[styles.mr3]} />
+                    <ExceededCommentLength commentLength={this.comment.length} style={[styles.mr3]} />
+                    <ReportTypingIndicator reportID={this.props.reportID} />
                 </View>
 
                 <View style={[


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

cc @Luke9389 

### Details
Fixes spacing in the compose metadata area

### Fixed Issues

$ https://github.com/Expensify/App/issues/9205

### Tests / QA

1. Open a chat
2. Go offline
3. Verify the offline message now appears above the compose input
4. Go back online
5. Compose a message with more than 60,000 characters (use copy/paste to do this easily)
6. Verify the comment exceeded meta data is displayed above the compose input
7. Open a second incognito browser and sign in as the other chat participant and start typing
8. Verify that the "user is typing" message is above the compose input
9. Open a third incognito browser and sign in as a third chat participant
10. Start a group chat with all three people
11. Quickly type something in the compose input in two of the browsers
12. Verify that in the third browser the "multiple people are typing" appears and it's displayed above the compose input
13. Verify that all the vertical and horizontal spacing looks OK

- [X] Verify that no errors appear in the JS console

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
![web](https://user-images.githubusercontent.com/7277067/170786229-b5081c15-7f9b-4b70-9204-5dacebcb96b5.png)

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
![mobile-web](https://user-images.githubusercontent.com/7277067/170786240-357727ae-d9a9-449f-9479-141c5a99fb8b.png)

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
![desktop](https://user-images.githubusercontent.com/7277067/170786246-09ad3771-d6be-404c-8101-bc1c1c5ba0b4.png)

#### iOS
![ios](https://user-images.githubusercontent.com/7277067/170786258-afb2146d-d8b8-4fbc-8e01-66974786fbe1.png)


#### Android
<!-- Insert screenshots of your changes on the Android platform-->
![android](https://user-images.githubusercontent.com/7277067/170786270-857921fa-af82-41b4-a642-02332f04dd71.png)

