### PR TITLE
fixed .XX issue

### DIFF
--- a/src/pages/iou/steps/IOUAmountPage.js
+++ b/src/pages/iou/steps/IOUAmountPage.js
@@ -113,7 +113,7 @@ class IOUAmountPage extends React.Component {
      * @returns {Boolean}
      */
     validateAmount(amount) {
-        const decimalNumberRegex = new RegExp(/^\d+(,\d+)*(\.\d{0,2})?$/, 'i');
+        const decimalNumberRegex = new RegExp(/^(\.\d{0,2})|\d+(,\d+)*(\.\d{0,2})?$/, 'i');
         return amount === '' || (decimalNumberRegex.test(amount) && this.calculateAmountLength(amount) <= CONST.IOU.AMOUNT_MAX_LENGTH);
     }
 


### PR DESCRIPTION
### Details
Currently, the regex is ^\d+(,\d+)*(\.\d{0,2})?$ in validateAmount function of /src/pages/iou/steps/IOUAmountPage.js

### Fixed Issues
I updated the regex to ^(\.\d{0,2})|\d+(,\d+)*(\.\d{0,2})?$

$ https://github.com/Expensify/App/issues/9389

### Tests
I tested it on regex101.com
