### PR TITLE
[No QA] Use commit hash from latest release tag

### DIFF
--- a/.github/workflows/deployHelpSite.yml
+++ b/.github/workflows/deployHelpSite.yml
@@ -20,7 +20,7 @@ jobs:
         run: cd help && bundle exec jekyll build
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@97637bffb09a6ef46a66b47207df5a18e3e7afc0
+        uses: peaceiris/actions-gh-pages@068dc23d9710f1ba62e86896f84735d869951305
         with:
           github_token: ${{ github.token }}
           publish_dir: ./help/_site


### PR DESCRIPTION
### Details
Main branch of https://github.com/peaceiris/actions-gh-pages does not have the release bundle under `lib/index.js` that's the [main executable from it's `action.yml` file](https://github.com/peaceiris/actions-gh-pages/blob/97637bffb09a6ef46a66b47207df5a18e3e7afc0/action.yml#L6). It worked when I used the `@v3` tag in a test repo: https://github.com/Andrew-Test-Org/Public-Test-Repo/pull/304/files#diff-485793c4ad92fb7d7366845a6b5a5e1d317cee350aa9f34ee627e0d7c1496527R25, but using a version tag goes against our GitHub Actions security guidelines in this repo. So this PR updates the commit hash to use the ref from the latest release tag, which has the `lib/index.js` file.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/216746

### Tests
1. Merge this PR
1. The help site should deploy on GitHub Actions.