### PR TITLE
[No QA] Pass secret as input to compound action

### DIFF
--- a/.github/actions/composite/announceFailedWorkflowInSlack/action.yml
+++ b/.github/actions/composite/announceFailedWorkflowInSlack/action.yml
@@ -1,5 +1,11 @@
 name: 'Announce failed workflow in Slack'
 description: 'Post failed workflow in Slack #announce channel'
+
+inputs:
+  SLACK_WEBHOOK:
+    description: 'URL of the slack webhook'
+    required: true
+
 runs:
   using: composite
   steps:
@@ -19,4 +25,4 @@ runs:
           }
       env:
         GITHUB_TOKEN: ${{ github.token }}
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+        SLACK_WEBHOOK_URL: ${{ inputs.SLACK_WEBHOOK }}

--- a/.github/workflows/createNewVersion.yml
+++ b/.github/workflows/createNewVersion.yml
@@ -76,3 +76,5 @@ jobs:
 
       - if: ${{ failure() }}
         uses: Expensify/App/.github/actions/composite/announceFailedWorkflowInSlack@main
+        with:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deployBlocker.yml
+++ b/.github/workflows/deployBlocker.yml
@@ -66,3 +66,5 @@ jobs:
 
       - if: ${{ failure() }}
         uses: Expensify/App/.github/actions/composite/announceFailedWorkflowInSlack@main
+        with:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/finishReleaseCycle.yml
+++ b/.github/workflows/finishReleaseCycle.yml
@@ -123,3 +123,5 @@ jobs:
 
       - if: ${{ failure() }}
         uses: Expensify/App/.github/actions/composite/announceFailedWorkflowInSlack@main
+        with:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/lockDeploys.yml
+++ b/.github/workflows/lockDeploys.yml
@@ -31,3 +31,5 @@ jobs:
 
       - if: ${{ failure() }}
         uses: Expensify/App/.github/actions/composite/announceFailedWorkflowInSlack@main
+        with:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -357,6 +357,8 @@ jobs:
     needs: [android, desktop, iOS, web]
     steps:
       - uses: Expensify/App/.github/actions/composite/announceFailedWorkflowInSlack@main
+        with:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
   postSlackMessageOnSuccess:
     name: Post a Slack message when all platforms deploy successfully

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - if: ${{ needs.lint.result == 'failure' || needs.test.result == 'failure' }}
         uses: Expensify/App/.github/actions/composite/announceFailedWorkflowInSlack@main
+        with:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
       - if: ${{ needs.lint.result == 'failure' || needs.test.result == 'failure' }}
         run: exit 1
@@ -168,6 +170,8 @@ jobs:
 
       - if: ${{ failure() }}
         uses: Expensify/App/.github/actions/composite/announceFailedWorkflowInSlack@main
+        with:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
   # Check if actor is member of Expensify organization by looking for Expensify/expensify team
   isExpensifyEmployee:

--- a/.github/workflows/updateProtectedBranch.yml
+++ b/.github/workflows/updateProtectedBranch.yml
@@ -136,3 +136,5 @@ jobs:
 
       - if: ${{ failure() }}
         uses: Expensify/App/.github/actions/composite/announceFailedWorkflowInSlack@main
+        with:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/warnCPLabel.yml
+++ b/.github/workflows/warnCPLabel.yml
@@ -21,3 +21,5 @@ jobs:
 
       - if: ${{ failure() }}
         uses: Expensify/App/.github/actions/composite/announceFailedWorkflowInSlack@main
+        with:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
### Details
Following-up on https://github.com/Expensify/App/pull/9618 to fix an oversight – secrets must be passed in as inputs to GitHub Actions:

> To make a secret available to an action, you must set the secret as an input or environment variable in the workflow file ... GitHub automatically redacts secrets printed to the log

### Fixed Issues
$ (partial) https://github.com/Expensify/Expensify/issues/195693

### Tests
1. Verify that PR checks pass on this PR.
1. Merge this PR.
1. Verify that other GH actions keep working. We'll notice if they don't 🙃
1. Purposely run a workflow with an action that we know will fail. For example, attempt to manually CP a PR w/ a number that belongs to an issue instead of a pull request. That will definitely fail and should ping in #announce.