### PR TITLE
Simplify new line indicator and message badge

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -202,7 +202,7 @@ export default {
         beginningOfChatHistoryPolicyExpenseChatPartTwo: ' and ',
         beginningOfChatHistoryPolicyExpenseChatPartThree: ' starts here! 🎉 This is the place to chat, request money and settle up.',
     },
-    newMessageCount: ({count}) => `${count} new message${count > 1 ? 's' : ''}`,
+    newMessages: 'New messages',
     reportTypingIndicator: {
         isTyping: 'is typing...',
         areTyping: 'are typing...',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -202,7 +202,7 @@ export default {
         beginningOfChatHistoryPolicyExpenseChatPartTwo: ' y ',
         beginningOfChatHistoryPolicyExpenseChatPartThree: ' empieza aquí! :tada: Este es el lugar donde chatear, pedir dinero y pagar.',
     },
-    newMessageCount: ({count}) => `${count} mensaje${count > 1 ? 's' : ''} nuevo${count > 1 ? 's' : ''}`,
+    newMessages: 'Mensajes nuevos',
     reportTypingIndicator: {
         isTyping: 'está escribiendo...',
         areTyping: 'están escribiendo...',

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -417,16 +417,6 @@ function fetchIOUReportByID(iouReportID, chatReportID, shouldRedirectIfEmpty = f
 }
 
 /**
- * @param {Number} reportID
- * @param {Number} sequenceNumber
- */
-function setNewMarkerPosition(reportID, sequenceNumber) {
-    Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, {
-        newMarkerSequenceNumber: sequenceNumber,
-    });
-}
-
-/**
  * Get the private pusher channel name for a Report.
  *
  * @param {Number} reportID
@@ -1121,7 +1111,6 @@ function markCommentAsUnread(reportID, sequenceNumber) {
                 onyxMethod: CONST.ONYX.METHOD.MERGE,
                 key: `${ONYXKEYS.COLLECTION.REPORT}${reportID}`,
                 value: {
-                    newMarkerSequenceNumber: sequenceNumber,
                     lastReadSequenceNumber: newLastReadSequenceNumber,
                     lastVisitedTimestamp: Date.now(),
                     unreadActionCount: calculateUnreadActionCount(reportID, newLastReadSequenceNumber, maxSequenceNumber),
@@ -1523,12 +1512,6 @@ function viewNewReportAction(reportID, action) {
         return;
     }
 
-    // When a new message comes in, if the New marker is not already set (newMarkerSequenceNumber === 0), set the marker above the incoming message.
-    const report = lodashGet(allReports, 'reportID', {});
-    if (lodashGet(report, 'newMarkerSequenceNumber', 0) === 0 && report.unreadActionCount > 0) {
-        setNewMarkerPosition(reportID, report.lastReadSequenceNumber + 1);
-    }
-
     Log.info('[LOCAL_NOTIFICATION] Creating notification');
     LocalNotification.showCommentNotification({
         reportAction: action,
@@ -1589,7 +1572,6 @@ export {
     addAttachment,
     reconnect,
     updateNotificationPreference,
-    setNewMarkerPosition,
     subscribeToReportTypingEvents,
     subscribeToUserEvents,
     subscribeToReportCommentPushNotifications,

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -674,7 +674,7 @@ function createOptimisticReport(participantList) {
         lastActorEmail: '',
         lastMessageHtml: '',
         lastMessageText: null,
-        lastReadSequenceNumber: undefined,
+        lastReadSequenceNumber: 0,
         lastMessageTimestamp: 0,
         lastVisitedTimestamp: 0,
         maxSequenceNumber: 0,

--- a/src/pages/home/ReportScreen.js
+++ b/src/pages/home/ReportScreen.js
@@ -53,9 +53,6 @@ const propTypes = {
         /** The largest sequenceNumber on this report */
         maxSequenceNumber: PropTypes.number,
 
-        /** The current position of the new marker */
-        newMarkerSequenceNumber: PropTypes.number,
-
         /** Whether there is an outstanding amount in IOU */
         hasOutstandingIOU: PropTypes.bool,
 

--- a/src/pages/home/report/FloatingMessageCounter/index.js
+++ b/src/pages/home/report/FloatingMessageCounter/index.js
@@ -11,14 +11,8 @@ import withLocalize, {withLocalizePropTypes} from '../../../../components/withLo
 import FloatingMessageCounterContainer from './FloatingMessageCounterContainer';
 
 const propTypes = {
-    /** Count of new messages to show in the badge */
-    count: PropTypes.number,
-
     /** Whether the marker is active */
-    active: PropTypes.bool,
-
-    /** Callback to be called when user closes the badge */
-    onClose: PropTypes.func,
+    isActive: PropTypes.bool,
 
     /** Callback to be called when user clicks the marker */
     onClick: PropTypes.func,
@@ -27,9 +21,7 @@ const propTypes = {
 };
 
 const defaultProps = {
-    count: 0,
-    active: false,
-    onClose: () => {},
+    isActive: false,
     onClick: () => {},
 };
 
@@ -45,7 +37,7 @@ class FloatingMessageCounter extends PureComponent {
     }
 
     componentDidUpdate() {
-        if (this.props.active && this.props.count > 0) {
+        if (this.props.isActive && this.props.count > 0) {
             this.show();
         } else {
             this.hide();
@@ -93,23 +85,9 @@ class FloatingMessageCounter extends PureComponent {
                                             styles.textWhite,
                                         ]}
                                     >
-                                        {this.props.translate(
-                                            'newMessageCount',
-                                            {count: this.props.count},
-                                        )}
+                                        {this.props.translate('newMessages')}
                                     </Text>
                                 </View>
-                            )}
-                            shouldRemoveRightBorderRadius
-                        />
-                        <Button
-                            success
-                            small
-                            style={[styles.buttonDropdown]}
-                            onPress={this.props.onClose}
-                            shouldRemoveLeftBorderRadius
-                            ContentComponent={() => (
-                                <Icon small src={Expensicons.Close} fill={themeColors.textReversed} />
                             )}
                         />
                     </View>

--- a/src/pages/home/report/FloatingMessageCounter/index.js
+++ b/src/pages/home/report/FloatingMessageCounter/index.js
@@ -37,7 +37,7 @@ class FloatingMessageCounter extends PureComponent {
     }
 
     componentDidUpdate() {
-        if (this.props.isActive && this.props.count > 0) {
+        if (this.props.isActive) {
             this.show();
         } else {
             this.hide();

--- a/src/pages/home/report/FloatingMessageCounter/index.js
+++ b/src/pages/home/report/FloatingMessageCounter/index.js
@@ -14,7 +14,7 @@ const propTypes = {
     /** Whether the marker is active */
     isActive: PropTypes.bool,
 
-    /** Callback to be called when user clicks the marker */
+    /** Callback to be called when user clicks the New Messages indicator */
     onClick: PropTypes.func,
 
     ...withLocalizePropTypes,

--- a/src/pages/home/report/FloatingMessageCounter/index.js
+++ b/src/pages/home/report/FloatingMessageCounter/index.js
@@ -11,7 +11,7 @@ import withLocalize, {withLocalizePropTypes} from '../../../../components/withLo
 import FloatingMessageCounterContainer from './FloatingMessageCounterContainer';
 
 const propTypes = {
-    /** Whether the marker is active */
+    /** Whether the New Messages indicator is active */
     isActive: PropTypes.bool,
 
     /** Callback to be called when user clicks the New Messages indicator */

--- a/src/pages/home/report/ReportActionsList.js
+++ b/src/pages/home/report/ReportActionsList.js
@@ -19,6 +19,9 @@ import CONST from '../../../CONST';
 import * as StyleUtils from '../../../styles/StyleUtils';
 
 const propTypes = {
+    /** Position of the "New" line marker */
+    newMarkerSequenceNumber: PropTypes.number.isRequired,
+
     /** Personal details of all the users */
     personalDetails: PropTypes.objectOf(participantPropTypes),
 
@@ -29,9 +32,6 @@ const propTypes = {
 
         /** The largest sequenceNumber on this report */
         maxSequenceNumber: PropTypes.number,
-
-        /** The current position of the new marker */
-        newMarkerSequenceNumber: PropTypes.number,
 
         /** Whether there is an outstanding amount in IOU */
         hasOutstandingIOU: PropTypes.bool,
@@ -134,8 +134,8 @@ class ReportActionsList extends React.Component {
         item,
         index,
     }) {
-        const shouldDisplayNewIndicator = this.props.report.newMarkerSequenceNumber > 0
-            && item.action.sequenceNumber === this.props.report.newMarkerSequenceNumber;
+        const shouldDisplayNewIndicator = this.props.newMarkerSequenceNumber > 0
+            && item.action.sequenceNumber === this.props.newMarkerSequenceNumber;
         return (
             <ReportActionItem
                 reportID={this.props.report.reportID}
@@ -171,7 +171,7 @@ class ReportActionsList extends React.Component {
     render() {
         // Native mobile does not render updates flatlist the changes even though component did update called.
         // To notify there something changes we can use extraData prop to flatlist
-        const extraData = (!this.props.isDrawerOpen && this.props.isSmallScreenWidth) ? this.props.report.newMarkerSequenceNumber : undefined;
+        const extraData = (!this.props.isDrawerOpen && this.props.isSmallScreenWidth) ? this.props.newMarkerSequenceNumber : undefined;
         const shouldShowReportRecipientLocalTime = ReportUtils.canShowReportRecipientLocalTime(this.props.personalDetails, this.props.report);
         return (
             <Animated.View style={StyleUtils.getReportListAnimationStyle(this.state.fadeInAnimation)}>

--- a/src/pages/home/report/ReportActionsList.js
+++ b/src/pages/home/report/ReportActionsList.js
@@ -134,6 +134,8 @@ class ReportActionsList extends React.Component {
         item,
         index,
     }) {
+        // When the new indicator should not be displayed we explicitly set it to 0. The marker should never be shown above the
+        // created action (which will have sequenceNumber of 0) so we use 0 to indicate "hidden".
         const shouldDisplayNewIndicator = this.props.newMarkerSequenceNumber > 0
             && item.action.sequenceNumber === this.props.newMarkerSequenceNumber;
         return (

--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -177,6 +177,9 @@ class ReportActionsView extends React.Component {
 
     componentDidUpdate(prevProps) {
         if (lodashGet(prevProps.network, 'isOffline') && !lodashGet(this.props.network, 'isOffline')) {
+            // When returning from offline to online state we want to trigger a request to OpenReport which
+            // will fetch the reportActions data and mark the report as read. If the report is not fully visible
+            // then we call ReconnectToReport which only loads the reportActions data without marking the report as read.
             if (this.getIsReportFullyVisible()) {
                 Report.openReport(this.props.report.reportID);
             } else {
@@ -221,10 +224,11 @@ class ReportActionsView extends React.Component {
 
         // Update the new marker position and last read action when we are closing the sidebar or moving from a small to large screen size
         if (isReportFullyVisible && reportBecomeVisible) {
-            const newMarkerSequenceNumber = this.props.report.unreadActionCount === 0
-                ? 0
-                : this.props.report.lastReadSequenceNumber + 1;
-            this.setState({newMarkerSequenceNumber});
+            this.setState({
+                newMarkerSequenceNumber: this.props.report.unreadActionCount === 0
+                    ? 0
+                    : this.props.report.lastReadSequenceNumber + 1,
+            });
             Report.openReport(this.props.report.reportID);
         }
 

--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -91,8 +91,6 @@ class ReportActionsView extends React.Component {
                 : 0,
         };
 
-        console.log('@marcaaron state in constructor ', this.state);
-
         this.currentScrollOffset = 0;
         this.sortedReportActions = ReportActionsUtils.getSortedReportActions(props.reportActions);
         this.mostRecentIOUReportSequenceNumber = ReportActionsUtils.getMostRecentIOUReportSequenceNumber(props.reportActions);
@@ -112,11 +110,9 @@ class ReportActionsView extends React.Component {
             // If the app user becomes active and they have no unread actions we clear the new marker to sync their device
             // e.g. they could have read these messages on another device and only just become active here
             if (state === 'active' && this.props.report.unreadActionCount === 0) {
-                console.log('@marcaaron callback with active state and no unreadActionCount resetting');
                 this.setState({newMarkerSequenceNumber: 0});
             }
 
-            console.log('@marcaaron openReport called in appStateChangeListener');
             Report.openReport(this.props.report.reportID);
         });
 

--- a/tests/actions/ReportTest.js
+++ b/tests/actions/ReportTest.js
@@ -242,7 +242,6 @@ describe('actions/Report', () => {
                             lastMessageTimestamp: 0,
                             lastMessageText: 'Comment 1',
                             lastActorEmail: USER_2_LOGIN,
-                            newMarkerSequenceNumber: 0,
                             lastReadSequenceNumber: 0,
                         },
                     },
@@ -286,7 +285,6 @@ describe('actions/Report', () => {
             .then(() => {
                 // The unreadActionCount will increase and the new marker will be set correctly
                 expect(report.unreadActionCount).toBe(1);
-                expect(report.newMarkerSequenceNumber).toBe(1);
 
                 // When a new comment is added by the current user
                 Report.addComment(REPORT_ID, 'Current User Comment 1');
@@ -391,7 +389,6 @@ describe('actions/Report', () => {
                 // Then we should expect the unreadActionCount to be updated
                 expect(report.unreadActionCount).toBe(2);
                 expect(report.lastReadSequenceNumber).toBe(2);
-                expect(report.newMarkerSequenceNumber).toBe(3);
 
                 // If the user deletes the last comment after the last read the unreadActionCount will decrease and the lastMessageText will reflect the new last comment
                 Report.deleteReportComment(REPORT_ID, reportActions[4]);

--- a/tests/actions/ReportTest.js
+++ b/tests/actions/ReportTest.js
@@ -283,7 +283,7 @@ describe('actions/Report', () => {
                 return waitForPromisesToResolve();
             })
             .then(() => {
-                // The unreadActionCount will increase and the new marker will be set correctly
+                // The unreadActionCount will increase
                 expect(report.unreadActionCount).toBe(1);
 
                 // When a new comment is added by the current user


### PR DESCRIPTION
### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/Expensify/issues/224876

### Tests
1. Start a chat between User A and User B.
1. Ensure User A is not looking at the chat.
1. Send a message as User B
1. Verify the LHN row shows in bold for User A to indicate unread messages
1. Visit the chat as User A and verify the LHN row no longer shows in bold
1. Verify there is a “----- New” line above the message sent by User B
1. Scroll up and verify that the “New Messages” button appears floating above the content.
1. Verify that tapping this button will scroll you to the bottom of the chat but not clear the “---- New” line marker.
1. Mark a comment as “unread”
1. Verify the “---- New” line marker appears
1. Mark as unread comments above and below the existing new marker
1. Verify the marker appears in the correct position each time
1. While the new marker is active leave a comment as User A
1. Verify the new marker and new messages badge both disappear
1. Mark another comment as unread.
1. Navigate away from the chat
1. Navigate back to the chat
1. Verify the chat in the LHN shows as read
1. Verify the New Line marker and new messages badge is still present
1. Navigate away one more time and back
1. Verify the new marker and new messages badge both disappear
1. Mark another comment as unread.
1. Navigate away from the chat
1. Navigate back to the chat
1. Minimize the app and reopen it
1. Verify the new marker and new message badge both disappear
1. Switch to a mobile view (small screen) and mark a message as unread
1. Tap the header to reveal the LHN
1. Verify the chat in the LHN shows as “unread”
1. Tap the chat
1. Verify the new marker and badge are present
1. Tap the header to reveal the LHN
1. Verify the chat in the LHN shows as “read”
1. Tap the chat
1. Verify the new marker and badge are no longer present.
1. Scroll up in the chat so that last comment is out of view
1. Leave a comment as User B
1. Verify the “new messages badge” shows for User A
1. Scroll down and verify the “new line marker” shows for User A in the correct position.
1. Scroll back up and leave another comment as User B
1. Scroll down as User A
1. Verify the new marker is in the same position as it was before

- [ ] Verify that no errors appear in the JS console

### PR Review Checklist
#### Contributor (PR Author) Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] Any functional components have the `displayName` property
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

<details>
<summary><h4>PR Reviewer Checklist</h4>

The Contributor+ will copy/paste it into a new comment and complete it after the author checklist is completed
</summary>

- [ ] I have verified the author checklist is complete (all boxes are checked off).
- [ ] I verified the correct issue is linked in the `### Fixed Issues` section above
- [ ] I verified testing steps are clear and they cover the changes made in this PR
    - [ ] I verified the steps for local testing are in the `Tests` section
    - [ ] I verified the steps for Staging and/or Production testing are in the `QA steps` section
    - [ ] I verified the steps cover any possible failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [ ] I checked that screenshots or videos are included for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I verified tests pass on **all platforms** & I tested again on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`).
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [ ] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I verified that this PR follows the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I verified other components that can be impacted by these changes have been tested, and I retested again (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` have been tested & I retested again)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] Any functional components have the `displayName` property
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] I have checked off every checkbox in the PR reviewer checklist, including those that don't apply to this PR.

</details>

### QA Steps

Same as Test Steps

- [ ] Verify that no errors appear in the JS console

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
