### PR TITLE
Bump react native SVG lib to unblcok Fabric

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -624,7 +624,7 @@ PODS:
   - RNScreens (3.17.0):
     - React-Core
     - React-RCTImage
-  - RNSVG (12.4.4):
+  - RNSVG (13.4.0):
     - React-Core
   - SDWebImage (5.11.1):
     - SDWebImage/Core (= 5.11.1)
@@ -1015,7 +1015,7 @@ SPEC CHECKSUMS:
   RNReactNativeHapticFeedback: 1e3efeca9628ff9876ee7cdd9edec1b336913f8c
   RNReanimated: 6c980139eb3b043569a08b8cb3d92cdf46bd54fa
   RNScreens: 0df01424e9e0ed7827200d6ed1087ddd06c493f9
-  RNSVG: ecd661f380a07ba690c9c5929c475a44f432d674
+  RNSVG: 07dbd870b0dcdecc99b3a202fa37c8ca163caec2
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,7 @@
         "react-native-render-html": "6.3.1",
         "react-native-safe-area-context": "4.4.1",
         "react-native-screens": "3.17.0",
-        "react-native-svg": "^12.4.4",
+        "react-native-svg": "git+https://github.com/software-mansion/react-native-svg#2a892a9eac4a0b11d33c0cf866b3475a6d332424",
         "react-native-webview": "^11.17.2",
         "react-pdf": "5.7.2",
         "react-plaid-link": "3.3.2",
@@ -35807,16 +35807,17 @@
       }
     },
     "node_modules/react-native-svg": {
-      "version": "12.4.4",
-      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-12.4.4.tgz",
-      "integrity": "sha512-LpcNlEVCURexqPAvQ9ne8KrPVfYz0wIDygwud8VMRmXLezysXzyQN/DTsjm1BO9lIfYp55WQsr3u3yW/vk6iiA==",
+      "version": "13.4.0",
+      "resolved": "git+ssh://git@github.com/software-mansion/react-native-svg.git#2a892a9eac4a0b11d33c0cf866b3475a6d332424",
+      "integrity": "sha512-1MlEJ3WpUEIedfWrcUC9rzIL8F66U9WUwFxID6F6te9UmSQipc1Thbh4Vm181g2uTvzU6Rkfg5qGfytcZMJOSg==",
+      "license": "MIT",
       "dependencies": {
         "css-select": "^5.1.0",
         "css-tree": "^1.1.3"
       },
       "peerDependencies": {
         "react": "*",
-        "react-native": ">=0.50.0"
+        "react-native": "*"
       }
     },
     "node_modules/react-native-svg-transformer": {
@@ -70502,9 +70503,9 @@
       }
     },
     "react-native-svg": {
-      "version": "12.4.4",
-      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-12.4.4.tgz",
-      "integrity": "sha512-LpcNlEVCURexqPAvQ9ne8KrPVfYz0wIDygwud8VMRmXLezysXzyQN/DTsjm1BO9lIfYp55WQsr3u3yW/vk6iiA==",
+      "version": "git+ssh://git@github.com/software-mansion/react-native-svg.git#2a892a9eac4a0b11d33c0cf866b3475a6d332424",
+      "integrity": "sha512-1MlEJ3WpUEIedfWrcUC9rzIL8F66U9WUwFxID6F6te9UmSQipc1Thbh4Vm181g2uTvzU6Rkfg5qGfytcZMJOSg==",
+      "from": "react-native-svg@git+https://github.com/software-mansion/react-native-svg#2a892a9eac4a0b11d33c0cf866b3475a6d332424",
       "requires": {
         "css-select": "^5.1.0",
         "css-tree": "^1.1.3"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "react-native-render-html": "6.3.1",
     "react-native-safe-area-context": "4.4.1",
     "react-native-screens": "3.17.0",
-    "react-native-svg": "^12.4.4",
+    "react-native-svg": "git+https://github.com/software-mansion/react-native-svg#2a892a9eac4a0b11d33c0cf866b3475a6d332424",
     "react-native-webview": "^11.17.2",
     "react-pdf": "5.7.2",
     "react-plaid-link": "3.3.2",


### PR DESCRIPTION
Discussed in slack starting [here](https://expensify.slack.com/archives/C01GTK53T8Q/p1666772722139979?thread_ts=1666696535.015619&cid=C01GTK53T8Q)

### Details
Upgrades react-native-svg to latest to support Fabric

### Fixed Issues
$ (partial) https://github.com/Expensify/App/issues/8503

### Tests / QA Steps
1. Run the app
1. Make sure icons and default avatars render correctly throughout the app. (note that avatars aren't cached offline correctly, but that's a separate known issue)

### PR Review Checklist
#### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->
<img width="1519" alt="Screenshot 2022-10-27 at 12 19 08 PM" src="https://user-images.githubusercontent.com/2838819/198368547-41f29ad4-6605-4d56-8f02-7930890c6c61.png">
<img width="1519" alt="Screenshot 2022-10-27 at 12 19 21 PM" src="https://user-images.githubusercontent.com/2838819/198368566-e7e6ba36-bbef-4085-9959-a4a048d16695.png">

#### Mobile Web - Chrome
<img width="1519" alt="Screenshot 2022-10-27 at 12 19 30 PM" src="https://user-images.githubusercontent.com/2838819/198368590-559fcb08-e3df-4bfe-a694-bb6938dd6ef2.png">
<img width="1519" alt="Screenshot 2022-10-27 at 12 19 41 PM" src="https://user-images.githubusercontent.com/2838819/198368595-25b3e654-7b53-4331-8d64-14fc041f61d0.png">


#### Mobile Web - Safari
<!-- Insert screenshots of your changes on the web platform (from safari mobile browser)-->
<img width="564" alt="Screenshot 2022-10-27 at 12 18 47 PM" src="https://user-images.githubusercontent.com/2838819/198368631-82306d4a-a2c7-444b-b6d3-9eec9fa52276.png">
<img width="564" alt="Screenshot 2022-10-27 at 12 18 36 PM" src="https://user-images.githubusercontent.com/2838819/198368635-d29b0fc4-1726-4a3c-bfb7-ff1286db964f.png">

#### Desktop
<img width="1312" alt="Screenshot 2022-10-27 at 12 22 51 PM" src="https://user-images.githubusercontent.com/2838819/198368934-4d0816ad-3317-4a1b-86be-cf3c0feecb26.png">
<img width="1312" alt="Screenshot 2022-10-27 at 12 22 39 PM" src="https://user-images.githubusercontent.com/2838819/198368942-1d2e2516-b5f4-4fa6-b81e-ba0de8f24cb5.png">


#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->
<img width="564" alt="Screenshot 2022-10-27 at 12 16 58 PM" src="https://user-images.githubusercontent.com/2838819/198368656-cad76242-9ffc-407e-8f3e-12dceb0c29ab.png">
<img width="564" alt="Screenshot 2022-10-27 at 12 16 44 PM" src="https://user-images.githubusercontent.com/2838819/198368659-1b54bf20-0ef4-4f1a-baa5-72a3969bf737.png">

#### Android
<img width="572" alt="Screenshot 2022-10-27 at 12 23 35 PM" src="https://user-images.githubusercontent.com/2838819/198368963-89e95d4a-1866-46f2-8b4a-151087d486b1.png">
<img width="572" alt="Screenshot 2022-10-27 at 12 23 43 PM" src="https://user-images.githubusercontent.com/2838819/198368964-992c56c3-6390-444e-ae34-5e613bdeedf3.png">

<!-- Insert screenshots of your changes on the Android platform-->

