### PR TITLE
Workspace - Error message for invalid phone number invite disappears fast

### DIFF
--- a/src/pages/workspace/WorkspaceMembersPage.js
+++ b/src/pages/workspace/WorkspaceMembersPage.js
@@ -95,7 +95,7 @@ class WorkspaceMembersPage extends React.Component {
          * This is due to how calling `Onyx::merge` on array fields overwrites the array.
          * see https://github.com/Expensify/App/issues/12265#issuecomment-1307889721 for more context
          */
-        const clientMemberEmails = _.keys(_.pick(this.props.policyMemberList, m => m.role));
+        const clientMemberEmails = _.keys(_.pick(this.props.policyMemberList, member => member.role));
         Policy.openWorkspaceMembersPage(this.props.route.params.policyID, clientMemberEmails);
     }
 

--- a/src/pages/workspace/WorkspaceMembersPage.js
+++ b/src/pages/workspace/WorkspaceMembersPage.js
@@ -75,10 +75,9 @@ class WorkspaceMembersPage extends React.Component {
     componentDidMount() {
         /**
          * clientMemberEmails should be filtered to only pass valid members, failure to do so
-         * will remove all non-exisiting members that should be displayed (e.g. non-exisiting members that should report an error)
-         * this is due to the merge from Onyx.
-         * Every valid member has the "role" property, thus the filter is based on that property.
-         * Ref #12265
+         * will remove all non-existing members that should be displayed (e.g. non-existing members that should display an error).
+         * This is due to how calling `Onyx::merge` on array fields overwrites the array.
+         * see https://github.com/Expensify/App/issues/12265#issuecomment-1307889721 for more context
          */
         const clientMemberEmails = _.keys(_.pick(this.props.policyMemberList, m => m.role));
         Policy.openWorkspaceMembersPage(this.props.route.params.policyID, clientMemberEmails);

--- a/src/pages/workspace/WorkspaceMembersPage.js
+++ b/src/pages/workspace/WorkspaceMembersPage.js
@@ -73,14 +73,7 @@ class WorkspaceMembersPage extends React.Component {
     }
 
     componentDidMount() {
-        /**
-         * clientMemberEmails should be filtered to only pass valid members, failure to do so
-         * will remove all non-existing members that should be displayed (e.g. non-existing members that should display an error).
-         * This is due to how calling `Onyx::merge` on array fields overwrites the array.
-         * see https://github.com/Expensify/App/issues/12265#issuecomment-1307889721 for more context
-         */
-        const clientMemberEmails = _.keys(_.pick(this.props.policyMemberList, member => member.role));
-        Policy.openWorkspaceMembersPage(this.props.route.params.policyID, clientMemberEmails);
+        this.getWorkspaceMembers();
     }
 
     componentDidUpdate(prevProps) {
@@ -89,6 +82,13 @@ class WorkspaceMembersPage extends React.Component {
             return;
         }
 
+        this.getWorkspaceMembers();
+    }
+
+    /**
+     * Get members for the current workspace
+     */
+    getWorkspaceMembers() {
         /**
          * clientMemberEmails should be filtered to only pass valid members, failure to do so
          * will remove all non-existing members that should be displayed (e.g. non-existing members that should display an error).

--- a/src/pages/workspace/WorkspaceMembersPage.js
+++ b/src/pages/workspace/WorkspaceMembersPage.js
@@ -79,7 +79,7 @@ class WorkspaceMembersPage extends React.Component {
          * This is due to how calling `Onyx::merge` on array fields overwrites the array.
          * see https://github.com/Expensify/App/issues/12265#issuecomment-1307889721 for more context
          */
-        const clientMemberEmails = _.keys(_.pick(this.props.policyMemberList, m => m.role));
+        const clientMemberEmails = _.keys(_.pick(this.props.policyMemberList, member => member.role));
         Policy.openWorkspaceMembersPage(this.props.route.params.policyID, clientMemberEmails);
     }
 

--- a/src/pages/workspace/WorkspaceMembersPage.js
+++ b/src/pages/workspace/WorkspaceMembersPage.js
@@ -73,7 +73,14 @@ class WorkspaceMembersPage extends React.Component {
     }
 
     componentDidMount() {
-        const clientMemberEmails = _.keys(this.props.policyMemberList);
+        /**
+         * clientMemberEmails should be filtered to only pass valid members, failure to do so
+         * will remove all non-exisiting members that should be displayed (e.g. non-exisiting members that should report an error)
+         * this is due to the merge from Onyx.
+         * Every valid member has the "role" property, thus the filter is based on that property.
+         * Ref #12265
+         */
+        const clientMemberEmails = _.keys(_.pick(this.props.policyMemberList, m => m.role));
         Policy.openWorkspaceMembersPage(this.props.route.params.policyID, clientMemberEmails);
     }
 
@@ -83,7 +90,14 @@ class WorkspaceMembersPage extends React.Component {
             return;
         }
 
-        const clientMemberEmails = _.keys(this.props.policyMemberList);
+        /**
+         * clientMemberEmails should be filtered to only pass valid members, failure to do so
+         * will remove all non-exisiting members that should be displayed (e.g. non-exisiting members that should report an error)
+         * this is due to the merge from Onyx.
+         * Every valid member has the "role" property, thus the filter is based on that property.
+         * Ref #12265
+         */
+        const clientMemberEmails = _.keys(_.pick(this.props.policyMemberList, m => m.role));
         Policy.openWorkspaceMembersPage(this.props.route.params.policyID, clientMemberEmails);
     }
 

--- a/src/pages/workspace/WorkspaceMembersPage.js
+++ b/src/pages/workspace/WorkspaceMembersPage.js
@@ -92,12 +92,10 @@ class WorkspaceMembersPage extends React.Component {
 
         /**
          * clientMemberEmails should be filtered to only pass valid members, failure to do so
-         * will remove all non-exisiting members that should be displayed (e.g. non-exisiting members that should report an error)
-         * this is due to the merge from Onyx.
-         * Every valid member has the "role" property, thus the filter is based on that property.
-         * Ref #12265
+         * will remove all non-existing members that should be displayed (e.g. non-existing members that should display an error).
+         * This is due to how calling `Onyx::merge` on array fields overwrites the array.
+         * see https://github.com/Expensify/App/issues/12265#issuecomment-1307889721 for more context
          */
-        const clientMemberEmails = _.keys(_.pick(this.props.policyMemberList, m => m.role));
         Policy.openWorkspaceMembersPage(this.props.route.params.policyID, clientMemberEmails);
     }
 

--- a/src/pages/workspace/WorkspaceMembersPage.js
+++ b/src/pages/workspace/WorkspaceMembersPage.js
@@ -95,6 +95,7 @@ class WorkspaceMembersPage extends React.Component {
          * This is due to how calling `Onyx::merge` on array fields overwrites the array.
          * see https://github.com/Expensify/App/issues/12265#issuecomment-1307889721 for more context
          */
+        const clientMemberEmails = _.keys(_.pick(this.props.policyMemberList, m => m.role));
         Policy.openWorkspaceMembersPage(this.props.route.params.policyID, clientMemberEmails);
     }
 


### PR DESCRIPTION
### Details
Error message for invalid phone number invite disappears fast

On src/pages/workspace/WorkspaceMembersPage.js

clientMemberEmails should be filtered to only pass valid members, failure to do so will remove all non-exisiting members that should be displayed (e.g. non-exisiting members that should report an error) this is due to the merge from Onyx.

Every valid member has the "role" property, thus the filter is based on that property.

### Fixed Issues
$ https://github.com/Expensify/App/issues/12265   
PROPOSAL: https://github.com/Expensify/App/issues/12265#issuecomment-1307889721


### Tests
1. Login with any account
2. Go to Settings -> Workspaces -> Select any workspace -> Manage members -> Invite
3. Invite any random non valid user (use an invalid phone number)
4. Make sure you see an error
5. Close sidebar
6. Open sidebar
7. Go to Settings -> Workspaces -> Select any workspace -> Manage members
8. Verify that the error is still there and verify that it won't disappear

- [X] Verify that no errors appear in the JS console

### QA Steps
1. Login with any account
2. Go to Settings -> Workspaces -> Select any workspace -> Manage members -> Invite
3. Invite any random non valid user (use an invalid phone number)
4. Make sure you see an error
5. Close sidebar
6. Open sidebar
7. Go to Settings -> Workspaces -> Select any workspace -> Manage members
8. Verify that the error is still there and verify that it won't disappear

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] iOS / native
    - [X] Android / native
    - [X] iOS / Safari
    - [X] Android / Chrome
    - [X] MacOS / Chrome
    - [X] MacOS / Desktop
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [X] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [X] If a new component is created I verified that:
    - [X] A similar component doesn't exist in the codebase
    - [X] All props are defined accurately and each prop has a `/** comment above it */`
    - [X] The file is named correctly
    - [X] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [X] The only data being stored in the state is data necessary for rendering and nothing else
    - [X] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [X] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [X] All JSX used for rendering exists in the render method
    - [X] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

<details>
<summary><h4>PR Reviewer Checklist</h4>

The reviewer will copy/paste it into a new comment and complete it after the author checklist is completed
</summary>

- [ ] I have verified the author checklist is complete (all boxes are checked off).
- [ ] I verified the correct issue is linked in the `### Fixed Issues` section above
- [ ] I verified testing steps are clear and they cover the changes made in this PR
    - [ ] I verified the steps for local testing are in the `Tests` section
    - [ ] I verified the steps for Staging and/or Production testing are in the `QA steps` section
    - [ ] I verified the steps cover any possible failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
- [ ] I checked that screenshots or videos are included for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I verified tests pass on **all platforms** & I tested again on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [ ] If there are any errors in the console that are unrelated to this PR, I either fixed them (preferred) or linked to where I reported them in Slack
- [ ] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`).
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [ ] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I verified that this PR follows the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I verified other components that can be impacted by these changes have been tested, and I retested again (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` have been tested & I retested again)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] I have checked off every checkbox in the PR reviewer checklist, including those that don't apply to this PR.

</details>

### Screenshots

#### Web

https://user-images.githubusercontent.com/16493223/202011484-c7134be8-89b7-46ae-9032-abb04e5bd8e6.mp4



#### Mobile Web - Chrome

https://user-images.githubusercontent.com/16493223/202011534-a8be2dc7-c2f1-4841-8f64-7ac69c1aeadb.mp4



#### Mobile Web - Safari

https://user-images.githubusercontent.com/16493223/202011567-7b19333b-77cf-42cf-bb70-d3c0beee5e19.mp4



#### Desktop

https://user-images.githubusercontent.com/16493223/202011605-2796e645-3233-4a88-afcf-4c2edc6fb4b4.mp4



#### iOS

https://user-images.githubusercontent.com/16493223/202011672-bf07927a-4b68-4ab7-983d-501194c037d2.mp4



#### Android


https://user-images.githubusercontent.com/16493223/202011750-109d29e1-8485-4a71-ab53-d9da9e29d7bb.mp4


