### PR TITLE
Use `main` now that `andrew-npm-8` is merged

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     if: ${{ github.actor != 'OSBotify' || github.event_name == 'workflow_call' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: Expensify/App/.github/actions/composite/setupNode@andrew-npm-8
+      - uses: Expensify/App/.github/actions/composite/setupNode@main
 
       - run: npm run lint
         env:

--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -31,7 +31,7 @@ jobs:
     if: ${{ fromJSON(needs.validateActor.outputs.IS_DEPLOYER) }}
     runs-on: ubuntu-latest
     steps:
-      - uses: Expensify/App/.github/actions/composite/setupNode@andrew-npm-8
+      - uses: Expensify/App/.github/actions/composite/setupNode@main
 
       - uses: ruby/setup-ruby@08245253a76fa4d1e459b7809579c62bd9eb718a
         with:
@@ -95,7 +95,7 @@ jobs:
     if: ${{ fromJSON(needs.validateActor.outputs.IS_DEPLOYER) }}
     runs-on: macos-11
     steps:
-      - uses: Expensify/App/.github/actions/composite/setupNode@andrew-npm-8
+      - uses: Expensify/App/.github/actions/composite/setupNode@main
 
       - name: Decrypt Developer ID Certificate
         run: cd desktop && gpg --quiet --batch --yes --decrypt --passphrase="$DEVELOPER_ID_SECRET_PASSPHRASE" --output developer_id.p12 developer_id.p12.gpg
@@ -130,7 +130,7 @@ jobs:
     if: ${{ fromJSON(needs.validateActor.outputs.IS_DEPLOYER) }}
     runs-on: macos-11
     steps:
-      - uses: Expensify/App/.github/actions/composite/setupNode@andrew-npm-8
+      - uses: Expensify/App/.github/actions/composite/setupNode@main
 
       - uses: ruby/setup-ruby@08245253a76fa4d1e459b7809579c62bd9eb718a
         with:
@@ -208,7 +208,7 @@ jobs:
     if: ${{ fromJSON(needs.validateActor.outputs.IS_DEPLOYER) }}
     runs-on: ubuntu-latest
     steps:
-      - uses: Expensify/App/.github/actions/composite/setupNode@andrew-npm-8
+      - uses: Expensify/App/.github/actions/composite/setupNode@main
 
       - name: Setup python
         run: sudo apt-get install python3-setuptools
@@ -336,7 +336,7 @@ jobs:
     if: ${{ always() }}
     needs: [android, desktop, iOS, web]
     steps:
-      - uses: Expensify/App/.github/actions/composite/setupNode@andrew-npm-8
+      - uses: Expensify/App/.github/actions/composite/setupNode@main
 
       - name: Set version
         run: echo "VERSION=$(npm run print-version --silent)" >> "$GITHUB_ENV"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     if: ${{ github.actor != 'OSBotify' || github.event_name == 'workflow_call' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: Expensify/App/.github/actions/composite/setupNode@andrew-npm-8
+      - uses: Expensify/App/.github/actions/composite/setupNode@main
 
       # If automatic signing is enabled, iOS builds will fail, so ensure we always have the proper profile specified
       - name: Check Provisioning Style

--- a/.github/workflows/validateGithubActions.yml
+++ b/.github/workflows/validateGithubActions.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.actor != 'OSBotify'
     runs-on: ubuntu-latest
     steps:
-      - uses: Expensify/App/.github/actions/composite/setupNode@andrew-npm-8
+      - uses: Expensify/App/.github/actions/composite/setupNode@main
 
       # Rebuild all the actions on this branch and check for a diff. Fail if there is one,
       # because that would be a sign that the PR author did not rebuild the Github Actions

--- a/.github/workflows/verifyPodfile.yml
+++ b/.github/workflows/verifyPodfile.yml
@@ -10,6 +10,6 @@ jobs:
     if: github.actor != 'OSBotify'
     runs-on: ubuntu-latest
     steps:
-      - uses: Expensify/App/.github/actions/composite/setupNode@andrew-npm-8
+      - uses: Expensify/App/.github/actions/composite/setupNode@main
 
       - run: ./.github/scripts/verifyPodfile.sh


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
In my previous PR here: https://github.com/Expensify/App/pull/10439 We had to use the `andrew-npm-8` branch to use the latest code to get the tests to pass.