### PR TITLE
Update teamID

### DIFF
--- a/desktop/notarize.js
+++ b/desktop/notarize.js
@@ -15,6 +15,6 @@ exports.default = function notarizing(context) {
         appPath: `${appOutDir}/${appName}.app`,
         appleId: process.env.APPLE_ID,
         appleIdPassword: process.env.APPLE_ID_PASSWORD,
-        teamId: '152696',
+        teamId: '368M544MTT',
     });
 };


### PR DESCRIPTION
### Details
<!-- Explanation of the change or anything fishy that is going on -->
Updates the teamID, since Desktop notarization is failing with the error:

```
Error: HTTP status code: 403. Invalid or inaccessible developer team ID for the provided Apple ID. Ensure the Team ID is correct and that you are a member of that team.
  failedTask=build stackTrace=Error: Failed to notarize via notarytool
```

From the developer account, it seems that teamID is 368M544MTT

![Screen Shot 2022-06-02 at 3 55 40 PM](https://user-images.githubusercontent.com/22219519/171745014-47e067f8-f404-4c68-b9d4-8ebfe2ad976e.png)

### Fixed Issues
$ https://github.com/Expensify/App/issues/9277

### Tests
1. Merge this PR
2. Verify the staging build is notarized correctly
