### PR TITLE
Wait for the drawer to be ready before loading the left navigation

### DIFF
--- a/src/libs/actions/App.js
+++ b/src/libs/actions/App.js
@@ -211,11 +211,11 @@ function setUpPoliciesAndNavigate(session) {
         return;
     }
     if (!isLoggingInAsNewUser && exitTo) {
-        // The drawer navigation is only created after we have fetched reports from the server.
-        // Thus, if we use the standard navigation and try to navigate to a drawer route before
-        // the reports have been fetched, we will fail to navigate.
         Navigation.isNavigationReady()
             .then(() => {
+                // The drawer navigation is only created after we have fetched reports from the server.
+                // Thus, if we use the standard navigation and try to navigate to a drawer route before
+                // the reports have been fetched, we will fail to navigate.
                 Navigation.isDrawerReady()
                     .then(() => {
                         // We must call dismissModal() to remove the /transition route from history

--- a/src/libs/actions/App.js
+++ b/src/libs/actions/App.js
@@ -214,7 +214,7 @@ function setUpPoliciesAndNavigate(session) {
         // The drawer navigation is only created after we have fetched reports from the server.
         // Thus, if we use the standard navigation and try to navigate to a drawer route before
         // the reports have been fetched, we will fail to navigate.
-        Navigation.isDrawerReady()
+        Navigation.isNavigationReady()
             .then(() => {
                 Navigation.isDrawerReady()
                     .then(() => {

--- a/src/libs/actions/App.js
+++ b/src/libs/actions/App.js
@@ -215,11 +215,14 @@ function setUpPoliciesAndNavigate(session) {
         // Thus, if we use the standard navigation and try to navigate to a drawer route before
         // the reports have been fetched, we will fail to navigate.
         Navigation.isDrawerReady()
+        .then(() => {
+            Navigation.isDrawerReady()
             .then(() => {
                 // We must call dismissModal() to remove the /transition route from history
                 Navigation.dismissModal();
                 Navigation.navigate(exitTo);
             });
+        });
     }
 }
 

--- a/src/libs/actions/App.js
+++ b/src/libs/actions/App.js
@@ -211,19 +211,10 @@ function setUpPoliciesAndNavigate(session) {
         return;
     }
     if (!isLoggingInAsNewUser && exitTo) {
-        if (Navigation.isDrawerRoute(exitTo)) {
-            // The drawer navigation is only created after we have fetched reports from the server.
-            // Thus, if we use the standard navigation and try to navigate to a drawer route before
-            // the reports have been fetched, we will fail to navigate.
-            Navigation.isDrawerReady()
-                .then(() => {
-                    // We must call dismissModal() to remove the /transition route from history
-                    Navigation.dismissModal();
-                    Navigation.navigate(exitTo);
-                });
-            return;
-        }
-        Navigation.isNavigationReady()
+        // The drawer navigation is only created after we have fetched reports from the server.
+        // Thus, if we use the standard navigation and try to navigate to a drawer route before
+        // the reports have been fetched, we will fail to navigate.
+        Navigation.isDrawerReady()
             .then(() => {
                 // We must call dismissModal() to remove the /transition route from history
                 Navigation.dismissModal();

--- a/src/libs/actions/App.js
+++ b/src/libs/actions/App.js
@@ -215,14 +215,14 @@ function setUpPoliciesAndNavigate(session) {
         // Thus, if we use the standard navigation and try to navigate to a drawer route before
         // the reports have been fetched, we will fail to navigate.
         Navigation.isDrawerReady()
-        .then(() => {
-            Navigation.isDrawerReady()
             .then(() => {
-                // We must call dismissModal() to remove the /transition route from history
-                Navigation.dismissModal();
-                Navigation.navigate(exitTo);
+                Navigation.isDrawerReady()
+                    .then(() => {
+                        // We must call dismissModal() to remove the /transition route from history
+                        Navigation.dismissModal();
+                        Navigation.navigate(exitTo);
+                    });
             });
-        });
     }
 }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/13026
PROPOSAL: GH_LINK_ISSUE(COMMENT)


### Tests

- [x] Verify that no errors appear in the JS console

1. Log out of NewDot
2. Navigate to OldDot and sign in to an account that has an existing workspace.
3. Go to Settings > Policies > Group and click on any Workspace policy
4. Verify you're redirected to NewDot, you're logged in with the same account as in OldDot and that the Workspace settings page is displayed with NO SPINNER.

---

1. Navigate to the OldDot page
2. Log in with a new account
3. Verify there are 3 options (Set up my company for free, Scan receipts & submit expenses, Split bills & chat with friends)
4. Tap on "Set up my company for free"
5. Verify you're redirected to NewDot
6. Tap on the back button to view the workspaces list and Verify 1 New Workspace has been created

### Offline tests
N/A

### QA Steps

- [x] Verify that no errors appear in the JS console

1. Log out of NewDot
2. Navigate to OldDot and sign in to an account that has an existing workspace.
3. Go to Settings > Policies > Group and click on any Workspace policy
4. Verify you're redirected to NewDot, you're logged in with the same account as in OldDot and that the Workspace settings page is displayed with NO SPINNER.

---

1. Navigate to the OldDot page
2. Log in with a new account
3. Verify there are 3 options (Set up my company for free, Scan receipts & submit expenses, Split bills & chat with friends)
4. Tap on "Set up my company for free"
5. Verify you're redirected to NewDot
6. Tap on the back button to view the workspaces list and Verify 1 New Workspace has been created

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://user-images.githubusercontent.com/6474442/205756667-9e792dd7-5c4b-47fd-8d1f-0fcc75518210.mp4

https://user-images.githubusercontent.com/6474442/205759783-fa2529d8-308f-4ba1-aeee-edd593197ab6.mp4

</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://user-images.githubusercontent.com/6474442/205763279-6bd7ee89-f9f2-4706-aec2-a75f9027d5e8.mp4

</details>

<details>
<summary>Mobile Web - Safari</summary>

https://user-images.githubusercontent.com/6474442/205759444-74ede641-9882-4650-9e04-7c32802301b3.mp4

</details>

<details>
<summary>Desktop</summary>

N/A

</details>

<details>
<summary>iOS</summary>

N/A

</details>

<details>
<summary>Android</summary>

N/A

</details>
