### PR TITLE
Revert "Refactor withFullPolicy"

### DIFF
--- a/src/components/AvatarWithIndicator.js
+++ b/src/components/AvatarWithIndicator.js
@@ -11,7 +11,7 @@ import policyMemberPropType from '../pages/policyMemberPropType';
 import bankAccountPropTypes from './bankAccountPropTypes';
 import cardPropTypes from './cardPropTypes';
 import userWalletPropTypes from '../pages/EnablePayments/userWalletPropTypes';
-import {policyPropTypes} from '../pages/workspace/withPolicy';
+import {fullPolicyPropTypes} from '../pages/workspace/withFullPolicy';
 import walletTermsPropTypes from '../pages/EnablePayments/walletTermsPropTypes';
 import * as PolicyUtils from '../libs/PolicyUtils';
 import * as PaymentMethods from '../libs/actions/PaymentMethods';
@@ -30,7 +30,7 @@ const propTypes = {
     policiesMemberList: PropTypes.objectOf(policyMemberPropType),
 
     /** All the user's policies (from Onyx via withFullPolicy) */
-    policies: PropTypes.objectOf(policyPropTypes.policy),
+    policies: PropTypes.objectOf(fullPolicyPropTypes.policy),
 
     /** List of bank accounts */
     bankAccountList: PropTypes.objectOf(bankAccountPropTypes),

--- a/src/components/RoomNameInput.js
+++ b/src/components/RoomNameInput.js
@@ -5,6 +5,7 @@ import CONST from '../CONST';
 import ONYXKEYS from '../ONYXKEYS';
 import compose from '../libs/compose';
 import withLocalize, {withLocalizePropTypes} from './withLocalize';
+import withFullPolicy, {fullPolicyDefaultProps, fullPolicyPropTypes} from '../pages/workspace/withFullPolicy';
 import TextInput from './TextInput';
 
 const propTypes = {
@@ -21,6 +22,7 @@ const propTypes = {
     errorText: PropTypes.string,
 
     ...withLocalizePropTypes,
+    ...fullPolicyPropTypes,
 
     /* Onyx Props */
 
@@ -51,6 +53,7 @@ const defaultProps = {
     initialValue: '',
     disabled: false,
     errorText: '',
+    ...fullPolicyDefaultProps,
     forwardedRef: () => {},
 };
 
@@ -111,6 +114,7 @@ RoomNameInput.defaultProps = defaultProps;
 
 export default compose(
     withLocalize,
+    withFullPolicy,
     withOnyx({
         reports: {
             key: ONYXKEYS.COLLECTION.REPORT,

--- a/src/pages/ReportSettingsPage.js
+++ b/src/pages/ReportSettingsPage.js
@@ -18,6 +18,7 @@ import Text from '../components/Text';
 import Button from '../components/Button';
 import RoomNameInput from '../components/RoomNameInput';
 import Picker from '../components/Picker';
+import withFullPolicy, {fullPolicyDefaultProps, fullPolicyPropTypes} from './workspace/withFullPolicy';
 import * as ValidationUtils from '../libs/ValidationUtils';
 import OfflineWithFeedback from '../components/OfflineWithFeedback';
 
@@ -30,6 +31,7 @@ const propTypes = {
         }),
     }).isRequired,
 
+    ...fullPolicyPropTypes,
     ...withLocalizePropTypes,
 
     /* Onyx Props */
@@ -75,6 +77,17 @@ const propTypes = {
         /** ID of the policy */
         id: PropTypes.string,
     }).isRequired,
+};
+
+const defaultProps = {
+    ...fullPolicyDefaultProps,
+    report: {
+        reportID: 0,
+        reportName: '',
+        policyID: '',
+        notificationPreference: '',
+        visibility: '',
+    },
 };
 
 class ReportSettingsPage extends Component {
@@ -274,9 +287,11 @@ class ReportSettingsPage extends Component {
 }
 
 ReportSettingsPage.propTypes = propTypes;
+ReportSettingsPage.defaultProps = defaultProps;
 
 export default compose(
     withLocalize,
+    withFullPolicy,
     withOnyx({
         report: {
             key: ({route}) => `${ONYXKEYS.COLLECTION.REPORT}${route.params.reportID}`,

--- a/src/pages/workspace/WorkspaceBankAccountPage.js
+++ b/src/pages/workspace/WorkspaceBankAccountPage.js
@@ -21,7 +21,7 @@ import Section from '../../components/Section';
 import WorkspaceResetBankAccountModal from './WorkspaceResetBankAccountModal';
 import styles from '../../styles/styles';
 import CONST from '../../CONST';
-import withPolicy from './withPolicy';
+import withFullPolicy from './withFullPolicy';
 import Button from '../../components/Button';
 import MenuItem from '../../components/MenuItem';
 import FullPageNotFoundView from '../../components/BlockingViews/FullPageNotFoundView';
@@ -131,5 +131,5 @@ export default compose(
             key: ONYXKEYS.REIMBURSEMENT_ACCOUNT,
         },
     }),
-    withPolicy,
+    withFullPolicy,
 )(WorkspaceBankAccountPage);

--- a/src/pages/workspace/WorkspaceInitialPage.js
+++ b/src/pages/workspace/WorkspaceInitialPage.js
@@ -20,7 +20,7 @@ import HeaderWithCloseButton from '../../components/HeaderWithCloseButton';
 import compose from '../../libs/compose';
 import Avatar from '../../components/Avatar';
 import FullPageNotFoundView from '../../components/BlockingViews/FullPageNotFoundView';
-import withPolicy, {policyPropTypes, policyDefaultProps} from './withPolicy';
+import withFullPolicy, {fullPolicyPropTypes, fullPolicyDefaultProps} from './withFullPolicy';
 import * as Policy from '../../libs/actions/Policy';
 import * as PolicyUtils from '../../libs/PolicyUtils';
 import CONST from '../../CONST';
@@ -30,7 +30,7 @@ import policyMemberPropType from '../policyMemberPropType';
 import OfflineWithFeedback from '../../components/OfflineWithFeedback';
 
 const propTypes = {
-    ...policyPropTypes,
+    ...fullPolicyPropTypes,
     ...withLocalizePropTypes,
 
     /** The employee list of this policy (coming from Onyx) */
@@ -38,7 +38,7 @@ const propTypes = {
 };
 
 const defaultProps = {
-    ...policyDefaultProps,
+    ...fullPolicyDefaultProps,
     policyMemberList: {},
 };
 
@@ -248,7 +248,7 @@ WorkspaceInitialPage.defaultProps = defaultProps;
 
 export default compose(
     withLocalize,
-    withPolicy,
+    withFullPolicy,
     withOnyx({
         policyMemberList: {
             key: ({policy}) => `${ONYXKEYS.COLLECTION.POLICY_MEMBER_LIST}${policy.id}`,

--- a/src/pages/workspace/WorkspaceInvitePage.js
+++ b/src/pages/workspace/WorkspaceInvitePage.js
@@ -20,7 +20,7 @@ import CONST from '../../CONST';
 import FullScreenLoadingIndicator from '../../components/FullscreenLoadingIndicator';
 import * as Link from '../../libs/actions/Link';
 import Text from '../../components/Text';
-import withPolicy, {policyPropTypes, policyDefaultProps} from './withPolicy';
+import withFullPolicy, {fullPolicyPropTypes, fullPolicyDefaultProps} from './withFullPolicy';
 import {withNetwork} from '../../components/OnyxProvider';
 import FullPageNotFoundView from '../../components/BlockingViews/FullPageNotFoundView';
 import networkPropTypes from '../../components/networkPropTypes';
@@ -53,12 +53,12 @@ const propTypes = {
         }),
     }).isRequired,
 
-    ...policyPropTypes,
+    ...fullPolicyPropTypes,
     ...withLocalizePropTypes,
     ...networkPropTypes,
 };
 
-const defaultProps = policyDefaultProps;
+const defaultProps = fullPolicyDefaultProps;
 
 class WorkspaceInvitePage extends React.Component {
     constructor(props) {
@@ -352,7 +352,7 @@ WorkspaceInvitePage.defaultProps = defaultProps;
 
 export default compose(
     withLocalize,
-    withPolicy,
+    withFullPolicy,
     withNetwork(),
     withOnyx({
         personalDetails: {

--- a/src/pages/workspace/WorkspaceMembersPage.js
+++ b/src/pages/workspace/WorkspaceMembersPage.js
@@ -25,7 +25,7 @@ import withWindowDimensions, {windowDimensionsPropTypes} from '../../components/
 import OptionRow from '../../components/OptionRow';
 import CheckboxWithTooltip from '../../components/CheckboxWithTooltip';
 import Hoverable from '../../components/Hoverable';
-import withPolicy, {policyPropTypes, policyDefaultProps} from './withPolicy';
+import withFullPolicy, {fullPolicyPropTypes, fullPolicyDefaultProps} from './withFullPolicy';
 import CONST from '../../CONST';
 import OfflineWithFeedback from '../../components/OfflineWithFeedback';
 import {withNetwork} from '../../components/OnyxProvider';
@@ -45,13 +45,13 @@ const propTypes = {
         }),
     }).isRequired,
 
-    ...policyPropTypes,
+    ...fullPolicyPropTypes,
     ...withLocalizePropTypes,
     ...windowDimensionsPropTypes,
     ...networkPropTypes,
 };
 
-const defaultProps = policyDefaultProps;
+const defaultProps = fullPolicyDefaultProps;
 
 class WorkspaceMembersPage extends React.Component {
     constructor(props) {
@@ -367,7 +367,7 @@ WorkspaceMembersPage.defaultProps = defaultProps;
 export default compose(
     withLocalize,
     withWindowDimensions,
-    withPolicy,
+    withFullPolicy,
     withNetwork(),
     withOnyx({
         personalDetails: {

--- a/src/pages/workspace/WorkspaceNewRoomPage.js
+++ b/src/pages/workspace/WorkspaceNewRoomPage.js
@@ -3,6 +3,7 @@ import {ScrollView, View} from 'react-native';
 import _ from 'underscore';
 import {withOnyx} from 'react-native-onyx';
 import PropTypes from 'prop-types';
+import withFullPolicy, {fullPolicyDefaultProps, fullPolicyPropTypes} from './withFullPolicy';
 import * as Report from '../../libs/actions/Report';
 import withLocalize, {withLocalizePropTypes} from '../../components/withLocalize';
 import compose from '../../libs/compose';
@@ -34,17 +35,17 @@ const propTypes = {
         policyID: PropTypes.string,
     }).isRequired,
 
-    /** List of betas available to current user */
-    betas: PropTypes.arrayOf(PropTypes.string),
-
     /** Are we loading the createPolicyRoom command */
     isLoadingCreatePolicyRoom: PropTypes.bool,
+
+    ...fullPolicyPropTypes,
 
     ...withLocalizePropTypes,
 };
 const defaultProps = {
     betas: [],
     isLoadingCreatePolicyRoom: false,
+    ...fullPolicyDefaultProps,
 };
 
 class WorkspaceNewRoomPage extends React.Component {
@@ -202,6 +203,7 @@ WorkspaceNewRoomPage.propTypes = propTypes;
 WorkspaceNewRoomPage.defaultProps = defaultProps;
 
 export default compose(
+    withFullPolicy,
     withOnyx({
         betas: {
             key: ONYXKEYS.BETAS,

--- a/src/pages/workspace/WorkspacePageWithSections.js
+++ b/src/pages/workspace/WorkspacePageWithSections.js
@@ -15,7 +15,7 @@ import * as BankAccounts from '../../libs/actions/BankAccounts';
 import BankAccount from '../../libs/models/BankAccount';
 import reimbursementAccountPropTypes from '../ReimbursementAccount/reimbursementAccountPropTypes';
 import userPropTypes from '../settings/userPropTypes';
-import withPolicy from './withPolicy';
+import withFullPolicy from './withFullPolicy';
 import {withNetwork} from '../../components/OnyxProvider';
 import networkPropTypes from '../../components/networkPropTypes';
 
@@ -131,6 +131,6 @@ export default compose(
             key: ONYXKEYS.REIMBURSEMENT_ACCOUNT,
         },
     }),
-    withPolicy,
+    withFullPolicy,
     withNetwork(),
 )(WorkspacePageWithSections);

--- a/src/pages/workspace/WorkspaceSettingsPage.js
+++ b/src/pages/workspace/WorkspaceSettingsPage.js
@@ -19,18 +19,18 @@ import Picker from '../../components/Picker';
 import TextInput from '../../components/TextInput';
 import FixedFooter from '../../components/FixedFooter';
 import WorkspacePageWithSections from './WorkspacePageWithSections';
-import withPolicy, {policyPropTypes, policyDefaultProps} from './withPolicy';
+import withFullPolicy, {fullPolicyPropTypes, fullPolicyDefaultProps} from './withFullPolicy';
 import {withNetwork} from '../../components/OnyxProvider';
 import OfflineWithFeedback from '../../components/OfflineWithFeedback';
 import FullPageNotFoundView from '../../components/BlockingViews/FullPageNotFoundView';
 
 const propTypes = {
-    ...policyPropTypes,
+    ...fullPolicyPropTypes,
     ...withLocalizePropTypes,
 };
 
 const defaultProps = {
-    ...policyDefaultProps,
+    ...fullPolicyDefaultProps,
 };
 
 class WorkspaceSettingsPage extends React.Component {
@@ -162,7 +162,7 @@ WorkspaceSettingsPage.propTypes = propTypes;
 WorkspaceSettingsPage.defaultProps = defaultProps;
 
 export default compose(
-    withPolicy,
+    withFullPolicy,
     withOnyx({
         currencyList: {key: ONYXKEYS.CURRENCY_LIST},
     }),

--- a/src/pages/workspace/reimburse/WorkspaceReimburseView.js
+++ b/src/pages/workspace/reimburse/WorkspaceReimburseView.js
@@ -17,7 +17,7 @@ import * as Link from '../../../libs/actions/Link';
 import compose from '../../../libs/compose';
 import ONYXKEYS from '../../../ONYXKEYS';
 import * as Policy from '../../../libs/actions/Policy';
-import withPolicy from '../withPolicy';
+import withFullPolicy from '../withFullPolicy';
 import CONST from '../../../CONST';
 import Button from '../../../components/Button';
 import {withNetwork} from '../../../components/OnyxProvider';
@@ -302,7 +302,7 @@ class WorkspaceReimburseView extends React.Component {
 WorkspaceReimburseView.propTypes = propTypes;
 
 export default compose(
-    withPolicy,
+    withFullPolicy,
     withLocalize,
     withNetwork(),
     withOnyx({

--- a/src/pages/workspace/withFullPolicy.js
+++ b/src/pages/workspace/withFullPolicy.js
@@ -2,6 +2,7 @@ import _ from 'underscore';
 import lodashGet from 'lodash/get';
 import React from 'react';
 import PropTypes from 'prop-types';
+import Str from 'expensify-common/lib/str';
 import {withOnyx} from 'react-native-onyx';
 import {useNavigationState} from '@react-navigation/native';
 import CONST from '../../CONST';
@@ -9,6 +10,9 @@ import getComponentDisplayName from '../../libs/getComponentDisplayName';
 import * as Policy from '../../libs/actions/Policy';
 import ONYXKEYS from '../../ONYXKEYS';
 import policyMemberPropType from '../policyMemberPropType';
+
+let previousRouteName = '';
+let previousRoutePolicyID = '';
 
 /**
  * @param {Object} route
@@ -18,7 +22,20 @@ function getPolicyIDFromRoute(route) {
     return lodashGet(route, 'params.policyID', '');
 }
 
-const policyPropTypes = {
+/**
+ * @param {String} routeName
+ * @param {String} policyID
+ * @returns {Boolean}
+ */
+function isPreviousRouteInSameWorkspace(routeName, policyID) {
+    return (
+        Str.startsWith(routeName, 'Workspace')
+        && Str.startsWith(previousRouteName, 'Workspace')
+        && policyID === previousRoutePolicyID
+    );
+}
+
+const fullPolicyPropTypes = {
     /** The policy object for the current route */
     policy: PropTypes.shape({
         /** The ID of the policy */
@@ -61,12 +78,12 @@ const policyPropTypes = {
     policyMemberList: PropTypes.objectOf(policyMemberPropType),
 };
 
-const policyDefaultProps = {
+const fullPolicyDefaultProps = {
     policy: {},
 };
 
 /*
- * HOC for connecting a policy in Onyx corresponding to the policyID in route params
+ * HOC for loading a full policy. It checks the route params and if current route has a policyID that the previous route did not, it full-loads that policy.
  */
 export default function (WrappedComponent) {
     const propTypes = {
@@ -74,39 +91,46 @@ export default function (WrappedComponent) {
           * That way, if a ref is passed to a component wrapped in the HOC, the ref is a reference to the wrapped component, not the HOC. */
         forwardedRef: PropTypes.func,
 
-        ...policyPropTypes,
+        ...fullPolicyPropTypes,
     };
 
     const defaultProps = {
         forwardedRef: () => {},
 
-        ...policyDefaultProps,
+        ...fullPolicyDefaultProps,
     };
 
-    const WithPolicy = (props) => {
+    const WithFullPolicy = (props) => {
         const currentRoute = _.last(useNavigationState(state => state.routes || []));
         const policyID = getPolicyIDFromRoute(currentRoute);
+        const isFromFullPolicy = lodashGet(props, 'policy.isFromFullPolicy', false) || lodashGet(props, `policy.policy_${policyID}.isFromFullPolicy`, false);
 
-        if (_.isString(policyID) && !_.isEmpty(policyID)) {
+        if (_.isString(policyID) && !_.isEmpty(policyID) && (!isFromFullPolicy || !isPreviousRouteInSameWorkspace(currentRoute.name, policyID))) {
+            Policy.loadFullPolicy(policyID);
             Policy.updateLastAccessedWorkspace(policyID);
         }
 
-        const rest = _.omit(props, ['forwardedRef']);
+        previousRouteName = currentRoute.name;
+        previousRoutePolicyID = policyID;
+
+        const rest = _.omit(props, ['forwardedRef', 'policy', 'policyMemberList']);
         return (
             <WrappedComponent
                 // eslint-disable-next-line react/jsx-props-no-spreading
                 {...rest}
                 ref={props.forwardedRef}
+                policy={props.policy}
+                policyMemberList={props.policyMemberList}
             />
         );
     };
 
-    WithPolicy.propTypes = propTypes;
-    WithPolicy.defaultProps = defaultProps;
-    WithPolicy.displayName = `withFullPolicy(${getComponentDisplayName(WrappedComponent)})`;
-    const withPolicy = React.forwardRef((props, ref) => (
+    WithFullPolicy.propTypes = propTypes;
+    WithFullPolicy.defaultProps = defaultProps;
+    WithFullPolicy.displayName = `withFullPolicy(${getComponentDisplayName(WrappedComponent)})`;
+    const withFullPolicy = React.forwardRef((props, ref) => (
         // eslint-disable-next-line react/jsx-props-no-spreading
-        <WithPolicy {...props} forwardedRef={ref} />
+        <WithFullPolicy {...props} forwardedRef={ref} />
     ));
 
     return withOnyx({
@@ -116,10 +140,10 @@ export default function (WrappedComponent) {
         policyMemberList: {
             key: props => `${ONYXKEYS.COLLECTION.POLICY_MEMBER_LIST}${getPolicyIDFromRoute(props.route)}`,
         },
-    })(withPolicy);
+    })(withFullPolicy);
 }
 
 export {
-    policyPropTypes,
-    policyDefaultProps,
+    fullPolicyPropTypes,
+    fullPolicyDefaultProps,
 };


### PR DESCRIPTION
Reverts Expensify/App#10873

cc @arosiclair @jasperhuangg 

$ https://github.com/Expensify/App/issues/10978


### QA / Tests
- Click on your avatar to open the Settings menu
- Click on your Workspace in the left panel
- Open the "Reimburse Expenses" page
- In the "Track Distance" section, make sure the default mileage rate populates
- Make sure you can edit the mileage rate
<img width="386" alt="image" src="https://user-images.githubusercontent.com/2229301/190026086-46d3b195-ad36-4871-becc-488da794eaf0.png">


----


#### Contributor (PR Author) Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] Any functional components have the `displayName` property
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.
