### PR TITLE
[No QA] Use inputs.TARGET_BRANCH instead of env.TARGET_BRANCH

### DIFF
--- a/.github/actions/composite/updateProtectedBranch/action.yml
+++ b/.github/actions/composite/updateProtectedBranch/action.yml
@@ -55,8 +55,8 @@ runs:
       shell: bash
       run: |
         git fetch
-        git checkout ${{ env.TARGET_BRANCH }}
-        git merge origin/${{ env.TARGET_BRANCH }}
+        git checkout ${{ inputs.TARGET_BRANCH }}
+        git merge origin/${{ inputs.TARGET_BRANCH }}
         git checkout ${{ env.SOURCE_BRANCH }}
         git merge origin/${{ env.SOURCE_BRANCH }}
 


### PR DESCRIPTION
Following-up on faulty https://github.com/Expensify/App/pull/9849

### Fixed Issues
$ n/a – slack context: https://expensify.slack.com/archives/C03V9A4TB/p1657653469315469

### Tests
1. Merge this PR
1. Retry failed jobs in https://github.com/Expensify/App/runs/7309636448?check_suite_focus=true#step:3:1
