### PR TITLE
Fix off-by-one error in scrollToIndex

### DIFF
--- a/src/components/OptionsSelector.js
+++ b/src/components/OptionsSelector.js
@@ -226,7 +226,7 @@ class OptionsSelector extends Component {
             focusedIndex: newFocusedIndex,
         });
 
-        if (newOptions.length <= newFocusedIndex) {
+        if (newOptions.length < newFocusedIndex) {
             return;
         }
         this.scrollToIndex(newFocusedIndex);


### PR DESCRIPTION
### Details
I'm not able to reproduce the error, but looking at the logs in the video it makes sense that this would fix it. If the length of options is equal to the index, then we'll get an index-out-of-bounds error:

<img width="257" alt="image" src="https://user-images.githubusercontent.com/47436092/176956465-91757eaa-f6fe-4d9b-ad79-b4c2d4cc7fea.png">

### Fixed Issues
$ https://github.com/Expensify/App/issues/9671

### Tests 
Unknown since the original issue is not consistently reproducible.

- [x] Verify that no errors appear in the JS console

### QA Steps
Attempt to reproduce https://github.com/Expensify/App/issues/9671 🤷 
