### PR TITLE
Fix: Cursor moves to end after adding space in Room Name

### DIFF
--- a/src/components/RoomNameInput/index.js
+++ b/src/components/RoomNameInput/index.js
@@ -1,7 +1,7 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import CONST from '../../CONST';
-import withLocalize, {withLocalizePropTypes} from '../withLocalize';
+import withLocalize from '../withLocalize';
 import TextInput from '../TextInput';
 import * as roomNameInputPropTypes from './roomNameInputPropTypes';
 

--- a/src/components/RoomNameInput/index.js
+++ b/src/components/RoomNameInput/index.js
@@ -3,6 +3,7 @@ import CONST from '../../CONST';
 import withLocalize from '../withLocalize';
 import TextInput from '../TextInput';
 import * as roomNameInputPropTypes from './roomNameInputPropTypes';
+import * as RoomNameInputUtils from '../../libs/RoomNameInputUtils';
 
 class RoomNameInput extends Component {
     constructor(props) {
@@ -22,7 +23,7 @@ class RoomNameInput extends Component {
      */
     setModifiedRoomName(event) {
         const roomName = event.nativeEvent.text;
-        const modifiedRoomName = this.modifyRoomName(roomName);
+        const modifiedRoomName = RoomNameInputUtils.modifyRoomName(roomName);
         this.props.onChangeText(modifiedRoomName);
 
         // Prevent cursor jump behaviour:
@@ -48,24 +49,6 @@ class RoomNameInput extends Component {
      */
     setSelection(selection) {
         this.setState({selection});
-    }
-
-    /**
-     * Modifies the room name to follow our conventions:
-     * - Max length 80 characters
-     * - Cannot not include space or special characters, and we automatically apply an underscore for spaces
-     * - Must be lowercase
-     * @param {String} roomName
-     * @returns {String}
-     */
-    modifyRoomName(roomName) {
-        const modifiedRoomNameWithoutHash = roomName
-            .replace(/ /g, '_')
-            .replace(/[^a-zA-Z\d_]/g, '')
-            .substr(0, CONST.REPORT.MAX_ROOM_NAME_LENGTH)
-            .toLowerCase();
-
-        return `${CONST.POLICY.ROOM_PREFIX}${modifiedRoomNameWithoutHash}`;
     }
 
     render() {

--- a/src/components/RoomNameInput/index.js
+++ b/src/components/RoomNameInput/index.js
@@ -64,7 +64,7 @@ class RoomNameInput extends Component {
             const selection = {
                 start: this.state.selection.start + offset,
                 end: this.state.selection.end + offset,
-            }
+            };
             this.setSelection(selection);
         }
     }
@@ -74,9 +74,7 @@ class RoomNameInput extends Component {
      * @param {Object} selection
      */
     setSelection(selection) {
-        this.setState({
-            selection: selection,
-        });
+        this.setState({selection});
     }
 
     /**
@@ -108,7 +106,7 @@ class RoomNameInput extends Component {
                 onChange={this.setModifiedRoomName}
                 value={this.props.value.substring(1)} // Since the room name always starts with a prefix, we omit the first character to avoid displaying it twice.
                 selection={this.state.selection}
-                onSelectionChange={(event) => this.setSelection(event.nativeEvent.selection)}
+                onSelectionChange={event => this.setSelection(event.nativeEvent.selection)}
                 errorText={this.props.errorText}
                 autoCapitalize="none"
             />

--- a/src/components/RoomNameInput/index.js
+++ b/src/components/RoomNameInput/index.js
@@ -1,5 +1,4 @@
 import React, {Component} from 'react';
-import PropTypes from 'prop-types';
 import CONST from '../../CONST';
 import withLocalize from '../withLocalize';
 import TextInput from '../TextInput';

--- a/src/components/RoomNameInput/index.js
+++ b/src/components/RoomNameInput/index.js
@@ -3,33 +3,7 @@ import PropTypes from 'prop-types';
 import CONST from '../../CONST';
 import withLocalize, {withLocalizePropTypes} from '../withLocalize';
 import TextInput from '../TextInput';
-
-const propTypes = {
-    /** Callback to execute when the text input is modified correctly */
-    onChangeText: PropTypes.func,
-
-    /** Room name to show in input field. This should include the '#' already prefixed to the name */
-    value: PropTypes.string,
-
-    /** Whether we should show the input as disabled */
-    disabled: PropTypes.bool,
-
-    /** Error text to show */
-    errorText: PropTypes.string,
-
-    ...withLocalizePropTypes,
-
-    /** A ref forwarded to the TextInput */
-    forwardedRef: PropTypes.func,
-};
-
-const defaultProps = {
-    onChangeText: () => {},
-    value: '',
-    disabled: false,
-    errorText: '',
-    forwardedRef: () => {},
-};
+import * as roomNameInputPropTypes from './roomNameInputPropTypes';
 
 class RoomNameInput extends Component {
     constructor(props) {
@@ -114,8 +88,8 @@ class RoomNameInput extends Component {
     }
 }
 
-RoomNameInput.propTypes = propTypes;
-RoomNameInput.defaultProps = defaultProps;
+RoomNameInput.propTypes = roomNameInputPropTypes.propTypes;
+RoomNameInput.defaultProps = roomNameInputPropTypes.defaultProps;
 
 export default withLocalize(
     React.forwardRef((props, ref) => (

--- a/src/components/RoomNameInput/index.js
+++ b/src/components/RoomNameInput/index.js
@@ -13,7 +13,7 @@ class RoomNameInput extends Component {
         this.setSelection = this.setSelection.bind(this);
 
         this.state = {
-            selection: {start: 0, end: 0},
+            selection: undefined,
         };
     }
 

--- a/src/components/RoomNameInput/index.js
+++ b/src/components/RoomNameInput/index.js
@@ -1,0 +1,127 @@
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+import CONST from '../../CONST';
+import withLocalize, {withLocalizePropTypes} from '../withLocalize';
+import TextInput from '../TextInput';
+
+const propTypes = {
+    /** Callback to execute when the text input is modified correctly */
+    onChangeText: PropTypes.func,
+
+    /** Room name to show in input field. This should include the '#' already prefixed to the name */
+    value: PropTypes.string,
+
+    /** Whether we should show the input as disabled */
+    disabled: PropTypes.bool,
+
+    /** Error text to show */
+    errorText: PropTypes.string,
+
+    ...withLocalizePropTypes,
+
+    /** A ref forwarded to the TextInput */
+    forwardedRef: PropTypes.func,
+};
+
+const defaultProps = {
+    onChangeText: () => {},
+    value: '',
+    disabled: false,
+    errorText: '',
+    forwardedRef: () => {},
+};
+
+class RoomNameInput extends Component {
+    constructor(props) {
+        super(props);
+
+        this.setModifiedRoomName = this.setModifiedRoomName.bind(this);
+        this.setSelection = this.setSelection.bind(this);
+
+        this.state = {
+            selection: {start: 0, end: 0},
+        };
+    }
+
+    /**
+     * Calls the onChangeText callback with a modified room name
+     * @param {Event} event
+     */
+    setModifiedRoomName(event) {
+        const roomName = event.nativeEvent.text;
+        const modifiedRoomName = this.modifyRoomName(roomName);
+        this.props.onChangeText(modifiedRoomName);
+
+        // Prevent cursor jump behaviour:
+        // Check if newRoomNameWithHash is the same as modifiedRoomName
+        // If it is then the room name is valid (does not contain unallowed characters); no action required
+        // If not then the room name contains unvalid characters and we must adjust the cursor position manually
+        // Read more: https://github.com/Expensify/App/issues/12741
+        const oldRoomNameWithHash = this.props.value || '';
+        const newRoomNameWithHash = `${CONST.POLICY.ROOM_PREFIX}${roomName}`;
+        if (modifiedRoomName !== newRoomNameWithHash) {
+            const offset = modifiedRoomName.length - oldRoomNameWithHash.length;
+            const selection = {
+                start: this.state.selection.start + offset,
+                end: this.state.selection.end + offset,
+            }
+            this.setSelection(selection);
+        }
+    }
+
+    /**
+     * Set the selection
+     * @param {Object} selection
+     */
+    setSelection(selection) {
+        this.setState({
+            selection: selection,
+        });
+    }
+
+    /**
+     * Modifies the room name to follow our conventions:
+     * - Max length 80 characters
+     * - Cannot not include space or special characters, and we automatically apply an underscore for spaces
+     * - Must be lowercase
+     * @param {String} roomName
+     * @returns {String}
+     */
+    modifyRoomName(roomName) {
+        const modifiedRoomNameWithoutHash = roomName
+            .replace(/ /g, '_')
+            .replace(/[^a-zA-Z\d_]/g, '')
+            .substr(0, CONST.REPORT.MAX_ROOM_NAME_LENGTH)
+            .toLowerCase();
+
+        return `${CONST.POLICY.ROOM_PREFIX}${modifiedRoomNameWithoutHash}`;
+    }
+
+    render() {
+        return (
+            <TextInput
+                ref={this.props.forwardedRef}
+                disabled={this.props.disabled}
+                label={this.props.translate('newRoomPage.roomName')}
+                prefixCharacter={CONST.POLICY.ROOM_PREFIX}
+                placeholder={this.props.translate('newRoomPage.social')}
+                onChange={this.setModifiedRoomName}
+                value={this.props.value.substring(1)} // Since the room name always starts with a prefix, we omit the first character to avoid displaying it twice.
+                selection={this.state.selection}
+                onSelectionChange={(event) => this.setSelection(event.nativeEvent.selection)}
+                errorText={this.props.errorText}
+                autoCapitalize="none"
+            />
+        );
+    }
+}
+
+RoomNameInput.propTypes = propTypes;
+RoomNameInput.defaultProps = defaultProps;
+
+export default withLocalize(
+    React.forwardRef((props, ref) => (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+        <RoomNameInput {...props} forwardedRef={ref} />
+    )),
+);

--- a/src/components/RoomNameInput/index.native.js
+++ b/src/components/RoomNameInput/index.native.js
@@ -1,7 +1,7 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import CONST from '../../CONST';
-import withLocalize, {withLocalizePropTypes} from '../withLocalize';
+import withLocalize from '../withLocalize';
 import TextInput from '../TextInput';
 import * as roomNameInputPropTypes from './roomNameInputPropTypes';
 

--- a/src/components/RoomNameInput/index.native.js
+++ b/src/components/RoomNameInput/index.native.js
@@ -1,8 +1,8 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import CONST from '../CONST';
-import withLocalize, {withLocalizePropTypes} from './withLocalize';
-import TextInput from './TextInput';
+import CONST from '../../CONST';
+import withLocalize, {withLocalizePropTypes} from '../withLocalize';
+import TextInput from '../TextInput';
 
 const propTypes = {
     /** Callback to execute when the text input is modified correctly */

--- a/src/components/RoomNameInput/index.native.js
+++ b/src/components/RoomNameInput/index.native.js
@@ -1,5 +1,4 @@
 import React, {Component} from 'react';
-import PropTypes from 'prop-types';
 import CONST from '../../CONST';
 import withLocalize from '../withLocalize';
 import TextInput from '../TextInput';

--- a/src/components/RoomNameInput/index.native.js
+++ b/src/components/RoomNameInput/index.native.js
@@ -3,33 +3,7 @@ import PropTypes from 'prop-types';
 import CONST from '../../CONST';
 import withLocalize, {withLocalizePropTypes} from '../withLocalize';
 import TextInput from '../TextInput';
-
-const propTypes = {
-    /** Callback to execute when the text input is modified correctly */
-    onChangeText: PropTypes.func,
-
-    /** Room name to show in input field. This should include the '#' already prefixed to the name */
-    value: PropTypes.string,
-
-    /** Whether we should show the input as disabled */
-    disabled: PropTypes.bool,
-
-    /** Error text to show */
-    errorText: PropTypes.string,
-
-    ...withLocalizePropTypes,
-
-    /** A ref forwarded to the TextInput */
-    forwardedRef: PropTypes.func,
-};
-
-const defaultProps = {
-    onChangeText: () => {},
-    value: '',
-    disabled: false,
-    errorText: '',
-    forwardedRef: () => {},
-};
+import * as roomNameInputPropTypes from './roomNameInputPropTypes';
 
 class RoomNameInput extends Component {
     constructor(props) {
@@ -83,8 +57,8 @@ class RoomNameInput extends Component {
     }
 }
 
-RoomNameInput.propTypes = propTypes;
-RoomNameInput.defaultProps = defaultProps;
+RoomNameInput.propTypes = roomNameInputPropTypes.propTypes;
+RoomNameInput.defaultProps = roomNameInputPropTypes.defaultProps;
 
 export default withLocalize(
     React.forwardRef((props, ref) => (

--- a/src/components/RoomNameInput/index.native.js
+++ b/src/components/RoomNameInput/index.native.js
@@ -3,6 +3,7 @@ import CONST from '../../CONST';
 import withLocalize from '../withLocalize';
 import TextInput from '../TextInput';
 import * as roomNameInputPropTypes from './roomNameInputPropTypes';
+import * as RoomNameInputUtils from '../../libs/RoomNameInputUtils';
 
 class RoomNameInput extends Component {
     constructor(props) {
@@ -17,26 +18,8 @@ class RoomNameInput extends Component {
      */
     setModifiedRoomName(event) {
         const roomName = event.nativeEvent.text;
-        const modifiedRoomName = this.modifyRoomName(roomName);
+        const modifiedRoomName = RoomNameInputUtils.modifyRoomName(roomName);
         this.props.onChangeText(modifiedRoomName);
-    }
-
-    /**
-     * Modifies the room name to follow our conventions:
-     * - Max length 80 characters
-     * - Cannot not include space or special characters, and we automatically apply an underscore for spaces
-     * - Must be lowercase
-     * @param {String} roomName
-     * @returns {String}
-     */
-    modifyRoomName(roomName) {
-        const modifiedRoomNameWithoutHash = roomName
-            .replace(/ /g, '_')
-            .replace(/[^a-zA-Z\d_]/g, '')
-            .substr(0, CONST.REPORT.MAX_ROOM_NAME_LENGTH)
-            .toLowerCase();
-
-        return `${CONST.POLICY.ROOM_PREFIX}${modifiedRoomNameWithoutHash}`;
     }
 
     render() {

--- a/src/components/RoomNameInput/roomNameInputPropTypes.js
+++ b/src/components/RoomNameInput/roomNameInputPropTypes.js
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import {withLocalizePropTypes} from '../withLocalize';
 
 const propTypes = {
     /** Callback to execute when the text input is modified correctly */

--- a/src/components/RoomNameInput/roomNameInputPropTypes.js
+++ b/src/components/RoomNameInput/roomNameInputPropTypes.js
@@ -1,0 +1,30 @@
+import PropTypes from 'prop-types';
+
+const propTypes = {
+    /** Callback to execute when the text input is modified correctly */
+    onChangeText: PropTypes.func,
+
+    /** Room name to show in input field. This should include the '#' already prefixed to the name */
+    value: PropTypes.string,
+
+    /** Whether we should show the input as disabled */
+    disabled: PropTypes.bool,
+
+    /** Error text to show */
+    errorText: PropTypes.string,
+
+    ...withLocalizePropTypes,
+
+    /** A ref forwarded to the TextInput */
+    forwardedRef: PropTypes.func,
+};
+
+const defaultProps = {
+    onChangeText: () => {},
+    value: '',
+    disabled: false,
+    errorText: '',
+    forwardedRef: () => {},
+};
+
+export {propTypes, defaultProps};

--- a/src/libs/RoomNameInputUtils.js
+++ b/src/libs/RoomNameInputUtils.js
@@ -1,0 +1,24 @@
+import CONST from '../CONST';
+
+/**
+ * Modifies the room name to follow our conventions:
+ * - Max length 80 characters
+ * - Cannot not include space or special characters, and we automatically apply an underscore for spaces
+ * - Must be lowercase
+ * @param {String} roomName
+ * @returns {String}
+ */
+function modifyRoomName(roomName) {
+    const modifiedRoomNameWithoutHash = roomName
+        .replace(/ /g, '_')
+        .replace(/[^a-zA-Z\d_]/g, '')
+        .substr(0, CONST.REPORT.MAX_ROOM_NAME_LENGTH)
+        .toLowerCase();
+
+    return `${CONST.POLICY.ROOM_PREFIX}${modifiedRoomNameWithoutHash}`;
+}
+
+export {
+    // eslint-disable-next-line import/prefer-default-export
+    modifyRoomName,
+};


### PR DESCRIPTION
### Details
On Web and Desktop: If the roomname input has been modified because it contains an invalid character we must adjust the cursor position manually, otherwise the cursor will jump to the end.
On Native: No change is required, the cursor does not jump.

### Fixed Issues
$ https://github.com/Expensify/App/issues/12741   
PROPOSAL: https://github.com/Expensify/App/issues/12741#issuecomment-1321197596


### Tests
1. Login with any account
2. Click green circle button
3. Create room
4. In the room name type: "test123"
5. Put the cursor just after the word "test"
6. Type a space
7. Verify that the result is "test_123" and that the cursor is right after the underscore and not in the end
8. Type a special char (e.g.: + or &)
9. Verify that the special char was not inserted and that the cursor is still at the same position and not in the end

- [X] Verify that no errors appear in the JS console

### Offline tests
Not Applicable

### QA Steps
1. Login with any account
2. Click green circle button
3. Create room
4. In the room name type: "test123"
5. Put the cursor just after the word "test"
6. Type a space
7. Verify that the result is "test_123" and that the cursor is right after the underscore and not in the end
8. Type a special char (e.g.: + or &)
9. Verify that the special char was not inserted and that the cursor is still at the same position and not in the end

- [X] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).

- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] iOS / native
    - [X] Android / native
    - [X] iOS / Safari
    - [X] Android / Chrome
    - [X] MacOS / Chrome
    - [X] MacOS / Desktop
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [X] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If a new component is created I verified that:
    - [X] A similar component doesn't exist in the codebase
    - [X] All props are defined accurately and each prop has a `/** comment above it */`
    - [X] The file is named correctly
    - [X] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [X] The only data being stored in the state is data necessary for rendering and nothing else
    - [X] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [X] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [X] All JSX used for rendering exists in the render method
    - [X] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

<details>
<summary><h4>PR Reviewer Checklist</h4>

The reviewer will copy/paste it into a new comment and complete it after the author checklist is completed
</summary>

- [ ] I have verified the author checklist is complete (all boxes are checked off).
- [ ] I verified the correct issue is linked in the `### Fixed Issues` section above
- [ ] I verified testing steps are clear and they cover the changes made in this PR
    - [ ] I verified the steps for local testing are in the `Tests` section
    - [ ] I verified the steps for expected offline behavior are in the `Offline steps` section
    - [ ] I verified the steps for Staging and/or Production testing are in the `QA steps` section
    - [ ] I verified the steps cover any possible failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I checked that screenshots or videos are included for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I verified tests pass on **all platforms** & I tested again on:
    - [ ] iOS / native
    - [ ] Android / native
    - [ ] iOS / Safari
    - [ ] Android / Chrome
    - [ ] MacOS / Chrome
    - [ ] MacOS / Desktop
- [ ] If there are any errors in the console that are unrelated to this PR, I either fixed them (preferred) or linked to where I reported them in Slack
- [ ] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`).
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [ ] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I verified that this PR follows the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I verified other components that can be impacted by these changes have been tested, and I retested again (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` have been tested & I retested again)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] I verified that if a function's arguments changed that all usages have also been updated correctly
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] I have checked off every checkbox in the PR reviewer checklist, including those that don't apply to this PR.

</details>

### Screenshots

#### Web



https://user-images.githubusercontent.com/16493223/203139523-4ba0c5e0-2ece-4e90-9e6b-abfa76028265.mp4




#### Mobile Web - Chrome

https://user-images.githubusercontent.com/16493223/203139208-f7dec20c-f6ae-494b-9e23-daf1a5c6af80.mp4



#### Mobile Web - Safari

https://user-images.githubusercontent.com/16493223/203139304-cdbcc433-14a4-4b7c-8504-3ff115a16106.mp4



#### Desktop

https://user-images.githubusercontent.com/16493223/203139372-bc674956-753e-43dd-a33e-aa673649f358.mp4



#### iOS
Not Applicable

#### Android
Not Applicable

PS: This PR does not introduce any change on native code.