### PR TITLE
Add a loading functionality to eliminate race condition in ResetFreeBankAccount

### DIFF
--- a/src/libs/actions/ReimbursementAccount/resetFreePlanBankAccount.js
+++ b/src/libs/actions/ReimbursementAccount/resetFreePlanBankAccount.js
@@ -18,14 +18,6 @@ function resetFreePlanBankAccount() {
         throw new Error('Missing credentials when attempting to reset free plan bank account');
     }
 
-    const achData = {
-        useOnfido: true,
-        policyID: '',
-        isInSetup: true,
-        domainLimit: 0,
-        currentStep: CONST.BANK_ACCOUNT.STEP.BANK_ACCOUNT,
-    };
-
     API.write('RestartBankAccountSetup',
         {
             bankAccountID,
@@ -33,18 +25,38 @@ function resetFreePlanBankAccount() {
         },
         {
             optimisticData: [{
-                onyxMethod: 'merge',
+                onyxMethod: 'set',
                 key: ONYXKEYS.REIMBURSEMENT_ACCOUNT,
-                value: {achData, shouldShowResetModal: false},
+                value: {
+                    achData: {},
+                    shouldShowResetModal: false,
+                    isResettingReimbursementAccount: true,
+                },
             },
             {
                 onyxMethod: 'set',
                 key: ONYXKEYS.REIMBURSEMENT_ACCOUNT_DRAFT,
                 value: null,
             }],
+            successData: [
+                {
+                    onyxMethod: CONST.ONYX.METHOD.MERGE,
+                    key: ONYXKEYS.REIMBURSEMENT_ACCOUNT,
+                    value: {
+                        isResettingReimbursementAccount: false,
+                    },
+                },
+            ],
+            failureData: [
+                {
+                    onyxMethod: CONST.ONYX.METHOD.MERGE,
+                    key: ONYXKEYS.REIMBURSEMENT_ACCOUNT,
+                    value: {
+                        isResettingReimbursementAccount: false,
+                    },
+                },
+            ],
         });
-
-    Navigation.navigate(ROUTES.getBankAccountRoute());
 }
 
 export default resetFreePlanBankAccount;

--- a/src/libs/actions/ReimbursementAccount/resetFreePlanBankAccount.js
+++ b/src/libs/actions/ReimbursementAccount/resetFreePlanBankAccount.js
@@ -2,8 +2,6 @@ import lodashGet from 'lodash/get';
 import ONYXKEYS from '../../../ONYXKEYS';
 import CONST from '../../../CONST';
 import * as store from './store';
-import Navigation from '../../Navigation/Navigation';
-import ROUTES from '../../../ROUTES';
 import * as API from '../../API';
 
 /**

--- a/src/pages/workspace/WorkspaceBankAccountPage.js
+++ b/src/pages/workspace/WorkspaceBankAccountPage.js
@@ -25,6 +25,7 @@ import withPolicy from './withPolicy';
 import Button from '../../components/Button';
 import MenuItem from '../../components/MenuItem';
 import FullPageNotFoundView from '../../components/BlockingViews/FullPageNotFoundView';
+import FullScreenLoadingIndicator from '../../components/FullscreenLoadingIndicator';
 
 const propTypes = {
     /** ACH data for the withdrawal account actively being set up */
@@ -58,6 +59,14 @@ class WorkspaceBankAccountPage extends React.Component {
         this.navigateToBankAccountRoute();
     }
 
+    componentDidUpdate(prevProps) {
+        const wasResetting = lodashGet(prevProps, 'reimbursementAccount.isResettingReimbursementAccount', false);
+        const isResetting = lodashGet(this.props, 'reimbursementAccount.isResettingReimbursementAccount', false);
+        if (wasResetting && !isResetting) {
+            this.navigateToBankAccountRoute();
+        }
+    }
+
     /**
      * If we have an open bank account or no bank account at all then we will immediately redirect the user to /bank-account to display the next step
      *
@@ -88,32 +97,36 @@ class WorkspaceBankAccountPage extends React.Component {
                         guidesCallTaskID={CONST.GUIDES_CALL_TASK_IDS.WORKSPACE_BANK_ACCOUNT}
                         shouldShowBackButton
                     />
-                    <ScrollView style={styles.flex1}>
-                        <Section
-                            title={this.props.translate('workspace.bankAccount.almostDone')}
-                            icon={Illustrations.BankArrowPink}
-                        >
-                            <Text>
-                                {this.props.translate('workspace.bankAccount.youreAlmostDone')}
-                            </Text>
-                        </Section>
-                        <Button
-                            text={this.props.translate('workspace.bankAccount.continueWithSetup')}
-                            onPress={this.navigateToBankAccountRoute}
-                            icon={Expensicons.Bank}
-                            style={[styles.mt2, styles.buttonCTA]}
-                            iconStyles={[styles.buttonCTAIcon]}
-                            shouldShowRightIcon
-                            large
-                            success
-                        />
-                        <MenuItem
-                            title={this.props.translate('workspace.bankAccount.startOver')}
-                            icon={Expensicons.RotateLeft}
-                            onPress={BankAccounts.requestResetFreePlanBankAccount}
-                            shouldShowRightIcon
-                        />
-                    </ScrollView>
+                    {this.props.reimbursementAccount.isResettingReimbursementAccount ? (
+                        <FullScreenLoadingIndicator style={[styles.flex1, styles.pRelative]} />
+                    ) : (
+                        <ScrollView style={styles.flex1}>
+                            <Section
+                                title={this.props.translate('workspace.bankAccount.almostDone')}
+                                icon={Illustrations.BankArrowPink}
+                            >
+                                <Text>
+                                    {this.props.translate('workspace.bankAccount.youreAlmostDone')}
+                                </Text>
+                            </Section>
+                            <Button
+                                text={this.props.translate('workspace.bankAccount.continueWithSetup')}
+                                onPress={this.navigateToBankAccountRoute}
+                                icon={Expensicons.Bank}
+                                style={[styles.mt2, styles.buttonCTA]}
+                                iconStyles={[styles.buttonCTAIcon]}
+                                shouldShowRightIcon
+                                large
+                                success
+                            />
+                            <MenuItem
+                                title={this.props.translate('workspace.bankAccount.startOver')}
+                                icon={Expensicons.RotateLeft}
+                                onPress={BankAccounts.requestResetFreePlanBankAccount}
+                                shouldShowRightIcon
+                            />
+                        </ScrollView>
+                    )}
                     <WorkspaceResetBankAccountModal />
                 </FullPageNotFoundView>
             </ScreenWrapper>


### PR DESCRIPTION
@Expensify/pullerbear @MariaHCD @nkuoch 

### Details
When adding a VBBA, and you click "Start Over". There is a race between:
1. ResetFreeBankAccount
2. Fetching the VBBA associated with the free plan when opening `ReimbursementAccountPage.js`

Sometimes ResetFreeBankAccount will not finish before we open the ReimbursementAccountPage, which means we still show the last step of the previous flow, despite the setup VBBA was reset

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/238317


### Tests / QA
1. Create a workspace
2. Go to workspace settings -> Connect Bank Account
3. Use plaid and use `user_good` and `pass_good`. Get past the CompanyStep, whatever you need to do to get to Personal Information (RequestorStep)
4. Now exit the flow
5. Go back to workspace settings -> Connect Bank Account
6. You will be presented with the option to continue the setup, or "Start Over".
    <img width="500" alt="image" src="https://user-images.githubusercontent.com/12980144/197649271-6f7cf56d-690d-44d9-93fd-65fc317a322e.png">
8. Click Start Over
9. Verify that you see a spinner, and that you are then directed to the original first step which makes you choose between Plaid and Manual
    <img width="500" alt="image" src="https://user-images.githubusercontent.com/12980144/197648120-9d249894-700f-4caf-815f-cae725c8ce44.png">

### PR Review Checklist
<!--
This is a checklist for PR authors & reviewers. Please make sure to complete all tasks and check them off once you do, or else Expensify has the right not to merge your PR!
-->
#### PR Author Checklist
- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [ ] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

<details>
<summary><h4>PR Reviewer Checklist</h4>

The reviewer will copy/paste it into a new comment and complete it after the author checklist is completed
</summary>

- [ ] I have verified the author checklist is complete (all boxes are checked off).
- [ ] I verified the correct issue is linked in the `### Fixed Issues` section above
- [ ] I verified testing steps are clear and they cover the changes made in this PR
    - [ ] I verified the steps for local testing are in the `Tests` section
    - [ ] I verified the steps for Staging and/or Production testing are in the `QA steps` section
    - [ ] I verified the steps cover any possible failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [ ] I checked that screenshots or videos are included for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I verified tests pass on **all platforms** & I tested again on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [ ] If there are any errors in the console that are unrelated to this PR, I either fixed them (preferred) or linked to where I reported them in Slack
- [ ] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`).
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [ ] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I verified that this PR follows the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I verified other components that can be impacted by these changes have been tested, and I retested again (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` have been tested & I retested again)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] I have checked off every checkbox in the PR reviewer checklist, including those that don't apply to this PR.

</details>

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<details>
<summary>Web
</summary>

![OwEUNLz5pt](https://user-images.githubusercontent.com/12980144/197649784-e6ee6f74-0aa5-4b8e-a4b1-1dbc43160f93.gif)

</details>

#### Mobile Web - Chrome
<details>
<summary>Mobile Chrome
</summary>

![xSlwcAgUv6](https://user-images.githubusercontent.com/12980144/197650021-931264c4-27e6-432a-9c53-f6a00d3677c1.gif)

</details>

#### Mobile Web - Safari
<details>
<summary>Mobile Safari
</summary>

![jvz1j2vpmQ](https://user-images.githubusercontent.com/12980144/197650639-bde99ea6-b8ed-4e40-af95-d6244b7c8b81.gif)

</details>

#### Desktop
<details>
<summary>Desktop</summary>

![jYtndGIw97](https://user-images.githubusercontent.com/12980144/197652454-17311f19-9031-4f73-aae6-8d9daec565b7.gif)

</details>

#### iOS
<details>
<summary>iOS</summary>

![jQKFKtEXND](https://user-images.githubusercontent.com/12980144/197671918-8a183f32-bd28-425a-8e89-e0bec03b0d16.gif)

</details>

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
