### PR TITLE
Only show reports without comments if they are non-archived policy rooms

### DIFF
--- a/src/libs/ReportUtils.js
+++ b/src/libs/ReportUtils.js
@@ -935,9 +935,9 @@ function shouldReportBeInOptionList(report, reportIDFromRoute, isInGSDMode, curr
     }
 
     // Exclude reports that don't have any comments
-    // Archived rooms or user created policy rooms are OK to show when the don't have any comments
+    // User created policy rooms are OK to show when the don't have any comments, only if they aren't archived.
     const hasNoComments = report.lastMessageTimestamp === 0;
-    if (hasNoComments && (isArchivedRoom(report) || isUserCreatedPolicyRoom(report))) {
+    if (hasNoComments && (isArchivedRoom(report) || !isUserCreatedPolicyRoom(report))) {
         return false;
     }
 

--- a/tests/unit/LHNFilterTest.js
+++ b/tests/unit/LHNFilterTest.js
@@ -562,10 +562,10 @@ describe('Sidebar', () => {
         const booleansWhichRemovesInactiveReport = [
             JSON.stringify([false, false, false, false, false, false, false]),
             JSON.stringify([false, false, false, true, false, false, false]),
+            JSON.stringify([false, false, false, false, true, false, false]),
+            JSON.stringify([false, false, false, true, true, false, false]),
             JSON.stringify([false, false, true, false, false, false, false]),
-            JSON.stringify([false, false, true, false, true, false, false]),
             JSON.stringify([false, false, true, true, false, false, false]),
-            JSON.stringify([false, false, true, true, true, false, false]),
             JSON.stringify([false, true, false, false, false, false, false]),
             JSON.stringify([false, true, false, false, true, false, false]),
             JSON.stringify([false, true, false, true, false, false, false]),

--- a/tests/unit/LHNFilterTest.js
+++ b/tests/unit/LHNFilterTest.js
@@ -247,6 +247,9 @@ describe('Sidebar', () => {
 
             // Given these combinations of booleans which result in the report being filtered out (not shown).
             const booleansWhichRemovesInactiveReport = [
+                // hasComments is false
+                JSON.stringify([false, false, false, false, false, false, false]),
+
                 // isUserCreatedPolicyRoom
                 JSON.stringify([false, false, true, false, false, false, false]),
 
@@ -258,6 +261,12 @@ describe('Sidebar', () => {
 
                 // isUserCreatedPolicyRoom, hasAddWorkspaceError, isUnread
                 JSON.stringify([false, false, true, true, true, false, false]),
+
+                // isUnread
+                JSON.stringify([false, false, false, false, true, false, false]),
+
+                // hasAddWorkspaceError
+                JSON.stringify([false, false, false, false, true, false, false]),
 
                 // isArchived
                 JSON.stringify([false, true, false, false, false, false, false]),

--- a/tests/unit/LHNFilterTest.js
+++ b/tests/unit/LHNFilterTest.js
@@ -247,7 +247,6 @@ describe('Sidebar', () => {
 
             // Given these combinations of booleans which result in the report being filtered out (not shown).
             const booleansWhichRemovesInactiveReport = [
-                // hasComments is false
                 JSON.stringify([false, false, false, false, false, false, false]),
 
                 // isUnread

--- a/tests/unit/LHNFilterTest.js
+++ b/tests/unit/LHNFilterTest.js
@@ -250,23 +250,14 @@ describe('Sidebar', () => {
                 // hasComments is false
                 JSON.stringify([false, false, false, false, false, false, false]),
 
-                // isUserCreatedPolicyRoom
-                JSON.stringify([false, false, true, false, false, false, false]),
-
-                // isUserCreatedPolicyRoom, isUnread
-                JSON.stringify([false, false, true, false, true, false, false]),
-
-                // isUserCreatedPolicyRoom, hasAddWorkspaceError
-                JSON.stringify([false, false, true, true, false, false, false]),
-
-                // isUserCreatedPolicyRoom, hasAddWorkspaceError, isUnread
-                JSON.stringify([false, false, true, true, true, false, false]),
-
                 // isUnread
                 JSON.stringify([false, false, false, false, true, false, false]),
 
+                // hasAddWorkspaceError, isUnread
+                JSON.stringify([false, false, false, true, true, false, false]),
+
                 // hasAddWorkspaceError
-                JSON.stringify([false, false, false, false, true, false, false]),
+                JSON.stringify([false, false, false, true, false, false, false]),
 
                 // isArchived
                 JSON.stringify([false, true, false, false, false, false, false]),

--- a/tests/unit/OptionsListUtilsTest.js
+++ b/tests/unit/OptionsListUtilsTest.js
@@ -283,8 +283,8 @@ describe('OptionsListUtils', () => {
         // Then the 2 personalDetails that don't have reports should be returned
         expect(results.personalDetails.length).toBe(2);
 
-        // Then all of the reports should be shown, including the one that has no message on them.
-        expect(results.recentReports.length).toBe(_.size(REPORTS));
+        // Then all of the reports should be shown EXCEPT the archived room, including the one that has no message on them.
+        expect(results.recentReports.length).toBe(_.size(REPORTS) - 1);
 
         // When we filter again but provide a searchValue
         results = OptionsListUtils.getSearchOptions(REPORTS, PERSONAL_DETAILS, 'spider');


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This fixes part of the refactor done `https://github.com/Expensify/App/blob/8203e1a1bfcadc5ebc1891d5848e317cfec4fbd3/src/libs/ReportUtils.js#L941` where the logic changed as part of the boolean rework

### Fixed Issues
<!---
Please replace GH_LINK with the link to the GitHub issue this Pull Request is fixing.
Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the issue; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/11633

### Tests
1. Open up the app and login.
2. Make sure your priority mode is `Most Recent`
3. Open a new chat with someone. Do not message them.
4. Switch to another chat, see that the old chat is no longer in the chat list LHN.

- [x] Verify that no errors appear in the JS console

### PR Review Checklist
<!--
This is a checklist for PR authors & reviewers. Please make sure to complete all tasks and check them off once you do, or else Expensify has the right not to merge your PR!
-->
#### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] Any functional components have the `displayName` property
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

<details>
<summary><h4>PR Reviewer Checklist</h4>

The reviewer will copy/paste it into a new comment and complete it after the author checklist is completed
</summary>

- [ ] I have verified the author checklist is complete (all boxes are checked off).
- [ ] I verified the correct issue is linked in the `### Fixed Issues` section above
- [ ] I verified testing steps are clear and they cover the changes made in this PR
    - [ ] I verified the steps for local testing are in the `Tests` section
    - [ ] I verified the steps for Staging and/or Production testing are in the `QA steps` section
    - [ ] I verified the steps cover any possible failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [ ] I checked that screenshots or videos are included for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I verified tests pass on **all platforms** & I tested again on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [ ] If there are any errors in the console that are unrelated to this PR, I either fixed them (preferred) or linked to where I reported them in Slack
- [ ] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`).
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [ ] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I verified that this PR follows the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I verified other components that can be impacted by these changes have been tested, and I retested again (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` have been tested & I retested again)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] Any functional components have the `displayName` property
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] I have checked off every checkbox in the PR reviewer checklist, including those that don't apply to this PR.

</details>

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
5. Upload an image via copy paste
6. Verify a modal appears displaying a preview of that image
--->
1. Open up the app and login.
2. Make sure your priority mode is `Most Recent`
3. Open a new chat with someone. Do not message them.
4. Switch to another chat, see that the old chat is no longer in the chat list LHN.


- [ ] Verify that no errors appear in the JS console

### Screenshots

#### Web

https://user-images.githubusercontent.com/5258036/194388880-762eca7f-d7e0-40d9-a897-2267d68c35db.mov

#### Mobile Web - Chrome
<!-- Insert screenshots 



of your changes on the web platform (from chrome mobile browser)-->

https://user-images.githubusercontent.com/5258036/194398646-172c2bf2-3b4d-48dd-b589-898dd28c070b.mov


#### Mobile Web - Safari

https://user-images.githubusercontent.com/5258036/194394632-3623a248-265d-4b28-8472-e07bc35ac407.mov



#### Desktop

https://user-images.githubusercontent.com/5258036/194391062-b7d95be1-0a13-4cc1-bd67-3098ecd28ac1.mov



#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

https://user-images.githubusercontent.com/5258036/194393985-a7632411-0a36-4814-b9d6-d8a083c040b7.mov



#### Android

https://user-images.githubusercontent.com/5258036/194397542-a3501b8a-b679-420f-aa1c-c9fd0345745d.mov


<!-- Insert screenshots of your changes on the Android platform-->
