### PR TITLE
[No QA] Fix NewDot deploys

### DIFF
--- a/.github/actions/composite/updateProtectedBranch/action.yml
+++ b/.github/actions/composite/updateProtectedBranch/action.yml
@@ -66,7 +66,9 @@ runs:
         git checkout ${{ inputs.TARGET_BRANCH }}
         BRANCH_NAME=update-${{ inputs.TARGET_BRANCH }}-from-${{ env.SOURCE_BRANCH }}
         git checkout -b "$BRANCH_NAME"
-        git merge -Xtheirs ${{ env.SOURCE_BRANCH }}
+        git merge -Xtheirs ${{ env.SOURCE_BRANCH }} \
+          || git diff --name-only --diff-filter=U | xargs git rm \
+          && git merge --continue
         git push --set-upstream origin "$BRANCH_NAME"
 
     - name: Create Pull Request

--- a/.github/actions/composite/updateProtectedBranch/action.yml
+++ b/.github/actions/composite/updateProtectedBranch/action.yml
@@ -68,9 +68,10 @@ runs:
         git checkout ${{ inputs.TARGET_BRANCH }}
         BRANCH_NAME=update-${{ inputs.TARGET_BRANCH }}-from-${{ env.SOURCE_BRANCH }}
         git checkout -b "$BRANCH_NAME"
-        git merge -Xtheirs ${{ env.SOURCE_BRANCH }} \
-          || git diff --name-only --diff-filter=U | xargs git rm \
-          && git merge --continue
+        git merge -Xtheirs ${{ env.SOURCE_BRANCH }} || {
+          git diff --name-only --diff-filter=U | xargs git rm;
+          git merge --continue;
+        }
         git push --set-upstream origin "$BRANCH_NAME"
 
     - name: Create Pull Request

--- a/.github/actions/composite/updateProtectedBranch/action.yml
+++ b/.github/actions/composite/updateProtectedBranch/action.yml
@@ -53,7 +53,9 @@ runs:
 
     - name: Checkout source branch
       shell: bash
-      run: git checkout ${{ env.SOURCE_BRANCH }}
+      run: |
+        git fetch
+        git checkout ${{ env.SOURCE_BRANCH }}
 
     - name: Set New Version
       shell: bash

--- a/.github/workflows/finishReleaseCycle.yml
+++ b/.github/workflows/finishReleaseCycle.yml
@@ -59,6 +59,7 @@ jobs:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           ref: main
+          fetch-depth: 0
           token: ${{ secrets.OS_BOTIFY_TOKEN }}
 
       - name: Update production branch

--- a/.github/workflows/finishReleaseCycle.yml
+++ b/.github/workflows/finishReleaseCycle.yml
@@ -59,7 +59,6 @@ jobs:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           ref: main
-          fetch-depth: 0
           token: ${{ secrets.OS_BOTIFY_TOKEN }}
 
       - name: Update production branch

--- a/tests/unit/getPullRequestsMergedBetweenTest.sh
+++ b/tests/unit/getPullRequestsMergedBetweenTest.sh
@@ -117,7 +117,7 @@ success "Version bumped to $(print_version) on main"
 info "Merging main into staging..."
 git checkout staging
 git checkout -b update-staging-from-main
-git merge --no-edit -Xtheirs main || git diff --name-only --diff-filter=U | xargs git rm && git merge --continue
+git merge --no-edit -Xtheirs main || { git diff --name-only --diff-filter=U | xargs git rm; git merge --continue; }
 git checkout staging
 git merge update-staging-from-main --no-ff -m "Merge pull request #3 from Expensify/update-staging-from-main"
 info "Merged PR #3 to staging"
@@ -219,7 +219,7 @@ title "Scenario #4A: Run the production deploy"
 info "Updating production from staging..."
 git checkout production
 git checkout -b update-production-from-staging
-git merge --no-edit -Xtheirs staging || git diff --name-only --diff-filter=U | xargs git rm && git merge --continue
+git merge --no-edit -Xtheirs staging || { git diff --name-only --diff-filter=U | xargs git rm; git merge --continue; }
 git checkout production
 git merge update-production-from-staging --no-ff -m "Merge pull request #8 from Expensify/update-production-from-staging"
 info "Merged PR #8 into production"
@@ -250,7 +250,7 @@ success "Successfully updated version to 1.1.0 on main!"
 info "Updating staging from main..."
 git checkout staging
 git checkout -b update-staging-from-main
-git merge --no-edit -Xtheirs main || git diff --name-only --diff-filter=U | xargs git rm && git merge --continue
+git merge --no-edit -Xtheirs main || { git diff --name-only --diff-filter=U | xargs git rm; git merge --continue; }
 git checkout staging
 git merge update-staging-from-main --no-ff -m "Merge pull request #10 from Expensify/update-staging-from-main"
 info "Merged PR #10 into staging"
@@ -299,7 +299,7 @@ success "Bumped version to 1.1.1 on main!"
 info "Merging main into staging..."
 git checkout staging
 git checkout -b update-staging-from-main
-git merge --no-edit -Xtheirs main || git diff --name-only --diff-filter=U | xargs git rm && git merge --continue
+git merge --no-edit -Xtheirs main || { git diff --name-only --diff-filter=U | xargs git rm; git merge --continue; }
 git checkout staging
 git merge update-staging-from-main --no-ff -m "Merge pull request #13 from Expensify/update-staging-from-main"
 info "Merged PR #13 into staging"

--- a/tests/unit/getPullRequestsMergedBetweenTest.sh
+++ b/tests/unit/getPullRequestsMergedBetweenTest.sh
@@ -117,7 +117,7 @@ success "Version bumped to $(print_version) on main"
 info "Merging main into staging..."
 git checkout staging
 git checkout -b update-staging-from-main
-git merge --no-edit -Xtheirs main
+git merge --no-edit -Xtheirs main || git diff --name-only --diff-filter=U | xargs git rm && git merge --continue
 git checkout staging
 git merge update-staging-from-main --no-ff -m "Merge pull request #3 from Expensify/update-staging-from-main"
 info "Merged PR #3 to staging"
@@ -219,7 +219,7 @@ title "Scenario #4A: Run the production deploy"
 info "Updating production from staging..."
 git checkout production
 git checkout -b update-production-from-staging
-git merge --no-edit -Xtheirs staging
+git merge --no-edit -Xtheirs staging || git diff --name-only --diff-filter=U | xargs git rm && git merge --continue
 git checkout production
 git merge update-production-from-staging --no-ff -m "Merge pull request #8 from Expensify/update-production-from-staging"
 info "Merged PR #8 into production"
@@ -250,7 +250,7 @@ success "Successfully updated version to 1.1.0 on main!"
 info "Updating staging from main..."
 git checkout staging
 git checkout -b update-staging-from-main
-git merge --no-edit -Xtheirs main
+git merge --no-edit -Xtheirs main || git diff --name-only --diff-filter=U | xargs git rm && git merge --continue
 git checkout staging
 git merge update-staging-from-main --no-ff -m "Merge pull request #10 from Expensify/update-staging-from-main"
 info "Merged PR #10 into staging"
@@ -299,7 +299,7 @@ success "Bumped version to 1.1.1 on main!"
 info "Merging main into staging..."
 git checkout staging
 git checkout -b update-staging-from-main
-git merge --no-edit -Xtheirs main
+git merge --no-edit -Xtheirs main || git diff --name-only --diff-filter=U | xargs git rm && git merge --continue
 git checkout staging
 git merge update-staging-from-main --no-ff -m "Merge pull request #13 from Expensify/update-staging-from-main"
 info "Merged PR #13 into staging"


### PR DESCRIPTION
### Details
Interestingly, there were two separate issues, one that caused the production deploy to fail, and another that caused the staging deploy to fail.

#### Production
First, the production deploy failed with this error:

`error: pathspec 'staging' did not match any file(s) known to git`

This happened because [this comment](https://github.com/Expensify/App/pull/9654/files#r911503910) wasn't entirely accurate. While we're guaranteed to have _a_ branch, we're not guaranteed to have all the branches we need. To fix that is simple – just run a `git fetch` from within the action. That way we'll have all the branches from the remote.

 #### Staging
 Second, the staging deploy failed because this command: `git merge -Xtheirs main` failed with this error:
 
 ```
CONFLICT (modify/delete): .github/actions/isPullRequestMergeable/isPullRequestMergeable.js deleted in main and modified in HEAD.  Version HEAD of .github/actions/isPullRequestMergeable/isPullRequestMergeable.js left in tree.
Auto-merging .github/actions/javascript/isPullRequestMergeable/index.js
Auto-merging .github/workflows/cherryPick.yml
Auto-merging .github/workflows/createNewVersion.yml
Auto-merging .github/workflows/deploy.yml
CONFLICT (modify/delete): .github/workflows/updateProtectedBranch.yml deleted in main and modified in HEAD.  Version HEAD of .github/workflows/updateProtectedBranch.yml left in tree.
Auto-merging android/app/build.gradle
Auto-merging ios/NewExpensify/Info.plist
Auto-merging ios/NewExpensifyTests/Info.plist
Auto-merging package-lock.json
Auto-merging package.json
Auto-merging src/components/OptionsSelector.js
Auto-merging src/libs/actions/Policy.js
Auto-merging src/libs/actions/Report.js
Auto-merging src/pages/home/report/ReportActionCompose.js
Auto-merging tests/unit/isPullRequestMergeableTest.js
Automatic merge failed; fix conflicts and then commit the result.
 ```
 
 I believe it's only by luck/coincidence that this hasn't happened before. Normally we do the following, with the intention of completely overwriting the `staging` branch with `main`:
 
 ```bash
 git checkout staging
BRANCH_NAME=update-staging-from-main
git checkout -b "$BRANCH_NAME"
git merge -Xtheirs main
git push --set-upstream origin "$BRANCH_NAME"
 ```

The key piece here is the `-Xtheirs` flag, which basically says "if there's a conflict, use the version of the code from `main`". However, that [doesn't work](https://stackoverflow.com/questions/25254037/git-merge-strategy-theirs-is-not-resolving-modify-delete-conflict) in the specific scenario where a file was modified on `staging` and deleted on `main`. Because we want to prioritize the changes from main, we'll automatically resolve the conflicts using the change from main, using the following command:

```bash
git merge -Xtheirs main || git diff --name-only --diff-filter=U | xargs git rm && git merge --continue
```

And what this says is basically:

> "Merge `main` into `staging`, and if there's a conflict, use the version of the code from `main`. If that doesn't work, delete any files that failed to merge automatically and continue."

This is safe, because the inverse scenario (a file is edited on main but deleted on staging) is not possible because all changes propagate from `main` -> `staging` -> `production`.

### Fixed Issues
$ n/a – broken deploys.

### Local Test
Go to the App repo locally and run these commands:

```bash
git fetch
git checkout main
git checkout -b fake-main
git checkout main
git checkout -b fake-staging
echo "Update README on staging" >> README.md
git add README.md
git commit -m "Update README on staging"
git checkout fake-main
rm README.md
git add README.md
git commit -m "Delete README on main"
git checkout fake-staging
git merge -Xtheirs fake-main || {
  git diff --name-only --diff-filter=U | xargs git rm;  
  git merge --continue;
}
```

It will most likely open a pager for the commit message (but that won't happen in the GH Actions runner by default), but otherwise the commit should succeed.

### Live Test
1. Merge this PR
1. Ship [the checklist](https://github.com/Expensify/App/issues/9586) again.
1. The deploy should work.