### PR TITLE
[No QA] Remove unused functions from src/libs/actions/ReportActions

### DIFF
--- a/src/libs/actions/ReportActions.js
+++ b/src/libs/actions/ReportActions.js
@@ -46,37 +46,6 @@ Onyx.connect({
 });
 
 /**
- * WARNING: Do not use this method to access the maxSequenceNumber for a report. This ONLY returns the maxSequenceNumber
- * for reportActions that are stored in Onyx under a reportActions_* key.
- *
- * @param {Number} reportID
- * @param {Boolean} shouldWarn
- * @returns {Number}
- */
-function dangerouslyGetReportActionsMaxSequenceNumber(reportID, shouldWarn = true) {
-    if (shouldWarn) {
-        console.error('WARNING: dangerouslyGetReportActionsMaxSequenceNumber is unreliable as it ONLY references '
-            + 'reportActions in storage. It should not be used to access the maxSequenceNumber for a report. Use '
-            + 'reportMaxSequenceNumbers[reportID] instead.');
-    }
-
-    return reportActionsMaxSequenceNumbers[reportID];
-}
-
-/**
- * Compares the maximum sequenceNumber that we know about with the most recent report action we have saved.
- * If we have no report actions at all for the report we will assume that it is missing actions.
- *
- * @param {Number} reportID
- * @param {Number} maxKnownSequenceNumber
- * @returns {Boolean}
- */
-function isReportMissingActions(reportID, maxKnownSequenceNumber) {
-    return _.isUndefined(reportActionsMaxSequenceNumbers[reportID])
-        || reportActionsMaxSequenceNumbers[reportID] < maxKnownSequenceNumber;
-}
-
-/**
  * Get the count of deleted messages after a sequence number of a report
  * @param {Number|String} reportID
  * @param {Number} sequenceNumber
@@ -141,8 +110,6 @@ function deleteClientAction(reportID, clientID) {
 }
 
 export {
-    isReportMissingActions,
-    dangerouslyGetReportActionsMaxSequenceNumber,
     getDeletedCommentsCount,
     getLastVisibleMessageText,
     isFromCurrentUser,


### PR DESCRIPTION
### Details
Just noticed that these functions are unused, so I created a cleanup PR to remove them.

### Fixed Issues
$ n/a

### Tests
Verify with a global search that these functions are not used anywhere in the repo:

<img width="748" alt="image" src="https://user-images.githubusercontent.com/47436092/184255459-27cbd6f7-9abb-4681-8d43-5c04236e74c7.png">

And here's a control just so that you know search is working:

<img width="904" alt="image" src="https://user-images.githubusercontent.com/47436092/184255504-ea9e9ffd-a9d6-4e4f-8ff1-0542f857459c.png">