### PR TITLE
[No QA] Allow linux platform in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -270,6 +270,7 @@ GEM
 PLATFORMS
   universal-darwin-20
   x86_64-darwin-19
+  x86_64-linux
 
 DEPENDENCIES
   cocoapods (~> 1)


### PR DESCRIPTION
### Details
Fixing broken android deploy: https://github.com/Expensify/App/runs/7328519799?check_suite_focus=true

### Fixed Issues
$ n/a – broken deploys

### Tests
1. Merge this PR
1. It should trigger a staging deploy