### PR TITLE
[NoQA] fix links for Expensify Help site

### DIFF
--- a/docs/_includes/home-lhn.html
+++ b/docs/_includes/home-lhn.html
@@ -1,6 +1,6 @@
 <ul class="lhn-items">
     <li class="home-link">
-        <a href="/index.html">Home</a>
+        <div class="link" onclick="navigateToHome()">Home</div>
     </li>
     <li>
         <div onclick="navigateTo('/hubs/send-money')" class="icon-with-link">

--- a/docs/_includes/request-money-lhn.html
+++ b/docs/_includes/request-money-lhn.html
@@ -1,6 +1,6 @@
 <ul class="lhn-items">
     <li class="home-link">
-        <a href="/index.html">Home</a>
+        <div class="link" onclick="navigateToHome()">Home</div>
     </li>
     <li>
         <div onclick="navigateTo('/hubs/send-money')" class="icon-with-link">

--- a/docs/_includes/send-money-lhn.html
+++ b/docs/_includes/send-money-lhn.html
@@ -1,6 +1,6 @@
 <ul class="lhn-items">
     <li class="home-link">
-        <a href="/index.html">Home</a>
+        <div class="link" onclick="navigateToHome()">Home</div>
     </li>
     <li>
         <div class="icon-with-link selected">

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -1,5 +1,5 @@
 
-/* eslint-disable no-use-before-define */
+/* eslint-disable no-unused-vars */
 function navigateTo(path) {
     window.location.href = path;
 }

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -1,9 +1,10 @@
 
-function navigateTo(path) { // eslint-disable-line no-unused-vars
+/* eslint-disable no-use-before-define */
+function navigateTo(path) {
     window.location.href = path;
 }
 
-function toggleHeaderMenu() { // eslint-disable-line no-unused-vars
+function toggleHeaderMenu() {
     const lhn = document.getElementById('lhn');
     const lhnContent = document.getElementById('lhn-content');
     const anguleUpIcon = document.getElementById('angle-up-icon');
@@ -23,7 +24,7 @@ function toggleHeaderMenu() { // eslint-disable-line no-unused-vars
     }
 }
 
-function navigateBack() { // eslint-disable-line no-unused-vars
+function navigateBack() {
     if (window.location.pathname.includes('/request-money/')) {
         window.location.href = '/hubs/request-money';
     } else {

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -25,9 +25,9 @@ function toggleHeaderMenu() { // eslint-disable-line no-unused-vars
 
 function navigateBack() { // eslint-disable-line no-unused-vars
     if (window.location.pathname.includes('/request-money/')) {
-        window.location.href = '/hubs/request-money/';
+        window.location.href = '/hubs/request-money';
     } else {
-        window.location.href = '/hubs/send-money/';
+        window.location.href = '/hubs/send-money';
     }
 
     // Add a little delay to avoid showing the previous content in a fraction of a time

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -4,6 +4,11 @@ function navigateTo(path) {
     window.location.href = path;
 }
 
+function navigateToHome() {
+    // TODO: Change to '/index' when the site is live
+    navigateTo('/main');
+}
+
 function toggleHeaderMenu() {
     const lhn = document.getElementById('lhn');
     const lhnContent = document.getElementById('lhn-content');


### PR DESCRIPTION
### Details
This PR fixes the links for the new Expensify Help (where the back button is not working as expected [here](https://help.expensify.com/articles/request-money/SmartScan)).

### Fixed Issues
N/A

### Tests
0. (you need ruby and bundler installed to do this, more info [here](https://github.com/Expensify/App/tree/main/docs#pre-requisites))
1. Run:

    ```bash
    cd docs
    bundle install
    bundle exec jekyll serve
    ```
2. Navigate to http://localhost:4000/articles/request-money/SmartScan and click on the `Back` button, it should redirect to the hub page (upper level)

<img width="1042" alt="Screen Shot 2022-07-14 at 15 10 08" src="https://user-images.githubusercontent.com/6829422/179074840-c77bd4c6-5ae8-4b4f-bc20-019c393a4d10.png">

3. Click on the `Home` button and verify it redirects you to the Homepage (currently it's an empty page) instead of the "Coming soon" page.

<img width="1041" alt="Screen Shot 2022-07-14 at 15 10 18" src="https://user-images.githubusercontent.com/6829422/179074875-9870ba46-0906-4689-956e-50bdd4223213.png">

