### PR TITLE
Get the notification preference for all report types

### DIFF
--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -167,9 +167,7 @@ function getSimplifiedReportObject(report) {
     const oldPolicyName = lodashGet(report, ['reportNameValuePairs', 'oldPolicyName'], '');
 
     const lastActorEmail = lodashGet(report, 'lastActionActorEmail', '');
-    const notificationPreference = ReportUtils.isChatRoom({chatType})
-        ? lodashGet(report, ['reportNameValuePairs', 'notificationPreferences', currentUserAccountID], 'daily')
-        : '';
+    const notificationPreference = lodashGet(report, ['reportNameValuePairs', 'notificationPreferences', currentUserAccountID], 'daily');
 
     // Used for User Created Policy Rooms, will denote how access to a chat room is given among workspace members
     const visibility = lodashGet(report, ['reportNameValuePairs', 'visibility']);


### PR DESCRIPTION
- [x] Held on https://github.com/Expensify/Web-Expensify/pull/34064

### Fixed Issues
$ https://github.com/Expensify/App/issues/9511 

### Tests
1. Be on the `policyExpenseChat` beta
1. Open a `policy expense` chat
2. Go to the report settings by clicking the report header
3. Change the notification preference to something that isn't `immediate`
4. Go to a different chat
5. Refresh the page
6. Go back to the policy expense chat
7. Go to the chat settings
8. Verify that the notification preference is what you set it to above

- [ ] Verify that no errors appear in the JS console

### QA Steps
Same as above. Not sure if you have access to that beta though? If not, please reach out and ask for access.

- [ ] Verify that no errors appear in the JS console

### Screenshots
I'm only including a video for web since this is all backend changes, there is no chance for a platform-specific regression

#### Web

https://user-images.githubusercontent.com/1228807/174844247-e5c560c2-b9bd-4370-9283-7b1ad749262d.mp4