### PR TITLE
Wrap setString instead of using Clipboard object

### DIFF
--- a/src/libs/Clipboard/index.js
+++ b/src/libs/Clipboard/index.js
@@ -27,8 +27,17 @@ const setHtml = (html, text) => {
     ]);
 };
 
+/**
+ * Sets a string on the Clipboard object via react-native-web
+ *
+ * @param {String} text
+ */
+const setString = (text) => {
+    Clipboard.setString(text);
+};
+
 export default {
-    ...Clipboard,
+    setString,
     canSetHtml,
     setHtml,
 };

--- a/src/libs/Clipboard/index.native.js
+++ b/src/libs/Clipboard/index.native.js
@@ -1,7 +1,16 @@
 import Clipboard from '@react-native-community/clipboard';
 
+/**
+ * Sets a string on the Clipboard object via @react-native-community/clipboard
+ *
+ * @param {String} text
+ */
+const setString = (text) => {
+    Clipboard.setString(text);
+};
+
 export default {
-    ...Clipboard,
+    setString,
 
     // We don't want to set HTML on native platforms so noop them.
     canSetHtml: () => false,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
I believe the issue is that `Clipboard` was slightly tweaked in an update of `react-native-web` breaking our ability to export it as an object. This wraps the `setString` method instead of directly accessing that method via the object in both native and web platforms.

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/10522

### Tests
1. Go to a chat
2. Click on a name
3. Click the clipboard icon
4. Verify no error ✅ 
5. Verify email is copied to clipboard

### Screenshots
<img width="564" alt="Screen Shot 2022-08-24 at 7 22 44 PM" src="https://user-images.githubusercontent.com/2838819/186484593-8412cb0a-f6c7-4a8e-87dc-d0060da8a740.png">

<img width="1529" alt="Screen Shot 2022-08-24 at 7 20 59 PM" src="https://user-images.githubusercontent.com/2838819/186484617-0db4625c-c72d-4e8b-bbc2-6f06d8053e3e.png">



