### PR TITLE
[No QA] Revert #9706. Rename file to `DeprecatedCustomActions.js` to prevent further editing

### DIFF
--- a/src/libs/Navigation/CustomActions.js
+++ b/src/libs/Navigation/CustomActions.js
@@ -3,10 +3,8 @@ import {
     CommonActions, StackActions, DrawerActions, getStateFromPath,
 } from '@react-navigation/native';
 import lodashGet from 'lodash/get';
-import {Dimensions} from 'react-native';
 import linkingConfig from './linkingConfig';
 import navigationRef from './navigationRef';
-import variables from '../../styles/variables';
 
 /**
  * @returns {Object}
@@ -71,9 +69,6 @@ function getScreenNameFromState(state) {
  */
 function pushDrawerRoute(route) {
     return (currentState) => {
-        const initialDimensions = Dimensions.get('window');
-        const isSmallScreenWidth = initialDimensions.width <= variables.mobileResponsiveWidthBreakpoint;
-
         // Parse the state, name, and params from the new route we want to navigate to.
         const newStateFromRoute = getStateFromPath(route, linkingConfig.config);
         const newScreenName = getScreenNameFromState(newStateFromRoute);
@@ -108,17 +103,12 @@ function pushDrawerRoute(route) {
         // Force drawer to close
         // https://github.com/react-navigation/react-navigation/blob/94ab791cae5061455f036cd3f6bc7fa63167e7c7/packages/routers/src/DrawerRouter.tsx#L142
         const hasDrawerhistory = _.find(state.history || [], h => h.type === 'drawer');
-        if (isSmallScreenWidth && (!hasDrawerhistory || currentState.type !== 'drawer')) {
+        if (!hasDrawerhistory || currentState.type !== 'drawer') {
             history.push({
                 type: 'drawer',
 
                 // If current state is not from drawer navigator then always use closed status to close the drawer
                 status: currentState.type !== 'drawer' || currentState.default === 'open' ? 'closed' : 'open',
-            });
-        } else {
-            history.push({
-                type: 'route',
-                name: newScreenName,
             });
         }
 

--- a/src/libs/Navigation/DeprecatedCustomActions.js
+++ b/src/libs/Navigation/DeprecatedCustomActions.js
@@ -16,6 +16,7 @@ function getActiveState() {
 
 /**
  * Go back to the Main Drawer
+ * @deprecated
  * @param {Object} navigationRef
  */
 function navigateBackToRootDrawer() {
@@ -64,6 +65,7 @@ function getScreenNameFromState(state) {
  *
  * More context here: https://github.com/react-navigation/react-navigation/issues/9744
  *
+ * @deprecated
  * @param {String} route
  * @returns {Function}
  */

--- a/src/libs/Navigation/Navigation.js
+++ b/src/libs/Navigation/Navigation.js
@@ -5,7 +5,7 @@ import Onyx from 'react-native-onyx';
 import Log from '../Log';
 import linkTo from './linkTo';
 import ROUTES from '../../ROUTES';
-import CustomActions from './CustomActions';
+import DeprecatedCustomActions from './DeprecatedCustomActions';
 import ONYXKEYS from '../../ONYXKEYS';
 import linkingConfig from './linkingConfig';
 import navigationRef from './navigationRef';
@@ -140,7 +140,7 @@ function navigate(route = ROUTES.HOME) {
     }
 
     if (isDrawerRoute(route)) {
-        navigationRef.current.dispatch(CustomActions.pushDrawerRoute(route));
+        navigationRef.current.dispatch(DeprecatedCustomActions.pushDrawerRoute(route));
         return;
     }
 
@@ -161,7 +161,7 @@ function dismissModal(shouldOpenDrawer = false) {
         ? shouldOpenDrawer
         : false;
 
-    CustomActions.navigateBackToRootDrawer();
+    DeprecatedCustomActions.navigateBackToRootDrawer();
     if (normalizedShouldOpenDrawer) {
         openDrawer();
     }


### PR DESCRIPTION
### Details

- Renaming these files so that people will stop editing the CustomActions file.
- We need a longer term solution for navigation issues and will track them instead of making temporary changes.

### Fixed Issues

No issues

### Tests

None as this is a revert.