### PR TITLE
Correct the logic for when bill split particpants can be selected

### DIFF
--- a/src/components/IOUConfirmationList.js
+++ b/src/components/IOUConfirmationList.js
@@ -275,7 +275,11 @@ class IOUConfirmationList extends Component {
         const shouldShowSettlementButton = this.props.iouType === CONST.IOU.IOU_TYPE.SEND;
         const shouldDisableButton = selectedParticipants.length === 0;
         const recipient = this.state.participants[0];
-        const canModifyParticipants = !this.props.isIOUAttachedToExistingChatReport && this.props.hasMultipleParticipants;
+
+        // The participants can only be modified when:
+        // 1. The action is initiated from directly within a group chat and not the floating-action-button (eg. this.props.isIOUAttachedToExistingChatReport === true)
+        // 2. There are multiple participants (eg. this.props.hasMultipleParticipants === true)
+        const canModifyParticipants = this.props.isIOUAttachedToExistingChatReport && this.props.hasMultipleParticipants;
 
         return (
             <OptionsSelector

--- a/src/components/IOUConfirmationList.js
+++ b/src/components/IOUConfirmationList.js
@@ -275,7 +275,13 @@ class IOUConfirmationList extends Component {
         const shouldShowSettlementButton = this.props.iouType === CONST.IOU.IOU_TYPE.SEND;
         const shouldDisableButton = selectedParticipants.length === 0;
         const recipient = this.state.participants[0];
-        const canModifyParticipants = !this.props.isIOUAttachedToExistingChatReport && this.props.hasMultipleParticipants;
+
+        // The participants can only be modified when:
+        // 1. The action is initiated from directly within a group chat and not the floating-action-button (eg. this.props.isIOUAttachedToExistingChatReport === true). This is because when
+        // there is a group of people, say they are on a trip, and you have some shared expenses with some of the people, but not all of them (maybe someone skipped out on dinner). Then
+        // it's nice to be able to select/deselect people from the group chat bill split rather than forcing the user to create a new group, just for that expense.
+        // 2. There are multiple participants (eg. this.props.hasMultipleParticipants === true). This is because splitting a bill with one person isn't a thing :D
+        const canModifyParticipants = this.props.isIOUAttachedToExistingChatReport && this.props.hasMultipleParticipants;
 
         return (
             <OptionsSelector

--- a/src/components/IOUConfirmationList.js
+++ b/src/components/IOUConfirmationList.js
@@ -57,7 +57,8 @@ const propTypes = {
         phoneNumber: PropTypes.string,
     })).isRequired,
 
-    /** Is this IOU associated with existing report */
+    /** Is this IOU associated with existing report. This is true when the action is initiated from inside a group chat and it's false when the action is initiated from the
+     * floating-action-button */
     isIOUAttachedToExistingChatReport: PropTypes.bool.isRequired,
 
     ...windowDimensionsPropTypes,

--- a/src/components/IOUConfirmationList.js
+++ b/src/components/IOUConfirmationList.js
@@ -57,9 +57,8 @@ const propTypes = {
         phoneNumber: PropTypes.string,
     })).isRequired,
 
-    /** Is this IOU associated with existing report. This is true when the action is initiated from inside a group chat and it's false when the action is initiated from the
-     * floating-action-button */
-    isIOUAttachedToExistingChatReport: PropTypes.bool.isRequired,
+    /** Can the participants be modified or not */
+    canModifyParticipants: PropTypes.bool,
 
     ...windowDimensionsPropTypes,
 
@@ -92,6 +91,7 @@ const defaultProps = {
     onUpdateComment: null,
     comment: '',
     iouType: CONST.IOU.IOU_TYPE.REQUEST,
+    canModifyParticipants: false,
     ...withCurrentUserPersonalDetailsDefaultProps,
 };
 
@@ -276,13 +276,7 @@ class IOUConfirmationList extends Component {
         const shouldShowSettlementButton = this.props.iouType === CONST.IOU.IOU_TYPE.SEND;
         const shouldDisableButton = selectedParticipants.length === 0;
         const recipient = this.state.participants[0];
-
-        // The participants can only be modified when:
-        // 1. The action is initiated from directly within a group chat and not the floating-action-button (eg. this.props.isIOUAttachedToExistingChatReport === true). This is because when
-        // there is a group of people, say they are on a trip, and you have some shared expenses with some of the people, but not all of them (maybe someone skipped out on dinner). Then
-        // it's nice to be able to select/deselect people from the group chat bill split rather than forcing the user to create a new group, just for that expense.
-        // 2. There are multiple participants (eg. this.props.hasMultipleParticipants === true). This is because splitting a bill with one person isn't a thing :D
-        const canModifyParticipants = this.props.isIOUAttachedToExistingChatReport && this.props.hasMultipleParticipants;
+        const canModifyParticipants = this.props.canModifyParticipants && this.props.hasMultipleParticipants;
 
         return (
             <OptionsSelector

--- a/src/pages/iou/IOUModal.js
+++ b/src/pages/iou/IOUModal.js
@@ -450,7 +450,13 @@ class IOUModal extends Component {
                                                 comment={this.state.comment}
                                                 onUpdateComment={this.updateComment}
                                                 iouType={this.props.iouType}
-                                                isIOUAttachedToExistingChatReport={!_.isEmpty(reportID)}
+
+                                                // The participants can only be modified when the action is initiated from directly within a group chat and not the floating-action-button.
+                                                // This is because when there is a group of people, say they are on a trip, and you have some shared expenses with some of the people,
+                                                // but not all of them (maybe someone skipped out on dinner). Then it's nice to be able to select/deselect people from the group chat bill
+                                                // split rather than forcing the user to create a new group, just for that expense. The reportID is empty, when the action was initiated from
+                                                // the floating-action-button (since it is something that exists outside the context of a report).
+                                                canModifyParticipants={!_.isEmpty(reportID)}
                                             />
                                         </AnimatedStep>
                                     )}

--- a/src/pages/iou/steps/IOUConfirmPage.js
+++ b/src/pages/iou/steps/IOUConfirmPage.js
@@ -43,14 +43,15 @@ const propTypes = {
     /** IOU type */
     iouType: PropTypes.string,
 
-    /** Is this IOU associated with existing report */
-    isIOUAttachedToExistingChatReport: PropTypes.bool.isRequired,
+    /** Can the participants be modified or not */
+    canModifyParticipants: PropTypes.bool,
 };
 
 const defaultProps = {
     onUpdateComment: null,
     comment: '',
     iouType: CONST.IOU.IOU_TYPE.REQUEST,
+    canModifyParticipants: false,
 };
 
 const IOUConfirmPage = props => (
@@ -63,7 +64,7 @@ const IOUConfirmPage = props => (
         onConfirm={props.onConfirm}
         onSendMoney={props.onSendMoney}
         iouType={props.iouType}
-        isIOUAttachedToExistingChatReport={props.isIOUAttachedToExistingChatReport}
+        canModifyParticipants={props.canModifyParticipants}
     />
 );
 


### PR DESCRIPTION
cc @luacmartins since it appears you flipped the logic in this PR: https://github.com/Expensify/App/pull/11597#issuecomment-1297711122. I was talking with @trjExpensify about it and that was a mistake.

### Fixed Issues
$ https://github.com/Expensify/App/issues/13220


### Tests
##### Test the floating-action-button
1. Click the floating action button
2. Select Split Bill
3. Enter an amount and click Next
4. Select multiple people and click Next
5. Verify that at the final confirmation screen, you CANNOT select or deselect anyone

##### Test the in-chat menu
1. Go to a group chat
2. Click the "+" button attached to the comment composer
3. Select Split bill
4. Enter an amount and click Next
5. Verify that at the final confirmation screen, you CAN select and deselect people

- [ ] Verify that no errors appear in the JS console

### Offline tests
Same as the above tests, it should behave the same

### QA Steps
Same tests as above

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/1228807/205361338-efc1c17a-6d16-4289-9dfa-4b6dbbeeb537.mp4


</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/1228807/205361355-f07c4522-2c5f-4157-83eb-bfd2f3d6c524.mp4



</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/1228807/205361377-205a4f94-3876-4e30-ac2e-9bca9f92660a.mp4



</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/1228807/205361396-265abbc7-ca0b-4ac7-ba76-8ca49542d2b5.mp4



</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/1228807/205361411-8e8aca8e-bb3f-4c68-91d6-c61cc789199c.mp4



</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/1228807/205361423-ef5958f2-73e5-4d6e-86e8-56e432ad0e20.mp4



</details>
