### PR TITLE
Update picker items

### DIFF
--- a/src/components/Picker/index.js
+++ b/src/components/Picker/index.js
@@ -8,7 +8,7 @@ import * as Expensicons from '../Icon/Expensicons';
 import FormHelpMessage from '../FormHelpMessage';
 import Text from '../Text';
 import styles from '../../styles/styles';
-import variables from '../../styles/variables';
+import themeColors from '../../styles/themes/default';
 import pickerStyles from './pickerStyles';
 
 const propTypes = {
@@ -108,12 +108,12 @@ class Picker extends PureComponent {
         // so we might need to color accordingly so it doesn't blend with the background.
         this.placeholder = _.isEmpty(this.props.placeholder) ? {} : {
             ...this.props.placeholder,
-            color: variables.pickerOptionsTextColor,
+            color: themeColors.pickerOptionsTextColor,
         };
         this.items = _.map(this.props.items, item => (
             {
                 ...item,
-                color: variables.pickerOptionsTextColor,
+                color: themeColors.pickerOptionsTextColor,
             }
         ));
     }

--- a/src/components/Picker/index.js
+++ b/src/components/Picker/index.js
@@ -110,12 +110,6 @@ class Picker extends PureComponent {
             ...this.props.placeholder,
             color: themeColors.pickerOptionsTextColor,
         };
-        this.items = _.map(this.props.items, item => (
-            {
-                ...item,
-                color: themeColors.pickerOptionsTextColor,
-            }
-        ));
     }
 
     componentDidMount() {
@@ -171,7 +165,9 @@ class Picker extends PureComponent {
                     )}
                     <RNPickerSelect
                         onValueChange={this.onInputChange}
-                        items={this.items}
+
+                        // We add a text color to prevent white text on white background dropdown items on Windows
+                        items={_.map(this.props.items, item => ({...item, color: themeColors.pickerOptionsTextColor}))}
                         style={this.props.size === 'normal' ? pickerStyles(this.props.isDisabled) : styles.pickerSmall}
                         useNativeAndroidPickerStyle={false}
                         placeholder={this.placeholder}

--- a/src/styles/colors.js
+++ b/src/styles/colors.js
@@ -33,8 +33,6 @@ export default {
     greenDefaultButtonHover: '#2C6755',
     greenDefaultButtonPressed: '#467164',
     greenDefaultButtonDisabled: '#8BA69E',
-
-    // Picker option text color, we set this to avoid white on white dropdowns in Windows
     midnight: '#002140',
 
     // DEPRECATED COLORS. Do not reference these colors. Will be deleted in color switch PR.

--- a/src/styles/colors.js
+++ b/src/styles/colors.js
@@ -34,6 +34,9 @@ export default {
     greenDefaultButtonPressed: '#467164',
     greenDefaultButtonDisabled: '#8BA69E',
 
+    // Picker option text color, we set this to avoid white on white dropdowns in Windows
+    midnight: '#002140',
+
     // DEPRECATED COLORS. Do not reference these colors. Will be deleted in color switch PR.
     gray1: '#FAFAFA',
     gray2: '#ECECEC',

--- a/src/styles/themes/default.js
+++ b/src/styles/themes/default.js
@@ -57,6 +57,7 @@ const darkTheme = {
     heroCard: colors.blue,
     uploadPreviewActivityIndicator: colors.greenHighlightBackground,
     checkBox: colors.green,
+    pickerOptionsTextColor: colors.midnight,
 };
 
 const oldTheme = {

--- a/src/styles/variables.js
+++ b/src/styles/variables.js
@@ -80,5 +80,4 @@ export default {
     INACTIVE_LABEL_TRANSLATE_Y: getValueUsingPixelRatio(16, 21),
     sliderBarHeight: 8,
     sliderKnobSize: 26,
-    pickerOptionsTextColor: '#002140',
 };


### PR DESCRIPTION
### Details
We changed the render items in Picker from `this.props.items` to `this.items` and updated them in the constructor only, which caused the items to not be translated when a different language is selected. This PR fixes that issue.

I'm also moving the new color to the themeColors file instead of variables.

### Fixed Issues
$ https://github.com/Expensify/App/issues/13341

### Tests
1. Navigate to `Settings > Preferences`
2. Change the language
3. Verify that the value in Priority mode is translated

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
Same as test steps

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

Windows
https://user-images.githubusercontent.com/22219519/206017878-8f4ead41-c62d-4088-9920-9963d9f742bb.mov

Mac
https://user-images.githubusercontent.com/22219519/206017899-e7a66ab4-8f30-48ff-b51f-3113273c20b7.mov

</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://user-images.githubusercontent.com/22219519/206017928-5dff50c3-df4a-4b2b-99b0-0a467cd6249c.mov

</details>

<details>
<summary>Mobile Web - Safari</summary>

https://user-images.githubusercontent.com/22219519/206017946-b7b326ed-8346-45a4-875c-62f5250be8d7.mov

</details>

<details>
<summary>Desktop</summary>

https://user-images.githubusercontent.com/22219519/206017966-97bc0539-958f-4bbf-b3d1-76a4714c01e8.mov

</details>

<details>
<summary>iOS</summary>

https://user-images.githubusercontent.com/22219519/206017990-b5627ffe-5d02-49e9-bf42-0ffece3a9576.mov

</details>

<details>
<summary>Android</summary>

https://user-images.githubusercontent.com/22219519/206018017-43d2f337-dea4-42b3-9ec0-7083a21c868f.mov

</details>
