### PR TITLE
[No QA] Run lint and test jobs in parallel

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,14 +1,14 @@
 name: Lint JavaScript
 
 on:
-  workflow_dispatch:
+  workflow_call:
   pull_request:
     types: [opened, synchronize]
     branches-ignore: [staging, production]
 
 jobs:
   lint:
-    if: ${{ github.actor != 'OSBotify' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.actor != 'OSBotify' || github.event_name == 'workflow_call' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -14,6 +14,7 @@ jobs:
   confirmPassingBuild:
     runs-on: ubuntu-latest
     needs: [lint, test]
+    if: ${{ always() && (needs.lint.result == 'failure' || needs.test.result == 'failure') }}
 
     steps:
       # This Slack step is duplicated in all workflows, if you make a change to this step, make sure to update all

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -8,18 +8,14 @@ jobs:
   lint:
     uses: ./.github/workflows/lint.yml
 
+  test:
+    uses: ./.github/workflows/test.yml
+
   confirmPassingBuild:
     runs-on: ubuntu-latest
-    needs: lint
+    needs: [lint, test]
 
     steps:
-      - name: Run tests
-        id: tests
-        uses: Expensify/App/.github/actions/triggerWorkflowAndWait@main
-        with:
-          WORKFLOW: test.yml
-          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
-
       # This Slack step is duplicated in all workflows, if you make a change to this step, make sure to update all
       # the other workflows with the same change
       - uses: 8398a7/action-slack@v3

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -5,17 +5,14 @@ on:
     branches: [main]
 
 jobs:
+  lint:
+    uses: ./.github/workflows/lint.yml
+
   confirmPassingBuild:
     runs-on: ubuntu-latest
+    needs: lint
 
     steps:
-      - name: Run lint
-        id: lint
-        uses: Expensify/App/.github/actions/triggerWorkflowAndWait@main
-        with:
-          WORKFLOW: lint.yml
-          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
-
       - name: Run tests
         id: tests
         uses: Expensify/App/.github/actions/triggerWorkflowAndWait@main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,14 +1,14 @@
 name: Jest Unit Tests
 
 on:
-  workflow_dispatch:
+  workflow_call:
   pull_request:
     types: [opened, synchronize]
     branches-ignore: [staging, production]
 
 jobs:
   test:
-    if: ${{ github.actor != 'OSBotify' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.actor != 'OSBotify' || github.event_name == 'workflow_call' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
### Details
This PR uses a new(ish) GitHub Actions features: [reusable workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows). Before we had a hacky workaround in place – a custom action called `triggerWorkflowAndWait`. By using the native feature we get a better dependency graph, more concise and transparent workflow syntax, and also get to run multiple reusable workflows in parallel, if we want.

### Fixed Issues
$ n/a, doing some exploratory/prep work for https://github.com/Expensify/Expensify/issues/195693

### Tests
Did some testing over in https://github.com/Andrew-Test-Org/Public-Test-Repo/pull/300.

### QA Steps
1. Merge this PR, the `preDeploy` workflow should run lint and test in parallel.
1. Merge another PR with purposely failing lint.
1. We should get alerted in slack that the preDeploy workflow failed.
1. Merge another PR to revert the purposely failing lint.
