### PR TITLE
Localize an optimistic error that was only in English

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -485,7 +485,7 @@ export default {
         error: {
             invalidFormatEmailLogin: 'The email entered is invalid. Please fix the format and try again.',
         },
-        cannotGetAccountDetails: 'Cannot get account details, please try again.',
+        cannotGetAccountDetails: 'Couldn\'t retrieve account details, please try to sign in again.',
     },
     personalDetails: {
         error: {

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -485,6 +485,7 @@ export default {
         error: {
             invalidFormatEmailLogin: 'The email entered is invalid. Please fix the format and try again.',
         },
+        cannotGetAccountDetails: 'Cannot get account details, please try again.',
     },
     personalDetails: {
         error: {

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -485,7 +485,7 @@ export default {
         error: {
             invalidFormatEmailLogin: 'El email introducido no es válido. Corrígelo e inténtalo de nuevo.',
         },
-        cannotGetAccountDetails: 'No se pudo obtener el detalle de la cuenta, por favor inténtalo de nuevo.',
+        cannotGetAccountDetails: 'No pudimos cargar los detalles de tu cuenta, por favor intenta iniciar sesión de nuevo.',
     },
     personalDetails: {
         error: {

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -485,6 +485,7 @@ export default {
         error: {
             invalidFormatEmailLogin: 'El email introducido no es válido. Corrígelo e inténtalo de nuevo.',
         },
+        cannotGetAccountDetails: 'No se pueden obtener los detalles de la cuenta. Por favor inténtalo de nuevo.',
     },
     personalDetails: {
         error: {

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -485,7 +485,7 @@ export default {
         error: {
             invalidFormatEmailLogin: 'El email introducido no es válido. Corrígelo e inténtalo de nuevo.',
         },
-        cannotGetAccountDetails: 'No se pueden obtener los detalles de la cuenta. Por favor inténtalo de nuevo.',
+        cannotGetAccountDetails: 'No se pudo obtener el detalle de la cuenta, por favor inténtalo de nuevo.',
     },
     personalDetails: {
         error: {

--- a/src/libs/actions/Session/index.js
+++ b/src/libs/actions/Session/index.js
@@ -131,7 +131,7 @@ function beginSignIn(login) {
             value: {
                 isLoading: false,
                 errors: {
-                    [DateUtils.getMicroseconds()]: 'Cannot get account details, please try again',
+                    [DateUtils.getMicroseconds()]: Localize.translateLocal('loginForm.cannotGetAccountDetails'),
                 },
             },
         },


### PR DESCRIPTION
@nkuoch please review

HOLD ON COPY CONFIRMATION: https://github.com/Expensify/Expensify/issues/218743#issuecomment-1221652943

### Details
Fixed the local failure data error message to be localized instead of just in English.

### Fixed Issues
None, just a comment from @iwiznia here: https://github.com/Expensify/App/pull/10269#discussion_r949330820

### Tests
- Added in a throw in the `BeginSignIn` API command
- When I attempted to log in, made sure the error message showed correctly (see screenshot below)

### QA Steps
- None

### Screenshots
<img width="340" alt="Screen Shot 2022-08-19 at 2 35 04 PM" src="https://user-images.githubusercontent.com/4741899/185558380-30ec6a90-37f6-4398-a1a5-acb95c47044f.png">

