### PR TITLE
Fix overflow issue on login screen

### DIFF
--- a/src/pages/signin/SignInPageLayout/SignInPageContent.js
+++ b/src/pages/signin/SignInPageLayout/SignInPageContent.js
@@ -49,7 +49,7 @@ const SignInPageContent = props => (
         <View style={[styles.flex1, styles.flexRow]}>
             <View style={[
                 styles.flex1,
-                props.isSmallScreenWidth && styles.signInPageNarrowContentContainer,
+                styles.signInPageNarrowContentContainer,
             ]}
             >
                 <SignInPageForm style={[


### PR DESCRIPTION
@techievivek Please review
cc @aimane-chnaif

### Details
I don't believe we need this conditional here as the SignIn page content will always be narrow.

### Fixed Issues
$ https://github.com/Expensify/App/issues/10419

### Tests
1. Go to the sign in page of new Expensify
2. Enter your login details but not your password (use long login name)
3. Press Forgot? on the password page

<img width="452" alt="Screen Shot 2022-08-17 at 12 16 41 PM" src="https://user-images.githubusercontent.com/4741899/185033548-2432b467-061c-4361-857e-34e9b38597b2.png">

