### PR TITLE
[No QA] Fetch tags before updating StagingDeployCash

### DIFF
--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -108,15 +108,14 @@ jobs:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
           ref: staging
+          fetch-depth: 0
 
       # Create a local git tag on staging so that GitUtils.getPullRequestsMergedBetween can use `git log` to generate a
       # list of pull requests that were merged between this version tag and another.
       # NOTE: This tag is only used locally and shouldn't be pushed to the remote.
       # If it was pushed, that would trigger the staging deploy which is handled in a separate workflow (deploy.yml)
       - name: Tag staging
-        run: |
-          git fetch --tags
-          git tag ${{ needs.createNewVersion.outputs.NEW_VERSION }}
+        run: git tag ${{ needs.createNewVersion.outputs.NEW_VERSION }}
 
       - name: Update StagingDeployCash
         uses: Expensify/App/.github/actions/javascript/createOrUpdateStagingDeploy@main

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -114,7 +114,9 @@ jobs:
       # NOTE: This tag is only used locally and shouldn't be pushed to the remote.
       # If it was pushed, that would trigger the staging deploy which is handled in a separate workflow (deploy.yml)
       - name: Tag staging
-        run: git tag ${{ needs.createNewVersion.outputs.NEW_VERSION }}
+        run: |
+          git fetch --tags
+          git tag ${{ needs.createNewVersion.outputs.NEW_VERSION }}
 
       - name: Update StagingDeployCash
         uses: Expensify/App/.github/actions/javascript/createOrUpdateStagingDeploy@main


### PR DESCRIPTION
### Details
I am looking at recent changes and noticed we removed this `fetch-depth: 0`: https://github.com/Expensify/App/pull/9812/files#diff-1219dd7a2951518446d9e9da907af2e02968bce34c2d2adda8ee4357bf22fa0cL87, which seems like a likely culprit for why our Git history would be messed up

### Fixed Issues
$ n/a – broken deploys https://github.com/Expensify/App/runs/7330727826?check_suite_focus=true

### Tests
1. Merge this PR
1. That should trigger a staging deploy and update the checklist.