### PR TITLE
Fix button opacity problem when saving personal details

### DIFF
--- a/src/components/OpacityView.js
+++ b/src/components/OpacityView.js
@@ -21,6 +21,7 @@ class OpacityView extends React.Component {
     constructor(props) {
         super(props);
         this.opacity = new Animated.Value(1);
+        this.undim = this.undim.bind(this);
     }
 
     componentDidUpdate(prevProps) {
@@ -33,12 +34,23 @@ class OpacityView extends React.Component {
         }
 
         if (prevProps.shouldDim && !this.props.shouldDim) {
-            Animated.timing(this.opacity, {
-                toValue: 1,
-                duration: 50,
-                useNativeDriver: true,
-            }).start();
+            this.undim()
         }
+    }
+
+    undim() {
+        Animated.timing(this.opacity, {
+            toValue: 1,
+            duration: 50,
+            useNativeDriver: true,
+        }).start(({finished}) => {
+            // If animation doesn't finish because Animation.stop was called
+            // (e.g. because it was interrupted by a gesture or another animation),
+            // restart animation so we always make sure the component gets completely shown.
+            if (!finished) {
+                this.undim();
+            }
+        });
     }
 
     render() {

--- a/src/components/OpacityView.js
+++ b/src/components/OpacityView.js
@@ -47,9 +47,10 @@ class OpacityView extends React.Component {
             // If animation doesn't finish because Animation.stop was called
             // (e.g. because it was interrupted by a gesture or another animation),
             // restart animation so we always make sure the component gets completely shown.
-            if (!finished) {
-                this.undim();
+            if (finished) {
+                return;
             }
+            this.undim();
         });
     }
 

--- a/src/components/OpacityView.js
+++ b/src/components/OpacityView.js
@@ -34,7 +34,7 @@ class OpacityView extends React.Component {
         }
 
         if (prevProps.shouldDim && !this.props.shouldDim) {
-            this.undim()
+            this.undim();
         }
     }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
cc @tgolen since you were also looking into this solution yesterday

### Details
<!-- Explanation of the change or anything fishy that is going on -->
The problem was, as mentioned [here](https://github.com/Expensify/App/issues/10215#issuecomment-1203763588), some rerendering or gestures made the Opacity animation stop before it finished. In that comment I show some console logs that indicate the Animation never finished, so in this fix I make sure the Undim animation will always finish. It's possible we'll need the same for Dim in the future, but that's not something we need to worry about right now.

One alternate solution I had was to try to check if the value of `this.opacity` was < 1 & if `this.props.shouldDim` was `false`, like this:

```js
if ((prevProps.shouldDim || this.opacity < 1) && !this.props.shouldDim) {
    this.undim();
}
```

However this doesn't work because `this.opacity` is an `Animated` value - to get its value you have to do something hacky (see [this SO](https://stackoverflow.com/questions/41932345/get-current-value-of-animated-value-react-native))

So instead of doing something hacky, we now just make sure it fully undims (becomes fully visible) when needed.

### Fixed Issues
$ https://github.com/Expensify/App/issues/10230

### Tests
1. Open Settings -> Profile
2. Edit your name or pronouns
3. Save changes
4. Edit again, verify that the "Save button" has full opacity - meaning it's fully visible, doesn't look disabled at all
5. Repeat steps 2 - 4 a few times, making sure the Save button always returns to full visibility after you start editing your details, and it becomes disabled (and isn't clickable) when the details have been saved & aren't edited

- [x] Verify that no errors appear in the JS console

### PR Review Checklist
<!--
This is a checklist for PR authors & reviewers. Please make sure to complete all tasks and check them off once you do, or else Expensify has the right not to merge your PR!
-->
#### Contributor (PR Author) Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [ ] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] Any functional components have the `displayName` property
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.


### QA Steps
1. Open Settings -> Profile
2. Edit your name or pronouns
3. Save changes
4. Edit again, verify that the "Save button" has full opacity - meaning it's fully visible, doesn't look disabled at all
5. Repeat steps 2 - 4 a few times, making sure the Save button always returns to full visibility after you start editing your details, and it becomes disabled (and isn't clickable) when the details have been saved & aren't edited

- [ ] Verify that no errors appear in the JS console

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

https://user-images.githubusercontent.com/3885503/182593316-4ce6495e-b6f6-4233-a8b1-ec40496880d4.mov


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

https://user-images.githubusercontent.com/3885503/182596108-9144783f-ee85-4053-95d7-f762d68e9789.mov


#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

https://user-images.githubusercontent.com/3885503/182599889-16681ff5-cd50-498d-b825-b38ea3a5ed1b.mov


#### Android
<!-- Insert screenshots of your changes on the Android platform-->

https://user-images.githubusercontent.com/3885503/182601319-89ad7971-1857-4281-b594-949300b29303.mov


