### PR TITLE
[No QA] Fixing the link to code of conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 * [API Details](contributingGuides/API.md)
 * [Offline First](contributingGuides/OFFLINE_UX.md)
 * [Contributing to Expensify](contributingGuides/CONTRIBUTING.md)
-* [Expensify Code of Conduct](contributingGuides/CODE_OF_CONDUCT.md)
+* [Expensify Code of Conduct](CODE_OF_CONDUCT.md)
 * [Contributor License Agreement](contributingGuides/CLA.md)
 
 ----


### PR DESCRIPTION
Just something I noticed from a recent PR

### Tests
1. View the README for e/app
2. Verify the link to the code of conduct works