### PR TITLE
Sort grouped things by the full report name

### DIFF
--- a/src/libs/SidebarUtils.js
+++ b/src/libs/SidebarUtils.js
@@ -190,7 +190,10 @@ function getOrderedReportIDs() {
 
     // Prioritizing reports with draft comments, add them before the normal recent report options
     // and sort them by report name.
-    const sortedDraftReports = _.sortBy(draftReportOptions, 'text');
+    const sortedDraftReports = _.sortBy(draftReportOptions, (report) => {
+        const personalDetailMap = OptionsListUtils.getPersonalDetailsForLogins(report.participants, personalDetails);
+        return ReportUtils.getReportName(report, personalDetailMap, policies);
+    });
     recentReportOptions = sortedDraftReports.concat(recentReportOptions);
 
     // Prioritizing IOUs the user owes, add them before the normal recent report options and reports
@@ -199,7 +202,10 @@ function getOrderedReportIDs() {
     recentReportOptions = sortedIOUReports.concat(recentReportOptions);
 
     // If we are prioritizing our pinned reports then shift them to the front and sort them by report name
-    const sortedPinnedReports = _.sortBy(pinnedReportOptions, 'text');
+    const sortedPinnedReports = _.sortBy(pinnedReportOptions, (report) => {
+        const personalDetailMap = OptionsListUtils.getPersonalDetailsForLogins(report.participants, personalDetails);
+        return ReportUtils.getReportName(report, personalDetailMap, policies);
+    });
     recentReportOptions = sortedPinnedReports.concat(recentReportOptions);
 
     return _.chain(recentReportOptions)

--- a/tests/unit/LHNOrderTest.js
+++ b/tests/unit/LHNOrderTest.js
@@ -499,6 +499,55 @@ describe('Sidebar', () => {
                     expect(reportOptions[2].children[0].props.children).toBe('ReportID, One');
                 });
         });
+
+        it('alphabetizes all the chats that are pinned', () => {
+            const sidebarLinks = getDefaultRenderedSidebarLinks();
+
+            return waitForPromisesToResolve()
+
+                // Given the sidebar is rendered in #focus mode (hides read chats)
+                // with all reports being pinned
+                .then(() => Onyx.multiSet({
+                    [ONYXKEYS.NVP_PRIORITY_MODE]: 'default',
+                    [ONYXKEYS.PERSONAL_DETAILS]: fakePersonalDetails,
+                    [ONYXKEYS.CURRENTLY_VIEWED_REPORTID]: '1',
+                    [`${ONYXKEYS.COLLECTION.REPORT}1`]: {...fakeReport1, isPinned: true},
+                    [`${ONYXKEYS.COLLECTION.REPORT}2`]: {...fakeReport2, isPinned: true},
+                    [`${ONYXKEYS.COLLECTION.REPORT}3`]: {...fakeReport3, isPinned: true},
+                    [`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}1`]: fakeReport1Actions,
+                    [`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}2`]: fakeReport2Actions,
+                    [`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}2`]: fakeReport3Actions,
+                }))
+
+                // Then the reports are in alphabetical order
+                .then(() => {
+                    const reportOptions = sidebarLinks.queryAllByText(/ReportID, /);
+                    expect(reportOptions).toHaveLength(3);
+                    expect(reportOptions[0].children[0].props.children).toBe('ReportID, One');
+                    expect(reportOptions[1].children[0].props.children).toBe('ReportID, Three');
+                    expect(reportOptions[2].children[0].props.children).toBe('ReportID, Two');
+                })
+
+                // When a new report is added
+                .then(() => Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}4`, {
+                    reportID: 4,
+                    reportName: 'Report Four',
+                    maxSequenceNumber: TEST_MAX_SEQUENCE_NUMBER,
+                    isPinned: true,
+                    lastMessageTimestamp: Date.now(),
+                    participants: ['email7@test.com', 'email8@test.com'],
+                }))
+
+                // Then they are still in alphabetical order
+                .then(() => {
+                    const reportOptions = sidebarLinks.queryAllByText(/ReportID, /);
+                    expect(reportOptions).toHaveLength(4);
+                    expect(reportOptions[0].children[0].props.children).toBe('ReportID, Four');
+                    expect(reportOptions[1].children[0].props.children).toBe('ReportID, One');
+                    expect(reportOptions[2].children[0].props.children).toBe('ReportID, Three');
+                    expect(reportOptions[3].children[0].props.children).toBe('ReportID, Two');
+                });
+        });
     });
 
     describe('in #focus mode', () => {

--- a/tests/unit/LHNOrderTest.js
+++ b/tests/unit/LHNOrderTest.js
@@ -548,6 +548,55 @@ describe('Sidebar', () => {
                     expect(reportOptions[3].children[0].props.children).toBe('ReportID, Two');
                 });
         });
+
+        it('alphabetizes all the chats that have drafts', () => {
+            const sidebarLinks = getDefaultRenderedSidebarLinks();
+
+            return waitForPromisesToResolve()
+
+                // Given the sidebar is rendered in default mode
+                // with all reports being pinned
+                .then(() => Onyx.multiSet({
+                    [ONYXKEYS.NVP_PRIORITY_MODE]: 'default',
+                    [ONYXKEYS.PERSONAL_DETAILS]: fakePersonalDetails,
+                    [ONYXKEYS.CURRENTLY_VIEWED_REPORTID]: '5',
+                    [`${ONYXKEYS.COLLECTION.REPORT}1`]: {...fakeReport1, hasDraft: true},
+                    [`${ONYXKEYS.COLLECTION.REPORT}2`]: {...fakeReport2, hasDraft: true},
+                    [`${ONYXKEYS.COLLECTION.REPORT}3`]: {...fakeReport3, hasDraft: true},
+                    [`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}1`]: fakeReport1Actions,
+                    [`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}2`]: fakeReport2Actions,
+                    [`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}2`]: fakeReport3Actions,
+                }))
+
+                // Then the reports are in alphabetical order
+                .then(() => {
+                    const reportOptions = sidebarLinks.queryAllByText(/ReportID, /);
+                    expect(reportOptions).toHaveLength(3);
+                    expect(reportOptions[0].children[0].props.children).toBe('ReportID, One');
+                    expect(reportOptions[1].children[0].props.children).toBe('ReportID, Three');
+                    expect(reportOptions[2].children[0].props.children).toBe('ReportID, Two');
+                })
+
+                // When a new report is added
+                .then(() => Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}4`, {
+                    reportID: 4,
+                    reportName: 'Report Four',
+                    maxSequenceNumber: TEST_MAX_SEQUENCE_NUMBER,
+                    hasDraft: true,
+                    lastMessageTimestamp: Date.now(),
+                    participants: ['email7@test.com', 'email8@test.com'],
+                }))
+
+                // Then they are still in alphabetical order
+                .then(() => {
+                    const reportOptions = sidebarLinks.queryAllByText(/ReportID, /);
+                    expect(reportOptions).toHaveLength(4);
+                    expect(reportOptions[0].children[0].props.children).toBe('ReportID, Four');
+                    expect(reportOptions[1].children[0].props.children).toBe('ReportID, One');
+                    expect(reportOptions[2].children[0].props.children).toBe('ReportID, Three');
+                    expect(reportOptions[3].children[0].props.children).toBe('ReportID, Two');
+                });
+        });
     });
 
     describe('in #focus mode', () => {

--- a/tests/unit/LHNOrderTest.js
+++ b/tests/unit/LHNOrderTest.js
@@ -505,7 +505,7 @@ describe('Sidebar', () => {
 
             return waitForPromisesToResolve()
 
-                // Given the sidebar is rendered in #focus mode (hides read chats)
+                // Given the sidebar is rendered in default mode
                 // with all reports being pinned
                 .then(() => Onyx.multiSet({
                     [ONYXKEYS.NVP_PRIORITY_MODE]: 'default',

--- a/tests/unit/LHNOrderTest.js
+++ b/tests/unit/LHNOrderTest.js
@@ -555,7 +555,7 @@ describe('Sidebar', () => {
             return waitForPromisesToResolve()
 
                 // Given the sidebar is rendered in default mode
-                // with all reports being pinned
+                // with all reports having drafts
                 .then(() => Onyx.multiSet({
                     [ONYXKEYS.NVP_PRIORITY_MODE]: 'default',
                     [ONYXKEYS.PERSONAL_DETAILS]: fakePersonalDetails,


### PR DESCRIPTION
Reported by @coleaeason here: https://expensify.slack.com/archives/C01GTK53T8Q/p1663860286166959

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/229779

### Tests
1. Make sure you are in default view mode
2. Make sure you have several pinned chats
3. Verify the group of pinned chats are sorted alphabetically in the LHN
4. Pin a new chat
5. Verify it gets added in the proper alphabetical order in the LHN
2. Make sure you have draft chats
3. Verify the group of draft chats are sorted alphabetically in the LHN
4. Add a new draft to a new report
5. Verify it gets added in the proper alphabetical order in the LHN

- [ ] Verify that no errors appear in the JS console

### Screenshots


#### Web
![image](https://user-images.githubusercontent.com/1228807/191801358-93909203-1ffe-43ed-882e-8b66c37cd31f.png)