### PR TITLE
Use context for `withWindowDimensions`

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -13,6 +13,7 @@ import HTMLEngineProvider from './components/HTMLEngineProvider';
 import ComposeProviders from './components/ComposeProviders';
 import SafeArea from './components/SafeArea';
 import * as Environment from './libs/Environment/Environment';
+import {WindowDimensionsProvider} from './components/withWindowDimensions';
 
 // For easier debugging and development, when we are in web we expose Onyx to the window, so you can more easily set data into Onyx
 if (window && Environment.isDevelopment()) {
@@ -37,6 +38,7 @@ const App = () => (
                 SafeArea,
                 LocaleContextProvider,
                 HTMLEngineProvider,
+                WindowDimensionsProvider,
             ]}
         >
             <CustomStatusBar />

--- a/src/components/withWindowDimensions.js
+++ b/src/components/withWindowDimensions.js
@@ -1,10 +1,12 @@
-import React, {Component} from 'react';
+/* eslint-disable react/no-unused-state */
+import React, {forwardRef, createContext} from 'react';
 import _ from 'underscore';
 import PropTypes from 'prop-types';
 import {Dimensions} from 'react-native';
 import getComponentDisplayName from '../libs/getComponentDisplayName';
 import variables from '../styles/variables';
 
+const WindowDimensionsContext = createContext(null);
 const windowDimensionsPropTypes = {
     // Width of the window
     windowWidth: PropTypes.number.isRequired,
@@ -19,98 +21,98 @@ const windowDimensionsPropTypes = {
     isMediumScreenWidth: PropTypes.bool.isRequired,
 };
 
-export default function (WrappedComponent) {
-    const propTypes = {
-        forwardedRef: PropTypes.func,
-    };
+const windowDimensionsProviderPropTypes = {
+    /* Actual content wrapped by this component */
+    children: PropTypes.node.isRequired,
+};
 
-    const defaultProps = {
-        forwardedRef: () => {},
-    };
+class WindowDimensionsProvider extends React.Component {
+    constructor(props) {
+        super(props);
 
-    class WithWindowDimensions extends Component {
-        constructor(props) {
-            super(props);
+        // Using debounce here as a temporary fix for a bug in react-native
+        // https://github.com/facebook/react-native/issues/29290
+        // When the app is sent to background on iPads, onDimensionChange callback is called with
+        // swapped window dimensions before it was called with correct dimensions within miliseconds, then
+        // drawer is being positioned incorrectly due to animation issues in react-navigation.
+        // Adding debounce here slows down window dimension changes to let
+        // react-navigation to complete the positioning of elements properly.
+        this.onDimensionChange = _.debounce(this.onDimensionChange.bind(this), 100);
 
-            // Using debounce here as a temporary fix for a bug in react-native
-            // https://github.com/facebook/react-native/issues/29290
-            // When the app is sent to background on iPads, onDimensionChange callback is called with
-            // swapped window dimensions before it was called with correct dimensions within miliseconds, then
-            // drawer is being positioned incorrectly due to animation issues in react-navigation.
-            // Adding debounce here slows down window dimension changes to let
-            // react-navigation to complete the positioning of elements properly.
-            this.onDimensionChange = _.debounce(this.onDimensionChange.bind(this), 100);
+        const initialDimensions = Dimensions.get('window');
+        const isSmallScreenWidth = initialDimensions.width <= variables.mobileResponsiveWidthBreakpoint;
+        const isMediumScreenWidth = initialDimensions.width > variables.mobileResponsiveWidthBreakpoint
+          && initialDimensions.width <= variables.tabletResponsiveWidthBreakpoint;
 
-            const initialDimensions = Dimensions.get('window');
-            const isSmallScreenWidth = initialDimensions.width <= variables.mobileResponsiveWidthBreakpoint;
-            const isMediumScreenWidth = initialDimensions.width > variables.mobileResponsiveWidthBreakpoint
-              && initialDimensions.width <= variables.tabletResponsiveWidthBreakpoint;
+        this.dimensionsEventListener = null;
 
-            this.dimensionsEventListener = null;
-
-            this.state = {
-                windowHeight: initialDimensions.height,
-                windowWidth: initialDimensions.width,
-                isSmallScreenWidth,
-                isMediumScreenWidth,
-            };
-        }
-
-        componentDidMount() {
-            this.dimensionsEventListener = Dimensions.addEventListener('change', this.onDimensionChange);
-        }
-
-        componentWillUnmount() {
-            if (!this.dimensionsEventListener) {
-                return;
-            }
-            this.dimensionsEventListener.remove();
-        }
-
-        /**
-         * Stores the application window's width and height in a component state variable.
-         * Called each time the application's window dimensions or screen dimensions change.
-         * @link https://reactnative.dev/docs/dimensions
-         * @param {Object} newDimensions Dimension object containing updated window and screen dimensions
-         */
-        onDimensionChange(newDimensions) {
-            const {window} = newDimensions;
-            const isSmallScreenWidth = window.width <= variables.mobileResponsiveWidthBreakpoint;
-            const isMediumScreenWidth = !isSmallScreenWidth && window.width <= variables.tabletResponsiveWidthBreakpoint;
-            this.setState({
-                windowHeight: window.height,
-                windowWidth: window.width,
-                isSmallScreenWidth,
-                isMediumScreenWidth,
-            });
-        }
-
-        render() {
-            // eslint-disable-next-line react/destructuring-assignment
-            const {forwardedRef, ...rest} = this.props;
-            return (
-                <WrappedComponent
-                    // eslint-disable-next-line react/jsx-props-no-spreading
-                    {...rest}
-                    ref={forwardedRef}
-                    windowHeight={this.state.windowHeight}
-                    windowWidth={this.state.windowWidth}
-                    isSmallScreenWidth={this.state.isSmallScreenWidth}
-                    isMediumScreenWidth={this.state.isMediumScreenWidth}
-                />
-            );
-        }
+        this.state = {
+            windowHeight: initialDimensions.height,
+            windowWidth: initialDimensions.width,
+            isSmallScreenWidth,
+            isMediumScreenWidth,
+        };
     }
 
-    WithWindowDimensions.propTypes = propTypes;
-    WithWindowDimensions.defaultProps = defaultProps;
-    WithWindowDimensions.displayName = `withWindowDimensions(${getComponentDisplayName(WrappedComponent)})`;
-    return React.forwardRef((props, ref) => (
-        // eslint-disable-next-line react/jsx-props-no-spreading
-        <WithWindowDimensions {...props} forwardedRef={ref} />
+    componentDidMount() {
+        this.dimensionsEventListener = Dimensions.addEventListener('change', this.onDimensionChange);
+    }
+
+    componentWillUnmount() {
+        if (!this.dimensionsEventListener) {
+            return;
+        }
+        this.dimensionsEventListener.remove();
+    }
+
+    /**
+     * Stores the application window's width and height in a component state variable.
+     * Called each time the application's window dimensions or screen dimensions change.
+     * @link https://reactnative.dev/docs/dimensions
+     * @param {Object} newDimensions Dimension object containing updated window and screen dimensions
+     */
+    onDimensionChange(newDimensions) {
+        const {window} = newDimensions;
+        const isSmallScreenWidth = window.width <= variables.mobileResponsiveWidthBreakpoint;
+        const isMediumScreenWidth = !isSmallScreenWidth && window.width <= variables.tabletResponsiveWidthBreakpoint;
+        this.setState({
+            windowHeight: window.height,
+            windowWidth: window.width,
+            isSmallScreenWidth,
+            isMediumScreenWidth,
+        });
+    }
+
+    render() {
+        return (
+            <WindowDimensionsContext.Provider value={this.state}>
+                {this.props.children}
+            </WindowDimensionsContext.Provider>
+        );
+    }
+}
+
+WindowDimensionsProvider.propTypes = windowDimensionsProviderPropTypes;
+
+/**
+ * @param {React.Component} WrappedComponent
+ * @returns {React.Component}
+ */
+export default function withWindowDimensions(WrappedComponent) {
+    const WithWindowDimensions = forwardRef((props, ref) => (
+        <WindowDimensionsContext.Consumer>
+            {windowDimensionsProps => (
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                <WrappedComponent {...windowDimensionsProps} {...props} ref={ref} />
+            )}
+        </WindowDimensionsContext.Consumer>
     ));
+
+    WithWindowDimensions.displayName = `withWindowDimensions(${getComponentDisplayName(WrappedComponent)})`;
+    return WithWindowDimensions;
 }
 
 export {
+    WindowDimensionsProvider,
     windowDimensionsPropTypes,
 };


### PR DESCRIPTION
### Details

Noticed while testing the app that many setState() calls are made to `ReportActionItem`. Wherever possible we should reduce the re-rendering of these components since they can be very numerous.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/230401

### Tests

1. Test changing the screen between small/large sizes
2. Verify app works normally

- [x] Verify that no errors appear in the JS console

### PR Review Checklist
<!--
This is a checklist for PR authors & reviewers. Please make sure to complete all tasks and check them off once you do, or else Expensify has the right not to merge your PR!
-->
#### Contributor (PR Author) Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] Any functional components have the `displayName` property
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

<details>
<summary><h4>PR Reviewer Checklist</h4>

The Contributor+ will copy/paste it into a new comment and complete it after the author checklist is completed
</summary>

- [x] I have verified the author checklist is complete (all boxes are checked off).
- [x] I verified the correct issue is linked in the `### Fixed Issues` section above
- [x] I verified testing steps are clear and they cover the changes made in this PR
    - [x] I verified the steps for local testing are in the `Tests` section
    - [x] I verified the steps for Staging and/or Production testing are in the `QA steps` section
    - [x] I verified the steps cover any possible failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [x] I checked that screenshots or videos are included for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I verified tests pass on **all platforms** & I tested again on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] If there are any errors in the console that are unrelated to this PR, I either fixed them (preferred) or linked to where I reported them in Slack
- [x] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`).
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I verified that this PR follows the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I verified other components that can be impacted by these changes have been tested, and I retested again (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` have been tested & I retested again)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] Any functional components have the `displayName` property
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] I have checked off every checkbox in the PR reviewer checklist, including those that don't apply to this PR.

</details>

### QA Steps
1. Test changing the screen between small/large sizes
2. Verify app works normally

- [x] Verify that no errors appear in the JS console

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web - Chrome
<!-- Insert screenshots of your changes on the web platform (from chrome mobile browser)-->

#### Mobile Web - Safari
<!-- Insert screenshots of your changes on the web platform (from safari mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
