### PR TITLE
Fix `OpenApp` failures due to expired authToken

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -836,6 +836,11 @@ const CONST = {
             },
         },
     },
+    API_REQUEST_TYPE: {
+        READ: 'read',
+        WRITE: 'write',
+        MAKE_REQUEST_WITH_SIDE_EFFECTS: 'makeRequestWithSideEffects',
+    },
 };
 
 export default CONST;

--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -64,11 +64,11 @@ function write(command, apiCommandParameters = {}, onyxData = {}) {
  * @param {Object} [onyxData.optimisticData] - Onyx instructions that will be passed to Onyx.update() before the request is made.
  * @param {Object} [onyxData.successData] - Onyx instructions that will be passed to Onyx.update() when the response has jsonCode === 200.
  * @param {Object} [onyxData.failureData] - Onyx instructions that will be passed to Onyx.update() when the response has jsonCode !== 200.
- * @param {String} [newAPIRequestType] - Can be either 'read', 'write', or 'makeRequestWithSideEffects'. We use this to either return the
- *                                       chained response back to the caller or to trigger reconnection callbacks when reauthentication is required.
+ * @param {String} [apiRequestType] - Can be either 'read', 'write', or 'makeRequestWithSideEffects'. We use this to either return the chained
+ *                                    response back to the caller or to trigger reconnection callbacks when re-authentication is required.
  * @returns {Promise}
  */
-function makeRequestWithSideEffects(command, apiCommandParameters = {}, onyxData = {}, newAPIRequestType = CONST.API_REQUEST_TYPE.MAKE_REQUEST_WITH_SIDE_EFFECTS) {
+function makeRequestWithSideEffects(command, apiCommandParameters = {}, onyxData = {}, apiRequestType = CONST.API_REQUEST_TYPE.MAKE_REQUEST_WITH_SIDE_EFFECTS) {
     // Optimistically update Onyx
     if (onyxData.optimisticData) {
         Onyx.update(onyxData.optimisticData);
@@ -78,7 +78,7 @@ function makeRequestWithSideEffects(command, apiCommandParameters = {}, onyxData
     const data = {
         ...apiCommandParameters,
         appversion: pkg.version,
-        newAPIRequestType,
+        apiRequestType,
     };
 
     // Assemble all the request data we'll be storing

--- a/src/libs/API.js
+++ b/src/libs/API.js
@@ -3,6 +3,7 @@ import Onyx from 'react-native-onyx';
 import * as Request from './Request';
 import * as SequentialQueue from './Network/SequentialQueue';
 import pkg from '../../package.json';
+import CONST from '../CONST';
 
 /**
  * All calls to API.write() will be persisted to disk as JSON with the params, successData, and failureData.
@@ -27,6 +28,7 @@ function write(command, apiCommandParameters = {}, onyxData = {}) {
     const data = {
         ...apiCommandParameters,
         appversion: pkg.version,
+        apiRequestType: CONST.API_REQUEST_TYPE.WRITE,
     };
 
     // Assemble all the request data we'll be storing in the queue
@@ -62,9 +64,11 @@ function write(command, apiCommandParameters = {}, onyxData = {}) {
  * @param {Object} [onyxData.optimisticData] - Onyx instructions that will be passed to Onyx.update() before the request is made.
  * @param {Object} [onyxData.successData] - Onyx instructions that will be passed to Onyx.update() when the response has jsonCode === 200.
  * @param {Object} [onyxData.failureData] - Onyx instructions that will be passed to Onyx.update() when the response has jsonCode !== 200.
+ * @param {String} [newAPIRequestType] - Can be either 'read', 'write', or 'makeRequestWithSideEffects'. We use this to either return the
+ *                                       chained response back to the caller or to trigger reconnection callbacks when reauthentication is required.
  * @returns {Promise}
  */
-function makeRequestWithSideEffects(command, apiCommandParameters = {}, onyxData = {}) {
+function makeRequestWithSideEffects(command, apiCommandParameters = {}, onyxData = {}, newAPIRequestType = CONST.API_REQUEST_TYPE.MAKE_REQUEST_WITH_SIDE_EFFECTS) {
     // Optimistically update Onyx
     if (onyxData.optimisticData) {
         Onyx.update(onyxData.optimisticData);
@@ -74,6 +78,7 @@ function makeRequestWithSideEffects(command, apiCommandParameters = {}, onyxData
     const data = {
         ...apiCommandParameters,
         appversion: pkg.version,
+        newAPIRequestType,
     };
 
     // Assemble all the request data we'll be storing
@@ -100,7 +105,7 @@ function makeRequestWithSideEffects(command, apiCommandParameters = {}, onyxData
  * @param {Object} [onyxData.failureData] - Onyx instructions that will be passed to Onyx.update() when the response has jsonCode !== 200.
  */
 function read(command, apiCommandParameters, onyxData) {
-    makeRequestWithSideEffects(command, apiCommandParameters, onyxData);
+    makeRequestWithSideEffects(command, apiCommandParameters, onyxData, CONST.API_REQUEST_TYPE.READ);
 }
 
 export {

--- a/src/libs/Middleware/Reauthentication.js
+++ b/src/libs/Middleware/Reauthentication.js
@@ -48,16 +48,8 @@ function Reauthentication(response, request, isFromSequentialQueue) {
                     return data;
                 }
 
-                // We are already authenticating
-                if (NetworkStore.isAuthenticating()) {
-                    if (isFromSequentialQueue) {
-                        // This should never happen in theory. If we go offline while we are Authenticating or handling a response with a 407 jsonCode then isAuthenticating should be
-                        // set to false. If we do somehow get here, we will log about it since we will never know it happened otherwise and it would be difficult to diagnose.
-                        const message = 'Cannot complete sequential request because we are already authenticating';
-                        Log.alert(`${CONST.ERROR.ENSURE_BUGBOT} ${message}`);
-                        throw new Error(message);
-                    }
-
+                // We are already authenticating and using the DeprecatedAPI so we will replay the request
+                if (!apiRequestType && NetworkStore.isAuthenticating()) {
                     MainQueue.replay(request);
                     return data;
                 }

--- a/src/libs/Middleware/Reauthentication.js
+++ b/src/libs/Middleware/Reauthentication.js
@@ -69,7 +69,7 @@ function Reauthentication(response, request, isFromSequentialQueue) {
                         }
 
                         if (apiRequestType === CONST.API_REQUEST_TYPE.READ) {
-                            NetworkConnection.triggerReconnectionCallbacks();
+                            NetworkConnection.triggerReconnectionCallbacks('read request made with expired authToken');
                             return Promise.resolve();
                         }
 

--- a/src/libs/NetworkConnection.js
+++ b/src/libs/NetworkConnection.js
@@ -14,7 +14,8 @@ let isOffline = false;
 let hasPendingNetworkCheck = false;
 
 // Holds all of the callbacks that need to be triggered when the network reconnects
-const reconnectionCallbacks = [];
+let callbackID = 0;
+const reconnectionCallbacks = {};
 
 /**
  * Loop over all reconnection callbacks and fire each one
@@ -99,9 +100,13 @@ function stopListeningForReconnect() {
  * Register callback to fire when we reconnect
  *
  * @param {Function} callback - must return a Promise
+ * @returns {Function} unsubscribe method
  */
 function onReconnect(callback) {
-    reconnectionCallbacks.push(callback);
+    const currentID = callbackID;
+    callbackID++;
+    reconnectionCallbacks[currentID] = callback;
+    return () => delete reconnectionCallbacks[currentID];
 }
 
 /**


### PR DESCRIPTION
cc @luacmartins 

### Details

This is kind of a quick fix, but I think in the longer term we will want to:

- Deprecate the old API completely
- Re-imagine our re-authentication logic

Here's the basic logic behind this PR...

- `READ` requests and `makeRequestWithSideEffects` were originally envisioned to be non-retryable requests
- At some point in the refactors, we missed a detail that these **still need to be retried if there's an authenticate failure**
- So this PR will add the behavior:
    - re-authenticate when a `read` or `makeRequestWithSideEffects` fails
    - if it's a `makeRequestWithSideEffects` we'll want the original response returned so we will chain them like we do requests in the sequential queue
    - if it's a `read` then we will reauthenticate but not call the original request directly and instead trigger the reconnection callbacks so that any registered fetchData() calls can be updated now that we have the new authToken from the authenticate response.

**Weird stuff...**

I also noticed that some writes that started after read requests failed because they also require re-authentication. It didn't make sense that we would encounter that situation before since two writes can't possibly happen simultaneously and reauthentication is blocking in the sequential queue.

I think it would be fairly safe to just remove that logic and if we are already reauthenticating then just let another reauthentication happen. So that's my general plan for this.

### Fixed Issues

$ https://github.com/Expensify/App/issues/11081

### Tests

1. Create a chat with User A and User B
1. As User A invalidate the authToken via the preferences panel and close out of the tab
2. In a separate session as User B send User A a message
3. Open the app as User A again
4. Verify that the auth response returned 407 jsonCode
5. Verify that we see a log about reconnection callbacks happening because of the expired authToken and that `ReconnectApp` eventually returns 200 jsonCode

```
[info] Finished API request - {"command":"OpenApp","jsonCode":407,"requestID":"bXfJAG"}
Log.js?f092:55 [info] Making API request - {"command":"Authenticate","shouldUseSecure":false}
Log.js?f092:55 [info] Finished API request - {"command":"OpenReport","jsonCode":407,"requestID":"BEvZV0"}
Log.js?f092:55 [info] Making API request - {"command":"Authenticate","shouldUseSecure":false}
Log.js?f092:55 [info] Finished API request - {"command":"AuthenticatePusher","jsonCode":407,"requestID":"lhi2ep"}
Log.js?f092:55 [info] Making API request - {"command":"Authenticate","shouldUseSecure":false}
Log.js?f092:55 [info] Finished API request - {"command":"AuthenticatePusher","jsonCode":407,"requestID":"67EeNR"}
Log.js?f092:55 [info] Making API request - {"command":"Authenticate","shouldUseSecure":false}
Log.js?f092:55 [info] [Onyx] set() called for key: reportDraftComment_7256767318622412 - ""
Log.js?f092:55 [info] Finished API request - {"command":"Authenticate","shouldUseSecure":false,"jsonCode":200,"requestID":"6iYCke"}
Log.js?f092:55 [info] [Onyx] set() called for key: session properties: loading,shouldShowComposeInput,authToken,accountID,email,encryptedAuthToken - ""
Log.js?f092:55 [info] [NetworkConnection] Firing reconnection callbacks because read request made with expired authToken - ""
Log.js?f092:55 [info] Making API request - {"command":"ReconnectApp"}
Timing.js?e2bb:46 Timing:expensify.cash.sidebar_links_filter_reports 0
Log.js?f092:55 [info] [Onyx] set() called for key: isLoadingReportData - ""
Log.js?f092:55 [info] Finished API request - {"command":"Authenticate","shouldUseSecure":false,"jsonCode":200,"requestID":"yeEGJh"}
Log.js?f092:55 [info] [Onyx] set() called for key: session properties: loading,shouldShowComposeInput,authToken,accountID,email,encryptedAuthToken - ""
Log.js?f092:55 [info] Making API request - {"command":"OpenReport"}
Timing.js?e2bb:46 Timing:expensify.cash.sidebar_links_filter_reports 0
Log.js?f092:55 [info] Finished API request - {"command":"Authenticate","shouldUseSecure":false,"jsonCode":200,"requestID":"5T4aDe"}
Log.js?f092:55 [info] [Onyx] set() called for key: session properties: loading,shouldShowComposeInput,authToken,accountID,email,encryptedAuthToken - ""
Log.js?f092:55 [info] Making API request - {"command":"AuthenticatePusher"}
Timing.js?e2bb:46 Timing:expensify.cash.sidebar_links_filter_reports 0
Log.js?f092:55 [info] Finished API request - {"command":"Authenticate","shouldUseSecure":false,"jsonCode":200,"requestID":"FNkbnZ"}
Log.js?f092:55 [info] [Onyx] set() called for key: session properties: loading,shouldShowComposeInput,authToken,accountID,email,encryptedAuthToken - ""
Log.js?f092:55 [info] Making API request - {"command":"AuthenticatePusher"}
Timing.js?e2bb:46 Timing:expensify.cash.sidebar_links_filter_reports 0
Log.js?f092:55 [info] Finished API request - {"command":"ReconnectApp","jsonCode":200,"requestID":"HxmSxI"}
```

- [ ] Verify that no errors appear in the JS console

### PR Review Checklist
<!--
This is a checklist for PR authors & reviewers. Please make sure to complete all tasks and check them off once you do, or else Expensify has the right not to merge your PR!
-->
#### Contributor (PR Author) Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] Any functional components have the `displayName` property
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

<details>
<summary><h4>PR Reviewer Checklist</h4>

The Contributor+ will copy/paste it into a new comment and complete it after the author checklist is completed
</summary>

- [ ] I have verified the author checklist is complete (all boxes are checked off).
- [ ] I verified the correct issue is linked in the `### Fixed Issues` section above
- [ ] I verified testing steps are clear and they cover the changes made in this PR
    - [ ] I verified the steps for local testing are in the `Tests` section
    - [ ] I verified the steps for Staging and/or Production testing are in the `QA steps` section
    - [ ] I verified the steps cover any possible failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [ ] I checked that screenshots or videos are included for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I verified tests pass on **all platforms** & I tested again on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [ ] If there are any errors in the console that are unrelated to this PR, I either fixed them (preferred) or linked to where I reported them in Slack
- [ ] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`).
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [ ] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I verified that this PR follows the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I verified other components that can be impacted by these changes have been tested, and I retested again (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` have been tested & I retested again)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] Any functional components have the `displayName` property
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] I have checked off every checkbox in the PR reviewer checklist, including those that don't apply to this PR.

</details>

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
7. Upload an image via copy paste
8. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web - Chrome
<!-- Insert screenshots of your changes on the web platform (from chrome mobile browser)-->

#### Mobile Web - Safari
<!-- Insert screenshots of your changes on the web platform (from safari mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
