### PR TITLE
Temp PR to test the fix for smart banner on iOS - Issue #8791

### DIFF
--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1929,6 +1929,11 @@ const styles = {
     navigationScreenCardStyle: {
         backgroundColor: themeColors.appBG,
         height: '100%',
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
     },
 
     navigationSceneFullScreenWrapper: {


### PR DESCRIPTION
Since the iOS Smart banner can't be shown while running the site locally, creating this PR so that my fix can be verified on staging.

Reference: [#8791 (comment)](https://github.com/Expensify/App/issues/8791#issuecomment-1153917051)

@AndrewGable