### PR TITLE
Adapt status bar color to modal backdrop

### DIFF
--- a/src/components/CustomStatusBar/index.web.js
+++ b/src/components/CustomStatusBar/index.web.js
@@ -6,7 +6,7 @@ export default class CustomStatusBar extends React.Component {
     componentDidMount() {
         StatusBar.setBarStyle('light-content', true);
 
-        // Match the default status bar color to the app's background color.
+        // For mobile web browsers, match the default status bar color to the app's background color
         document.querySelector('meta[name=theme-color]').content = themeColors.appBG;
     }
 

--- a/src/components/CustomStatusBar/index.web.js
+++ b/src/components/CustomStatusBar/index.web.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import {StatusBar} from 'react-native';
+import themeColors from '../../styles/themes/default';
+
+export default class CustomStatusBar extends React.Component {
+    componentDidMount() {
+        StatusBar.setBarStyle('light-content', true);
+
+        // Match the default status bar color to the app's background color.
+        document.querySelector('meta[name=theme-color]').content = themeColors.appBG;
+    }
+
+    render() {
+        return <StatusBar />;
+    }
+}

--- a/src/components/Modal/index.web.js
+++ b/src/components/Modal/index.web.js
@@ -6,7 +6,9 @@ import * as StyleUtils from '../../styles/StyleUtils';
 
 const Modal = (props) => {
     const setStatusBarColor = (color = '') => {
-        if (!props.fullscreen) { return; }
+        if (!props.fullscreen) {
+            return;
+        }
 
         // Change the color of the status bar to align with the modal's backdrop (refer to https://github.com/Expensify/App/issues/12156).
         document.querySelector('meta[name=theme-color]').content = color;

--- a/src/components/Modal/index.web.js
+++ b/src/components/Modal/index.web.js
@@ -19,7 +19,7 @@ const Modal = props => (
         onModalShow={() => {
             if (props.fullscreen) {
                 // The color of the status bar should align with the modal's backdrop (refer to https://github.com/Expensify/App/issues/12156).
-                document.querySelector('meta[name=theme-color]').content = StyleUtils.getThemeColor();
+                document.querySelector('meta[name=theme-color]').content = StyleUtils.getThemeBackgroundColor();
             }
 
             props.onModalShow();

--- a/src/components/Modal/index.web.js
+++ b/src/components/Modal/index.web.js
@@ -4,30 +4,33 @@ import BaseModal from './BaseModal';
 import {propTypes, defaultProps} from './modalPropTypes';
 import * as StyleUtils from '../../styles/StyleUtils';
 
-const Modal = props => (
-    <BaseModal
-            // eslint-disable-next-line react/jsx-props-no-spreading
-        {...props}
-        onModalHide={() => {
-            if (props.fullscreen) {
-                // With the modal hidden, we can revert to the default status bar color (refer to https://github.com/Expensify/App/issues/12156).
-                document.querySelector('meta[name=theme-color]').content = '';
-            }
+const Modal = (props) => {
+    const setStatusBarColor = (color = '') => {
+        if (!props.fullscreen) { return; }
 
-            props.onModalHide();
-        }}
-        onModalShow={() => {
-            if (props.fullscreen) {
-                // The color of the status bar should align with the modal's backdrop (refer to https://github.com/Expensify/App/issues/12156).
-                document.querySelector('meta[name=theme-color]').content = StyleUtils.getThemeBackgroundColor();
-            }
+        // Change the color of the status bar to align with the modal's backdrop (refer to https://github.com/Expensify/App/issues/12156).
+        document.querySelector('meta[name=theme-color]').content = color;
+    };
+    const hideModal = () => {
+        setStatusBarColor();
+        props.onModalHide();
+    };
+    const showModal = () => {
+        setStatusBarColor(StyleUtils.getThemeBackgroundColor());
+        props.onModalShow();
+    };
 
-            props.onModalShow();
-        }}
-    >
-        {props.children}
-    </BaseModal>
-);
+    return (
+        <BaseModal
+                // eslint-disable-next-line react/jsx-props-no-spreading
+            {...props}
+            onModalHide={hideModal}
+            onModalShow={showModal}
+        >
+            {props.children}
+        </BaseModal>
+    );
+};
 
 Modal.propTypes = propTypes;
 Modal.defaultProps = defaultProps;

--- a/src/components/Modal/index.web.js
+++ b/src/components/Modal/index.web.js
@@ -14,10 +14,12 @@ const Modal = (props) => {
         // Change the color of the status bar to align with the modal's backdrop (refer to https://github.com/Expensify/App/issues/12156).
         document.querySelector('meta[name=theme-color]').content = color;
     };
+
     const hideModal = () => {
         setStatusBarColor();
         props.onModalHide();
     };
+
     const showModal = () => {
         setStatusBarColor(StyleUtils.getThemeBackgroundColor());
         props.onModalShow();

--- a/src/components/Modal/index.web.js
+++ b/src/components/Modal/index.web.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import withWindowDimensions from '../withWindowDimensions';
+import BaseModal from './BaseModal';
+import {propTypes, defaultProps} from './modalPropTypes';
+import * as StyleUtils from '../../styles/StyleUtils';
+
+const Modal = props => (
+    <BaseModal
+            // eslint-disable-next-line react/jsx-props-no-spreading
+        {...props}
+        onModalHide={() => {
+            if (props.fullscreen) {
+                // With the modal hidden, we can revert to the default status bar color (refer to https://github.com/Expensify/App/issues/12156).
+                document.querySelector('meta[name=theme-color]').content = '';
+            }
+
+            props.onModalHide();
+        }}
+        onModalShow={() => {
+            if (props.fullscreen) {
+                // The color of the status bar should align with the modal's backdrop (refer to https://github.com/Expensify/App/issues/12156).
+                document.querySelector('meta[name=theme-color]').content = StyleUtils.getThemeColor();
+            }
+
+            props.onModalShow();
+        }}
+    >
+        {props.children}
+    </BaseModal>
+);
+
+Modal.propTypes = propTypes;
+Modal.defaultProps = defaultProps;
+Modal.displayName = 'Modal';
+export default withWindowDimensions(Modal);

--- a/src/components/Modal/index.web.js
+++ b/src/components/Modal/index.web.js
@@ -3,9 +3,10 @@ import withWindowDimensions from '../withWindowDimensions';
 import BaseModal from './BaseModal';
 import {propTypes, defaultProps} from './modalPropTypes';
 import * as StyleUtils from '../../styles/StyleUtils';
+import themeColors from '../../styles/themes/default';
 
 const Modal = (props) => {
-    const setStatusBarColor = (color = '') => {
+    const setStatusBarColor = (color = themeColors.appBG) => {
         if (!props.fullscreen) {
             return;
         }

--- a/src/components/Modal/index.web.js
+++ b/src/components/Modal/index.web.js
@@ -24,7 +24,7 @@ const Modal = (props) => {
 
     return (
         <BaseModal
-                // eslint-disable-next-line react/jsx-props-no-spreading
+            // eslint-disable-next-line react/jsx-props-no-spreading
             {...props}
             onModalHide={hideModal}
             onModalShow={showModal}

--- a/src/styles/StyleUtils.js
+++ b/src/styles/StyleUtils.js
@@ -229,7 +229,7 @@ function getBackgroundColorWithOpacityStyle(backgroundColor, opacity) {
     const result = hexadecimalToRGBComponents(backgroundColor);
     if (result !== null) {
         return {
-            backgroundColor: `rgba(${result[1]}, ${result[1]}, ${result[1]}, ${opacity})`,
+            backgroundColor: `rgba(${result[0]}, ${result[1]}, ${result[2]}, ${opacity})`,
         };
     }
     return {};

--- a/src/styles/StyleUtils.js
+++ b/src/styles/StyleUtils.js
@@ -648,7 +648,7 @@ export {
     getMiniReportActionContextMenuWrapperStyle,
     getKeyboardShortcutsModalWidth,
     getPaymentMethodMenuWidth,
-    getThemeBackgroundColor as getThemeColor,
+    getThemeBackgroundColor,
     parseStyleAsArray,
     combineStyles,
     getPaddingLeft,

--- a/src/styles/StyleUtils.js
+++ b/src/styles/StyleUtils.js
@@ -481,26 +481,26 @@ function convertRGBAToRGB(foregroundRGB, backgroundRGB, opacity) {
 }
 
 /**
- * Denormalizes the three components of a color in RGB notation.
+ * Converts three unit values to the three components of a color in RGB notation.
  *
- * @param {number} red The first normalized component of a color in RGB notation.
- * @param {number} green The second normalized component of a color in RGB notation.
- * @param {number} blue The third normalized component of a color in RGB notation.
- * @returns {Array} An array with the three denormalized components of a color in RGB notation.
+ * @param {number} red A unit value representing the first component of a color in RGB notation.
+ * @param {number} green A unit value representing the second component of a color in RGB notation.
+ * @param {number} blue A unit value representing the third component of a color in RGB notation.
+ * @returns {Array} An array with the three components of a color in RGB notation.
  */
-function denormalizeRGB(red, green, blue) {
+function convertUnitValuesToRGB(red, green, blue) {
     return [Math.floor(red * 255), Math.floor(green * 255), Math.floor(blue * 255)];
 }
 
 /**
- * Normalizes the three components of a color in RGB notation.
+ * Converts the three components of a color in RGB notation to three unit values.
  *
- * @param {number} red The first denormalized component of a color in RGB notation.
- * @param {number} green The second denormalized component of a color in RGB notation.
- * @param {number} blue The third denormalized component of a color in RGB notation.
- * @returns {Array} An array with the three normalized components of a color in RGB notation.
+ * @param {number} red The first component of a color in RGB notation.
+ * @param {number} green The second component of a color in RGB notation.
+ * @param {number} blue The third component of a color in RGB notation.
+ * @returns {Array} An array with three unit values representing the components of a color in RGB notation.
  */
-function normalizeRGB(red, green, blue) {
+function convertRGBToUnitValues(red, green, blue) {
     return [red / 255, green / 255, blue / 255];
 }
 
@@ -515,8 +515,8 @@ function getThemeBackgroundColor() {
 
     const [backgroundRed, backgroundGreen, backgroundBlue] = hexadecimalToRGBComponents(themeColors.appBG);
     const [backdropRed, backdropGreen, backdropBlue] = hexadecimalToRGBComponents(themeColors.modalBackdrop);
-    const normalizedBackdropRGB = normalizeRGB(backdropRed, backdropGreen, backdropBlue);
-    const normalizedBackgroundRGB = normalizeRGB(
+    const normalizedBackdropRGB = convertRGBToUnitValues(backdropRed, backdropGreen, backdropBlue);
+    const normalizedBackgroundRGB = convertRGBToUnitValues(
         backgroundRed,
         backgroundGreen,
         backgroundBlue,
@@ -526,7 +526,7 @@ function getThemeBackgroundColor() {
         normalizedBackgroundRGB,
         backdropOpacity,
     );
-    const themeRGB = denormalizeRGB(...themeRGBNormalized);
+    const themeRGB = convertUnitValuesToRGB(...themeRGBNormalized);
 
     return `rgb(${themeRGB.join(', ')})`;
 }

--- a/src/styles/StyleUtils.js
+++ b/src/styles/StyleUtils.js
@@ -206,16 +206,14 @@ function getBackgroundColorStyle(backgroundColor) {
  * Converts a color in hexadecimal notation into RGB notation.
  *
  * @param {String} hexadecimal A color in hexadecimal notation.
- * @returns {Array} `null` if the input color is not in hexadecimal notation. Otherwise, the RGB components of the input color.
+ * @returns {Array} `undefined` if the input color is not in hexadecimal notation. Otherwise, the RGB components of the input color.
  */
-function hexadecimalToRGBComponents(hexadecimal) {
+function hexadecimalToRGBArray(hexadecimal) {
     const components = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hexadecimal);
 
-    if (components !== null) {
-        return _.map(components.slice(1), component => parseInt(component, 16));
-    }
+    if (components === null) { return undefined; }
 
-    return null;
+    return _.map(components.slice(1), component => parseInt(component, 16));
 }
 
 /**
@@ -226,8 +224,8 @@ function hexadecimalToRGBComponents(hexadecimal) {
  * @returns {Object}
  */
 function getBackgroundColorWithOpacityStyle(backgroundColor, opacity) {
-    const result = hexadecimalToRGBComponents(backgroundColor);
-    if (result !== null) {
+    const result = hexadecimalToRGBArray(backgroundColor);
+    if (result !== undefined) {
         return {
             backgroundColor: `rgba(${result[0]}, ${result[1]}, ${result[2]}, ${opacity})`,
         };
@@ -513,8 +511,8 @@ function convertRGBToUnitValues(red, green, blue) {
 function getThemeBackgroundColor() {
     const backdropOpacity = variables.modalFullscreenBackdropOpacity;
 
-    const [backgroundRed, backgroundGreen, backgroundBlue] = hexadecimalToRGBComponents(themeColors.appBG);
-    const [backdropRed, backdropGreen, backdropBlue] = hexadecimalToRGBComponents(themeColors.modalBackdrop);
+    const [backgroundRed, backgroundGreen, backgroundBlue] = hexadecimalToRGBArray(themeColors.appBG);
+    const [backdropRed, backdropGreen, backdropBlue] = hexadecimalToRGBArray(themeColors.modalBackdrop);
     const normalizedBackdropRGB = convertRGBToUnitValues(backdropRed, backdropGreen, backdropBlue);
     const normalizedBackgroundRGB = convertRGBToUnitValues(
         backgroundRed,

--- a/src/styles/StyleUtils.js
+++ b/src/styles/StyleUtils.js
@@ -470,38 +470,38 @@ function getPaymentMethodMenuWidth(isSmallScreenWidth) {
  * @returns {Array} The RGB components of the RGBA color converted to RGB.
  */
 function convertRGBAToRGB(foregroundRGB, backgroundRGB, opacity) {
-    const [foregroundR, foregroundG, foregroundB] = foregroundRGB;
-    const [backgroundR, backgroundG, backgroundB] = backgroundRGB;
+    const [foregroundRed, foregroundGreen, foregroundBlue] = foregroundRGB;
+    const [backgroundRed, backgroundGreen, backgroundBlue] = backgroundRGB;
 
     return [
-        ((1 - opacity) * backgroundR) + (opacity * foregroundR),
-        ((1 - opacity) * backgroundG) + (opacity * foregroundG),
-        ((1 - opacity) * backgroundB) + (opacity * foregroundB),
+        ((1 - opacity) * backgroundRed) + (opacity * foregroundRed),
+        ((1 - opacity) * backgroundGreen) + (opacity * foregroundGreen),
+        ((1 - opacity) * backgroundBlue) + (opacity * foregroundBlue),
     ];
 }
 
 /**
  * Denormalizes the three components of a color in RGB notation.
  *
- * @param {number} r The first normalized component of a color in RGB notation.
- * @param {number} g The second normalized component of a color in RGB notation.
- * @param {number} b The third normalized component of a color in RGB notation.
+ * @param {number} red The first normalized component of a color in RGB notation.
+ * @param {number} green The second normalized component of a color in RGB notation.
+ * @param {number} blue The third normalized component of a color in RGB notation.
  * @returns {Array} An array with the three denormalized components of a color in RGB notation.
  */
-function denormalizeRGB(r, g, b) {
-    return [Math.floor(r * 255), Math.floor(g * 255), Math.floor(b * 255)];
+function denormalizeRGB(red, green, blue) {
+    return [Math.floor(red * 255), Math.floor(green * 255), Math.floor(blue * 255)];
 }
 
 /**
  * Normalizes the three components of a color in RGB notation.
  *
- * @param {number} r The first denormalized component of a color in RGB notation.
- * @param {number} g The second denormalized component of a color in RGB notation.
- * @param {number} b The third denormalized component of a color in RGB notation.
+ * @param {number} red The first denormalized component of a color in RGB notation.
+ * @param {number} green The second denormalized component of a color in RGB notation.
+ * @param {number} blue The third denormalized component of a color in RGB notation.
  * @returns {Array} An array with the three normalized components of a color in RGB notation.
  */
-function normalizeRGB(r, g, b) {
-    return [r / 255, g / 255, b / 255];
+function normalizeRGB(red, green, blue) {
+    return [red / 255, green / 255, blue / 255];
 }
 
 /**
@@ -513,13 +513,13 @@ function normalizeRGB(r, g, b) {
 function getThemeBackgroundColor() {
     const backdropOpacity = variables.modalFullscreenBackdropOpacity;
 
-    const [backgroundR, backgroundG, backgroundB] = hexadecimalToRGBComponents(themeColors.appBG);
-    const [backdropR, backdropG, backdropB] = hexadecimalToRGBComponents(themeColors.modalBackdrop);
-    const normalizedBackdropRGB = normalizeRGB(backdropR, backdropG, backdropB);
+    const [backgroundRed, backgroundGreen, backgroundBlue] = hexadecimalToRGBComponents(themeColors.appBG);
+    const [backdropRed, backdropGreen, backdropBlue] = hexadecimalToRGBComponents(themeColors.modalBackdrop);
+    const normalizedBackdropRGB = normalizeRGB(backdropRed, backdropGreen, backdropBlue);
     const normalizedBackgroundRGB = normalizeRGB(
-        backgroundR,
-        backgroundG,
-        backgroundB,
+        backgroundRed,
+        backgroundGreen,
+        backgroundBlue,
     );
     const themeRGBNormalized = convertRGBAToRGB(
         normalizedBackdropRGB,

--- a/src/styles/StyleUtils.js
+++ b/src/styles/StyleUtils.js
@@ -206,9 +206,9 @@ function getBackgroundColorStyle(backgroundColor) {
  * Converts a color in hexadecimal notation into RGB notation.
  *
  * @param {String} hexadecimal A color in hexadecimal notation.
- * @returns {Array} `null` if the input color is not in hexadecimal notation. Otherwise, the input color as RGB value.
+ * @returns {Array} `null` if the input color is not in hexadecimal notation. Otherwise, the RGB components of the input color.
  */
-function hexadecimalToRGB(hexadecimal) {
+function hexadecimalToRGBComponents(hexadecimal) {
     const components = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hexadecimal);
 
     if (components !== null) {
@@ -226,7 +226,7 @@ function hexadecimalToRGB(hexadecimal) {
  * @returns {Object}
  */
 function getBackgroundColorWithOpacityStyle(backgroundColor, opacity) {
-    const result = hexadecimalToRGB(backgroundColor);
+    const result = hexadecimalToRGBComponents(backgroundColor);
     if (result !== null) {
         return {
             backgroundColor: `rgba(${result[1]}, ${result[1]}, ${result[1]}, ${opacity})`,
@@ -462,14 +462,14 @@ function getPaymentMethodMenuWidth(isSmallScreenWidth) {
 }
 
 /**
- * Approximates a color in RGBA notation with an equivalent color in RGB notation.
+ * Converts a color in RGBA notation to an equivalent color in RGB notation.
  *
  * @param {Array} foregroundRGB The three components of the foreground color in RGB notation.
  * @param {Array} backgroundRGB The three components of the background color in RGB notation.
  * @param {number} opacity The desired opacity of the foreground color.
- * @returns {Array} A color in RGB notation that approximates the foreground color with the given opacity on top of the background color.
+ * @returns {Array} The RGB components of the RGBA color converted to RGB.
  */
-function approximateRGBAWithRGB(foregroundRGB, backgroundRGB, opacity) {
+function convertRGBAToRGB(foregroundRGB, backgroundRGB, opacity) {
     const [foregroundR, foregroundG, foregroundB] = foregroundRGB;
     const [backgroundR, backgroundG, backgroundB] = backgroundRGB;
 
@@ -505,30 +505,30 @@ function normalizeRGB(r, g, b) {
 }
 
 /**
- * Approximates the theme color for a modal based on the app's background color,
+ * Determines the theme color for a modal based on the app's background color,
  * the modal's backdrop, and the backdrop's opacity.
  *
  * @returns {String} The theme color as an RGB value.
  */
-function getThemeColor() {
+function getThemeBackgroundColor() {
     const backdropOpacity = variables.modalFullscreenBackdropOpacity;
 
-    const [backgroundR, backgroundG, backgroundB] = hexadecimalToRGB(themeColors.appBG);
-    const [backdropR, backdropG, backdropB] = hexadecimalToRGB(themeColors.modalBackdrop);
+    const [backgroundR, backgroundG, backgroundB] = hexadecimalToRGBComponents(themeColors.appBG);
+    const [backdropR, backdropG, backdropB] = hexadecimalToRGBComponents(themeColors.modalBackdrop);
     const normalizedBackdropRGB = normalizeRGB(backdropR, backdropG, backdropB);
     const normalizedBackgroundRGB = normalizeRGB(
         backgroundR,
         backgroundG,
         backgroundB,
     );
-    const approximatedThemeRGBNormalized = approximateRGBAWithRGB(
+    const themeRGBNormalized = convertRGBAToRGB(
         normalizedBackdropRGB,
         normalizedBackgroundRGB,
         backdropOpacity,
     );
-    const approximatedThemeRGB = denormalizeRGB(...approximatedThemeRGBNormalized);
+    const themeRGB = denormalizeRGB(...themeRGBNormalized);
 
-    return `rgb(${approximatedThemeRGB.join(', ')})`;
+    return `rgb(${themeRGB.join(', ')})`;
 }
 
 /**
@@ -648,7 +648,7 @@ export {
     getMiniReportActionContextMenuWrapperStyle,
     getKeyboardShortcutsModalWidth,
     getPaymentMethodMenuWidth,
-    getThemeColor,
+    getThemeBackgroundColor as getThemeColor,
     parseStyleAsArray,
     combineStyles,
     getPaddingLeft,

--- a/src/styles/variables.js
+++ b/src/styles/variables.js
@@ -42,6 +42,7 @@ export default {
     emojiLineHeight: 28,
     iouAmountTextSize: 40,
     mobileResponsiveWidthBreakpoint: 800,
+    modalFullscreenBackdropOpacity: 0.5,
     tabletResponsiveWidthBreakpoint: 1024,
     safeInsertPercentage: 0.7,
     sideBarWidth: 375,

--- a/web/index.html
+++ b/web/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <title>New Expensify</title>
     <meta name="description" content="Corporate cards, reimbursements, receipt scanning, invoicing, and bill pay. One app, all free.">
+    <meta name="theme-color" content="">
     <meta property="twitter:card" content="summary">
     <meta property="twitter:site" content="@expensify">
     <meta property="og:type" content="website">


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
@eVoloshchak 
@tgolen 

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Previously, the status bar color did not match the backdrop of a modal on Safari. This pull request fixes this issue by changing the status bar color as soon as a modal opens.

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/12156   
$ https://github.com/Expensify/App/issues/12156#issuecomment-1330441326


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Open a chat.
2. Tap long onto a message to open its context menu.
3. Discard the context menu by shortly tapping outside of it.

By design, these steps only apply on iOS / Safari and Android / Chrome since the issue never appeared on iOS / native and Android / native. The remaining platforms do not offer a comparable context menu.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

See the steps from above.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
5. Upload an image via copy paste
6. Verify a modal appears displaying a preview of that image
--->

See the steps from above.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->
Not applicable.

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->
[Android.webm](https://user-images.githubusercontent.com/13868083/204932775-bfad6622-d3f5-4094-b356-dadf4e60a8d4.webm)

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->
https://user-images.githubusercontent.com/13868083/204932846-4e1ee82d-b9d0-4010-9262-c479e3bb4d87.MP4

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->
Not applicable.

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->
Not applicable.

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->
Not applicable.

</details>
