### PR TITLE
Add labels to chat list icons

### DIFF
--- a/src/components/LHNOptionsList/OptionRowLHN.js
+++ b/src/components/LHNOptionsList/OptionRowLHN.js
@@ -205,7 +205,7 @@ const OptionRowLHN = (props) => {
                         {optionItem.hasDraftComment && (
                             <View
                                 style={styles.ml2}
-                                accessibilityLabel="Has draft message"
+                                accessibilityLabel="Drafted message"
                             >
                                 <Icon src={Expensicons.Pencil} height={16} width={16} />
                             </View>

--- a/src/components/LHNOptionsList/OptionRowLHN.js
+++ b/src/components/LHNOptionsList/OptionRowLHN.js
@@ -198,9 +198,15 @@ const OptionRowLHN = (props) => {
                             )}
                         </View>
                     </View>
-                    <View style={[styles.flexRow, styles.alignItemsCenter]}>
+                    <View
+                        style={[styles.flexRow, styles.alignItemsCenter]}
+                        accessible={false}
+                    >
                         {optionItem.hasDraftComment && (
-                            <View style={styles.ml2}>
+                            <View
+                                style={styles.ml2}
+                                accessibilityLabel="Has draft message"
+                            >
                                 <Icon src={Expensicons.Pencil} height={16} width={16} />
                             </View>
                         )}
@@ -208,7 +214,10 @@ const OptionRowLHN = (props) => {
                             <IOUBadge iouReportID={optionItem.iouReportID} />
                         )}
                         {optionItem.isPinned && (
-                            <View style={styles.ml2}>
+                            <View
+                                style={styles.ml2}
+                                accessibilityLabel="Chat pinned"
+                            >
                                 <Icon src={Expensicons.Pin} height={16} width={16} />
                             </View>
                         )}

--- a/src/components/LHNOptionsList/OptionRowLHN.js
+++ b/src/components/LHNOptionsList/OptionRowLHN.js
@@ -205,7 +205,7 @@ const OptionRowLHN = (props) => {
                         {optionItem.hasDraftComment && (
                             <View
                                 style={styles.ml2}
-                                accessibilityLabel="Drafted message"
+                                accessibilityLabel={props.translate('sidebarScreen.draftedMessage')}
                             >
                                 <Icon src={Expensicons.Pencil} height={16} width={16} />
                             </View>
@@ -216,7 +216,7 @@ const OptionRowLHN = (props) => {
                         {optionItem.isPinned && (
                             <View
                                 style={styles.ml2}
-                                accessibilityLabel="Chat pinned"
+                                accessibilityLabel={props.translate('sidebarScreen.chatPinned')}
                             >
                                 <Icon src={Expensicons.Pin} height={16} width={16} />
                             </View>

--- a/src/components/OptionRow.js
+++ b/src/components/OptionRow.js
@@ -240,7 +240,7 @@ const OptionRow = (props) => {
                             {props.option.hasDraftComment && (
                                 <View
                                     style={styles.ml2}
-                                    accessibilityLabel="Has draft message"
+                                    accessibilityLabel="Drafted message"
                                 >
                                     <Icon src={Expensicons.Pencil} height={16} width={16} />
                                 </View>

--- a/src/components/OptionRow.js
+++ b/src/components/OptionRow.js
@@ -240,7 +240,7 @@ const OptionRow = (props) => {
                             {props.option.hasDraftComment && (
                                 <View
                                     style={styles.ml2}
-                                    accessibilityLabel="Drafted message"
+                                    accessibilityLabel={props.translate('sidebarScreen.draftedMessage')}
                                 >
                                     <Icon src={Expensicons.Pencil} height={16} width={16} />
                                 </View>
@@ -251,7 +251,7 @@ const OptionRow = (props) => {
                             {props.option.isPinned && (
                                 <View
                                     style={styles.ml2}
-                                    accessibilityLabel="Chat pinned"
+                                    accessibilityLabel={props.translate('sidebarScreen.chatPinned')}
                                 >
                                     <Icon src={Expensicons.Pin} height={16} width={16} />
                                 </View>

--- a/src/components/OptionRow.js
+++ b/src/components/OptionRow.js
@@ -233,9 +233,15 @@ const OptionRow = (props) => {
                         </View>
                     </View>
                     {!props.hideAdditionalOptionStates && (
-                        <View style={[styles.flexRow, styles.alignItemsCenter]}>
+                        <View
+                            style={[styles.flexRow, styles.alignItemsCenter]}
+                            accessible={false}
+                        >
                             {props.option.hasDraftComment && (
-                                <View style={styles.ml2}>
+                                <View
+                                    style={styles.ml2}
+                                    accessibilityLabel="Has draft message"
+                                >
                                     <Icon src={Expensicons.Pencil} height={16} width={16} />
                                 </View>
                             )}
@@ -243,7 +249,10 @@ const OptionRow = (props) => {
                                 <IOUBadge iouReportID={props.option.iouReportID} />
                             )}
                             {props.option.isPinned && (
-                                <View style={styles.ml2}>
+                                <View
+                                    style={styles.ml2}
+                                    accessibilityLabel="Chat pinned"
+                                >
                                     <Icon src={Expensicons.Pin} height={16} width={16} />
                                 </View>
                             )}

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -235,6 +235,8 @@ export default {
         buttonSearch: 'Search',
         buttonMySettings: 'My settings',
         fabNewChat: 'New chat(Floating Action)',
+        chatPinned: 'Chat pinned',
+        draftedMessage: 'Drafted message',
     },
     iou: {
         amount: 'Amount',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -235,6 +235,8 @@ export default {
         buttonSearch: 'Buscar',
         buttonMySettings: 'Mi configuración',
         fabNewChat: 'Nuevo chat',
+        chatPinned: 'Chat fijado',
+        draftedMessage: 'Mensaje borrador',
     },
     iou: {
         amount: 'Importe',


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
cc @stitesExpensify 

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Added accessibility labels for the icons in the LHN. **Note: I only was able to test this on web because testing screenreader stuff on emulators is incredibly difficult. Any suggestions would be appreciated!**

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/5671

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. I ran through the page using the tab key with [VoiceOver](https://support.apple.com/guide/voiceover/turn-voiceover-on-or-off-vo2682/mac) on on web and desktop, and it correctly calls out the icons with no other changes to the interface.
2. I have not been able to test screen readers on mobile devices as this seems to be close to impossible without physical devices. **These may have to wait until production for QA with actual devices.**

- [x] Verify that no errors appear in the JS console

### PR Review Checklist
<!--
This is a checklist for PR authors & reviewers. Please make sure to complete all tasks and check them off once you do, or else Expensify has the right not to merge your PR!
-->
#### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

<details>
<summary><h4>PR Reviewer Checklist</h4>

The reviewer will copy/paste it into a new comment and complete it after the author checklist is completed
</summary>

- [ ] I have verified the author checklist is complete (all boxes are checked off).
- [ ] I verified the correct issue is linked in the `### Fixed Issues` section above
- [ ] I verified testing steps are clear and they cover the changes made in this PR
    - [ ] I verified the steps for local testing are in the `Tests` section
    - [ ] I verified the steps for Staging and/or Production testing are in the `QA steps` section
    - [ ] I verified the steps cover any possible failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [ ] I checked that screenshots or videos are included for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I verified tests pass on **all platforms** & I tested again on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [ ] If there are any errors in the console that are unrelated to this PR, I either fixed them (preferred) or linked to where I reported them in Slack
- [ ] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`).
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [ ] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I verified that this PR follows the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I verified other components that can be impacted by these changes have been tested, and I retested again (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` have been tested & I retested again)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] I have checked off every checkbox in the PR reviewer checklist, including those that don't apply to this PR.

</details>

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
3. Upload an image via copy paste
4. Verify a modal appears displaying a preview of that image
--->
1. Pin a chat to the top of the list
2. Add a draft message in that chat, and switch to another chat
3. Confirm there are no visible changes from current behavior
5. Turn on a screen reader and navigate through the page (using the tab key on desktop)
6. Confirm that "Has draft message" and "Chat pinned" are read to the user.

- [ ] Verify that no errors appear in the JS console

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->
Should be no visible changes (although in Desktop and Web I included the VoiceOver window showing the updated reading).

#### Web
<!-- Insert screenshots of your changes on the web platform-->  
<img width="1728" alt="Screen Shot 2022-10-14 at 16 05 03" src="https://user-images.githubusercontent.com/5487802/195956297-6154c586-edbf-4a87-bcba-b5eb7298414a.png">

#### Mobile Web - Chrome
<!-- Insert screenshots of your changes on the web platform (from chrome mobile browser)-->
<img width="551" alt="Screen Shot 2022-10-14 at 16 10 03" src="https://user-images.githubusercontent.com/5487802/195956283-236639d1-5a75-43f8-8230-409071a63c9e.png">

#### Mobile Web - Safari
<!-- Insert screenshots of your changes on the web platform (from safari mobile browser)-->
<img width="564" alt="Screen Shot 2022-10-14 at 16 08 44" src="https://user-images.githubusercontent.com/5487802/195956277-f89d410d-93d3-40c7-83f9-e7f13f93f9e7.png">

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
<img width="1199" alt="Screen Shot 2022-10-14 at 16 03 42" src="https://user-images.githubusercontent.com/5487802/195956271-6257dbf5-2152-4180-8262-14ee0eba8679.png">

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
<img width="564" alt="Screen Shot 2022-10-14 at 16 06 09" src="https://user-images.githubusercontent.com/5487802/195956255-7e691d53-481e-4668-9a23-2dc30233c67a.png">

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
<img width="551" alt="Screen Shot 2022-10-14 at 16 07 08" src="https://user-images.githubusercontent.com/5487802/195956249-85dfe012-99bc-422b-8be3-0db01baef85f.png">

