### PR TITLE
[No QA] Fix staging gradle build

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -154,33 +154,6 @@ android {
         multiDexEnabled rootProject.ext.multiDexEnabled
         versionCode 1001018806
         versionName "1.1.88-6"
-        buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
-
-        if (isNewArchitectureEnabled()) {
-            // We configure the NDK build only if you decide to opt-in for the New Architecture.
-            externalNativeBuild {
-                ndkBuild {
-                    arguments "APP_PLATFORM=android-21",
-                        "APP_STL=c++_shared",
-                        "NDK_TOOLCHAIN_VERSION=clang",
-                        "GENERATED_SRC_DIR=$buildDir/generated/source",
-                        "PROJECT_BUILD_DIR=$buildDir",
-                        "REACT_ANDROID_DIR=$rootDir/../node_modules/react-native/ReactAndroid",
-                        "REACT_ANDROID_BUILD_DIR=$rootDir/../node_modules/react-native/ReactAndroid/build",
-                        "NODE_MODULES_DIR=$rootDir/../node_modules"
-                    cFlags "-Wall", "-Werror", "-fexceptions", "-frtti", "-DWITH_INSPECTOR=1"
-                    cppFlags "-std=c++17"
-                    // Make sure this target name is the same you specify inside the
-                    // src/main/jni/Android.mk file for the `LOCAL_MODULE` variable.
-                    targets "rndiffapp_appmodules"
-                }
-            }
-            if (!enableSeparateBuildPerCPUArchitecture) {
-                ndk {
-                    abiFilters (*reactNativeArchitectures())
-                }
-            }
-        }
     }
     splits {
         abi {


### PR DESCRIPTION
### Details
Should fix failing Android deploys ([example](https://github.com/Expensify/App/runs/7730172776?check_suite_focus=true))

- [This PR](https://github.com/Expensify/App/pull/10294) updated the app version on main to 1.1.88-4
- When CP'd to staging, that PR somehow introduced [this code](https://github.com/Expensify/App/blame/staging/android/app/build.gradle#L157-L183) on staging, which should not have happened.

So even though we're not seeing a detailed log, I'm certain that is our problem. We are attempting to use the isNewArchitectureEnabled function when it is not defined on staging

### Fixed Issues
$ n/a

### Tests
Going to live-test this bad-boy