### PR TITLE
[No QA] Use force-push to update staging and production

### DIFF
--- a/.github/actions/composite/updateProtectedBranch/action.yml
+++ b/.github/actions/composite/updateProtectedBranch/action.yml
@@ -1,9 +1,9 @@
 name: Update Protected Branch
-description: Create, approve, and merge a pull request against a protected branch
+description: Update a protected branch
 
 inputs:
   TARGET_BRANCH:
-    description: The target branch to update. This becomes the base branch of the pull request.
+    description: The target branch to update.
     required: true
   SOURCE_BRANCH:
     description: If updating main, you must also provide a head branch to update main with.
@@ -23,7 +23,7 @@ runs:
       if: ${{ !contains(fromJSON('["main", "staging", "production"]'), inputs.TARGET_BRANCH) }}
       shell: bash
       run: |
-        echo "Target branch must be one of ['main', 'staging', 'production]"
+        echo "Target branch must be one of ['main', 'staging', 'production']"
         exit 1
 
     # If updating main, SOURCE_BRANCH must not be empty
@@ -69,21 +69,9 @@ runs:
       shell: bash
       run: echo "NEW_VERSION=$(npm run print-version --silent)" >> "$GITHUB_ENV"
 
-    - name: Create temporary branch to resolve conflicts
-      if: ${{ contains(fromJSON('["staging", "production"]'), inputs.TARGET_BRANCH) }}
-      shell: bash
-      run: |
-        git checkout ${{ inputs.TARGET_BRANCH }}
-        BRANCH_NAME=update-${{ inputs.TARGET_BRANCH }}-from-${{ env.SOURCE_BRANCH }}
-        git checkout -b "$BRANCH_NAME"
-        git merge -Xtheirs ${{ env.SOURCE_BRANCH }} || {
-          git diff --name-only --diff-filter=U | xargs git rm;
-          git -c core.editor=true merge --continue;
-        }
-        git push --set-upstream origin "$BRANCH_NAME"
-
     - name: Create Pull Request
       id: createPullRequest
+      if: ${{ inputs.TARGET_BRANCH == 'main' }}
       shell: bash
       run: |
         gh pr create \
@@ -111,12 +99,14 @@ runs:
       run: exit 1
 
     - name: Auto-approve the PR
+      if: ${{ inputs.TARGET_BRANCH == 'main' }}
       shell: bash
       run: gh pr review --approve
       env:
         GITHUB_TOKEN: ${{ github.token }}
 
     - name: Check if pull request is mergeable
+      if: ${{ inputs.TARGET_BRANCH == 'main' }}
       id: isPullRequestMergeable
       uses: Expensify/App/.github/actions/javascript/isPullRequestMergeable@main
       with:
@@ -124,7 +114,7 @@ runs:
         PULL_REQUEST_NUMBER: ${{ steps.createPullRequest.outputs.PR_NUMBER }}
 
     - name: Leave comment if PR is not mergeable
-      if: ${{ !fromJSON(steps.isPullRequestMergeable.outputs.IS_MERGEABLE) }}
+      if: ${{ inputs.TARGET_BRANCH == 'main' && !fromJSON(steps.isPullRequestMergeable.outputs.IS_MERGEABLE) }}
       shell: bash
       run: |
         gh pr comment --body \
@@ -134,12 +124,24 @@ runs:
         GITHUB_TOKEN: ${{ inputs.OS_BOTIFY_TOKEN }}
 
     - name: Fail workflow if PR is not mergeable
-      if: ${{ steps.isPullRequestMergeable.outputs.IS_MERGEABLE == 'false' }}
+      if: ${{ inputs.TARGET_BRANCH == 'main' && steps.isPullRequestMergeable.outputs.IS_MERGEABLE == 'false' }}
       shell: bash
       run: exit 1
 
     - name: Auto-merge the PR
+      if: ${{ inputs.TARGET_BRANCH == 'main' }}
       shell: bash
       run: gh pr merge ${{ steps.createPullRequest.outputs.PR_NUMBER }} --merge --delete-branch
+      env:
+        GITHUB_TOKEN: ${{ inputs.OS_BOTIFY_TOKEN }}
+
+    - name: Delete staging/production and replace it with contents of main/staging
+      if: ${{ inputs.TARGET_BRANCH != 'main' }}
+      shell: bash
+      run: |
+        git checkout ${{ env.SOURCE_BRANCH }}
+        git branch -D ${{ inputs.TARGET_BRANCH }}
+        git checkout -b ${{ inputs.TARGET_BRANCH }}
+        git push --force origin ${{ inputs.TARGET_BRANCH }}
       env:
         GITHUB_TOKEN: ${{ inputs.OS_BOTIFY_TOKEN }}


### PR DESCRIPTION
### Details
Slack context: https://expensify.slack.com/archives/C07J32337/p1660240289078479

This PR utilizes OSBotify's new ability to bypass branch protection permissions that require pull requests to push changes and prohibit force-pushing to a protected branch. Furthermore, when updating staging, we'll just delete the staging branch and re-create it from main. When updating production, we'll just delete the production branch and re-create it from staging. This eliminates the possibility of conflicts, simplifies deploy workflows, and also fixes https://github.com/Expensify/App/issues/10214

I believe there's more we could do to clean things up (including using the same strategy to update `main`, but for now this PR is focused on unblocking deploys.

### Fixed Issues
$ https://github.com/Expensify/App/issues/10214

### Tests
Merge this PR with the CP staging label. Verify that the staging build is fixed and that staging deploys successfully.