### PR TITLE
[No QA] Change job outputs to UPPER_SNAKE_CASE

### DIFF
--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -29,10 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: confirmPassingBuild
     outputs:
-      mergedPullRequest: ${{ steps.getMergedPullRequest.outputs.number }}
-      isAutomatedPullRequest: ${{ steps.isAutomatedPullRequest.outputs.IS_AUTOMATED_PR }}
-      shouldDeploy: ${{ steps.shouldDeploy.outputs.SHOULD_DEPLOY }}
-      shouldCherryPick: ${{ steps.isStagingDeployLocked.outputs.IS_LOCKED && steps.hasCherryPickLabel.outputs.HAS_CP_LABEL }}
+      MERGED_PR: ${{ steps.getMergedPullRequest.outputs.number }}
+      IS_AUTOMATED_PR: ${{ steps.isAutomatedPullRequest.outputs.IS_AUTOMATED_PR }}
+      SHOULD_DEPLOY: ${{ steps.shouldDeploy.outputs.SHOULD_DEPLOY }}
+      SHOULD_CP: ${{ steps.isStagingDeployLocked.outputs.IS_LOCKED && steps.hasCherryPickLabel.outputs.HAS_CP_LABEL }}
 
     steps:
       - name: Get merged pull request
@@ -62,19 +62,19 @@ jobs:
   skipDeploy:
     runs-on: ubuntu-latest
     needs: chooseDeployActions
-    if: ${{ !fromJSON(needs.chooseDeployActions.outputs.shouldDeploy) && !fromJSON(needs.chooseDeployActions.outputs.isAutomatedPullRequest) }}
+    if: ${{ !fromJSON(needs.chooseDeployActions.outputs.SHOULD_DEPLOY) && !fromJSON(needs.chooseDeployActions.outputs.IS_AUTOMATED_PR) }}
     steps:
       - name: Comment on deferred PR
         uses: actions-ecosystem/action-create-comment@cd098164398331c50e7dfdd0dfa1b564a1873fac
         with:
           github_token: ${{ secrets.OS_BOTIFY_TOKEN }}
-          number: ${{ needs.chooseDeployActions.outputs.mergedPullRequest }}
+          number: ${{ needs.chooseDeployActions.outputs.MERGED_PR }}
           body: |
             :hand: This PR was not deployed to staging yet because QA is ongoing. It will be automatically deployed to staging after the next production release.
 
   createNewVersion:
     needs: chooseDeployActions
-    if: ${{ fromJSON(needs.chooseDeployActions.outputs.shouldDeploy) }}
+    if: ${{ fromJSON(needs.chooseDeployActions.outputs.SHOULD_DEPLOY) }}
     uses: Expensify/App/.github/workflows/createNewVersion.yml@main
     secrets: inherit
 
@@ -89,7 +89,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Update staging branch from main
-        if: ${{ !fromJSON(needs.chooseDeployActions.outputs.shouldCherryPick) }}
+        if: ${{ !fromJSON(needs.chooseDeployActions.outputs.SHOULD_CP) }}
         uses: Expensify/App/.github/actions/composite/updateProtectedBranch@main
         with:
           TARGET_BRANCH: staging
@@ -97,12 +97,12 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
 
       - name: Cherry-pick PR to staging
-        if: ${{ fromJSON(needs.chooseDeployActions.outputs.shouldCherryPick) }}
+        if: ${{ fromJSON(needs.chooseDeployActions.outputs.SHOULD_CP) }}
         uses: Expensify/App/.github/actions/javascript/triggerWorkflowAndWait@main
         with:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
           WORKFLOW: cherryPick.yml
-          INPUTS: '{ "PULL_REQUEST_NUMBER": "${{ needs.chooseDeployActions.outputs.mergedPullRequest }}", "NEW_VERSION": "${{ needs.createNewVersion.outputs.NEW_VERSION }}" }'
+          INPUTS: '{ "PULL_REQUEST_NUMBER": "${{ needs.chooseDeployActions.outputs.MERGED_PR }}", "NEW_VERSION": "${{ needs.createNewVersion.outputs.NEW_VERSION }}" }'
 
       # Version: 3.0.2
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -129,9 +129,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 
       - name: Comment in StagingDeployCash to alert Applause that a new pull request has been cherry-picked
-        if: ${{ fromJSON(needs.chooseDeployActions.outputs.shouldCherryPick) }}
+        if: ${{ fromJSON(needs.chooseDeployActions.outputs.SHOULD_CP) }}
         run: |
-          PR_URL="https://github.com/Expensify/App/pull/${{ needs.chooseDeployActions.outputs.mergedPullRequest }}"
+          PR_URL="https://github.com/Expensify/App/pull/${{ needs.chooseDeployActions.outputs.MERGED_PR }}"
           printf -v COMMENT ":clap: Heads up @Expensify/applauseleads :clap:\nA [new pull request](%s) has been :cherries: cherry-picked :cherries: to staging, and will be deployed to staging in version \`%s\` :rocket:" "$PR_URL" ${{ needs.createNewVersion.outputs.NEW_VERSION }}
           gh issue comment \
             ${{ steps.getStagingDeployCash.outputs.STAGING_DEPLOY_CASH }} \
@@ -140,14 +140,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 
       - name: Wait for staging deploys to finish
-        if: ${{ fromJSON(needs.chooseDeployActions.outputs.shouldCherryPick) }}
+        if: ${{ fromJSON(needs.chooseDeployActions.outputs.SHOULD_CP) }}
         uses: Expensify/App/.github/actions/javascript/awaitStagingDeploys@main
         with:
           GITHUB_TOKEN: ${{ github.token }}
           TAG: ${{ needs.createNewVersion.outputs.NEW_VERSION }}
 
       - name: Comment in StagingDeployCash to alert Applause that cherry-picked pull request has been deployed.
-        if: ${{ fromJSON(needs.chooseDeployActions.outputs.shouldCherryPick) }}
+        if: ${{ fromJSON(needs.chooseDeployActions.outputs.SHOULD_CP) }}
         run: |
           gh issue comment \
             ${{ steps.getStagingDeployCash.outputs.STAGING_DEPLOY_CASH }} \


### PR DESCRIPTION
### Details
We are unsure why the `createNewVersion` job is [being skipped](https://github.com/Expensify/App/runs/7311035060?check_suite_focus=true), and we're unable to reproduce the problem in the test repo.

So now I'm just wanting to retry to see if it's some GitHub bug / fluke, and this PR puts this workflow inline with our existing conventions for job outputs.

### Fixed Issues
$ n/a

### Tests
1. Merge this PR
2. Hope it triggers a deploy.