### PR TITLE
[No QA] Fix updateProtectedBranch composite action

### DIFF
--- a/.github/actions/composite/updateProtectedBranch/action.yml
+++ b/.github/actions/composite/updateProtectedBranch/action.yml
@@ -133,8 +133,3 @@ runs:
       run: gh pr merge ${{ steps.createPullRequest.outputs.PR_NUMBER }} --merge --delete-branch
       env:
         GITHUB_TOKEN: ${{ inputs.OS_BOTIFY_TOKEN }}
-
-    - if: ${{ failure() }}
-      uses: Expensify/App/.github/actions/composite/announceFailedWorkflowInSlack@main
-      with:
-        SLACK_WEBHOOK: ${{ inputs.SLACK_WEBHOOK }}

--- a/.github/actions/composite/updateProtectedBranch/action.yml
+++ b/.github/actions/composite/updateProtectedBranch/action.yml
@@ -15,9 +15,6 @@ inputs:
   GPG_PASSPHRASE:
     description: Passphrase used to decrypt GPG key for OSBotify
     required: true
-  SLACK_WEBHOOK:
-    description: URL of the slack webhook
-    required: true
 
 runs:
   using: composite

--- a/.github/actions/composite/updateProtectedBranch/action.yml
+++ b/.github/actions/composite/updateProtectedBranch/action.yml
@@ -20,7 +20,7 @@ runs:
   using: composite
   steps:
     - name: Validate target branch
-      if: ${{ !contains(fromJSON('["main", "staging", "production"]'), github.event.inputs.TARGET_BRANCH) }}
+      if: ${{ !contains(fromJSON('["main", "staging", "production"]'), inputs.TARGET_BRANCH) }}
       shell: bash
       run: |
         echo "Target branch must be one of ['main', 'staging', 'production]"
@@ -28,7 +28,7 @@ runs:
 
     # If updating main, SOURCE_BRANCH must not be empty
     - name: Validate source branch
-      if: github.event.inputs.TARGET_BRANCH == 'main' && github.event.inputs.SOURCE_BRANCH == ''
+      if: inputs.TARGET_BRANCH == 'main' && inputs.SOURCE_BRANCH == ''
       shell: bash
       run: |
         echo "Cannot update main branch without specifying a source branch"
@@ -39,12 +39,12 @@ runs:
     - name: Set source branch
       shell: bash
       run: |
-        if [[ ${{ github.event.inputs.TARGET_BRANCH }} == 'staging' ]]; then
+        if [[ ${{ inputs.TARGET_BRANCH }} == 'staging' ]]; then
           echo "SOURCE_BRANCH=main" >> "$GITHUB_ENV"
-        elif [[ ${{ github.event.inputs.TARGET_BRANCH }} == 'production' ]]; then
+        elif [[ ${{ inputs.TARGET_BRANCH }} == 'production' ]]; then
           echo "SOURCE_BRANCH=staging" >> "$GITHUB_ENV"
         else
-          echo "SOURCE_BRANCH=${{ github.event.inputs.SOURCE_BRANCH }}" >> "$GITHUB_ENV"
+          echo "SOURCE_BRANCH=${{ inputs.SOURCE_BRANCH }}" >> "$GITHUB_ENV"
         fi
 
     - uses: Expensify/App/.github/actions/composite/setupGitForOSBotify@main
@@ -60,11 +60,11 @@ runs:
       run: echo "NEW_VERSION=$(npm run print-version --silent)" >> "$GITHUB_ENV"
 
     - name: Create temporary branch to resolve conflicts
-      if: ${{ contains(fromJSON('["staging", "production"]'), github.event.inputs.TARGET_BRANCH) }}
+      if: ${{ contains(fromJSON('["staging", "production"]'), inputs.TARGET_BRANCH) }}
       shell: bash
       run: |
-        git checkout ${{ github.event.inputs.TARGET_BRANCH }}
-        BRANCH_NAME=update-${{ github.event.inputs.TARGET_BRANCH }}-from-${{ env.SOURCE_BRANCH }}
+        git checkout ${{ inputs.TARGET_BRANCH }}
+        BRANCH_NAME=update-${{ inputs.TARGET_BRANCH }}-from-${{ env.SOURCE_BRANCH }}
         git checkout -b "$BRANCH_NAME"
         git merge -Xtheirs ${{ env.SOURCE_BRANCH }}
         git push --set-upstream origin "$BRANCH_NAME"
@@ -74,17 +74,17 @@ runs:
       shell: bash
       run: |
         gh pr create \
-          --title "Update version to ${{ env.NEW_VERSION }} on ${{ github.event.inputs.TARGET_BRANCH }}" \
+          --title "Update version to ${{ env.NEW_VERSION }} on ${{ inputs.TARGET_BRANCH }}" \
           --body "Update version to ${{ env.NEW_VERSION }}" \
           --label "automerge" \
-          --base ${{ github.event.inputs.TARGET_BRANCH }}
+          --base ${{ inputs.TARGET_BRANCH }}
         sleep 5
         echo "::set-output name=PR_NUMBER::$(gh pr view --json 'number' --jq '.number')"
       env:
         GITHUB_TOKEN: ${{ inputs.OS_BOTIFY_TOKEN }}
 
     - name: Check changed files
-      if: ${{ github.event.inputs.TARGET_BRANCH == 'main' }}
+      if: ${{ inputs.TARGET_BRANCH == 'main' }}
       id: changedFiles
       # Version: 3.3.0
       uses: umani/changed-files@1d252c611c64289d35243fc37ece7323ea5e93e1
@@ -93,7 +93,7 @@ runs:
         pr-number: ${{ steps.createPullRequest.outputs.PR_NUMBER }}
 
     - name: Validate changed files
-      if: ${{ github.event.inputs.TARGET_BRANCH == 'main' && (steps.changedFiles.outputs.files_updated != 'android/app/build.gradle ios/NewExpensify/Info.plist ios/NewExpensifyTests/Info.plist package-lock.json package.json' || steps.changedFiles.outputs.files_created != '' || steps.changedFiles.outputs.files_deleted != '') }}
+      if: ${{ inputs.TARGET_BRANCH == 'main' && (steps.changedFiles.outputs.files_updated != 'android/app/build.gradle ios/NewExpensify/Info.plist ios/NewExpensifyTests/Info.plist package-lock.json package.json' || steps.changedFiles.outputs.files_created != '' || steps.changedFiles.outputs.files_deleted != '') }}
       shell: bash
       run: exit 1
 

--- a/.github/workflows/createNewVersion.yml
+++ b/.github/workflows/createNewVersion.yml
@@ -61,7 +61,6 @@ jobs:
           SOURCE_BRANCH: ${{ env.VERSION_BRANCH }}
           OS_BOTIFY_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
           GPG_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
       - if: ${{ failure() }}
         uses: Expensify/App/.github/actions/composite/announceFailedWorkflowInSlack@main

--- a/.github/workflows/finishReleaseCycle.yml
+++ b/.github/workflows/finishReleaseCycle.yml
@@ -67,7 +67,6 @@ jobs:
           TARGET_BRANCH: production
           OS_BOTIFY_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
           GPG_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
   # Deploy deferred PRs to staging and create a new StagingDeployCash for the next release cycle.
   createNewStagingDeployCash:
@@ -101,7 +100,6 @@ jobs:
           TARGET_BRANCH: staging
           OS_BOTIFY_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
           GPG_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
       - name: Pull staging to get the new version
         run: |

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -113,7 +113,6 @@ jobs:
           TARGET_BRANCH: staging
           OS_BOTIFY_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
           GPG_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
       - name: Determine if this pull request will be cherry-picked
         run: echo "DO_CHERRY_PICK=${{ fromJSON(needs.chooseDeployActions.outputs.isStagingDeployLocked) && fromJSON(needs.chooseDeployActions.outputs.shouldCherryPick) }}" >> "$GITHUB_ENV"


### PR DESCRIPTION
### Details
Following-up on https://github.com/Expensify/App/pull/9654 to fix https://github.com/Expensify/App/runs/7206613686?check_suite_focus=true and the [double slack announcement](https://expensify.slack.com/archives/C03V9A4TB/p1657069305776599). 

When migrating the workflow over to an action, I didn't use the correct syntax for action inputs, and instead used the syntax for workflow inputs. Examples of correct action inputs can be found in other composite actions: https://github.com/Expensify/App/blob/ab39f7ddab4fca7283765148a6b86f3c5c8c552c/.github/actions/composite/announceFailedWorkflowInSlack/action.yml#L28

### Fixed Issues
$ n/a – broken deploys

### Tests
1. Merge this pull request with the CP Staging label
1. Verify that it triggers a deploy as expected.