### PR TITLE
fix "Upload photo" popup menu not hiding

### DIFF
--- a/src/components/AttachmentPicker/index.js
+++ b/src/components/AttachmentPicker/index.js
@@ -41,6 +41,9 @@ class AttachmentPicker extends React.Component {
                         // Cleanup after selecting a file to start from a fresh state
                         this.fileInput.value = null;
                     }}
+
+                    // Prevent parent's onclick event from firing
+                    onClick={e => e.stopPropagation()}
                     accept={getAcceptableFileTypes(this.props.type)}
                 />
                 {this.props.children({

--- a/src/components/AttachmentPicker/index.js
+++ b/src/components/AttachmentPicker/index.js
@@ -42,7 +42,8 @@ class AttachmentPicker extends React.Component {
                         this.fileInput.value = null;
                     }}
 
-                    // Prevent parent's onclick event from firing
+                    // We are stopping the event propagation because triggering the `click()` on the hidden input
+                    // causes the event to unexpectedly bubble up to anything wrapping this component e.g. Pressable
                     onClick={e => e.stopPropagation()}
                     accept={getAcceptableFileTypes(this.props.type)}
                 />


### PR DESCRIPTION
### Details
Prevent parent's onclick event from firing when file input is clicked

### Fixed Issues
$ https://github.com/Expensify/App/issues/13435
PROPOSAL: https://github.com/Expensify/App/issues/13435#issuecomment-1343381405


### Tests
1. Login with any account
2. Go to Settings -> Profile
3. Click Profile Photo
4. Select Upload photo
5. Verify that popup menu with "Upload photo" hides and file select native modal shows

- [x] Verify that no errors appear in the JS console

### Offline tests
1. Login with any account
2. Disable network
3. Go to Settings -> Profile
4. Click Profile Photo
5. Select Upload photo
6. Verify that popup menu with "Upload photo" hides and file select native modal shows

### QA Steps
1. Login with any account
2. Go to Settings -> Profile
3. Click Profile Photo
4. Select Upload photo
5. Verify that popup menu with "Upload photo" hides and file select native modal shows

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>


https://user-images.githubusercontent.com/97473779/206584301-1b5b72d4-60b7-4a3d-b4b8-ed271b5da580.mov



</details>

<details>
<summary>Mobile Web - Chrome</summary>

![mchrome](https://user-images.githubusercontent.com/97473779/206584245-dd4a9913-09f0-47e1-8d1e-a035ea9b5e69.gif)


</details>

<details>
<summary>Mobile Web - Safari</summary>


https://user-images.githubusercontent.com/97473779/206584225-92681d40-70ec-4380-b3bb-a32add2c557f.mp4



</details>

<details>
<summary>Desktop</summary>


https://user-images.githubusercontent.com/97473779/206584191-3b864642-74d9-4639-95bb-378fa75bcf2c.mov



</details>

<details>
<summary>iOS</summary>


https://user-images.githubusercontent.com/97473779/206584076-0a0f9dfc-e703-419e-898e-cef78eaa7176.mp4



</details>

<details>
<summary>Android</summary>

![android](https://user-images.githubusercontent.com/97473779/206584141-5bc40730-1079-4656-afd2-edf7bf136286.gif)


</details>
