### PR TITLE
Revert "Fix status bar color when a modal is open"

### DIFF
--- a/src/components/Modal/BaseModal.js
+++ b/src/components/Modal/BaseModal.js
@@ -77,7 +77,6 @@ class BaseModal extends PureComponent {
         );
         return (
             <ReactNativeModal
-                statusBarTranslucent
                 onBackdropPress={(e) => {
                     if (e && e.type === 'keydown' && e.key === 'Enter') {
                         return;


### PR DESCRIPTION
Reverts Expensify/App#9210 because of https://github.com/Expensify/App/issues/9280 deployblocker

It is a straight revert so not posting the screenshots. Alex has confirmed locally it fixes the problem.

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/9280

### Tests

1. Log in to NewDot with any account
2. Go to a chat or create one if needed
3. Hit the "+" button at the bottom left of the chat input, then select "Add attachment" and upload a picture
4. Wait for the attachment to finish uploading
5. Make sure the eader of attachment is not overlapping with phone icons