### PR TITLE
Move the user is typing and other metadata back below the composer box

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25192,7 +25192,7 @@
     "good-listener": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
-      "integrity": "sha512-goW1b+d9q/HIwbVYZzZ6SsTr4IgE+WA44A0GmPIQstuOrgsFcT7VEJ48nmr9GaRtNu0XTKacFLGnBPAM6Afouw==",
+      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
       "requires": {
         "delegate": "^3.1.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25192,7 +25192,7 @@
     "good-listener": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
-      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+      "integrity": "sha512-goW1b+d9q/HIwbVYZzZ6SsTr4IgE+WA44A0GmPIQstuOrgsFcT7VEJ48nmr9GaRtNu0XTKacFLGnBPAM6Afouw==",
       "requires": {
         "delegate": "^3.1.2"
       }

--- a/src/components/ExceededCommentLength.js
+++ b/src/components/ExceededCommentLength.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
 import CONST from '../CONST';
 import Text from './Text';
 import styles from '../styles/styles';

--- a/src/components/ExceededCommentLength.js
+++ b/src/components/ExceededCommentLength.js
@@ -1,21 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import _ from 'underscore';
+
 import CONST from '../CONST';
 import Text from './Text';
 import styles from '../styles/styles';
-import stylePropTypes from '../styles/stylePropTypes';
 
 const propTypes = {
     /** The current length of the comment */
     commentLength: PropTypes.number.isRequired,
-
-    /** Additional style props */
-    style: stylePropTypes,
-};
-
-const defaultProps = {
-    style: [],
 };
 
 const ExceededCommentLength = (props) => {
@@ -23,17 +15,14 @@ const ExceededCommentLength = (props) => {
         return null;
     }
 
-    const additionalStyles = _.isArray(props.style) ? props.style : [props.style];
-
     return (
-        <Text style={[styles.textMicro, styles.textDanger, ...additionalStyles]}>
+        <Text style={[styles.textMicro, styles.textDanger]}>
             {`${props.commentLength}/${CONST.MAX_COMMENT_LENGTH}`}
         </Text>
     );
 };
 
 ExceededCommentLength.propTypes = propTypes;
-ExceededCommentLength.defaultProps = defaultProps;
 ExceededCommentLength.displayName = 'ExceededCommentLength';
 
 export default ExceededCommentLength;

--- a/src/components/ExceededCommentLength.js
+++ b/src/components/ExceededCommentLength.js
@@ -10,7 +10,7 @@ const propTypes = {
 };
 
 const ExceededCommentLength = (props) => {
-    if (props.commentLength >= CONST.MAX_COMMENT_LENGTH) {
+    if (props.commentLength <= CONST.MAX_COMMENT_LENGTH) {
         return null;
     }
 

--- a/src/components/ExceededCommentLength.js
+++ b/src/components/ExceededCommentLength.js
@@ -10,7 +10,7 @@ const propTypes = {
 };
 
 const ExceededCommentLength = (props) => {
-    if (props.commentLength <= CONST.MAX_COMMENT_LENGTH) {
+    if (props.commentLength >= CONST.MAX_COMMENT_LENGTH) {
         return null;
     }
 

--- a/src/components/ExceededCommentLength.js
+++ b/src/components/ExceededCommentLength.js
@@ -16,7 +16,7 @@ const ExceededCommentLength = (props) => {
     }
 
     return (
-        <Text style={[styles.textMicro, styles.textDanger]}>
+        <Text style={[styles.textMicro, styles.textDanger, styles.chatItemComposeSecondaryRow]}>
             {`${props.commentLength}/${CONST.MAX_COMMENT_LENGTH}`}
         </Text>
     );

--- a/src/components/OfflineIndicator.js
+++ b/src/components/OfflineIndicator.js
@@ -23,7 +23,11 @@ const OfflineIndicator = (props) => {
     }
 
     return (
-        <View style={[styles.flexRow]}>
+        <View style={[
+            styles.chatItemComposeSecondaryRowOffset,
+            styles.flexRow,
+            styles.alignItemsCenter]}
+        >
             <Icon
                 src={Expensicons.Offline}
                 width={variables.iconSizeExtraSmall}

--- a/src/components/OfflineIndicator.js
+++ b/src/components/OfflineIndicator.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import {View} from 'react-native';
-import _ from 'underscore';
 import {withNetwork} from './OnyxProvider';
 import networkPropTypes from './networkPropTypes';
 import Icon from './Icon';
@@ -10,20 +9,12 @@ import Text from './Text';
 import styles from '../styles/styles';
 import compose from '../libs/compose';
 import withLocalize, {withLocalizePropTypes} from './withLocalize';
-import stylePropTypes from '../styles/stylePropTypes';
 
 const propTypes = {
     /** Information about the network */
     network: networkPropTypes.isRequired,
 
-    /** Additional style props */
-    style: stylePropTypes,
-
     ...withLocalizePropTypes,
-};
-
-const defaultProps = {
-    style: [],
 };
 
 const OfflineIndicator = (props) => {
@@ -31,10 +22,8 @@ const OfflineIndicator = (props) => {
         return null;
     }
 
-    const additionalStyles = _.isArray(props.style) ? props.style : [props.style];
-
     return (
-        <View style={[styles.flexRow, ...additionalStyles]}>
+        <View style={[styles.flexRow]}>
             <Icon
                 src={Expensicons.Offline}
                 width={variables.iconSizeExtraSmall}
@@ -48,7 +37,6 @@ const OfflineIndicator = (props) => {
 };
 
 OfflineIndicator.propTypes = propTypes;
-OfflineIndicator.defaultProps = defaultProps;
 OfflineIndicator.displayName = 'OfflineIndicator';
 
 export default compose(

--- a/src/pages/home/report/ParticipantLocalTime.js
+++ b/src/pages/home/report/ParticipantLocalTime.js
@@ -1,4 +1,7 @@
 import React, {PureComponent} from 'react';
+import {
+    View,
+} from 'react-native';
 import lodashGet from 'lodash/get';
 import Str from 'expensify-common/lib/str';
 import styles from '../../../styles/styles';
@@ -57,18 +60,23 @@ class ParticipantLocalTime extends PureComponent {
                 : this.props.participant.displayName);
 
         return (
-            <Text
-                style={[styles.chatItemComposeSecondaryRowSubText]}
-                numberOfLines={1}
-            >
-                {this.props.translate(
-                    'reportActionCompose.localTime',
-                    {
-                        user: reportRecipientDisplayName,
-                        time: this.state.localTime,
-                    },
-                )}
-            </Text>
+            <View style={[styles.chatItemComposeSecondaryRow]}>
+                <Text
+                    style={[
+                        styles.chatItemComposeSecondaryRowSubText,
+                        styles.chatItemComposeSecondaryRowOffset,
+                    ]}
+                    numberOfLines={1}
+                >
+                    {this.props.translate(
+                        'reportActionCompose.localTime',
+                        {
+                            user: reportRecipientDisplayName,
+                            time: this.state.localTime,
+                        },
+                    )}
+                </Text>
+            </View>
         );
     }
 }

--- a/src/pages/home/report/ParticipantLocalTime.js
+++ b/src/pages/home/report/ParticipantLocalTime.js
@@ -1,7 +1,6 @@
 import React, {PureComponent} from 'react';
 import lodashGet from 'lodash/get';
 import Str from 'expensify-common/lib/str';
-import _ from 'underscore';
 import styles from '../../../styles/styles';
 import withLocalize, {withLocalizePropTypes} from '../../../components/withLocalize';
 import participantPropTypes from '../../../components/participantPropTypes';
@@ -9,20 +8,12 @@ import Text from '../../../components/Text';
 import Timers from '../../../libs/Timers';
 import CONST from '../../../CONST';
 import DateUtils from '../../../libs/DateUtils';
-import stylePropTypes from '../../../styles/stylePropTypes';
 
 const propTypes = {
     /** Personal details of the participant */
     participant: participantPropTypes.isRequired,
 
-    /** Additional style props */
-    style: stylePropTypes,
-
     ...withLocalizePropTypes,
-};
-
-const defaultProps = {
-    style: [],
 };
 
 class ParticipantLocalTime extends PureComponent {
@@ -60,7 +51,6 @@ class ParticipantLocalTime extends PureComponent {
     }
 
     render() {
-        const additionalStyles = _.isArray(this.props.style) ? this.props.style : [this.props.style];
         const reportRecipientDisplayName = this.props.participant.firstName
             || (Str.isSMSLogin(this.props.participant.login)
                 ? this.props.toLocalPhone(this.props.participant.displayName)
@@ -68,7 +58,7 @@ class ParticipantLocalTime extends PureComponent {
 
         return (
             <Text
-                style={[styles.chatItemComposeSecondaryRowSubText, ...additionalStyles]}
+                style={[styles.chatItemComposeSecondaryRowSubText]}
                 numberOfLines={1}
             >
                 {this.props.translate(
@@ -84,5 +74,4 @@ class ParticipantLocalTime extends PureComponent {
 }
 
 ParticipantLocalTime.propTypes = propTypes;
-ParticipantLocalTime.defaultProps = defaultProps;
 export default withLocalize(ParticipantLocalTime);

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -444,13 +444,25 @@ class ReportActionCompose extends React.Component {
 
         return (
             <View style={[styles.chatItemComposeWithFirstRow]}>
-                <View style={[styles.flexRow, styles.chatItemComposeSecondaryRow, styles.chatItemComposeSecondaryRowOffset, styles.flexWrap, styles.tester]}>
-                    {shouldShowReportRecipientLocalTime && (
-                        <ParticipantLocalTime participant={reportRecipient} style={[styles.mr3]} />
-                    )}
-                    <OfflineIndicator style={[styles.mr3]} />
-                    <ExceededCommentLength commentLength={this.comment.length} style={[styles.mr3]} />
-                    <ReportTypingIndicator reportID={this.props.reportID} />
+                <View style={[styles.flexRow, styles.chatItemComposeSecondaryRow, styles.chatItemComposeSecondaryRowOffset, styles.flexWrap]}>
+                    {shouldShowReportRecipientLocalTime
+                        && (
+                            <View style={[styles.mr3]}>
+                                <ParticipantLocalTime participant={reportRecipient} />
+                            </View>
+                        )}
+
+                    <View style={[styles.mr3]}>
+                        <OfflineIndicator />
+                    </View>
+
+                    <View style={[styles.mr3]}>
+                        <ExceededCommentLength commentLength={this.comment.length} />
+                    </View>
+
+                    <View style={[styles.mr3]}>
+                        <ReportTypingIndicator reportID={this.props.reportID} />
+                    </View>
                 </View>
 
                 <View style={[

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -443,28 +443,9 @@ class ReportActionCompose extends React.Component {
         const hasExceededMaxCommentLength = this.comment.length > CONST.MAX_COMMENT_LENGTH;
 
         return (
-            <View style={[styles.chatItemComposeWithFirstRow]}>
-                <View style={[styles.flexRow, styles.chatItemComposeSecondaryRow, styles.chatItemComposeSecondaryRowOffset, styles.flexWrap]}>
-                    {shouldShowReportRecipientLocalTime
-                        && (
-                            <View style={[styles.mr3]}>
-                                <ParticipantLocalTime participant={reportRecipient} />
-                            </View>
-                        )}
-
-                    <View style={[styles.mr3]}>
-                        <OfflineIndicator />
-                    </View>
-
-                    <View style={[styles.mr3]}>
-                        <ExceededCommentLength commentLength={this.comment.length} />
-                    </View>
-
-                    <View style={[styles.mr3]}>
-                        <ReportTypingIndicator reportID={this.props.reportID} />
-                    </View>
-                </View>
-
+            <View style={[shouldShowReportRecipientLocalTime && styles.chatItemComposeWithFirstRow]}>
+                {shouldShowReportRecipientLocalTime
+                    && <ParticipantLocalTime participant={reportRecipient} />}
                 <View style={[
                     (!isBlockedFromConcierge && (this.state.isFocused || this.state.isDraggingOver))
                         ? styles.chatItemComposeBoxFocusedColor
@@ -603,6 +584,11 @@ class ReportActionCompose extends React.Component {
                             </TouchableOpacity>
                         </Tooltip>
                     </View>
+                </View>
+                <View style={[styles.chatItemComposeSecondaryRow, styles.flexRow, styles.justifyContentBetween, styles.alignItemsCenter]}>
+                    <OfflineIndicator />
+                    <ReportTypingIndicator reportID={this.props.reportID} />
+                    <ExceededCommentLength commentLength={this.comment.length} />
                 </View>
             </View>
         );

--- a/src/pages/home/report/ReportTypingIndicator.js
+++ b/src/pages/home/report/ReportTypingIndicator.js
@@ -57,13 +57,18 @@ class ReportTypingIndicator extends React.Component {
                         leadingText={PersonalDetails.getDisplayName(this.state.usersTyping[0])}
                         trailingText={` ${this.props.translate('reportTypingIndicator.isTyping')}`}
                         textStyle={[styles.chatItemComposeSecondaryRowSubText]}
+                        wrapperStyle={styles.chatItemComposeSecondaryRow}
+                        leadingTextParentStyle={styles.chatItemComposeSecondaryRowOffset}
                     />
                 );
 
             default:
                 return (
                     <Text
-                        style={[styles.chatItemComposeSecondaryRowSubText]}
+                        style={[
+                            styles.chatItemComposeSecondaryRowSubText,
+                            styles.chatItemComposeSecondaryRowOffset,
+                        ]}
                         numberOfLines={1}
                     >
                         {this.props.translate('reportTypingIndicator.multipleUsers')}

--- a/src/pages/home/report/ReportTypingIndicator.js
+++ b/src/pages/home/report/ReportTypingIndicator.js
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
 import {withOnyx} from 'react-native-onyx';
+import {withNetwork} from '../../../components/OnyxProvider';
+import networkPropTypes from '../../../components/networkPropTypes';
 import compose from '../../../libs/compose';
 import ONYXKEYS from '../../../ONYXKEYS';
 import styles from '../../../styles/styles';
@@ -13,6 +15,9 @@ import TextWithEllipsis from '../../../components/TextWithEllipsis';
 const propTypes = {
     /** Key-value pairs of user logins and whether or not they are typing. Keys are logins. */
     userTypingStatuses: PropTypes.objectOf(PropTypes.bool),
+
+    /** Information about the network */
+    network: networkPropTypes.isRequired,
 
     ...withLocalizePropTypes,
 };
@@ -45,6 +50,11 @@ class ReportTypingIndicator extends React.Component {
 
     render() {
         const numUsersTyping = _.size(this.state.usersTyping);
+
+        // If we are offline, the user typing statuses are not up-to-date so do not show them
+        if (this.props.network.isOffline) {
+            return null;
+        }
 
         // Decide on the Text element that will hold the display based on the number of users that are typing.
         switch (numUsersTyping) {
@@ -84,6 +94,7 @@ ReportTypingIndicator.defaultProps = defaultProps;
 
 export default compose(
     withLocalize,
+    withNetwork(),
     withOnyx({
         userTypingStatuses: {
             key: ({reportID}) => `${ONYXKEYS.COLLECTION.REPORT_USER_IS_TYPING}${reportID}`,

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -648,7 +648,7 @@ const styles = {
     },
 
     chatItemComposeSecondaryRow: {
-        minHeight: 15,
+        height: 15,
         marginBottom: 5,
         marginTop: 5,
     },


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

Thanks for the review!

Basically, this does not introduce much of a new code. I am just reverting these 2 PRs:
- https://github.com/Expensify/App/pull/9095
- https://github.com/Expensify/App/pull/9206

**But** I am keeping some things from the original refactoring as its own component for the `OfflineIndicator` as that is handy.

### Details
<!-- Explanation of the change or anything fishy that is going on -->

We have decided to move the metadata back to above and below the composer box and make sure that the text is vertically aligned.

I am still using some of the refactoring introduced when the changes were made as they seemed appropriate and handy.

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/9251

### Tests / QA Steps
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

**First set of test**

- Get some other account to type a message to you so you can see the typing indicator
- Make sure it is back below the compose box and that it is correctly vertically aligned, looking something like this:
 
![image](https://user-images.githubusercontent.com/36083550/171638957-a538453f-5619-45a2-9e6f-60c3fc2046e9.png)

**Second set of tests**

- Create some group chat
- Make sure there is not large spacing between the last message and the composer box as it was here:
![image](https://user-images.githubusercontent.com/36083550/171639236-66f049c6-1cd2-4a49-980f-31ad5b40c9d5.png)

**Third set of tests**
- go offline 
- make sure the offline indicator appears below the composer box
- Copy some large text and paste it in so that you get more than 60000 character
- Confirm that the maximum character limit message shows up below the composer box too


- [x] Verify that no errors appear in the JS console

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

<img width="1137" alt="image" src="https://user-images.githubusercontent.com/36083550/171637528-d828c3a6-08a4-4437-ab7e-fe7391f56aa1.png">

Group chat - notice the padding at the bottom of the chat to the composer box is back to normal:
<img width="1137" alt="image" src="https://user-images.githubusercontent.com/36083550/171637610-6e75d05d-e23b-414c-b31a-f987c74aa4d0.png">


#### Web
<!-- Insert screenshots of your changes on the web platform-->

<img width="1137" alt="image" src="https://user-images.githubusercontent.com/36083550/171637520-07ece916-a411-44e1-b47f-7cd344a31b29.png">

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->
![simulator_screenshot_12C3C2E9-F3DF-4ABC-A044-08C11E002EE2](https://user-images.githubusercontent.com/36083550/171650962-40cde67e-001d-4de1-8317-63cc572c632a.png)

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
![Simulator Screen Shot - iPhone 13 - 2022-06-02 at 15 14 47](https://user-images.githubusercontent.com/36083550/171649755-c8df6bd6-ea96-4bd5-bde2-ccd75927eef7.png)

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
