### PR TITLE
Delete old unused `UpdateProfile` param

### DIFF
--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -265,8 +265,6 @@ function setPersonalDetails(details, shouldGrowl) {
 function updateProfile(firstName, lastName, pronouns, timezone) {
     const myPersonalDetails = personalDetails[currentUserEmail];
     API.write('UpdateProfile', {
-        // 'details' is an old param that will be removed in https://github.com/Expensify/Expensify/issues/220321
-        details: JSON.stringify({firstName, lastName, pronouns}),
         firstName,
         lastName,
         pronouns,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

Removing a param that we stopped supporting in https://github.com/Expensify/Web-Expensify/pull/34450

### Details
$ https://github.com/Expensify/Expensify/issues/220321

### Tests
1. Go to Settings - Profile
2. Update a few profile items (first name, last name, pronouns, and / or timezone)
3. Save profile
4. Navigate away, then navigate back
5. Repeat steps 2 - 4 a few times, making sure everything updates correctly and there's no console errors

### QA Steps

1. Go to Settings - Profile
2. Update a few profile items (first name, last name, pronouns, and / or timezone)
3. Save profile
4. Navigate away, then navigate back
5. Repeat steps 2 - 4 a few times, making sure everything updates correctly and there's no console errors

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
