### PR TITLE
[No QA] Continue merge without requiring editor

### DIFF
--- a/.github/actions/composite/updateProtectedBranch/action.yml
+++ b/.github/actions/composite/updateProtectedBranch/action.yml
@@ -70,7 +70,7 @@ runs:
         git checkout -b "$BRANCH_NAME"
         git merge -Xtheirs ${{ env.SOURCE_BRANCH }} || {
           git diff --name-only --diff-filter=U | xargs git rm;
-          git merge --continue;
+          git -c core.editor=true merge --continue;
         }
         git push --set-upstream origin "$BRANCH_NAME"
 

--- a/tests/unit/getPullRequestsMergedBetweenTest.sh
+++ b/tests/unit/getPullRequestsMergedBetweenTest.sh
@@ -117,7 +117,7 @@ success "Version bumped to $(print_version) on main"
 info "Merging main into staging..."
 git checkout staging
 git checkout -b update-staging-from-main
-git merge --no-edit -Xtheirs main || { git diff --name-only --diff-filter=U | xargs git rm; git merge --continue; }
+git merge --no-edit -Xtheirs main || { git diff --name-only --diff-filter=U | xargs git rm; git -c core.editor=true merge --continue; }
 git checkout staging
 git merge update-staging-from-main --no-ff -m "Merge pull request #3 from Expensify/update-staging-from-main"
 info "Merged PR #3 to staging"
@@ -219,7 +219,7 @@ title "Scenario #4A: Run the production deploy"
 info "Updating production from staging..."
 git checkout production
 git checkout -b update-production-from-staging
-git merge --no-edit -Xtheirs staging || { git diff --name-only --diff-filter=U | xargs git rm; git merge --continue; }
+git merge --no-edit -Xtheirs staging || { git diff --name-only --diff-filter=U | xargs git rm; git -c core.editor=true merge --continue; }
 git checkout production
 git merge update-production-from-staging --no-ff -m "Merge pull request #8 from Expensify/update-production-from-staging"
 info "Merged PR #8 into production"
@@ -250,7 +250,7 @@ success "Successfully updated version to 1.1.0 on main!"
 info "Updating staging from main..."
 git checkout staging
 git checkout -b update-staging-from-main
-git merge --no-edit -Xtheirs main || { git diff --name-only --diff-filter=U | xargs git rm; git merge --continue; }
+git merge --no-edit -Xtheirs main || { git diff --name-only --diff-filter=U | xargs git rm; git -c core.editor=true merge --continue; }
 git checkout staging
 git merge update-staging-from-main --no-ff -m "Merge pull request #10 from Expensify/update-staging-from-main"
 info "Merged PR #10 into staging"
@@ -299,7 +299,7 @@ success "Bumped version to 1.1.1 on main!"
 info "Merging main into staging..."
 git checkout staging
 git checkout -b update-staging-from-main
-git merge --no-edit -Xtheirs main || { git diff --name-only --diff-filter=U | xargs git rm; git merge --continue; }
+git merge --no-edit -Xtheirs main || { git diff --name-only --diff-filter=U | xargs git rm; git -c core.editor=true merge --continue; }
 git checkout staging
 git merge update-staging-from-main --no-ff -m "Merge pull request #13 from Expensify/update-staging-from-main"
 info "Merged PR #13 into staging"


### PR DESCRIPTION
### Details
In the local testing of https://github.com/Expensify/App/pull/9771 the editor was required to finish the merge commit. I thought that this wouldn't happen in the GH runner because they have pager disabled by default, but I was wrong. This PR makes it so that, even testing locally, the editor is not required to finish the merge commit.

### Fixed Issues
$ n/a – broken deploys.

### Local Tests
1. Go to the App repo locally and run these commands:

	  ```bash
	  git fetch
	  git checkout main
	  git checkout -b fake-main
	  git checkout main
	  git checkout -b fake-staging
	  echo "Update README on staging" >> README.md
	  git add README.md
	  git commit -m "Update README on staging"
	  git checkout fake-main
	  rm README.md
	  git add README.md
	  git commit -m "Delete README on main"
	  git checkout fake-staging
	  git merge -Xtheirs fake-main || {
	    git diff --name-only --diff-filter=U | xargs git rm;  
	    git merge -c core.editor=true --continue;
	  }
	  ```
1. Verify that the merge in the last command succeeds and that it _DOES NOT_ open an editor and prompt you for a commit message.

### Live Tests
1. Merge this PR
1. RE-ship https://github.com/Expensify/App/issues/9586 and the deploy should work.