### PR TITLE
Remove message and error on ResendValidationForm load

### DIFF
--- a/src/libs/actions/Session/index.js
+++ b/src/libs/actions/Session/index.js
@@ -385,7 +385,8 @@ function cleanupSession() {
 function clearAccountMessages() {
     Onyx.merge(ONYXKEYS.ACCOUNT, {
         success: '',
-        errors: [],
+        errors: null,
+        message: null,
         isLoading: false,
     });
 }

--- a/src/pages/SetPasswordPage.js
+++ b/src/pages/SetPasswordPage.js
@@ -80,6 +80,10 @@ class SetPasswordPage extends Component {
         };
     }
 
+    componentWillUnmount() {
+        Session.clearAccountMessages();
+    }
+
     validateAndSubmitForm() {
         if (!this.state.isFormValid) {
             return;

--- a/src/pages/signin/ResendValidationForm.js
+++ b/src/pages/signin/ResendValidationForm.js
@@ -47,60 +47,69 @@ const defaultProps = {
     account: {},
 };
 
-const ResendValidationForm = (props) => {
-    const isSMSLogin = Str.isSMSLogin(props.credentials.login);
-    const login = isSMSLogin ? props.toLocalPhone(Str.removeSMSDomain(props.credentials.login)) : props.credentials.login;
-    const loginType = (isSMSLogin ? props.translate('common.phone') : props.translate('common.email')).toLowerCase();
+class ResendValidationForm extends React.Component {
+    constructor(props) {
+        super(props);
 
-    return (
-        <>
-            <View style={[styles.mt3, styles.flexRow, styles.alignItemsCenter, styles.justifyContentStart]}>
-                <Avatar
-                    source={ReportUtils.getDefaultAvatar(props.credentials.login)}
-                    imageStyles={[styles.mr2]}
-                />
-                <View style={[styles.flex1]}>
-                    <Text style={[styles.textStrong]}>
-                        {login}
+        if (this.props.account.errors || this.props.account.message) {
+            Session.clearAccountMessages();
+        }
+    }
+
+    render() {
+        const isSMSLogin = Str.isSMSLogin(this.props.credentials.login);
+        const login = isSMSLogin ? this.props.toLocalPhone(Str.removeSMSDomain(this.props.credentials.login)) : this.props.credentials.login;
+        const loginType = (isSMSLogin ? this.props.translate('common.phone') : this.props.translate('common.email')).toLowerCase();
+
+        return (
+            <>
+                <View style={[styles.mt3, styles.flexRow, styles.alignItemsCenter, styles.justifyContentStart]}>
+                    <Avatar
+                        source={ReportUtils.getDefaultAvatar(this.props.credentials.login)}
+                        imageStyles={[styles.mr2]}
+                    />
+                    <View style={[styles.flex1]}>
+                        <Text style={[styles.textStrong]}>
+                            {login}
+                        </Text>
+                    </View>
+                </View>
+                <View style={[styles.mv5]}>
+                    <Text>
+                        {this.props.translate('resendValidationForm.weSentYouMagicSignInLink', {login, loginType})}
                     </Text>
                 </View>
-            </View>
-            <View style={[styles.mv5]}>
-                <Text>
-                    {props.translate('resendValidationForm.weSentYouMagicSignInLink', {login, loginType})}
-                </Text>
-            </View>
-            {!_.isEmpty(props.account.message) && (
+                {!_.isEmpty(this.props.account.message) && (
 
-                // DotIndicatorMessage mostly expects onyxData errors so we need to mock an object so that the messages looks similar to prop.account.errors
-                <DotIndicatorMessage style={[styles.mb5]} type="success" messages={{0: props.account.message}} />
-            )}
-            {!_.isEmpty(props.account.errors) && (
-                <DotIndicatorMessage style={[styles.mb5]} type="error" messages={props.account.errors} />
-            )}
-            <View style={[styles.mb4, styles.flexRow, styles.justifyContentBetween, styles.alignItemsCenter]}>
-                <TouchableOpacity onPress={() => redirectToSignIn()}>
-                    <Text>
-                        {props.translate('common.back')}
-                    </Text>
-                </TouchableOpacity>
-                <Button
-                    medium
-                    success
-                    text={props.translate('resendValidationForm.resendLink')}
-                    isLoading={props.account.isLoading}
-                    onPress={() => (props.account.validated ? Session.resendResetPassword() : Session.resendValidationLink())}
-                    isDisabled={props.network.isOffline}
-                />
-            </View>
-            <OfflineIndicator containerStyles={[styles.mv1]} />
-        </>
-    );
-};
+                    // DotIndicatorMessage mostly expects onyxData errors so we need to mock an object so that the messages looks similar to prop.account.errors
+                    <DotIndicatorMessage style={[styles.mb5]} type="success" messages={{0: this.props.account.message}} />
+                )}
+                {!_.isEmpty(this.props.account.errors) && (
+                    <DotIndicatorMessage style={[styles.mb5]} type="error" messages={this.props.account.errors} />
+                )}
+                <View style={[styles.mb4, styles.flexRow, styles.justifyContentBetween, styles.alignItemsCenter]}>
+                    <TouchableOpacity onPress={() => redirectToSignIn()}>
+                        <Text>
+                            {this.props.translate('common.back')}
+                        </Text>
+                    </TouchableOpacity>
+                    <Button
+                        medium
+                        success
+                        text={this.props.translate('resendValidationForm.resendLink')}
+                        isLoading={this.props.account.isLoading}
+                        onPress={() => (this.props.account.validated ? Session.resendResetPassword() : Session.resendValidationLink())}
+                        isDisabled={this.props.network.isOffline}
+                    />
+                </View>
+                <OfflineIndicator containerStyles={[styles.mv1]} />
+            </>
+        );
+    }
+}
 
 ResendValidationForm.propTypes = propTypes;
 ResendValidationForm.defaultProps = defaultProps;
-ResendValidationForm.displayName = 'ResendValidationForm';
 
 export default compose(
     withLocalize,

--- a/src/pages/signin/ResendValidationForm.js
+++ b/src/pages/signin/ResendValidationForm.js
@@ -47,69 +47,60 @@ const defaultProps = {
     account: {},
 };
 
-class ResendValidationForm extends React.Component {
-    constructor(props) {
-        super(props);
+const ResendValidationForm = (props) => {
+    const isSMSLogin = Str.isSMSLogin(props.credentials.login);
+    const login = isSMSLogin ? props.toLocalPhone(Str.removeSMSDomain(props.credentials.login)) : props.credentials.login;
+    const loginType = (isSMSLogin ? props.translate('common.phone') : props.translate('common.email')).toLowerCase();
 
-        if (this.props.account.errors || this.props.account.message) {
-            Session.clearAccountMessages();
-        }
-    }
-
-    render() {
-        const isSMSLogin = Str.isSMSLogin(this.props.credentials.login);
-        const login = isSMSLogin ? this.props.toLocalPhone(Str.removeSMSDomain(this.props.credentials.login)) : this.props.credentials.login;
-        const loginType = (isSMSLogin ? this.props.translate('common.phone') : this.props.translate('common.email')).toLowerCase();
-
-        return (
-            <>
-                <View style={[styles.mt3, styles.flexRow, styles.alignItemsCenter, styles.justifyContentStart]}>
-                    <Avatar
-                        source={ReportUtils.getDefaultAvatar(this.props.credentials.login)}
-                        imageStyles={[styles.mr2]}
-                    />
-                    <View style={[styles.flex1]}>
-                        <Text style={[styles.textStrong]}>
-                            {login}
-                        </Text>
-                    </View>
-                </View>
-                <View style={[styles.mv5]}>
-                    <Text>
-                        {this.props.translate('resendValidationForm.weSentYouMagicSignInLink', {login, loginType})}
+    return (
+        <>
+            <View style={[styles.mt3, styles.flexRow, styles.alignItemsCenter, styles.justifyContentStart]}>
+                <Avatar
+                    source={ReportUtils.getDefaultAvatar(props.credentials.login)}
+                    imageStyles={[styles.mr2]}
+                />
+                <View style={[styles.flex1]}>
+                    <Text style={[styles.textStrong]}>
+                        {login}
                     </Text>
                 </View>
-                {!_.isEmpty(this.props.account.message) && (
+            </View>
+            <View style={[styles.mv5]}>
+                <Text>
+                    {props.translate('resendValidationForm.weSentYouMagicSignInLink', {login, loginType})}
+                </Text>
+            </View>
+            {!_.isEmpty(props.account.message) && (
 
-                    // DotIndicatorMessage mostly expects onyxData errors so we need to mock an object so that the messages looks similar to prop.account.errors
-                    <DotIndicatorMessage style={[styles.mb5]} type="success" messages={{0: this.props.account.message}} />
-                )}
-                {!_.isEmpty(this.props.account.errors) && (
-                    <DotIndicatorMessage style={[styles.mb5]} type="error" messages={this.props.account.errors} />
-                )}
-                <View style={[styles.mb4, styles.flexRow, styles.justifyContentBetween, styles.alignItemsCenter]}>
-                    <TouchableOpacity onPress={() => redirectToSignIn()}>
-                        <Text>
-                            {this.props.translate('common.back')}
-                        </Text>
-                    </TouchableOpacity>
-                    <Button
-                        medium
-                        success
-                        text={this.props.translate('resendValidationForm.resendLink')}
-                        isLoading={this.props.account.isLoading}
-                        onPress={() => (this.props.account.validated ? Session.resendResetPassword() : Session.resendValidationLink())}
-                        isDisabled={this.props.network.isOffline}
-                    />
-                </View>
-                <OfflineIndicator containerStyles={[styles.mv1]} />
-            </>
-        );
-    }
-}
+                // DotIndicatorMessage mostly expects onyxData errors so we need to mock an object so that the messages looks similar to prop.account.errors
+                <DotIndicatorMessage style={[styles.mb5]} type="success" messages={{0: props.account.message}} />
+            )}
+            {!_.isEmpty(props.account.errors) && (
+                <DotIndicatorMessage style={[styles.mb5]} type="error" messages={props.account.errors} />
+            )}
+            <View style={[styles.mb4, styles.flexRow, styles.justifyContentBetween, styles.alignItemsCenter]}>
+                <TouchableOpacity onPress={() => redirectToSignIn()}>
+                    <Text>
+                        {props.translate('common.back')}
+                    </Text>
+                </TouchableOpacity>
+                <Button
+                    medium
+                    success
+                    text={props.translate('resendValidationForm.resendLink')}
+                    isLoading={props.account.isLoading}
+                    onPress={() => (props.account.validated ? Session.resendResetPassword() : Session.resendValidationLink())}
+                    isDisabled={props.network.isOffline}
+                />
+            </View>
+            <OfflineIndicator containerStyles={[styles.mv1]} />
+        </>
+    );
+};
 
 ResendValidationForm.propTypes = propTypes;
 ResendValidationForm.defaultProps = defaultProps;
+ResendValidationForm.displayName = 'ResendValidationForm';
 
 export default compose(
     withLocalize,


### PR DESCRIPTION
cc @MonilBhavsar

### Details
Clears `message` and `errors` when rendering `ResendValidationForm`.

### Fixed Issues
$ https://github.com/Expensify/App/issues/11186

### Tests
On android and iOS only:

1. Enter your email in the login page
2. Tap Continue
3. Tap `Forgot?`
4. In your terminal, run the command below to send a deep link to the simulator:

Android:
```
adb shell am start -W -a android.intent.action.VIEW -d "http://new.expensify.com/setpassword/2/HFSKDF"
```
iOS:
```
xcrun simctl openurl booted https://new.expensify.com/setpassword/2/HFSKDF
```
7. Type a new password and tap `Set password`
8. This should result in an error for invalid link
10. On android: Tap on back button from the android OS
11. On iOS: Swipe right to go back
12. You should go back to the `Forgot?` page and the `Link has been re-sent` or error messages should disappear shortly after

- [x] Verify that no errors appear in the JS console

### PR Review Checklist

#### Contributor (PR Author) Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] Any functional components have the `displayName` property
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

<details>
<summary><h4>PR Reviewer Checklist</h4>

The Contributor+ will copy/paste it into a new comment and complete it after the author checklist is completed
</summary>

- [x] I have verified the author checklist is complete (all boxes are checked off).
- [x] I verified the correct issue is linked in the `### Fixed Issues` section above
- [x] I verified testing steps are clear and they cover the changes made in this PR
    - [x] I verified the steps for local testing are in the `Tests` section
    - [x] I verified the steps for Staging and/or Production testing are in the `QA steps` section
    - [x] I verified the steps cover any possible failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [x] I checked that screenshots or videos are included for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I verified tests pass on **all platforms** & I tested again on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] If there are any errors in the console that are unrelated to this PR, I either fixed them (preferred) or linked to where I reported them in Slack
- [x] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`).
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I verified that this PR follows the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I verified other components that can be impacted by these changes have been tested, and I retested again (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` have been tested & I retested again)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] Any functional components have the `displayName` property
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] I have checked off every checkbox in the PR reviewer checklist, including those that don't apply to this PR.

</details>

### QA Steps

On android and iOS only:

1. Enter your email in the login page
2. Tap Continue
3. Tap `Forgot?`
4. Tap the Resent link button twice, you should see a `Link has been re-sent` message
6. Go to you email and find the magic sign-in link email from Concierge (you should have received a few of them)
7. Tap the link from the oldest email, this link should be invalid now but that's what we want here
8. Type your new password
9. Tap `Set Password`, see the invalid link error
10. On android: Tap on back button from the android OS
11. On iOS: Swipe right to go back
13. You should go back to the `Forgot?` page, and notice that the `Link has been re-sent` or any error messages disappear (there might be a small delay for them to disappear)

- [ ] Verify that no errors appear in the JS console

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web - Chrome
<!-- Insert screenshots of your changes on the web platform (from chrome mobile browser)-->

#### Mobile Web - Safari
<!-- Insert screenshots of your changes on the web platform (from safari mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS

https://user-images.githubusercontent.com/22219519/192861944-27b1fd98-885a-4188-bff2-3fa8f3d5091e.mov

#### Android

https://user-images.githubusercontent.com/22219519/192859801-5fc6c953-6a15-43cb-b408-4df579ddd1f4.mov
