### PR TITLE
[No QA] Alert failed deployHelpSite workflow in slack

### DIFF
--- a/.github/workflows/deployHelpSite.yml
+++ b/.github/workflows/deployHelpSite.yml
@@ -24,3 +24,8 @@ jobs:
         with:
           github_token: ${{ github.token }}
           publish_dir: ./help/_site
+
+      - if: ${{ failure() }}
+        uses: Expensify/App/.github/actions/composite/announceFailedWorkflowInSlack@main
+        with:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
### Details
This makes it so that if the deployHelpSite workflow fails, we'll get pinged in the announce Slack room.

### Fixed Issues
$ (partial) GH_LINK

### Tests
1. Merge this PR
1. We expect it to fail like last time: https://github.com/Expensify/App/runs/7204996726?check_suite_focus=true
1. Only this time it should ping mobile-deployers in slack in the announce room.