### PR TITLE
Fix failed to load PDF error color and translation

### DIFF
--- a/src/components/PDFView/index.js
+++ b/src/components/PDFView/index.js
@@ -9,7 +9,9 @@ import CONST from '../../CONST';
 import PDFPasswordForm from './PDFPasswordForm';
 import * as pdfViewPropTypes from './pdfViewPropTypes';
 import withWindowDimensions from '../withWindowDimensions';
+import withLocalize from '../withLocalize';
 import Text from '../Text';
+import compose from '../../libs/compose';
 
 class PDFView extends Component {
     constructor(props) {
@@ -126,7 +128,7 @@ class PDFView extends Component {
                     onLayout={event => this.setState({windowWidth: event.nativeEvent.layout.width})}
                 >
                     <Document
-                        error={<Text style={[styles.textLabel, styles.textLarge]}>Failed to load PDF file.</Text>}
+                        error={<Text style={[styles.textLabel, styles.textLarge]}>{this.props.translate('attachmentView.failedToLoadPDF')}</Text>}
                         loading={<FullScreenLoadingIndicator />}
                         file={this.props.sourceURL}
                         options={{
@@ -163,4 +165,7 @@ class PDFView extends Component {
 PDFView.propTypes = pdfViewPropTypes.propTypes;
 PDFView.defaultProps = pdfViewPropTypes.defaultProps;
 
-export default withWindowDimensions(PDFView);
+export default compose(
+    withLocalize,
+    withWindowDimensions,
+)(PDFView);

--- a/src/components/PDFView/index.js
+++ b/src/components/PDFView/index.js
@@ -9,6 +9,7 @@ import CONST from '../../CONST';
 import PDFPasswordForm from './PDFPasswordForm';
 import * as pdfViewPropTypes from './pdfViewPropTypes';
 import withWindowDimensions from '../withWindowDimensions';
+import Text from '../Text';
 
 class PDFView extends Component {
     constructor(props) {
@@ -125,6 +126,7 @@ class PDFView extends Component {
                     onLayout={event => this.setState({windowWidth: event.nativeEvent.layout.width})}
                 >
                     <Document
+                        error={<Text style={[styles.textLabel, styles.textLarge]}>Failed to load PDF file.</Text>}
                         loading={<FullScreenLoadingIndicator />}
                         file={this.props.sourceURL}
                         options={{

--- a/src/components/PDFView/index.js
+++ b/src/components/PDFView/index.js
@@ -25,7 +25,7 @@ class PDFView extends Component {
         };
         this.onDocumentLoadSuccess = this.onDocumentLoadSuccess.bind(this);
         this.initiatePasswordChallenge = this.initiatePasswordChallenge.bind(this);
-        this.attemptPdfLoad = this.attemptPdfLoad.bind(this);
+        this.attemptPDFLoad = this.attemptPDFLoad.bind(this);
         this.toggleKeyboardOnSmallScreens = this.toggleKeyboardOnSmallScreens.bind(this);
     }
 
@@ -84,7 +84,7 @@ class PDFView extends Component {
      *
      * @param {String} password Password to send via callback to react-pdf
      */
-    attemptPdfLoad(password) {
+    attemptPDFLoad(password) {
         this.onPasswordCallback(password);
     }
 
@@ -150,7 +150,7 @@ class PDFView extends Component {
                 </View>
                 {this.state.shouldRequestPassword && (
                     <PDFPasswordForm
-                        onSubmit={this.attemptPdfLoad}
+                        onSubmit={this.attemptPDFLoad}
                         onPasswordUpdated={() => this.setState({isPasswordInvalid: false})}
                         isPasswordInvalid={this.state.isPasswordInvalid}
                         shouldAutofocusPasswordField={!this.props.isSmallScreenWidth}

--- a/src/components/PDFView/index.native.js
+++ b/src/components/PDFView/index.native.js
@@ -32,15 +32,15 @@ class PDFView extends Component {
         super(props);
         this.state = {
             shouldRequestPassword: false,
-            shouldAttemptPdfLoad: true,
+            shouldAttemptPDFLoad: true,
             shouldShowLoadingIndicator: true,
             isPasswordInvalid: false,
             failedToLoadPDF: false,
             password: '',
         };
         this.initiatePasswordChallenge = this.initiatePasswordChallenge.bind(this);
-        this.attemptPdfLoadWithPassword = this.attemptPdfLoadWithPassword.bind(this);
-        this.finishPdfLoad = this.finishPdfLoad.bind(this);
+        this.attemptPDFLoadWithPassword = this.attemptPDFLoadWithPassword.bind(this);
+        this.finishPDFLoad = this.finishPDFLoad.bind(this);
         this.handleFailureToLoadPDF = this.handleFailureToLoadPDF.bind(this);
     }
 
@@ -56,7 +56,7 @@ class PDFView extends Component {
 
         this.setState({
             failedToLoadPDF: true,
-            shouldAttemptPdfLoad: false,
+            shouldAttemptPDFLoad: false,
         });
     }
 
@@ -74,7 +74,7 @@ class PDFView extends Component {
         // Render password form, and don't render PDF and loading indicator.
         this.setState({
             shouldRequestPassword: true,
-            shouldAttemptPdfLoad: false,
+            shouldAttemptPDFLoad: false,
         });
 
         // The message provided by react-native-pdf doesn't indicate whether this
@@ -92,13 +92,13 @@ class PDFView extends Component {
      *
      * @param {String} password Password submitted via PDFPasswordForm
      */
-    attemptPdfLoadWithPassword(password) {
+    attemptPDFLoadWithPassword(password) {
         // Render react-native-pdf/PDF so that it can validate the password.
         // Note that at this point in the password challenge, shouldRequestPassword is true.
         // Thus react-native-pdf/PDF will be rendered - but not visible.
         this.setState({
             password,
-            shouldAttemptPdfLoad: true,
+            shouldAttemptPDFLoad: true,
             shouldShowLoadingIndicator: true,
         });
     }
@@ -107,7 +107,7 @@ class PDFView extends Component {
      * After the PDF is successfully loaded hide PDFPasswordForm and the loading
      * indicator.
      */
-    finishPdfLoad() {
+    finishPDFLoad() {
         this.setState({
             shouldRequestPassword: false,
             shouldShowLoadingIndicator: false,
@@ -146,7 +146,7 @@ class PDFView extends Component {
                         </Text>
                     </View>
                 )}
-                {this.state.shouldAttemptPdfLoad && (
+                {this.state.shouldAttemptPDFLoad && (
                     <TouchableWithoutFeedback style={touchableStyles}>
                         <PDF
                             trustAllCerts={false}
@@ -155,14 +155,14 @@ class PDFView extends Component {
                             style={pdfStyles}
                             onError={this.handleFailureToLoadPDF}
                             password={this.state.password}
-                            onLoadComplete={this.finishPdfLoad}
+                            onLoadComplete={this.finishPDFLoad}
                         />
                     </TouchableWithoutFeedback>
                 )}
                 {this.state.shouldRequestPassword && (
                     <KeyboardAvoidingView style={styles.flex1}>
                         <PDFPasswordForm
-                            onSubmit={this.attemptPdfLoadWithPassword}
+                            onSubmit={this.attemptPDFLoadWithPassword}
                             onPasswordUpdated={() => this.setState({isPasswordInvalid: false})}
                             isPasswordInvalid={this.state.isPasswordInvalid}
                             shouldShowLoadingIndicator={this.state.shouldShowLoadingIndicator}

--- a/src/components/PDFView/index.native.js
+++ b/src/components/PDFView/index.native.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import {TouchableWithoutFeedback, StyleSheet, View} from 'react-native';
+import {TouchableWithoutFeedback, View} from 'react-native';
 import PDF from 'react-native-pdf';
 import KeyboardAvoidingView from '../KeyboardAvoidingView';
 import styles from '../../styles/styles';

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -631,6 +631,7 @@ export default {
         unknownFilename: 'Unknown filename',
         passwordRequired: 'Please enter a password',
         passwordIncorrect: 'Incorrect password. Please try again.',
+        failedToLoadPDF: 'Failed to load PDF file.',
         pdfPasswordForm: {
             title: 'Password protected PDF',
             infoText: 'This PDF is password protected.',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -631,6 +631,7 @@ export default {
         unknownFilename: 'Archivo desconocido',
         passwordRequired: 'Por favor introduce tu contraseña',
         passwordIncorrect: 'Contraseña incorrecta. Por favor intenta de nuevo.',
+        failedToLoadPDF: 'Hubo un error al intentar cargar el PDF.',
         pdfPasswordForm: {
             title: 'PDF protegido con contraseña',
             infoText: 'Este PDF esta protegido con contraseña.',


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

- Added translations for the error
- For web:
- The library component `Document` has a prop to fully control the rendering of the error message.
For native:
- We were not doing anything for errors that were not related to the PDF having a password. Added code to show an error if the error is not related to password.


### Fixed Issues

$ https://github.com/Expensify/App/issues/13406
PROPOSAL: N/A


### Tests

1. Go to Settings > Preferences and change your language to "English"
1. Attach a PDF in a chat
2. Go offline
3. Open the PDF attachment
4. Verify that the error message is white and reads "Failed to load PDF file."
5. Go online
6. Go to Settings > Preferences and change your language to "Español"
7. Find the same chat with the attachment
8. Go offline
3. Open the PDF attachment
4. Verify that the error message is white and reads "Hubo un error al intentar cargar el PDF."


- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
10. Upload an image via copy paste
11. Verify a modal appears displaying a preview of that image
--->

1. Go to Settings > Preferences and change your language to "English"
1. Attach a PDF in a chat
2. Go offline
3. Open the PDF attachment
4. Verify that the error message is white and reads "Failed to load PDF file."
5. Go online
6. Go to Settings > Preferences and change your language to "Español"
7. Find the same chat with the attachment
8. Go offline
3. Open the PDF attachment
4. Verify that the error message is white and reads "Hubo un error al intentar cargar el PDF."

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

![Screen Shot 2022-12-07 at 1 00 30 PM](https://user-images.githubusercontent.com/87341702/206295280-886cc228-ad77-4e67-9a17-5dd6600d0d85.png)
![Screen Shot 2022-12-07 at 1 00 42 PM](https://user-images.githubusercontent.com/87341702/206295288-9c422ec5-71aa-4574-8bf2-805e31d12738.png)
![Screen Shot 2022-12-07 at 12 52 06 PM](https://user-images.githubusercontent.com/87341702/206295297-648fe8f4-5b2b-4ae4-ac34-f9f29ab17a8e.png)
![Screen Shot 2022-12-07 at 12 52 20 PM](https://user-images.githubusercontent.com/87341702/206295298-75722824-4129-4a30-8416-2ee816b98049.png)


</details>

<details>
<summary>Mobile Web - Chrome</summary>

<img width="440" alt="Screen Shot 2022-12-07 at 2 15 50 PM" src="https://user-images.githubusercontent.com/87341702/206308462-b80966d6-85a5-42d5-acfa-c13da50b6cd7.png">

<img width="436" alt="Screen Shot 2022-12-07 at 1 49 55 PM" src="https://user-images.githubusercontent.com/87341702/206306939-8009cdcd-e24f-433d-abb0-967fdfa285ee.png">


</details>

<details>
<summary>Mobile Web - Safari</summary>

<img width="434" alt="Screen Shot 2022-12-07 at 1 08 09 PM" src="https://user-images.githubusercontent.com/87341702/206296333-8536db3b-9b3c-4b54-ad05-8a2a77fabd43.png">
<img width="427" alt="Screen Shot 2022-12-07 at 1 49 30 PM" src="https://user-images.githubusercontent.com/87341702/206306835-8c99d805-c7c9-4687-8338-756d2abad682.png">


</details>

<details>
<summary>Desktop</summary>

<img width="1210" alt="Screen Shot 2022-12-07 at 1 07 40 PM" src="https://user-images.githubusercontent.com/87341702/206296262-2b19b831-1e79-4b06-a7d4-db0811cc7a80.png">
<img width="1213" alt="Screen Shot 2022-12-07 at 2 07 41 PM" src="https://user-images.githubusercontent.com/87341702/206307069-5e4e4449-d29f-430c-9d30-51e2d66152a7.png">


</details>

<details>
<summary>iOS</summary>

<img width="432" alt="Screen Shot 2022-12-07 at 2 01 08 PM" src="https://user-images.githubusercontent.com/87341702/206306619-5b215043-c04d-4f75-9623-e6db18bb0029.png">
<img width="435" alt="Screen Shot 2022-12-07 at 2 01 29 PM" src="https://user-images.githubusercontent.com/87341702/206306622-b2a19c1a-be84-4df8-af9a-ddcaa0f9ac5f.png">


</details>

<details>
<summary>Android</summary>

<img width="437" alt="Screen Shot 2022-12-07 at 1 47 54 PM" src="https://user-images.githubusercontent.com/87341702/206306552-0b4291b0-6d23-4dd6-b38a-0d14ca95d7e7.png">
<img width="437" alt="Screen Shot 2022-12-07 at 1 48 17 PM" src="https://user-images.githubusercontent.com/87341702/206306556-729a2d05-842f-4b13-819c-08f95edd3e28.png">


</details>
