### PR TITLE
[WIP / Experiment] Onyx state tracking w/ global state proof of concept

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,7 @@
         "react-native-webview": "^11.17.2",
         "react-pdf": "5.7.2",
         "react-plaid-link": "3.3.2",
+        "react-tracked": "^1.7.10",
         "react-web-config": "^1.0.0",
         "save": "^2.4.0",
         "shim-keyboard-event-key": "^1.0.3",
@@ -34994,6 +34995,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-compare": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-2.3.0.tgz",
+      "integrity": "sha512-c3L2CcAi7f7pvlD0D7xsF+2CQIW8C3HaYx2Pfgq8eA4HAl3GAH6/dVYsyBbYF/0XJs2ziGLrzmz5fmzPm6A0pQ=="
+    },
     "node_modules/prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -36291,6 +36297,29 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
+    },
+    "node_modules/react-tracked": {
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/react-tracked/-/react-tracked-1.7.10.tgz",
+      "integrity": "sha512-+zOm+Pr+zFrrEOwtLUtHwoxf9Kg7Ur7OMjD9kNFw5JA9lAs+mInXVEOvwpReEoR2FQMS4KUFxLv5VYoR5ADBiQ==",
+      "dependencies": {
+        "proxy-compare": "2.3.0",
+        "use-context-selector": "1.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": "*",
+        "react-native": "*",
+        "scheduler": ">=0.19.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-web-config": {
       "version": "1.0.0",
@@ -41323,6 +41352,25 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/use-context-selector": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/use-context-selector/-/use-context-selector-1.4.1.tgz",
+      "integrity": "sha512-Io2ArvcRO+6MWIhkdfMFt+WKQX+Vb++W8DS2l03z/Vw/rz3BclKpM0ynr4LYGyU85Eke+Yx5oIhTY++QR0ZDoA==",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": "*",
+        "react-native": "*",
+        "scheduler": ">=0.19.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/use-sync-external-store": {
@@ -69735,6 +69783,11 @@
         "ipaddr.js": "1.9.1"
       }
     },
+    "proxy-compare": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-2.3.0.tgz",
+      "integrity": "sha512-c3L2CcAi7f7pvlD0D7xsF+2CQIW8C3HaYx2Pfgq8eA4HAl3GAH6/dVYsyBbYF/0XJs2ziGLrzmz5fmzPm6A0pQ=="
+    },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -70698,6 +70751,15 @@
           "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
           "dev": true
         }
+      }
+    },
+    "react-tracked": {
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/react-tracked/-/react-tracked-1.7.10.tgz",
+      "integrity": "sha512-+zOm+Pr+zFrrEOwtLUtHwoxf9Kg7Ur7OMjD9kNFw5JA9lAs+mInXVEOvwpReEoR2FQMS4KUFxLv5VYoR5ADBiQ==",
+      "requires": {
+        "proxy-compare": "2.3.0",
+        "use-context-selector": "1.4.1"
       }
     },
     "react-web-config": {
@@ -74673,6 +74735,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+    },
+    "use-context-selector": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/use-context-selector/-/use-context-selector-1.4.1.tgz",
+      "integrity": "sha512-Io2ArvcRO+6MWIhkdfMFt+WKQX+Vb++W8DS2l03z/Vw/rz3BclKpM0ynr4LYGyU85Eke+Yx5oIhTY++QR0ZDoA==",
+      "requires": {}
     },
     "use-sync-external-store": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "react-native-webview": "^11.17.2",
     "react-pdf": "5.7.2",
     "react-plaid-link": "3.3.2",
+    "react-tracked": "^1.7.10",
     "react-web-config": "^1.0.0",
     "save": "^2.4.0",
     "shim-keyboard-event-key": "^1.0.3",

--- a/src/App.js
+++ b/src/App.js
@@ -13,6 +13,8 @@ import HTMLEngineProvider from './components/HTMLEngineProvider';
 import ComposeProviders from './components/ComposeProviders';
 import SafeArea from './components/SafeArea';
 import * as Environment from './libs/Environment/Environment';
+import ONYXKEYS from './ONYXKEYS';
+import OnyxStateProvider from './libs/OnyxContext';
 
 // For easier debugging and development, when we are in web we expose Onyx to the window, so you can more easily set data into Onyx
 if (window && Environment.isDevelopment()) {
@@ -30,20 +32,22 @@ const fill = {flex: 1};
 
 const App = () => (
     <GestureHandlerRootView style={fill}>
-        <ComposeProviders
-            components={[
-                OnyxProvider,
-                SafeAreaProvider,
-                SafeArea,
-                LocaleContextProvider,
-                HTMLEngineProvider,
-            ]}
-        >
-            <CustomStatusBar />
-            <ErrorBoundary errorMessage="NewExpensify crash caught by error boundary">
-                <Expensify />
-            </ErrorBoundary>
-        </ComposeProviders>
+        <OnyxStateProvider onyxKeys={ONYXKEYS}>
+            <ComposeProviders
+                components={[
+                    OnyxProvider,
+                    SafeAreaProvider,
+                    SafeArea,
+                    LocaleContextProvider,
+                    HTMLEngineProvider,
+                ]}
+            >
+                <CustomStatusBar />
+                <ErrorBoundary errorMessage="NewExpensify crash caught by error boundary">
+                    <Expensify />
+                </ErrorBoundary>
+            </ComposeProviders>
+        </OnyxStateProvider>
     </GestureHandlerRootView>
 );
 

--- a/src/Expensify.js
+++ b/src/Expensify.js
@@ -22,6 +22,7 @@ import compose from './libs/compose';
 import withLocalize, {withLocalizePropTypes} from './components/withLocalize';
 import * as User from './libs/actions/User';
 import NetworkConnection from './libs/NetworkConnection';
+import withOnyxContext from './components/withOnyxContext';
 
 Onyx.registerLogger(({level, message}) => {
     if (level === 'alert') {
@@ -214,19 +215,21 @@ Expensify.propTypes = propTypes;
 Expensify.defaultProps = defaultProps;
 export default compose(
     withLocalize,
-    withOnyx({
+    withOnyxContext({
         session: {
             key: ONYXKEYS.SESSION,
-        },
-        updateAvailable: {
-            key: ONYXKEYS.UPDATE_AVAILABLE,
-            initWithStoredValues: false,
         },
         isSidebarLoaded: {
             key: ONYXKEYS.IS_SIDEBAR_LOADED,
         },
         screenShareRequest: {
             key: ONYXKEYS.SCREEN_SHARE_REQUEST,
+        },
+    }),
+    withOnyx({
+        updateAvailable: {
+            key: ONYXKEYS.UPDATE_AVAILABLE,
+            initWithStoredValues: false,
         },
     }),
 )(Expensify);

--- a/src/components/AvatarWithIndicator.js
+++ b/src/components/AvatarWithIndicator.js
@@ -2,7 +2,6 @@ import _ from 'underscore';
 import React from 'react';
 import {StyleSheet, View} from 'react-native';
 import PropTypes from 'prop-types';
-import {withOnyx} from 'react-native-onyx';
 import Avatar from './Avatar';
 import styles from '../styles/styles';
 import Tooltip from './Tooltip';
@@ -15,6 +14,7 @@ import {policyPropTypes} from '../pages/workspace/withPolicy';
 import walletTermsPropTypes from '../pages/EnablePayments/walletTermsPropTypes';
 import * as PolicyUtils from '../libs/PolicyUtils';
 import * as PaymentMethods from '../libs/actions/PaymentMethods';
+import withOnyxContext from './withOnyxContext';
 
 const propTypes = {
     /** URL for the avatar */
@@ -104,7 +104,7 @@ AvatarWithIndicator.defaultProps = defaultProps;
 AvatarWithIndicator.propTypes = propTypes;
 AvatarWithIndicator.displayName = 'AvatarWithIndicator';
 
-export default withOnyx({
+export default withOnyxContext({
     policiesMemberList: {
         key: ONYXKEYS.COLLECTION.POLICY_MEMBER_LIST,
     },

--- a/src/components/EmojiPicker/EmojiPickerMenu/index.js
+++ b/src/components/EmojiPicker/EmojiPickerMenu/index.js
@@ -20,6 +20,7 @@ import getOperatingSystem from '../../../libs/getOperatingSystem';
 import * as User from '../../../libs/actions/User';
 import EmojiSkinToneList from '../EmojiSkinToneList';
 import * as EmojiUtils from '../../../libs/EmojiUtils';
+import withOnyxContext from '../../withOnyxContext';
 
 const propTypes = {
     /** Function to add the selected emoji to the main compose text input */
@@ -518,7 +519,7 @@ EmojiPickerMenu.defaultProps = defaultProps;
 export default compose(
     withWindowDimensions,
     withLocalize,
-    withOnyx({
+    withOnyxContext({
         preferredSkinTone: {
             key: ONYXKEYS.PREFERRED_EMOJI_SKIN_TONE,
         },

--- a/src/components/EmojiPicker/EmojiPickerMenu/index.native.js
+++ b/src/components/EmojiPicker/EmojiPickerMenu/index.native.js
@@ -14,6 +14,7 @@ import withLocalize, {withLocalizePropTypes} from '../../withLocalize';
 import EmojiSkinToneList from '../EmojiSkinToneList';
 import * as EmojiUtils from '../../../libs/EmojiUtils';
 import * as User from '../../../libs/actions/User';
+import withOnyxContext from '../../withOnyxContext';
 
 const propTypes = {
     /** Function to add the selected emoji to the main compose text input */
@@ -154,7 +155,7 @@ EmojiPickerMenu.defaultProps = defaultProps;
 export default compose(
     withWindowDimensions,
     withLocalize,
-    withOnyx({
+    withOnyxContext({
         preferredSkinTone: {
             key: ONYXKEYS.PREFERRED_EMOJI_SKIN_TONE,
         },

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -2,12 +2,12 @@ import React from 'react';
 import {ScrollView, View} from 'react-native';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
-import {withOnyx} from 'react-native-onyx';
 import compose from '../libs/compose';
 import withLocalize, {withLocalizePropTypes} from './withLocalize';
 import * as FormActions from '../libs/actions/FormActions';
 import styles from '../styles/styles';
 import FormAlertWithSubmitButton from './FormAlertWithSubmitButton';
+import withOnyxContext from './withOnyxContext';
 
 const propTypes = {
     /** A unique Onyx key identifying the form */
@@ -207,7 +207,7 @@ Form.defaultProps = defaultProps;
 
 export default compose(
     withLocalize,
-    withOnyx({
+    withOnyxContext({
         formState: {
             key: props => props.formID,
         },

--- a/src/components/KeyboardShortcutsModal.js
+++ b/src/components/KeyboardShortcutsModal.js
@@ -14,6 +14,7 @@ import compose from '../libs/compose';
 import KeyboardShortcut from '../libs/KeyboardShortcut';
 import * as KeyboardShortcutsActions from '../libs/actions/KeyboardShortcuts';
 import ONYXKEYS from '../ONYXKEYS';
+import withOnyxContext from './withOnyxContext';
 
 const propTypes = {
     /** prop to set shortcuts modal visibility */
@@ -105,7 +106,7 @@ KeyboardShortcutsModal.defaultProps = defaultProps;
 export default compose(
     withWindowDimensions,
     withLocalize,
-    withOnyx({
+    withOnyxContext({
         isShortcutsModalOpen: {key: ONYXKEYS.IS_SHORTCUTS_MODAL_OPEN},
     }),
 )(KeyboardShortcutsModal);

--- a/src/components/ReportActionItem/IOUAction.js
+++ b/src/components/ReportActionItem/IOUAction.js
@@ -8,6 +8,7 @@ import IOUPreview from './IOUPreview';
 import Navigation from '../../libs/Navigation/Navigation';
 import ROUTES from '../../ROUTES';
 import styles from '../../styles/styles';
+import withOnyxContext from '../withOnyxContext';
 
 const propTypes = {
     /** All the data of the action */
@@ -62,7 +63,7 @@ IOUAction.propTypes = propTypes;
 IOUAction.defaultProps = defaultProps;
 IOUAction.displayName = 'IOUAction';
 
-export default withOnyx({
+export default withOnyxContext({
     chatReport: {
         key: ({chatReportID}) => `${ONYXKEYS.COLLECTION.REPORT}${chatReportID}`,
     },

--- a/src/components/ReportActionItem/IOUPreview.js
+++ b/src/components/ReportActionItem/IOUPreview.js
@@ -24,6 +24,7 @@ import Text from '../Text';
 import * as PaymentMethods from '../../libs/actions/PaymentMethods';
 import OfflineWithFeedback from '../OfflineWithFeedback';
 import walletTermsPropTypes from '../../pages/EnablePayments/walletTermsPropTypes';
+import withOnyxContext from '../withOnyxContext';
 
 const propTypes = {
     /** Additional logic for displaying the pay button */
@@ -206,7 +207,7 @@ IOUPreview.displayName = 'IOUPreview';
 
 export default compose(
     withLocalize,
-    withOnyx({
+    withOnyxContext({
         personalDetails: {
             key: ONYXKEYS.PERSONAL_DETAILS,
         },

--- a/src/components/ReportWelcomeText.js
+++ b/src/components/ReportWelcomeText.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import lodashGet from 'lodash/get';
-import {withOnyx} from 'react-native-onyx';
 import _ from 'underscore';
 import styles from '../styles/styles';
 import Text from './Text';
@@ -13,6 +12,7 @@ import ONYXKEYS from '../ONYXKEYS';
 import Navigation from '../libs/Navigation/Navigation';
 import ROUTES from '../ROUTES';
 import Tooltip from './Tooltip';
+import withOnyxContext from './withOnyxContext';
 
 const personalDetailsPropTypes = PropTypes.shape({
     /** The login of the person (either email or phone number) */
@@ -130,7 +130,7 @@ ReportWelcomeText.displayName = 'ReportWelcomeText';
 
 export default compose(
     withLocalize,
-    withOnyx({
+    withOnyxContext({
         personalDetails: {
             key: ONYXKEYS.PERSONAL_DETAILS,
         },

--- a/src/components/ScreenWrapper/BaseScreenWrapper.js
+++ b/src/components/ScreenWrapper/BaseScreenWrapper.js
@@ -2,7 +2,6 @@ import {KeyboardAvoidingView, View} from 'react-native';
 import React from 'react';
 import {SafeAreaInsetsContext} from 'react-native-safe-area-context';
 import _ from 'underscore';
-import {withOnyx} from 'react-native-onyx';
 import CONST from '../../CONST';
 import KeyboardShortcut from '../../libs/KeyboardShortcut';
 import Navigation from '../../libs/Navigation/Navigation';
@@ -18,6 +17,7 @@ import withWindowDimensions from '../withWindowDimensions';
 import ONYXKEYS from '../../ONYXKEYS';
 import {withNetwork} from '../OnyxProvider';
 import {propTypes, defaultProps} from './propTypes';
+import withOnyxContext from '../withOnyxContext';
 
 class BaseScreenWrapper extends React.Component {
     constructor(props) {
@@ -106,7 +106,7 @@ BaseScreenWrapper.defaultProps = defaultProps;
 export default compose(
     withNavigation,
     withWindowDimensions,
-    withOnyx({
+    withOnyxContext({
         modal: {
             key: ONYXKEYS.MODAL,
         },

--- a/src/components/createOnyxContext.js
+++ b/src/components/createOnyxContext.js
@@ -1,8 +1,8 @@
 import React, {createContext, forwardRef} from 'react';
 import PropTypes from 'prop-types';
-import {withOnyx} from 'react-native-onyx';
 import Str from 'expensify-common/lib/str';
 import getComponentDisplayName from '../libs/getComponentDisplayName';
+import withOnyxContext from './withOnyxContext';
 
 const propTypes = {
     /** Rendered child component */
@@ -20,7 +20,7 @@ export default (onyxKeyName) => {
     Provider.propTypes = propTypes;
     Provider.displayName = `${Str.UCFirst(onyxKeyName)}Provider`;
 
-    const ProviderWithOnyx = withOnyx({
+    const ProviderWithOnyx = withOnyxContext({
         [onyxKeyName]: {
             key: onyxKeyName,
         },

--- a/src/components/withCurrentUserPersonalDetails.js
+++ b/src/components/withCurrentUserPersonalDetails.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {withOnyx} from 'react-native-onyx';
 import getComponentDisplayName from '../libs/getComponentDisplayName';
 import ONYXKEYS from '../ONYXKEYS';
 import personalDetailsPropType from '../pages/personalDetailsPropType';
+import withOnyxContext from './withOnyxContext';
 
 const withCurrentUserPersonalDetailsPropTypes = {
     currentUserPersonalDetails: personalDetailsPropType,
@@ -56,7 +56,7 @@ export default function (WrappedComponent) {
         <WithCurrentUserPersonalDetails {...props} forwardedRef={ref} />
     ));
 
-    return withOnyx({
+    return withOnyxContext({
         personalDetails: {
             key: ONYXKEYS.PERSONAL_DETAILS,
         },

--- a/src/components/withLocalize.js
+++ b/src/components/withLocalize.js
@@ -9,6 +9,7 @@ import * as LocalePhoneNumber from '../libs/LocalePhoneNumber';
 import * as NumberFormatUtils from '../libs/NumberFormatUtils';
 import * as LocaleDigitUtils from '../libs/LocaleDigitUtils';
 import CONST from '../CONST';
+import withOnyxContext from './withOnyxContext';
 
 const LocaleContext = createContext(null);
 
@@ -152,7 +153,7 @@ class LocaleContextProvider extends React.Component {
 LocaleContextProvider.propTypes = localeProviderPropTypes;
 LocaleContextProvider.defaultProps = localeProviderDefaultProps;
 
-const Provider = withOnyx({
+const Provider = withOnyxContext({
     preferredLocale: {
         key: ONYXKEYS.NVP_PREFERRED_LOCALE,
     },

--- a/src/components/withOnyxContext.js
+++ b/src/components/withOnyxContext.js
@@ -1,0 +1,50 @@
+import Str from 'expensify-common/lib/str';
+import React, {forwardRef} from 'react';
+import _ from 'underscore';
+import {useTrackedState} from '../libs/onyxContextStore';
+
+/**
+ * @param {String} key
+ * @returns {String} collection key or empty
+ */
+function extractCollectionKeyFromMemberKey(key) {
+    const keyParts = key.split('_');
+    if (keyParts.length <= 1) {
+        return '';
+    }
+
+    if (keyParts[1] === '') {
+        return '';
+    }
+
+    return `${keyParts[0]}_`;
+}
+
+export default function withOnyxContext(mapping) {
+    return (WrappedComponent) => {
+        const WithOnyx2 = (props) => {
+            // Welcome to the future!
+            // This new version of withOnyx() uses black magic to only update wrapped component when the exact state they care about changes
+            const onyxState = useTrackedState();
+
+            // "initWithStoredValues" doesn't work yet...
+            const propsToPass = _.reduce(mapping, (finalProps, value, key) => {
+                const keyInOnyxState = Str.result(value.key, props);
+                const collectionKey = extractCollectionKeyFromMemberKey(keyInOnyxState);
+                const result = collectionKey ? (onyxState[collectionKey] || {})[keyInOnyxState] : onyxState[keyInOnyxState];
+
+                // eslint-disable-next-line no-param-reassign
+                finalProps[key] = !_.isNull(result) ? result : undefined;
+                return finalProps;
+            }, {});
+
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            return <WrappedComponent {...props} ref={props.forwardedRef} {...propsToPass} />;
+        };
+
+        return forwardRef((props, ref) => (
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            <WithOnyx2 {...props} forwardedRef={ref} />
+        ));
+    };
+}

--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Onyx, {withOnyx} from 'react-native-onyx';
+import Onyx from 'react-native-onyx';
 import moment from 'moment';
 import _ from 'underscore';
 import lodashGet from 'lodash/get';
@@ -36,6 +36,7 @@ import * as App from '../../actions/App';
 import * as Session from '../../actions/Session';
 import LogOutPreviousUserPage from '../../../pages/LogOutPreviousUserPage';
 import ConciergePage from '../../../pages/ConciergePage';
+import withOnyxContext from '../../../components/withOnyxContext';
 
 let currentUserEmail;
 Onyx.connect({
@@ -319,7 +320,7 @@ class AuthScreens extends React.Component {
 AuthScreens.propTypes = propTypes;
 export default compose(
     withWindowDimensions,
-    withOnyx({
+    withOnyxContext({
         session: {
             key: ONYXKEYS.SESSION,
         },

--- a/src/libs/Navigation/AppNavigator/MainDrawerNavigator.js
+++ b/src/libs/Navigation/AppNavigator/MainDrawerNavigator.js
@@ -13,6 +13,7 @@ import ReportScreen from '../../../pages/home/ReportScreen';
 import SidebarScreen from '../../../pages/home/sidebar/SidebarScreen';
 import BaseDrawerNavigator from './BaseDrawerNavigator';
 import * as ReportUtils from '../../ReportUtils';
+import withOnyxContext from '../../../components/withOnyxContext';
 
 const propTypes = {
     /** Available reports that would be displayed in this navigator */
@@ -85,7 +86,7 @@ MainDrawerNavigator.propTypes = propTypes;
 MainDrawerNavigator.defaultProps = defaultProps;
 MainDrawerNavigator.displayName = 'MainDrawerNavigator';
 
-export default withOnyx({
+export default withOnyxContext({
     reports: {
         key: ONYXKEYS.COLLECTION.REPORT,
     },

--- a/src/libs/OnyxContext.js
+++ b/src/libs/OnyxContext.js
@@ -1,0 +1,85 @@
+/* eslint-disable react/prop-types */
+import Onyx from 'react-native-onyx';
+import _ from 'underscore';
+import React, {useState, useEffect} from 'react';
+import {Provider, useSetState} from './onyxContextStore';
+
+function isCollectionKey(key) {
+    const keyParts = key.split('_');
+    return keyParts.length === 2 && keyParts[1] === '';
+}
+
+/**
+ * @param {Object} object
+ * @returns {Object}
+ */
+function flattenOnyxKeys(object) {
+    return _.reduce(object, (prev, value) => {
+        if (_.isObject(value)) {
+            return [...prev, ...flattenOnyxKeys(value)];
+        }
+
+        prev.push(value);
+        return prev;
+    }, []);
+}
+
+const OnyxStateUpdater = (props) => {
+    const setState = useSetState();
+
+    // Set up Onyx subscriptions here once and update the state on change
+    useEffect(() => {
+        let keysConnected = 0;
+        const keys = flattenOnyxKeys(props.onyxKeys);
+
+        keys.forEach((key) => {
+            if (isCollectionKey(key)) {
+                Onyx.connect({
+                    key,
+                    callback: (val, memberKey) => {
+                        setState(prev => ({
+                            ...prev,
+                            [key]: {
+                                ...prev[key],
+                                [memberKey]: val,
+                            },
+                        }));
+                        keysConnected++;
+                        if (keysConnected === keys.length) {
+                            props.onAllKeysLoaded();
+                        }
+                    },
+                });
+                return;
+            }
+
+            Onyx.connect({
+                key,
+                callback: (val) => {
+                    setState(prev => ({
+                        ...prev,
+                        [key]: val,
+                    }));
+                    keysConnected++;
+                    if (keysConnected === keys.length) {
+                        props.onAllKeysLoaded();
+                    }
+                },
+            });
+        });
+    }, []);
+
+    return null;
+};
+
+const OnyxStateProvider = (props) => {
+    const [isInitialDataReady, setIsInitialDataReady] = useState(false);
+    return (
+        <Provider>
+            <OnyxStateUpdater onyxKeys={props.onyxKeys} onAllKeysLoaded={() => setIsInitialDataReady(true)} />
+            {isInitialDataReady && props.children}
+        </Provider>
+    );
+};
+
+export default OnyxStateProvider;

--- a/src/libs/onyxContextStore.js
+++ b/src/libs/onyxContextStore.js
@@ -1,0 +1,14 @@
+import {createContainer} from 'react-tracked';
+import {useState} from 'react';
+
+const useValue = () => useState({});
+
+const {
+    Provider,
+    useTrackedState,
+    useUpdate: useSetState,
+} = createContainer(useValue);
+
+export {
+    Provider, useTrackedState, useSetState,
+};

--- a/src/pages/home/HeaderView.js
+++ b/src/pages/home/HeaderView.js
@@ -2,7 +2,6 @@ import _ from 'underscore';
 import React from 'react';
 import {View, Pressable} from 'react-native';
 import PropTypes from 'prop-types';
-import {withOnyx} from 'react-native-onyx';
 import lodashGet from 'lodash/get';
 import styles from '../../styles/styles';
 import ONYXKEYS from '../../ONYXKEYS';
@@ -26,6 +25,7 @@ import Text from '../../components/Text';
 import Tooltip from '../../components/Tooltip';
 import variables from '../../styles/variables';
 import colors from '../../styles/colors';
+import withOnyxContext from '../../components/withOnyxContext';
 
 const propTypes = {
     /** Toggles the navigationMenu open and closed */
@@ -190,7 +190,7 @@ HeaderView.defaultProps = defaultProps;
 export default compose(
     withWindowDimensions,
     withLocalize,
-    withOnyx({
+    withOnyxContext({
         report: {
             key: ({reportID}) => `${ONYXKEYS.COLLECTION.REPORT}${reportID}`,
         },

--- a/src/pages/home/ReportScreen.js
+++ b/src/pages/home/ReportScreen.js
@@ -30,6 +30,7 @@ import withWindowDimensions, {windowDimensionsPropTypes} from '../../components/
 import OfflineIndicator from '../../components/OfflineIndicator';
 import OfflineWithFeedback from '../../components/OfflineWithFeedback';
 import withDrawerState, {withDrawerPropTypes} from '../../components/withDrawerState';
+import withOnyxContext from '../../components/withOnyxContext';
 
 const propTypes = {
     /** Navigation route context info provided by react navigation */
@@ -314,7 +315,7 @@ export default compose(
     withWindowDimensions,
     withDrawerState,
     withNetwork(),
-    withOnyx({
+    withOnyxContext({
         isSidebarLoaded: {
             key: ONYXKEYS.IS_SIDEBAR_LOADED,
         },

--- a/src/pages/home/report/ContextMenu/BaseReportActionContextMenu.js
+++ b/src/pages/home/report/ContextMenu/BaseReportActionContextMenu.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import {View} from 'react-native';
-import {withOnyx} from 'react-native-onyx';
 import _ from 'underscore';
 import PropTypes from 'prop-types';
 import getReportActionContextMenuStyles from '../../../../styles/getReportActionContextMenuStyles';
@@ -14,6 +13,7 @@ import ContextMenuActions, {CONTEXT_MENU_TYPES} from './ContextMenuActions';
 import compose from '../../../../libs/compose';
 import withWindowDimensions, {windowDimensionsPropTypes} from '../../../../components/withWindowDimensions';
 import ONYXKEYS from '../../../../ONYXKEYS';
+import withOnyxContext from '../../../../components/withOnyxContext';
 
 const propTypes = {
     /** String representing the context menu type [LINK, REPORT_ACTION] which controls context menu choices  */
@@ -71,7 +71,7 @@ BaseReportActionContextMenu.defaultProps = defaultProps;
 
 export default compose(
     withLocalize,
-    withOnyx({
+    withOnyxContext({
         betas: {
             key: ONYXKEYS.BETAS,
         },

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -7,7 +7,6 @@ import {
 } from 'react-native';
 import _ from 'underscore';
 import lodashGet from 'lodash/get';
-import {withOnyx} from 'react-native-onyx';
 import lodashIntersection from 'lodash/intersection';
 import styles from '../../../styles/styles';
 import themeColors from '../../../styles/themes/default';
@@ -45,6 +44,7 @@ import toggleReportActionComposeView from '../../../libs/toggleReportActionCompo
 import OfflineIndicator from '../../../components/OfflineIndicator';
 import ExceededCommentLength from '../../../components/ExceededCommentLength';
 import withNavigationFocus from '../../../components/withNavigationFocus';
+import withOnyxContext from '../../../components/withOnyxContext';
 
 const propTypes = {
     /** Beta features list */
@@ -709,7 +709,7 @@ export default compose(
     withNetwork(),
     withPersonalDetails(),
     withCurrentUserPersonalDetails,
-    withOnyx({
+    withOnyxContext({
         betas: {
             key: ONYXKEYS.BETAS,
         },

--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -33,6 +33,7 @@ import * as User from '../../../libs/actions/User';
 import * as ReportUtils from '../../../libs/ReportUtils';
 import OfflineWithFeedback from '../../../components/OfflineWithFeedback';
 import * as ReportActions from '../../../libs/actions/ReportActions';
+import withOnyxContext from '../../../components/withOnyxContext';
 
 const propTypes = {
     /** Report for this action */
@@ -249,7 +250,7 @@ export default compose(
             return lodashGet(drafts, draftKey, '');
         },
     }),
-    withOnyx({
+    withOnyxContext({
         blockedFromConcierge: {
             key: ONYXKEYS.NVP_BLOCKED_FROM_CONCIERGE,
         },

--- a/src/pages/home/report/ReportActionItemCreated.js
+++ b/src/pages/home/report/ReportActionItemCreated.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import {Pressable, View} from 'react-native';
 import lodashGet from 'lodash/get';
-import {withOnyx} from 'react-native-onyx';
 import PropTypes from 'prop-types';
 import ONYXKEYS from '../../../ONYXKEYS';
 import RoomHeaderAvatars from '../../../components/RoomHeaderAvatars';
@@ -11,6 +10,7 @@ import * as ReportUtils from '../../../libs/ReportUtils';
 import styles from '../../../styles/styles';
 import OfflineWithFeedback from '../../../components/OfflineWithFeedback';
 import * as Report from '../../../libs/actions/Report';
+import withOnyxContext from '../../../components/withOnyxContext';
 
 const propTypes = {
     /** The report currently being looked at */
@@ -76,7 +76,7 @@ ReportActionItemCreated.defaultProps = defaultProps;
 ReportActionItemCreated.propTypes = propTypes;
 ReportActionItemCreated.displayName = 'ReportActionItemCreated';
 
-export default withOnyx({
+export default withOnyxContext({
     report: {
         key: ({reportID}) => `${ONYXKEYS.COLLECTION.REPORT}${reportID}`,
     },

--- a/src/pages/home/report/ReportTypingIndicator.js
+++ b/src/pages/home/report/ReportTypingIndicator.js
@@ -11,6 +11,7 @@ import * as PersonalDetails from '../../../libs/actions/PersonalDetails';
 import withLocalize, {withLocalizePropTypes} from '../../../components/withLocalize';
 import Text from '../../../components/Text';
 import TextWithEllipsis from '../../../components/TextWithEllipsis';
+import withOnyxContext from '../../../components/withOnyxContext';
 
 const propTypes = {
     /** Key-value pairs of user logins and whether or not they are typing. Keys are logins. */
@@ -95,7 +96,7 @@ ReportTypingIndicator.defaultProps = defaultProps;
 export default compose(
     withLocalize,
     withNetwork(),
-    withOnyx({
+    withOnyxContext({
         userTypingStatuses: {
             key: ({reportID}) => `${ONYXKEYS.COLLECTION.REPORT_USER_IS_TYPING}${reportID}`,
         },

--- a/src/pages/home/sidebar/SidebarLinks.js
+++ b/src/pages/home/sidebar/SidebarLinks.js
@@ -2,7 +2,6 @@ import React from 'react';
 import {View, TouchableOpacity} from 'react-native';
 import _ from 'underscore';
 import PropTypes from 'prop-types';
-import {withOnyx} from 'react-native-onyx';
 import styles from '../../../styles/styles';
 import * as StyleUtils from '../../../styles/StyleUtils';
 import ONYXKEYS from '../../../ONYXKEYS';
@@ -26,6 +25,7 @@ import Timing from '../../../libs/actions/Timing';
 import reportActionPropTypes from '../report/reportActionPropTypes';
 import LHNOptionsList from '../../../components/LHNOptionsList/LHNOptionsList';
 import SidebarUtils from '../../../libs/SidebarUtils';
+import withOnyxContext from '../../../components/withOnyxContext';
 
 const propTypes = {
     /** Toggles the navigation menu open and closed */
@@ -178,7 +178,7 @@ export default compose(
     withLocalize,
     withCurrentUserPersonalDetails,
     withWindowDimensions,
-    withOnyx({
+    withOnyxContext({
         // Note: It is very important that the keys subscribed to here are the same
         // keys that are subscribed to at the top of SidebarUtils.js. If there was a key missing from here and data was updated
         // for that key, then there would be no re-render and the options wouldn't reflect the new data because SidebarUtils.getOrderedReportIDs() wouldn't be triggered.

--- a/src/pages/home/sidebar/SidebarScreen/index.js
+++ b/src/pages/home/sidebar/SidebarScreen/index.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import {withOnyx} from 'react-native-onyx';
 import compose from '../../../../libs/compose';
 import withWindowDimensions from '../../../../components/withWindowDimensions';
 import withLocalize from '../../../../components/withLocalize';
@@ -7,6 +6,7 @@ import ONYXKEYS from '../../../../ONYXKEYS';
 import {sidebarPropTypes, sidebarDefaultProps} from './sidebarPropTypes';
 import BaseSidebarScreen from './BaseSidebarScreen';
 import withNavigation from '../../../../components/withNavigation';
+import withOnyxContext from '../../../../components/withOnyxContext';
 
 const SidebarScreen = (props) => {
     let baseSidebarScreen = null;
@@ -43,7 +43,7 @@ export default compose(
     withNavigation,
     withLocalize,
     withWindowDimensions,
-    withOnyx({
+    withOnyxContext({
         allPolicies: {
             key: ONYXKEYS.COLLECTION.POLICY,
         },

--- a/src/pages/home/sidebar/SidebarScreen/index.native.js
+++ b/src/pages/home/sidebar/SidebarScreen/index.native.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import {withOnyx} from 'react-native-onyx';
 import compose from '../../../../libs/compose';
 import withWindowDimensions from '../../../../components/withWindowDimensions';
 import withLocalize from '../../../../components/withLocalize';
@@ -7,6 +6,7 @@ import ONYXKEYS from '../../../../ONYXKEYS';
 import {sidebarPropTypes, sidebarDefaultProps} from './sidebarPropTypes';
 import BaseSidebarScreen from './BaseSidebarScreen';
 import withNavigation from '../../../../components/withNavigation';
+import withOnyxContext from '../../../../components/withOnyxContext';
 
 // eslint-disable-next-line react/jsx-props-no-spreading
 const SidebarScreen = props => <BaseSidebarScreen {...props} />;
@@ -19,7 +19,7 @@ export default compose(
     withNavigation,
     withLocalize,
     withWindowDimensions,
-    withOnyx({
+    withOnyxContext({
         allPolicies: {
             key: ONYXKEYS.COLLECTION.POLICY,
         },

--- a/src/pages/settings/AddSecondaryLoginPage.js
+++ b/src/pages/settings/AddSecondaryLoginPage.js
@@ -20,6 +20,7 @@ import FixedFooter from '../../components/FixedFooter';
 import TextInput from '../../components/TextInput';
 import userPropTypes from './userPropTypes';
 import * as LoginUtils from '../../libs/LoginUtils';
+import withOnyxContext from '../../components/withOnyxContext';
 
 const propTypes = {
     /* Onyx Props */
@@ -162,7 +163,7 @@ AddSecondaryLoginPage.defaultProps = defaultProps;
 
 export default compose(
     withLocalize,
-    withOnyx({
+    withOnyxContext({
         user: {
             key: ONYXKEYS.USER,
         },

--- a/src/pages/workspace/WorkspaceInitialPage.js
+++ b/src/pages/workspace/WorkspaceInitialPage.js
@@ -28,6 +28,7 @@ import * as ReimbursementAccount from '../../libs/actions/ReimbursementAccount';
 import ONYXKEYS from '../../ONYXKEYS';
 import policyMemberPropType from '../policyMemberPropType';
 import OfflineWithFeedback from '../../components/OfflineWithFeedback';
+import withOnyxContext from '../../components/withOnyxContext';
 
 const propTypes = {
     ...policyPropTypes,
@@ -250,7 +251,7 @@ WorkspaceInitialPage.defaultProps = defaultProps;
 export default compose(
     withLocalize,
     withPolicy,
-    withOnyx({
+    withOnyxContext({
         policyMemberList: {
             key: ({policy}) => `${ONYXKEYS.COLLECTION.POLICY_MEMBER_LIST}${policy.id}`,
         },

--- a/src/pages/workspace/WorkspaceInvitePage.js
+++ b/src/pages/workspace/WorkspaceInvitePage.js
@@ -24,6 +24,7 @@ import withPolicy, {policyPropTypes, policyDefaultProps} from './withPolicy';
 import {withNetwork} from '../../components/OnyxProvider';
 import FullPageNotFoundView from '../../components/BlockingViews/FullPageNotFoundView';
 import networkPropTypes from '../../components/networkPropTypes';
+import withOnyxContext from '../../components/withOnyxContext';
 
 const personalDetailsPropTypes = PropTypes.shape({
     /** The login of the person (either email or phone number) */
@@ -354,7 +355,7 @@ export default compose(
     withLocalize,
     withPolicy,
     withNetwork(),
-    withOnyx({
+    withOnyxContext({
         personalDetails: {
             key: ONYXKEYS.PERSONAL_DETAILS,
         },

--- a/src/pages/workspace/WorkspaceMembersPage.js
+++ b/src/pages/workspace/WorkspaceMembersPage.js
@@ -31,6 +31,7 @@ import OfflineWithFeedback from '../../components/OfflineWithFeedback';
 import {withNetwork} from '../../components/OnyxProvider';
 import FullPageNotFoundView from '../../components/BlockingViews/FullPageNotFoundView';
 import networkPropTypes from '../../components/networkPropTypes';
+import withOnyxContext from '../../components/withOnyxContext';
 
 const propTypes = {
     /** The personal details of the person who is logged in */
@@ -369,7 +370,7 @@ export default compose(
     withWindowDimensions,
     withPolicy,
     withNetwork(),
-    withOnyx({
+    withOnyxContext({
         personalDetails: {
             key: ONYXKEYS.PERSONAL_DETAILS,
         },

--- a/src/pages/workspace/WorkspaceNewRoomPage.js
+++ b/src/pages/workspace/WorkspaceNewRoomPage.js
@@ -20,6 +20,7 @@ import FixedFooter from '../../components/FixedFooter';
 import Permissions from '../../libs/Permissions';
 import Log from '../../libs/Log';
 import * as ValidationUtils from '../../libs/ValidationUtils';
+import withOnyxContext from '../../components/withOnyxContext';
 
 const propTypes = {
     /** All reports shared with the user */
@@ -195,7 +196,7 @@ WorkspaceNewRoomPage.propTypes = propTypes;
 WorkspaceNewRoomPage.defaultProps = defaultProps;
 
 export default compose(
-    withOnyx({
+    withOnyxContext({
         betas: {
             key: ONYXKEYS.BETAS,
         },

--- a/src/pages/workspace/WorkspacePageWithSections.js
+++ b/src/pages/workspace/WorkspacePageWithSections.js
@@ -18,6 +18,7 @@ import userPropTypes from '../settings/userPropTypes';
 import withPolicy from './withPolicy';
 import {withNetwork} from '../../components/OnyxProvider';
 import networkPropTypes from '../../components/networkPropTypes';
+import withOnyxContext from '../../components/withOnyxContext';
 
 const propTypes = {
     /** Information about the network from Onyx */
@@ -123,7 +124,7 @@ WorkspacePageWithSections.defaultProps = defaultProps;
 
 export default compose(
     withLocalize,
-    withOnyx({
+    withOnyxContext({
         user: {
             key: ONYXKEYS.USER,
         },

--- a/src/pages/workspace/WorkspaceResetBankAccountModal.js
+++ b/src/pages/workspace/WorkspaceResetBankAccountModal.js
@@ -13,6 +13,7 @@ import bankAccountPropTypes from '../../components/bankAccountPropTypes';
 import Text from '../../components/Text';
 import styles from '../../styles/styles';
 import BankAccount from '../../libs/models/BankAccount';
+import withOnyxContext from '../../components/withOnyxContext';
 
 const propTypes = {
     /** Reimbursement account data */
@@ -63,10 +64,12 @@ WorkspaceResetBankAccountModal.defaultProps = defaultProps;
 
 export default compose(
     withLocalize,
-    withOnyx({
+    withOnyxContext({
         reimbursementAccount: {
             key: ONYXKEYS.REIMBURSEMENT_ACCOUNT,
         },
+    }),
+    withOnyx({
         bankAccountList: {
             key: ONYXKEYS.BANK_ACCOUNT_LIST,
             initWithStoredValues: false,

--- a/src/pages/workspace/WorkspaceSettingsPage.js
+++ b/src/pages/workspace/WorkspaceSettingsPage.js
@@ -23,6 +23,7 @@ import withPolicy, {policyPropTypes, policyDefaultProps} from './withPolicy';
 import {withNetwork} from '../../components/OnyxProvider';
 import OfflineWithFeedback from '../../components/OfflineWithFeedback';
 import FullPageNotFoundView from '../../components/BlockingViews/FullPageNotFoundView';
+import withOnyxContext from '../../components/withOnyxContext';
 
 const propTypes = {
     ...policyPropTypes,
@@ -163,7 +164,7 @@ WorkspaceSettingsPage.defaultProps = defaultProps;
 
 export default compose(
     withPolicy,
-    withOnyx({
+    withOnyxContext({
         currencyList: {key: ONYXKEYS.CURRENCY_LIST},
     }),
     withLocalize,

--- a/src/pages/workspace/bills/WorkspaceBillsFirstSection.js
+++ b/src/pages/workspace/bills/WorkspaceBillsFirstSection.js
@@ -15,6 +15,7 @@ import compose from '../../../libs/compose';
 import ONYXKEYS from '../../../ONYXKEYS';
 import userPropTypes from '../../settings/userPropTypes';
 import TextLink from '../../../components/TextLink';
+import withOnyxContext from '../../../components/withOnyxContext';
 
 const propTypes = {
     /** The policy ID currently being configured */
@@ -78,7 +79,7 @@ WorkspaceBillsFirstSection.displayName = 'WorkspaceBillsFirstSection';
 
 export default compose(
     withLocalize,
-    withOnyx({
+    withOnyxContext({
         session: {
             key: ONYXKEYS.SESSION,
         },

--- a/src/pages/workspace/card/WorkspaceCardVBANoECardView.js
+++ b/src/pages/workspace/card/WorkspaceCardVBANoECardView.js
@@ -12,6 +12,7 @@ import * as User from '../../../libs/actions/User';
 import ONYXKEYS from '../../../ONYXKEYS';
 import compose from '../../../libs/compose';
 import CONST from '../../../CONST';
+import withOnyxContext from '../../../components/withOnyxContext';
 
 const propTypes = {
     ...withLocalizePropTypes,
@@ -56,7 +57,7 @@ WorkspaceCardVBANoECardView.displayName = 'WorkspaceCardVBANoECardView';
 
 export default compose(
     withLocalize,
-    withOnyx({
+    withOnyxContext({
         user: {
             key: ONYXKEYS.USER,
         },


### PR DESCRIPTION
cc @roryabraham 

### Details

Proof of Concept for switching `withOnyx()` calls to get their values from a global state provider + consumers which get updated "magically" when the properties of the state they are interested in change.

Not optimized and haven't benchmarked. It seems a bit slower or equivalent than what we have now so I think needs tweaking. I am also sure there are things about this `react-tracked` library that I don't quite understand. 

But the concept is pretty interesting -> https://react-tracked.js.org/docs/introduction/

This could be further improved on by having some kind of more specific selector e.g. if a component only needs one field it could in theory do:

```js
withTrackedState((state, props) => ({
    report: state[`${ONYXKEYS.COLLECTION.REPORT}${props.reportID}`].notificationPreference,
}))(NotificationPreferenceComponent);
```

There are also other libraries in the same realm like [`valtio`](https://github.com/pmndrs/valtio) that look interesting.