### PR TITLE
Ignore `forbid-prop-types` to fix lint

### DIFF
--- a/src/components/Section.js
+++ b/src/components/Section.js
@@ -24,6 +24,7 @@ const propTypes = {
     children: PropTypes.node,
 
     /** Customize the Section container */
+    // eslint-disable-next-line react/forbid-prop-types
     containerStyles: PropTypes.arrayOf(PropTypes.object),
 };
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Ignore `forbid-prop-types` to fix lint on `main`!