### PR TITLE
Fix incorporation date error

### DIFF
--- a/src/pages/ReimbursementAccount/CompanyStep.js
+++ b/src/pages/ReimbursementAccount/CompanyStep.js
@@ -101,9 +101,7 @@ class CompanyStep extends React.Component {
 
         if (!values.incorporationDate || !ValidationUtils.isValidDate(values.incorporationDate)) {
             errors.incorporationDate = this.props.translate('bankAccount.error.incorporationDate');
-        }
-
-        if (!values.incorporationDate || !ValidationUtils.isValidPastDate(values.incorporationDate)) {
+        } else if (!values.incorporationDate || !ValidationUtils.isValidPastDate(values.incorporationDate)) {
             errors.incorporationDate = this.props.translate('bankAccount.error.incorporationDateFuture');
         }
 

--- a/src/pages/ReimbursementAccount/CompanyStep.js
+++ b/src/pages/ReimbursementAccount/CompanyStep.js
@@ -104,7 +104,7 @@ class CompanyStep extends React.Component {
         }
 
         if (!values.incorporationDate || !ValidationUtils.isValidPastDate(values.incorporationDate)) {
-            errors.incorporationDateFuture = this.props.translate('bankAccount.error.incorporationDateFuture');
+            errors.incorporationDate = this.props.translate('bankAccount.error.incorporationDateFuture');
         }
 
         if (!values.incorporationState) {


### PR DESCRIPTION
### Fixed Issues

$ https://github.com/Expensify/App/issues/13261

### Tests

Same as QA 

- [ ] Verify that no errors appear in the JS console

### Offline tests

### QA Steps

1. Go to Profile > Workspace > Connect a bank account > Connect manually
2. Enter a valid routing number and account number (**Tip:** See https://stackoverflowteams.com/c/expensify/questions/342)
3. Click save & continue
4. On company information page, click on the incorporation date field
5. Enter a future date manually and click Save & Continue
6. Verify that an error appears indicating the date is not in range

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

![2022-12-07_12-52-14](https://user-images.githubusercontent.com/32969087/206314087-8a47cfd9-16cc-4d62-bf01-fa0eda60acb0.png)

</details>

<details>
<summary>Mobile Web - Chrome</summary>

Same as Android native - can't test due to inability to enter a future date

<img width="382" alt="2022-12-07_14-24-00" src="https://user-images.githubusercontent.com/32969087/206326097-3cd5f4b7-ad19-4daf-89cc-9e23348e343b.png">

</details>

<details>
<summary>Mobile Web - Safari</summary>

![2022-12-07_13-08-32](https://user-images.githubusercontent.com/32969087/206316713-0eeb8a66-3db7-46cf-9bb1-9cb6ecc7e99c.png)

</details>

<details>
<summary>Desktop</summary>

<img width="1200" alt="2022-12-07_13-11-00" src="https://user-images.githubusercontent.com/32969087/206317092-6579fdd3-a298-43ff-9032-037f3e4e69c7.png">

</details>

<details>
<summary>iOS</summary>

Tests are not relevant on iOS since the input prevents you from entering anything in the future but leaving proof that I tried 🤔 

![2022-12-07_12-59-24](https://user-images.githubusercontent.com/32969087/206315301-2a18cc75-0e21-44ef-92b4-017efc08d8bd.png)

</details>

<details>
<summary>Android</summary>

Not really testable since future dates are not allowed.

<img width="382" alt="2022-12-07_13-17-10" src="https://user-images.githubusercontent.com/32969087/206318038-7d9dafd5-1820-4a50-a29f-951de6cbee59.png">

</details>
