### PR TITLE
Do not append & to internal Expenisfy URLs that have a # symbol.

### DIFF
--- a/src/libs/actions/Link.js
+++ b/src/libs/actions/Link.js
@@ -39,7 +39,11 @@ function openOldDotLink(url) {
     }
 
     function buildOldDotURL({shortLivedAuthToken}) {
-        return `${CONFIG.EXPENSIFY.EXPENSIFY_URL}${url}${url.indexOf('?') === -1 ? '?' : '&'}authToken=${shortLivedAuthToken}&email=${encodeURIComponent(currentUserEmail)}`;
+        const hasHashParams = url.indexOf('#') !== -1;
+        const hasURLParams = url.indexOf('?') !== -1;
+
+        // If the URL contains # or ?, we can assume they don't need to have the `?` token to start listing url parameters.
+        return `${CONFIG.EXPENSIFY.EXPENSIFY_URL}${url}${hasHashParams || hasURLParams ? '&' : '?'}authToken=${shortLivedAuthToken}&email=${encodeURIComponent(currentUserEmail)}`;
     }
 
     asyncOpenURL(DeprecatedAPI.GetShortLivedAuthToken(), buildOldDotURL);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Some internal links use hash params which don't expect `?` in the URL. Instead they should be continued via `&` so this will fix the issue of some internal links appending data like the token to data fields rather than as a new param.

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ 

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/9416

### Tests 

## IF TESTING ON STAGING REPLACE `www` WITH `staging` IN THE URL

1. Send a message with the following contents:
https://www.expensify.com/api.php
https://www.expensify.com/api.php?test=1
https://www.expensify.com/api.php#123
https://www.expensify.com/_devportal/tools/logSearch/#sort=asc&size=10000&query=blob%3A%22Expensiworks_CaptureAgentActivity%22%20AND%20blob%3A%22isDoneWorking%3A%20'true'%22%20AND%20email%3A%22monte%40expensify.com%22%20AND%20timestamp%3A%5B2022-05-25T12%3A00%20TO%202022-05-25T14%3A00%5D

2. See that clicking each will result in the following in the end-point URL
> https://www.expensify.com/api.php

AuthToken is appended with `?authToken=`

> https://www.expensify.com/api.php?test=1

AuthToken is appended with `&authToken=`

> https://www.expensify.com/api.php#123

AuthToken is appended with `&authToken=`

> https://www.expensify.com/_devportal/tools/logSearch/#sort=asc&size=10000&query=blob%3A%22Expensiworks_CaptureAgentActivity%22%20AND%20blob%3A%22isDoneWorking%3A%20'true'%22%20AND%20email%3A%22monte%40expensify.com%22%20AND%20timestamp%3A%5B2022-05-25T12%3A00%20TO%202022-05-25T14%3A00%5D

AuthToken is appended with `&authToken=` as is not part of the log request

- [X] Verify that no errors appear in the JS console

### Screenshots
#### Web
https://user-images.githubusercontent.com/5258036/173607237-4fa6954d-7d3a-459b-ab20-73d290b11e15.mov

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
