### PR TITLE
Remove workspace chats on delete even if they are pinned

### DIFF
--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -413,6 +413,8 @@ function getOptions(reports, personalDetails, activeReportID, {
 
     const allReportOptions = [];
     _.each(orderedReports, (report) => {
+        console.log(report.reportName);
+        console.log(ReportUtils.isArchivedRoom(report));
         const isChatRoom = ReportUtils.isChatRoom(report);
         const isDefaultRoom = ReportUtils.isDefaultRoom(report);
         const isPolicyExpenseChat = ReportUtils.isPolicyExpenseChat(report);
@@ -527,8 +529,9 @@ function getOptions(reports, personalDetails, activeReportID, {
             }
 
             // If the report is pinned and we are using the option to display pinned reports on top then we need to
-            // collect the pinned reports so we can sort them alphabetically once they are collected
-            if (prioritizePinnedReports && reportOption.isPinned) {
+            // collect the pinned reports so we can sort them alphabetically once they are collected. We want to skip
+            // archived rooms
+            if (prioritizePinnedReports && reportOption.isPinned && !reportOption.isArchivedRoom) {
                 pinnedReportOptions.push(reportOption);
             } else if (prioritizeIOUDebts && reportOption.hasOutstandingIOU && !reportOption.isIOUReportOwner) {
                 iouDebtReportOptions.push(reportOption);

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -413,8 +413,6 @@ function getOptions(reports, personalDetails, activeReportID, {
 
     const allReportOptions = [];
     _.each(orderedReports, (report) => {
-        console.log(report.reportName);
-        console.log(ReportUtils.isArchivedRoom(report));
         const isChatRoom = ReportUtils.isChatRoom(report);
         const isDefaultRoom = ReportUtils.isDefaultRoom(report);
         const isPolicyExpenseChat = ReportUtils.isPolicyExpenseChat(report);

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -232,6 +232,7 @@ function createOption(logins, personalDetails, report, reportActions = {}, {
     const personalDetailMap = getPersonalDetailsForLogins(logins, personalDetails);
     const personalDetailList = _.values(personalDetailMap);
     const isArchivedRoom = ReportUtils.isArchivedRoom(report);
+    const isDefaultRoom = ReportUtils.isDefaultRoom(report);
     const hasMultipleParticipants = personalDetailList.length > 1 || isChatRoom || isPolicyExpenseChat;
     const personalDetail = personalDetailList[0];
     const hasDraftComment = hasReportDraftComment(report);
@@ -297,6 +298,7 @@ function createOption(logins, personalDetails, report, reportActions = {}, {
         iouReportAmount: lodashGet(iouReport, 'total', 0),
         isChatRoom,
         isArchivedRoom,
+        isDefaultRoom,
         shouldShowSubscript: isPolicyExpenseChat && !report.isOwnPolicyExpenseChat && !isArchivedRoom,
         isPolicyExpenseChat,
     };

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -441,8 +441,9 @@ function getOptions(reports, personalDetails, activeReportID, {
 
         const shouldFilterReportIfRead = hideReadReports && report.unreadActionCount === 0;
         const shouldFilterReport = shouldFilterReportIfEmpty || shouldFilterReportIfRead;
+
         if (report.reportID !== activeReportID
-            && !report.isPinned
+            && (!report.isPinned || isDefaultRoom)
             && !hasDraftComment
             && shouldFilterReport
             && !reportContainsIOUDebt) {

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -531,8 +531,8 @@ function getOptions(reports, personalDetails, activeReportID, {
             // If the report is pinned and we are using the option to display pinned reports on top then we need to
             // collect the pinned reports so we can sort them alphabetically once they are collected. We want to skip
             // default archived rooms.
-            if (prioritizePinnedReports && reportOption.isPinned &&
-                !(reportOption.isArchivedRoom && reportOption.isDefaultRoom)) {
+            if (prioritizePinnedReports && reportOption.isPinned
+                && !(reportOption.isArchivedRoom && reportOption.isDefaultRoom)) {
                 pinnedReportOptions.push(reportOption);
             } else if (prioritizeIOUDebts && reportOption.hasOutstandingIOU && !reportOption.isIOUReportOwner) {
                 iouDebtReportOptions.push(reportOption);

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -530,8 +530,9 @@ function getOptions(reports, personalDetails, activeReportID, {
 
             // If the report is pinned and we are using the option to display pinned reports on top then we need to
             // collect the pinned reports so we can sort them alphabetically once they are collected. We want to skip
-            // archived rooms
-            if (prioritizePinnedReports && reportOption.isPinned && !reportOption.isArchivedRoom) {
+            // default archived rooms.
+            if (prioritizePinnedReports && reportOption.isPinned &&
+                !(reportOption.isArchivedRoom && reportOption.isDefaultRoom)) {
                 pinnedReportOptions.push(reportOption);
             } else if (prioritizeIOUDebts && reportOption.hasOutstandingIOU && !reportOption.isIOUReportOwner) {
                 iouDebtReportOptions.push(reportOption);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/10355

### Tests / QA Steps
1. Create a new workspace in Newdot if you don't have one:
<img width="372" alt="Screen Shot 2022-08-30 at 3 29 35 PM" src="https://user-images.githubusercontent.com/19366280/187449810-05c2f04e-e468-4762-9de0-cb72670a1de3.png">

2. It will create some default rooms:
<img width="381" alt="Screen Shot 2022-08-30 at 3 34 55 PM" src="https://user-images.githubusercontent.com/19366280/187451110-9496fc02-f7e4-494e-a613-69d3518b77b4.png">

3. Choose the `Admins` or `Announce` one and pin it. Then, **move to a different chat**.
4. Delete the Workspace:
<img width="416" alt="Screen Shot 2022-08-30 at 3 36 01 PM" src="https://user-images.githubusercontent.com/19366280/187451389-389fef86-6585-425f-a7d3-ccc12ea23445.png">

5. The Pinned chat should disappear from the list (It may take a refresh, as that list doesn't auto-refresh that often)