### PR TITLE
Add teamdot check to SideBarUtils.js

### DIFF
--- a/src/libs/SidebarUtils.js
+++ b/src/libs/SidebarUtils.js
@@ -1,6 +1,7 @@
 import Onyx from 'react-native-onyx';
 import _ from 'underscore';
 import Str from 'expensify-common/lib/str';
+import lodashGet from 'lodash/get';
 import ONYXKEYS from '../ONYXKEYS';
 import * as ReportUtils from './ReportUtils';
 import * as Localize from './Localize';
@@ -8,7 +9,6 @@ import CONST from '../CONST';
 import * as OptionsListUtils from './OptionsListUtils';
 import * as CollectionUtils from './CollectionUtils';
 import Permissions from './Permissions';
-import lodashGet from 'lodash/get';
 
 // Note: It is very important that the keys subscribed to here are the same
 // keys that are connected to SidebarLinks withOnyx(). If there was a key missing from SidebarLinks and it's data was updated

--- a/src/libs/SidebarUtils.js
+++ b/src/libs/SidebarUtils.js
@@ -8,6 +8,7 @@ import CONST from '../CONST';
 import * as OptionsListUtils from './OptionsListUtils';
 import * as CollectionUtils from './CollectionUtils';
 import Permissions from './Permissions';
+import lodashGet from 'lodash/get';
 
 // Note: It is very important that the keys subscribed to here are the same
 // keys that are connected to SidebarLinks withOnyx(). If there was a key missing from SidebarLinks and it's data was updated
@@ -143,8 +144,12 @@ function getOrderedReportIDs() {
             return false;
         }
 
-        // We let Free Plan default rooms to be shown in the App - it's the one exception to the beta, otherwise do not show policy rooms in product
-        if (ReportUtils.isDefaultRoom(report) && !Permissions.canUseDefaultRooms(betas) && ReportUtils.getPolicyType(report, policies) !== CONST.POLICY.TYPE.FREE) {
+        // We let Free Plan default rooms to be shown in the App, or rooms that also have a Guide in them.
+        // It's the two exceptions to the beta, otherwise do not show policy rooms in product
+        if (ReportUtils.isDefaultRoom(report)
+            && !Permissions.canUseDefaultRooms(betas)
+            && ReportUtils.getPolicyType(report, policies) !== CONST.POLICY.TYPE.FREE
+            && !ReportUtils.hasExpensifyGuidesEmails(lodashGet(report, ['participants'], []))) {
             return false;
         }
 


### PR DESCRIPTION
@tgolen will you review please? 

### Details
While you were working on https://github.com/Expensify/App/pull/10800, we added another bypass to the beta in https://github.com/Expensify/App/pull/10855. As a result, SideBarUtils didn't have this check. This PR adds the extra bypass check to SideBarUtils as well

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/229968

### Tests
1. (Dev) turned off all forced betas
2. Signed into an account that was not on the beta, but had an assigned guide
3. _Verified_ I saw the #admins room in the sidebar
<img width="1195" alt="image" src="https://user-images.githubusercontent.com/22447860/192014196-d4cea584-0394-43ab-9f85-c0dcd99514f4.png">
- [ ] Verify that no errors appear in the JS console

### QA Steps
1. On OldDot, from a public domain account (gmail.com for example), create a new corporate policy
2. Navigate to NewDot and sign in to the same account
3. _Verify_ you see the #admins room in the side bar 
<img width="1195" alt="image" src="https://user-images.githubusercontent.com/22447860/192014430-b4ac5134-f152-458a-978a-d88c8a243313.png">
- [ ] Verify that no errors appear in the JS console