### PR TITLE
Ensure correct background is present for `horizontalStackedAvatar` style

### DIFF
--- a/src/components/LHNOptionsList/OptionRowLHN.js
+++ b/src/components/LHNOptionsList/OptionRowLHN.js
@@ -138,6 +138,7 @@ const OptionRowLHN = (props) => {
                                 && (
                                     optionItem.shouldShowSubscript ? (
                                         <SubscriptAvatar
+                                            backgroundColor={props.isFocused ? themeColors.activeComponentBG : themeColors.sidebar}
                                             mainAvatar={optionItem.icons[0]}
                                             secondaryAvatar={optionItem.icons[1]}
                                             mainTooltip={optionItem.ownerEmail}

--- a/src/components/MenuItem.js
+++ b/src/components/MenuItem.js
@@ -157,6 +157,8 @@ const MenuItem = (props) => {
                         {!_.isEmpty(props.floatRightAvatars) && (
                             <View style={[styles.justifyContentCenter, (props.brickRoadIndicator ? styles.mr4 : styles.mr3)]}>
                                 <MultipleAvatars
+                                    isHovered={hovered}
+                                    isPressed={pressed}
                                     icons={props.floatRightAvatars}
                                     size={props.viewMode === CONST.OPTION_MODE.COMPACT ? CONST.AVATAR_SIZE.SMALL : CONST.AVATAR_SIZE.DEFAULT}
                                     fallbackIcon={Expensicons.Workspace}

--- a/src/components/MultipleAvatars.js
+++ b/src/components/MultipleAvatars.js
@@ -29,6 +29,12 @@ const propTypes = {
 
     /** Prop to identify if we should load avatars vertically instead of diagonally */
     shouldStackHorizontally: PropTypes.bool,
+
+    /** Whether the avatars are hovered */
+    isHovered: PropTypes.bool,
+
+    /** Whether the avatars are in an element being pressed */
+    isPressed: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -38,6 +44,8 @@ const defaultProps = {
     avatarTooltips: [],
     fallbackIcon: undefined,
     shouldStackHorizontally: false,
+    isHovered: false,
+    isPressed: false,
 };
 
 const MultipleAvatars = (props) => {
@@ -75,7 +83,7 @@ const MultipleAvatars = (props) => {
                         _.map([...props.icons].splice(0, 4).reverse(), (icon, index) => (
                             <View
                                 key={`stackedAvatars-${index}`}
-                                style={[styles.horizontalStackedAvatar, styles.alignItemsCenter, horizontalStyles[index]]}
+                                style={[StyleUtils.getHorizontalStackedAvatarStyle(props.isHovered, props.isPressed), styles.alignItemsCenter, horizontalStyles[index]]}
                             >
                                 <Avatar
                                     source={icon || props.fallbackIcon}

--- a/src/components/MultipleAvatars.js
+++ b/src/components/MultipleAvatars.js
@@ -83,7 +83,7 @@ const MultipleAvatars = (props) => {
                         _.map([...props.icons].splice(0, 4).reverse(), (icon, index) => (
                             <View
                                 key={`stackedAvatars-${index}`}
-                                style={[StyleUtils.getHorizontalStackedAvatarStyle(props.isHovered, props.isPressed), horizontalStyles[index]]}
+                                style={[styles.horizontalStackedAvatar, StyleUtils.getHorizontalStackedAvatarBorderStyle(props.isHovered, props.isPressed), horizontalStyles[index]]}
                             >
                                 <Avatar
                                     source={icon || props.fallbackIcon}
@@ -94,7 +94,14 @@ const MultipleAvatars = (props) => {
                         ))
                     }
                     {props.icons.length > 4 && (
-                        <View style={[styles.alignItemsCenter, styles.justifyContentCenter, styles.horizontalStackedAvatar4Overlay]}>
+                        <View
+                            style={[
+                                styles.alignItemsCenter,
+                                styles.justifyContentCenter,
+                                StyleUtils.getHorizontalStackedAvatarBorderStyle(props.isHovered, props.isPressed),
+                                styles.horizontalStackedAvatar4Overlay,
+                            ]}
+                        >
                             <Text style={styles.avatarInnerTextSmall}>
                                 {`+${props.icons.length - 4}`}
                             </Text>

--- a/src/components/MultipleAvatars.js
+++ b/src/components/MultipleAvatars.js
@@ -83,7 +83,7 @@ const MultipleAvatars = (props) => {
                         _.map([...props.icons].splice(0, 4).reverse(), (icon, index) => (
                             <View
                                 key={`stackedAvatars-${index}`}
-                                style={[StyleUtils.getHorizontalStackedAvatarStyle(props.isHovered, props.isPressed), styles.alignItemsCenter, horizontalStyles[index]]}
+                                style={[StyleUtils.getHorizontalStackedAvatarStyle(props.isHovered, props.isPressed), horizontalStyles[index]]}
                             >
                                 <Avatar
                                     source={icon || props.fallbackIcon}

--- a/src/components/SubscriptAvatar.js
+++ b/src/components/SubscriptAvatar.js
@@ -24,12 +24,16 @@ const propTypes = {
 
     /** Set the size of avatars */
     size: PropTypes.oneOf(_.values(CONST.AVATAR_SIZE)),
+
+    /** Background color used for subscript avatar border */
+    backgroundColor: PropTypes.string,
 };
 
 const defaultProps = {
     mainTooltip: '',
     secondaryTooltip: '',
     size: CONST.AVATAR_SIZE.DEFAULT,
+    backgroundColor: themeColors.componentBG,
 };
 
 const SubscriptAvatar = props => (
@@ -42,7 +46,7 @@ const SubscriptAvatar = props => (
         </Tooltip>
         <View style={[
             props.size === CONST.AVATAR_SIZE.SMALL ? styles.secondAvatarSubscriptCompact : styles.secondAvatarSubscript,
-            StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)]}
+            StyleUtils.getBackgroundAndBorderStyle(props.backgroundColor)]}
         >
             <Tooltip text={props.secondaryTooltip}>
                 <Avatar

--- a/src/styles/StyleUtils.js
+++ b/src/styles/StyleUtils.js
@@ -548,7 +548,7 @@ function getHorizontalStackedAvatarStyle(isHovered, isPressed) {
     let backgroundColor = themeColors.appBG;
 
     if (isHovered) {
-        backgroundColor = colors.greenDefaultButtonHover;
+        backgroundColor = themeColors.buttonHoveredBG;
     }
 
     if (isPressed) {
@@ -560,6 +560,7 @@ function getHorizontalStackedAvatarStyle(isHovered, isPressed) {
         width: 28,
         borderRadius: 33,
         paddingTop: 2,
+        alignItems: 'center',
         backgroundColor,
     };
 }

--- a/src/styles/StyleUtils.js
+++ b/src/styles/StyleUtils.js
@@ -539,6 +539,31 @@ function getKeyboardShortcutsModalWidth(isSmallScreenWidth) {
     return {maxWidth: 600};
 }
 
+/**
+ * @param {Boolean} isHovered
+ * @param {Boolean} isPressed
+ * @returns {Object}
+ */
+function getHorizontalStackedAvatarStyle(isHovered, isPressed) {
+    let backgroundColor = 'transparent';
+
+    if (isHovered) {
+        backgroundColor = colors.greenDefaultButtonHover;
+    }
+
+    if (isPressed) {
+        backgroundColor = themeColors.buttonPressedBG;
+    }
+
+    return {
+        height: 28,
+        width: 28,
+        borderRadius: 33,
+        paddingTop: 2,
+        backgroundColor,
+    };
+}
+
 export {
     getAvatarSize,
     getAvatarStyle,
@@ -572,4 +597,5 @@ export {
     hasSafeAreas,
     getHeight,
     fade,
+    getHorizontalStackedAvatarStyle,
 };

--- a/src/styles/StyleUtils.js
+++ b/src/styles/StyleUtils.js
@@ -545,7 +545,7 @@ function getKeyboardShortcutsModalWidth(isSmallScreenWidth) {
  * @returns {Object}
  */
 function getHorizontalStackedAvatarStyle(isHovered, isPressed) {
-    let backgroundColor = 'transparent';
+    let backgroundColor = themeColors.appBG;
 
     if (isHovered) {
         backgroundColor = colors.greenDefaultButtonHover;

--- a/src/styles/StyleUtils.js
+++ b/src/styles/StyleUtils.js
@@ -544,7 +544,7 @@ function getKeyboardShortcutsModalWidth(isSmallScreenWidth) {
  * @param {Boolean} isPressed
  * @returns {Object}
  */
-function getHorizontalStackedAvatarStyle(isHovered, isPressed) {
+function getHorizontalStackedAvatarBorderStyle(isHovered, isPressed) {
     let backgroundColor = themeColors.appBG;
 
     if (isHovered) {
@@ -556,12 +556,8 @@ function getHorizontalStackedAvatarStyle(isHovered, isPressed) {
     }
 
     return {
-        height: 28,
-        width: 28,
-        borderRadius: 33,
-        paddingTop: 2,
-        alignItems: 'center',
         backgroundColor,
+        borderColor: backgroundColor,
     };
 }
 
@@ -598,5 +594,5 @@ export {
     hasSafeAreas,
     getHeight,
     fade,
-    getHorizontalStackedAvatarStyle,
+    getHorizontalStackedAvatarBorderStyle,
 };

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1563,13 +1563,6 @@ const styles = {
         borderRadius: 24,
     },
 
-    horizontalStackedAvatar: {
-        height: 28,
-        width: 28,
-        borderRadius: 33,
-        paddingTop: 2,
-    },
-
     singleSubscript: {
         height: variables.iconSizeNormal,
         width: variables.iconSizeNormal,

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1566,7 +1566,6 @@ const styles = {
     horizontalStackedAvatar: {
         height: 28,
         width: 28,
-        backgroundColor: themeColors.appBG,
         borderRadius: 33,
         paddingTop: 2,
     },

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1563,6 +1563,15 @@ const styles = {
         borderRadius: 24,
     },
 
+    horizontalStackedAvatar: {
+        height: 28,
+        width: 28,
+        backgroundColor: themeColors.appBG,
+        borderRadius: 33,
+        paddingTop: 2,
+        alignItems: 'center',
+    },
+
     singleSubscript: {
         height: variables.iconSizeNormal,
         width: variables.iconSizeNormal,
@@ -1724,7 +1733,6 @@ const styles = {
         width: 28,
         borderWidth: 2,
         borderStyle: 'solid',
-        borderColor: themeColors.appBG,
         backgroundColor: themeColors.opaqueAvatar,
         borderRadius: 24,
         zIndex: 6,


### PR DESCRIPTION
### Details

Looks like we want to the border on avatars to be more of a pass through than matching the app background color. Noticed there was a style of `appBG` being passed to the avatar.

### Fixed Issues

$ https://github.com/Expensify/App/issues/13347

### Tests

Same as QA

- [ ] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps

1. Create a new workspace
2. Navigate to `/settings`
3. Verify that the avatar does not have a black border around it
4. Hover over the item
5. Verify the border matches the background of the containing element
6. Press the item
7. Verify the border again matches the background of the containing element
8. Create another workspace
9. Repeat the previous steps of the test and verify the borders around the avatars match the background colors of the row correctly.
10. Keep adding more workspaces until the counter for workspaces appears and they are limited to 4 avatars
11. Verify the borders around the avatars match the background colors of the row correctly.
12. Locate a workspace chat in the sidebar
13. Verify the background color around the smaller subscript avatar matches the background of the row
14. Navigate to the chat
15. Verify the background color around the smaller subscript avatar matches the lighter background of the row

**General regression testing idea:** Verify that other avatar styles in the app look correct.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://user-images.githubusercontent.com/32969087/205786564-d93f593f-a165-4000-bf01-d256ef147e60.mp4

</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://user-images.githubusercontent.com/32969087/205793353-292a3dcd-cbe9-4351-913a-aaeb1b37b707.mp4

</details>

<details>
<summary>Mobile Web - Safari</summary>

https://user-images.githubusercontent.com/32969087/205791802-9c3301e6-b74b-49e5-bac9-262cae85cf91.mp4

</details>

<details>
<summary>Desktop</summary>

https://user-images.githubusercontent.com/32969087/205790141-42171941-90de-44b1-80ca-b6f526bf22b2.mp4

</details>

<details>
<summary>iOS</summary>

https://user-images.githubusercontent.com/32969087/205844098-43adbc07-e7ed-486f-839f-aa29aba658da.mp4

</details>

<details>
<summary>Android</summary>

https://user-images.githubusercontent.com/32969087/205794612-5bd795d4-da27-40a4-ac6f-8849a72c5e1e.mp4

</details>
