### PR TITLE
Stop crash when user signs out and onyx is cleared

### DIFF
--- a/src/libs/SidebarUtils.js
+++ b/src/libs/SidebarUtils.js
@@ -221,7 +221,11 @@ function getOrderedReportIDs() {
  */
 function getOptionData(reportID) {
     const report = reports[`${ONYXKEYS.COLLECTION.REPORT}${reportID}`];
-    if (!report) {
+
+    // When a user signs out, Onyx is cleared. Due to the lazy rendering with a virtual list, it's possible for
+    // this method to be called after the Onyx data has been cleared out. In that case, it's fine to do
+    // a null check here and return early.
+    if (!report || !personalDetails) {
         return;
     }
     const result = {


### PR DESCRIPTION
### Fixed Issues
$ https://github.com/Expensify/App/issues/11234

### Tests
1. Sign out

- [x] Verify that no errors appear in the JS console

### QA Steps
1. Sign out

- [ ] Verify that no errors appear in the JS console and app doesn't crash