### PR TITLE
Make sure that archived reports are shown properly in the LHN and the search options

### DIFF
--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -282,6 +282,8 @@ function createOption(logins, personalDetails, report, reportActions = {}, {
     let hasMultipleParticipants = personalDetailList.length > 1;
     let subtitle;
 
+    result.participantsList = personalDetailList;
+
     if (report) {
         result.isChatRoom = ReportUtils.isChatRoom(report);
         result.isDefaultRoom = ReportUtils.isDefaultRoom(report);
@@ -333,6 +335,12 @@ function createOption(logins, personalDetails, report, reportActions = {}, {
                 ? lastMessageText
                 : Str.removeSMSDomain(personalDetail.login);
         }
+
+        const reportName = ReportUtils.getReportName(report, personalDetailMap, policies);
+        result.text = reportName;
+        result.searchText = getSearchText(report, reportName, personalDetailList, result.isChatRoom || result.isPolicyExpenseChat);
+        result.icons = ReportUtils.getIcons(report, personalDetails, policies, personalDetail.avatar);
+        result.subtitle = subtitle;
     } else {
         result.keyForList = personalDetail.login;
         result.alternateText = Str.removeSMSDomain(personalDetail.login);
@@ -351,13 +359,6 @@ function createOption(logins, personalDetails, report, reportActions = {}, {
         result.phoneNumber = personalDetail.phoneNumber;
         result.payPalMeAddress = personalDetail.payPalMeAddress;
     }
-
-    const reportName = ReportUtils.getReportName(report, personalDetailMap, policies);
-    result.text = reportName;
-    result.subtitle = subtitle;
-    result.participantsList = personalDetailList;
-    result.icons = ReportUtils.getIcons(report, personalDetails, policies, personalDetail.avatar);
-    result.searchText = getSearchText(report, reportName, personalDetailList, result.isChatRoom || result.isPolicyExpenseChat);
 
     return result;
 }
@@ -505,7 +506,7 @@ function getOptions(reports, personalDetails, {
 
     if (sortPersonalDetailsByAlphaAsc) {
         // PersonalDetails should be ordered Alphabetically by default - https://github.com/Expensify/App/issues/8220#issuecomment-1104009435
-        allPersonalDetailsOptions = lodashOrderBy(allPersonalDetailsOptions, [personalDetail => personalDetail.text.toLowerCase()], 'asc');
+        allPersonalDetailsOptions = lodashOrderBy(allPersonalDetailsOptions, [personalDetail => personalDetail.text && personalDetail.text.toLowerCase()], 'asc');
     }
 
     // Always exclude already selected options and the currently logged in user

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -336,11 +336,6 @@ function createOption(logins, personalDetails, report, reportActions = {}, {
                 : Str.removeSMSDomain(personalDetail.login);
         }
 
-        const reportName = ReportUtils.getReportName(report, personalDetailMap, policies);
-        result.text = reportName;
-        result.searchText = getSearchText(report, reportName, personalDetailList, result.isChatRoom || result.isPolicyExpenseChat);
-        result.icons = ReportUtils.getIcons(report, personalDetails, policies, personalDetail.avatar);
-        result.subtitle = subtitle;
     } else {
         result.keyForList = personalDetail.login;
         result.alternateText = Str.removeSMSDomain(personalDetail.login);
@@ -359,6 +354,12 @@ function createOption(logins, personalDetails, report, reportActions = {}, {
         result.phoneNumber = personalDetail.phoneNumber;
         result.payPalMeAddress = personalDetail.payPalMeAddress;
     }
+
+    const reportName = ReportUtils.getReportName(report, personalDetailMap, policies);
+    result.text = reportName;
+    result.searchText = getSearchText(report, reportName, personalDetailList, result.isChatRoom || result.isPolicyExpenseChat);
+    result.icons = ReportUtils.getIcons(report, personalDetails, policies, personalDetail.avatar);
+    result.subtitle = subtitle;
 
     return result;
 }

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -335,7 +335,6 @@ function createOption(logins, personalDetails, report, reportActions = {}, {
                 ? lastMessageText
                 : Str.removeSMSDomain(personalDetail.login);
         }
-
     } else {
         result.keyForList = personalDetail.login;
         result.alternateText = Str.removeSMSDomain(personalDetail.login);

--- a/src/libs/ReportUtils.js
+++ b/src/libs/ReportUtils.js
@@ -244,16 +244,11 @@ function findLastAccessedReport(reports, ignoreDefaultRooms, policies) {
 /**
  * Whether the provided report is an archived room
  * @param {Object} report
- * @param {String} report.chatType
  * @param {Number} report.stateNum
  * @param {Number} report.statusNum
  * @returns {Boolean}
  */
 function isArchivedRoom(report) {
-    // if (!isChatRoom(report) && !isPolicyExpenseChat(report)) {
-    //     return false;
-    // }
-
     return report.statusNum === CONST.REPORT.STATUS.CLOSED && report.stateNum === CONST.REPORT.STATE_NUM.SUBMITTED;
 }
 

--- a/src/libs/ReportUtils.js
+++ b/src/libs/ReportUtils.js
@@ -249,7 +249,7 @@ function findLastAccessedReport(reports, ignoreDefaultRooms, policies) {
  * @returns {Boolean}
  */
 function isArchivedRoom(report) {
-    return report.statusNum === CONST.REPORT.STATUS.CLOSED && report.stateNum === CONST.REPORT.STATE_NUM.SUBMITTED;
+    return lodashGet(report, ['statusNum']) === CONST.REPORT.STATUS.CLOSED && lodashGet(report, ['stateNum']) === CONST.REPORT.STATE_NUM.SUBMITTED;
 }
 
 /**

--- a/src/libs/ReportUtils.js
+++ b/src/libs/ReportUtils.js
@@ -250,9 +250,9 @@ function findLastAccessedReport(reports, ignoreDefaultRooms, policies) {
  * @returns {Boolean}
  */
 function isArchivedRoom(report) {
-    if (!isChatRoom(report) && !isPolicyExpenseChat(report)) {
-        return false;
-    }
+    // if (!isChatRoom(report) && !isPolicyExpenseChat(report)) {
+    //     return false;
+    // }
 
     return report.statusNum === CONST.REPORT.STATUS.CLOSED && report.stateNum === CONST.REPORT.STATE_NUM.SUBMITTED;
 }
@@ -903,6 +903,8 @@ function hasOutstandingIOU(report, currentUserLogin, iouReports) {
  * @returns {boolean}
  */
 function shouldReportBeInOptionList(report, reportIDFromRoute, isInGSDMode, currentUserLogin, iouReports, betas, policies) {
+    const isInDefaultMode = !isInGSDMode;
+
     // Exclude reports that have no data because there wouldn't be anything to show in the option item.
     // This can happen if data is currently loading from the server or a report is in various stages of being created.
     if (!report || !report.reportID || !report.participants || _.isEmpty(report.participants)) {
@@ -928,17 +930,14 @@ function shouldReportBeInOptionList(report, reportIDFromRoute, isInGSDMode, curr
         return true;
     }
 
-    // Exclude reports that don't have any comments
-    // User created policy rooms are OK to show when the don't have any comments, only if they aren't archived.
-    const hasNoComments = report.lastMessageTimestamp === 0;
-    if (hasNoComments && (isArchivedRoom(report) || !isUserCreatedPolicyRoom(report))) {
-        return false;
-    }
-
-    // Include unread reports when in GSD mode
-    // GSD mode is specifically for focusing the user on the most relevant chats, primarily, the unread ones
+    // All unread chats (even archived ones) in GSD mode will be shown. This is because GSD mode is specifically for focusing the user on the most relevant chats, primarily, the unread ones
     if (isInGSDMode) {
         return isUnread(report);
+    }
+
+    // Archived reports should always be shown when in default (most recent) mode. This is because you should still be able to access and search for the chats to find them.
+    if (isInDefaultMode && isArchivedRoom(report)) {
+        return true;
     }
 
     // Include default rooms for free plan policies

--- a/src/libs/SidebarUtils.js
+++ b/src/libs/SidebarUtils.js
@@ -113,7 +113,15 @@ function getOrderedReportIDs(reportIDFromRoute) {
     // - Regardless of mode, all archived reports should remain at the bottom
     const orderedReports = _.sortBy(filteredReportsWithReportName, (report) => {
         if (ReportUtils.isArchivedRoom(report)) {
-            return isInDefaultMode ? -Infinity : 'ZZZZZZZZZZZZZ';
+            return isInDefaultMode
+
+                // -Infinity is used here because there is no chance that a report will ever have an older timestamp than -Infinity and it ensures that archived reports
+                // will always be listed last
+                ? -Infinity
+
+                // Similar logic is used for 'ZZZZZZZZZZZZZ' to reasonably assume that no report will ever have a report name that will be listed alphabetically after this, ensuring that
+                // archived reports will be listed last
+                : 'ZZZZZZZZZZZZZ';
         }
 
         return isInDefaultMode ? report.lastMessageTimestamp : report.reportDisplayName;

--- a/tests/unit/LHNFilterTest.js
+++ b/tests/unit/LHNFilterTest.js
@@ -639,7 +639,7 @@ describe('Sidebar', () => {
 
     describe('Archived chat', () => {
         describe('in default (most recent) mode', () => {
-            it('is shown when it has comments', () => {
+            it('is shown regardless if it has comments or not', () => {
                 const sidebarLinks = LHNTestUtils.getDefaultRenderedSidebarLinks();
 
                 // Given an archived report with no comments
@@ -667,10 +667,10 @@ describe('Sidebar', () => {
                         [`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`]: report,
                     }))
 
-                    // Then the report is not rendered in the LHN
+                    // Then the report is rendered in the LHN
                     .then(() => {
                         const optionRows = sidebarLinks.queryAllByA11yHint('Navigates to a chat');
-                        expect(optionRows).toHaveLength(0);
+                        expect(optionRows).toHaveLength(1);
                     })
 
                     // When the report has comments
@@ -819,7 +819,7 @@ describe('Sidebar', () => {
                     });
             });
 
-            it('is hidden when it is empty', () => {
+            it('is hidden regardless of how many comments it has', () => {
                 const sidebarLinks = LHNTestUtils.getDefaultRenderedSidebarLinks();
 
                 // Given an archived report with no comments
@@ -856,10 +856,10 @@ describe('Sidebar', () => {
                     // When the report has comments
                     .then(() => Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`, {lastMessageTimestamp: Date.now()}))
 
-                    // Then the report is rendered in the LHN
+                    // Then the report is not rendered in the LHN
                     .then(() => {
                         const optionRows = sidebarLinks.queryAllByA11yHint('Navigates to a chat');
-                        expect(optionRows).toHaveLength(1);
+                        expect(optionRows).toHaveLength(0);
                     });
             });
         });

--- a/tests/unit/LHNFilterTest.js
+++ b/tests/unit/LHNFilterTest.js
@@ -4,7 +4,6 @@ import lodashGet from 'lodash/get';
 import * as LHNTestUtils from '../utils/LHNTestUtils';
 import waitForPromisesToResolve from '../utils/waitForPromisesToResolve';
 import CONST from '../../src/CONST';
-import {TEST_MAX_SEQUENCE_NUMBER} from '../utils/LHNTestUtils';
 
 // Be sure to include the mocked permissions library or else the beta tests won't work
 jest.mock('../../src/libs/Permissions');
@@ -217,7 +216,7 @@ describe('Sidebar', () => {
                 });
         });
 
-        describe('all combinations of hasComments, isArchived, isUserCreatedPolicyRoom, hasAddWorkspaceError, isUnread, isPinned, hasDraft', () => {
+        describe('all combinations of isArchived, isUserCreatedPolicyRoom, hasAddWorkspaceError, isUnread, isPinned, hasDraft', () => {
             // Given a report that is the active report and doesn't change
             const report1 = LHNTestUtils.getFakeReport(['email3@test.com', 'email4@test.com']);
 
@@ -235,59 +234,28 @@ describe('Sidebar', () => {
                 CONST.BETAS.POLICY_EXPENSE_CHAT,
             ];
 
-            // Given there are 7 boolean variables tested in the filtering logic:
-            // 1. hasComments
-            // 2. isArchived
-            // 3. isUserCreatedPolicyRoom
-            // 4. hasAddWorkspaceError
-            // 5. isUnread
-            // 6. isPinned
-            // 7. hasDraft
+            // Given there are 6 boolean variables tested in the filtering logic:
+            // 1. isArchived
+            // 2. isUserCreatedPolicyRoom
+            // 3. hasAddWorkspaceError
+            // 4. isUnread
+            // 5. isPinned
+            // 6. hasDraft
             // There is one setting not represented here, which is hasOutstandingIOU. In order to test that setting, there must be
             // additional reports in Onyx, so it's being left out for now. It's identical to the logic for hasDraft and isPinned though.
 
             // Given these combinations of booleans which result in the report being filtered out (not shown).
-            const booleansWhichRemovesInactiveReport = [
-                JSON.stringify([false, false, false, false, false, false, false]),
-
-                // isUnread
-                JSON.stringify([false, false, false, false, true, false, false]),
-
-                // hasAddWorkspaceError, isUnread
-                JSON.stringify([false, false, false, true, true, false, false]),
-
-                // hasAddWorkspaceError
-                JSON.stringify([false, false, false, true, false, false, false]),
-
-                // isArchived
-                JSON.stringify([false, true, false, false, false, false, false]),
-
-                // isArchived, isUnread
-                JSON.stringify([false, true, false, false, true, false, false]),
-
-                // isArchived, hasAddWorkspaceError
-                JSON.stringify([false, true, false, true, false, false, false]),
-
-                // isArchived, hasAddWorkspaceError, isUnread
-                JSON.stringify([false, true, false, true, true, false, false]),
-
-                // isArchived, isUserCreatedPolicyRoom
-                JSON.stringify([false, true, true, false, false, false, false]),
-
-                // isArchived, isUserCreatedPolicyRoom, isUnread
-                JSON.stringify([false, true, true, false, true, false, false]),
-
-                // isArchived, isUserCreatedPolicyRoom, hasAddWorkspaceError
-                JSON.stringify([false, true, true, true, false, false, false]),
-
-                // isArchived, isUserCreatedPolicyRoom, hasAddWorkspaceError, isUnread
-                JSON.stringify([false, true, true, true, true, false, false]),
+            const booleansWhichRemovesActiveReport = [
+                JSON.stringify([false, false, false, false, false, false]),
+                JSON.stringify([false, true, false, false, false, false]),
+                JSON.stringify([true, false, false, false, false, false]),
+                JSON.stringify([true, true, false, false, false, false]),
             ];
 
             // When every single combination of those booleans is tested
 
             // Taken from https://stackoverflow.com/a/39734979/9114791 to generate all possible boolean combinations
-            const AMOUNT_OF_VARIABLES = 7;
+            const AMOUNT_OF_VARIABLES = 6;
             // eslint-disable-next-line no-bitwise
             for (let i = 0; i < (1 << AMOUNT_OF_VARIABLES); i++) {
                 const boolArr = [];
@@ -298,7 +266,7 @@ describe('Sidebar', () => {
 
                 // To test a failing set of conditions, comment out the for loop above and then use a hardcoded array
                 // for the specific case that's failing. You can then debug the code to see why the test is not passing.
-                // const boolArr = [false, true, false, false, false, false, false];
+                // const boolArr = [false, false, true, false, false, false];
 
                 it(`the booleans ${JSON.stringify(boolArr)}`, () => {
                     const report2 = {
@@ -311,6 +279,7 @@ describe('Sidebar', () => {
 
                         // When Onyx is updated to contain that data and the sidebar re-renders
                         .then(() => Onyx.multiSet({
+                            [ONYXKEYS.NVP_PRIORITY_MODE]: CONST.PRIORITY_MODE.GSD,
                             [ONYXKEYS.BETAS]: betas,
                             [ONYXKEYS.PERSONAL_DETAILS]: LHNTestUtils.fakePersonalDetails,
                             [`${ONYXKEYS.COLLECTION.REPORT}${report1.reportID}`]: report1,
@@ -320,7 +289,7 @@ describe('Sidebar', () => {
 
                         // Then depending on the outcome, either one or two reports are visible
                         .then(() => {
-                            if (booleansWhichRemovesInactiveReport.indexOf(JSON.stringify(boolArr)) > -1) {
+                            if (booleansWhichRemovesActiveReport.indexOf(JSON.stringify(boolArr)) > -1) {
                                 // Only one report visible
                                 expect(sidebarLinks.queryAllByA11yHint('Navigates to a chat')).toHaveLength(1);
                                 expect(sidebarLinks.queryAllByA11yLabel('Chat user display names')).toHaveLength(1);
@@ -530,7 +499,7 @@ describe('Sidebar', () => {
         });
     });
 
-    describe('all combinations of hasComments, isArchived, isUserCreatedPolicyRoom, hasAddWorkspaceError, isUnread, isPinned, hasDraft', () => {
+    describe('all combinations of isArchived, isUserCreatedPolicyRoom, hasAddWorkspaceError, isUnread, isPinned, hasDraft', () => {
         // Given a report that is the active report and doesn't change
         const report1 = LHNTestUtils.getFakeReport(['email3@test.com', 'email4@test.com']);
 
@@ -548,47 +517,28 @@ describe('Sidebar', () => {
             CONST.BETAS.POLICY_EXPENSE_CHAT,
         ];
 
-        // Given there are 7 boolean variables tested in the filtering logic:
-        // 1. hasComments
-        // 2. isArchived
-        // 3. isUserCreatedPolicyRoom
-        // 4. hasAddWorkspaceError
-        // 5. isUnread
-        // 6. isPinned
-        // 7. hasDraft
+        // Given there are 6 boolean variables tested in the filtering logic:
+        // 1. isArchived
+        // 2. isUserCreatedPolicyRoom
+        // 3. hasAddWorkspaceError
+        // 4. isUnread
+        // 5. isPinned
+        // 6. hasDraft
         // There is one setting not represented here, which is hasOutstandingIOU. In order to test that setting, there must be
         // additional reports in Onyx, so it's being left out for now. It's identical to the logic for hasDraft and isPinned though.
 
         // Given these combinations of booleans which result in the report being filtered out (not shown).
-        const booleansWhichRemovesInactiveReport = [
-            JSON.stringify([false, false, false, false, false, false, false]),
-            JSON.stringify([false, false, false, true, false, false, false]),
-            JSON.stringify([false, false, false, false, true, false, false]),
-            JSON.stringify([false, false, false, true, true, false, false]),
-            JSON.stringify([false, false, true, false, false, false, false]),
-            JSON.stringify([false, false, true, true, false, false, false]),
-            JSON.stringify([false, true, false, false, false, false, false]),
-            JSON.stringify([false, true, false, false, true, false, false]),
-            JSON.stringify([false, true, false, true, false, false, false]),
-            JSON.stringify([false, true, false, true, true, false, false]),
-            JSON.stringify([false, true, true, false, false, false, false]),
-            JSON.stringify([false, true, true, false, true, false, false]),
-            JSON.stringify([false, true, true, true, false, false, false]),
-            JSON.stringify([false, true, true, true, true, false, false]),
-            JSON.stringify([true, false, false, false, false, false, false]),
-            JSON.stringify([true, false, false, true, false, false, false]),
-            JSON.stringify([true, false, true, false, false, false, false]),
-            JSON.stringify([true, false, true, true, false, false, false]),
-            JSON.stringify([true, true, false, false, false, false, false]),
-            JSON.stringify([true, true, false, true, false, false, false]),
-            JSON.stringify([true, true, true, false, false, false, false]),
-            JSON.stringify([true, true, true, true, false, false, false]),
+        const booleansWhichRemovesActiveReport = [
+            JSON.stringify([false, false, false, false, false, false]),
+            JSON.stringify([false, true, false, false, false, false]),
+            JSON.stringify([true, false, false, false, false, false]),
+            JSON.stringify([true, true, false, false, false, false]),
         ];
 
         // When every single combination of those booleans is tested
 
         // Taken from https://stackoverflow.com/a/39734979/9114791 to generate all possible boolean combinations
-        const AMOUNT_OF_VARIABLES = 7;
+        const AMOUNT_OF_VARIABLES = 6;
         // eslint-disable-next-line no-bitwise
         for (let i = 0; i < (1 << AMOUNT_OF_VARIABLES); i++) {
             const boolArr = [];
@@ -622,7 +572,7 @@ describe('Sidebar', () => {
 
                     // Then depending on the outcome, either one or two reports are visible
                     .then(() => {
-                        if (booleansWhichRemovesInactiveReport.indexOf(JSON.stringify(boolArr)) > -1) {
+                        if (booleansWhichRemovesActiveReport.indexOf(JSON.stringify(boolArr)) > -1) {
                             // Only one report visible
                             expect(sidebarLinks.queryAllByA11yHint('Navigates to a chat')).toHaveLength(1);
                             expect(sidebarLinks.queryAllByA11yLabel('Chat user display names')).toHaveLength(1);
@@ -691,7 +641,7 @@ describe('Sidebar', () => {
                 // Given an archived report that has all comments read
                 const report = {
                     ...LHNTestUtils.getFakeReport(),
-                    lastReadSequenceNumber: TEST_MAX_SEQUENCE_NUMBER,
+                    lastReadSequenceNumber: LHNTestUtils.TEST_MAX_SEQUENCE_NUMBER,
                     statusNum: CONST.REPORT.STATUS.CLOSED,
                     stateNum: CONST.REPORT.STATE_NUM.SUBMITTED,
                 };
@@ -720,7 +670,7 @@ describe('Sidebar', () => {
                     })
 
                     // When the report has a new comment and is now unread
-                    .then(() => Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`, {lastReadSequenceNumber: TEST_MAX_SEQUENCE_NUMBER - 1}))
+                    .then(() => Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`, {lastReadSequenceNumber: LHNTestUtils.TEST_MAX_SEQUENCE_NUMBER - 1}))
 
                     // Then the report is rendered in the LHN
                     .then(() => {

--- a/tests/unit/LHNFilterTest.js
+++ b/tests/unit/LHNFilterTest.js
@@ -33,7 +33,7 @@ describe('Sidebar', () => {
         Onyx.clear();
     });
 
-    describe('in default mode', () => {
+    describe('in default (most recent) mode', () => {
         it('excludes a report with no participants', () => {
             const sidebarLinks = LHNTestUtils.getDefaultRenderedSidebarLinks();
 
@@ -634,5 +634,45 @@ describe('Sidebar', () => {
                     });
             });
         }
+    });
+
+    describe('Archived chats', () => {
+        it('are shown an hidden properly depending on the view mode and number of comments', () => {
+            const sidebarLinks = LHNTestUtils.getDefaultRenderedSidebarLinks();
+
+            // Given a report with no comments
+            const report = {
+                ...LHNTestUtils.getFakeReport(),
+                lastMessageTimestamp: 0,
+                // statusNum: CONST.REPORT.STATUS.CLOSED,
+                // stateNum: CONST.REPORT.STATE_NUM.SUBMITTED,
+            };
+
+            // Given the user is in all betas
+            const betas = [
+                CONST.BETAS.DEFAULT_ROOMS,
+                CONST.BETAS.POLICY_ROOMS,
+                CONST.BETAS.POLICY_EXPENSE_CHAT,
+            ];
+
+            // Given the LHN is in the default (most recent) view mode
+            const currentViewMode = CONST.PRIORITY_MODE.DEFAULT;
+
+            return waitForPromisesToResolve()
+
+                // When Onyx is updated to contain that data and the sidebar re-renders
+                .then(() => Onyx.multiSet({
+                    [ONYXKEYS.NVP_PRIORITY_MODE]: currentViewMode,
+                    [ONYXKEYS.BETAS]: betas,
+                    [ONYXKEYS.PERSONAL_DETAILS]: LHNTestUtils.fakePersonalDetails,
+                    [`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`]: report,
+                }))
+
+                // Then the report is rendered in the LHN
+                .then(() => {
+                    const optionRows = sidebarLinks.queryAllByA11yHint('Navigates to a chat');
+                    expect(optionRows).toHaveLength(1);
+                });
+        });
     });
 });

--- a/tests/unit/OptionsListUtilsTest.js
+++ b/tests/unit/OptionsListUtilsTest.js
@@ -283,8 +283,8 @@ describe('OptionsListUtils', () => {
         // Then the 2 personalDetails that don't have reports should be returned
         expect(results.personalDetails.length).toBe(2);
 
-        // Then all of the reports should be shown EXCEPT the archived room, including the one that has no message on them.
-        expect(results.recentReports.length).toBe(_.size(REPORTS) - 1);
+        // Then all of the reports should be shown including the archived rooms.
+        expect(results.recentReports.length).toBe(_.size(REPORTS));
 
         // When we filter again but provide a searchValue
         results = OptionsListUtils.getSearchOptions(REPORTS, PERSONAL_DETAILS, 'spider');

--- a/tests/utils/LHNTestUtils.js
+++ b/tests/utils/LHNTestUtils.js
@@ -85,7 +85,6 @@ function getFakeReport(participants = ['email1@test.com', 'email2@test.com'], mi
  * There is one setting not represented here, which is hasOutstandingIOU. In order to test that setting, there must be
  * additional reports in Onyx, so it's being left out for now.
  *
- * @param {boolean} hasComments
  * @param {boolean} isArchived
  * @param {boolean} isUserCreatedPolicyRoom
  * @param {boolean} hasAddWorkspaceError
@@ -94,14 +93,13 @@ function getFakeReport(participants = ['email1@test.com', 'email2@test.com'], mi
  * @param {boolean} hasDraft
  * @returns {Object}
  */
-function getAdvancedFakeReport(hasComments, isArchived, isUserCreatedPolicyRoom, hasAddWorkspaceError, isUnread, isPinned, hasDraft) {
+function getAdvancedFakeReport(isArchived, isUserCreatedPolicyRoom, hasAddWorkspaceError, isUnread, isPinned, hasDraft) {
     return {
         ...getFakeReport(),
         chatType: isUserCreatedPolicyRoom ? CONST.REPORT.CHAT_TYPE.POLICY_ROOM : CONST.REPORT.CHAT_TYPE.POLICY_ADMINS,
-        lastMessageTimestamp: hasComments ? Date.now() : 0,
         statusNum: isArchived ? CONST.REPORT.STATUS.CLOSED : 0,
         stateNum: isArchived ? CONST.REPORT.STATE_NUM.SUBMITTED : 0,
-        errorFields: hasAddWorkspaceError ? {errorFields: {addWorkspaceRoom: 'blah'}} : null,
+        errorFields: hasAddWorkspaceError ? {addWorkspaceRoom: 'blah'} : null,
         lastReadSequenceNumber: isUnread ? TEST_MAX_SEQUENCE_NUMBER - 1 : TEST_MAX_SEQUENCE_NUMBER,
         isPinned,
         hasDraft,


### PR DESCRIPTION
### Fixed Issues
$ https://github.com/Expensify/App/issues/11685
$ https://github.com/Expensify/App/issues/11686


### Tests
#### Testing that policy rooms show up properly
1. Set your view mode to `#focus`
2. Create a new workspace
3. Verify that there are no workspace rooms for that workspace shown in the LHN
4. Create several workspace rooms for that workspace (one pinned, one with a draft, one that is neither draft nor pinned but is your active chat)
5. Verify that all three user-created rooms are shown in the LHN
6. Verify that none of the default rooms are shown in the LHN (announce, admins, domain)
7. Verify that all three user-created rooms are shown in the report search options
8. Switch view mode to `most recent`
9. Verify that all three user-created rooms and all the default rooms are shown in the LHN
9. Verify that all three user-created rooms and all the default rooms are shown in the report search options

#### Testing that archived rooms show up properly
1. Set your view mode to `#focus`
2. Delete the workspace
3. Verify that all three user-created rooms are still shown in the LHN
4. Unpin the one chat, remove the draft on the other chat, and select the concierge chat
3. Verify that all three user-created rooms are no longer shown in the LHN
9. Verify that all three user-created rooms and all the default rooms are still shown in the report search options
8. Switch view mode to `most recent`
9. Verify that all three user-created rooms and all the default rooms are shown in the LHN

#### Testing that an invited user gets access to workspace chats
1. Invite a user to a new workspace
2. Login as that user
3. Verify they see the `#announce` room for that workspace

- [x] Verify that no errors appear in the JS console

### PR Review Checklist
<!--
This is a checklist for PR authors & reviewers. Please make sure to complete all tasks and check them off once you do, or else Expensify has the right not to merge your PR!
-->
#### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] Any functional components have the `displayName` property
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

<details>
<summary><h4>PR Reviewer Checklist</h4>

The reviewer will copy/paste it into a new comment and complete it after the author checklist is completed
</summary>

- [ ] I have verified the author checklist is complete (all boxes are checked off).
- [ ] I verified the correct issue is linked in the `### Fixed Issues` section above
- [ ] I verified testing steps are clear and they cover the changes made in this PR
    - [ ] I verified the steps for local testing are in the `Tests` section
    - [ ] I verified the steps for Staging and/or Production testing are in the `QA steps` section
    - [ ] I verified the steps cover any possible failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [ ] I checked that screenshots or videos are included for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I verified tests pass on **all platforms** & I tested again on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [ ] If there are any errors in the console that are unrelated to this PR, I either fixed them (preferred) or linked to where I reported them in Slack
- [ ] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`).
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [ ] I verified any copy / text that was added to the app is correct English and approved by marketing by tagging the marketing team on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I verified that this PR follows the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I verified other components that can be impacted by these changes have been tested, and I retested again (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` have been tested & I retested again)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] I have checked off every checkbox in the PR reviewer checklist, including those that don't apply to this PR.

</details>

### QA Steps
Same as all the tests written in the test section

- [x] Verify that no errors appear in the JS console

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

<details>

<summary>Web screenhots</summary>

![image](https://user-images.githubusercontent.com/1228807/195183434-1b3bc0b7-b5b7-4f07-b829-fc2021477383.png)
![image](https://user-images.githubusercontent.com/1228807/195183883-cc35c84f-2a6f-42e4-9608-abd0600257d3.png)

</details>

<details>

<summary>Mobile Web - Chrome screenhots</summary>
focus mode:
![image](https://user-images.githubusercontent.com/1228807/195188346-fa6f092a-4147-4821-ab44-6379fcbde999.png)
![image](https://user-images.githubusercontent.com/1228807/195188370-68de012c-d255-459c-b796-07cc44187de0.png)

most recent mode:
![image](https://user-images.githubusercontent.com/1228807/195188043-248ced2c-1ab8-4f6d-87dc-eb6dfcd45269.png)
![image](https://user-images.githubusercontent.com/1228807/195188084-9a5cf11d-b98e-4540-aa11-f83e2c074622.png)


</details>

<details>

<summary>Mobile Web - Safari screenhots</summary>
focus mode:
![image](https://user-images.githubusercontent.com/1228807/195189359-8448dbb0-820f-44db-ac53-87f4d962b334.png)
![image](https://user-images.githubusercontent.com/1228807/195189379-76c3d99a-64a5-47b2-8ad4-675dcdb7fbea.png)


most recent mode:
![image](https://user-images.githubusercontent.com/1228807/195189286-d56872ca-ec6f-4543-ad76-10f347feb4d8.png)
![image](https://user-images.githubusercontent.com/1228807/195189308-9f904e6d-bfa3-47eb-9e42-57d662785b68.png)


</details>

<details>

<summary>Desktop screenhots</summary>

![image](https://user-images.githubusercontent.com/1228807/195184459-94146002-41f7-46d4-b7b7-5067334f661f.png)

![image](https://user-images.githubusercontent.com/1228807/195184408-c8b04eb2-de84-4210-93dc-336247d7474f.png)

</details>

<details>

<summary>iOS screenhots</summary>
Focus mode:
![image](https://user-images.githubusercontent.com/1228807/195188755-b1410b4f-fac4-4029-913a-17c13dae0b4c.png)
![image](https://user-images.githubusercontent.com/1228807/195188792-7df74b6a-dd1a-4a42-9442-ad91f500190b.png)

most recent mode:
![image](https://user-images.githubusercontent.com/1228807/195188851-b2d8ce13-95b6-4bcc-a3cf-f2a9c1f99bb9.png)
![image](https://user-images.githubusercontent.com/1228807/195188881-a36c5915-231e-47f6-ae23-5e3e59ed926b.png)


</details>

<details>

<summary>Android screenhots</summary>

focus mode:
![image](https://user-images.githubusercontent.com/1228807/195186611-426801cd-6f89-4e27-b8d2-1fdef0f966cb.png)
![image](https://user-images.githubusercontent.com/1228807/195186852-e027729f-e6a6-4d48-904c-f1f9ff0e7d54.png)


most recent mode:
![image](https://user-images.githubusercontent.com/1228807/195186486-d6b0e740-f6e8-4656-927d-6387562c1305.png)
![image](https://user-images.githubusercontent.com/1228807/195186538-0bbbd241-cc1a-488a-9db4-8b26ec452000.png)

</details>
