### PR TITLE
[No QA] Fix mobile transitions for some emails

### DIFF
--- a/src/libs/SessionUtils.js
+++ b/src/libs/SessionUtils.js
@@ -16,11 +16,18 @@ function isLoggingInAsNewUser(transitionURL, sessionEmail) {
     const params = new URLSearchParams(transitionURL);
     const paramsEmail = params.get('email');
 
+    // If the email param matches what is stored in the session then we are
+    // definitely not logging in as a new user
+    if (paramsEmail === sessionEmail) {
+        return false;
+    }
+
+    // If they do not match it might be due to encoding, so check the raw value
     // Capture the un-encoded text in the email param
     const emailParamRegex = /[?&]email=([^&]*)/g;
     const matches = emailParamRegex.exec(transitionURL);
     const linkedEmail = lodashGet(matches, 1, null);
-    return paramsEmail !== sessionEmail && linkedEmail !== sessionEmail;
+    return linkedEmail !== sessionEmail;
 }
 
 export {

--- a/src/libs/SessionUtils.js
+++ b/src/libs/SessionUtils.js
@@ -1,0 +1,29 @@
+import lodashGet from 'lodash/get';
+
+/**
+ * Determine if the transitioning user is logging in as a new user.
+ *
+ * @param {String} transitionURL
+ * @param {String} sessionEmail
+ * @returns {Boolean}
+ */
+function isLoggingInAsNewUser(transitionURL, sessionEmail) {
+    // The OldDot mobile app does not URL encode the parameters, but OldDot web
+    // does. We don't want to deploy OldDot mobile again, so as a work around we
+    // compare both the raw and decoded email from the transition link. If both don't match
+    // the session email, then we are logging in as a new user.
+    // See https://github.com/Expensify/Mobile-Expensify/pull/12280#issuecomment-1155633503
+    const params = new URLSearchParams(transitionURL);
+    const paramsEmail = params.get('email');
+
+    // Capture the un-encoded text in the email param
+    const emailParamRegex = /[?&]email=([^&]*)/g;
+    const matches = emailParamRegex.exec(transitionURL);
+    const linkedEmail = lodashGet(matches, 1, null);
+    return paramsEmail !== sessionEmail && linkedEmail !== sessionEmail;
+}
+
+export {
+    // eslint-disable-next-line import/prefer-default-export
+    isLoggingInAsNewUser,
+};

--- a/src/libs/SessionUtils.js
+++ b/src/libs/SessionUtils.js
@@ -10,9 +10,7 @@ import lodashGet from 'lodash/get';
 function isLoggingInAsNewUser(transitionURL, sessionEmail) {
     // The OldDot mobile app does not URL encode the parameters, but OldDot web
     // does. We don't want to deploy OldDot mobile again, so as a work around we
-    // compare both the raw and decoded email from the transition link. If both don't match
-    // the session email, then we are logging in as a new user.
-    // See https://github.com/Expensify/Mobile-Expensify/pull/12280#issuecomment-1155633503
+    // compare the session email to both the decoded and raw email from the transition link.
     const params = new URLSearchParams(transitionURL);
     const paramsEmail = params.get('email');
 

--- a/src/libs/actions/App.js
+++ b/src/libs/actions/App.js
@@ -18,6 +18,7 @@ import * as Policy from './Policy';
 import NetworkConnection from '../NetworkConnection';
 import Navigation from '../Navigation/Navigation';
 import ROUTES from '../../ROUTES';
+import * as SessionUtils from '../SessionUtils';
 
 let currentUserAccountID;
 Onyx.connect({
@@ -171,8 +172,7 @@ function setUpPoliciesAndNavigate(session) {
             const path = new URL(url).pathname;
             const params = new URLSearchParams(url);
             const exitTo = params.get('exitTo');
-            const email = params.get('email');
-            const isLoggingInAsNewUser = session.email !== email;
+            const isLoggingInAsNewUser = SessionUtils.isLoggingInAsNewUser(url, session.email);
             const shouldCreateFreePolicy = !isLoggingInAsNewUser
                         && Str.startsWith(path, Str.normalizeUrl(ROUTES.TRANSITION_FROM_OLD_DOT))
                         && exitTo === ROUTES.WORKSPACE_NEW;

--- a/src/pages/LogOutPreviousUserPage.js
+++ b/src/pages/LogOutPreviousUserPage.js
@@ -1,4 +1,5 @@
 import React, {Component} from 'react';
+import {Linking} from 'react-native';
 import lodashGet from 'lodash/get';
 import PropTypes from 'prop-types';
 import {withOnyx} from 'react-native-onyx';
@@ -6,17 +7,9 @@ import ONYXKEYS from '../ONYXKEYS';
 import * as Session from '../libs/actions/Session';
 import FullScreenLoadingIndicator from '../components/FullscreenLoadingIndicator';
 import Navigation from '../libs/Navigation/Navigation';
+import * as SessionUtils from '../libs/SessionUtils';
 
 const propTypes = {
-    /** The parameters needed to authenticate with a short lived token are in the URL */
-    route: PropTypes.shape({
-        /** Each parameter passed via the URL */
-        params: PropTypes.shape({
-            /** The email of the transitioning user */
-            email: PropTypes.string,
-        }),
-    }).isRequired,
-
     /** The data about the current session which will be set once the user is authenticated and we return to this component as an AuthScreen */
     session: PropTypes.shape({
         /** The user's email for the current session */
@@ -26,20 +19,23 @@ const propTypes = {
 
 class LogOutPreviousUserPage extends Component {
     componentDidMount() {
-        const paramsEmail = lodashGet(this.props.route, 'params.email', null);
-        const sessionEmail = lodashGet(this.props.session, 'email', '');
-        if (paramsEmail !== sessionEmail) {
-            Session.signOutAndRedirectToSignIn();
-            return;
-        }
+        Linking.getInitialURL()
+            .then((transitionURL) => {
+                const sessionEmail = lodashGet(this.props.session, 'email', '');
+                const isLoggingInAsNewUser = SessionUtils.isLoggingInAsNewUser(transitionURL, sessionEmail);
+                if (isLoggingInAsNewUser) {
+                    Session.signOutAndRedirectToSignIn();
+                    return;
+                }
 
-        // Since we conditionally render navigators in the AppNavigator, when we
-        // sign out and sign back in there will be a moment where no navigator
-        // is rendered and the navigation state is null. We can't navigate at
-        // that time, so we use a promise to delay transition navigation until
-        // it is ready. We set the navigation ready here since we know that the
-        // navigator is now rendered.
-        Navigation.setIsNavigationReady();
+                // Since we conditionally render navigators in the AppNavigator, when we
+                // sign out and sign back in there will be a moment where no navigator
+                // is rendered and the navigation state is null. We can't navigate at
+                // that time, so we use a promise to delay transition navigation until
+                // it is ready. We set the navigation ready here since we know that the
+                // navigator is now rendered.
+                Navigation.setIsNavigationReady();
+            });
     }
 
     render() {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
OldDot mobile does not encode URL parameters for the transition link. We can't fix it on OldDot mobile because we don't deploy it anymore, so this PR is a work around. 

When determining if the transitioning user is logged in we compare the email in the URL param to the session email, and we also compare it to the un-encoded email extracted from the link with a regex. If both of those do not match, then we know that a new user is logging in.

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/9426

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

Check out the Web-Expensify branch [neil-test-mobile-transition](https://github.com/Expensify/Web-Expensify/tree/neil-test-mobile-transition) which creates the transition link without encoding the URL params like OldDot mobile.

1. Make sure you are signed out of NewDot
2. Go to OldDot and sign in to an account that includes a `+` in the email E.x `neil+test@gmail.com`
3. Go to Settings > Policies > Group and note the number of free policies (or delete all of them)
4. Click New Policy in the top right
5. Click select on the free plan
6. You should be directed to NewDot and have a new workspace created
7. Hit the back button next to "Workspace" and verify that 1 additional workspace was created
8. Repeat steps 2-7 to test the case where you are signed in to the same account on NewDot
9. Sign in to a different account on OldDot
10. Repeat steps 3-7 to test the case where you are signed in to a different account on NewDot

Checkout Web-Expensify branch `main`
1. Run the transition tests for at least flows B and D described [here](https://github.com/Expensify/Expensify/issues/214321) with an email that includes a `+`.

- [ ] Verify that no errors appear in the JS console

### PR Review Checklist
<!--
This is a checklist for PR authors & reviewers. Please make sure to complete all tasks and check them off once you do, or else Expensify has the right not to merge your PR!
-->
#### Contributor (PR Author) Checklist
- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [ ] I verified there are no console errors (if there’s a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained “why” the code was doing something instead of only explaining “what” the code was doing.
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [ ] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named “index.js”. All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] Any functional components have the `displayName` property
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose and it is
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn’t already exist
    - [ ] The style can’t be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.


<details>
<summary><h4>PR Reviewer Checklist</h4></summary>

- [ ] I verified the correct issue is linked in the `### Fixed Issues` section above
- [ ] I verified testing steps are clear and they cover the changes made in this PR
    - [ ] I verified the steps for local testing are in the `Tests` section
    - [ ] I verified the steps for Staging and/or Production testing are in the `QA steps` section
    - [ ] I verified the steps cover any possible failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [ ] I checked that screenshots or videos are included for tests on [all platforms](https://github.com/Expensify/App/blob/main/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I verified tests pass on **all platforms** & I tested again on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [ ] I verified there are no console errors (if there’s a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`).
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained “why” the code was doing something instead of only explaining “what” the code was doing.
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [ ] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named “index.js”. All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I verified that this PR follows the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/PR_REVIEW_GUIDELINES.md)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] Any functional components have the `displayName` property
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose and it is broken down into smaller components in order to separate concerns and functions
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn’t already exist
    - [ ] The style can’t be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.

</details>

### Production QA / Regression Tests
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Test the OldDot mobile app flows:

**A. Get started inbox task**

1. Make sure you are signed out of NewDot on mobile web
2. Go to the OldDot mobile app and sign up for a new account with a `+` in it and @gmail.com. E.x `neil+test@gmail.com`
3. Click on the "Get started" on the inbox task that says "Would you like to get started with our free plan?".
4. You should be directed to NewDot on mobile web and have a new workspace created, and the workspace settings should open.
5. Hit the back button next to "Workspace" and verify that 1 workspace was created
6. Repeat steps 2-5 to test the case where you are signed in to a different account on NewDot

**B. Edit a free policy**
1. Make sure you are signed out of NewDot on mobile web
2. Go to the OldDot mobile app and sign into an account that has a free policy / workspace **and** includes a `+` in the email E.x `neil+test@gmail.com`
3. Click the hamburger menu (3 horizontal lines) in the upper left hand corner to open the side navigation bar
4. Click on "Settings"
5. Scroll down to the "Policies" section
6. Click "View all" at the right on the first policy shown
7. Select the "Group" tab
8. Click "Edit" on a workspace
9. NewDot should open on mobile web and your workspace settings should open.
10. Repeat step 8 to test the case where you are signed into the same account on NewDot
12. Go to the OldDot mobile app and sign into a **different** account that has a free policy / workspace
13. Repeat steps 3-9 to test the case where you are signed in to a different account on NewDot

- [ ] Verify that no errors appear in the JS console

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->
N/A