### PR TITLE
[No QA] Add documentation about HelpDot deploys

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,9 @@ created to house a collection of items in plural form and using camelCase (eg: p
 - pages: These are components that define pages in the app. The component that defines the page itself should be named
 `<pageName>Page` if there are components used only inside one page, they should live in its own directory named after the `<pageName>`.
 - styles: These files define styles used among components/pages
+- contributingGuides: This is just a set of markdown files providing guides and insights to aid developers in learning how to contribute to this repo.
+
+**Note:** There is also a directory called `/docs`, which houses the Expensify Help site. It's a static site that's built with Jekyll and hosted on GitHub Pages.
 
 ## File naming/structure
 Files should be named after the component/function/constants they export, respecting the casing used for it. ie:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,14 @@
 # Welcome to the Expensify Help site
 
-Expensify Help is mainly composed of static HTML (`.html`) and Markdown (`.md`) files. We use [Jekyll](https://jekyllrb.com/) to generate a static site from those HTML and Markdown files.
+[Expensify Help](https://help.expensify.com/) is mainly composed of static HTML (`.html`) and Markdown (`.md`) files. We use [Jekyll](https://jekyllrb.com/) to generate a static site from those HTML and Markdown files.
 
-# Test locally
+### Table of Contents
+* [Testing Locally](#testing-locally)
+* [How the project is structured](#how-the-project-is-structured)
+* [How to add a new Article](#how-to-add-a-new-article)
+* [How the site is deployed](#how-the-site-is-deployed)
+
+# Testing Locally
 
 ## Pre-requisites
 
@@ -168,3 +174,6 @@ Add the next HTML block inside of the corresponding Stage title anchor:
 ```
 
 Where `./request-money/SmartScan` will be the relative path of the file name (exactly the same as in the `Add a Card button` example above).
+
+# How the site is deployed
+This site is hosted on GitHub Pages. GitHub Pages has a built-in Jekyll integration, and we have it configured such that whenever code is merged to main, GitHub will automatically build the Jekyll site housed in the `/docs` directory and deploy it straight to production. The help site is publicly discoverable at https://help.expensify.com/


### PR DESCRIPTION
Just some documentation updates.

Note that links to https://help.expensify.com/ won't take you to the new help site until https://github.com/Expensify/Expensify/issues/216752 is completed.