### PR TITLE
Fix proptype error in AddDebitCard page

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -265,6 +265,7 @@ class Form extends React.Component {
                     <View style={[this.props.style]}>
                         {_.map(this.childrenWrapperWithProps(this.props.children), child => (
                             <View
+                                key={child.inputID}
                                 onLayout={(event) => {
                                     this.setPosition(child, event.nativeEvent.layout.y);
                                 }}

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -265,7 +265,7 @@ class Form extends React.Component {
                     <View style={[this.props.style]}>
                         {_.map(this.childrenWrapperWithProps(this.props.children), child => (
                             <View
-                                key={child.inputID}
+                                key={child.key}
                                 onLayout={(event) => {
                                     this.setPosition(child, event.nativeEvent.layout.y);
                                 }}

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -261,6 +261,7 @@ class Form extends React.Component {
                     contentContainerStyle={styles.flexGrow1}
                     keyboardShouldPersistTaps="handled"
                     ref={el => this.form = el}
+                    accessibilityRole="form"
                 >
                     <View style={[this.props.style]}>
                         {_.map(this.childrenWrapperWithProps(this.props.children), child => (

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -261,7 +261,6 @@ class Form extends React.Component {
                     contentContainerStyle={styles.flexGrow1}
                     keyboardShouldPersistTaps="handled"
                     ref={el => this.form = el}
-                    accessibilityRole="form"
                 >
                     <View style={[this.props.style]}>
                         {_.map(this.childrenWrapperWithProps(this.props.children), child => (

--- a/src/pages/settings/Payments/AddDebitCardPage.js
+++ b/src/pages/settings/Payments/AddDebitCardPage.js
@@ -25,7 +25,7 @@ import Form from '../../../components/Form';
 const propTypes = {
     /* Onyx Props */
     formData: PropTypes.shape({
-        setupComplete: PropTypes.boolean,
+        setupComplete: PropTypes.bool,
     }),
 
     ...withLocalizePropTypes,


### PR DESCRIPTION
### Details
Fixes the prop type error and adds a key to the list in Form.

### Fixed Issues
$ https://github.com/Expensify/App/issues/13068

### Tests
1. Open your browser console
2. Navigate to `Settings > Payments > Add payment method > Debit card`
3. Verify that the console errors/warnings below don't show up

![204149242-55c70e9e-290a-401d-bfea-e57072b0ac8b](https://user-images.githubusercontent.com/22219519/205765875-0529741d-495b-4c77-b364-8360ea72bb86.png)
![Screenshot 2022-12-05 at 4 26 38 PM](https://user-images.githubusercontent.com/22219519/205765908-84314d9f-7f6e-4f09-a74e-6999d8feca17.png)

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
Same as test steps

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://user-images.githubusercontent.com/22219519/205766110-d0d65ac4-f0c7-4623-b1c7-52dc34b6100e.mov

</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://user-images.githubusercontent.com/22219519/205766147-97d64cce-f993-4108-8cf9-6c0005d14b3b.mov

</details>

<details>
<summary>Mobile Web - Safari</summary>

https://user-images.githubusercontent.com/22219519/205766196-114a0540-6514-45c2-bffb-153fbc11932a.mov

</details>

<details>
<summary>Desktop</summary>

https://user-images.githubusercontent.com/22219519/205766235-5cee7f9a-56fd-4003-a937-c419f3cc246d.mov

</details>

<details>
<summary>iOS</summary>

https://user-images.githubusercontent.com/22219519/205766288-4b28bd0e-704d-45a2-95e3-c46d3cef3388.mov

</details>

<details>
<summary>Android</summary>

https://user-images.githubusercontent.com/22219519/205766348-3c34f773-3cd7-432c-be64-521452197306.mov

</details>
