### PR TITLE
Fix ArrowKeyFocusManager for lists with only two options

### DIFF
--- a/src/components/ArrowKeyFocusManager.js
+++ b/src/components/ArrowKeyFocusManager.js
@@ -26,7 +26,7 @@ class ArrowKeyFocusManager extends Component {
         const arrowDownConfig = CONST.KEYBOARD_SHORTCUTS.ARROW_DOWN;
 
         this.unsubscribeArrowUpKey = KeyboardShortcut.subscribe(arrowUpConfig.shortcutKey, () => {
-            if (this.props.maxIndex <= 1) {
+            if (this.props.maxIndex < 1) {
                 return;
             }
 
@@ -41,7 +41,7 @@ class ArrowKeyFocusManager extends Component {
         }, arrowUpConfig.descriptionKey, arrowUpConfig.modifiers, true);
 
         this.unsubscribeArrowDownKey = KeyboardShortcut.subscribe(arrowDownConfig.shortcutKey, () => {
-            if (this.props.maxIndex <= 1) {
+            if (this.props.maxIndex < 1) {
                 return;
             }
 


### PR DESCRIPTION
### Details
Fixes the `ArrowKeyFocusManager` for any list with only two options.

### Fixed Issues
$ https://github.com/Expensify/App/issues/9678

### Tests / QA Steps
1. Open the search page, new group page, IOU currency selector, or any other page that uses an `OptionSelector`
1. Edit the search query such that there's only two options in the list.
1. Verify that the arrow keys work as expected to highlight options.

- [x] Verify that no errors appear in the JS console
