### PR TITLE
[No QA] Use updateProtectedBranch action to deploy help site

### DIFF
--- a/.github/actions/composite/updateProtectedBranch/action.yml
+++ b/.github/actions/composite/updateProtectedBranch/action.yml
@@ -26,10 +26,10 @@ runs:
   using: composite
   steps:
     - name: Validate target branch
-      if: ${{ !contains(fromJSON('["main", "staging", "production"]'), inputs.TARGET_BRANCH) }}
+      if: ${{ !contains(fromJSON('["main", "staging", "production", "gh-pages"]'), inputs.TARGET_BRANCH) }}
       shell: bash
       run: |
-        echo "Target branch must be one of ['main', 'staging', 'production]"
+        echo "Target branch must be one of ['main', 'staging', 'production', 'gh-pages']"
         exit 1
 
     # If updating main, SOURCE_BRANCH must not be empty
@@ -40,12 +40,12 @@ runs:
         echo "Cannot update main branch without specifying a source branch"
         exit 1
 
-    # If updating staging, the source branch will always be main
+    # If updating staging or gh-pages, the source branch will always be main
     # If updating production, the source branch will always be staging
     - name: Set source branch
       shell: bash
       run: |
-        if [[ ${{ inputs.TARGET_BRANCH }} == 'staging' ]]; then
+        if [[ ${{ inputs.TARGET_BRANCH }} == 'staging' || ${{ inputs.TARGET_BRANCH }} == 'gh-pages' ]]; then
           echo "SOURCE_BRANCH=main" >> "$GITHUB_ENV"
         elif [[ ${{ inputs.TARGET_BRANCH }} == 'production' ]]; then
           echo "SOURCE_BRANCH=staging" >> "$GITHUB_ENV"
@@ -61,12 +61,8 @@ runs:
       shell: bash
       run: git checkout ${{ env.SOURCE_BRANCH }}
 
-    - name: Set New Version
-      shell: bash
-      run: echo "NEW_VERSION=$(npm run print-version --silent)" >> "$GITHUB_ENV"
-
     - name: Create temporary branch to resolve conflicts
-      if: ${{ contains(fromJSON('["staging", "production"]'), inputs.TARGET_BRANCH) }}
+      if: ${{ inputs.TARGET_BRANCH != 'main' }}
       shell: bash
       run: |
         git checkout ${{ inputs.TARGET_BRANCH }}
@@ -79,9 +75,18 @@ runs:
       id: createPullRequest
       shell: bash
       run: |
+        PR_TITLE="${{ inputs.PR_TITLE }}"
+        PR_BODY="${{ inputs.PR_BODY }}"
+
+        if [[ -z "$PR_TITLE" || -z "$PR_BODY" ]]; then
+          NEW_VERSION="$(npm run print-version --silent)"
+          PR_TITLE="Update version to $NEW_VERSION on ${{ inputs.TARGET_BRANCH }}"
+          PR_BODY="Update version to $NEW_VERSION"
+        fi
+
         gh pr create \
-          --title "Update version to ${{ env.NEW_VERSION }} on ${{ inputs.TARGET_BRANCH }}" \
-          --body "Update version to ${{ env.NEW_VERSION }}" \
+          --title "$PR_TITLE" \
+          --body "$PR_BODY" \
           --label "automerge" \
           --base ${{ inputs.TARGET_BRANCH }}
         sleep 5

--- a/.github/actions/composite/updateProtectedBranch/action.yml
+++ b/.github/actions/composite/updateProtectedBranch/action.yml
@@ -71,6 +71,18 @@ runs:
         git merge -Xtheirs ${{ env.SOURCE_BRANCH }}
         git push --set-upstream origin "$BRANCH_NAME"
 
+    - name: Overwrite root directory with static site
+      if: ${{ inputs.TARGET_BRANCH == 'gh-pages' }}
+      shell: bash
+      run: |
+        cd Expensify/App
+        find . -delete -mindepth 1 -not -regex "^\.\/(\.git|help/_site)(\/.*)?" -regextype posix-extended
+        mv -v help/_site/* .  
+        rm -rf help/_site
+        touch ./.nojekyll
+        git add -A
+        git commit -m "Overwrite root directory with static site"
+
     - name: Create Pull Request
       id: createPullRequest
       shell: bash

--- a/.github/actions/composite/updateProtectedBranch/action.yml
+++ b/.github/actions/composite/updateProtectedBranch/action.yml
@@ -9,6 +9,12 @@ inputs:
     description: If updating main, you must also provide a head branch to update main with.
     required: false
     default: ''
+  PR_TITLE:
+    description: Optional title for the PR used to update the protected branch
+    required: false
+  PR_BODY:
+    description: Optional body for the PR used to update the protected branch
+    required: false
   OS_BOTIFY_TOKEN:
     description: GitHub token for OSBotify
     required: true

--- a/.github/workflows/deployHelpSite.yml
+++ b/.github/workflows/deployHelpSite.yml
@@ -11,6 +11,12 @@ jobs:
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
+      - name: Get merged pull request
+        id: getMergedPullRequest
+        uses: roryabraham/action-get-merged-pull-request@7a7a194f6ff8f3eef58c822083695a97314ebec1
+        with:
+          github_token: ${{ github.token }}
+
       - uses: ruby/setup-ruby@08245253a76fa4d1e459b7809579c62bd9eb718a
         with:
           ruby-version: 3.0
@@ -19,11 +25,14 @@ jobs:
       - name: Build
         run: cd help && bundle exec jekyll build
 
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@068dc23d9710f1ba62e86896f84735d869951305
+      - name: Update production branch
+        uses: Expensify/App/.github/actions/composite/updateProtectedBranch@main
         with:
-          github_token: ${{ github.token }}
-          publish_dir: ./help/_site
+          TARGET_BRANCH: gh-pages
+          PR_TITLE: 'Deploy help site PR #${{ steps.getMergedPullRequest.outputs.number }}'
+          PR_BODY: 'Deploy help site PR #${{ steps.getMergedPullRequest.outputs.number }}'
+          OS_BOTIFY_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+          GPG_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
 
       - if: ${{ failure() }}
         uses: Expensify/App/.github/actions/composite/announceFailedWorkflowInSlack@main

--- a/.github/workflows/deployHelpSite.yml
+++ b/.github/workflows/deployHelpSite.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Build
         run: cd help && bundle exec jekyll build
 
-      - name: Update production branch
+      - name: Update gh-pages branch
         uses: Expensify/App/.github/actions/composite/updateProtectedBranch@main
         with:
           TARGET_BRANCH: gh-pages

--- a/.github/workflows/deployHelpSite.yml
+++ b/.github/workflows/deployHelpSite.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Build
         run: cd help && bundle exec jekyll build
 
-      - name: Update gh-pages branch
+      - name: Deploy
         uses: Expensify/App/.github/actions/composite/updateProtectedBranch@main
         with:
           TARGET_BRANCH: gh-pages


### PR DESCRIPTION
Slack context: https://expensify.slack.com/archives/C03V9A4TB/p1657061234949019

### Details
This PR replaces the [actions-gh-pages community action](https://github.com/peaceiris/actions-gh-pages) with some custom logic in our `updateProtectedBranch` composite action. This allows us to keep branch protections for the `gh-pages` branch (from which the GitHub Pages site is deployed), without making an exception for anyone, even `OSBotify`.

As an added bonus, I think that this is much more explicit/transparent than the `actions-gh-pages` action, and will make it easier for future engineers to understand how the help site is deployed.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/216746

### Tests
1. Merge this PR
1. Verify that the help site is deployed to GitHub Pages correctly.