### PR TITLE
Desktop - Add "Check For Update" system menu item

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -142,7 +142,7 @@ const showKeyboardShortcutsModal = (browserWindow) => {
 };
 
 // Defines the system-level menu item to manually apply an update
-// This menu item should become visible after an update is download and ready to be applied
+// This menu item should become visible after an update is downloaded and ready to be applied
 const updateAppMenuItem = new MenuItem({
     label: 'Update New Expensify',
     visible: false,

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -93,23 +93,26 @@ const manuallyCheckForUpdates = (menuItem, browserWindow) => {
     menuItem.enabled = false;
 
     autoUpdater.checkForUpdates()
+        .catch(error => ({error}))
         .then((result) => {
             const downloadPromise = result && result.downloadPromise;
-            const icon = `${__dirname}/../icon-dev.png`;
-            const type = 'info';
 
             if (downloadPromise) {
                 dialog.showMessageBox(browserWindow, {
-                    icon,
-                    type,
+                    type: 'info',
                     message: 'Update Available',
                     detail: 'The new version will be available shortly. We’ll notify you when we’re ready to apply the update',
                     buttons: ['Can’t wait to update'],
                 });
+            } else if (result && result.error) {
+                dialog.showMessageBox(browserWindow, {
+                    type: 'error',
+                    message: 'Update check failed',
+                    detail: 'We were unable to check for updates at this time',
+                });
             } else {
                 dialog.showMessageBox(browserWindow, {
-                    icon,
-                    type,
+                    type: 'info',
                     message: 'Update Not Available',
                     detail: 'We don’t have an update right now, but you get a star 🌟 for trying',
                     buttons: ['Funny', 'Not Funny', 'Close'],

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -101,21 +101,22 @@ const manuallyCheckForUpdates = (menuItem, browserWindow) => {
                 dialog.showMessageBox(browserWindow, {
                     type: 'info',
                     message: 'Update Available',
-                    detail: 'The new version will be available shortly. We’ll notify you when we’re ready to apply the update',
-                    buttons: ['Can’t wait to update'],
+                    detail: 'The new version will be available shortly. We’ll notify you when we’re ready to update.',
+                    buttons: ['Sounds good'],
                 });
             } else if (result && result.error) {
                 dialog.showMessageBox(browserWindow, {
                     type: 'error',
-                    message: 'Update check failed',
-                    detail: 'We were unable to check for updates at this time',
+                    message: 'Update Check Failed',
+                    detail: 'We couldn’t look for an update. Please check again in a bit!',
+                    buttons: ['Okay'],
                 });
             } else {
                 dialog.showMessageBox(browserWindow, {
                     type: 'info',
                     message: 'Update Not Available',
-                    detail: 'We don’t have an update right now, but you get a star 🌟 for trying',
-                    buttons: ['Funny', 'Not Funny', 'Close'],
+                    detail: 'There is no update available as of now! Check again at a later time.',
+                    buttons: ['Okay'],
                     cancelId: 2,
                 });
             }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Add a "Check for Updates" system menu item 
The "Check for Updates" appears until an update is downloaded (either manually or automatically), then it gets swapped by the "Update New Expensify" system menu item

Since the "Update available" notification is displayed only after an update is downloaded I've included a feedback dialog
The dialog is shown soon after clicking "Check for Updates" and the user is informed whether an update is available and being downloaded, or not update is available right now

_Note: As other content (menu items) in `desktop/main.js` the texts are not localized.
Dialogs, notifications, menus localization is out current scope_

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/11817
PROPOSAL: N/A

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

To test in dev (temporarily) add the following file inside `./desktop/dev-app-update.yml`

```yml
provider: s3
bucket: staging-expensify-cash
channel: latest
updaterCacheDirName: new.expensify.desktop-updater
```

This would allow the "Check For Update" menu item to work in dev (otherwise the `checkForUpdates` action fails with an error)

#### Testing on DEV

In DEV update checks resolve with no update available (even when there's a new version):
- [ ] Verify "Check for updates" menu item appears in DEV
- [ ] Verify pressing "Check for updates" shows a dialog with the result shortly
- [ ] Verify "Update New Expensify" menu item does not appear

#### Testing building and running the staging/prod app

1. Build the desktop app for staging and/or prod: `npm run desktop-build` or `npm run desktop-build-staging`
2. Install `desktop-build/NewExpensify.dmg` to Applications
3. Go offline before you launch the installed app - we do this in order to prevent the automatic update feature to download and install an update, so we can test the "Check for Update" functionality

- [ ] Press on the system menu to see the "Check for updates" option - pressing it should shortly display a dialog that an update is available. The update is being downloaded - sometimes it takes a few minutes, before we get a system notification that the update is ready to be installed. At that point "Check for updates" should no longer be displayed in the system menu
  - [ ] You can discard or not press on the "Update ready" (downloaded) notification and see that "Check for updates" indeed is no longer in the system menu, but "Update New Expensify" is reviewed
  - [ ] Verify that pressing "Update New Expensify" still works - I couldn't easily check this, perhaps we can leave it for QA, otherwise we'd need to setup local update server - explained in more detail in [this comment](https://github.com/Expensify/App/pull/12607#:~:text=The%20Update%20New%20Expensify%20didn%27t%20nothing%20for%20me%20even%20before%20the%20changes%20in%20the%20current%20PR%0AI%20suspect%20it%20might%20be%20because%3A) 
  - [ ] Verify pressing the "Update ready" notification still works the same way as before - it displays the in-app modal that lets you apply the update ASAP

To simulates that there are no updates available in staging or prod, go to main `package.json` and set the app version, to the latest released version or newer. 
Now build the desktop app and launch it
- [ ] Verify the "Check for updates" option appears in the system menu
- [ ] Verify pressing it shows a dialog that there are no updates right now

- [ ] Verify "Check for Updates" works offline
   - launch the app offline
   - press "Check for Updates" - see a dialog explaining the check for updates failed
   - optionally resume connectivity and retry - now you should get actual results whether update exists or no

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
4. Upload an image via copy paste
5. Verify a modal appears displaying a preview of that image
--->

#### Preparation Steps

1. Install `desktop-build/NewExpensify.dmg` to Applications
2. Go offline before you launch the installed app - we do this in order to prevent the automatic update feature to download and install an update, so we can test the "Check for Update" functionality
3. Launch the app, wait a bit then enable internet connectivity

#### Verify the new menu item exists
- [ ] Find "Check for Updates" in the system menu - this item is displayed in the menu until an update have been downloaded
- [ ] "Check for Updates" appears as disabled while an update is being downloaded - press "Check for Updates", then open the system menu again - the item should be disabled while checking/downloading a new version

#### Verify "Check for Updates" informs us of a new version
I'm not sure whether it would be possible to test this in staging right away - if this (PR) is the latest version on Staging, checking for updates would, of course, respond that there are no new versions

I think in order to test you should save the `New Expensify.dmg` somewhere and install it (again) after a newer version is available on staging. 
Keep a `New Expensify.dmg` so you can start over and test again in case you need to - installing an older version of `New Expensify` would allow you to receive notifications that updates are available 

Follow the **Preparation Steps** then

- [ ] pressing system menu item "Check for Updates" shows that update is available - a dialog should appear informing you that a new version is being downloaded
- [ ] a system notification appears when the update is ready to be installed. Some caveats mentioned here: https://github.com/Expensify/App/pull/12607#issuecomment-1322400244

#### Verify applying the update works 
After checking for updates and when update is available it would be downloaded automatically
When the download is over you should receive a notification like this
![image](https://user-images.githubusercontent.com/12156624/203127887-6c1cbd13-d30f-4bc0-ba33-295b03c69605.png)

Clicking on the Notification should bring focus to App and prompt you to install the update now or skip
![image](https://user-images.githubusercontent.com/12156624/203128209-371620d4-4bd4-4be5-9c04-e9806a4f2e8e.png)

- [ ] Verify applying the "Update app" button on the prompt works - App should restart and be updated to the newer version
- [ ] You can also apply the update form the system menu - the "Check for Updates" option should be replaced by an "Update New Expnsify" option: 
![image](https://user-images.githubusercontent.com/12156624/203128747-acf5a78c-3fe9-47e8-9a43-b256b5b4a1f1.png)
- [ ] You can also dismiss the update and keep using App
- [ ] When you Quit and restart App the update should be applied automatically (only if you've seen the Update Available notification, but dismissed it, or didn't use it) (e.g. you didn't quick App, before the update was downloaded) 

#### Verify "Check for Updates" informs us of that there's no newer version
This should be the case initially when this PR is the latest code on staging, or after installing an update

Follow the **Preparation Steps** then

- [ ] pressing system menu item "Check for Updates" shows that update is NOT available - a dialog informing you that you're using the latest version should appear

#### Verify "Check for Updates" doesn't crash the app when used offline

Follow the **Preparation Steps** but stay offline

- [ ] Verify "Check for Updates" works offline
   - launch the app offline
   - press "Check for Updates" - see a dialog explaining the check for updates failed
   - optionally resume connectivity and retry - now you should get actual results whether update exists or no

#### Verify the auto update check on startup still works 

Follow the **Preparation Steps** but don't go offline at all

- [ ] Launching the app should automatically check, download and notify of existing updates - just launch the app and do nothing at all, but wait a few or several minutes - you should receive a system notification that update is available

#### Verify the auto update check the runs every 8 hrs still works

Follow the **Preparation Steps* and do stay offline

Launch the app, wait for several seconds and resume internet connectivity

There are 2 cases
- [ ] After 8 hours, if App is focused you get a notification that update is available
- [ ] After 8 hours if App is not focused the update is applied automatically and App is restarted 

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).

- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

<details>
<summary><h4>PR Reviewer Checklist</h4>

The reviewer will copy/paste it into a new comment and complete it after the author checklist is completed
</summary>

- [ ] I have verified the author checklist is complete (all boxes are checked off).
- [ ] I verified the correct issue is linked in the `### Fixed Issues` section above
- [ ] I verified testing steps are clear and they cover the changes made in this PR
    - [ ] I verified the steps for local testing are in the `Tests` section
    - [ ] I verified the steps for Staging and/or Production testing are in the `QA steps` section
    - [ ] I verified the steps cover any possible failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [ ] I checked that screenshots or videos are included for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I verified tests pass on **all platforms** & I tested again on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [ ] If there are any errors in the console that are unrelated to this PR, I either fixed them (preferred) or linked to where I reported them in Slack
- [ ] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`).
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [ ] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I verified that this PR follows the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I verified other components that can be impacted by these changes have been tested, and I retested again (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` have been tested & I retested again)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] I have checked off every checkbox in the PR reviewer checklist, including those that don't apply to this PR.

</details>

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

#### Mobile Web - Chrome
<!-- Insert screenshots of your changes on the web platform (from chrome mobile browser)-->

#### Mobile Web - Safari
<!-- Insert screenshots of your changes on the web platform (from safari mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->
<img width="1268" alt="Screenshot 2022-11-09 at 16 31 08" src="https://user-images.githubusercontent.com/12156624/200919034-37f691b0-b8dd-4a42-8052-ad92a8e4fcd3.png">


https://user-images.githubusercontent.com/12156624/200919148-d70c05d1-3d4b-48ad-8898-866f42ea6cfd.mov

<img width="1312" alt="Screenshot 2022-11-09 at 21 23 02" src="https://user-images.githubusercontent.com/12156624/200923555-b4a1c994-9074-4948-9cb8-ac280ae21f27.png">

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
