### PR TITLE
Capture desktop renderer process logs to file

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -147,3 +147,4 @@ The expected size of `app.asar` = `desktop/dist/www/` + `desktop/node_modules/`;
 
 - `main` process logs are written to `~/Library/Logs/new.expensify.desktop/main.log`
 - `renderer` logs can be observed live in the developer console (⌘ Cmd + ⌥ Option + I)
+  - staging and prod builds capture renderer logs at `~/Library/Logs/new.expensify.desktop/renderer.log`

--- a/desktop/contextBridge.js
+++ b/desktop/contextBridge.js
@@ -74,5 +74,5 @@ contextBridge.exposeInMainWorld('electron', {
      * Expose electron-log to the renderer world, data logged with electron.log would be captured to file
      * (~/Library/Logs/new.expensify.desktop/renderer.log)
      */
-    log,
+    log: log.create('renderer'),
 });

--- a/desktop/contextBridge.js
+++ b/desktop/contextBridge.js
@@ -3,6 +3,7 @@ const {
     contextBridge,
     ipcRenderer,
 } = require('electron');
+const log = require('electron-log');
 const ELECTRON_EVENTS = require('./ELECTRON_EVENTS');
 
 const WHITELIST_CHANNELS_RENDERER_TO_MAIN = [
@@ -18,7 +19,7 @@ const WHITELIST_CHANNELS_MAIN_TO_RENDERER = [
 ];
 
 /**
- * The following methods will be available in the renderer process under `window.electron`.
+ * The following methods and props will be available in the renderer process under `window.electron`.
  */
 contextBridge.exposeInMainWorld('electron', {
     /**
@@ -68,4 +69,10 @@ contextBridge.exposeInMainWorld('electron', {
         // Deliberately strip event as it includes `sender`
         ipcRenderer.on(channel, (event, ...args) => func(...args));
     },
+
+    /**
+     * Expose electron-log to the renderer world, data logged with electron.log would be captured to file
+     * (~/Library/Logs/new.expensify.desktop/renderer.log)
+     */
+    log,
 });

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -45,12 +45,15 @@ contextMenu({
 
 // Send all autoUpdater logs to a log file: ~/Library/Logs/new.expensify.desktop/main.log
 // See https://www.npmjs.com/package/electron-log
-autoUpdater.logger = log;
-autoUpdater.logger.transports.file.level = 'info';
+autoUpdater.logger = log.scope('autoUpdater');
+log.transports.file.level = 'info';
+
+// Set `ipc` level to enable and see main process logs in dev tools (⌘ Cmd + ⌥ Option + I)
+log.transports.ipc.level = 'info';
 
 // Send all Console logs to a log file: ~/Library/Logs/new.expensify.desktop/main.log
 // See https://www.npmjs.com/package/electron-log
-_.assign(console, log.functions);
+_.assign(console, log.scope('main'));
 
 // This sets up the command line arguments used to manage the update. When
 // the --expected-update-version flag is set, the app will open pre-hidden

--- a/src/libs/Log/clientLoggingCallback.desktop.js
+++ b/src/libs/Log/clientLoggingCallback.desktop.js
@@ -1,0 +1,7 @@
+// Use logging utils exposed from desktop/contextBridge.js to persist logs to file
+// See https://www.npmjs.com/package/electron-log for all the options
+
+// Prefix custom logs with a scope label, so they are easily distinguished in the log file
+const scope = window.electron.log.scope('renderer:Log');
+
+export default scope.debug;

--- a/src/libs/Log/clientLoggingCallback.js
+++ b/src/libs/Log/clientLoggingCallback.js
@@ -1,0 +1,2 @@
+// On most platforms we just log on the debug channel
+export default console.debug;

--- a/src/libs/Log/index.js
+++ b/src/libs/Log/index.js
@@ -2,10 +2,11 @@
 // action would likely cause confusion about which one to use. But most other API methods should happen inside an action file.
 /* eslint-disable rulesdir/no-api-in-views */
 import Logger from 'expensify-common/lib/Logger';
-import getPlatform from './getPlatform';
-import {version} from '../../package.json';
-import requireParameters from './requireParameters';
-import * as Network from './Network';
+import getPlatform from '../getPlatform';
+import {version} from '../../../package.json';
+import requireParameters from '../requireParameters';
+import * as Network from '../Network';
+import clientLoggingCallback from './clientLoggingCallback';
 
 let timeout = null;
 
@@ -51,9 +52,7 @@ function serverLoggingCallback(logger, params) {
 // callback methods are passed in here so we can decouple the logging library from the logging methods.
 const Log = new Logger({
     serverLoggingCallback,
-    clientLoggingCallback: (message) => {
-        console.debug(message);
-    },
+    clientLoggingCallback,
     isDebug: true,
 });
 timeout = setTimeout(() => Log.info('Flushing logs older than 10 minutes', true, {}, true), 10 * 60 * 1000);

--- a/src/setup/platformSetup/index.desktop.js
+++ b/src/setup/platformSetup/index.desktop.js
@@ -1,4 +1,5 @@
 import {AppRegistry} from 'react-native';
+import _ from 'underscore';
 import Config from '../../CONFIG';
 import LocalNotification from '../../libs/Notification/LocalNotification';
 import * as KeyboardShortcuts from '../../libs/actions/KeyboardShortcuts';
@@ -9,6 +10,9 @@ export default function () {
     AppRegistry.runApplication(Config.APP_NAME, {
         rootTag: document.getElementById('root'),
     });
+
+    // Capture generic logs in dev tools console as well as on file
+    _.assign(console, window.electron.log.scope('renderer:generic'));
 
     // Send local notification when update is downloaded
     window.electron.on(ELECTRON_EVENTS.UPDATE_DOWNLOADED, () => {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
@roryabraham 
Related to this comment: https://github.com/Expensify/App/issues/9794#issuecomment-1197106599

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Adds a few enhancements to Desktop logging 
- see `main` process logging in the Dev tools console (⌘ Cmd + ⌥ Option + I) (namely we see logs from the auto updater easily)
- capture `renderer` logs to file - `~/Library/Logs/new.expensify.desktop/renderer.log` (e.g. all the stuff we log through `libs/Log` (and more)
- distinct logs with different scopes - auto updater logs are prefixed with `autoUpdater`, renderer logs are prefixed with `renderer:generic` or `renderer:Log` 

#### Sample logs 
 
<details>
    <summary>main.log</summary>

```log
[2022-08-09 00:07:13.815] [info]  (autoUpdater) Checking for update
[2022-08-09 00:07:14.951] [info]  (autoUpdater) Found version 1.1.88-7 (url: New Expensify-1.1.88-7-mac.zip, NewExpensify.dmg)
[2022-08-09 00:07:14.951] [info]  (autoUpdater) Downloading update from New Expensify-1.1.88-7-mac.zip, NewExpensify.dmg
[2022-08-09 00:07:14.954] [info]  (autoUpdater) Checked for macOS Rosetta environment (isRosetta=false)
[2022-08-09 00:07:14.956] [info]  (autoUpdater) Checked 'uname -a': arm64=true
[2022-08-09 00:07:15.165] [info]  (autoUpdater) Update has already been downloaded to /Users/kidroca/Library/Application Support/Caches/new.expensify.desktop-updater/pending/New Expensify-1.1.88-7-mac.zip).
[2022-08-09 00:07:15.179] [info]  (autoUpdater) / requested
[2022-08-09 00:07:15.182] [info]  (autoUpdater) /1827f488460-33e.zip requested
[2022-08-09 00:07:15.183] [info]  (autoUpdater) /1827f488460-33e.zip requested by Squirrel.Mac, pipe /Users/kidroca/Library/Application Support/Caches/new.expensify.desktop-updater/pending/New Expensify-1.1.88-7-mac.zip
[2022-08-09 00:07:20.285] [info]  (autoUpdater) Proxy server for native Squirrel.Mac is closed (fileToProxy=https://staging-expensify-cash.s3.amazonaws.com/New%20Expensify-1.1.88-7-mac.zip)
[2022-08-09 00:07:20.553] [warn]  (autoUpdater) Error: Code signature at URL file:///Users/kidroca/Library/Caches/com.expensifyreactnative.chat.ShipIt/update.mo69slL/New%20Expensify.app/ did not pass validation: code failed to satisfy specified code requirement(s)
[2022-08-09 00:07:20.553] [error] (autoUpdater) Error: Error: Code signature at URL file:///Users/kidroca/Library/Caches/com.expensifyreactnative.chat.ShipIt/update.mo69slL/New%20Expensify.app/ did not pass validation: code failed to satisfy specified code requirement(s)
```
</details>

<details>
<summary>renderer.log</summary>

```log
[2022-08-09 00:07:14.333] [debug] (renderer:Log)     [info] [Onyx] set() called for key: currentDate - ""
[2022-08-09 00:07:14.408] [debug] (renderer:Log)     [info] [Migrate Onyx] start - ""
[2022-08-09 00:07:14.409] [debug] (renderer:Log)     [info] [Onyx] set() called for key: activeClients properties: 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19 - ""
[2022-08-09 00:07:14.409] [debug] (renderer:Log)     [info] [Migrate Onyx] Skipped migration MoveToIndexedDB (Not applicable to logged out users) - ""
[2022-08-09 00:07:14.409] [debug] (renderer:Log)     [info] [Onyx] set() called for key: activeClients properties: 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18 - ""
[2022-08-09 00:07:14.410] [debug] (renderer:Log)     [info] [Migrate Onyx] Skipped migration RenameActiveClientsKey - ""
[2022-08-09 00:07:14.410] [debug] (renderer:Log)     [info] [Migrate Onyx] Skipped migration RenamePriorityModeKey - ""
[2022-08-09 00:07:14.410] [debug] (renderer:Log)     [info] [Migrate Onyx] Skipped migration AddEncryptedAuthToken - ""
[2022-08-09 00:07:14.410] [debug] (renderer:Log)     [info] [Migrate Onyx] Skipped migration RenameExpensifyNewsStatus - ""
[2022-08-09 00:07:14.410] [debug] (renderer:Log)     [info] [Migrate Onyx] finished in 2ms - ""
[2022-08-09 00:07:14.422] [debug] (renderer:Log)     [info] [NetworkConnection] listenForReconnect called - ""
[2022-08-09 00:07:14.424] [debug] (renderer:Log)     [info] Making API request - {"command":"Get","shouldUseSecure":false,"returnValueList":"userWallet"}
[2022-08-09 00:07:14.424] [debug] (renderer:Log)     [info] [Onyx] set() called for key: isLoadingReportData - ""
[2022-08-09 00:07:14.424] [debug] (renderer:Log)     [info] Making API request - {"command":"Get","shouldUseSecure":false,"returnValueList":"chatList"}
[2022-08-09 00:07:14.424] [debug] (renderer:Log)     [info] Making API request - {"command":"OpenApp"}
[2022-08-09 00:07:14.425] [debug] (renderer:Log)     [info] Making API request - {"command":"User_FixAccount","shouldUseSecure":false}
[2022-08-09 00:07:14.425] [debug] (renderer:generic) Timing:expensify.cash.homepage_initial_render 11
[2022-08-09 00:07:14.425] [debug] (renderer:Log)     [info] [Onyx] set() called for key: networkRequestQueue properties: 0 - ""
[2022-08-09 00:07:14.427] [debug] (renderer:Log)     [info] [NetworkConnection] NetInfo state change - {"isInternetReachable":null,"isConnected":true,"type":"wifi","details":{"isConnectionExpensive":false,"ssid":null,"bssid":null,"strength":null,"ipAddress":null,"subnet":null,"frequency":null}}
[2022-08-09 00:07:14.427] [debug] (renderer:Log)     [info] Making API request - {"command":"SendPerformanceTiming"}
[2022-08-09 00:07:14.427] [debug] (renderer:Log)     [info] [Onyx] set() called for key: network properties: isOffline - ""
[2022-08-09 00:07:14.434] [debug] (renderer:Log)     [info] Navigating to route - {"path":"/"}
[2022-08-09 00:07:14.468] [debug] (renderer:Log)     [info] Navigating to route - {"path":"/r/71402263"}
[2022-08-09 00:07:14.469] [debug] (renderer:Log)     [info] [Onyx] set() called for key: session properties: loading,shouldShowComposeInput,authToken,accountID,email,encryptedAuthToken - ""
[2022-08-09 00:07:14.469] [debug] (renderer:Log)     [info] [Onyx] set() called for key: currentlyViewedReportID - ""
[2022-08-09 00:07:14.567] [debug] (renderer:Log)     [info] [Onyx] set() called for key: isSidebarLoaded - ""
[2022-08-09 00:07:14.568] [debug] (renderer:generic) Timing:expensify.cash.sidebar_loaded 99
[2022-08-09 00:07:14.568] [debug] (renderer:Log)     [info] [Onyx] set() called for key: networkRequestQueue properties: 0,1 - ""
[2022-08-09 00:07:14.608] [warn]  (renderer:generic) Animated: `useNativeDriver` is not supported because the native animated module is missing. Falling back to JS-based animation. To resolve this, add `RCTAnimation` module to this app, or remove `useNativeDriver`. Make sure to run `pod install` first. Read more about autolinking: https://github.com/react-native-community/cli/blob/master/docs/autolinking.md
[2022-08-09 00:07:14.608] [debug] (renderer:Log)     [info] [Onyx] set() called for key: reportUserIsTyping_71402263 properties:  - ""
[2022-08-09 00:07:14.608] [debug] (renderer:Log)     [info] [Pusher] Attempting to subscribe to channel - {"channelName":"private-report-reportID-71402263","eventName":"client-userIsTyping"}
[2022-08-09 00:07:14.609] [debug] (renderer:Log)     [info] [Onyx] set() called for key: isLoadingInitialReportActions_71402263 - ""
[2022-08-09 00:07:14.772] [debug] (renderer:Log)     [info] [Onyx] set() called for key: reportWithDraft_71402263 - ""
[2022-08-09 00:07:14.782] [debug] (renderer:Log)     [info] [NetworkConnection] NetInfo state change - {"isInternetReachable":true,"isConnected":true,"type":"wifi","details":{"isConnectionExpensive":false,"ssid":null,"bssid":null,"strength":null,"ipAddress":null,"subnet":null,"frequency":null}}
[2022-08-09 00:07:14.782] [debug] (renderer:Log)     [info] [Onyx] set() called for key: network properties: isOffline - ""
[2022-08-09 00:07:14.831] [debug] (renderer:Log)     [info] Finished API request - {"command":"Get","shouldUseSecure":false,"returnValueList":"userWallet","jsonCode":200,"requestID":"737b38703e608eec-SAN"}
[2022-08-09 00:07:14.831] [debug] (renderer:Log)     [info] Finished API request - {"command":"Get","shouldUseSecure":false,"returnValueList":"chatList","jsonCode":200,"requestID":"737b38703e5c8eec-SAN"}
[2022-08-09 00:07:14.857] [debug] (renderer:Log)     [info] Finished API request - {"command":"User_FixAccount","shouldUseSecure":false,"jsonCode":200,"requestID":"737b38703e628eec-SAN"}
[2022-08-09 00:07:14.911] [debug] (renderer:Log)     [info] [Onyx] set() called for key: userWallet properties: availableBalance,bankAccountID,currentBalance,currentStep,tier,tierName,walletLinkedAccountID,walletLinkedAccountType,shouldShowFailedKYC - ""
[2022-08-09 00:07:14.978] [debug] (renderer:Log)     [info] [PusherConnectionManager] unhandled event - {"eventName":"state_change"}
[2022-08-09 00:07:14.978] [debug] (renderer:Log)     [info] [PusherAuthorizer] Attempting to authorize Pusher - {"channelName":"private-report-reportID-71402263"}
[2022-08-09 00:07:14.978] [debug] (renderer:Log)     [info] Making API request - {"command":"AuthenticatePusher"}
[2022-08-09 00:07:14.978] [debug] (renderer:Log)     [info] [PusherConnectionManager] connected event - ""
[2022-08-09 00:07:14.979] [debug] (renderer:Log)     [info] [Pusher] Attempting to subscribe to channel - {"channelName":"private-encrypted-user-accountID-9952973","eventName":"reportCommentEdit"}
[2022-08-09 00:07:14.979] [debug] (renderer:Log)     [info] [PusherAuthorizer] Attempting to authorize Pusher - {"channelName":"private-encrypted-user-accountID-9952973"}
[2022-08-09 00:07:14.979] [debug] (renderer:Log)     [info] Making API request - {"command":"AuthenticatePusher"}
[2022-08-09 00:07:14.979] [debug] (renderer:Log)     [info] [Pusher] Attempting to subscribe to channel - {"channelName":"private-encrypted-user-accountID-9952973","eventName":"onyxApiUpdate"}
[2022-08-09 00:07:14.979] [debug] (renderer:Log)     [info] [Pusher] Attempting to subscribe to channel - {"channelName":"private-encrypted-user-accountID-9952973","eventName":"preferredLocale"}
[2022-08-09 00:07:14.979] [debug] (renderer:Log)     [info] [Pusher] Attempting to subscribe to channel - {"channelName":"private-encrypted-user-accountID-9952973","eventName":"screenshareRequest"}
[2022-08-09 00:07:14.980] [debug] (renderer:Log)     [info] [Pusher] Attempting to subscribe to channel - {"channelName":"public-policyEditor-30A1181E5CC41BEA","eventName":"policyEmployeeRemoved"}
[2022-08-09 00:07:14.980] [debug] (renderer:Log)     [info] [Pusher] Attempting to subscribe to channel - {"channelName":"public-policyEditor-34EC92640D4C4FDE","eventName":"policyEmployeeRemoved"}
[2022-08-09 00:07:14.980] [debug] (renderer:Log)     [info] [Pusher] Attempting to subscribe to channel - {"channelName":"public-policyEditor-8B8FE0ED6446C0C3","eventName":"policyEmployeeRemoved"}
[2022-08-09 00:07:14.981] [debug] (renderer:Log)     [info] Finished API request - {"command":"OpenApp","jsonCode":200,"requestID":"737b38703e5d8eec-SAN"}
[2022-08-09 00:07:14.981] [debug] (renderer:Log)     [info] [Onyx] set() called for key: frequentlyUsedEmojis properties: 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18 - ""
[2022-08-09 00:07:14.982] [debug] (renderer:Log)     [info] [Onyx] set() called for key: loginList properties: 0 - ""
[2022-08-09 00:07:14.982] [debug] (renderer:Log)     [info] [Onyx] set() called for key: betas properties: 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70 - ""
[2022-08-09 00:07:14.982] [debug] (renderer:Log)     [info] [Onyx] set() called for key: user properties: loginList,validated,isFromPublicDomain,isUsingExpensifyCard,isSubscribedToNewsletter - ""
[2022-08-09 00:07:14.982] [debug] (renderer:Log)     [info] [Onyx] set() called for key: nvp_priorityMode - ""
[2022-08-09 00:07:14.982] [debug] (renderer:Log)     [info] [Onyx] set() called for key: preferredLocale - ""
[2022-08-09 00:07:14.983] [debug] (renderer:Log)     [info] [Onyx] set() called for key: private_blockedFromConcierge properties:  - ""
[2022-08-09 00:07:14.983] [debug] (renderer:Log)     [info] [Onyx] set() called for key: personalDetails properties: alexbeaman@expensify.com,chronos@expensify.com,concierge@expensify.com,dbarrett@expensify.com,expensify10@kidroca.com,expensify11@kidroca.com,expensify12@kidroca.com,expensify13@kidroca.com,expensify14@kidroca.com,expensify15@kidroca.com,expensify2@kidroca.com,expensify3@kidroca.com,expensify5@kidroca.com,expensify6@kidroca.com,expensify7@kidroca.com,expensify8@kidroca.com,expensify9@kidroca.com,expensify@kidroca.com,ionatan@expensify.com,kbecciv+1110@gmail.com,mallen@expensify.com,mhaxhiu@expensify.com,rory@expensify.com,expense2@kidroca.com,expense3@kidroca.com,expensify4@kidroca.com,expensify.old-image-picker@kidroca.com,old-image-picker@kidroca.com,new-image-picker@kidroca.com,replies+77685962@expensify.com - ""
[2022-08-09 00:07:15.001] [debug] (renderer:Log)     [info] [Onyx] set() called for key: countryCode - ""
[2022-08-09 00:07:15.001] [debug] (renderer:Log)     [info] [Onyx] set() called for key: policy_30A1181E5CC41BEA properties: isFromFullPolicy,id,name,role,type,owner,outputCurrency,avatarURL,employeeList - ""
[2022-08-09 00:07:15.001] [debug] (renderer:Log)     [info] [Onyx] set() called for key: policy_34EC92640D4C4FDE properties: isFromFullPolicy,id,name,role,type,owner,outputCurrency,avatarURL,employeeList - ""
[2022-08-09 00:07:15.001] [debug] (renderer:Log)     [info] [Onyx] set() called for key: policy_8B8FE0ED6446C0C3 properties: isFromFullPolicy,id,name,role,type,owner,outputCurrency,avatarURL,employeeList - ""
[2022-08-09 00:07:15.124] [debug] (renderer:Log)     [info] Finished API request - {"command":"SendPerformanceTiming","jsonCode":200,"requestID":"737b38703e5e8eec-SOF"}
[2022-08-09 00:07:15.125] [debug] (renderer:Log)     [info] [Onyx] set() called for key: networkRequestQueue properties: 0 - ""
[2022-08-09 00:07:15.143] [debug] (renderer:Log)     [info] Making API request - {"command":"SendPerformanceTiming"}
[2022-08-09 00:07:15.147] [debug] (renderer:Log)     [info] [Onyx] set() called for key: currencyList properties: AED,AFN,ALL,AMD,ANG,AOA,ARS,AUD,AWG,AZN,BAM,BBD,BDT,BGN,BHD,BIF,BMD,BND,BOB,BRL,BSD,BTN,BWP,BYN,BYR,BZD,CAD,CDF,CHF,CLP,CNY,COP,CRC,CUC,CUP,CVE,CZK,DJF,DKK,DOP,DZD,EEK,EGP,ERN,ETB,EUR,FJD,FKP,GBP,GEL,GHS,GIP,GMD,GNF,GTQ,GYD,HKD,HNL,HRK,HTG,HUF,IDR,ILS,INR,IQD,IRR,ISK,JMD,JOD,JPY,KES,KGS,KHR,KMF,KPW,KRW,KWD,KYD,KZT,LAK,LBP,LKR,LRD,LSL,LTL,LVL,LYD,MAD,MDL,MGA,MKD,MMK,MNT,MOP,MRO,MRU,MUR,MVR,MWK,MXN,MYR,MZN,NAD,NGN,NIO,NOK,NPR,NZD,OMR,PAB,PEN,PGK,PHP,PKR,PLN,PYG,QAR,RON,RSD,RUB,RWF,SAR,SBD,SCR,SDG,SEK,SGD,SHP,SLL,SOS,SRD,STD,STN,SVC,SYP,SZL,THB,TJS,TMT,TND,TOP,TRY,TTD,TWD,TZS,UAH,UGX,USD,UYU,UZS,VEB,VEF,VES,VND,VUV,WST,XAF,XCD,XOF,XPF,YER,ZAR,ZMK,ZMW - ""
[2022-08-09 00:07:15.148] [debug] (renderer:Log)     [info] [Onyx] set() called for key: isFirstTimeNewExpensifyUser - ""
[2022-08-09 00:07:15.148] [debug] (renderer:Log)     [info] [Onyx] set() called for key: nvp_paypalMeAddress - ""
[2022-08-09 00:07:15.148] [debug] (renderer:Log)     [info] [Onyx] set() called for key: preferredEmojiSkinTone - ""
[2022-08-09 00:07:15.224] [debug] (renderer:Log)     [info] Finished API request - {"command":"AuthenticatePusher","jsonCode":200,"requestID":"737b38735ceb8eec-SAN"}
[2022-08-09 00:07:15.224] [debug] (renderer:Log)     [info] [PusherAuthorizer] Pusher authenticated successfully - {"channelName":"private-encrypted-user-accountID-9952973"}
[2022-08-09 00:07:15.230] [debug] (renderer:Log)     [info] Finished API request - {"command":"AuthenticatePusher","jsonCode":200,"requestID":"737b38735ce78eec-SAN"}
[2022-08-09 00:07:15.259] [debug] (renderer:Log)     [info] [PusherAuthorizer] Pusher authenticated successfully - {"channelName":"private-report-reportID-71402263"}
[2022-08-09 00:07:15.391] [debug] (renderer:Log)     [info] Finished API request - {"command":"SendPerformanceTiming","jsonCode":200,"requestID":"737b38745ebe8eec-SAN"}
[2022-08-09 00:07:15.392] [debug] (renderer:Log)     [info] [Onyx] set() called for key: networkRequestQueue properties:  - ""
[2022-08-09 00:07:15.458] [debug] (renderer:Log)     [info] Making API request - {"command":"Report_GetHistory","shouldUseSecure":false}
[2022-08-09 00:07:15.470] [debug] (renderer:Log)     [info] Making API request - {"command":"Get","shouldUseSecure":false,"returnValueList":"reportSummaryList"}
[2022-08-09 00:07:15.714] [debug] (renderer:Log)     [info] Previous log requestID - {"requestID":"737b38766b628eec-SAN"}
[2022-08-09 00:07:15.731] [debug] (renderer:Log)     [info] Finished API request - {"command":"Report_GetHistory","shouldUseSecure":false,"jsonCode":200,"requestID":"737b38766b5d8eec-SOF"}
[2022-08-09 00:07:15.752] [debug] (renderer:Log)     [info] [Onyx] set() called for key: reportActions_71402263 properties: 47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97 - ""
[2022-08-09 00:07:15.752] [debug] (renderer:Log)     [info] [Onyx] set() called for key: report_71402263 properties: reportID,reportName,chatType,ownerEmail,policyID,unreadActionCount,maxSequenceNumber,participants,isPinned,lastVisitedTimestamp,lastReadSequenceNumber,lastMessageTimestamp,lastMessageText,lastActorEmail,notificationPreference,stateNum,statusNum,oldPolicyName,visibility,isOwnPolicyExpenseChat,lastMessageHtml,newMarkerSequenceNumber,optimisticReportActionIDs - ""
[2022-08-09 00:07:15.752] [debug] (renderer:Log)     [info] [Onyx] set() called for key: isLoadingInitialReportActions_71402263 - ""
[2022-08-09 00:07:15.777] [debug] (renderer:Log)     [info] [Onyx] set() called for key: reportDraftComment_71402263 - ""
[2022-08-09 00:07:15.780] [debug] (renderer:Log)     [info] Finished API request - {"command":"Get","shouldUseSecure":false,"returnValueList":"reportSummaryList","jsonCode":200,"requestID":"737b38766b5f8eec-SAN"}
[2022-08-09 00:07:15.780] [debug] (renderer:Log)     [info] [Report] successfully fetched report data - {"chatList":["71402263","71403817","71403849","71734617","71955477","72156283","72207410","73013597","73164379","75049759","75369514","75369778","75373284","77703941","78543753","78543754","78818182","79854977","81393827","81524148","84424326","84424995","84425187","84425417","86238969","86239793","87620615","87620616","87620698","87620699","87622023","87622024","87622104","87622105","87622125","87622126","87622461","87622462","88356939","88356940","88356956","88356957","88357606","88357607","88358400","88358401","88615879","88632597","89854950","89855182","89855240","89855272","89855312","89855351","89855429","89855494","89855647","89994867","93008089","93008101","93128210","93835793"]}
[2022-08-09 00:07:15.780] [debug] (renderer:Log)     [info] Making API request - {"command":"GetIOUReport","shouldUseSecure":false}
[2022-08-09 00:07:15.781] [debug] (renderer:Log)     [info] Making API request - {"command":"GetIOUReport","shouldUseSecure":false}
[2022-08-09 00:07:15.781] [debug] (renderer:Log)     [info] Making API request - {"command":"GetIOUReport","shouldUseSecure":false}
[2022-08-09 00:07:15.781] [debug] (renderer:Log)     [info] Making API request - {"command":"GetIOUReport","shouldUseSecure":false}
[2022-08-09 00:07:15.782] [debug] (renderer:Log)     [info] Making API request - {"command":"GetIOUReport","shouldUseSecure":false}
[2022-08-09 00:07:15.782] [debug] (renderer:Log)     [info] Making API request - {"command":"GetIOUReport","shouldUseSecure":false}
[2022-08-09 00:07:16.050] [debug] (renderer:Log)     [info] Finished API request - {"command":"GetIOUReport","shouldUseSecure":false,"jsonCode":200,"requestID":"737b38785f8c8eec-SAN"}
[2022-08-09 00:07:16.059] [debug] (renderer:Log)     [info] Making API request - {"command":"Get","shouldUseSecure":false,"returnValueList":"reportStuff"}
[2022-08-09 00:07:16.060] [debug] (renderer:Log)     [info] Finished API request - {"command":"GetIOUReport","shouldUseSecure":false,"jsonCode":200,"requestID":"737b38786f938eec-SAN"}
[2022-08-09 00:07:16.060] [debug] (renderer:Log)     [info] Making API request - {"command":"Get","shouldUseSecure":false,"returnValueList":"reportStuff"}
[2022-08-09 00:07:16.061] [debug] (renderer:Log)     [info] Finished API request - {"command":"GetIOUReport","shouldUseSecure":false,"jsonCode":200,"requestID":"737b38785f868eec-SAN"}
[2022-08-09 00:07:16.061] [debug] (renderer:Log)     [info] Making API request - {"command":"Get","shouldUseSecure":false,"returnValueList":"reportStuff"}
[2022-08-09 00:07:16.063] [debug] (renderer:Log)     [info] Finished API request - {"command":"GetIOUReport","shouldUseSecure":false,"jsonCode":200,"requestID":"737b38786f908eec-SAN"}
[2022-08-09 00:07:16.063] [debug] (renderer:Log)     [info] Making API request - {"command":"Get","shouldUseSecure":false,"returnValueList":"reportStuff"}
[2022-08-09 00:07:16.311] [debug] (renderer:Log)     [info] Finished API request - {"command":"Get","shouldUseSecure":false,"returnValueList":"reportStuff","jsonCode":200,"requestID":"737b387a1c0c8eec-SOF"}
[2022-08-09 00:07:16.323] [debug] (renderer:Log)     [info] Finished API request - {"command":"Get","shouldUseSecure":false,"returnValueList":"reportStuff","jsonCode":200,"requestID":"737b387a1c018eec-SAN"}
[2022-08-09 00:07:16.323] [debug] (renderer:Log)     [info] Finished API request - {"command":"Get","shouldUseSecure":false,"returnValueList":"reportStuff","jsonCode":200,"requestID":"737b387a1bf88eec-SAN"}
[2022-08-09 00:07:16.329] [debug] (renderer:Log)     [info] Finished API request - {"command":"Get","shouldUseSecure":false,"returnValueList":"reportStuff","jsonCode":200,"requestID":"737b387a1c0e8eec-SAN"}
[2022-08-09 00:07:16.567] [debug] (renderer:Log)     [info] Finished API request - {"command":"GetIOUReport","shouldUseSecure":false,"jsonCode":200,"requestID":"737b38785f8d8eec-SAN"}
[2022-08-09 00:07:16.568] [debug] (renderer:Log)     [info] Making API request - {"command":"Get","shouldUseSecure":false,"returnValueList":"reportStuff"}
[2022-08-09 00:07:16.598] [debug] (renderer:Log)     [info] Finished API request - {"command":"GetIOUReport","shouldUseSecure":false,"jsonCode":200,"requestID":"737b38786f958eec-SAN"}
[2022-08-09 00:07:16.607] [debug] (renderer:Log)     [info] Making API request - {"command":"Get","shouldUseSecure":false,"returnValueList":"reportStuff"}
[2022-08-09 00:07:16.728] [debug] (renderer:Log)     [info] Previous log requestID - {"requestID":"737b387c99bf8eec-SAN"}
[2022-08-09 00:07:16.830] [debug] (renderer:Log)     [info] Finished API request - {"command":"Get","shouldUseSecure":false,"returnValueList":"reportStuff","jsonCode":200,"requestID":"737b387d4b768eec-SAN"}
[2022-08-09 00:07:16.863] [debug] (renderer:Log)     [info] Finished API request - {"command":"Get","shouldUseSecure":false,"returnValueList":"reportStuff","jsonCode":200,"requestID":"737b387d8c0c8eec-SAN"}
[2022-08-09 00:07:16.873] [debug] (renderer:Log)     [info] Making API request - {"command":"PersonalDetails_GetForEmails","shouldUseSecure":false}
[2022-08-09 00:07:16.903] [debug] (renderer:Log)     [info] [Onyx] set() called for key: initialReportDataLoaded - ""
[2022-08-09 00:07:16.903] [debug] (renderer:Log)     [info] [Onyx] set() called for key: isLoadingReportData - ""
[2022-08-09 00:07:16.903] [debug] (renderer:generic) Timing:expensify.cash.homepage_reports_loaded 2489
[2022-08-09 00:07:16.903] [debug] (renderer:Log)     [info] [Onyx] set() called for key: networkRequestQueue properties: 0 - ""
[2022-08-09 00:07:16.910] [debug] (renderer:Log)     [info] [Onyx] set() called for key: report_71402263 properties: reportID,reportName,chatType,ownerEmail,policyID,unreadActionCount,maxSequenceNumber,participants,isPinned,lastVisitedTimestamp,lastReadSequenceNumber,lastMessageTimestamp,lastMessageText,lastActorEmail,notificationPreference,stateNum,statusNum,oldPolicyName,visibility,isOwnPolicyExpenseChat,lastMessageHtml,newMarkerSequenceNumber,optimisticReportActionIDs - ""
[2022-08-09 00:07:16.911] [debug] (renderer:Log)     [info] Making API request - {"command":"SendPerformanceTiming"}
[2022-08-09 00:07:17.114] [debug] (renderer:Log)     [info] Finished API request - {"command":"PersonalDetails_GetForEmails","shouldUseSecure":false,"jsonCode":200,"requestID":"737b387f28808eec-SAN"}
[2022-08-09 00:07:17.116] [debug] (renderer:generic) Timing:expensify.cash.personal_details_formatted 0
[2022-08-09 00:07:17.116] [debug] (renderer:Log)     [info] [Onyx] set() called for key: networkRequestQueue properties: 0,1 - ""
[2022-08-09 00:07:17.118] [debug] (renderer:Log)     [info] [Onyx] set() called for key: personalDetails properties: alexbeaman@expensify.com,chronos@expensify.com,concierge@expensify.com,dbarrett@expensify.com,expensify10@kidroca.com,expensify11@kidroca.com,expensify12@kidroca.com,expensify13@kidroca.com,expensify14@kidroca.com,expensify15@kidroca.com,expensify2@kidroca.com,expensify3@kidroca.com,expensify5@kidroca.com,expensify6@kidroca.com,expensify7@kidroca.com,expensify8@kidroca.com,expensify9@kidroca.com,expensify@kidroca.com,ionatan@expensify.com,kbecciv+1110@gmail.com,mallen@expensify.com,mhaxhiu@expensify.com,rory@expensify.com,expense2@kidroca.com,expense3@kidroca.com,expensify4@kidroca.com,expensify.old-image-picker@kidroca.com,old-image-picker@kidroca.com,new-image-picker@kidroca.com,replies+77685962@expensify.com - ""
[2022-08-09 00:07:17.192] [debug] (renderer:Log)     [info] Finished API request - {"command":"SendPerformanceTiming","jsonCode":200,"requestID":"737b387f79578eec-SOF"}
[2022-08-09 00:07:17.192] [debug] (renderer:Log)     [info] [Onyx] set() called for key: networkRequestQueue properties: 0 - ""
[2022-08-09 00:07:17.193] [debug] (renderer:Log)     [info] Making API request - {"command":"SendPerformanceTiming"}
[2022-08-09 00:07:17.467] [debug] (renderer:Log)     [info] Finished API request - {"command":"SendPerformanceTiming","jsonCode":200,"requestID":"737b38812d448eec-SAN"}
[2022-08-09 00:07:17.500] [debug] (renderer:Log)     [info] [Onyx] set() called for key: networkRequestQueue properties:  - ""
[2022-08-09 00:07:44.444] [debug] (renderer:Log)     [info] [BootSplash] splash screen status - {"appState":"active","status":"hidden"}
[2022-08-09 00:17:16.329] [debug] (renderer:Log)     [info] Flushing logs older than 10 minutes - {}
```
</details>

<details>
<summary>main logs in dev console</summary>

![Screenshot 2022-08-09 at 0 12 41](https://user-images.githubusercontent.com/12156624/183515600-a5893ff8-2b88-4c69-a644-35166776aa3c.png)
</details>

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ GH_LINK

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

### PR Review Checklist
<!--
This is a checklist for PR authors & reviewers. Please make sure to complete all tasks and check them off once you do, or else Expensify has the right not to merge your PR!
-->
#### Contributor (PR Author) Checklist
- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [ ] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] Any functional components have the `displayName` property
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

<details>
<summary><h4>PR Reviewer Checklist</h4>

The Contributor+ will copy/paste it into a new comment and complete it after the author checklist is completed
</summary>

- [ ] I have verified the author checklist is complete (all boxes are checked off).
- [ ] I verified the correct issue is linked in the `### Fixed Issues` section above
- [ ] I verified testing steps are clear and they cover the changes made in this PR
    - [ ] I verified the steps for local testing are in the `Tests` section
    - [ ] I verified the steps for Staging and/or Production testing are in the `QA steps` section
    - [ ] I verified the steps cover any possible failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [ ] I checked that screenshots or videos are included for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I verified tests pass on **all platforms** & I tested again on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`).
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [ ] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I verified that this PR follows the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I verified other components that can be impacted by these changes have been tested, and I retested again (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` have been tested & I retested again)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] Any functional components have the `displayName` property
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] I have checked off every checkbox in the PR reviewer checklist, including those that don't apply to this PR.

</details>

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
