### PR TITLE
[No QA] Prevent setting a pusher suffix for the staging or production api

### DIFF
--- a/scripts/set-pusher-suffix.sh
+++ b/scripts/set-pusher-suffix.sh
@@ -4,8 +4,10 @@
 # config file to be parsed for the suffix (relative to current project root)
 CONFIG_FILE="../Web-Expensify/_config.local.php"
 
-# Export vars from the .env file
-export $(grep -v '^#' .env | xargs)
+if [ -f ".env" ]; then
+    # Export vars from the .env file to access the $EXPENSIFY_URL
+    export $(grep -v '^#' .env | xargs)
+fi
 
 # use the suffix only when the config file can be found
 if [ -f "$CONFIG_FILE" ]; then

--- a/scripts/set-pusher-suffix.sh
+++ b/scripts/set-pusher-suffix.sh
@@ -4,8 +4,17 @@
 # config file to be parsed for the suffix (relative to current project root)
 CONFIG_FILE="../Web-Expensify/_config.local.php"
 
+# Export vars from the .env file
+export $(grep -v '^#' .env | xargs)
+
 # use the suffix only when the config file can be found
 if [ -f "$CONFIG_FILE" ]; then
+    # If we are pointing to the staging or production api don't add the suffix
+    if [[ $EXPENSIFY_URL == "https://www.expensify.com/" ]]; then
+        echo "Ignoring the PUSHER_DEV_SUFFIX since we are not pointing to the dev API"
+        exit 0
+    fi
+
     echo "Using PUSHER_DEV_SUFFIX from $CONFIG_FILE"
 
     PATTERN="PUSHER_DEV_SUFFIX.*'(.+)'"


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
cc @Beamanator since you expressed interest in this

### Details
<!-- Explanation of the change or anything fishy that is going on -->
When testing on dev against the [staging](https://stackoverflow.com/c/expensify/questions/8638) or [production API](https://stackoverflow.com/c/expensify/questions/11993), the `set-pusher-suffix` script adds a dev pusher suffix, which means that Pusher won't work correctly.

I have modified this script so that it does nothing if we are pointing to the staging or production API. To determine that I looked at the value of `EXPENSIFY_URL` in the .env file because it is set to `https://www.expensify.com/` on staging and production, and `https://www.expensify.com.dev/` on dev.

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/Expensify/issues/244501
PROPOSAL: N/A


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
**Set up NewDot dev to hit the staging API, then make sure Pusher works.**
1. Rename your `.env` file to `.env.dev`
2. Rename `.env.staging` to `.env`
3. `npm run desktop`
4. Open `.env` and make sure a pusher dev suffix was **not** added
5. Sign in with any account
6. Go to Settings > Preferences and take a note of your priority mode
7. Go to NewDot staging on web and sign in with the same account
8. Go to Settings > Preferences, change your priority mode, and click save
9. Go back to desktop and make sure that the priority mode updated properly

**Shell tests**
With a `.env` file
1. Make sure your normal `.env` file is set up (copy from `env.example` if needed)
2. Delete the pusher dev suffix in `.env` (if it exists)
3. In the terminal in the App directory run `scripts/set-pusher-suffix.sh`
4. Make sure the pusher dev suffix is added

Without one
1. Rename your `.env` file to `.env.dev` so that you don't have a `.env` file
2. In the terminal in the App directory run `scripts/set-pusher-suffix.sh`
3. Verify that a `.env` file is created and the pusher suffix is added

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
6. Upload an image via copy paste
10. Verify a modal appears displaying a preview of that image
--->
N/A
- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
All platforms aside from Desktop are not applicable.
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

</details>


Desktop

https://user-images.githubusercontent.com/26260477/205407695-c49de1c4-c165-4fc1-95d9-5fe1a21563b8.mov



<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>
