### PR TITLE
navigate to workspaces page on back button press 

### DIFF
--- a/src/pages/workspace/WorkspaceInitialPage.js
+++ b/src/pages/workspace/WorkspaceInitialPage.js
@@ -148,7 +148,10 @@ class WorkspaceInitialPage extends React.Component {
 
         return (
             <ScreenWrapper>
-                <FullPageNotFoundView shouldShow={_.isEmpty(this.props.policy)}>
+                <FullPageNotFoundView
+                    shouldShow={_.isEmpty(this.props.policy)}
+                    onBackButtonPress={() => Navigation.navigate(ROUTES.SETTINGS_WORKSPACES)}
+                >
                     <HeaderWithCloseButton
                         title={this.props.translate('workspace.common.workspace')}
                         shouldShowBackButton

--- a/src/pages/workspace/WorkspaceInvitePage.js
+++ b/src/pages/workspace/WorkspaceInvitePage.js
@@ -24,6 +24,7 @@ import withPolicy, {policyPropTypes, policyDefaultProps} from './withPolicy';
 import {withNetwork} from '../../components/OnyxProvider';
 import FullPageNotFoundView from '../../components/BlockingViews/FullPageNotFoundView';
 import networkPropTypes from '../../components/networkPropTypes';
+import ROUTES from '../../ROUTES';
 
 const personalDetailsPropTypes = PropTypes.shape({
     /** The login of the person (either email or phone number) */
@@ -252,7 +253,10 @@ class WorkspaceInvitePage extends React.Component {
         return (
             <ScreenWrapper>
                 {({didScreenTransitionEnd}) => (
-                    <FullPageNotFoundView shouldShow={_.isEmpty(this.props.policy)}>
+                    <FullPageNotFoundView
+                        shouldShow={_.isEmpty(this.props.policy)}
+                        onBackButtonPress={() => Navigation.navigate(ROUTES.SETTINGS_WORKSPACES)}
+                    >
                         <>
                             <HeaderWithCloseButton
                                 title={this.props.translate('workspace.invite.invitePeople')}

--- a/src/pages/workspace/WorkspaceMembersPage.js
+++ b/src/pages/workspace/WorkspaceMembersPage.js
@@ -318,7 +318,10 @@ class WorkspaceMembersPage extends React.Component {
 
         return (
             <ScreenWrapper style={[styles.defaultModalContainer]}>
-                <FullPageNotFoundView shouldShow={_.isEmpty(this.props.policy)}>
+                <FullPageNotFoundView
+                    shouldShow={_.isEmpty(this.props.policy)}
+                    onBackButtonPress={() => Navigation.navigate(ROUTES.SETTINGS_WORKSPACES)}
+                >
                     <HeaderWithCloseButton
                         title={this.props.translate('workspace.common.members')}
                         subtitle={policyName}

--- a/src/pages/workspace/WorkspacePageWithSections.js
+++ b/src/pages/workspace/WorkspacePageWithSections.js
@@ -106,7 +106,10 @@ class WorkspacePageWithSections extends React.Component {
 
         return (
             <ScreenWrapper>
-                <FullPageNotFoundView shouldShowBackButton={false} shouldShow={_.isEmpty(this.props.policy)}>
+                <FullPageNotFoundView
+                    shouldShow={_.isEmpty(this.props.policy)}
+                    onBackButtonPress={() => Navigation.navigate(ROUTES.SETTINGS_WORKSPACES)}
+                >
                     <HeaderWithCloseButton
                         title={this.props.headerText}
                         subtitle={policyName}

--- a/src/pages/workspace/WorkspaceSettingsPage.js
+++ b/src/pages/workspace/WorkspaceSettingsPage.js
@@ -20,7 +20,6 @@ import WorkspacePageWithSections from './WorkspacePageWithSections';
 import withPolicy, {policyPropTypes, policyDefaultProps} from './withPolicy';
 import {withNetwork} from '../../components/OnyxProvider';
 import OfflineWithFeedback from '../../components/OfflineWithFeedback';
-import FullPageNotFoundView from '../../components/BlockingViews/FullPageNotFoundView';
 import Form from '../../components/Form';
 
 const propTypes = {
@@ -72,72 +71,70 @@ class WorkspaceSettingsPage extends React.Component {
 
     render() {
         return (
-            <FullPageNotFoundView shouldShow={_.isEmpty(this.props.policy)}>
-                <WorkspacePageWithSections
-                    headerText={this.props.translate('workspace.common.settings')}
-                    route={this.props.route}
-                    guidesCallTaskID={CONST.GUIDES_CALL_TASK_IDS.WORKSPACE_SETTINGS}
-                >
-                    {hasVBA => (
-                        <Form
-                            formID={ONYXKEYS.FORMS.WORKSPACE_SETTINGS_FORM}
-                            submitButtonText={this.props.translate('workspace.editor.save')}
-                            style={[styles.mh5, styles.mt5, styles.flexGrow1]}
-                            validate={this.validate}
-                            onSubmit={this.submit}
-                            enabledWhenOffline
+            <WorkspacePageWithSections
+                headerText={this.props.translate('workspace.common.settings')}
+                route={this.props.route}
+                guidesCallTaskID={CONST.GUIDES_CALL_TASK_IDS.WORKSPACE_SETTINGS}
+            >
+                {hasVBA => (
+                    <Form
+                        formID={ONYXKEYS.FORMS.WORKSPACE_SETTINGS_FORM}
+                        submitButtonText={this.props.translate('workspace.editor.save')}
+                        style={[styles.mh5, styles.mt5, styles.flexGrow1]}
+                        validate={this.validate}
+                        onSubmit={this.submit}
+                        enabledWhenOffline
+                    >
+                        <OfflineWithFeedback
+                            pendingAction={lodashGet(this.props.policy, 'pendingFields.avatar', null)}
+                            errors={lodashGet(this.props.policy, 'errorFields.avatar', null)}
+                            onClose={() => Policy.clearAvatarErrors(this.props.policy.id)}
                         >
-                            <OfflineWithFeedback
-                                pendingAction={lodashGet(this.props.policy, 'pendingFields.avatar', null)}
-                                errors={lodashGet(this.props.policy, 'errorFields.avatar', null)}
-                                onClose={() => Policy.clearAvatarErrors(this.props.policy.id)}
-                            >
-                                <AvatarWithImagePicker
-                                    isUploading={this.props.policy.isAvatarUploading}
-                                    avatarURL={lodashGet(this.props.policy, 'avatar')}
-                                    size={CONST.AVATAR_SIZE.LARGE}
-                                    DefaultAvatar={() => (
-                                        <Icon
-                                            src={Expensicons.Workspace}
-                                            height={80}
-                                            width={80}
-                                            fill={defaultTheme.iconSuccessFill}
-                                        />
-                                    )}
-                                    fallbackIcon={Expensicons.FallbackWorkspaceAvatar}
-                                    style={[styles.mb3]}
-                                    anchorPosition={{top: 172, right: 18}}
-                                    isUsingDefaultAvatar={!lodashGet(this.props.policy, 'avatar', null)}
-                                    onImageSelected={file => Policy.updateWorkspaceAvatar(lodashGet(this.props.policy, 'id', ''), file)}
-                                    onImageRemoved={() => Policy.deleteWorkspaceAvatar(lodashGet(this.props.policy, 'id', ''))}
-                                />
-                            </OfflineWithFeedback>
-                            <OfflineWithFeedback
-                                pendingAction={lodashGet(this.props.policy, 'pendingFields.generalSettings')}
-                            >
-                                <TextInput
-                                    inputID="name"
-                                    label={this.props.translate('workspace.editor.nameInputLabel')}
-                                    containerStyles={[styles.mt4]}
-                                    defaultValue={this.props.policy.name}
-                                />
-                                <View style={[styles.mt4]}>
-                                    <Picker
-                                        inputID="currency"
-                                        label={this.props.translate('workspace.editor.currencyInputLabel')}
-                                        items={this.getCurrencyItems()}
-                                        isDisabled={hasVBA}
-                                        defaultValue={this.props.policy.outputCurrency}
+                            <AvatarWithImagePicker
+                                isUploading={this.props.policy.isAvatarUploading}
+                                avatarURL={lodashGet(this.props.policy, 'avatar')}
+                                size={CONST.AVATAR_SIZE.LARGE}
+                                DefaultAvatar={() => (
+                                    <Icon
+                                        src={Expensicons.Workspace}
+                                        height={80}
+                                        width={80}
+                                        fill={defaultTheme.iconSuccessFill}
                                     />
-                                </View>
-                                <Text style={[styles.textLabel, styles.colorMuted, styles.mt2]}>
-                                    {this.props.translate('workspace.editor.currencyInputHelpText')}
-                                </Text>
-                            </OfflineWithFeedback>
-                        </Form>
-                    )}
-                </WorkspacePageWithSections>
-            </FullPageNotFoundView>
+                                )}
+                                fallbackIcon={Expensicons.FallbackWorkspaceAvatar}
+                                style={[styles.mb3]}
+                                anchorPosition={{top: 172, right: 18}}
+                                isUsingDefaultAvatar={!lodashGet(this.props.policy, 'avatar', null)}
+                                onImageSelected={file => Policy.updateWorkspaceAvatar(lodashGet(this.props.policy, 'id', ''), file)}
+                                onImageRemoved={() => Policy.deleteWorkspaceAvatar(lodashGet(this.props.policy, 'id', ''))}
+                            />
+                        </OfflineWithFeedback>
+                        <OfflineWithFeedback
+                            pendingAction={lodashGet(this.props.policy, 'pendingFields.generalSettings')}
+                        >
+                            <TextInput
+                                inputID="name"
+                                label={this.props.translate('workspace.editor.nameInputLabel')}
+                                containerStyles={[styles.mt4]}
+                                defaultValue={this.props.policy.name}
+                            />
+                            <View style={[styles.mt4]}>
+                                <Picker
+                                    inputID="currency"
+                                    label={this.props.translate('workspace.editor.currencyInputLabel')}
+                                    items={this.getCurrencyItems()}
+                                    isDisabled={hasVBA}
+                                    defaultValue={this.props.policy.outputCurrency}
+                                />
+                            </View>
+                            <Text style={[styles.textLabel, styles.colorMuted, styles.mt2]}>
+                                {this.props.translate('workspace.editor.currencyInputHelpText')}
+                            </Text>
+                        </OfflineWithFeedback>
+                    </Form>
+                )}
+            </WorkspacePageWithSections>
         );
     }
 }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
https://github.com/Expensify/App/issues/13276#issuecomment-1335583147
### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/13276
PROPOSAL: https://github.com/Expensify/App/issues/13276#issuecomment-1335583147


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Login with the same account on 2 different devices
2. On device 1 go to settings > workspaces
3. Open a workspace
4. Now at device 2 go to the same workspace and delete it
5. At device 1 verify you see not found page and pressing back button navigates you to the workspace list page

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
No specific offline case
### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
7. Upload an image via copy paste
8. Verify a modal appears displaying a preview of that image
--->
1. Login with the same account on 2 different devices
2. On device 1 go to settings > workspaces
3. Open a workspace
4. Now at device 2 go to the same workspace and delete it
5. At device 1 verify you see not found page and pressing back button navigates you to the workspace list page
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://user-images.githubusercontent.com/101883770/206282385-3ce07936-534f-438e-a1de-fdc1d6a3f618.mov



<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/101883770/206282172-45df0169-1248-4f62-95c2-941cfd123769.mov



</details>

<details>
<summary>Mobile Web - Safari</summary>

https://user-images.githubusercontent.com/101883770/206282153-12a0b27d-3572-4dd0-b9c2-4c970bd5eec1.mov


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>



https://user-images.githubusercontent.com/101883770/206282701-05fec460-813c-4fde-a22c-f7590a1c5c7e.mov



</details>

<details>
<summary>iOS</summary>

https://user-images.githubusercontent.com/101883770/206282130-54fd5cd4-198e-4173-a86a-30fda0d168a1.mov


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>

https://user-images.githubusercontent.com/101883770/206282099-7ee6ddb1-930b-456d-8c3a-4b16e6fffc98.mov


<!-- add screenshots or videos here -->

</details>
