### PR TITLE
Remove has draft collection

### DIFF
--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -182,12 +182,10 @@ function getSearchText(report, reportName, personalDetailList, isChatRoomOrPolic
  * Determines whether a report has a draft comment.
  *
  * @param {Object} report
- * @param {Object} reportsWithDraft
  * @return {Boolean}
  */
-function hasReportDraftComment(report, reportsWithDraft = {}) {
-    return report
-        && lodashGet(reportsWithDraft, `${ONYXKEYS.COLLECTION.REPORTS_WITH_DRAFT}${report.reportID}`, false);
+function hasReportDraftComment(report) {
+    return lodashGet(report, 'hasDraft', false);
 }
 
 /**
@@ -219,14 +217,13 @@ function getBrickRoadIndicatorStatusForReport(report, reportActions) {
  * @param {Array<String>} logins
  * @param {Object} personalDetails
  * @param {Object} report
- * @param {Object} reportsWithDraft
  * @param {Object} reportActions
  * @param {Object} options
  * @param {Boolean} [options.showChatPreviewLine]
  * @param {Boolean} [options.forcePolicyNamePreview]
  * @returns {Object}
  */
-function createOption(logins, personalDetails, report, reportsWithDraft, reportActions = {}, {
+function createOption(logins, personalDetails, report, reportActions = {}, {
     showChatPreviewLine = false,
     forcePolicyNamePreview = false,
 }) {
@@ -237,7 +234,7 @@ function createOption(logins, personalDetails, report, reportsWithDraft, reportA
     const isArchivedRoom = ReportUtils.isArchivedRoom(report);
     const hasMultipleParticipants = personalDetailList.length > 1 || isChatRoom || isPolicyExpenseChat;
     const personalDetail = personalDetailList[0];
-    const hasDraftComment = hasReportDraftComment(report, reportsWithDraft);
+    const hasDraftComment = hasReportDraftComment(report);
     const hasOutstandingIOU = lodashGet(report, 'hasOutstandingIOU', false);
     const iouReport = hasOutstandingIOU
         ? lodashGet(iouReports, `${ONYXKEYS.COLLECTION.REPORT_IOUS}${report.iouReportID}`, {})
@@ -369,7 +366,6 @@ function isCurrentUser(userDetails) {
  * @private
  */
 function getOptions(reports, personalDetails, activeReportID, {
-    reportsWithDraft = {},
     reportActions = {},
     betas = [],
     selectedOptions = [],
@@ -428,7 +424,7 @@ function getOptions(reports, personalDetails, activeReportID, {
             return;
         }
 
-        const hasDraftComment = hasReportDraftComment(report, reportsWithDraft);
+        const hasDraftComment = hasReportDraftComment(report);
         const iouReportOwner = lodashGet(report, 'hasOutstandingIOU', false)
             ? lodashGet(iouReports, [`${ONYXKEYS.COLLECTION.REPORT_IOUS}${report.iouReportID}`, 'ownerEmail'], '')
             : '';
@@ -475,7 +471,7 @@ function getOptions(reports, personalDetails, activeReportID, {
             reportMapForLogins[logins[0]] = report;
         }
         const isSearchingSomeonesPolicyExpenseChat = !report.isOwnPolicyExpenseChat && searchValue !== '';
-        allReportOptions.push(createOption(logins, personalDetails, report, reportsWithDraft, reportActions, {
+        allReportOptions.push(createOption(logins, personalDetails, report, reportActions, {
             showChatPreviewLine,
             forcePolicyNamePreview: isPolicyExpenseChat ? isSearchingSomeonesPolicyExpenseChat : forcePolicyNamePreview,
         }));
@@ -485,7 +481,6 @@ function getOptions(reports, personalDetails, activeReportID, {
         [personalDetail.login],
         personalDetails,
         reportMapForLogins[personalDetail.login],
-        reportsWithDraft,
         reportActions,
         {
             showChatPreviewLine,
@@ -608,7 +603,7 @@ function getOptions(reports, personalDetails, activeReportID, {
         const login = (Str.isValidPhone(searchValue) && !searchValue.includes('+'))
             ? `+${countryCodeByIP}${searchValue}`
             : searchValue;
-        userToInvite = createOption([login], personalDetails, null, reportsWithDraft, reportActions, {
+        userToInvite = createOption([login], personalDetails, null, reportActions, {
             showChatPreviewLine,
         });
         userToInvite.icons = [ReportUtils.getDefaultAvatar(login)];
@@ -770,11 +765,10 @@ function getMemberInviteOptions(
  * @param {Number} activeReportID
  * @param {String} priorityMode
  * @param {Array<String>} betas
- * @param {Object} reportsWithDraft
  * @param {Object} reportActions
  * @returns {Object}
  */
-function calculateSidebarOptions(reports, personalDetails, activeReportID, priorityMode, betas, reportsWithDraft, reportActions) {
+function calculateSidebarOptions(reports, personalDetails, activeReportID, priorityMode, betas, reportActions) {
     let sideBarOptions = {
         prioritizeIOUDebts: true,
         prioritizeReportsWithDraftComments: true,
@@ -794,7 +788,6 @@ function calculateSidebarOptions(reports, personalDetails, activeReportID, prior
         showChatPreviewLine: true,
         prioritizePinnedReports: true,
         ...sideBarOptions,
-        reportsWithDraft,
         reportActions,
     });
 }

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -1154,7 +1154,7 @@ function saveReportComment(reportID, comment) {
  * @returns {Promise}
  */
 function setReportWithDraft(reportID, hasDraft) {
-    return Onyx.merge(`${ONYXKEYS.COLLECTION.REPORTS_WITH_DRAFT}${reportID}`, hasDraft);
+    return Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, {hasDraft});
 }
 
 /**

--- a/src/libs/migrateOnyx.js
+++ b/src/libs/migrateOnyx.js
@@ -5,7 +5,6 @@ import RenameActiveClientsKey from './migrations/RenameActiveClientsKey';
 import RenamePriorityModeKey from './migrations/RenamePriorityModeKey';
 import MoveToIndexedDB from './migrations/MoveToIndexedDB';
 import RenameExpensifyNewsStatus from './migrations/RenameExpensifyNewsStatus';
-import MoveReportHasDraftCollectionToReportObject from './migrations/MoveReportHasDraftCollectionToReportObject';
 
 export default function () {
     const startTime = Date.now();
@@ -19,7 +18,6 @@ export default function () {
             RenamePriorityModeKey,
             AddEncryptedAuthToken,
             RenameExpensifyNewsStatus,
-            MoveReportHasDraftCollectionToReportObject,
         ];
 
         // Reduce all promises down to a single promise. All promises run in a linear fashion, waiting for the

--- a/src/libs/migrateOnyx.js
+++ b/src/libs/migrateOnyx.js
@@ -5,6 +5,7 @@ import RenameActiveClientsKey from './migrations/RenameActiveClientsKey';
 import RenamePriorityModeKey from './migrations/RenamePriorityModeKey';
 import MoveToIndexedDB from './migrations/MoveToIndexedDB';
 import RenameExpensifyNewsStatus from './migrations/RenameExpensifyNewsStatus';
+import MoveReportHasDraftCollectionToReportObject from './migrations/MoveReportHasDraftCollectionToReportObject';
 
 export default function () {
     const startTime = Date.now();
@@ -18,6 +19,7 @@ export default function () {
             RenamePriorityModeKey,
             AddEncryptedAuthToken,
             RenameExpensifyNewsStatus,
+            MoveReportHasDraftCollectionToReportObject,
         ];
 
         // Reduce all promises down to a single promise. All promises run in a linear fashion, waiting for the

--- a/src/pages/home/sidebar/SidebarLinks.js
+++ b/src/pages/home/sidebar/SidebarLinks.js
@@ -52,9 +52,6 @@ const propTypes = {
         unreadActionCount: PropTypes.number,
     })),
 
-    /** Reports having a draft */
-    reportsWithDraft: PropTypes.objectOf(PropTypes.bool),
-
     /** List of users' personal details */
     personalDetails: PropTypes.objectOf(participantPropTypes),
 
@@ -87,7 +84,6 @@ const propTypes = {
 
 const defaultProps = {
     reports: {},
-    reportsWithDraft: {},
     personalDetails: {},
     currentUserPersonalDetails: {
         avatar: ReportUtils.getDefaultAvatar(),
@@ -132,7 +128,6 @@ class SidebarLinks extends React.Component {
             activeReportID,
             props.priorityMode,
             props.betas,
-            props.reportsWithDraft,
             props.reportActions,
         );
         return sidebarOptions.recentReports;
@@ -189,7 +184,7 @@ class SidebarLinks extends React.Component {
         this.state = {
             activeReport: {
                 reportID: props.currentlyViewedReportID,
-                hasDraftHistory: lodashGet(props.reportsWithDraft, `${ONYXKEYS.COLLECTION.REPORTS_WITH_DRAFT}${props.currentlyViewedReportID}`, false),
+                hasDraftHistory: lodashGet(props.reports, `${ONYXKEYS.COLLECTION.REPORT}${props.currentlyViewedReportID}.hasDraft`, false),
                 lastMessageTimestamp: lodashGet(props.reports, `${ONYXKEYS.COLLECTION.REPORT}${props.currentlyViewedReportID}.lastMessageTimestamp`, 0),
             },
             orderedReports: [],
@@ -213,7 +208,7 @@ class SidebarLinks extends React.Component {
         } else if (isActiveReportSame && prevState.activeReport.hasDraftHistory) {
             hasDraftHistory = true;
         } else {
-            hasDraftHistory = lodashGet(nextProps.reportsWithDraft, `${ONYXKEYS.COLLECTION.REPORTS_WITH_DRAFT}${nextProps.currentlyViewedReportID}`, false);
+            hasDraftHistory = lodashGet(nextProps.reports, `${ONYXKEYS.COLLECTION.REPORT}${nextProps.currentlyViewedReportID}.hasDraft`, false);
         }
 
         const shouldReorder = SidebarLinks.shouldReorder(nextProps, hasDraftHistory, prevState.orderedReports, prevState.activeReport.reportID, prevState.unreadReports);
@@ -359,9 +354,6 @@ export default compose(
         },
         betas: {
             key: ONYXKEYS.BETAS,
-        },
-        reportsWithDraft: {
-            key: ONYXKEYS.COLLECTION.REPORTS_WITH_DRAFT,
         },
         reportActions: {
             key: ONYXKEYS.COLLECTION.REPORT_ACTIONS,

--- a/tests/unit/OptionsListUtilsTest.js
+++ b/tests/unit/OptionsListUtilsTest.js
@@ -17,6 +17,7 @@ describe('OptionsListUtils', () => {
             participants: ['tonystark@expensify.com', 'reedrichards@expensify.com'],
             reportName: 'Iron Man, Mister Fantastic',
             unreadActionCount: 1,
+            hasDraft: true,
         },
         2: {
             lastVisitedTimestamp: 1610666739296,
@@ -684,7 +685,6 @@ describe('OptionsListUtils', () => {
                     0,
                     CONST.PRIORITY_MODE.DEFAULT,
                     [],
-                    {[`${ONYXKEYS.COLLECTION.REPORTS_WITH_DRAFT}${1}`]: true},
                 );
 
                 // Then expect all of the reports to be shown both multiple and single participant except the
@@ -724,7 +724,6 @@ describe('OptionsListUtils', () => {
                     0,
                     CONST.PRIORITY_MODE.GSD,
                     [],
-                    {[`${ONYXKEYS.COLLECTION.REPORTS_WITH_DRAFT}${1}`]: true},
                 );
 
                 // Then expect all of the reports to be shown both multiple and single participant except the
@@ -844,7 +843,6 @@ describe('OptionsListUtils', () => {
             0,
             CONST.PRIORITY_MODE.DEFAULT,
             [],
-            {},
         );
 
         // Then expect all of the reports to be shown except the archived policyExpenseChats and defaultRooms


### PR DESCRIPTION
We recently discussed the removal of these collections that only hold boolean values.

While starting to work on https://github.com/Expensify/App/issues/7948 I wanted to start with fixing these drafts to help clean things up before getting into the meat of the issue.

### Details
This PR removes the old Onyx collection for `reportHasDraft_` and move the information to a `hasDraft` property on each report.

### Fixed Issues
Related to https://github.com/Expensify/App/issues/7948

### Tests
Covered by unit tests

- [ ] Verify that no errors appear in the JS console

### QA Steps
1. Open a chat
2. Start writing a comment
3. Verify the edit/pencil icon appears in the LHN for the active report
4. While still having a draft comment, switch to another report
5. Start writing a comment on the new report
6. Verify that both reports have the edit/pencil icon showing, since they have drafts

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
