### PR TITLE
Fix timezone not showing correct timezone after save

### DIFF
--- a/src/libs/actions/App.js
+++ b/src/libs/actions/App.js
@@ -211,7 +211,7 @@ function setUpPoliciesAndNavigate(session, currentPath) {
 function openProfile() {
     const oldTimezoneData = myPersonalDetails.timezone || {};
     let newTimezoneData;
-    
+
     if (lodashGet(oldTimezoneData, 'automatic', true)) {
         newTimezoneData = {
             automatic: true,

--- a/src/libs/actions/App.js
+++ b/src/libs/actions/App.js
@@ -210,10 +210,16 @@ function setUpPoliciesAndNavigate(session, currentPath) {
 
 function openProfile() {
     const oldTimezoneData = myPersonalDetails.timezone || {};
-    const newTimezoneData = {
-        automatic: lodashGet(oldTimezoneData, 'automatic', true),
-        selected: moment.tz.guess(true),
-    };
+    let newTimezoneData;
+    
+    if (lodashGet(oldTimezoneData, 'automatic', true)) {
+        newTimezoneData = {
+            automatic: true,
+            selected: moment.tz.guess(true),
+        };
+    } else {
+        newTimezoneData = oldTimezoneData;
+    }
 
     API.write('OpenProfile', {
         timezone: JSON.stringify(newTimezoneData),

--- a/src/libs/actions/App.js
+++ b/src/libs/actions/App.js
@@ -210,15 +210,13 @@ function setUpPoliciesAndNavigate(session, currentPath) {
 
 function openProfile() {
     const oldTimezoneData = myPersonalDetails.timezone || {};
-    let newTimezoneData;
+    let newTimezoneData = oldTimezoneData;
 
     if (lodashGet(oldTimezoneData, 'automatic', true)) {
         newTimezoneData = {
             automatic: true,
             selected: moment.tz.guess(true),
         };
-    } else {
-        newTimezoneData = oldTimezoneData;
     }
 
     API.write('OpenProfile', {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
cc @vitHoracek since you helped test my previous timezone change

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This was broken in this PR: https://github.com/Expensify/App/pull/9696 because I assumed we could optimistically update timezone with automatic timezone, but that doesn't work when automatic timezone is not set

**Note**: In the videos you'll see that the "Save" button is sometimes grayed out / looks disabled too often -> This is being fixed in a different PR: https://github.com/Expensify/App/pull/10229

### Fixed Issues
$ https://github.com/Expensify/App/issues/10217

### Tests
1. Open Settings -> Profile
2. Modify timezone (sometimes change automatic setting, sometimes change timezone)
3. Save profile
4. Navigate back to Settings, then back to Profile
5. Make sure the timezone shows what you previously set
6. Repeat steps 2 - 5 with a variety of "automatic" settings, timezones, etc

- [x] Verify that no errors appear in the JS console

### PR Review Checklist
<!--
This is a checklist for PR authors & reviewers. Please make sure to complete all tasks and check them off once you do, or else Expensify has the right not to merge your PR!
-->
#### Contributor (PR Author) Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [ ] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] Any functional components have the `displayName` property
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### QA Steps
1. Open Settings -> Profile
2. Modify timezone (sometimes change automatic setting, sometimes change timezone)
3. Save profile
4. Navigate back to Settings, then back to Profile
5. Make sure the timezone shows what you previously set
6. Repeat steps 2 - 5 with a variety of "automatic" settings, timezones, etc

- [ ] Verify that no errors appear in the JS console

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->
In progress...

#### Web
<!-- Insert screenshots of your changes on the web platform-->

https://user-images.githubusercontent.com/3885503/182608047-5190a3fc-31fd-41a0-a33e-682bcdd31d93.mov


#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->


https://user-images.githubusercontent.com/3885503/182609635-9b727464-47d8-42c3-a6da-537e2968fe20.mov



#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->


https://user-images.githubusercontent.com/3885503/182610426-d3d682e2-650f-4d16-bbc7-e40700be7497.mov



#### Android
<!-- Insert screenshots of your changes on the Android platform-->
