### PR TITLE
Correct the Onyx beta key that sidebar connects to

### DIFF
--- a/src/libs/SidebarUtils.js
+++ b/src/libs/SidebarUtils.js
@@ -44,7 +44,7 @@ Onyx.connect({
 
 let betas;
 Onyx.connect({
-    key: ONYXKEYS.NVP_PRIORITY_MODE,
+    key: ONYXKEYS.BETAS,
     callback: val => betas = val,
 });
 


### PR DESCRIPTION
I noticed this bug from https://github.com/Expensify/App/pull/10800

### Tests & QA
1. Make sure you have an account in the `policyRooms` beta
2. Create a `# New Room` from the global create menu 
3. Verify that the new room appears in the LHN after creating it

cc @marcaaron @neil-marcellini oops!