### PR TITLE
[No QA] Change reportID type from number to string

### DIFF
--- a/src/components/ArchivedReportFooter.js
+++ b/src/components/ArchivedReportFooter.js
@@ -9,6 +9,7 @@ import compose from '../libs/compose';
 import personalDetailsPropType from '../pages/personalDetailsPropType';
 import ONYXKEYS from '../ONYXKEYS';
 import * as ReportUtils from '../libs/ReportUtils';
+import reportPropTypes from '../pages/reportPropTypes';
 
 const propTypes = {
     /** The reason this report was archived */
@@ -27,10 +28,7 @@ const propTypes = {
     }),
 
     /** The archived report */
-    report: PropTypes.shape({
-        /** The policy this report is attached to */
-        policyID: PropTypes.string,
-    }).isRequired,
+    report: reportPropTypes.isRequired,
 
     /** Personal details of all users */
     personalDetails: PropTypes.objectOf(personalDetailsPropType).isRequired,

--- a/src/components/IOUBadge.js
+++ b/src/components/IOUBadge.js
@@ -8,25 +8,11 @@ import compose from '../libs/compose';
 import withLocalize, {withLocalizePropTypes} from './withLocalize';
 import CONST from '../CONST';
 import Badge from './Badge';
+import iouReportPropTypes from '../pages/iouReportPropTypes';
 
 const propTypes = {
     /** IOU Report data object */
-    iouReport: PropTypes.shape({
-        /** The report ID of the IOU */
-        reportID: PropTypes.number,
-
-        /** The report ID of the chat associated with the IOU */
-        chatReportID: PropTypes.number,
-
-        /** The total amount in cents */
-        total: PropTypes.number,
-
-        /** The owner of the IOUReport */
-        ownerEmail: PropTypes.string,
-
-        /** The currency of the IOUReport */
-        currency: PropTypes.string,
-    }),
+    iouReport: iouReportPropTypes,
 
     /** Session of currently logged in user */
     session: PropTypes.shape({

--- a/src/components/IOUConfirmationList.js
+++ b/src/components/IOUConfirmationList.js
@@ -51,7 +51,7 @@ const propTypes = {
         keyForList: PropTypes.string,
         isPinned: PropTypes.bool,
         isUnread: PropTypes.bool,
-        reportID: PropTypes.number,
+        reportID: PropTypes.string,
         // eslint-disable-next-line react/forbid-prop-types
         participantsList: PropTypes.arrayOf(PropTypes.object),
         payPalMeAddress: PropTypes.string,

--- a/src/components/ReportWelcomeText.js
+++ b/src/components/ReportWelcomeText.js
@@ -13,6 +13,7 @@ import ONYXKEYS from '../ONYXKEYS';
 import Navigation from '../libs/Navigation/Navigation';
 import ROUTES from '../ROUTES';
 import Tooltip from './Tooltip';
+import reportPropTypes from '../pages/reportPropTypes';
 
 const personalDetailsPropTypes = PropTypes.shape({
     /** The login of the person (either email or phone number) */
@@ -28,7 +29,7 @@ const personalDetailsPropTypes = PropTypes.shape({
 
 const propTypes = {
     /** The report currently being looked at */
-    report: PropTypes.oneOfType([PropTypes.object]),
+    report: reportPropTypes,
 
     /* Onyx Props */
 

--- a/src/components/ReportWelcomeText.js
+++ b/src/components/ReportWelcomeText.js
@@ -46,6 +46,7 @@ const propTypes = {
 };
 
 const defaultProps = {
+    report: {},
     policies: {},
 };
 

--- a/src/components/optionPropTypes.js
+++ b/src/components/optionPropTypes.js
@@ -16,7 +16,7 @@ export default PropTypes.shape({
     login: PropTypes.string,
 
     // reportID (only present when there is a matching report)
-    reportID: PropTypes.number,
+    reportID: PropTypes.string,
 
     // Whether the report has read or not
     isUnread: PropTypes.bool,

--- a/src/libs/Navigation/AppNavigator/MainDrawerNavigator.js
+++ b/src/libs/Navigation/AppNavigator/MainDrawerNavigator.js
@@ -13,12 +13,11 @@ import ReportScreen from '../../../pages/home/ReportScreen';
 import SidebarScreen from '../../../pages/home/sidebar/SidebarScreen';
 import BaseDrawerNavigator from './BaseDrawerNavigator';
 import * as ReportUtils from '../../ReportUtils';
+import reportPropTypes from '../../../pages/reportPropTypes';
 
 const propTypes = {
     /** Available reports that would be displayed in this navigator */
-    reports: PropTypes.objectOf(PropTypes.shape({
-        reportID: PropTypes.number,
-    })),
+    reports: PropTypes.objectOf(reportPropTypes),
 
     /** Beta features list */
     betas: PropTypes.arrayOf(PropTypes.string),

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -501,7 +501,7 @@ function getOptions(reports, personalDetails, activeReportID, {
         const shouldFilterReportIfRead = hideReadReports && !ReportUtils.isUnread(report);
         const shouldFilterReport = shouldFilterReportIfEmpty || shouldFilterReportIfRead;
 
-        if (report.reportID.toString() !== activeReportID
+        if (report.reportID !== activeReportID
             && (!report.isPinned || isDefaultRoom)
             && !hasDraftComment
             && shouldFilterReport

--- a/src/libs/ReportActionsUtils.js
+++ b/src/libs/ReportActionsUtils.js
@@ -99,7 +99,7 @@ function isConsecutiveActionMadeByPreviousActor(reportActions, actionIndex) {
 
 /**
  * Get the message text for the last action that was not deleted
- * @param {Number} reportID
+ * @param {String} reportID
  * @param {Object} [actionsToMerge]
  * @return {String}
  */
@@ -120,7 +120,7 @@ function getLastVisibleMessageText(reportID, actionsToMerge = {}) {
 }
 
 /**
- * @param {Number} reportID
+ * @param {String} reportID
  * @param {Object} [actionsToMerge]
  * @param {Number} deletedSequenceNumber
  * @param {Number} lastReadSequenceNumber

--- a/src/libs/SidebarUtils.js
+++ b/src/libs/SidebarUtils.js
@@ -136,7 +136,7 @@ function getOrderedReportIDs() {
 
         const shouldFilterReportIfRead = hideReadReports && !ReportUtils.isUnread(report);
         const shouldFilterReport = shouldFilterReportIfEmpty || shouldFilterReportIfRead;
-        if (report.reportID.toString() !== currentlyViewedReportID
+        if (report.reportID !== currentlyViewedReportID
             && !report.isPinned
             && !hasDraftComment
             && shouldFilterReport
@@ -186,7 +186,7 @@ function getOrderedReportIDs() {
 
         // If the active report has a draft, we do not put it in the group of draft reports because we want it to maintain it's current position. Otherwise the report's position
         // jumps around in the LHN and it's kind of confusing to the user to see the LHN reorder when they start typing a comment on a report.
-        } else if (report.hasDraft && report.reportID.toString() !== currentlyViewedReportID) {
+        } else if (report.hasDraft && report.reportID !== currentlyViewedReportID) {
             draftReportOptions.push(report);
         } else {
             recentReportOptions.push(report);
@@ -213,10 +213,7 @@ function getOrderedReportIDs() {
     });
     recentReportOptions = sortedPinnedReports.concat(recentReportOptions);
 
-    return _.chain(recentReportOptions)
-        .pluck('reportID')
-        .map(reportID => reportID.toString())
-        .value();
+    return _.pluck(recentReportOptions, 'reportID');
 }
 
 /**

--- a/src/libs/actions/IOU.js
+++ b/src/libs/actions/IOU.js
@@ -262,7 +262,7 @@ function buildPayPalPaymentUrl(amount, submitterPayPalMeAddress, currency) {
  *
  * @param {Object} params
  * @param {Number} params.chatReportID
- * @param {Number} params.reportID
+ * @param {String} params.reportID
  * @param {String} params.paymentMethodType - one of CONST.IOU.PAYMENT_TYPE
  * @param {Number} params.amount
  * @param {String} params.currency

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -127,6 +127,7 @@ function getSimplifiedReportObject(report) {
     ]);
 
     return {
+        // This needs to be cast to a string until the IOU API has been fully migrated to OfflineFirst API
         reportID: report.reportID.toString(),
         reportName: report.reportName,
         chatType,

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -127,7 +127,7 @@ function getSimplifiedReportObject(report) {
     ]);
 
     return {
-        reportID: report.reportID,
+        reportID: report.reportID.toString(),
         reportName: report.reportName,
         chatType,
         ownerEmail: LoginUtils.getEmailWithoutMergedAccountPrefix(lodashGet(report, ['ownerEmail'], '')),

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -52,7 +52,7 @@ let conciergeChatReportID;
 const typingWatchTimers = {};
 
 /**
- * @param {Number} reportID
+ * @param {String} reportID
  * @returns {Number}
  */
 function getLastReadSequenceNumber(reportID) {
@@ -60,7 +60,7 @@ function getLastReadSequenceNumber(reportID) {
 }
 
 /**
- * @param {Number} reportID
+ * @param {String} reportID
  * @returns {Number}
  */
 function getMaxSequenceNumber(reportID) {
@@ -378,7 +378,7 @@ function fetchIOUReportByID(iouReportID, chatReportID, shouldRedirectIfEmpty = f
 /**
  * Get the private pusher channel name for a Report.
  *
- * @param {Number} reportID
+ * @param {String} reportID
  * @returns {String}
  */
 function getReportChannelName(reportID) {
@@ -434,7 +434,7 @@ function getNormalizedTypingStatus(typingStatus) {
 /**
  * Initialize our pusher subscriptions to listen for someone typing in a report.
  *
- * @param {Number} reportID
+ * @param {String} reportID
  */
 function subscribeToReportTypingEvents(reportID) {
     if (!reportID) {
@@ -479,7 +479,7 @@ function subscribeToReportTypingEvents(reportID) {
 /**
  * Remove our pusher subscriptions to listen for someone typing in a report.
  *
- * @param {Number} reportID
+ * @param {String} reportID
  */
 function unsubscribeFromReportChannel(reportID) {
     if (!reportID) {
@@ -583,7 +583,7 @@ function fetchAllReports(
  * - Adding one attachment
  * - Add both a comment and attachment simultaneously
  *
- * @param {Number} reportID
+ * @param {String} reportID
  * @param {String} [text]
  * @param {Object} [file]
  */
@@ -682,7 +682,7 @@ function addActions(reportID, text = '', file) {
  *
  * Add an attachment and optional comment.
  *
- * @param {Number} reportID
+ * @param {String} reportID
  * @param {File} file
  * @param {String} [text]
  */
@@ -693,7 +693,7 @@ function addAttachment(reportID, file, text = '') {
 /**
  * Add a single comment to a report
  *
- * @param {Number} reportID
+ * @param {String} reportID
  * @param {String} text
  */
 function addComment(reportID, text) {
@@ -703,7 +703,7 @@ function addComment(reportID, text) {
 /**
  * Gets the latest page of report actions and updates the last read message
  *
- * @param {Number} reportID
+ * @param {String} reportID
  */
 function openReport(reportID) {
     API.write('OpenReport',
@@ -740,7 +740,7 @@ function openReport(reportID) {
 /**
  * Get the latest report history without marking the report as read.
  *
- * @param {Number} reportID
+ * @param {String} reportID
  */
 function reconnect(reportID) {
     API.write('ReconnectToReport',
@@ -774,7 +774,7 @@ function reconnect(reportID) {
  * Gets the older actions that have not been read yet.
  * Normally happens when you scroll up on a chat, and the actions have not been read yet.
  *
- * @param {Number} reportID
+ * @param {String} reportID
  * @param {Number} oldestActionSequenceNumber
  */
 function readOldestAction(reportID, oldestActionSequenceNumber) {
@@ -824,7 +824,7 @@ function openPaymentDetailsPage(chatReportID, iouReportID) {
 /**
  * Marks the new report actions as read
  *
- * @param {Number} reportID
+ * @param {String} reportID
  */
 function readNewestAction(reportID) {
     const sequenceNumber = getMaxSequenceNumber(reportID);
@@ -848,7 +848,7 @@ function readNewestAction(reportID) {
 /**
  * Sets the last read comment on a report
  *
- * @param {Number} reportID
+ * @param {String} reportID
  * @param {Number} sequenceNumber
  */
 function markCommentAsUnread(reportID, sequenceNumber) {
@@ -897,7 +897,7 @@ function togglePinnedState(report) {
  * Saves the comment left by the user as they are typing. By saving this data the user can switch between chats, close
  * tab, refresh etc without worrying about loosing what they typed out.
  *
- * @param {Number} reportID
+ * @param {String} reportID
  * @param {String} comment
  */
 function saveReportComment(reportID, comment) {
@@ -918,7 +918,7 @@ function setReportWithDraft(reportID, hasDraft) {
 /**
  * Broadcasts whether or not a user is typing on a report over the report's private pusher channel.
  *
- * @param {Number} reportID
+ * @param {String} reportID
  */
 function broadcastUserIsTyping(reportID) {
     const privateReportChannelName = getReportChannelName(reportID);
@@ -954,7 +954,7 @@ function handleReportChanged(report) {
 }
 
 /**
- * @param {Number} reportID
+ * @param {String} reportID
  */
 function updateCurrentlyViewedReportID(reportID) {
     Onyx.merge(ONYXKEYS.CURRENTLY_VIEWED_REPORTID, String(reportID));
@@ -968,7 +968,7 @@ Onyx.connect({
 /**
  * Deletes a comment from the report, basically sets it as empty string
  *
- * @param {Number} reportID
+ * @param {String} reportID
  * @param {Object} reportAction
  */
 function deleteReportComment(reportID, reportAction) {
@@ -1054,7 +1054,7 @@ function deleteReportComment(reportID, reportAction) {
 /**
  * Saves a new message for a comment. Marks the comment as edited, which will be reflected in the UI.
  *
- * @param {Number} reportID
+ * @param {String} reportID
  * @param {Object} originalReportAction
  * @param {String} textForNewComment
  */
@@ -1134,7 +1134,7 @@ function editReportComment(reportID, originalReportAction, textForNewComment) {
 /**
  * Saves the draft for a comment report action. This will put the comment into "edit mode"
  *
- * @param {Number} reportID
+ * @param {String} reportID
  * @param {Number} reportActionID
  * @param {String} draftMessage
  */
@@ -1176,7 +1176,7 @@ function syncChatAndIOUReports(chatReport, iouReport) {
 }
 
 /**
- * @param {Number} reportID
+ * @param {String} reportID
  * @param {String} previousValue
  * @param {String} newValue
  */
@@ -1330,7 +1330,7 @@ function addPolicyReport(policy, reportName, visibility) {
 }
 
 /**
- * @param {Number} reportID The reportID of the policy report (workspace room)
+ * @param {String} reportID The reportID of the policy report (workspace room)
  */
 function navigateToConciergeChatAndDeletePolicyReport(reportID) {
     navigateToConciergeChat();
@@ -1388,7 +1388,7 @@ function updatePolicyRoomName(policyRoomReport, policyRoomName) {
 }
 
 /**
- * @param {Number} reportID The reportID of the policy room.
+ * @param {String} reportID The reportID of the policy room.
  */
 function clearPolicyRoomNameErrors(reportID) {
     Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, {
@@ -1402,7 +1402,7 @@ function clearPolicyRoomNameErrors(reportID) {
 }
 
 /**
- * @param {Number} reportID
+ * @param {String} reportID
  * @param {Boolean} isComposerFullSize
  */
 function setIsComposerFullSize(reportID, isComposerFullSize) {
@@ -1410,7 +1410,7 @@ function setIsComposerFullSize(reportID, isComposerFullSize) {
 }
 
 /**
- * @param {Number} reportID
+ * @param {String} reportID
  * @param {Object} action
  */
 function viewNewReportAction(reportID, action) {
@@ -1470,7 +1470,7 @@ function viewNewReportAction(reportID, action) {
 /**
  * Clear the errors associated with the IOUs of a given report.
  *
- * @param {Number} reportID
+ * @param {String} reportID
  */
 function clearIOUError(reportID) {
     Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, {errorFields: {iou: null}});

--- a/src/libs/actions/ReportActions.js
+++ b/src/libs/actions/ReportActions.js
@@ -2,7 +2,7 @@ import Onyx from 'react-native-onyx';
 import ONYXKEYS from '../../ONYXKEYS';
 
 /**
- * @param {Number} reportID
+ * @param {String} reportID
  * @param {String} sequenceNumber
  */
 function deleteOptimisticReportAction(reportID, sequenceNumber) {
@@ -12,7 +12,7 @@ function deleteOptimisticReportAction(reportID, sequenceNumber) {
 }
 
 /**
- * @param {Number} reportID
+ * @param {String} reportID
  * @param {String} sequenceNumber
  */
 function clearReportActionErrors(reportID, sequenceNumber) {

--- a/src/pages/NewChatPage.js
+++ b/src/pages/NewChatPage.js
@@ -17,6 +17,7 @@ import FullScreenLoadingIndicator from '../components/FullscreenLoadingIndicator
 import withLocalize, {withLocalizePropTypes} from '../components/withLocalize';
 import compose from '../libs/compose';
 import personalDetailsPropType from './personalDetailsPropType';
+import reportPropTypes from './reportPropTypes';
 
 const propTypes = {
     /** Whether screen is used to create group chat */
@@ -29,10 +30,7 @@ const propTypes = {
     personalDetails: personalDetailsPropType.isRequired,
 
     /** All reports shared with the user */
-    reports: PropTypes.shape({
-        reportID: PropTypes.number,
-        reportName: PropTypes.string,
-    }).isRequired,
+    reports: PropTypes.objectOf(reportPropTypes).isRequired,
 
     /** Session of currently logged in user */
     session: PropTypes.shape({

--- a/src/pages/ReportDetailsPage.js
+++ b/src/pages/ReportDetailsPage.js
@@ -21,6 +21,7 @@ import ROUTES from '../ROUTES';
 import MenuItem from '../components/MenuItem';
 import Text from '../components/Text';
 import CONST from '../CONST';
+import reportPropTypes from './reportPropTypes';
 
 const propTypes = {
     ...withLocalizePropTypes,
@@ -31,19 +32,7 @@ const propTypes = {
     }).isRequired,
 
     /** The report currently being looked at */
-    report: PropTypes.shape({
-        /** Name of the report */
-        reportName: PropTypes.string,
-
-        /** List of primarylogins of participants of the report */
-        participants: PropTypes.arrayOf(PropTypes.string),
-
-        /** List of icons for report participants */
-        icons: PropTypes.arrayOf(PropTypes.string),
-
-        /** ID of the report */
-        reportID: PropTypes.number,
-    }).isRequired,
+    report: reportPropTypes.isRequired,
 
     /** The policies which the user has access to and which the report could be tied to */
     policies: PropTypes.shape({

--- a/src/pages/ReportParticipantsPage.js
+++ b/src/pages/ReportParticipantsPage.js
@@ -18,6 +18,7 @@ import personalDetailsPropType from './personalDetailsPropType';
 import withLocalize, {withLocalizePropTypes} from '../components/withLocalize';
 import compose from '../libs/compose';
 import * as ReportUtils from '../libs/ReportUtils';
+import reportPropTypes from './reportPropTypes';
 
 const propTypes = {
     /* Onyx Props */
@@ -26,16 +27,7 @@ const propTypes = {
     personalDetails: personalDetailsPropType.isRequired,
 
     /** The active report */
-    report: PropTypes.shape({
-        /** The list of icons */
-        icons: PropTypes.arrayOf(PropTypes.string),
-
-        /** The report name */
-        reportName: PropTypes.string,
-
-        /** Array of participants */
-        participants: PropTypes.arrayOf(PropTypes.string),
-    }).isRequired,
+    report: reportPropTypes.isRequired,
 
     /** Route params */
     route: PropTypes.shape({

--- a/src/pages/ReportSettingsPage.js
+++ b/src/pages/ReportSettingsPage.js
@@ -20,6 +20,7 @@ import RoomNameInput from '../components/RoomNameInput';
 import Picker from '../components/Picker';
 import * as ValidationUtils from '../libs/ValidationUtils';
 import OfflineWithFeedback from '../components/OfflineWithFeedback';
+import reportPropTypes from './reportPropTypes';
 
 const propTypes = {
     /** Route params */
@@ -35,25 +36,7 @@ const propTypes = {
     /* Onyx Props */
 
     /** The active report */
-    report: PropTypes.shape({
-        /** The list of icons */
-        icons: PropTypes.arrayOf(PropTypes.string),
-
-        /** The report name */
-        reportName: PropTypes.string,
-
-        /** ID of the report */
-        reportID: PropTypes.number,
-
-        /** The current user's notification preference for this report */
-        notificationPreference: PropTypes.string,
-
-        /** Access setting e.g. whether the report is "restricted" */
-        visibility: PropTypes.string,
-
-        /** Linked policy's ID */
-        policyID: PropTypes.string,
-    }).isRequired,
+    report: reportPropTypes.isRequired,
 
     /** All reports shared with the user */
     reports: PropTypes.objectOf(PropTypes.shape({

--- a/src/pages/SearchPage.js
+++ b/src/pages/SearchPage.js
@@ -18,6 +18,7 @@ import CONST from '../CONST';
 import withLocalize, {withLocalizePropTypes} from '../components/withLocalize';
 import compose from '../libs/compose';
 import personalDetailsPropType from './personalDetailsPropType';
+import reportPropTypes from './reportPropTypes';
 
 const propTypes = {
     /* Onyx Props */
@@ -29,10 +30,7 @@ const propTypes = {
     personalDetails: personalDetailsPropType.isRequired,
 
     /** All reports shared with the user */
-    reports: PropTypes.shape({
-        reportID: PropTypes.number,
-        reportName: PropTypes.string,
-    }).isRequired,
+    reports: PropTypes.objectOf(reportPropTypes).isRequired,
 
     /** Session of currently logged in user */
     session: PropTypes.shape({

--- a/src/pages/home/HeaderView.js
+++ b/src/pages/home/HeaderView.js
@@ -26,6 +26,7 @@ import Text from '../../components/Text';
 import Tooltip from '../../components/Tooltip';
 import variables from '../../styles/variables';
 import colors from '../../styles/colors';
+import reportPropTypes from '../reportPropTypes';
 
 const propTypes = {
     /** Toggles the navigationMenu open and closed */
@@ -34,16 +35,7 @@ const propTypes = {
     /* Onyx Props */
 
     /** The report currently being looked at */
-    report: PropTypes.shape({
-        /** Name of the report */
-        reportName: PropTypes.string,
-
-        /** List of primarylogins of participants of the report */
-        participants: PropTypes.arrayOf(PropTypes.string),
-
-        /** Value indicating if the report is pinned or not */
-        isPinned: PropTypes.bool,
-    }),
+    report: reportPropTypes,
 
     /** The policies which the user has access to and which the report could be tied to */
     policies: PropTypes.shape({

--- a/src/pages/home/ReportScreen.js
+++ b/src/pages/home/ReportScreen.js
@@ -30,6 +30,7 @@ import withWindowDimensions, {windowDimensionsPropTypes} from '../../components/
 import OfflineIndicator from '../../components/OfflineIndicator';
 import OfflineWithFeedback from '../../components/OfflineWithFeedback';
 import withDrawerState, {withDrawerPropTypes} from '../../components/withDrawerState';
+import reportPropTypes from '../reportPropTypes';
 
 const propTypes = {
     /** Navigation route context info provided by react navigation */
@@ -50,19 +51,7 @@ const propTypes = {
     }),
 
     /** The report currently being looked at */
-    report: PropTypes.shape({
-        /** The largest sequenceNumber on this report */
-        maxSequenceNumber: PropTypes.number,
-
-        /** Whether there is an outstanding amount in IOU */
-        hasOutstandingIOU: PropTypes.bool,
-
-        /** Flag to check if the report actions data are loading */
-        isLoadingReportActions: PropTypes.bool,
-
-        /** ID for the report */
-        reportID: PropTypes.number,
-    }),
+    report: reportPropTypes,
 
     /** Array of report actions for this report */
     reportActions: PropTypes.objectOf(PropTypes.shape(reportActionPropTypes)),

--- a/src/pages/home/report/ContextMenu/PopoverReportActionContextMenu.js
+++ b/src/pages/home/report/ContextMenu/PopoverReportActionContextMenu.js
@@ -18,7 +18,7 @@ class PopoverReportActionContextMenu extends React.Component {
         super(props);
 
         this.state = {
-            reportID: 0,
+            reportID: '0',
             reportAction: {},
             selection: '',
             reportActionDraftMessage: '',
@@ -105,7 +105,7 @@ class PopoverReportActionContextMenu extends React.Component {
      * @param {Object} [event] - A press event.
      * @param {String} [selection] - Copied content.
      * @param {Element} contextMenuAnchor - popoverAnchor
-     * @param {Number} reportID - Active Report Id
+     * @param {String} reportID - Active Report Id
      * @param {Object} reportAction - ReportAction for ContextMenu
      * @param {String} draftMessage - ReportAction Draftmessage
      * @param {Function} [onShow] - Run a callback when Menu is shown
@@ -202,7 +202,7 @@ class PopoverReportActionContextMenu extends React.Component {
             this.onPopoverHideActionCallback = onHideActionCallback;
         }
         this.setState({
-            reportID: 0,
+            reportID: '0',
             reportAction: {},
             selection: '',
             reportActionDraftMessage: '',
@@ -247,7 +247,7 @@ class PopoverReportActionContextMenu extends React.Component {
     hideDeleteModal() {
         this.callbackWhenDeleteModalHide = () => this.onCancelDeleteModal = this.runAndResetCallback(this.onCancelDeleteModal);
         this.setState({
-            reportID: 0,
+            reportID: '0',
             reportAction: {},
             isDeleteCommentConfirmModalVisible: false,
             shouldSetModalVisibilityForDeleteConfirmation: true,

--- a/src/pages/home/report/ContextMenu/PopoverReportActionContextMenu.js
+++ b/src/pages/home/report/ContextMenu/PopoverReportActionContextMenu.js
@@ -256,7 +256,7 @@ class PopoverReportActionContextMenu extends React.Component {
 
     /**
      * Opens the Confirm delete action modal
-     * @param {Number} reportID
+     * @param {String} reportID
      * @param {Object} reportAction
      * @param {Boolean} [shouldSetModalVisibility]
      * @param {Function} [onConfirm]

--- a/src/pages/home/report/ContextMenu/ReportActionContextMenu.js
+++ b/src/pages/home/report/ContextMenu/ReportActionContextMenu.js
@@ -9,7 +9,7 @@ const contextMenuRef = React.createRef();
  * @param {Object} [event] - A press event.
  * @param {String} [selection] - Copied content.
  * @param {Element} contextMenuAnchor - popoverAnchor
- * @param {Number} reportID - Active Report Id
+ * @param {String} reportID - Active Report Id
  * @param {Object} reportAction - ReportAction for ContextMenu
  * @param {String} draftMessage - ReportAction Draftmessage
  * @param {Function} [onShow=() => {}] - Run a callback when Menu is shown
@@ -20,7 +20,7 @@ function showContextMenu(
     event,
     selection,
     contextMenuAnchor,
-    reportID = 0,
+    reportID = '0',
     reportAction = {},
     draftMessage = '',
     onShow = () => {},
@@ -80,7 +80,7 @@ function hideDeleteModal() {
 
 /**
  * Opens the Confirm delete action modal
- * @param {Number} reportID
+ * @param {String} reportID
  * @param {Object} reportAction
  * @param {Boolean} [shouldSetModalVisibility]
  * @param {Function} [onConfirm]

--- a/src/pages/home/report/ContextMenu/genericReportActionContextMenuPropTypes.js
+++ b/src/pages/home/report/ContextMenu/genericReportActionContextMenuPropTypes.js
@@ -3,7 +3,7 @@ import reportActionPropTypes from '../reportActionPropTypes';
 
 const propTypes = {
     /** The ID of the report this report action is attached to. */
-    reportID: PropTypes.number.isRequired,
+    reportID: PropTypes.string.isRequired,
 
     /** The report action this context menu is attached to. */
     reportAction: PropTypes.shape(reportActionPropTypes).isRequired,

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -45,6 +45,7 @@ import toggleReportActionComposeView from '../../../libs/toggleReportActionCompo
 import OfflineIndicator from '../../../components/OfflineIndicator';
 import ExceededCommentLength from '../../../components/ExceededCommentLength';
 import withNavigationFocus from '../../../components/withNavigationFocus';
+import reportPropTypes from '../../reportPropTypes';
 
 const propTypes = {
     /** Beta features list */
@@ -69,11 +70,7 @@ const propTypes = {
     personalDetails: PropTypes.objectOf(participantPropTypes),
 
     /** The report currently being looked at */
-    report: PropTypes.shape({
-
-        /** participants associated with current report */
-        participants: PropTypes.arrayOf(PropTypes.string),
-    }),
+    report: reportPropTypes,
 
     /** Array of report actions for this report */
     reportActions: PropTypes.objectOf(PropTypes.shape(reportActionPropTypes)),
@@ -387,12 +384,12 @@ class ReportActionCompose extends React.Component {
 
         // Indicate that draft has been created.
         if (this.comment.length === 0 && newComment.length !== 0) {
-            Report.setReportWithDraft(this.props.reportID.toString(), true);
+            Report.setReportWithDraft(this.props.reportID, true);
         }
 
         // The draft has been deleted.
         if (newComment.length === 0) {
-            Report.setReportWithDraft(this.props.reportID.toString(), false);
+            Report.setReportWithDraft(this.props.reportID, false);
         }
 
         this.comment = newComment;

--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -33,13 +33,11 @@ import * as User from '../../../libs/actions/User';
 import * as ReportUtils from '../../../libs/ReportUtils';
 import OfflineWithFeedback from '../../../components/OfflineWithFeedback';
 import * as ReportActions from '../../../libs/actions/ReportActions';
+import reportPropTypes from '../../reportPropTypes';
 
 const propTypes = {
     /** Report for this action */
-    report: PropTypes.shape({
-        /** The ID of the report this action is on. */
-        reportID: PropTypes.number.isRequired,
-    }).isRequired,
+    report: reportPropTypes.isRequired,
 
     /** All the data of the action item */
     action: PropTypes.shape(reportActionPropTypes).isRequired,

--- a/src/pages/home/report/ReportActionItemCreated.js
+++ b/src/pages/home/report/ReportActionItemCreated.js
@@ -11,19 +11,11 @@ import * as ReportUtils from '../../../libs/ReportUtils';
 import styles from '../../../styles/styles';
 import OfflineWithFeedback from '../../../components/OfflineWithFeedback';
 import * as Report from '../../../libs/actions/Report';
+import reportPropTypes from '../../reportPropTypes';
 
 const propTypes = {
     /** The report currently being looked at */
-    report: PropTypes.shape({
-        /** The id of the report */
-        reportID: PropTypes.number,
-
-        /**  Avatars corresponding to a chat */
-        icons: PropTypes.arrayOf(PropTypes.string),
-
-        /** Whether the user is not an admin of policyExpenseChat chat */
-        isOwnPolicyExpenseChat: PropTypes.bool,
-    }),
+    report: reportPropTypes,
 
     /** Personal details of all the users */
     personalDetails: PropTypes.objectOf(participantPropTypes),

--- a/src/pages/home/report/ReportActionItemCreated.js
+++ b/src/pages/home/report/ReportActionItemCreated.js
@@ -30,6 +30,7 @@ const propTypes = {
     }),
 };
 const defaultProps = {
+    report: {},
     personalDetails: {},
     policies: {},
 };

--- a/src/pages/home/report/ReportActionItemMessageEdit.js
+++ b/src/pages/home/report/ReportActionItemMessageEdit.js
@@ -18,6 +18,7 @@ import compose from '../../../libs/compose';
 import EmojiPickerButton from '../../../components/EmojiPicker/EmojiPickerButton';
 import * as ReportActionContextMenu from './ContextMenu/ReportActionContextMenu';
 import VirtualKeyboard from '../../../libs/VirtualKeyboard';
+import reportPropTypes from '../../reportPropTypes';
 
 const propTypes = {
     /** All the data of the action */
@@ -27,7 +28,7 @@ const propTypes = {
     draftMessage: PropTypes.string.isRequired,
 
     /** ReportID that holds the comment we're editing */
-    reportID: PropTypes.number.isRequired,
+    reportID: PropTypes.string.isRequired,
 
     /** Position index of the report action in the overall report FlatList view */
     index: PropTypes.number.isRequired,
@@ -36,10 +37,8 @@ const propTypes = {
     forwardedRef: PropTypes.func,
 
     /** The report currently being looked at */
-    report: PropTypes.shape({
-        /** Participants associated with current report */
-        participants: PropTypes.arrayOf(PropTypes.string),
-    }),
+    // eslint-disable-next-line react/no-unused-prop-types
+    report: reportPropTypes,
 
     // Whether or not the emoji picker is disabled
     shouldDisableEmojiPicker: PropTypes.bool,

--- a/src/pages/home/report/ReportActionsList.js
+++ b/src/pages/home/report/ReportActionsList.js
@@ -17,6 +17,7 @@ import * as ReportActionsUtils from '../../../libs/ReportActionsUtils';
 import reportActionPropTypes from './reportActionPropTypes';
 import CONST from '../../../CONST';
 import * as StyleUtils from '../../../styles/StyleUtils';
+import reportPropTypes from '../../reportPropTypes';
 
 const propTypes = {
     /** Position of the "New" line marker */
@@ -26,13 +27,7 @@ const propTypes = {
     personalDetails: PropTypes.objectOf(participantPropTypes),
 
     /** The report currently being looked at */
-    report: PropTypes.shape({
-        /** The largest sequenceNumber on this report */
-        maxSequenceNumber: PropTypes.number,
-
-        /** Whether there is an outstanding amount in IOU */
-        hasOutstandingIOU: PropTypes.bool,
-    }).isRequired,
+    report: reportPropTypes.isRequired,
 
     /** Sorted actions prepared for display */
     sortedReportActions: PropTypes.arrayOf(PropTypes.shape({

--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -30,24 +30,13 @@ import CopySelectionHelper from '../../../components/CopySelectionHelper';
 import EmojiPicker from '../../../components/EmojiPicker/EmojiPicker';
 import * as ReportActionsUtils from '../../../libs/ReportActionsUtils';
 import * as ReportUtils from '../../../libs/ReportUtils';
+import reportPropTypes from '../../reportPropTypes';
 
 const propTypes = {
     /* Onyx Props */
 
     /** The report currently being looked at */
-    report: PropTypes.shape({
-        /** The ID of the report actions will be created for */
-        reportID: PropTypes.number.isRequired,
-
-        /** The largest sequenceNumber on this report */
-        maxSequenceNumber: PropTypes.number,
-
-        /** Whether there is an outstanding amount in IOU */
-        hasOutstandingIOU: PropTypes.bool,
-
-        /** Are we loading more report actions? */
-        isLoadingMoreReportActions: PropTypes.bool,
-    }).isRequired,
+    report: reportPropTypes.isRequired,
 
     /** Array of report actions for this report */
     reportActions: PropTypes.objectOf(PropTypes.shape(reportActionPropTypes)),

--- a/src/pages/home/report/reportActionFragmentPropTypes.js
+++ b/src/pages/home/report/reportActionFragmentPropTypes.js
@@ -12,7 +12,7 @@ export default PropTypes.shape({
     style: PropTypes.string,
 
     // ID of a report
-    reportID: PropTypes.number,
+    reportID: PropTypes.string,
 
     // ID of a policy
     policyID: PropTypes.string,

--- a/src/pages/home/sidebar/SidebarLinks.js
+++ b/src/pages/home/sidebar/SidebarLinks.js
@@ -26,6 +26,7 @@ import Timing from '../../../libs/actions/Timing';
 import reportActionPropTypes from '../report/reportActionPropTypes';
 import LHNOptionsList from '../../../components/LHNOptionsList/LHNOptionsList';
 import SidebarUtils from '../../../libs/SidebarUtils';
+import reportPropTypes from '../../reportPropTypes';
 
 const propTypes = {
     /** Toggles the navigation menu open and closed */
@@ -40,16 +41,7 @@ const propTypes = {
     /* Onyx Props */
     /** List of reports */
     // eslint-disable-next-line react/no-unused-prop-types
-    reports: PropTypes.objectOf(PropTypes.shape({
-        /** ID of the report */
-        reportID: PropTypes.number,
-
-        /** Name of the report */
-        reportName: PropTypes.string,
-
-        /** Whether the report has a draft comment */
-        hasDraft: PropTypes.bool,
-    })),
+    reports: PropTypes.objectOf(reportPropTypes),
 
     /** All report actions for all reports */
     // eslint-disable-next-line react/no-unused-prop-types

--- a/src/pages/iou/IOUModal.js
+++ b/src/pages/iou/IOUModal.js
@@ -28,6 +28,7 @@ import withCurrentUserPersonalDetails from '../../components/withCurrentUserPers
 import ROUTES from '../../ROUTES';
 import networkPropTypes from '../../components/networkPropTypes';
 import {withNetwork} from '../../components/OnyxProvider';
+import reportPropTypes from '../reportPropTypes';
 
 /**
  * IOU modal for requesting money and splitting bills.
@@ -40,10 +41,8 @@ const propTypes = {
     iouType: PropTypes.string,
 
     /** The report passed via the route */
-    report: PropTypes.shape({
-        /** Participants associated with current report */
-        participants: PropTypes.arrayOf(PropTypes.string),
-    }),
+    // eslint-disable-next-line react/no-unused-prop-types
+    report: reportPropTypes,
 
     /** Information about the network */
     network: networkPropTypes.isRequired,
@@ -296,7 +295,7 @@ class IOUModal extends Component {
 
         IOU.payIOUReport({
             chatReportID: lodashGet(this.props, 'route.params.reportID', ''),
-            reportID: 0,
+            reportID: '0',
             paymentMethodType,
             amount,
             currency,

--- a/src/pages/iou/steps/IOUConfirmPage.js
+++ b/src/pages/iou/steps/IOUConfirmPage.js
@@ -33,7 +33,7 @@ const propTypes = {
         keyForList: PropTypes.string,
         isPinned: PropTypes.bool,
         isUnread: PropTypes.bool,
-        reportID: PropTypes.number,
+        reportID: PropTypes.string,
         // eslint-disable-next-line react/forbid-prop-types
         participantsList: PropTypes.arrayOf(PropTypes.object),
         payPalMeAddress: PropTypes.string,

--- a/src/pages/iou/steps/IOUParticipantsPage/IOUParticipantsPage.js
+++ b/src/pages/iou/steps/IOUParticipantsPage/IOUParticipantsPage.js
@@ -29,7 +29,7 @@ const propTypes = {
         keyForList: PropTypes.string,
         isPinned: PropTypes.bool,
         isUnread: PropTypes.bool,
-        reportID: PropTypes.number,
+        reportID: PropTypes.string,
         phoneNumber: PropTypes.string,
         payPalMeAddress: PropTypes.string,
     })),

--- a/src/pages/iou/steps/IOUParticipantsPage/IOUParticipantsRequest.js
+++ b/src/pages/iou/steps/IOUParticipantsPage/IOUParticipantsRequest.js
@@ -9,6 +9,7 @@ import withLocalize, {withLocalizePropTypes} from '../../../../components/withLo
 import compose from '../../../../libs/compose';
 import CONST from '../../../../CONST';
 import personalDetailsPropType from '../../../personalDetailsPropType';
+import reportPropTypes from '../../../reportPropTypes';
 
 const propTypes = {
     /** Beta features list */
@@ -24,10 +25,7 @@ const propTypes = {
     personalDetails: PropTypes.objectOf(personalDetailsPropType).isRequired,
 
     /** All reports shared with the user */
-    reports: PropTypes.shape({
-        reportID: PropTypes.number,
-        reportName: PropTypes.string,
-    }).isRequired,
+    reports: PropTypes.objectOf(reportPropTypes).isRequired,
 
     ...withLocalizePropTypes,
 };

--- a/src/pages/iou/steps/IOUParticipantsPage/IOUParticipantsSplit.js
+++ b/src/pages/iou/steps/IOUParticipantsPage/IOUParticipantsSplit.js
@@ -12,6 +12,7 @@ import withLocalize, {withLocalizePropTypes} from '../../../../components/withLo
 import compose from '../../../../libs/compose';
 import Text from '../../../../components/Text';
 import personalDetailsPropType from '../../../personalDetailsPropType';
+import reportPropTypes from '../../../reportPropTypes';
 
 const propTypes = {
     /** Beta features list */
@@ -41,10 +42,7 @@ const propTypes = {
     personalDetails: PropTypes.objectOf(personalDetailsPropType).isRequired,
 
     /** All reports shared with the user */
-    reports: PropTypes.shape({
-        reportID: PropTypes.number,
-        reportName: PropTypes.string,
-    }).isRequired,
+    reports: PropTypes.objectOf(reportPropTypes).isRequired,
 
     ...withLocalizePropTypes,
 };

--- a/src/pages/iou/steps/IOUParticipantsPage/IOUParticipantsSplit.js
+++ b/src/pages/iou/steps/IOUParticipantsPage/IOUParticipantsSplit.js
@@ -35,7 +35,7 @@ const propTypes = {
         keyForList: PropTypes.string,
         isPinned: PropTypes.bool,
         isUnread: PropTypes.bool,
-        reportID: PropTypes.number,
+        reportID: PropTypes.string,
     })),
 
     /** All of the personal details for everyone */

--- a/src/pages/iouReportPropTypes.js
+++ b/src/pages/iouReportPropTypes.js
@@ -1,0 +1,18 @@
+import PropTypes from 'prop-types';
+
+export default PropTypes.shape({
+    /** The report ID of the IOU */
+    reportID: PropTypes.string,
+
+    /** The report ID of the chat associated with the IOU */
+    chatReportID: PropTypes.number,
+
+    /** The total amount in cents */
+    total: PropTypes.number,
+
+    /** The owner of the IOUReport */
+    ownerEmail: PropTypes.string,
+
+    /** The currency of the IOUReport */
+    currency: PropTypes.string,
+});

--- a/src/pages/reportPropTypes.js
+++ b/src/pages/reportPropTypes.js
@@ -31,6 +31,9 @@ export default PropTypes.shape({
     /** Flag to check if the report actions data are loading */
     isLoadingReportActions: PropTypes.bool,
 
+    /** Whether the user is not an admin of policyExpenseChat chat */
+    isOwnPolicyExpenseChat: PropTypes.bool,
+
     chatType: PropTypes.string,
     ownerEmail: PropTypes.string,
     isPinned: PropTypes.bool,

--- a/src/pages/reportPropTypes.js
+++ b/src/pages/reportPropTypes.js
@@ -1,0 +1,15 @@
+import PropTypes from 'prop-types';
+
+export default PropTypes.shape({
+    /** Name of the report */
+    reportName: PropTypes.string,
+
+    /** List of primarylogins of participants of the report */
+    participants: PropTypes.arrayOf(PropTypes.string),
+
+    /** List of icons for report participants */
+    icons: PropTypes.arrayOf(PropTypes.string),
+
+    /** ID of the report */
+    reportID: PropTypes.string,
+});

--- a/src/pages/reportPropTypes.js
+++ b/src/pages/reportPropTypes.js
@@ -11,5 +11,14 @@ export default PropTypes.shape({
     icons: PropTypes.arrayOf(PropTypes.string),
 
     /** ID of the report */
-    reportID: PropTypes.string,
+    reportID: PropTypes.string.isRequired,
+
+    /** The largest sequenceNumber on this report */
+    maxSequenceNumber: PropTypes.number,
+
+    /** Whether there is an outstanding amount in IOU */
+    hasOutstandingIOU: PropTypes.bool,
+
+    /** Are we loading more report actions? */
+    isLoadingMoreReportActions: PropTypes.bool,
 });

--- a/src/pages/reportPropTypes.js
+++ b/src/pages/reportPropTypes.js
@@ -66,7 +66,7 @@ export default PropTypes.shape({
     reportName: PropTypes.string,
 
     /** ID of the report */
-    reportID: PropTypes.string.isRequired,
+    reportID: PropTypes.string,
 
     /** The state that the report is currently in */
     stateNum: PropTypes.oneOf(_.values(CONST.REPORT.STATE_NUM)),

--- a/src/pages/reportPropTypes.js
+++ b/src/pages/reportPropTypes.js
@@ -21,4 +21,21 @@ export default PropTypes.shape({
 
     /** Are we loading more report actions? */
     isLoadingMoreReportActions: PropTypes.bool,
+
+    chatType: PropTypes.string,
+    ownerEmail: PropTypes.string,
+    policyID: PropTypes.string,
+    isPinned: PropTypes.bool,
+    lastVisitedTimestamp: PropTypes.number,
+    lastReadSequenceNumber: PropTypes.number,
+    lastMessageTimestamp: PropTypes.number,
+    lastMessageText: PropTypes.string,
+    lastActorEmail: PropTypes.string,
+    notificationPreference: PropTypes.oneOf('mute', 'daily', 'always'),
+    stateNum: PropTypes.number,
+    statusNum: PropTypes.number,
+    oldPolicyName: PropTypes.string,
+    visibility: PropTypes.string,
+    isOwnPolicyExpenseChat: PropTypes.bool,
+    lastMessageHtml: PropTypes.string,
 });

--- a/src/pages/reportPropTypes.js
+++ b/src/pages/reportPropTypes.js
@@ -3,32 +3,18 @@ import PropTypes from 'prop-types';
 import CONST from '../CONST';
 
 export default PropTypes.shape({
-    /** Name of the report */
-    reportName: PropTypes.string,
 
-    /** List of primarylogins of participants of the report */
-    participants: PropTypes.arrayOf(PropTypes.string),
-
-    /** List of icons for report participants */
-    icons: PropTypes.arrayOf(PropTypes.string),
-
-    /** ID of the report */
-    reportID: PropTypes.string.isRequired,
-
-    /** The largest sequenceNumber on this report */
-    maxSequenceNumber: PropTypes.number,
+    /** The specific type of chat */
+    chatType: PropTypes.oneOf(_.values(CONST.REPORT.CHAT_TYPE)),
 
     /** Whether there is an outstanding amount in IOU */
     hasOutstandingIOU: PropTypes.bool,
 
+    /** List of icons for report participants */
+    icons: PropTypes.arrayOf(PropTypes.string),
+
     /** Are we loading more report actions? */
     isLoadingMoreReportActions: PropTypes.bool,
-
-    /** The current user's notification preference for this report */
-    notificationPreference: PropTypes.oneOf(['mute', 'daily', 'always']),
-
-    /** Linked policy's ID */
-    policyID: PropTypes.string,
 
     /** Flag to check if the report actions data are loading */
     isLoadingReportActions: PropTypes.bool,
@@ -36,36 +22,51 @@ export default PropTypes.shape({
     /** Whether the user is not an admin of policyExpenseChat chat */
     isOwnPolicyExpenseChat: PropTypes.bool,
 
-    /** The specific type of chat */
-    chatType: PropTypes.oneOf(_.values(CONST.REPORT.CHAT_TYPE)),
-
-    /** The email address of the report owner */
-    ownerEmail: PropTypes.string,
-
     /** Indicates if the report is pinned to the LHN or not */
     isPinned: PropTypes.bool,
 
-    /** The last time the report was visited */
-    lastVisitedTimestamp: PropTypes.number,
-
-    /** The sequence number of the last action read by the user */
-    lastReadSequenceNumber: PropTypes.number,
-
-    /** The time of the last message on the report */
-    lastMessageTimestamp: PropTypes.number,
+    /** The email of the last message's actor */
+    lastActorEmail: PropTypes.string,
 
     /** The text of the last message on the report */
     lastMessageText: PropTypes.string,
 
-    /** The email of the last message's actor */
-    lastActorEmail: PropTypes.string,
+    /** The time of the last message on the report */
+    lastMessageTimestamp: PropTypes.number,
+
+    /** The sequence number of the last action read by the user */
+    lastReadSequenceNumber: PropTypes.number,
+
+    /** The last time the report was visited */
+    lastVisitedTimestamp: PropTypes.number,
+
+    /** The largest sequenceNumber on this report */
+    maxSequenceNumber: PropTypes.number,
+
+    /** The current user's notification preference for this report */
+    notificationPreference: PropTypes.oneOf(['mute', 'daily', 'always']),
+
+    /** The policy name to use for an archived report */
+    oldPolicyName: PropTypes.string,
+
+    /** The email address of the report owner */
+    ownerEmail: PropTypes.string,
+
+    /** List of primarylogins of participants of the report */
+    participants: PropTypes.arrayOf(PropTypes.string),
+
+    /** Linked policy's ID */
+    policyID: PropTypes.string,
+
+    /** Name of the report */
+    reportName: PropTypes.string,
+
+    /** ID of the report */
+    reportID: PropTypes.string.isRequired,
 
     /** The state that the report is currently in */
     stateNum: PropTypes.oneOf(_.values(CONST.REPORT.STATE_NUM)),
 
     /** The status of the current report */
     statusNum: PropTypes.oneOf(_.values(CONST.REPORT.STATUS)),
-
-    /** The policy name to use for an archived report */
-    oldPolicyName: PropTypes.string,
 });

--- a/src/pages/reportPropTypes.js
+++ b/src/pages/reportPropTypes.js
@@ -1,4 +1,6 @@
+import _ from 'underscore';
 import PropTypes from 'prop-types';
+import CONST from '../CONST';
 
 export default PropTypes.shape({
     /** Name of the report */
@@ -34,15 +36,36 @@ export default PropTypes.shape({
     /** Whether the user is not an admin of policyExpenseChat chat */
     isOwnPolicyExpenseChat: PropTypes.bool,
 
-    chatType: PropTypes.string,
+    /** The specific type of chat */
+    chatType: PropTypes.oneOf(_.values(CONST.REPORT.CHAT_TYPE)),
+
+    /** The email address of the report owner */
     ownerEmail: PropTypes.string,
+
+    /** Indicates if the report is pinned to the LHN or not */
     isPinned: PropTypes.bool,
+
+    /** The last time the report was visited */
     lastVisitedTimestamp: PropTypes.number,
+
+    /** The sequence number of the last action read by the user */
     lastReadSequenceNumber: PropTypes.number,
+
+    /** The time of the last message on the report */
     lastMessageTimestamp: PropTypes.number,
+
+    /** The text of the last message on the report */
     lastMessageText: PropTypes.string,
+
+    /** The email of the last message's actor */
     lastActorEmail: PropTypes.string,
-    stateNum: PropTypes.number,
-    statusNum: PropTypes.number,
+
+    /** The state that the report is currently in */
+    stateNum: PropTypes.oneOf(_.values(CONST.REPORT.STATE_NUM)),
+
+    /** The status of the current report */
+    statusNum: PropTypes.oneOf(_.values(CONST.REPORT.STATUS)),
+
+    /** The policy name to use for an archived report */
     oldPolicyName: PropTypes.string,
 });

--- a/src/pages/reportPropTypes.js
+++ b/src/pages/reportPropTypes.js
@@ -22,20 +22,24 @@ export default PropTypes.shape({
     /** Are we loading more report actions? */
     isLoadingMoreReportActions: PropTypes.bool,
 
+    /** The current user's notification preference for this report */
+    notificationPreference: PropTypes.oneOf(['mute', 'daily', 'always']),
+
+    /** Linked policy's ID */
+    policyID: PropTypes.string,
+
+    /** Flag to check if the report actions data are loading */
+    isLoadingReportActions: PropTypes.bool,
+
     chatType: PropTypes.string,
     ownerEmail: PropTypes.string,
-    policyID: PropTypes.string,
     isPinned: PropTypes.bool,
     lastVisitedTimestamp: PropTypes.number,
     lastReadSequenceNumber: PropTypes.number,
     lastMessageTimestamp: PropTypes.number,
     lastMessageText: PropTypes.string,
     lastActorEmail: PropTypes.string,
-    notificationPreference: PropTypes.oneOf('mute', 'daily', 'always'),
     stateNum: PropTypes.number,
     statusNum: PropTypes.number,
     oldPolicyName: PropTypes.string,
-    visibility: PropTypes.string,
-    isOwnPolicyExpenseChat: PropTypes.bool,
-    lastMessageHtml: PropTypes.string,
 });

--- a/src/pages/reportPropTypes.js
+++ b/src/pages/reportPropTypes.js
@@ -5,7 +5,7 @@ import CONST from '../CONST';
 export default PropTypes.shape({
 
     /** The specific type of chat */
-    chatType: PropTypes.oneOf(_.values(CONST.REPORT.CHAT_TYPE)),
+    chatType: PropTypes.oneOf(['', ..._.values(CONST.REPORT.CHAT_TYPE)]),
 
     /** Whether there is an outstanding amount in IOU */
     hasOutstandingIOU: PropTypes.bool,
@@ -44,7 +44,11 @@ export default PropTypes.shape({
     maxSequenceNumber: PropTypes.number,
 
     /** The current user's notification preference for this report */
-    notificationPreference: PropTypes.oneOf(['mute', 'daily', 'always']),
+    notificationPreference: PropTypes.oneOfType([
+        // Some old reports have numbers for the notification preference
+        PropTypes.number,
+        PropTypes.string,
+    ]),
 
     /** The policy name to use for an archived report */
     oldPolicyName: PropTypes.string,

--- a/tests/unit/LHNOrderTest.js
+++ b/tests/unit/LHNOrderTest.js
@@ -72,7 +72,7 @@ const fakePersonalDetails = {
 };
 
 const fakeReport1 = {
-    reportID: 1,
+    reportID: '1',
     reportName: 'Report One',
     maxSequenceNumber: TEST_MAX_SEQUENCE_NUMBER,
     lastReadSequenceNumber: TEST_MAX_SEQUENCE_NUMBER,
@@ -82,7 +82,7 @@ const fakeReport1 = {
     participants: ['email1@test.com', 'email2@test.com'],
 };
 const fakeReport2 = {
-    reportID: 2,
+    reportID: '2',
     reportName: 'Report Two',
     maxSequenceNumber: TEST_MAX_SEQUENCE_NUMBER,
     lastReadSequenceNumber: TEST_MAX_SEQUENCE_NUMBER,
@@ -90,7 +90,7 @@ const fakeReport2 = {
     participants: ['email3@test.com', 'email4@test.com'],
 };
 const fakeReport3 = {
-    reportID: 3,
+    reportID: '3',
     reportName: 'Report Three',
     maxSequenceNumber: TEST_MAX_SEQUENCE_NUMBER,
     lastReadSequenceNumber: TEST_MAX_SEQUENCE_NUMBER,
@@ -98,7 +98,7 @@ const fakeReport3 = {
     participants: ['email5@test.com', 'email6@test.com'],
 };
 const fakeReportIOU = {
-    reportID: 4,
+    reportID: '4',
     reportName: 'Report IOU Four',
     maxSequenceNumber: TEST_MAX_SEQUENCE_NUMBER,
     lastReadSequenceNumber: TEST_MAX_SEQUENCE_NUMBER,
@@ -530,7 +530,7 @@ describe('Sidebar', () => {
 
                 // When a new report is added
                 .then(() => Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}4`, {
-                    reportID: 4,
+                    reportID: '4',
                     reportName: 'Report Four',
                     maxSequenceNumber: TEST_MAX_SEQUENCE_NUMBER,
                     isPinned: true,
@@ -579,7 +579,7 @@ describe('Sidebar', () => {
 
                 // When a new report is added
                 .then(() => Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}4`, {
-                    reportID: 4,
+                    reportID: '4',
                     reportName: 'Report Four',
                     maxSequenceNumber: TEST_MAX_SEQUENCE_NUMBER,
                     hasDraft: true,


### PR DESCRIPTION
### Fixed Issues
Part of https://github.com/Expensify/Expensify/issues/227425
- [x] HOLD on Web-E PR https://github.com/Expensify/Web-Expensify/pull/34976

### Tests
1. Select a chat in the LHN
2. Verify that the row in the LHN shows that the chat is selected (it has a slightly darker background than the rest)

There are a few propType warnings that happen regarding the IOU chat reportIDs, but that API is not fully migrated over to an OfflineFirst world, so those will be fixed later when it's migrated.

- [x] Verify that no errors appear in the JS console

### QA Steps
1. Select a chat in the LHN
2. Verify that the row in the LHN shows that the chat is selected (it has a slightly darker background than the rest)

- [ ] Verify that no errors appear in the JS console