### PR TITLE
Replace Report_AddComment with AddComment (Part 2)

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -701,6 +701,12 @@ const CONST = {
 
     // There's a limit of 60k characters in Auth - https://github.com/Expensify/Auth/blob/198d59547f71fdee8121325e8bc9241fc9c3236a/auth/lib/Request.h#L28
     MAX_COMMENT_LENGTH: 60000,
+
+    ONYX: {
+        METHOD: {
+            MERGE: 'merge',
+        },
+    },
 };
 
 export default CONST;

--- a/src/components/InlineSystemMessage.js
+++ b/src/components/InlineSystemMessage.js
@@ -9,7 +9,11 @@ import Icon from './Icon';
 
 const propTypes = {
     /** Error to display */
-    message: PropTypes.string.isRequired,
+    message: PropTypes.string,
+};
+
+const defaultProps = {
+    message: '',
 };
 
 const InlineSystemMessage = (props) => {
@@ -25,5 +29,6 @@ const InlineSystemMessage = (props) => {
 };
 
 InlineSystemMessage.propTypes = propTypes;
+InlineSystemMessage.defaultProps = defaultProps;
 InlineSystemMessage.displayName = 'InlineSystemMessage';
 export default InlineSystemMessage;

--- a/src/libs/DateUtils.js
+++ b/src/libs/DateUtils.js
@@ -115,21 +115,38 @@ function startCurrentDateUpdater() {
     });
 }
 
+/**
+ * @returns {Object}
+ */
+function getCurrentTimezone() {
+    const currentTimezone = moment.tz.guess(true);
+    if (timezone.automatic && timezone.selected !== currentTimezone) {
+        return {...timezone, selected: currentTimezone};
+    }
+    return timezone;
+}
+
 /*
  * Updates user's timezone, if their timezone is set to automatic and
  * is different from current timezone
  */
 function updateTimezone() {
-    const currentTimezone = moment.tz.guess(true);
-    if (timezone.automatic && timezone.selected !== currentTimezone) {
-        PersonalDetails.setPersonalDetails({timezone: {...timezone, selected: currentTimezone}});
-    }
+    PersonalDetails.setPersonalDetails({timezone: getCurrentTimezone()});
 }
 
-/*
- * Returns a version of updateTimezone function throttled by 5 minutes
+// Used to throttle updates to the timezone when necessary
+let lastUpdatedTimezoneTime = moment();
+
+/**
+ * @returns {Boolean}
  */
-const throttledUpdateTimezone = _.throttle(() => updateTimezone(), 1000 * 60 * 5);
+function canUpdateTimezone() {
+    return lastUpdatedTimezoneTime.isBefore(moment().subtract(5, 'minutes'));
+}
+
+function setTimezoneUpdated() {
+    lastUpdatedTimezoneTime = moment();
+}
 
 /**
  * @namespace DateUtils
@@ -139,8 +156,10 @@ const DateUtils = {
     timestampToDateTime,
     startCurrentDateUpdater,
     updateTimezone,
-    throttledUpdateTimezone,
     getLocalMomentFromTimestamp,
+    getCurrentTimezone,
+    canUpdateTimezone,
+    setTimezoneUpdated,
 };
 
 export default DateUtils;

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -919,7 +919,7 @@ function addComment(reportID, text, file) {
             isFirstItem: false,
             isAttachment,
             attachmentInfo,
-            isPending: true,
+            isLoading: true,
             shouldShow: true,
         },
     };
@@ -961,7 +961,7 @@ function addComment(reportID, text, file) {
         DateUtils.setTimezoneUpdated();
     }
 
-    API.write(isAttachment ? 'AddAttachmentWithOptionalComment' : 'AddComment', parameters, {
+    API.write(isAttachment ? 'AddAttachment' : 'AddComment', parameters, {
         optimisticData,
         failureData: [
             {
@@ -969,7 +969,7 @@ function addComment(reportID, text, file) {
                 key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`,
                 value: {
                     [optimisticReportActionID]: {
-                        isPending: false,
+                        isLoading: false,
                     },
                 },
             },
@@ -981,7 +981,7 @@ function addComment(reportID, text, file) {
  * @param {Number} reportID
  * @param {Object} file
  */
-function addAttachmentWithOptionalComment(reportID, file) {
+function addAttachment(reportID, file) {
     addComment(reportID, '', file);
 }
 
@@ -1494,7 +1494,7 @@ export {
     fetchIOUReportByID,
     fetchIOUReportByIDAndUpdateChatReport,
     addComment,
-    addAttachmentWithOptionalComment,
+    addAttachment,
     updateLastReadActionID,
     updateNotificationPreference,
     setNewMarkerPosition,

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -534,64 +534,6 @@ function updateReportActionMessage(reportID, sequenceNumber, message) {
 }
 
 /**
- * Updates a report in the store with a new report action
- *
- * @param {Number} reportID
- * @param {Object} reportAction
- * @param {String} [notificationPreference] On what cadence the user would like to be notified
- */
-function updateReportWithNewAction(
-    reportID,
-    reportAction,
-    notificationPreference = CONST.REPORT.NOTIFICATION_PREFERENCE.ALWAYS,
-) {
-    const messageHtml = reportAction.actionName === CONST.REPORT.ACTIONS.TYPE.RENAMED
-        ? lodashGet(reportAction, 'originalMessage.html', '')
-        : lodashGet(reportAction, ['message', 0, 'html'], '');
-
-    const parser = new ExpensiMark();
-    const messageText = parser.htmlToText(messageHtml);
-
-    const updatedReportObject = {
-        // Always merge the reportID into Onyx. If the report doesn't exist in Onyx yet, then all the rest of the data will be filled out by handleReportChanged
-        reportID,
-        maxSequenceNumber: reportAction.sequenceNumber,
-        notificationPreference,
-        lastMessageTimestamp: reportAction.timestamp,
-        lastMessageText: ReportUtils.formatReportLastMessageText(messageText),
-        lastActorEmail: reportAction.actorEmail,
-    };
-
-    Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, updatedReportObject);
-
-    const reportActionsToMerge = {};
-    if (reportAction.clientID) {
-        // Remove the optimistic action from the report since we are about to replace it
-        // with the real one (which has the true sequenceNumber)
-        reportActionsToMerge[reportAction.clientID] = null;
-    }
-
-    // Add the action into Onyx
-    reportActionsToMerge[reportAction.sequenceNumber] = {
-        ...reportAction,
-        isAttachment: ReportUtils.isReportMessageAttachment(lodashGet(reportAction, ['message', 0], {})),
-        loading: false,
-    };
-
-    Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`, reportActionsToMerge);
-}
-
-/**
- * Updates a report in Onyx with a new pinned state.
- *
- * @param {Number} reportID
- * @param {Boolean} isPinned
- */
-function updateReportPinnedState(reportID, isPinned) {
-   Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, {isPinned});
-}
-
-/**
  * Get the private pusher channel name for a Report.
  *
  * @param {Number} reportID

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -1004,12 +1004,12 @@ function addAction(reportID, text, file) {
     API.write('AddComment', parameters, {
         optimisticData: [
             {
-                onyxMethod: 'merge',
+                onyxMethod: CONST.ONYX.METHOD.MERGE,
                 key: `${ONYXKEYS.COLLECTION.REPORT}${reportID}`,
                 value: optimisticReport,
             },
             {
-                onyxMethod: 'merge',
+                onyxMethod: CONST.ONYX.METHOD.MERGE,
                 key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`,
                 value: optimisticReportActions,
             },

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -954,7 +954,7 @@ function addAction(reportID, text, file) {
     // Update the timezone if it's been 5 minutes from the last time the user added a comment
     if (DateUtils.canUpdateTimezone()) {
         const timezone = DateUtils.getCurrentTimezone();
-        parameters.timezone = timezone;
+        parameters.timezone = JSON.stringify(timezone);
         optimisticData.push({
             onyxMethod: CONST.ONYX.METHOD.MERGE,
             key: ONYXKEYS.MY_PERSONAL_DETAILS,

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -945,38 +945,38 @@ function addAction(reportID, text, file) {
     optimisticReport.optimisticReportActionIDs = [...(optimisticReportActionIDs[reportID] || []), optimisticReportActionID];
 
     // Optimistically add the new comment to the store before waiting to save it to the server
-    const optimisticReportActions = {};
+    const optimisticReportActions = {
+        [optimisticReportActionID]: {
+            actionName: CONST.REPORT.ACTIONS.TYPE.ADDCOMMENT,
+            actorEmail: currentUserEmail,
+            actorAccountID: currentUserAccountID,
+            person: [
+                {
+                    style: 'strong',
+                    text: myPersonalDetails.displayName || currentUserEmail,
+                    type: 'TEXT',
+                },
+            ],
+            automatic: false,
 
-    optimisticReportActions[optimisticReportActionID] = {
-        actionName: CONST.REPORT.ACTIONS.TYPE.ADDCOMMENT,
-        actorEmail: currentUserEmail,
-        actorAccountID: currentUserAccountID,
-        person: [
-            {
-                style: 'strong',
-                text: myPersonalDetails.displayName || currentUserEmail,
-                type: 'TEXT',
-            },
-        ],
-        automatic: false,
-
-        // Use the client generated ID as a optimistic action ID so we can remove it later
-        sequenceNumber: optimisticReportActionID,
-        clientID: optimisticReportActionID,
-        avatar: myPersonalDetails.avatar,
-        timestamp: moment().unix(),
-        message: [
-            {
-                type: CONST.REPORT.MESSAGE.TYPE.COMMENT,
-                html: htmlForNewComment,
-                text: textForNewComment,
-            },
-        ],
-        isFirstItem: false,
-        isAttachment,
-        attachmentInfo,
-        loading: true,
-        shouldShow: true,
+            // Use the client generated ID as a optimistic action ID so we can remove it later
+            sequenceNumber: optimisticReportActionID,
+            clientID: optimisticReportActionID,
+            avatar: myPersonalDetails.avatar,
+            timestamp: moment().unix(),
+            message: [
+                {
+                    type: CONST.REPORT.MESSAGE.TYPE.COMMENT,
+                    html: htmlForNewComment,
+                    text: textForNewComment,
+                },
+            ],
+            isFirstItem: false,
+            isAttachment,
+            attachmentInfo,
+            loading: true,
+            shouldShow: true,
+        },
     };
 
     const parameters = {

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -944,7 +944,7 @@ function addAction(reportID, text, file) {
             isFirstItem: false,
             isAttachment,
             attachmentInfo,
-            loading: true,
+            isPending: true,
             shouldShow: true,
         },
     };
@@ -967,6 +967,17 @@ function addAction(reportID, text, file) {
                 onyxMethod: CONST.ONYX.METHOD.MERGE,
                 key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`,
                 value: optimisticReportActions,
+            },
+        ],
+        failureData: [
+            {
+                onyxMethod: CONST.ONYX.METHOD.MERGE,
+                key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`,
+                value: {
+                    [optimisticReportActionID]: {
+                        isPending: false,
+                    },
+                },
             },
         ],
     });

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -968,7 +968,7 @@ function createComment(reportID, text, file) {
         DateUtils.setTimezoneUpdated();
     }
 
-    API.write(isAttachment ? 'CreateAttachment' : 'CreateComment', parameters, {
+    API.write(isAttachment ? 'CreateAttachmentWithOptionalComment' : 'CreateComment', parameters, {
         optimisticData,
         failureData: [
             {
@@ -988,7 +988,7 @@ function createComment(reportID, text, file) {
  * @param {Number} reportID
  * @param {Object} file
  */
-function createAttachment(reportID, file) {
+function createAttachmentWithOptionalComment(reportID, file) {
     createComment(reportID, '', file);
 }
 
@@ -1493,7 +1493,7 @@ export {
     fetchIOUReportByID,
     fetchIOUReportByIDAndUpdateChatReport,
     createComment,
-    createAttachment,
+    createAttachmentWithOptionalComment,
     updateLastReadActionID,
     updateNotificationPreference,
     setNewMarkerPosition,

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -957,8 +957,13 @@ function addAction(reportID, text, file) {
         parameters.timezone = timezone;
         optimisticData.push({
             onyxMethod: CONST.ONYX.METHOD.MERGE,
-            key: ONYXKEYS.PERSONAL_DETAILS,
+            key: ONYXKEYS.MY_PERSONAL_DETAILS,
             value: {timezone},
+        });
+        optimisticData.push({
+            onyxMethod: CONST.ONYX.METHOD.MERGE,
+            key: ONYXKEYS.PERSONAL_DETAILS,
+            value: {[currentUserEmail]: timezone},
         });
         DateUtils.setTimezoneUpdated();
     }

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -855,7 +855,7 @@ function fetchAllReports(
  * @param {String} text
  * @param {File} [file]
  */
-function createComment(reportID, text, file) {
+function addComment(reportID, text, file) {
     // For comments shorter than 10k chars, convert the comment from MD into HTML because that's how it is stored in the database
     // For longer comments, skip parsing and display plaintext for performance reasons. It takes over 40s to parse a 100k long string!!
     const parser = new ExpensiMark();
@@ -968,7 +968,7 @@ function createComment(reportID, text, file) {
         DateUtils.setTimezoneUpdated();
     }
 
-    API.write(isAttachment ? 'CreateAttachmentWithOptionalComment' : 'CreateComment', parameters, {
+    API.write(isAttachment ? 'AddAttachmentWithOptionalComment' : 'AddComment', parameters, {
         optimisticData,
         failureData: [
             {
@@ -988,8 +988,8 @@ function createComment(reportID, text, file) {
  * @param {Number} reportID
  * @param {Object} file
  */
-function createAttachmentWithOptionalComment(reportID, file) {
-    createComment(reportID, '', file);
+function addAttachmentWithOptionalComment(reportID, file) {
+    addComment(reportID, '', file);
 }
 
 /**
@@ -1500,8 +1500,8 @@ export {
     fetchChatReportsByIDs,
     fetchIOUReportByID,
     fetchIOUReportByIDAndUpdateChatReport,
-    createComment,
-    createAttachmentWithOptionalComment,
+    addComment,
+    addAttachmentWithOptionalComment,
     updateLastReadActionID,
     updateNotificationPreference,
     setNewMarkerPosition,

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -537,51 +537,6 @@ function updateReportActionMessage(reportID, sequenceNumber, message) {
 }
 
 /**
- * Updates a report in the store with a new report action
- *
- * @param {Number} reportID
- * @param {Object} reportAction
- * @param {String} [notificationPreference] On what cadence the user would like to be notified
- */
-function updateReportWithNewAction(
-    reportID,
-    reportAction,
-    notificationPreference = CONST.REPORT.NOTIFICATION_PREFERENCE.ALWAYS,
-) {
-    const messageText = reportAction.actionName === CONST.REPORT.ACTIONS.TYPE.RENAMED
-        ? lodashGet(reportAction, 'originalMessage.html', '')
-        : lodashGet(reportAction, ['message', 0, 'text'], '');
-
-    const updatedReportObject = {
-        // Always merge the reportID into Onyx. If the report doesn't exist in Onyx yet, then all the rest of the data will be filled out by handleReportChanged
-        reportID,
-        maxSequenceNumber: reportAction.sequenceNumber,
-        notificationPreference,
-        lastMessageTimestamp: reportAction.timestamp,
-        lastMessageText: ReportUtils.formatReportLastMessageText(messageText),
-        lastActorEmail: reportAction.actorEmail,
-    };
-
-    Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, updatedReportObject);
-
-    const reportActionsToMerge = {};
-    if (reportAction.clientID) {
-        // Remove the optimistic action from the report since we are about to replace it
-        // with the real one (which has the true sequenceNumber)
-        reportActionsToMerge[reportAction.clientID] = null;
-    }
-
-    // Add the action into Onyx
-    reportActionsToMerge[reportAction.sequenceNumber] = {
-        ...reportAction,
-        isAttachment: ReportUtils.isReportMessageAttachment(lodashGet(reportAction, ['message', 0], {})),
-        loading: false,
-    };
-
-    Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`, reportActionsToMerge);
-}
-
-/**
  * Updates a report in Onyx with a new pinned state.
  *
  * @param {Number} reportID
@@ -638,9 +593,9 @@ function subscribeToUserEvents() {
  * Setup reportComment push notification callbacks.
  */
 function subscribeToReportCommentPushNotifications() {
-    PushNotification.onReceived(PushNotification.TYPE.REPORT_COMMENT, ({reportID, reportAction}) => {
+    PushNotification.onReceived(PushNotification.TYPE.REPORT_COMMENT, ({reportID, onyxData}) => {
         Log.info('[Report] Handled event sent by Airship', false, {reportID});
-        updateReportWithNewAction(reportID, reportAction);
+        Onyx.update(onyxData);
     });
 
     // Open correct report when push notification is clicked

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -855,7 +855,7 @@ function fetchAllReports(
  * @param {String} text
  * @param {File} [file]
  */
-function addAction(reportID, text, file) {
+function createComment(reportID, text, file) {
     // For comments shorter than 10k chars, convert the comment from MD into HTML because that's how it is stored in the database
     // For longer comments, skip parsing and display plaintext for performance reasons. It takes over 40s to parse a 100k long string!!
     const parser = new ExpensiMark();
@@ -968,7 +968,7 @@ function addAction(reportID, text, file) {
         DateUtils.setTimezoneUpdated();
     }
 
-    API.write('AddComment', parameters, {
+    API.write(isAttachment ? 'CreateAttachment' : 'CreateComment', parameters, {
         optimisticData,
         failureData: [
             {
@@ -982,6 +982,14 @@ function addAction(reportID, text, file) {
             },
         ],
     });
+}
+
+/**
+ * @param {Number} reportID
+ * @param {Object} file
+ */
+function createAttachment(reportID, file) {
+    createComment(reportID, '', file);
 }
 
 /**
@@ -1484,7 +1492,8 @@ export {
     fetchChatReportsByIDs,
     fetchIOUReportByID,
     fetchIOUReportByIDAndUpdateChatReport,
-    addAction,
+    createComment,
+    createAttachment,
     updateLastReadActionID,
     updateNotificationPreference,
     setNewMarkerPosition,

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -26,6 +26,7 @@ import * as ReportActions from './ReportActions';
 import Growl from '../Growl';
 import * as Localize from '../Localize';
 import PusherUtils from '../PusherUtils';
+import DateUtils from '../DateUtils';
 
 let currentUserEmail;
 let currentUserAccountID;
@@ -937,19 +938,33 @@ function addAction(reportID, text, file) {
         clientID: optimisticReportActionID,
     };
 
+    const optimisticData = [
+        {
+            onyxMethod: CONST.ONYX.METHOD.MERGE,
+            key: `${ONYXKEYS.COLLECTION.REPORT}${reportID}`,
+            value: optimisticReport,
+        },
+        {
+            onyxMethod: CONST.ONYX.METHOD.MERGE,
+            key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`,
+            value: optimisticReportActions,
+        },
+    ];
+
+    // Update the timezone if it's been 5 minutes from the last time the user added a comment
+    if (DateUtils.canUpdateTimezone()) {
+        const timezone = DateUtils.getCurrentTimezone();
+        parameters.timezone = timezone;
+        optimisticData.push({
+            onyxMethod: CONST.ONYX.METHOD.MERGE,
+            key: ONYXKEYS.PERSONAL_DETAILS,
+            value: {timezone},
+        });
+        DateUtils.setTimezoneUpdated();
+    }
+
     API.write('AddComment', parameters, {
-        optimisticData: [
-            {
-                onyxMethod: CONST.ONYX.METHOD.MERGE,
-                key: `${ONYXKEYS.COLLECTION.REPORT}${reportID}`,
-                value: optimisticReport,
-            },
-            {
-                onyxMethod: CONST.ONYX.METHOD.MERGE,
-                key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`,
-                value: optimisticReportActions,
-            },
-        ],
+        optimisticData,
         failureData: [
             {
                 onyxMethod: CONST.ONYX.METHOD.MERGE,

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -10,7 +10,6 @@ import * as Pusher from '../Pusher/pusher';
 import LocalNotification from '../Notification/LocalNotification';
 import PushNotification from '../Notification/PushNotification';
 import * as PersonalDetails from './PersonalDetails';
-import * as User from './User';
 import Navigation from '../Navigation/Navigation';
 import * as ActiveClientManager from '../ActiveClientManager';
 import Visibility from '../Visibility';
@@ -27,6 +26,7 @@ import * as ReportActions from './ReportActions';
 import Growl from '../Growl';
 import * as Localize from '../Localize';
 import PusherUtils from '../PusherUtils';
+import * as API from '../API';
 
 let currentUserEmail;
 let currentUserAccountID;
@@ -537,51 +537,6 @@ function updateReportActionMessage(reportID, sequenceNumber, message) {
 }
 
 /**
- * Updates a report in the store with a new report action
- *
- * @param {Number} reportID
- * @param {Object} reportAction
- * @param {String} [notificationPreference] On what cadence the user would like to be notified
- */
-function updateReportWithNewAction(
-    reportID,
-    reportAction,
-    notificationPreference = CONST.REPORT.NOTIFICATION_PREFERENCE.ALWAYS,
-) {
-    const messageText = reportAction.actionName === CONST.REPORT.ACTIONS.TYPE.RENAMED
-        ? lodashGet(reportAction, 'originalMessage.html', '')
-        : lodashGet(reportAction, ['message', 0, 'text'], '');
-
-    const updatedReportObject = {
-        // Always merge the reportID into Onyx. If the report doesn't exist in Onyx yet, then all the rest of the data will be filled out by handleReportChanged
-        reportID,
-        maxSequenceNumber: reportAction.sequenceNumber,
-        notificationPreference,
-        lastMessageTimestamp: reportAction.timestamp,
-        lastMessageText: ReportUtils.formatReportLastMessageText(messageText),
-        lastActorEmail: reportAction.actorEmail,
-    };
-
-    Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, updatedReportObject);
-
-    const reportActionsToMerge = {};
-    if (reportAction.clientID) {
-        // Remove the optimistic action from the report since we are about to replace it
-        // with the real one (which has the true sequenceNumber)
-        reportActionsToMerge[reportAction.clientID] = null;
-    }
-
-    // Add the action into Onyx
-    reportActionsToMerge[reportAction.sequenceNumber] = {
-        ...reportAction,
-        isAttachment: ReportUtils.isReportMessageAttachment(lodashGet(reportAction, ['message', 0], {})),
-        loading: false,
-    };
-
-    Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`, reportActionsToMerge);
-}
-
-/**
  * Updates a report in Onyx with a new pinned state.
  *
  * @param {Number} reportID
@@ -615,21 +570,6 @@ function subscribeToUserEvents() {
         return;
     }
 
-    // Live-update a report's actions when a 'report comment' event is received.
-    PusherUtils.subscribeToPrivateUserChannelEvent(
-        Pusher.TYPE.REPORT_COMMENT,
-        currentUserAccountID,
-        pushJSON => updateReportWithNewAction(pushJSON.reportID, pushJSON.reportAction, pushJSON.notificationPreference),
-    );
-
-    // Live-update a report's actions when a 'chunked report comment' event is received.
-    PusherUtils.subscribeToPrivateUserChannelEvent(
-        Pusher.TYPE.REPORT_COMMENT_CHUNK,
-        currentUserAccountID,
-        pushJSON => updateReportWithNewAction(pushJSON.reportID, pushJSON.reportAction, pushJSON.notificationPreference),
-        true,
-    );
-
     // Live-update a report's actions when an 'edit comment' event is received.
     PusherUtils.subscribeToPrivateUserChannelEvent(Pusher.TYPE.REPORT_COMMENT_EDIT,
         currentUserAccountID,
@@ -655,7 +595,37 @@ function subscribeToUserEvents() {
 function subscribeToReportCommentPushNotifications() {
     PushNotification.onReceived(PushNotification.TYPE.REPORT_COMMENT, ({reportID, reportAction}) => {
         Log.info('[Report] Handled event sent by Airship', false, {reportID});
-        updateReportWithNewAction(reportID, reportAction);
+        const messageText = reportAction.actionName === CONST.REPORT.ACTIONS.TYPE.RENAMED
+            ? lodashGet(reportAction, 'originalMessage.html', '')
+            : lodashGet(reportAction, ['message', 0, 'text'], '');
+
+        const updatedReportObject = {
+            // Always merge the reportID into Onyx. If the report doesn't exist in Onyx yet, then all the rest of the data will be filled out by handleReportChanged
+            reportID,
+            maxSequenceNumber: reportAction.sequenceNumber,
+            notificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.ALWAYS,
+            lastMessageTimestamp: reportAction.timestamp,
+            lastMessageText: ReportUtils.formatReportLastMessageText(messageText),
+            lastActorEmail: reportAction.actorEmail,
+        };
+
+        Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, updatedReportObject);
+
+        const reportActionsToMerge = {};
+        if (reportAction.clientID) {
+            // Remove the optimistic action from the report since we are about to replace it
+            // with the real one (which has the true sequenceNumber)
+            reportActionsToMerge[reportAction.clientID] = null;
+        }
+
+        // Add the action into Onyx
+        reportActionsToMerge[reportAction.sequenceNumber] = {
+            ...reportAction,
+            isAttachment: ReportUtils.isReportMessageAttachment(lodashGet(reportAction, ['message', 0], {})),
+            loading: false,
+        };
+
+        Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`, reportActionsToMerge);
     });
 
     // Open correct report when push notification is clicked
@@ -951,12 +921,12 @@ function addAction(reportID, text, file) {
         : htmlForNewComment.replace(/((<br[^>]*>)+)/gi, ' ').replace(/<[^>]*>?/gm, '');
 
     // Update the report in Onyx to have the new sequence number
-    Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, {
+    const optimisticReport = {
         maxSequenceNumber: newSequenceNumber,
         lastMessageTimestamp: moment().unix(),
         lastMessageText: ReportUtils.formatReportLastMessageText(textForNewComment),
         lastActorEmail: currentUserEmail,
-    });
+    };
 
     // Generate a clientID so we can save the optimistic action to storage with the clientID as key. Later, we will
     // remove the optimistic action when we add the real action created in the server. We do this because it's not
@@ -972,75 +942,64 @@ function addAction(reportID, text, file) {
     // Store the optimistic action ID on the report the comment was added to. It will be removed later when refetching
     // report actions in order to clear out any stuck actions (i.e. actions where the client never received a Pusher
     // event, for whatever reason, from the server with the new action data
-    Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, {
-        optimisticReportActionIDs: [...(optimisticReportActionIDs[reportID] || []), optimisticReportActionID],
-    });
+    optimisticReport.optimisticReportActionIDs = [...(optimisticReportActionIDs[reportID] || []), optimisticReportActionID];
 
     // Optimistically add the new comment to the store before waiting to save it to the server
-    Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`, {
-        [optimisticReportActionID]: {
-            actionName: CONST.REPORT.ACTIONS.TYPE.ADDCOMMENT,
-            actorEmail: currentUserEmail,
-            actorAccountID: currentUserAccountID,
-            person: [
-                {
-                    style: 'strong',
-                    text: myPersonalDetails.displayName || currentUserEmail,
-                    type: 'TEXT',
-                },
-            ],
-            automatic: false,
+    const optimisticReportActions = {};
 
-            // Use the client generated ID as a optimistic action ID so we can remove it later
-            sequenceNumber: optimisticReportActionID,
-            clientID: optimisticReportActionID,
-            avatar: myPersonalDetails.avatar,
-            timestamp: moment().unix(),
-            message: [
-                {
-                    type: CONST.REPORT.MESSAGE.TYPE.COMMENT,
-                    html: htmlForNewComment,
-                    text: textForNewComment,
-                },
-            ],
-            isFirstItem: false,
-            isAttachment,
-            attachmentInfo,
-            loading: true,
-            shouldShow: true,
-        },
-    });
+    optimisticReportActions[optimisticReportActionID] = {
+        actionName: CONST.REPORT.ACTIONS.TYPE.ADDCOMMENT,
+        actorEmail: currentUserEmail,
+        actorAccountID: currentUserAccountID,
+        person: [
+            {
+                style: 'strong',
+                text: myPersonalDetails.displayName || currentUserEmail,
+                type: 'TEXT',
+            },
+        ],
+        automatic: false,
 
-    DeprecatedAPI.Report_AddComment({
+        // Use the client generated ID as a optimistic action ID so we can remove it later
+        sequenceNumber: optimisticReportActionID,
+        clientID: optimisticReportActionID,
+        avatar: myPersonalDetails.avatar,
+        timestamp: moment().unix(),
+        message: [
+            {
+                type: CONST.REPORT.MESSAGE.TYPE.COMMENT,
+                html: htmlForNewComment,
+                text: textForNewComment,
+            },
+        ],
+        isFirstItem: false,
+        isAttachment,
+        attachmentInfo,
+        loading: true,
+        shouldShow: true,
+    };
+
+    const parameters = {
         reportID,
         file,
         reportComment: commentText,
         clientID: optimisticReportActionID,
-        persist: true,
-    })
-        .then((response) => {
-            if (response.jsonCode === 408) {
-                Growl.error(Localize.translateLocal('reportActionCompose.fileUploadFailed'));
-                Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`, {
-                    [optimisticReportActionID]: null,
-                });
-                console.error(response.message);
-                return;
-            }
+    };
 
-            if (response.jsonCode === 666 && reportID === conciergeChatReportID) {
-                Growl.error(Localize.translateLocal('reportActionCompose.blockedFromConcierge'));
-                Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`, {
-                    [optimisticReportActionID]: null,
-                });
-
-                // The fact that the API is returning this error means the BLOCKED_FROM_CONCIERGE nvp in the user details has changed since the last time we checked, so let's update
-                User.getUserDetails();
-                return;
-            }
-
-            updateReportWithNewAction(reportID, response.reportAction);
-        });
+    API.write('AddComment', parameters, {
+        optimisticData: [
+            {
+                onyxMethod: 'merge',
+                key: `${ONYXKEYS.COLLECTION.REPORT}${reportID}`,
+                value: optimisticReport,
+            },
+            {
+                onyxMethod: 'merge',
+                key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`,
+                value: optimisticReportActions,
+            },
+        ],
+    });
 }
 
 /**

--- a/src/libs/actions/ReportActions.js
+++ b/src/libs/actions/ReportActions.js
@@ -34,7 +34,7 @@ Onyx.connect({
         const reportID = CollectionUtils.extractCollectionItemID(key);
         const actionsArray = _.toArray(actions);
         reportActions[reportID] = actionsArray;
-        const mostRecentNonLoadingActionIndex = _.findLastIndex(actionsArray, action => !action.isPending);
+        const mostRecentNonLoadingActionIndex = _.findLastIndex(actionsArray, action => !action.isLoading);
         const mostRecentAction = actionsArray[mostRecentNonLoadingActionIndex];
         if (!mostRecentAction || _.isUndefined(mostRecentAction.sequenceNumber)) {
             return;

--- a/src/libs/actions/ReportActions.js
+++ b/src/libs/actions/ReportActions.js
@@ -33,7 +33,7 @@ Onyx.connect({
         const reportID = CollectionUtils.extractCollectionItemID(key);
         const actionsArray = _.toArray(actions);
         reportActions[reportID] = actionsArray;
-        const mostRecentNonLoadingActionIndex = _.findLastIndex(actionsArray, action => !action.loading);
+        const mostRecentNonLoadingActionIndex = _.findLastIndex(actionsArray, action => !action.isPending);
         const mostRecentAction = actionsArray[mostRecentNonLoadingActionIndex];
         if (!mostRecentAction || _.isUndefined(mostRecentAction.sequenceNumber)) {
             return;

--- a/src/pages/home/ReportScreen.js
+++ b/src/pages/home/ReportScreen.js
@@ -136,7 +136,7 @@ class ReportScreen extends React.Component {
      * @param {String} text
      */
     onSubmitComment(text) {
-        Report.createComment(getReportID(this.props.route), text);
+        Report.addComment(getReportID(this.props.route), text);
     }
 
     /**

--- a/src/pages/home/ReportScreen.js
+++ b/src/pages/home/ReportScreen.js
@@ -122,7 +122,7 @@ class ReportScreen extends React.Component {
      * @param {String} text
      */
     onSubmitComment(text) {
-        Report.addAction(getReportID(this.props.route), text);
+        Report.createComment(getReportID(this.props.route), text);
     }
 
     /**

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -36,7 +36,6 @@ import ReportActionComposeFocusManager from '../../../libs/ReportActionComposeFo
 import participantPropTypes from '../../../components/participantPropTypes';
 import ParticipantLocalTime from './ParticipantLocalTime';
 import {withPersonalDetails} from '../../../components/OnyxProvider';
-import DateUtils from '../../../libs/DateUtils';
 import * as User from '../../../libs/actions/User';
 import Tooltip from '../../../components/Tooltip';
 import EmojiPickerButton from '../../../components/EmojiPicker/EmojiPickerButton';
@@ -421,8 +420,6 @@ class ReportActionCompose extends React.Component {
         if (this.state.isCommentEmpty || trimmedComment.length > CONST.MAX_COMMENT_LENGTH) {
             return;
         }
-
-        DateUtils.throttledUpdateTimezone();
 
         this.props.onSubmit(trimmedComment);
         this.updateComment('');

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -495,7 +495,7 @@ class ReportActionCompose extends React.Component {
                         headerTitle={this.props.translate('reportActionCompose.sendAttachment')}
                         onConfirm={(file) => {
                             this.submitForm();
-                            Report.createAttachment(this.props.reportID, file);
+                            Report.addAttachment(this.props.reportID, file);
                             this.setTextInputShouldClear(false);
                         }}
                     >

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -462,7 +462,7 @@ class ReportActionCompose extends React.Component {
                         headerTitle={this.props.translate('reportActionCompose.sendAttachment')}
                         onConfirm={(file) => {
                             this.submitForm();
-                            Report.addAction(this.props.reportID, '', file);
+                            Report.createAttachment(this.props.reportID, file);
                             this.setTextInputShouldClear(false);
                         }}
                     >

--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -204,7 +204,7 @@ class ReportActionItem extends Component {
                         </View>
                     )}
                 </Hoverable>
-                <View style={styles.ml10}>
+                <View style={styles.reportActionSystemMessageContainer}>
                     <InlineSystemMessage message={this.props.action.error} />
                 </View>
             </PressableWithSecondaryInteraction>

--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -175,7 +175,7 @@ class ReportActionItem extends Component {
                                     hovered
                                     || this.state.isContextMenuActive
                                     || this.props.draftMessage,
-                                    (this.props.network.isOffline && this.props.action.isPending) || this.props.action.error,
+                                    (this.props.network.isOffline && this.props.action.isLoading) || this.props.action.error,
                                 )}
                             >
                                 {!this.props.displayAsGroup

--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -24,7 +24,7 @@ import canUseTouchScreen from '../../../libs/canUseTouchscreen';
 import MiniReportActionContextMenu from './ContextMenu/MiniReportActionContextMenu';
 import * as ReportActionContextMenu from './ContextMenu/ReportActionContextMenu';
 import * as ContextMenuActions from './ContextMenu/ContextMenuActions';
-import {withReportActionsDrafts} from '../../../components/OnyxProvider';
+import {withNetwork, withReportActionsDrafts} from '../../../components/OnyxProvider';
 import RenameAction from '../../../components/ReportActionItem/RenameAction';
 import InlineSystemMessage from '../../../components/InlineSystemMessage';
 import styles from '../../../styles/styles';
@@ -175,7 +175,7 @@ class ReportActionItem extends Component {
                                     hovered
                                     || this.state.isContextMenuActive
                                     || this.props.draftMessage,
-                                    this.props.action.isPending || this.props.action.error,
+                                    (this.props.network.isOffline && this.props.action.isPending) || this.props.action.error,
                                 )}
                             >
                                 {!this.props.displayAsGroup
@@ -216,6 +216,7 @@ ReportActionItem.defaultProps = defaultProps;
 
 export default compose(
     withWindowDimensions,
+    withNetwork(),
     withReportActionsDrafts({
         propName: 'draftMessage',
         transformValue: (drafts, props) => {

--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -26,6 +26,8 @@ import * as ReportActionContextMenu from './ContextMenu/ReportActionContextMenu'
 import * as ContextMenuActions from './ContextMenu/ContextMenuActions';
 import {withReportActionsDrafts} from '../../../components/OnyxProvider';
 import RenameAction from '../../../components/ReportActionItem/RenameAction';
+import InlineSystemMessage from '../../../components/InlineSystemMessage';
+import styles from '../../../styles/styles';
 
 const propTypes = {
     /** The ID of the report this action is on. */
@@ -202,6 +204,9 @@ class ReportActionItem extends Component {
                         </View>
                     )}
                 </Hoverable>
+                <View style={styles.ml10}>
+                    <InlineSystemMessage message={this.props.action.error} />
+                </View>
             </PressableWithSecondaryInteraction>
         );
     }

--- a/src/pages/home/report/ReportActionItemMessage.js
+++ b/src/pages/home/report/ReportActionItemMessage.js
@@ -22,7 +22,7 @@ const propTypes = {
 };
 
 const ReportActionItemMessage = (props) => {
-    const isUnsent = props.network.isOffline && props.action.loading;
+    const isUnsent = props.network.isOffline && props.action.isPending;
 
     return (
         <View style={[styles.chatItemMessage, isUnsent && styles.chatItemUnsentMessage]}>
@@ -32,7 +32,7 @@ const ReportActionItemMessage = (props) => {
                     fragment={fragment}
                     isAttachment={props.action.isAttachment}
                     attachmentInfo={props.action.attachmentInfo}
-                    loading={props.action.loading}
+                    loading={props.action.isPending}
                 />
             ))}
         </View>

--- a/src/pages/home/report/ReportActionItemMessage.js
+++ b/src/pages/home/report/ReportActionItemMessage.js
@@ -22,7 +22,7 @@ const propTypes = {
 };
 
 const ReportActionItemMessage = (props) => {
-    const isUnsent = props.network.isOffline && props.action.isPending;
+    const isUnsent = props.network.isOffline && props.action.isLoading;
 
     return (
         <View style={[styles.chatItemMessage, isUnsent && styles.chatItemUnsentMessage]}>
@@ -32,7 +32,7 @@ const ReportActionItemMessage = (props) => {
                     fragment={fragment}
                     isAttachment={props.action.isAttachment}
                     attachmentInfo={props.action.attachmentInfo}
-                    loading={props.action.isPending}
+                    loading={props.action.isLoading}
                 />
             ))}
         </View>

--- a/src/pages/home/report/ReportActionItemSingle.js
+++ b/src/pages/home/report/ReportActionItemSingle.js
@@ -92,7 +92,7 @@ const ReportActionItemSingle = (props) => {
                                     fragment={fragment}
                                     tooltipText={props.action.actorEmail}
                                     isAttachment={props.action.isAttachment}
-                                    isLoading={props.action.loading}
+                                    isLoading={props.action.isPending}
                                     isSingleLine
                                 />
                             ))}

--- a/src/pages/home/report/ReportActionItemSingle.js
+++ b/src/pages/home/report/ReportActionItemSingle.js
@@ -92,7 +92,7 @@ const ReportActionItemSingle = (props) => {
                                     fragment={fragment}
                                     tooltipText={props.action.actorEmail}
                                     isAttachment={props.action.isAttachment}
-                                    isLoading={props.action.isPending}
+                                    isLoading={props.action.isLoading}
                                     isSingleLine
                                 />
                             ))}

--- a/src/pages/home/report/reportActionPropTypes.js
+++ b/src/pages/home/report/reportActionPropTypes.js
@@ -25,7 +25,7 @@ export default {
     }),
 
     /** Whether we have received a response back from the server */
-    isPending: PropTypes.bool,
+    isLoading: PropTypes.bool,
 
     /** Error message that's come back from the server. */
     error: PropTypes.string,

--- a/src/pages/home/report/reportActionPropTypes.js
+++ b/src/pages/home/report/reportActionPropTypes.js
@@ -24,8 +24,7 @@ export default {
         IOUTransactionID: PropTypes.string,
     }),
 
-    /** If the reportAction is pending, that means we have not yet sent the Report_AddComment command to the server.
-    This should most often occur when the client is offline. */
+    /** Whether we have received a response back from the server */
     isPending: PropTypes.bool,
 
     /** Error message that's come back from the server. */

--- a/src/styles/StyleUtils.js
+++ b/src/styles/StyleUtils.js
@@ -387,10 +387,10 @@ function getLoginPagePromoStyle() {
  * Generate the styles for the ReportActionItem wrapper view.
  *
  * @param {Boolean} [isHovered]
- * @param {Boolean} [isPending]
+ * @param {Boolean} [isLoading]
  * @returns {Object}
  */
-function getReportActionItemStyle(isHovered = false, isPending = false) {
+function getReportActionItemStyle(isHovered = false, isLoading = false) {
     return {
         display: 'flex',
         justifyContent: 'space-between',
@@ -399,7 +399,7 @@ function getReportActionItemStyle(isHovered = false, isPending = false) {
 
             // Warning: Setting this to a non-transparent color will cause unread indicator to break on Android
             : colors.transparent,
-        opacity: isPending ? 0.5 : 1,
+        opacity: isLoading ? 0.5 : 1,
         cursor: 'default',
     };
 }

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1802,6 +1802,10 @@ const styles = {
         ...{borderRadius: variables.componentBorderRadiusSmall},
     },
 
+    reportActionSystemMessageContainer: {
+        marginLeft: 42,
+    },
+
     reportDetailsTitleContainer: {
         ...flex.dFlex,
         ...flex.flexColumn,
@@ -2530,7 +2534,7 @@ const styles = {
         color: themeColors.textSupporting,
         fontSize: variables.fontSizeLabel,
         fontFamily: fontFamily.GTA,
-        marginLeft: 4,
+        marginLeft: 6,
     },
 };
 

--- a/src/styles/utilities/spacing.js
+++ b/src/styles/utilities/spacing.js
@@ -117,10 +117,6 @@ export default {
         marginLeft: 32,
     },
 
-    ml10: {
-        marginLeft: 40,
-    },
-
     mln5: {
         marginLeft: -20,
     },

--- a/src/styles/utilities/spacing.js
+++ b/src/styles/utilities/spacing.js
@@ -117,6 +117,10 @@ export default {
         marginLeft: 32,
     },
 
+    ml10: {
+        marginLeft: 40,
+    },
+
     mln5: {
         marginLeft: -20,
     },

--- a/tests/README.md
+++ b/tests/README.md
@@ -60,7 +60,7 @@ describe('actions/Report', () => {
         }));
 
         // When we add a new action to that report
-        Report.createComment(REPORT_ID, 'Hello!');
+        Report.addComment(REPORT_ID, 'Hello!');
         return waitForPromisesToResolve()
             .then(() => {
                 const action = reportActions[ACTION_ID];

--- a/tests/README.md
+++ b/tests/README.md
@@ -69,7 +69,7 @@ describe('actions/Report', () => {
                 // the comment we left and it will be in a loading state because
                 // it's an "optimistic comment"
                 expect(action.message[0].text).toBe('Hello!');
-                expect(action.loading).toBe(true);
+                expect(action.isPending).toBe(true);
             });
     });
 });

--- a/tests/README.md
+++ b/tests/README.md
@@ -60,7 +60,7 @@ describe('actions/Report', () => {
         }));
 
         // When we add a new action to that report
-        addAction(REPORT_ID, 'Hello!');
+        Report.createComment(REPORT_ID, 'Hello!');
         return waitForPromisesToResolve()
             .then(() => {
                 const action = reportActions[ACTION_ID];

--- a/tests/actions/ReportTest.js
+++ b/tests/actions/ReportTest.js
@@ -101,7 +101,7 @@ describe('actions/Report', () => {
                 clientID = resultAction.sequenceNumber;
                 expect(resultAction.message).toEqual(REPORT_ACTION.message);
                 expect(resultAction.person).toEqual(REPORT_ACTION.person);
-                expect(resultAction.isPending).toEqual(true);
+                expect(resultAction.isLoading).toEqual(true);
 
                 // We subscribed to the Pusher channel above and now we need to simulate a reportComment action
                 // Pusher event so we can verify that action was handled correctly and merged into the reportActions.
@@ -141,7 +141,7 @@ describe('actions/Report', () => {
                 const resultAction = reportActions[ACTION_ID];
 
                 // Verify that our action is no longer in the loading state
-                expect(resultAction.isPending).not.toBeDefined();
+                expect(resultAction.isLoading).not.toBeDefined();
             });
     });
 

--- a/tests/actions/ReportTest.js
+++ b/tests/actions/ReportTest.js
@@ -101,7 +101,7 @@ describe('actions/Report', () => {
                 clientID = resultAction.sequenceNumber;
                 expect(resultAction.message).toEqual(REPORT_ACTION.message);
                 expect(resultAction.person).toEqual(REPORT_ACTION.person);
-                expect(resultAction.loading).toEqual(true);
+                expect(resultAction.isPending).toEqual(true);
 
                 // We subscribed to the Pusher channel above and now we need to simulate a reportComment action
                 // Pusher event so we can verify that action was handled correctly and merged into the reportActions.
@@ -141,7 +141,7 @@ describe('actions/Report', () => {
                 const resultAction = reportActions[ACTION_ID];
 
                 // Verify that our action is no longer in the loading state
-                expect(resultAction.loading).not.toBeDefined();
+                expect(resultAction.isPending).not.toBeDefined();
             });
     });
 

--- a/tests/actions/ReportTest.js
+++ b/tests/actions/ReportTest.js
@@ -91,7 +91,7 @@ describe('actions/Report', () => {
             .then(() => {
                 // This is a fire and forget response, but once it completes we should be able to verify that we
                 // have an "optimistic" report action in Onyx.
-                Report.createComment(REPORT_ID, 'Testing a comment');
+                Report.addComment(REPORT_ID, 'Testing a comment');
                 return waitForPromisesToResolve();
             })
             .then(() => {
@@ -197,7 +197,7 @@ describe('actions/Report', () => {
                 }
 
                 // And leave a comment on a report
-                Report.createComment(REPORT_ID, 'Testing a comment');
+                Report.addComment(REPORT_ID, 'Testing a comment');
 
                 // Then we should expect that there is on persisted request
                 expect(PersistedRequests.getAll().length).toBe(1);
@@ -208,8 +208,8 @@ describe('actions/Report', () => {
             .then(() => {
                 // THEN only ONE call to AddComment will happen
                 const URL_ARGUMENT_INDEX = 0;
-                const createCommentCalls = _.filter(global.fetch.mock.calls, callArguments => callArguments[URL_ARGUMENT_INDEX].includes('CreateComment'));
-                expect(createCommentCalls.length).toBe(1);
+                const addCommentCalls = _.filter(global.fetch.mock.calls, callArguments => callArguments[URL_ARGUMENT_INDEX].includes('AddComment'));
+                expect(addCommentCalls.length).toBe(1);
             });
     });
 });

--- a/tests/actions/ReportTest.js
+++ b/tests/actions/ReportTest.js
@@ -208,8 +208,8 @@ describe('actions/Report', () => {
             .then(() => {
                 // THEN only ONE call to AddComment will happen
                 const URL_ARGUMENT_INDEX = 0;
-                const reportAddCommentCalls = _.filter(global.fetch.mock.calls, callArguments => callArguments[URL_ARGUMENT_INDEX].includes('AddComment'));
-                expect(reportAddCommentCalls.length).toBe(1);
+                const createCommentCalls = _.filter(global.fetch.mock.calls, callArguments => callArguments[URL_ARGUMENT_INDEX].includes('CreateComment'));
+                expect(createCommentCalls.length).toBe(1);
             });
     });
 });

--- a/tests/actions/ReportTest.js
+++ b/tests/actions/ReportTest.js
@@ -91,7 +91,7 @@ describe('actions/Report', () => {
             .then(() => {
                 // This is a fire and forget response, but once it completes we should be able to verify that we
                 // have an "optimistic" report action in Onyx.
-                Report.addAction(REPORT_ID, 'Testing a comment');
+                Report.createComment(REPORT_ID, 'Testing a comment');
                 return waitForPromisesToResolve();
             })
             .then(() => {
@@ -197,7 +197,7 @@ describe('actions/Report', () => {
                 }
 
                 // And leave a comment on a report
-                Report.addAction(REPORT_ID, 'Testing a comment');
+                Report.createComment(REPORT_ID, 'Testing a comment');
 
                 // Then we should expect that there is on persisted request
                 expect(PersistedRequests.getAll().length).toBe(1);


### PR DESCRIPTION
### Details

This PR:

- Remove the `reportComment` Pusher subscriptions (`updateReportWithNewAction()` remains and is used in the Urban Airship notification as I'm not sure how we are handling "onyx updates" there yet)
- Updates `DeprecatedAPI.Report_AddComment()` to `API.write('AddComment')`

To minimize changes I decided to keep the "attachment" and "comment" flows together for now.

Test in connection with: https://github.com/Expensify/Web-Expensify/pull/33951

### Fixed Issues (Related to
https://github.com/Expensify/Expensify/issues/211241

### Tests 

Same as QA but with an additional test to verify that users blocked by Concierge will see an error message inline.

**Test Blocked from Concierge**

1. Log in with a test user account
2. Begin chatting with Concierge
3. Sign into OldDot with your local expensify.com account
4. Block the test user via Concierge
![2022-06-23_08-29-17](https://user-images.githubusercontent.com/32969087/175369509-420c710b-80cd-44ea-b9e5-72b5873abdcf.png)
5. Send a message from the user account to Concierge DM
6. Verify an inline message appears and the chat composer is disabled
<img width="947" alt="2022-06-23_08-29-56" src="https://user-images.githubusercontent.com/32969087/175369629-cf7a3f9c-dc90-4bba-9f07-470634e8de8a.png">

### QA Steps

**Testing a report comment is sent in realtime**

1. Create two accounts and a chat between them. Open a new NewDot window in a new Chrome session (do not use incognito mode).
8. Send messages back and forth from each account to the other in a DM chat
9. Verify they appear in realtime

**Testing a report comment browser notification appears when the chat is not active (web)**

1. Create two accounts and a chat between them. Open a new NewDot window in a new Chrome session (do not use incognito mode).
2. Send message from Account A to Account B while Account B is focused on another chat
3. Verify a browser notification appears for Account B

**Testing a report comment is queued while offline and sent when online again**

1. Create two accounts and a chat between them. Open a new NewDot window in a new Chrome session (do not use incognito mode).
2. Send message from Account A to Account B while Account A is "offline"
3. Verify Account A sees the message in a grey "pending" state
10. Bring Account A back online
11. Verify the message darkens to indicate it was created.
12. Verify Account B can also see the message now

**Add an attachment**

1. Create two accounts and a chat between them. Open a new NewDot window in a new Chrome session (do not use incognito mode).
2. Add an attachment to the chat between these two users.
3. Verify the attachment appears in realtime for the other user (**Note:** it may take some time for it to upload - this is normal).


**Add an attachment (offline)**

1. Create two accounts and a chat between them. Open a new NewDot window in a new Chrome session (do not use incognito mode).
2. Add an attachment to the chat between these two users while offline.
3. Verify the attachment appears greyed to indicate that it is pending.
4. Bring the user online.
5. Verify the attachment darkens to indicate it is created
3. Verify the attachment appears in realtime for the other user

**Add attachment with text**

1. Create two accounts and a chat between them. Open a new NewDot window in a new Chrome session (do not use incognito mode).
2. Add an attachment to the chat between these two users while there is text in the composer.
3. Verify the attachment and text appears in realtime for the other user.

- [ ] Verify that no errors appear in the JS console

### PR Review Checklist
<!--
This is a checklist for PR authors & reviewers. Please make sure to complete all tasks and check them off once you do, or else Expensify has the right not to merge your PR!
-->
#### Contributor (PR Author) Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [x] I verified there are no console errors (if there’s a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained “why” the code was doing something instead of only explaining “what” the code was doing.
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [ ] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named “index.js”. All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] Any functional components have the `displayName` property
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose and it is
- [x] If a new CSS style is added I verified that:
    - [ ] A similar style doesn’t already exist
    - [ ] The style can’t be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.


<details>
<summary><h4>PR Reviewer Checklist</h4></summary>

- [ ] I verified the correct issue is linked in the `### Fixed Issues` section above
- [ ] I verified testing steps are clear and they cover the changes made in this PR
    - [ ] I verified the steps for local testing are in the `Tests` section
    - [ ] I verified the steps for Staging and/or Production testing are in the `QA steps` section
    - [ ] I verified the steps cover any possible failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [ ] I checked that screenshots or videos are included for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I verified tests pass on **all platforms** & I tested again on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [ ] I verified there are no console errors (if there’s a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`).
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained “why” the code was doing something instead of only explaining “what” the code was doing.
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [ ] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named “index.js”. All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I verified that this PR follows the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] Any functional components have the `displayName` property
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose and it is broken down into smaller components in order to separate concerns and functions
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn’t already exist
    - [ ] The style can’t be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.

</details>

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web

<img width="375" alt="2022-06-23_08-36-00" src="https://user-images.githubusercontent.com/32969087/175371694-7489f749-a2b3-4542-bca5-e922f6b64599.png">

#### Mobile Web

<img width="399" alt="2022-07-05_06-56-53" src="https://user-images.githubusercontent.com/32969087/177378872-08e6f2bd-d448-4152-b758-efc07b82d972.png">

#### Desktop

<img width="1200" alt="2022-07-05_07-01-39" src="https://user-images.githubusercontent.com/32969087/177379496-0c103a91-e1b9-4fc0-ba8f-c58b250da1b3.png">

#### iOS

![2022-07-05_06-47-18](https://user-images.githubusercontent.com/32969087/177377694-dd5df432-c413-4524-bd30-3574068a8937.png)
<img width="399" alt="2022-07-05_06-50-42" src="https://user-images.githubusercontent.com/32969087/177377707-4fcf62bf-2d27-46cb-a6ac-f385c2303845.png">

#### Android
![2022-07-05_07-39-42](https://user-images.githubusercontent.com/32969087/177385112-79dc691d-433a-46b0-8868-513933f3dd54.png)

