### PR TITLE
[No QA] Remove broken defaultProps

### DIFF
--- a/src/pages/iou/steps/IOUAmountPage.js
+++ b/src/pages/iou/steps/IOUAmountPage.js
@@ -42,15 +42,9 @@ const propTypes = {
 
         /** Selected Currency Code of the current IOU */
         selectedCurrencyCode: PropTypes.string,
-    }),
+    }).isRequired,
 
     ...withLocalizePropTypes,
-};
-
-const defaultProps = {
-    iou: {
-        selectedCurrencyCode: CONST.CURRENCY.USD,
-    },
 };
 
 class IOUAmountPage extends React.Component {
@@ -222,7 +216,7 @@ class IOUAmountPage extends React.Component {
                         placeholder={this.props.numberFormat(0)}
                         preferredLocale={this.props.preferredLocale}
                         ref={el => this.textInput = el}
-                        selectedCurrencyCode={this.props.iou.selectedCurrencyCode}
+                        selectedCurrencyCode={this.props.iou.selectedCurrencyCode || CONST.CURRENCY.USD}
                     />
                 </View>
                 <View style={[styles.w100, styles.justifyContentEnd]}>
@@ -248,7 +242,6 @@ class IOUAmountPage extends React.Component {
 }
 
 IOUAmountPage.propTypes = propTypes;
-IOUAmountPage.defaultProps = defaultProps;
 
 export default compose(
     withLocalize,


### PR DESCRIPTION
### Details
Removes broken default props from IOUAmountPage. If any key in `props.iou` is returned, the defaultProps for iou doesn't actually check that `iou.selectedCurrencyCode` is set, which makes it useless.

cc @mountiny @PauloGasparSv 

### Fixed Issues
$ https://github.com/Expensify/App/issues/9889

### Tests
1. Comment [this line](https://github.com/Expensify/App/blob/fd5a491e1840be55f487b9cc0ce223648fa264e0/src/libs/actions/App.js#L96) 
2. Log into an account
3. Navigate to `+ > Request money`
4. Verify that you see the default `USD` currency

- [x] Verify that no errors appear in the JS console
