### PR TITLE
Use measureLayout to calculate scrolling

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -269,7 +269,9 @@ class Form extends React.Component {
                                 }
 
                                 // We substract 10 to scroll slightly above the input
-                                focusInput.measureLayout(this.form, (x, y) => this.form.scrollTo({y: y - 10, animated: false}));
+                                if (focusInput.measureLayout && typeof focusInput.measureLayout === 'function') {
+                                    focusInput.measureLayout(this.form, (x, y) => this.form.scrollTo({y: y - 10, animated: false}));
+                                }
                             }}
                             containerStyles={[styles.mh0, styles.mt5]}
                             enabledWhenOffline={this.props.enabledWhenOffline}

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -79,7 +79,6 @@ class Form extends React.Component {
 
         this.inputRefs = {};
         this.touchedInputs = {};
-        this.childPosition = {};
 
         this.setTouchedInput = this.setTouchedInput.bind(this);
         this.validate = this.validate.bind(this);
@@ -107,21 +106,6 @@ class Form extends React.Component {
         }
 
         return _.first(_.keys(hasStateErrors ? this.state.erorrs : this.props.formState.errorFields));
-    }
-
-    setPosition(element, position) {
-        // Some elements might not have props defined, e.g. Text
-        if (!element.props) {
-            return;
-        }
-
-        if (!element.props.inputID && element.props.children) {
-            _.forEach(element.props.children, (child) => {
-                this.setPosition(child, position);
-            });
-        } else {
-            this.childPosition[element.props.inputID] = position;
-        }
     }
 
     submit() {
@@ -268,16 +252,7 @@ class Form extends React.Component {
                     ref={el => this.form = el}
                 >
                     <View style={[this.props.style]}>
-                        {_.map(this.childrenWrapperWithProps(this.props.children), child => (
-                            <View
-                                key={child.key}
-                                onLayout={(event) => {
-                                    this.setPosition(child, event.nativeEvent.layout.y);
-                                }}
-                            >
-                                {child}
-                            </View>
-                        ))}
+                        {this.childrenWrapperWithProps(this.props.children)}
                         {this.props.isSubmitButtonVisible && (
                         <FormAlertWithSubmitButton
                             buttonText={this.props.submitButtonText}
@@ -289,10 +264,12 @@ class Form extends React.Component {
                                 const errors = !_.isEmpty(this.state.errors) ? this.state.errors : this.props.formState.errorFields;
                                 const focusKey = _.find(_.keys(this.inputRefs), key => _.keys(errors).includes(key));
                                 const focusInput = this.inputRefs[focusKey];
-                                this.form.scrollTo({y: this.childPosition[focusKey], animated: false});
                                 if (focusInput.focus && typeof focusInput.focus === 'function') {
                                     focusInput.focus();
                                 }
+
+                                // We substract 10 to scroll slightly above the input
+                                focusInput.measureLayout(this.form, (x, y) => this.form.scrollTo({y: y - 10, animated: false}));
                             }}
                             containerStyles={[styles.mh0, styles.mt5]}
                             enabledWhenOffline={this.props.enabledWhenOffline}


### PR DESCRIPTION
### Details

- Partially reverts https://github.com/Expensify/App/pull/12954
- Use `measureLayout` to find out where to scroll to

### Fixed Issues

$ https://github.com/Expensify/App/issues/13401   
PROPOSAL: GH_LINK_ISSUE(COMMENT)


### Tests

1. Login in New Dot
2. Go to Settings > Payments
4. Click "Add payment method" and select "Debit card"
5. Click "Save" without entering any data
6. Verify that all inputs have errors
7. if you are in web or desktop, resize the window enough to have scrolling in the RHN:
    ![image](https://user-images.githubusercontent.com/87341702/206823060-51332d2e-cde0-4c9f-b7d1-24e329c075c1.png)
8. Scroll down and click "fix the errors"
9. Verify that the first input gets focused and you are scrolled until it is fully visible (including the top border)
10. Input something in the first input "Name on card"
11. Scroll down and click again "fix the errors"
12. Verify that the second input gets focused and you are scrolled until it is fully visible (including the top border)
13. Go back to the Settings > Payments page
4. Click "Add payment method" and select "Bank account"
5. Verify that the spinner is in the middle and not in the top
    ![image](https://user-images.githubusercontent.com/87341702/206823150-e009919f-f7e7-4a58-9d69-22bf55211798.png)


- [x] Verify that no errors appear in the JS console

### Offline tests

N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
15. Upload an image via copy paste
16. Verify a modal appears displaying a preview of that image
--->

1. Login in New Dot
2. Go to Settings > Payments
4. Click "Add payment method" and select "Debit card"
5. Click "Save" without entering any data
6. Verify that all inputs have errors
7. if you are in web or desktop, resize the window enough to have scrolling in the RHN:
    ![image](https://user-images.githubusercontent.com/87341702/206823060-51332d2e-cde0-4c9f-b7d1-24e329c075c1.png)
8. Scroll down and click "fix the errors"
9. Verify that the first input gets focused and you are scrolled until it is fully visible (including the top border)
10. Input something in the first input "Name on card"
11. Scroll down and click again "fix the errors"
12. Verify that the second input gets focused and you are scrolled until it is fully visible (including the top border)
13. Go back to the Settings > Payments page
4. Click "Add payment method" and select "Bank account"
5. Verify that the spinner is in the middle and not in the top
    ![image](https://user-images.githubusercontent.com/87341702/206823150-e009919f-f7e7-4a58-9d69-22bf55211798.png)

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>


https://user-images.githubusercontent.com/87341702/206822933-83c9b42f-3e02-4fc7-9b6f-1caa67bf859a.mov



</details>

<details>
<summary>Mobile Web - Chrome</summary>


https://user-images.githubusercontent.com/87341702/206822921-a4808d34-e4d1-4123-9da2-5d929dabb12f.mov



</details>

<details>
<summary>Mobile Web - Safari</summary>


https://user-images.githubusercontent.com/87341702/206822914-2ce6dfc8-2093-4f1a-a6af-69b9c5609df9.mov



</details>

<details>
<summary>Desktop</summary>


https://user-images.githubusercontent.com/87341702/206822908-19eb4d1f-9a65-4636-9574-ca9d000d224f.mov



</details>

<details>
<summary>iOS</summary>


https://user-images.githubusercontent.com/87341702/206822900-5f2796bf-99d5-475d-bd8d-bb7ffa694b95.mov



</details>

<details>
<summary>Android</summary>


https://user-images.githubusercontent.com/87341702/206822887-a47dc14e-2c3f-49d9-8617-fee2f5cba49d.mov



</details>
