### PR TITLE
Add isDrawerReady method

### DIFF
--- a/src/libs/Navigation/AppNavigator/BaseDrawerNavigator.js
+++ b/src/libs/Navigation/AppNavigator/BaseDrawerNavigator.js
@@ -49,6 +49,12 @@ class BaseDrawerNavigator extends Component {
         };
     }
 
+    componentDidMount() {
+        // We need to resolve the isDrawerReady promise so that any pending drawer actions, like direct navigation from OldDot to
+        // a NewDot report, can happen.
+        Navigation.setIsDrawerReady();
+    }
+
     componentDidUpdate(prevProps) {
         if (prevProps.isSmallScreenWidth === this.props.isSmallScreenWidth) {
             return;
@@ -58,10 +64,6 @@ class BaseDrawerNavigator extends Component {
         this.setState({
             defaultStatus: Navigation.getDefaultDrawerState(this.props.isSmallScreenWidth),
         });
-    }
-
-    componentDidMount() {
-        Navigation.setIsDrawerReady();
     }
 
     render() {

--- a/src/libs/Navigation/AppNavigator/BaseDrawerNavigator.js
+++ b/src/libs/Navigation/AppNavigator/BaseDrawerNavigator.js
@@ -60,6 +60,10 @@ class BaseDrawerNavigator extends Component {
         });
     }
 
+    componentDidMount() {
+        Navigation.setIsDrawerReady();
+    }
+
     render() {
         const content = (
             <Drawer.Navigator

--- a/src/libs/Navigation/AppNavigator/MainDrawerNavigator.js
+++ b/src/libs/Navigation/AppNavigator/MainDrawerNavigator.js
@@ -13,6 +13,7 @@ import ReportScreen from '../../../pages/home/ReportScreen';
 import SidebarScreen from '../../../pages/home/sidebar/SidebarScreen';
 import BaseDrawerNavigator from './BaseDrawerNavigator';
 import * as ReportUtils from '../../ReportUtils';
+import Navigation from '../Navigation';
 
 const propTypes = {
     /** Available reports that would be displayed in this navigator */

--- a/src/libs/Navigation/AppNavigator/MainDrawerNavigator.js
+++ b/src/libs/Navigation/AppNavigator/MainDrawerNavigator.js
@@ -13,7 +13,6 @@ import ReportScreen from '../../../pages/home/ReportScreen';
 import SidebarScreen from '../../../pages/home/sidebar/SidebarScreen';
 import BaseDrawerNavigator from './BaseDrawerNavigator';
 import * as ReportUtils from '../../ReportUtils';
-import Navigation from '../Navigation';
 
 const propTypes = {
     /** Available reports that would be displayed in this navigator */

--- a/src/libs/Navigation/Navigation.js
+++ b/src/libs/Navigation/Navigation.js
@@ -15,6 +15,11 @@ const navigationIsReadyPromise = new Promise((resolve) => {
     resolveNavigationIsReadyPromise = resolve;
 });
 
+let resolveDrawerIsReadyPromise;
+const drawerIsReadyPromise = new Promise((resolve) => {
+    resolveDrawerIsReadyPromise = resolve;
+});
+
 let isLoggedIn = false;
 Onyx.connect({
     key: ONYXKEYS.SESSION,
@@ -202,6 +207,17 @@ function setIsNavigationReady() {
     resolveNavigationIsReadyPromise();
 }
 
+/**
+ * @returns {Promise}
+ */
+function isDrawerReady() {
+    return drawerIsReadyPromise;
+}
+
+function setIsDrawerReady() {
+    resolveDrawerIsReadyPromise();
+}
+
 export default {
     canNavigate,
     navigate,
@@ -214,6 +230,9 @@ export default {
     setDidTapNotification,
     isNavigationReady,
     setIsNavigationReady,
+    isDrawerReady,
+    setIsDrawerReady,
+    isDrawerRoute,
 };
 
 export {

--- a/src/libs/actions/App.js
+++ b/src/libs/actions/App.js
@@ -11,7 +11,7 @@ import Log from '../Log';
 import Performance from '../Performance';
 import Timing from './Timing';
 import * as Policy from './Policy';
-import Navigation from '../Navigation/Navigation';
+import Navigation, {navigationRef} from '../Navigation/Navigation';
 import ROUTES from '../../ROUTES';
 import * as SessionUtils from '../SessionUtils';
 import getCurrentUrl from '../Navigation/currentUrl';
@@ -196,6 +196,15 @@ function setUpPoliciesAndNavigate(session) {
         return;
     }
     if (!isLoggingInAsNewUser && exitTo) {
+        if (Navigation.isDrawerRoute(exitTo)) {
+            Navigation.isDrawerReady()
+                .then(() => {
+                    // We must call dismissModal() to remove the /transition route from history
+                    Navigation.dismissModal();
+                    Navigation.navigate(exitTo);
+                });
+            return;
+        }
         Navigation.isNavigationReady()
             .then(() => {
                 // We must call dismissModal() to remove the /transition route from history

--- a/src/libs/actions/App.js
+++ b/src/libs/actions/App.js
@@ -11,7 +11,7 @@ import Log from '../Log';
 import Performance from '../Performance';
 import Timing from './Timing';
 import * as Policy from './Policy';
-import Navigation, {navigationRef} from '../Navigation/Navigation';
+import Navigation from '../Navigation/Navigation';
 import ROUTES from '../../ROUTES';
 import * as SessionUtils from '../SessionUtils';
 import getCurrentUrl from '../Navigation/currentUrl';
@@ -197,6 +197,9 @@ function setUpPoliciesAndNavigate(session) {
     }
     if (!isLoggingInAsNewUser && exitTo) {
         if (Navigation.isDrawerRoute(exitTo)) {
+            // The drawer navigation is only created after we have fetched reports from the server.
+            // Thus, if we use the standard navigation and try to navigate to a drawer route before
+            // the reports have been fetched, we will fail to navigate.
             Navigation.isDrawerReady()
                 .then(() => {
                     // We must call dismissModal() to remove the /transition route from history


### PR DESCRIPTION
### Details
The drawer navigator is conditionally rendered, only after reports are fetched from the server. We need to wait on transition links for this to load if the link is to a drawer component, like a report.

### Fixed Issues
Part of https://github.com/Expensify/Expensify/issues/230725

### Tests
1. Pulled https://github.com/Expensify/Web-Expensify/pull/34988 locally
2. Fetched a report ID from newdot
3. Signed out of newdot
4. Navigated to `expensify.com.dev/newdotreport?reportID=<reportID>`
5. _Verified_ I was logged into newdot, and dropped into the correct report

1. Created a free plan workspace from Olddot
2. _Verified_ the transition worked as expected 

### QA Steps
1. Create a free plan workspace from Old Dot
2. _Verify_ the transition works as expected
- [ ] Verify that no errors appear in the JS console