### PR TITLE
fix issues in pdf password form

### DIFF
--- a/src/components/PDFView/PDFPasswordForm.js
+++ b/src/components/PDFView/PDFPasswordForm.js
@@ -5,10 +5,7 @@ import {View, ScrollView} from 'react-native';
 import Button from '../Button';
 import Text from '../Text';
 import TextInput from '../TextInput';
-import Icon from '../Icon';
-import * as Expensicons from '../Icon/Expensicons';
 import styles from '../../styles/styles';
-import colors from '../../styles/colors';
 import PDFInfoMessage from './PDFInfoMessage';
 import compose from '../../libs/compose';
 import withLocalize, {withLocalizePropTypes} from '../withLocalize';
@@ -120,26 +117,16 @@ class PDFPasswordForm extends Component {
                             onChangeText={this.updatePassword}
                             returnKeyType="done"
                             onSubmitEditing={this.submitPassword}
-                            errorText={this.state.validationErrorText}
+                            errorText={this.props.isPasswordInvalid ? this.props.translate('attachmentView.passwordIncorrect') : this.state.validationErrorText}
                             onFocus={() => this.props.onPasswordFieldFocused(true)}
                             onBlur={this.validateAndNotifyPasswordBlur}
                             autoFocus={this.props.shouldAutofocusPasswordField}
                             secureTextEntry
                         />
-                        {this.props.isPasswordInvalid && (
-                        <View style={[styles.flexRow, styles.alignItemsCenter, styles.mt3]}>
-                            <Icon src={Expensicons.Exclamation} fill={colors.red} />
-                            <View style={[styles.flexRow, styles.ml2, styles.flexWrap, styles.flex1]}>
-                                <Text style={styles.mutedTextLabel}>
-                                    {this.props.translate('attachmentView.passwordIncorrect')}
-                                </Text>
-                            </View>
-                        </View>
-                        )}
                         <Button
                             text={this.props.translate('common.confirm')}
                             onPress={this.submitPassword}
-                            style={styles.pt4}
+                            style={styles.mt4}
                             isLoading={this.props.shouldShowLoadingIndicator}
                             pressOnEnter
                         />

--- a/src/components/PDFView/index.native.js
+++ b/src/components/PDFView/index.native.js
@@ -142,7 +142,7 @@ class PDFView extends Component {
                     </TouchableWithoutFeedback>
                 )}
                 {this.state.shouldRequestPassword && (
-                    <KeyboardAvoidingView>
+                    <KeyboardAvoidingView style={styles.flex1}>
                         <PDFPasswordForm
                             onSubmit={this.attemptPdfLoadWithPassword}
                             onPasswordUpdated={() => this.setState({isPasswordInvalid: false})}


### PR DESCRIPTION
### Details
https://github.com/Expensify/App/pull/12098 was an original PR which standardizes only form error styles.
This is an add-on PR which fixes 3 issues related to password form for protected pdf:
- https://github.com/Expensify/App/issues/11908#issuecomment-1306266927 (non-form error style standardization)
- https://github.com/Expensify/App/issues/12480 (preview broken issue)
- https://github.com/Expensify/App/issues/12520 (blue border around Confirm button padding issue)

### Fixed Issues
$ https://github.com/Expensify/App/issues/11908
$ https://github.com/Expensify/App/issues/12520
$ https://github.com/Expensify/App/issues/12480
PROPOSAL: https://github.com/Expensify/App/issues/11908#issuecomment-1289043961

### Tests
1. Login with any account
2. Go to any chat room
3. Attach any protected PDF file
4. Open the PDF file
5. Verify that preview is not broken
6. Click `enter the password`
7. Click `Confirm` button
8. Verify that error styles match design guideline
9. Input any wrong password
10. Verify that invalid error styles match design guideline
For web/desktop only:
11.  Press Tab and try to focus `Confirm` button
12. Verify that blue focus outline has no extra padding on top

Design guideline is [here](https://github.com/Expensify/App/issues/11908#issue-1411859773)

- [x] Verify that no errors appear in the JS console

### QA Steps
1. Login with any account
2. Go to any chat room
3. Attach any protected PDF file
4. Open the PDF file
5. Verify that preview is not broken
6. Click `enter the password`
7. Click `Confirm` button
8. Verify that error styles match design guideline
9. Input any wrong password
10. Verify that invalid error styles match design guideline
For web/desktop only:
11.  Press Tab and try to focus `Confirm` button
12. Verify that blue focus outline has no extra padding on top

Design guideline is [here](https://github.com/Expensify/App/issues/11908#issue-1411859773)

- [ ] Verify that no errors appear in the JS console

### PR Review Checklist
#### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

<details>
<summary><h4>PR Reviewer Checklist</h4>

The reviewer will copy/paste it into a new comment and complete it after the author checklist is completed
</summary>

- [ ] I have verified the author checklist is complete (all boxes are checked off).
- [ ] I verified the correct issue is linked in the `### Fixed Issues` section above
- [ ] I verified testing steps are clear and they cover the changes made in this PR
    - [ ] I verified the steps for local testing are in the `Tests` section
    - [ ] I verified the steps for Staging and/or Production testing are in the `QA steps` section
    - [ ] I verified the steps cover any possible failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [ ] I checked that screenshots or videos are included for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I verified tests pass on **all platforms** & I tested again on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [ ] If there are any errors in the console that are unrelated to this PR, I either fixed them (preferred) or linked to where I reported them in Slack
- [ ] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`).
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [ ] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I verified that this PR follows the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I verified other components that can be impacted by these changes have been tested, and I retested again (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` have been tested & I retested again)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] I have checked off every checkbox in the PR reviewer checklist, including those that don't apply to this PR.

</details>

### Screenshots

#### Web

https://user-images.githubusercontent.com/97473779/200528601-2b17aae6-1109-4854-960f-e64527b575d3.mov


#### Mobile Web - Chrome
![mchrome-error](https://user-images.githubusercontent.com/97473779/200528666-d31be21c-d00c-4cd6-b66a-f09f3f350668.jpg)

#### Mobile Web - Safari
![msafari-error](https://user-images.githubusercontent.com/97473779/200528684-d3909905-2456-4d10-bdae-2c6988342c8f.png)

#### Desktop

https://user-images.githubusercontent.com/97473779/200528493-74b61582-472e-4f78-b5af-94219b022c6a.mov


#### iOS

https://user-images.githubusercontent.com/97473779/200528246-06494149-da70-40a1-b997-781ea34d6612.mp4


#### Android

https://user-images.githubusercontent.com/97473779/200527341-7f6e51a6-6eb7-4cba-9720-443b64a10fbc.mp4


**NOTE:**
I couldn't take screenshots on mWeb because of this known issue recently:
https://github.com/Expensify/App/issues/12512#issuecomment-1306845262