### PR TITLE
[No QA] Revert "Toggle staging and production server api"

### DIFF
--- a/src/CONFIG.js
+++ b/src/CONFIG.js
@@ -9,8 +9,6 @@ import CONST from './CONST';
 const ENVIRONMENT = lodashGet(Config, 'ENVIRONMENT', CONST.ENVIRONMENT.DEV);
 const newExpensifyURL = Url.addTrailingForwardSlash(lodashGet(Config, 'NEW_EXPENSIFY_URL', 'https://new.expensify.com/'));
 const expensifyURL = Url.addTrailingForwardSlash(lodashGet(Config, 'EXPENSIFY_URL', 'https://www.expensify.com/'));
-const stagingExpensifyURL = Url.addTrailingForwardSlash(lodashGet(Config, 'STAGING_EXPENSIFY_URL', 'https://staging.expensify.com/'));
-const stagingSecureExpensifyUrl = Url.addTrailingForwardSlash(lodashGet(Config, 'STAGING_SECURE_EXPENSIFY_URL', 'https://staging-secure.expensify.com/'));
 const ngrokURL = Url.addTrailingForwardSlash(lodashGet(Config, 'NGROK_URL', ''));
 const secureNgrokURL = Url.addTrailingForwardSlash(lodashGet(Config, 'SECURE_NGROK_URL', ''));
 const secureExpensifyUrl = Url.addTrailingForwardSlash(lodashGet(
@@ -48,15 +46,12 @@ export default {
         SECURE_EXPENSIFY_URL: secureURLRoot,
         NEW_EXPENSIFY_URL: newExpensifyURL,
         URL_API_ROOT: expensifyURLRoot,
-        STAGING_EXPENSIFY_URL: stagingExpensifyURL,
-        STAGING_SECURE_EXPENSIFY_URL: stagingSecureExpensifyUrl,
         PARTNER_NAME: lodashGet(Config, 'EXPENSIFY_PARTNER_NAME', 'chat-expensify-com'),
         PARTNER_PASSWORD: lodashGet(Config, 'EXPENSIFY_PARTNER_PASSWORD', 'e21965746fd75f82bb66'),
         EXPENSIFY_CASH_REFERER: 'ecash',
         CONCIERGE_URL: conciergeUrl,
     },
     IS_IN_PRODUCTION: Platform.OS === 'web' ? process.env.NODE_ENV === 'production' : !__DEV__,
-    IS_IN_STAGING: ENVIRONMENT === CONST.ENVIRONMENT.STAGING,
     IS_USING_LOCAL_WEB: useNgrok || expensifyURLRoot.includes('dev'),
     PUSHER: {
         APP_KEY: lodashGet(Config, 'PUSHER_APP_KEY', '268df511a204fbb60884'),

--- a/src/CONST.js
+++ b/src/CONST.js
@@ -232,6 +232,7 @@ const CONST = {
     MANAGE_CARDS_URL: 'domain_companycards',
     FEES_URL: `${USE_EXPENSIFY_URL}/fees`,
     CFPB_PREPAID_URL: 'https://cfpb.gov/prepaid',
+    STAGING_SECURE_URL: 'https://staging-secure.expensify.com/',
     STAGING_NEW_EXPENSIFY_URL: 'https://staging.new.expensify.com',
 
     // Use Environment.getEnvironmentURL to get the complete URL with port number

--- a/src/components/TestToolMenu.js
+++ b/src/components/TestToolMenu.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {withOnyx} from 'react-native-onyx';
-import lodashGet from 'lodash/get';
 import styles from '../styles/styles';
 import Switch from './Switch';
 import Text from './Text';
@@ -19,7 +18,7 @@ const propTypes = {
     /** User object in Onyx */
     user: PropTypes.shape({
         /** Whether we should use the staging version of the secure API server */
-        shouldUseStagingServer: PropTypes.bool,
+        shouldUseSecureStaging: PropTypes.bool,
     }),
 
     /** Network object in Onyx */
@@ -28,7 +27,7 @@ const propTypes = {
 
 const defaultProps = {
     user: {
-        shouldUseStagingServer: false,
+        shouldUseSecureStaging: false,
     },
 };
 
@@ -40,10 +39,10 @@ const TestToolMenu = props => (
 
         {/* Option to switch from using the staging secure endpoint or the production secure endpoint.
         This enables QA and internal testers to take advantage of sandbox environments for 3rd party services like Plaid and Onfido. */}
-        <TestToolRow title="Use Staging Server">
+        <TestToolRow title="Use Secure Staging Server">
             <Switch
-                isOn={lodashGet(props, 'user.shouldUseStagingServer', true)}
-                onToggle={() => User.setShouldUseStagingServer(!lodashGet(props, 'user.shouldUseStagingServer', true))}
+                isOn={props.user.shouldUseSecureStaging || false}
+                onToggle={() => User.setShouldUseSecureStaging(!props.user.shouldUseSecureStaging)}
             />
         </TestToolRow>
 

--- a/src/libs/HttpUtils.js
+++ b/src/libs/HttpUtils.js
@@ -1,15 +1,14 @@
 import Onyx from 'react-native-onyx';
-import lodashGet from 'lodash/get';
 import _ from 'underscore';
 import CONFIG from '../CONFIG';
 import CONST from '../CONST';
 import ONYXKEYS from '../ONYXKEYS';
 import HttpsError from './Errors/HttpsError';
 
-let shouldUseStagingServer = false;
+let shouldUseSecureStaging = false;
 Onyx.connect({
     key: ONYXKEYS.USER,
-    callback: val => shouldUseStagingServer = lodashGet(val, 'shouldUseStagingServer', true),
+    callback: val => shouldUseSecureStaging = (val && _.isBoolean(val.shouldUseSecureStaging)) ? val.shouldUseSecureStaging : false,
 });
 
 let shouldFailAllRequests = false;
@@ -95,11 +94,10 @@ function xhr(command, data, type = CONST.NETWORK.METHOD.POST, shouldUseSecure = 
 
         formData.append(key, val);
     });
-
     let apiRoot = shouldUseSecure ? CONFIG.EXPENSIFY.SECURE_EXPENSIFY_URL : CONFIG.EXPENSIFY.URL_API_ROOT;
 
-    if (CONFIG.IS_IN_STAGING && shouldUseStagingServer) {
-        apiRoot = shouldUseSecure ? CONFIG.EXPENSIFY.STAGING_SECURE_EXPENSIFY_URL : CONFIG.EXPENSIFY.STAGING_EXPENSIFY_URL;
+    if (shouldUseSecure && shouldUseSecureStaging) {
+        apiRoot = CONST.STAGING_SECURE_URL;
     }
 
     return processHTTPRequest(`${apiRoot}api?command=${command}`, type, formData, data.canCancel);

--- a/src/libs/actions/User.js
+++ b/src/libs/actions/User.js
@@ -426,10 +426,10 @@ function updateChatPriorityMode(mode) {
 }
 
 /**
- * @param {Boolean} shouldUseStagingServer
+ * @param {Boolean} shouldUseSecureStaging
  */
-function setShouldUseStagingServer(shouldUseStagingServer) {
-    Onyx.merge(ONYXKEYS.USER, {shouldUseStagingServer});
+function setShouldUseSecureStaging(shouldUseSecureStaging) {
+    Onyx.merge(ONYXKEYS.USER, {shouldUseSecureStaging});
 }
 
 function clearUserErrorMessage() {
@@ -484,7 +484,7 @@ export {
     isBlockedFromConcierge,
     subscribeToUserEvents,
     updatePreferredSkinTone,
-    setShouldUseStagingServer,
+    setShouldUseSecureStaging,
     clearUserErrorMessage,
     subscribeToExpensifyCardUpdates,
     updateFrequentlyUsedEmojis,

--- a/src/pages/settings/PreferencesPage.js
+++ b/src/pages/settings/PreferencesPage.js
@@ -30,7 +30,7 @@ const propTypes = {
     user: PropTypes.shape({
         /** Whether or not the user is subscribed to news updates */
         isSubscribedToNewsletter: PropTypes.bool,
-        shouldUseStagingServer: PropTypes.bool,
+        shouldUseSecureStaging: PropTypes.bool,
     }),
 
     ...withLocalizePropTypes,


### PR DESCRIPTION
The changes to allow us to use the Staging Web-E server are not working because of CSP.

We will need to update the rules so the requests go through just fine.

Reverts Expensify/App#10690

Fixes https://github.com/Expensify/App/issues/10917