### PR TITLE
[No QA] Proceed with web deploy even if storybook build fails

### DIFF
--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -329,6 +329,7 @@ jobs:
 
       - name: Build docs
         run: npm run storybook-build
+        continue-on-error: true
 
       - name: Deploy production to S3
         if: ${{ fromJSON(env.SHOULD_DEPLOY_PRODUCTION) }}


### PR DESCRIPTION
### Details
This ensures that the web deploy will continue even if the storybook build step fails.

### Fixed Issues
$ https://github.com/Expensify/App/issues/9782

### Tests
The only testing I did was a POC [here](https://github.com/Andrew-Test-Org/Public-Test-Repo/runs/7246673603?check_suite_focus=true) with [this PR](https://github.com/Andrew-Test-Org/Public-Test-Repo/pull/307), but that gives me enough confidence to assume that this will work as expected.