### PR TITLE
[No QA] Change createNewVersion back to dispatchable workflow

### DIFF
--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -41,7 +41,6 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
           WORKFLOW: createNewVersion.yml
-          INPUTS: '{ "SEMVER_LEVEL": "BUILD" }'
 
       - name: Pull main to get the new version
         id: getNewVersion

--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -26,9 +26,29 @@ jobs:
 
   createNewVersion:
     needs: validateActor
+    runs-on: ubuntu-latest
     if: ${{ fromJSON(needs.validateActor.outputs.IS_DEPLOYER) && github.event.inputs.NEW_VERSION == '' }}
-    uses: Expensify/App/.github/workflows/createNewVersion.yml@main
-    secrets: inherit
+    outputs:
+      NEW_VERSION: ${{ steps.getNewVersion.outputs.NEW_VERSION }}
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        with:
+          ref: main
+
+      - name: Create new BUILD version
+        uses: Expensify/App/.github/actions/javascript/triggerWorkflowAndWait@main
+        with:
+          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+          WORKFLOW: createNewVersion.yml
+          INPUTS: '{ "SEMVER_LEVEL": "BUILD" }'
+
+      - name: Pull main to get the new version
+        id: getNewVersion
+        run: |
+          git pull origin main
+          echo "New version is $(npm run print-version --silent)"
+          echo "::set-output name=NEW_VERSION::$(npm run print-version --silent)"
 
   cherryPick:
     needs: [validateActor, createNewVersion]

--- a/.github/workflows/createNewVersion.yml
+++ b/.github/workflows/createNewVersion.yml
@@ -1,37 +1,16 @@
 name: Create new version
 
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       SEMVER_LEVEL:
         description: One of {BUILD, PATCH, MINOR, MAJOR}
-        required: false
-        default: BUILD
-        type: string
-
-    outputs:
-      NEW_VERSION:
-        description: The new version string
-        value: ${{ jobs.createNewVersion.outputs.NEW_VERSION }}
-
-    secrets:
-      LARGE_SECRET_PASSPHRASE:
-        description: Passphrase used to decrypt GPG key
-        required: true
-      OS_BOTIFY_TOKEN:
-        description: Token for the OSBotify user
-        required: true
-      SLACK_WEBHOOK:
-        description: Webhook used to comment in slack
         required: true
 
 jobs:
   createNewVersion:
     if: github.actor == 'OSBotify'
     runs-on: macos-latest
-
-    outputs:
-      NEW_VERSION: ${{ steps.bumpVersion.outputs.NEW_VERSION }}
 
     steps:
       # Version: 3.0.2

--- a/.github/workflows/createNewVersion.yml
+++ b/.github/workflows/createNewVersion.yml
@@ -5,7 +5,8 @@ on:
     inputs:
       SEMVER_LEVEL:
         description: One of {BUILD, PATCH, MINOR, MAJOR}
-        required: true
+        required: false
+        default: BUILD
 
 jobs:
   createNewVersion:

--- a/.github/workflows/finishReleaseCycle.yml
+++ b/.github/workflows/finishReleaseCycle.yml
@@ -94,8 +94,8 @@ jobs:
 
       - name: Pull staging to get the new version
         run: |
-          git fetch
-          git switch staging
+          git checkout -b staging
+          git pull origin staging
           echo "NEW_VERSION=$(npm run print-version --silent)" >> "$GITHUB_ENV"
           echo "New version is ${{ env.NEW_VERSION }}"
 

--- a/.github/workflows/finishReleaseCycle.yml
+++ b/.github/workflows/finishReleaseCycle.yml
@@ -66,6 +66,7 @@ jobs:
   # Deploy deferred PRs to staging and create a new StagingDeployCash for the next release cycle.
   createNewStagingDeployCash:
     runs-on: ubuntu-latest
+    needs: validate
     if: ${{ fromJSON(needs.validate.outputs.isValid) }}
     steps:
       # Version: 3.0.2

--- a/.github/workflows/finishReleaseCycle.yml
+++ b/.github/workflows/finishReleaseCycle.yml
@@ -63,20 +63,27 @@ jobs:
           OS_BOTIFY_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
           GPG_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
 
-  # Create a new patch version to prep for next release cycle
-  createNewPatchVersion:
-    needs: validate
-    if: ${{ fromJSON(needs.validate.outputs.isValid) }}
-    uses: Expensify/App/.github/workflows/createNewVersion.yml@main
-    secrets: inherit
-    with:
-      SEMVER_LEVEL: PATCH
-
   # Deploy deferred PRs to staging and create a new StagingDeployCash for the next release cycle.
   createNewStagingDeployCash:
     runs-on: ubuntu-latest
-    needs: createNewPatchVersion
+    if: ${{ fromJSON(needs.validate.outputs.isValid) }}
     steps:
+      # Version: 3.0.2
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+
+      - uses: softprops/turnstyle@8db075d65b19bf94e6e8687b504db69938dc3c65
+        with:
+          poll-interval-seconds: 10
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create new PATCH version
+        uses: Expensify/App/.github/actions/javascript/triggerWorkflowAndWait@main
+        with:
+          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+          WORKFLOW: createNewVersion.yml
+          INPUTS: '{ "SEMVER_LEVEL": "PATCH" }'
+
       - name: Update staging branch to trigger staging deploy
         uses: Expensify/App/.github/actions/composite/updateProtectedBranch@main
         with:
@@ -84,18 +91,25 @@ jobs:
           OS_BOTIFY_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
           GPG_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
 
+      - name: Pull staging to get the new version
+        run: |
+          git fetch
+          git switch staging
+          echo "NEW_VERSION=$(npm run print-version --silent)" >> "$GITHUB_ENV"
+          echo "New version is ${{ env.NEW_VERSION }}"
+
         # Create a local git tag so that GitUtils.getPullRequestsMergedBetween can use `git log` to generate a
         # list of pull requests that were merged between this version tag and another.
         # NOTE: This tag is only used locally and shouldn't be pushed to the remote.
         # If it was pushed, that would trigger the staging deploy which is handled in a separate workflow (deploy.yml)
       - name: Tag version
-        run: git tag ${{ needs.createNewPatchVersion.outputs.NEW_VERSION }}
+        run: git tag ${{ env.NEW_VERSION }}
 
       - name: Create new StagingDeployCash
         uses: Expensify/App/.github/actions/javascript/createOrUpdateStagingDeploy@main
         with:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
-          NPM_VERSION: ${{ needs.createNewPatchVersion.outputs.NEW_VERSION }}
+          NPM_VERSION: ${{ env.NEW_VERSION }}
 
       - if: ${{ failure() }}
         uses: Expensify/App/.github/actions/composite/announceFailedWorkflowInSlack@main

--- a/.github/workflows/finishReleaseCycle.yml
+++ b/.github/workflows/finishReleaseCycle.yml
@@ -71,6 +71,8 @@ jobs:
     steps:
       # Version: 3.0.2
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          fetch-depth: 0
 
       - uses: softprops/turnstyle@8db075d65b19bf94e6e8687b504db69938dc3c65
         with:
@@ -94,7 +96,7 @@ jobs:
 
       - name: Pull staging to get the new version
         run: |
-          git checkout -b staging
+          git checkout staging
           git pull origin staging
           echo "NEW_VERSION=$(npm run print-version --silent)" >> "$GITHUB_ENV"
           echo "New version is ${{ env.NEW_VERSION }}"

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -59,18 +59,6 @@ jobs:
         id: shouldDeploy
         run: echo "::set-output name=SHOULD_DEPLOY::${{ fromJSON(steps.hasCherryPickLabel.outputs.HAS_CP_LABEL) || (!fromJSON(steps.isStagingDeployLocked.outputs.IS_LOCKED) && !fromJSON(steps.isAutomatedPullRequest.outputs.IS_AUTOMATED_PR)) }}"
 
-  debugChooseDeployActions:
-    runs-on: ubuntu-latest
-    needs: chooseDeployActions
-    steps:
-      - if: ${{ fromJSON(needs.chooseDeployActions.outputs.SHOULD_DEPLOY) }}
-        run: echo 'This proves that the expected output is true and this is a GitHub bug'
-
-      - if: ${{ !fromJSON(needs.chooseDeployActions.outputs.SHOULD_DEPLOY) }}
-        run: echo 'This is weird'
-
-      - run: echo '${{ needs.chooseDeployActions.outputs.SHOULD_DEPLOY }}'
-
   skipDeploy:
     runs-on: ubuntu-latest
     needs: chooseDeployActions

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -93,7 +93,6 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
           WORKFLOW: createNewVersion.yml
-          INPUTS: '{ "SEMVER_LEVEL": "BUILD" }'
 
       - name: Pull main to get the new version
         run: |

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -84,21 +84,34 @@ jobs:
           body: |
             :hand: This PR was not deployed to staging yet because QA is ongoing. It will be automatically deployed to staging after the next production release.
 
-  createNewVersion:
+  version:
+    runs-on: ubuntu-latest
     needs: chooseDeployActions
     if: ${{ fromJSON(needs.chooseDeployActions.outputs.SHOULD_DEPLOY) }}
-    uses: Expensify/App/.github/workflows/createNewVersion.yml@main
-    secrets: inherit
-
-  updateStaging:
-    needs: [chooseDeployActions, createNewVersion]
-    runs-on: ubuntu-latest
     steps:
+      # Version: 3.0.2
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          fetch-depth: 0
+
       - uses: softprops/turnstyle@8db075d65b19bf94e6e8687b504db69938dc3c65
         with:
           poll-interval-seconds: 10
         env:
           GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Create new BUILD version
+        uses: Expensify/App/.github/actions/javascript/triggerWorkflowAndWait@main
+        with:
+          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+          WORKFLOW: createNewVersion.yml
+          INPUTS: '{ "SEMVER_LEVEL": "BUILD" }'
+
+      - name: Pull main to get the new version
+        run: |
+          git pull origin main
+          echo "NEW_VERSION=$(npm run print-version --silent)" >> "$GITHUB_ENV"
+          echo "New version is ${{ env.NEW_VERSION }}"
 
       - name: Update staging branch from main
         if: ${{ !fromJSON(needs.chooseDeployActions.outputs.SHOULD_CP) }}
@@ -114,25 +127,23 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
           WORKFLOW: cherryPick.yml
-          INPUTS: '{ "PULL_REQUEST_NUMBER": "${{ needs.chooseDeployActions.outputs.MERGED_PR }}", "NEW_VERSION": "${{ needs.createNewVersion.outputs.NEW_VERSION }}" }'
-
-      # Version: 3.0.2
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-        with:
-          ref: staging
+          INPUTS: '{ "PULL_REQUEST_NUMBER": "${{ needs.chooseDeployActions.outputs.MERGED_PR }}", "NEW_VERSION": "${{ env.NEW_VERSION }}" }'
 
       # Create a local git tag on staging so that GitUtils.getPullRequestsMergedBetween can use `git log` to generate a
       # list of pull requests that were merged between this version tag and another.
       # NOTE: This tag is only used locally and shouldn't be pushed to the remote.
       # If it was pushed, that would trigger the staging deploy which is handled in a separate workflow (deploy.yml)
       - name: Tag staging
-        run: git tag ${{ needs.createNewVersion.outputs.NEW_VERSION }}
+        run: |
+          git checkout staging
+          git pull origin staging
+          git tag ${{ env.NEW_VERSION }}
 
       - name: Update StagingDeployCash
         uses: Expensify/App/.github/actions/javascript/createOrUpdateStagingDeploy@main
         with:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
-          NPM_VERSION: ${{ needs.createNewVersion.outputs.NEW_VERSION }}
+          NPM_VERSION: ${{ env.NEW_VERSION }}
 
       - name: Find open StagingDeployCash
         id: getStagingDeployCash
@@ -144,7 +155,7 @@ jobs:
         if: ${{ fromJSON(needs.chooseDeployActions.outputs.SHOULD_CP) }}
         run: |
           PR_URL="https://github.com/Expensify/App/pull/${{ needs.chooseDeployActions.outputs.MERGED_PR }}"
-          printf -v COMMENT ":clap: Heads up @Expensify/applauseleads :clap:\nA [new pull request](%s) has been :cherries: cherry-picked :cherries: to staging, and will be deployed to staging in version \`%s\` :rocket:" "$PR_URL" ${{ needs.createNewVersion.outputs.NEW_VERSION }}
+          printf -v COMMENT ":clap: Heads up @Expensify/applauseleads :clap:\nA [new pull request](%s) has been :cherries: cherry-picked :cherries: to staging, and will be deployed to staging in version \`%s\` :rocket:" "$PR_URL" ${{ env.NEW_VERSION }}
           gh issue comment \
             ${{ steps.getStagingDeployCash.outputs.STAGING_DEPLOY_CASH }} \
             --body "$COMMENT"
@@ -156,14 +167,14 @@ jobs:
         uses: Expensify/App/.github/actions/javascript/awaitStagingDeploys@main
         with:
           GITHUB_TOKEN: ${{ github.token }}
-          TAG: ${{ needs.createNewVersion.outputs.NEW_VERSION }}
+          TAG: ${{ env.NEW_VERSION }}
 
       - name: Comment in StagingDeployCash to alert Applause that cherry-picked pull request has been deployed.
         if: ${{ fromJSON(needs.chooseDeployActions.outputs.SHOULD_CP) }}
         run: |
           gh issue comment \
             ${{ steps.getStagingDeployCash.outputs.STAGING_DEPLOY_CASH }} \
-            --body ":tada: All set?…You bet! @Expensify/applauseleads https://github.com/Expensify/App/releases/tag/${{ needs.createNewVersion.outputs.NEW_VERSION }} has been deployed to staging :tada:"
+            --body ":tada: All set?…You bet! @Expensify/applauseleads https://github.com/Expensify/App/releases/tag/${{ env.NEW_VERSION }} has been deployed to staging :tada:"
         env:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 


### PR DESCRIPTION
### Details
This is a partial revert of https://github.com/Expensify/App/pull/9812, which didn't work due to a GitHub Actions bug, which can be tracked in a few places:

- [Community post](https://github.community/t/job-level-if-condition-is-not-evaluated-correctly/261486)
- [Support ticket](https://support.github.com/ticket/personal/0/1704129)
- [Issue in runner repo](https://github.com/actions/runner/issues/1996)

I've optimistically curated the revert to include some best practices updates, reduce the diff, and see if this bug we're seeing is related to the use of a callable action, as I suspect. This should hopefully make it easier to un-revert once the bug is fixed.

### Fixed Issues
$ n/a – broken deploys

### Tests
1. Merge this PR
1. Verify that a staging deploy happens, as expected.