### PR TITLE
Check for unread reports at the end of the filter logic

### DIFF
--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -448,7 +448,6 @@ function getOptions(reports, personalDetails, {
     sortPersonalDetailsByAlphaAsc = true,
     forcePolicyNamePreview = false,
 }) {
-    const isInGSDMode = priorityMode === CONST.PRIORITY_MODE.GSD;
     let recentReportOptions = [];
     let personalDetailsOptions = [];
     const reportMapForLogins = {};
@@ -457,7 +456,7 @@ function getOptions(reports, personalDetails, {
     const filteredReports = _.filter(reports, report => ReportUtils.shouldReportBeInOptionList(
         report,
         Navigation.getReportIDFromRoute(),
-        isInGSDMode,
+        false,
         currentUserLogin,
         iouReports,
         betas,

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -106,6 +106,9 @@ function addSMSDomainIfPhoneNumber(login) {
  */
 function getPersonalDetailsForLogins(logins, personalDetails) {
     const personalDetailsForLogins = {};
+    if (!personalDetails) {
+        return personalDetailsForLogins;
+    }
     _.each(logins, (login) => {
         let personalDetail = personalDetails[login];
         if (!personalDetail) {

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -23,12 +23,6 @@ Onyx.connect({
     callback: val => currentUserLogin = val && val.email,
 });
 
-let priorityMode;
-Onyx.connect({
-    key: ONYXKEYS.NVP_PRIORITY_MODE,
-    callback: val => priorityMode = val,
-});
-
 let loginList;
 Onyx.connect({
     key: ONYXKEYS.LOGIN_LIST,

--- a/src/libs/ReportUtils.js
+++ b/src/libs/ReportUtils.js
@@ -916,12 +916,6 @@ function shouldReportBeInOptionList(report, reportIDFromRoute, isInGSDMode, curr
         return true;
     }
 
-    // Include unread reports when in GSD mode
-    // GSD mode is specifically for focusing the user on the most relevant chats, primarily, the unread ones
-    if (isInGSDMode) {
-        return isUnread(report);
-    }
-
     // Include reports if they have a draft, are pinned, or have an outstanding IOU
     // These are always relevant to the user no matter what view mode the user prefers
     if (report.hasDraft || report.isPinned || hasOutstandingIOU(report, currentUserLogin, iouReports)) {
@@ -959,6 +953,12 @@ function shouldReportBeInOptionList(report, reportIDFromRoute, isInGSDMode, curr
     // Include policy expense chats if the user isn't in the policy expense chat beta
     if (isPolicyExpenseChat(report) && !Permissions.canUsePolicyExpenseChat(betas)) {
         return false;
+    }
+
+    // Include unread reports when in GSD mode
+    // GSD mode is specifically for focusing the user on the most relevant chats, primarily, the unread ones
+    if (isInGSDMode) {
+        return isUnread(report);
     }
 
     return true;

--- a/src/libs/ReportUtils.js
+++ b/src/libs/ReportUtils.js
@@ -935,6 +935,12 @@ function shouldReportBeInOptionList(report, reportIDFromRoute, isInGSDMode, curr
         return false;
     }
 
+    // Include unread reports when in GSD mode
+    // GSD mode is specifically for focusing the user on the most relevant chats, primarily, the unread ones
+    if (isInGSDMode) {
+        return isUnread(report);
+    }
+
     // Include default rooms for free plan policies
     if (isDefaultRoom(report) && getPolicyType(report, policies) === CONST.POLICY.TYPE.FREE) {
         return true;
@@ -953,12 +959,6 @@ function shouldReportBeInOptionList(report, reportIDFromRoute, isInGSDMode, curr
     // Include policy expense chats if the user isn't in the policy expense chat beta
     if (isPolicyExpenseChat(report) && !Permissions.canUsePolicyExpenseChat(betas)) {
         return false;
-    }
-
-    // Include unread reports when in GSD mode
-    // GSD mode is specifically for focusing the user on the most relevant chats, primarily, the unread ones
-    if (isInGSDMode) {
-        return isUnread(report);
     }
 
     return true;

--- a/tests/unit/LHNFilterTest.js
+++ b/tests/unit/LHNFilterTest.js
@@ -529,4 +529,111 @@ describe('Sidebar', () => {
                 });
         });
     });
+
+    describe('all combinations of hasComments, isArchived, isUserCreatedPolicyRoom, hasAddWorkspaceError, isUnread, isPinned, hasDraft', () => {
+        // Given a report that is the active report and doesn't change
+        const report1 = LHNTestUtils.getFakeReport(['email3@test.com', 'email4@test.com']);
+
+        // Given a free policy that doesn't change
+        const policy = {
+            name: 'Policy One',
+            policyID: '1',
+            type: CONST.POLICY.TYPE.FREE,
+        };
+
+        // Given the user is in all betas
+        const betas = [
+            CONST.BETAS.DEFAULT_ROOMS,
+            CONST.BETAS.POLICY_ROOMS,
+            CONST.BETAS.POLICY_EXPENSE_CHAT,
+        ];
+
+        // Given there are 7 boolean variables tested in the filtering logic:
+        // 1. hasComments
+        // 2. isArchived
+        // 3. isUserCreatedPolicyRoom
+        // 4. hasAddWorkspaceError
+        // 5. isUnread
+        // 6. isPinned
+        // 7. hasDraft
+        // There is one setting not represented here, which is hasOutstandingIOU. In order to test that setting, there must be
+        // additional reports in Onyx, so it's being left out for now. It's identical to the logic for hasDraft and isPinned though.
+
+        // Given these combinations of booleans which result in the report being filtered out (not shown).
+        const booleansWhichRemovesInactiveReport = [
+            JSON.stringify([false, false, false, false, false, false, false]),
+            JSON.stringify([false, false, false, true, false, false, false]),
+            JSON.stringify([false, false, true, false, false, false, false]),
+            JSON.stringify([false, false, true, false, true, false, false]),
+            JSON.stringify([false, false, true, true, false, false, false]),
+            JSON.stringify([false, false, true, true, true, false, false]),
+            JSON.stringify([false, true, false, false, false, false, false]),
+            JSON.stringify([false, true, false, false, true, false, false]),
+            JSON.stringify([false, true, false, true, false, false, false]),
+            JSON.stringify([false, true, false, true, true, false, false]),
+            JSON.stringify([false, true, true, false, false, false, false]),
+            JSON.stringify([false, true, true, false, true, false, false]),
+            JSON.stringify([false, true, true, true, false, false, false]),
+            JSON.stringify([false, true, true, true, true, false, false]),
+            JSON.stringify([true, false, false, false, false, false, false]),
+            JSON.stringify([true, false, false, true, false, false, false]),
+            JSON.stringify([true, false, true, false, false, false, false]),
+            JSON.stringify([true, false, true, true, false, false, false]),
+            JSON.stringify([true, true, false, false, false, false, false]),
+            JSON.stringify([true, true, false, true, false, false, false]),
+            JSON.stringify([true, true, true, false, false, false, false]),
+            JSON.stringify([true, true, true, true, false, false, false]),
+        ];
+
+        // When every single combination of those booleans is tested
+
+        // Taken from https://stackoverflow.com/a/39734979/9114791 to generate all possible boolean combinations
+        const AMOUNT_OF_VARIABLES = 7;
+        // eslint-disable-next-line no-bitwise
+        for (let i = 0; i < (1 << AMOUNT_OF_VARIABLES); i++) {
+            const boolArr = [];
+            for (let j = AMOUNT_OF_VARIABLES - 1; j >= 0; j--) {
+                // eslint-disable-next-line no-bitwise
+                boolArr.push(Boolean(i & (1 << j)));
+            }
+
+            // To test a failing set of conditions, comment out the for loop above and then use a hardcoded array
+            // for the specific case that's failing. You can then debug the code to see why the test is not passing.
+            // const boolArr = [false, false, false, true, false, false, false];
+
+            it(`the booleans ${JSON.stringify(boolArr)}`, () => {
+                const report2 = {
+                    ...LHNTestUtils.getAdvancedFakeReport(...boolArr),
+                    policyID: policy.policyID,
+                };
+                const sidebarLinks = LHNTestUtils.getDefaultRenderedSidebarLinks(report1.reportID);
+
+                return waitForPromisesToResolve()
+
+                    // When Onyx is updated to contain that data and the sidebar re-renders
+                    .then(() => Onyx.multiSet({
+                        [ONYXKEYS.NVP_PRIORITY_MODE]: CONST.PRIORITY_MODE.GSD,
+                        [ONYXKEYS.BETAS]: betas,
+                        [ONYXKEYS.PERSONAL_DETAILS]: LHNTestUtils.fakePersonalDetails,
+                        [`${ONYXKEYS.COLLECTION.REPORT}${report1.reportID}`]: report1,
+                        [`${ONYXKEYS.COLLECTION.REPORT}${report2.reportID}`]: report2,
+                        [`${ONYXKEYS.COLLECTION.POLICY}${policy.policyID}`]: policy,
+                    }))
+
+                    // Then depending on the outcome, either one or two reports are visible
+                    .then(() => {
+                        if (booleansWhichRemovesInactiveReport.indexOf(JSON.stringify(boolArr)) > -1) {
+                            // Only one report visible
+                            expect(sidebarLinks.queryAllByA11yHint('Navigates to a chat')).toHaveLength(1);
+                            expect(sidebarLinks.queryAllByA11yLabel('Chat user display names')).toHaveLength(1);
+                            const displayNames = sidebarLinks.queryAllByA11yLabel('Chat user display names');
+                            expect(lodashGet(displayNames, [0, 'props', 'children'])).toBe('Three, Four');
+                        } else {
+                            // Both reports visible
+                            expect(sidebarLinks.queryAllByA11yHint('Navigates to a chat')).toHaveLength(2);
+                        }
+                    });
+            });
+        }
+    });
 });

--- a/tests/unit/LHNFilterTest.js
+++ b/tests/unit/LHNFilterTest.js
@@ -398,5 +398,40 @@ describe('Sidebar', () => {
                     expect(sidebarLinks.queryAllByText(/One, Two/)).toHaveLength(0);
                 });
         });
+
+        it('always shows pinned and draft chats', () => {
+            // Given a draft report and an unread report
+            const draftReport = {
+                ...LHNTestUtils.getFakeReport(['email1@test.com', 'email2@test.com']),
+                hasDraft: true,
+            };
+            const pinnedReport = {
+                ...LHNTestUtils.getFakeReport(['email3@test.com', 'email4@test.com']),
+                isPinned: true,
+            };
+            const sidebarLinks = LHNTestUtils.getDefaultRenderedSidebarLinks(draftReport.reportID);
+
+            return waitForPromisesToResolve()
+
+                // When Onyx is updated to contain that data and the sidebar re-renders
+                .then(() => Onyx.multiSet({
+                    [ONYXKEYS.NVP_PRIORITY_MODE]: CONST.PRIORITY_MODE.GSD,
+                    [ONYXKEYS.PERSONAL_DETAILS]: LHNTestUtils.fakePersonalDetails,
+                    [`${ONYXKEYS.COLLECTION.REPORT}${draftReport.reportID}`]: draftReport,
+                    [`${ONYXKEYS.COLLECTION.REPORT}${pinnedReport.reportID}`]: pinnedReport,
+                }))
+
+                // Then both reports are visible
+                .then(() => {
+                    const displayNames = sidebarLinks.queryAllByA11yLabel('Chat user display names');
+                    expect(displayNames).toHaveLength(2);
+                    expect(lodashGet(displayNames, [0, 'props', 'children'])).toBe('Three, Four');
+                    expect(lodashGet(displayNames, [1, 'props', 'children'])).toBe('One, Two');
+                });
+        });
+
+        it('does not show archived or policy rooms unless they are unread', () => {
+
+        });
     });
 });

--- a/tests/unit/LHNFilterTest.js
+++ b/tests/unit/LHNFilterTest.js
@@ -400,7 +400,7 @@ describe('Sidebar', () => {
         });
 
         it('always shows pinned and draft chats', () => {
-            // Given a draft report and an unread report
+            // Given a draft report and a pinned report
             const draftReport = {
                 ...LHNTestUtils.getFakeReport(['email1@test.com', 'email2@test.com']),
                 hasDraft: true,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/11624

### Tests
1. Make sure you are in focus view mode in preferences
2. Have multiple pinned reports
3. Verify all pinned reports are showing in the LHN
4. Have some chats which are not pinned that have unread messages
5. Verify the unread chats also show up in the LHN
6. Verify there are no archived reports showing in the LHN
7. Verify there are no policy rooms showing in the LHN (unless they have unread messages)
8. Open the report search
9. Check both view modes (most recent and focus mode) and verify that the reports listed in the search options are always sorted by most recently accessed

- [ ] Verify that no errors appear in the JS console

### PR Review Checklist
<!--
This is a checklist for PR authors & reviewers. Please make sure to complete all tasks and check them off once you do, or else Expensify has the right not to merge your PR!
-->
#### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] Any functional components have the `displayName` property
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

<details>
<summary><h4>PR Reviewer Checklist</h4>

The reviewer will copy/paste it into a new comment and complete it after the author checklist is completed
</summary>

- [x] I have verified the author checklist is complete (all boxes are checked off).
- [x] I verified the correct issue is linked in the `### Fixed Issues` section above
- [x] I verified testing steps are clear and they cover the changes made in this PR
    - [x] I verified the steps for local testing are in the `Tests` section
    - [x] I verified the steps for Staging and/or Production testing are in the `QA steps` section
    - [x] I verified the steps cover any possible failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [x] I checked that screenshots or videos are included for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I verified tests pass on **all platforms** & I tested again on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] If there are any errors in the console that are unrelated to this PR, I either fixed them (preferred) or linked to where I reported them in Slack
- [x] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`).
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I verified that this PR follows the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I verified other components that can be impacted by these changes have been tested, and I retested again (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` have been tested & I retested again)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] Any functional components have the `displayName` property
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] I have checked off every checkbox in the PR reviewer checklist, including those that don't apply to this PR.

</details>


<details>
<summary><h4>PR Reviewer Checklist</h4>

The reviewer will copy/paste it into a new comment and complete it after the author checklist is completed
</summary>

- [ ] I have verified the author checklist is complete (all boxes are checked off).
- [ ] I verified the correct issue is linked in the `### Fixed Issues` section above
- [ ] I verified testing steps are clear and they cover the changes made in this PR
    - [ ] I verified the steps for local testing are in the `Tests` section
    - [ ] I verified the steps for Staging and/or Production testing are in the `QA steps` section
    - [ ] I verified the steps cover any possible failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [ ] I checked that screenshots or videos are included for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I verified tests pass on **all platforms** & I tested again on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [ ] If there are any errors in the console that are unrelated to this PR, I either fixed them (preferred) or linked to where I reported them in Slack
- [ ] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`).
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [ ] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I verified that this PR follows the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I verified other components that can be impacted by these changes have been tested, and I retested again (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` have been tested & I retested again)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] Any functional components have the `displayName` property
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] I have checked off every checkbox in the PR reviewer checklist, including those that don't apply to this PR.

</details>

### QA Steps
1. Make sure you are in focus view mode in preferences
2. Have multiple pinned reports
3. Verify all pinned reports are showing in the LHN
4. Have some chats which are not pinned that have unread messages
5. Verify the unread chats also show up in the LHN
6. Verify there are no archived reports showing in the LHN
7. Verify there are no policy rooms showing in the LHN (unless they have unread messages)
8. Open the report search
9. Check both view modes (most recent and focus mode) and verify that the reports listed in the search options are always sorted by most recently accessed

- [ ] Verify that no errors appear in the JS console

### Screenshots
Tried to get screenshots using the staging API in as many platforms as I could

#### Web
![image](https://user-images.githubusercontent.com/1228807/194365649-ed23641b-eca7-4476-aeef-b12ac7de08b0.png)



#### Mobile Web - Chrome
![image](https://user-images.githubusercontent.com/1228807/194365451-c65bc71f-e6aa-48bf-a23f-787db7c2b9d2.png)


#### Mobile Web - Safari
![image](https://user-images.githubusercontent.com/1228807/194365817-60e17a92-3d3b-4ca7-a31a-3014f57dc4b1.png)


#### Desktop
![image](https://user-images.githubusercontent.com/1228807/194366812-5d05716b-629f-4d55-a6c4-7442bd69d54c.png)



#### iOS
![image](https://user-images.githubusercontent.com/1228807/194365741-0ba30006-7a2f-4f9d-9a45-8b2c2c1a113c.png)



#### Android
![image](https://user-images.githubusercontent.com/1228807/194365311-627b3660-6484-4934-a7f8-f02fcc4fe05e.png)


