### PR TITLE
[No QA] Make createNewVersion callable by anyone with write access

### DIFF
--- a/.github/workflows/createNewVersion.yml
+++ b/.github/workflows/createNewVersion.yml
@@ -26,21 +26,7 @@ on:
         required: true
 
 jobs:
-  validateActor:
-    runs-on: ubuntu-latest
-    outputs:
-      IS_DEPLOYER: ${{ fromJSON(steps.isUserDeployer.outputs.isTeamMember) || github.actor == 'OSBotify' }}
-    steps:
-      - id: isUserDeployer
-        uses: tspascoal/get-user-teams-membership@baf2e6adf4c3b897bd65a7e3184305c165aec872
-        with:
-          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
-          username: ${{ github.actor }}
-          team: mobile-deployers
-
   createNewVersion:
-    needs: validateActor
-    if: ${{ fromJSON(needs.validateActor.outputs.IS_DEPLOYER) }}
     runs-on: macos-latest
 
     outputs:

--- a/.github/workflows/createNewVersion.yml
+++ b/.github/workflows/createNewVersion.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: Get user permissions
         id: getUserPermissions
-        run: echo "::set-output name=PERMISSION::$(gh api /repos/Expensify/App/collaborators/roryabraham/permission | jq -r '.permission')"
+        run: echo "::set-output name=PERMISSION::$(gh api /repos/Expensify/App/collaborators/${{ github.actor }}/permission | jq -r '.permission')"
         env:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 

--- a/.github/workflows/createNewVersion.yml
+++ b/.github/workflows/createNewVersion.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: Get user permissions
         id: getUserPermissions
-        run: echo "::set-output name=PERMISSION::$(gh api /repos/Expensify/App/collaborators/${{ github.actor }}/permission | jq -r '.permission')"
+        run: echo "::set-output name=PERMISSION::$(gh api /repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission | jq -r '.permission')"
         env:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 

--- a/.github/workflows/createNewVersion.yml
+++ b/.github/workflows/createNewVersion.yml
@@ -35,7 +35,7 @@ jobs:
         id: getUserPermissions
         run: echo "::set-output name=PERMISSION::$(gh api /repos/Expensify/App/collaborators/roryabraham/permission | jq -r '.permission')"
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 
   createNewVersion:
     runs-on: macos-latest

--- a/.github/workflows/createNewVersion.yml
+++ b/.github/workflows/createNewVersion.yml
@@ -29,7 +29,7 @@ jobs:
   validateActor:
     runs-on: ubuntu-latest
     outputs:
-      HAS_WRITE_ACCESS: ${{ contains(fromJSON(["write", "admin"]), steps.getUserPermissions.outputs.PERMISSION) }}
+      HAS_WRITE_ACCESS: ${{ contains(fromJSON('["write", "admin"]'), steps.getUserPermissions.outputs.PERMISSION) }}
     steps:
       - name: Get user permissions
         id: getUserPermissions

--- a/.github/workflows/createNewVersion.yml
+++ b/.github/workflows/createNewVersion.yml
@@ -26,8 +26,19 @@ on:
         required: true
 
 jobs:
+  validateActor:
+    runs-on: ubuntu-latest
+    outputs:
+      HAS_WRITE_ACCESS: ${{ contains(fromJSON(["write", "admin"]), steps.getUserPermissions.outputs.PERMISSION) }}
+    steps:
+      - name: Get user permissions
+        id: getUserPermissions
+        run: echo "::set-output name=PERMISSION::$(gh api /repos/Expensify/App/collaborators/roryabraham/permission | jq -r '.permission')"
+
   createNewVersion:
     runs-on: macos-latest
+    needs: validateActor
+    if: ${{ fromJSON(needs.validateActor.outputs.HAS_WRITE_ACCESS) }}
 
     outputs:
       NEW_VERSION: ${{ steps.bumpVersion.outputs.NEW_VERSION }}

--- a/.github/workflows/createNewVersion.yml
+++ b/.github/workflows/createNewVersion.yml
@@ -34,6 +34,8 @@ jobs:
       - name: Get user permissions
         id: getUserPermissions
         run: echo "::set-output name=PERMISSION::$(gh api /repos/Expensify/App/collaborators/roryabraham/permission | jq -r '.permission')"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
   createNewVersion:
     runs-on: macos-latest

--- a/.github/workflows/createNewVersion.yml
+++ b/.github/workflows/createNewVersion.yml
@@ -26,8 +26,21 @@ on:
         required: true
 
 jobs:
+  validateActor:
+    runs-on: ubuntu-latest
+    outputs:
+      IS_DEPLOYER: ${{ fromJSON(steps.isUserDeployer.outputs.isTeamMember) || github.actor == 'OSBotify' }}
+    steps:
+      - id: isUserDeployer
+        uses: tspascoal/get-user-teams-membership@baf2e6adf4c3b897bd65a7e3184305c165aec872
+        with:
+          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+          username: ${{ github.actor }}
+          team: mobile-deployers
+
   createNewVersion:
-    if: github.actor == 'OSBotify'
+    needs: validateActor
+    if: ${{ fromJSON(needs.validateActor.outputs.IS_DEPLOYER) }}
     runs-on: macos-latest
 
     outputs:


### PR DESCRIPTION
### Details
The `createNewVersion` workflow was not being called when the actor was not OSBotify. We need it to able to = be called by anyone with write access to the repo.

### Fixed Issues
$ n/a – broken deploys

### Tests
0. Validation step tested in `Public-Test-Repo`: https://github.com/Andrew-Test-Org/Public-Test-Repo/actions/runs/2665173073
1. Merge this PR
1. It should trigger a deploy