### PR TITLE
Allow video files to be uploaded

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -14,7 +14,7 @@ const CONST = {
 
     API_ATTACHMENT_VALIDATIONS: {
         // Same as the PHP layer allows
-        ALLOWED_EXTENSIONS: ['jpg', 'jpeg', 'png', 'gif', 'pdf', 'html', 'txt', 'rtf', 'doc', 'docx', 'htm', 'tiff', 'tif', 'xml'],
+        ALLOWED_EXTENSIONS: ['jpg', 'jpeg', 'png', 'gif', 'pdf', 'html', 'txt', 'rtf', 'doc', 'docx', 'htm', 'tiff', 'tif', 'xml', 'mp3', 'mp4', 'mov'],
 
         // 50 megabytes in bytes
         MAX_SIZE: 52428800,


### PR DESCRIPTION
### Fixed Issues
Addresses a comment from an earlier PR: https://github.com/Expensify/App/pull/10118#issuecomment-1210895657

### Tests and QA
- Upload an mov, mp3, or mp4 file under 50mb