### PR TITLE
[No QA] Checkout repo before trying to use setupGitForOSBotify

### DIFF
--- a/.github/actions/composite/updateProtectedBranch/action.yml
+++ b/.github/actions/composite/updateProtectedBranch/action.yml
@@ -47,6 +47,12 @@ runs:
           echo "SOURCE_BRANCH=${{ inputs.SOURCE_BRANCH }}" >> "$GITHUB_ENV"
         fi
 
+    # Version: 3.0.2
+    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      with:
+        ref: ${{ env.SOURCE_BRANCH }}
+        fetch-depth: 0
+
     - uses: Expensify/App/.github/actions/composite/setupGitForOSBotify@main
       with:
         GPG_PASSPHRASE: ${{ inputs.GPG_PASSPHRASE }}
@@ -54,7 +60,6 @@ runs:
     - name: Update target and source branches
       shell: bash
       run: |
-        git fetch
         git checkout ${{ inputs.TARGET_BRANCH }}
         git merge origin/${{ inputs.TARGET_BRANCH }}
         git checkout ${{ env.SOURCE_BRANCH }}

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -59,18 +59,6 @@ jobs:
         id: shouldDeploy
         run: echo "::set-output name=SHOULD_DEPLOY::${{ fromJSON(steps.hasCherryPickLabel.outputs.HAS_CP_LABEL) || (!fromJSON(steps.isStagingDeployLocked.outputs.IS_LOCKED) && !fromJSON(steps.isAutomatedPullRequest.outputs.IS_AUTOMATED_PR)) }}"
 
-  debugChooseDeployActions:
-    runs-on: ubuntu-latest
-    needs: chooseDeployActions
-    steps:
-      - if: ${{ fromJSON(needs.chooseDeployActions.outputs.SHOULD_DEPLOY) }}
-        run: echo 'This proves that the expected output is true and this is a GitHub bug'
-
-      - if: ${{ !fromJSON(needs.chooseDeployActions.outputs.SHOULD_DEPLOY) }}
-        run: echo 'This is weird'
-
-      - run: echo '${{ needs.chooseDeployActions.outputs.SHOULD_DEPLOY }}'
-
   skipDeploy:
     runs-on: ubuntu-latest
     needs: chooseDeployActions


### PR DESCRIPTION
### Details
We were trying to decrypt files in the repo before checking it out. As a bonus, got rid of old debug job.

### Fixed Issues
$ n/a – broken workflow: https://github.com/Expensify/App/runs/7326575491?check_suite_focus=true

### Tests
1. Merge this PR
1. It should deploy to staging.