### PR TITLE
Stop the call to getBetas in getAppData

### DIFF
--- a/src/libs/actions/App.js
+++ b/src/libs/actions/App.js
@@ -79,7 +79,6 @@ AppState.addEventListener('change', (nextAppState) => {
  */
 function getAppData(shouldSyncPolicyList = true) {
     User.getUserDetails();
-    User.getBetas();
     User.getDomainInfo();
     PersonalDetails.fetchLocalCurrency();
     GeoLocation.fetchCountryCodeByRequestIP();


### PR DESCRIPTION
@luacmartins please review

HOLD ON https://github.com/Expensify/Web-Expensify/pull/34251 DEPLOYED TO PRODUCTION

### Details
Stop calling getBetas in getAppData, since we are now returning that info via the `OpenApp` command

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/213881

### Tests
1. Login via an `expensifail.com` account, make sure that you can see the `#expensifail.com` domain room.
2. Login via a vanilla Gmail account, make sure that you cannot see any default rooms (make sure you have not created a workspace, but have created a policy on OldDot that you are a member of) 

