### PR TITLE
Update Onfido sdk to 6.0, ditch fork

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -217,9 +217,9 @@ PODS:
     - nanopb/encode (= 2.30908.0)
   - nanopb/decode (2.30908.0)
   - nanopb/encode (2.30908.0)
-  - Onfido (25.1.0)
-  - onfido-react-native-sdk (5.4.0):
-    - Onfido (= 25.1.0)
+  - Onfido (26.0.1)
+  - onfido-react-native-sdk (6.0.0):
+    - Onfido (= 26.0.1)
     - React
   - OpenSSL-Universal (1.1.1100)
   - Permission-LocationAccuracy (3.6.1):
@@ -941,8 +941,8 @@ SPEC CHECKSUMS:
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   libwebp: 60305b2e989864154bd9be3d772730f08fc6a59c
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
-  Onfido: a1645279c7b6ca8de5bb95d27af53c523ffd731c
-  onfido-react-native-sdk: cfdfd1d4acf53e469a82b9684f92982d39744bb8
+  Onfido: 91935f0dcee9a6647fdb386fa87cb4af9d9a3c70
+  onfido-react-native-sdk: bc72114ac430a2636cd2f02972ddf5b8b3b397c6
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   Permission-LocationAccuracy: 76df17de5c6b8bc2eee34e61ee92cdd7a864c73d
   Permission-LocationAlways: 8d99b025c9f73c696e0cdb367e42525f2e9a26f2

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@formatjs/intl-numberformat": "^6.2.5",
         "@formatjs/intl-pluralrules": "^4.0.13",
         "@oguzhnatly/react-native-image-manipulator": "github:Expensify/react-native-image-manipulator#c5f654fc9d0ad7cc5b89d50b34ecf8b0e3f4d050",
-        "@onfido/react-native-sdk": "github:Expensify/react-native-sdk#d70947f263b2e59899d82f8d1ef3841d053927ff",
+        "@onfido/react-native-sdk": "6.0.0",
         "@pieter-pot/react-native-fast-image": "8.5.11",
         "@react-native-async-storage/async-storage": "^1.17.10",
         "@react-native-community/cameraroll": "git+https://github.com/react-native-cameraroll/react-native-cameraroll.git#3f0aed96db68e134f199171c7b06c1b4d6cb382b",
@@ -4154,12 +4154,11 @@
       }
     },
     "node_modules/@onfido/react-native-sdk": {
-      "version": "5.4.0",
-      "resolved": "git+ssh://git@github.com/Expensify/react-native-sdk.git#d70947f263b2e59899d82f8d1ef3841d053927ff",
-      "integrity": "sha512-xqQ9ERZhnJPkWVaaPBaoeBQ8UMHVy/cCPxEzow5rBuPuzmA1KYvrbu1FUqTMriUhVnLFR57TDCyZR8s/+u/eRg==",
-      "license": "MIT",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@onfido/react-native-sdk/-/react-native-sdk-6.0.0.tgz",
+      "integrity": "sha512-TJWeiEh0Vil37/Xm9H+uiOpiuYD2NhOhixdvaAkohTzLI3uUNiG7bph66jCUa+SpqFURQdCZMYWFwHwj2nXs2Q==",
       "peerDependencies": {
-        "react": ">=16.8.1 <=18.x.x",
+        "react": ">=16.8.1",
         "react-native": ">=0.60.0-rc.0 <1.0.x"
       }
     },
@@ -46067,9 +46066,9 @@
       }
     },
     "@onfido/react-native-sdk": {
-      "version": "git+ssh://git@github.com/Expensify/react-native-sdk.git#d70947f263b2e59899d82f8d1ef3841d053927ff",
-      "integrity": "sha512-xqQ9ERZhnJPkWVaaPBaoeBQ8UMHVy/cCPxEzow5rBuPuzmA1KYvrbu1FUqTMriUhVnLFR57TDCyZR8s/+u/eRg==",
-      "from": "@onfido/react-native-sdk@github:Expensify/react-native-sdk#d70947f263b2e59899d82f8d1ef3841d053927ff",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@onfido/react-native-sdk/-/react-native-sdk-6.0.0.tgz",
+      "integrity": "sha512-TJWeiEh0Vil37/Xm9H+uiOpiuYD2NhOhixdvaAkohTzLI3uUNiG7bph66jCUa+SpqFURQdCZMYWFwHwj2nXs2Q==",
       "requires": {}
     },
     "@pieter-pot/react-native-fast-image": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@formatjs/intl-numberformat": "^6.2.5",
     "@formatjs/intl-pluralrules": "^4.0.13",
     "@oguzhnatly/react-native-image-manipulator": "github:Expensify/react-native-image-manipulator#c5f654fc9d0ad7cc5b89d50b34ecf8b0e3f4d050",
-    "@onfido/react-native-sdk": "github:Expensify/react-native-sdk#d70947f263b2e59899d82f8d1ef3841d053927ff",
+    "@onfido/react-native-sdk": "6.0.0",
     "@pieter-pot/react-native-fast-image": "8.5.11",
     "@react-native-async-storage/async-storage": "^1.17.10",
     "@react-native-community/cameraroll": "git+https://github.com/react-native-cameraroll/react-native-cameraroll.git#3f0aed96db68e134f199171c7b06c1b4d6cb382b",


### PR DESCRIPTION
### Details
We recently standardized on using node 16 / npm 8 in this project. NPM 8 changed the way peer dependencies were handled, such that any unmet peer dependencies became errors instead of warnings.

However, at the time we had conflicting peer dependencies where we needed to upgrade to React 18, but the Onfido SDK listed a peer dependency with React 17. ([issue](https://github.com/onfido/react-native-sdk/issues/90)). To work around this, we forked the Onfido repo and used our own version with a more flexible peer dependency (allowing for React 18).

10 days ago, Onfido released a new version of their react native SDK that fixed this problem, so we no longer need to maintain our own fork. Instead, we can just upgrade Onfido to the latest upstream version. That's what this PR does.

### Fixed Issues
$ n/a 

### Tests
1. Apply the following diff in NewDot:

	```diff
	diff --git a/src/pages/EnablePayments/EnablePaymentsPage.js b/src/pages/EnablePayments/EnablePaymentsPage.js
	index 4ebbb982a..7e0821db3 100644
	--- a/src/pages/EnablePayments/EnablePaymentsPage.js
	+++ b/src/pages/EnablePayments/EnablePaymentsPage.js
	@@ -71,7 +71,7 @@ class EnablePaymentsPage extends React.Component {
	             );
	         }
	 
	-        const currentStep = this.props.userWallet.currentStep || CONST.WALLET.STEP.ADDITIONAL_DETAILS;
	+        const currentStep = CONST.WALLET.STEP.ONFIDO
	 
	         return (
	             <ScreenWrapper>
	diff --git a/src/pages/EnablePayments/OnfidoPrivacy.js b/src/pages/EnablePayments/OnfidoPrivacy.js
	index 921d85e14..5d4b4849b 100644
	--- a/src/pages/EnablePayments/OnfidoPrivacy.js
	+++ b/src/pages/EnablePayments/OnfidoPrivacy.js
	@@ -46,9 +46,9 @@ class OnfidoPrivacy extends React.Component {
	 
	     openOnfidoFlow() {
	         BankAccounts.openOnfidoFlow(
	-            this.props.walletAdditionalDetailsDraft.legalFirstName,
	-            this.props.walletAdditionalDetailsDraft.legalLastName,
	-            this.props.walletAdditionalDetailsDraft.dob,
	+            'Roreth',
	+            'Goodingsplat',
	+            '1990-01-01',
	         );
	     }
	 
	diff --git a/src/pages/EnablePayments/OnfidoStep.js b/src/pages/EnablePayments/OnfidoStep.js
	index 776576346..6d7a8ca25 100644
	--- a/src/pages/EnablePayments/OnfidoStep.js
	+++ b/src/pages/EnablePayments/OnfidoStep.js
	@@ -36,9 +36,9 @@ const defaultProps = {
	 class OnfidoStep extends React.Component {
	     componentDidMount() {
	         // Once in Onfido step, if we somehow don't have the personal info, go back to previous step, as we need them for Onfido{
	-        const firstName = lodashGet(this.props, 'walletAdditionalDetailsDraft.legalFirstName');
	-        const lastName = lodashGet(this.props, 'walletAdditionalDetailsDraft.legalLastName');
	-        const dob = lodashGet(this.props, 'walletAdditionalDetailsDraft.dob');
	+        const firstName = 'Roreth';
	+        const lastName = 'Goodingsplat';
	+        const dob = '1990-01-01';
	 
	         if (!firstName || !lastName || !dob) {
	             Wallet.updateCurrentStep(CONST.WALLET.STEP.ADDITIONAL_DETAILS);
	
	```

1. Run the app
1. Use a deeplink to go to the `enable-payments` page:
    - iOS: `xcrun simctl openurl booted new-expensify://enable-payments`
    - Android: `adb shell am start -a android.intent.action.VIEW -d new-expensify://enable-payments`

1. Click `Continue` on the `Verify Identify` page
1. Verify that the Onfido SDK opens correctly.

- [x] Verify that no errors appear in the JS console

### PR Review Checklist
<!--
This is a checklist for PR authors & reviewers. Please make sure to complete all tasks and check them off once you do, or else Expensify has the right not to merge your PR!
-->
#### Contributor (PR Author) Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] Any functional components have the `displayName` property
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

<details>
<summary><h4>PR Reviewer Checklist</h4>

The Contributor+ will copy/paste it into a new comment and complete it after the author checklist is completed
</summary>

- [x] I have verified the author checklist is complete (all boxes are checked off).
- [x] I verified the correct issue is linked in the `### Fixed Issues` section above
- [x] I verified testing steps are clear and they cover the changes made in this PR
    - [x] I verified the steps for local testing are in the `Tests` section
    - [x] I verified the steps for Staging and/or Production testing are in the `QA steps` section
    - [x] I verified the steps cover any possible failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [x] I checked that screenshots or videos are included for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I verified tests pass on **all platforms** & I tested again on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`).
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I verified that this PR follows the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I verified other components that can be impacted by these changes have been tested, and I retested again (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` have been tested & I retested again)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] Any functional components have the `displayName` property
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] I have checked off every checkbox in the PR reviewer checklist, including those that don't apply to this PR.

</details>

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Follow the steps in [this SO](https://stackoverflow.com/c/expensify/questions/10698) to test Onfido on staging. If you only have access to an iOS OR Android device, find someone else to test the other platform.

- [x] Verify that no errors appear in the JS console

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
None

#### Mobile Web - Chrome
None

#### Mobile Web - Safari
None

#### Desktop
None

#### iOS
<img width="458" alt="image" src="https://user-images.githubusercontent.com/47436092/192065845-df4a8d02-3059-4615-b741-7130e0dfb803.png">

#### Android
![Screenshot_20220923-161721](https://user-images.githubusercontent.com/47436092/192068862-7ad523c6-4203-428a-829f-113edaa1126f.png)

![Screenshot_20220923-161721 (1)](https://user-images.githubusercontent.com/47436092/192068872-6bfb71a0-7895-4345-b4d6-e718823c32d6.png)

![Screenshot_20220923-161753](https://user-images.githubusercontent.com/47436092/192068876-622a6347-2a76-4645-9e23-e2de9b5b7849.png)

![Screenshot_20220923-161826](https://user-images.githubusercontent.com/47436092/192068883-8d02eaeb-3eee-4791-a914-ab87d008d34a.png)

![Screenshot_20220923-161832](https://user-images.githubusercontent.com/47436092/192068889-86910114-48d4-4083-8748-0a5be6b9de9b.png)

![Screenshot_20220923-161932](https://user-images.githubusercontent.com/47436092/192068898-8ff6f4da-13fa-42f9-bd43-2c3cccce9810.png)

![Screenshot_20220923-162030](https://user-images.githubusercontent.com/47436092/192068909-8d48bace-eee9-4960-b6f2-87f25dfafe17.png)

![Screenshot_20220923-162037](https://user-images.githubusercontent.com/47436092/192068917-24e6c53f-5a0c-4e24-b6f7-850a24142b31.png)
