### PR TITLE
Add focus to the 2FA field once password is successful

### DIFF
--- a/src/pages/signin/PasswordForm.js
+++ b/src/pages/signin/PasswordForm.js
@@ -68,6 +68,9 @@ class PasswordForm extends React.Component {
         if (prevProps.isVisible && !this.props.isVisible && this.state.password) {
             this.clearPassword();
         }
+        if (!prevProps.account.requiresTwoFactorAuth && this.props.account.requiresTwoFactorAuth) {
+            this.input2FA.focus();
+        }
     }
 
     /**


### PR DESCRIPTION
### Details
When the 2FA pop up shows up (the account has 2fa enabled), this changes the focus from the password field to the 2FA field.

### Fixed Issues
$ https://github.com/Expensify/App/issues/10601

### Tests and QA steps

- [x] Sign into an account on the sign in page without 2fa enabled and see success and no focus-changing abnormal behaviors (focus stays on the active field)
- [x] Sign into an account on the sign in page **with** 2fa and see that the 2fa field is focused on when it first appears, not in any other flow.
    - Go to URL https://staging.new.expensify.com/
    - In the log in screen enter an account that has 2FA enabled
    - Enter the correct password in the password field and press "Enter" key in the keyboard
    - See that the 2FA field is focused on for new text


Uploading Screen Recording 2022-08-29 at 10.27.13 AM.mov…

- [x] Verify that no errors appear in the JS console

### Tested On

- [x] Web
- [X] Desktop
- [x] iOS
- [x] Android
- [X] Mobile Web
