### PR TITLE
[No QA] Add documentation about error onyx best practice under API.md

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -43,7 +43,7 @@ The data will automatically be sent to the user via Pusher.
 #### WRITE Response Errors
 When there is an error on a WRITE response (`jsonCode!==200`), the error must come back to the client on the HTTPS response. The error is only relevant to the client that made the request and it wouldn't make sense to send it out to all connected clients.
 
-Error messages should be returned and stored as a String under the `error` property. If absoultely needed, additional error properties can be stored under other, more specific fields that sit at the same level as `error`:
+Error messages should be returned and stored as a String under the `error` property. If absolutely needed, additional error properties can be stored under other, more specific fields that sit at the same level as `error`:
 ```php
 [
     'onyxMethod' => Onyx::METHOD_MERGE,

--- a/docs/API.md
+++ b/docs/API.md
@@ -46,7 +46,7 @@ When there is an error on a WRITE response (`jsonCode!==200`), the error must co
 Error messages should be returned and stored as a String under the `error` property. If absoultely needed, additional error properties can be stored under other, more specific fields that sit at the same level as `error`:
 ```php
 [
-    'onyxMethod' => 'merge',
+    'onyxMethod' => Onyx::METHOD_MERGE,
     'key' => OnyxKeys::WALLET_ADDITIONAL_DETAILS,
     'value' => [
         'error' => 'We\'re having trouble verifying your SSN. Please enter the full 9 digits of your SSN.',

--- a/docs/API.md
+++ b/docs/API.md
@@ -42,6 +42,19 @@ The data will automatically be sent to the user via Pusher.
 
 #### WRITE Response Errors
 When there is an error on a WRITE response (`jsonCode!==200`), the error must come back to the client on the HTTPS response. The error is only relevant to the client that made the request and it wouldn't make sense to send it out to all connected clients.
+
+Error messages should be returned and stored as a String under the `error` property. If absoultely needed, additional error properties can be stored under other, more specific fields that sit at the same level as `error`:
+```
+[
+    'onyxMethod' => 'merge',
+    'key' => OnyxKeys::WALLET_ADDITIONAL_DETAILS,
+    'value' => [
+        'error' => 'We\'re having trouble verifying your SSN. Please enter the full 9 digits of your SSN.',
+        'errorCode' => 'ssnError'
+    ],
+]
+```
+
 ### Hybrid READ/WRITE Responses
 There are some commands which might technically be a READ and a WRITE.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -44,7 +44,7 @@ The data will automatically be sent to the user via Pusher.
 When there is an error on a WRITE response (`jsonCode!==200`), the error must come back to the client on the HTTPS response. The error is only relevant to the client that made the request and it wouldn't make sense to send it out to all connected clients.
 
 Error messages should be returned and stored as a String under the `error` property. If absoultely needed, additional error properties can be stored under other, more specific fields that sit at the same level as `error`:
-```
+```php
 [
     'onyxMethod' => 'merge',
     'key' => OnyxKeys::WALLET_ADDITIONAL_DETAILS,


### PR DESCRIPTION
Pullerbearing (@neil-marcellini)
cc @nkuoch @marcaaron @tgolen @iwiznia @Julesssss @MariaHCD @aldo-expensify @luacmartins 

### Details
Adding what was discussed in [this thread](https://expensify.slack.com/archives/C02HWMSMZEC/p1655291987616659) about errors returned and stored in Onyx being stored under `error`

### Fixed Issues
None

### Tests
None