### PR TITLE
Fix: Scroll to Picker TextInput on open

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "react-native-pdf": "^6.6.2",
         "react-native-performance": "^2.0.0",
         "react-native-permissions": "^3.0.1",
-        "react-native-picker-select": "git+https://github.com/chrispader/expensify-react-native-picker-select.git#fix/scroll-to-input-on-open",
+        "react-native-picker-select": "git+https://github.com/Expensify/react-native-picker-select.git#77cc9d42c474a693755941b10ee4c2d6f50e5346",
         "react-native-plaid-link-sdk": "^7.2.0",
         "react-native-reanimated": "3.0.0-rc.6",
         "react-native-render-html": "6.3.1",
@@ -35528,7 +35528,8 @@
     },
     "node_modules/react-native-picker-select": {
       "version": "8.0.4",
-      "resolved": "git+ssh://git@github.com/chrispader/expensify-react-native-picker-select.git#f72d50ccff5d2d229f7dee21d10293bbc203605a",
+      "resolved": "git+ssh://git@github.com/Expensify/react-native-picker-select.git#77cc9d42c474a693755941b10ee4c2d6f50e5346",
+      "integrity": "sha512-KhadZYEWeoTQv/dj2tXpCRQvoY3L9tMGcVnopiYNSzlPdbnDzJUdvdDwf2bVdR3zQXrmHjzsYUVUJx3FFu6LAA==",
       "license": "MIT",
       "dependencies": {
         "lodash.isequal": "^4.5.0"
@@ -69866,8 +69867,9 @@
       "requires": {}
     },
     "react-native-picker-select": {
-      "version": "git+ssh://git@github.com/chrispader/expensify-react-native-picker-select.git#f72d50ccff5d2d229f7dee21d10293bbc203605a",
-      "from": "react-native-picker-select@git+https://github.com/chrispader/expensify-react-native-picker-select.git#fix/scroll-to-input-on-open",
+      "version": "git+ssh://git@github.com/Expensify/react-native-picker-select.git#77cc9d42c474a693755941b10ee4c2d6f50e5346",
+      "integrity": "sha512-KhadZYEWeoTQv/dj2tXpCRQvoY3L9tMGcVnopiYNSzlPdbnDzJUdvdDwf2bVdR3zQXrmHjzsYUVUJx3FFu6LAA==",
+      "from": "react-native-picker-select@git+https://github.com/Expensify/react-native-picker-select.git#77cc9d42c474a693755941b10ee4c2d6f50e5346",
       "requires": {
         "lodash.isequal": "^4.5.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "react-native-pdf": "^6.6.2",
         "react-native-performance": "^2.0.0",
         "react-native-permissions": "^3.0.1",
-        "react-native-picker-select": "git+https://github.com/Expensify/react-native-picker-select.git#7f09b2c15ffae320d769788f75bdf8948714bb10",
+        "react-native-picker-select": "git+https://github.com/chrispader/expensify-react-native-picker-select.git#fix/scroll-to-input-on-open",
         "react-native-plaid-link-sdk": "^7.2.0",
         "react-native-reanimated": "3.0.0-rc.6",
         "react-native-render-html": "6.3.1",
@@ -35528,8 +35528,7 @@
     },
     "node_modules/react-native-picker-select": {
       "version": "8.0.4",
-      "resolved": "git+ssh://git@github.com/Expensify/react-native-picker-select.git#7f09b2c15ffae320d769788f75bdf8948714bb10",
-      "integrity": "sha512-fKuK7NBPYmf0rfQIPcOK1OrM31DIlQVEtdEBANWxudBXwj+okAakY9hIXPXkCd1Ow7gj5P3Z2XNle2ak6NtYPg==",
+      "resolved": "git+ssh://git@github.com/chrispader/expensify-react-native-picker-select.git#235fb856d07470cd3b550cb5c2aaeffd0d1631c8",
       "license": "MIT",
       "dependencies": {
         "lodash.isequal": "^4.5.0"
@@ -69867,9 +69866,8 @@
       "requires": {}
     },
     "react-native-picker-select": {
-      "version": "git+ssh://git@github.com/Expensify/react-native-picker-select.git#7f09b2c15ffae320d769788f75bdf8948714bb10",
-      "integrity": "sha512-fKuK7NBPYmf0rfQIPcOK1OrM31DIlQVEtdEBANWxudBXwj+okAakY9hIXPXkCd1Ow7gj5P3Z2XNle2ak6NtYPg==",
-      "from": "react-native-picker-select@git+https://github.com/Expensify/react-native-picker-select.git#7f09b2c15ffae320d769788f75bdf8948714bb10",
+      "version": "git+ssh://git@github.com/chrispader/expensify-react-native-picker-select.git#235fb856d07470cd3b550cb5c2aaeffd0d1631c8",
+      "from": "react-native-picker-select@git+https://github.com/chrispader/expensify-react-native-picker-select.git#fix/scroll-to-input-on-open",
       "requires": {
         "lodash.isequal": "^4.5.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -35528,7 +35528,7 @@
     },
     "node_modules/react-native-picker-select": {
       "version": "8.0.4",
-      "resolved": "git+ssh://git@github.com/chrispader/expensify-react-native-picker-select.git#235fb856d07470cd3b550cb5c2aaeffd0d1631c8",
+      "resolved": "git+ssh://git@github.com/chrispader/expensify-react-native-picker-select.git#f72d50ccff5d2d229f7dee21d10293bbc203605a",
       "license": "MIT",
       "dependencies": {
         "lodash.isequal": "^4.5.0"
@@ -69866,7 +69866,7 @@
       "requires": {}
     },
     "react-native-picker-select": {
-      "version": "git+ssh://git@github.com/chrispader/expensify-react-native-picker-select.git#235fb856d07470cd3b550cb5c2aaeffd0d1631c8",
+      "version": "git+ssh://git@github.com/chrispader/expensify-react-native-picker-select.git#f72d50ccff5d2d229f7dee21d10293bbc203605a",
       "from": "react-native-picker-select@git+https://github.com/chrispader/expensify-react-native-picker-select.git#fix/scroll-to-input-on-open",
       "requires": {
         "lodash.isequal": "^4.5.0"

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "react-native-pdf": "^6.6.2",
     "react-native-performance": "^2.0.0",
     "react-native-permissions": "^3.0.1",
-    "react-native-picker-select": "git+https://github.com/Expensify/expensify-react-native-picker-select.git#77cc9d42c474a693755941b10ee4c2d6f50e5346",
+    "react-native-picker-select": "git+https://github.com/Expensify/react-native-picker-select.git#77cc9d42c474a693755941b10ee4c2d6f50e5346",
     "react-native-plaid-link-sdk": "^7.2.0",
     "react-native-reanimated": "3.0.0-rc.6",
     "react-native-render-html": "6.3.1",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "react-native-pdf": "^6.6.2",
     "react-native-performance": "^2.0.0",
     "react-native-permissions": "^3.0.1",
-    "react-native-picker-select": "git+https://github.com/Expensify/react-native-picker-select.git#7f09b2c15ffae320d769788f75bdf8948714bb10",
+    "react-native-picker-select": "git+https://github.com/chrispader/expensify-react-native-picker-select.git#fix/scroll-to-input-on-open",
     "react-native-plaid-link-sdk": "^7.2.0",
     "react-native-reanimated": "3.0.0-rc.6",
     "react-native-render-html": "6.3.1",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "react-native-pdf": "^6.6.2",
     "react-native-performance": "^2.0.0",
     "react-native-permissions": "^3.0.1",
-    "react-native-picker-select": "git+https://github.com/chrispader/expensify-react-native-picker-select.git#fix/scroll-to-input-on-open",
+    "react-native-picker-select": "git+https://github.com/Expensify/expensify-react-native-picker-select.git",
     "react-native-plaid-link-sdk": "^7.2.0",
     "react-native-reanimated": "3.0.0-rc.6",
     "react-native-render-html": "6.3.1",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "react-native-pdf": "^6.6.2",
     "react-native-performance": "^2.0.0",
     "react-native-permissions": "^3.0.1",
-    "react-native-picker-select": "git+https://github.com/Expensify/expensify-react-native-picker-select.git",
+    "react-native-picker-select": "git+https://github.com/Expensify/expensify-react-native-picker-select.git#77cc9d42c474a693755941b10ee4c2d6f50e5346",
     "react-native-plaid-link-sdk": "^7.2.0",
     "react-native-reanimated": "3.0.0-rc.6",
     "react-native-render-html": "6.3.1",

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -10,7 +10,7 @@ import * as FormActions from '../libs/actions/FormActions';
 import * as ErrorUtils from '../libs/ErrorUtils';
 import styles from '../styles/styles';
 import FormAlertWithSubmitButton from './FormAlertWithSubmitButton';
-import ScrollViewWithPickers from './ScrollViewWithPickers';
+import ScrollViewWithContext from './ScrollViewWithContext';
 
 const propTypes = {
     /** A unique Onyx key identifying the form */
@@ -250,7 +250,7 @@ class Form extends React.Component {
     render() {
         return (
             <>
-                <ScrollViewWithPickers
+                <ScrollViewWithContext
                     style={[styles.w100, styles.flex1]}
                     contentContainerStyle={styles.flexGrow1}
                     keyboardShouldPersistTaps="handled"
@@ -284,7 +284,7 @@ class Form extends React.Component {
                         />
                         )}
                     </View>
-                </ScrollViewWithPickers>
+                </ScrollViewWithContext>
             </>
         );
     }

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -1,6 +1,6 @@
 import lodashGet from 'lodash/get';
 import React from 'react';
-import {ScrollView, View} from 'react-native';
+import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
 import {withOnyx} from 'react-native-onyx';
@@ -10,6 +10,7 @@ import * as FormActions from '../libs/actions/FormActions';
 import * as ErrorUtils from '../libs/ErrorUtils';
 import styles from '../styles/styles';
 import FormAlertWithSubmitButton from './FormAlertWithSubmitButton';
+import ScrollViewWithPickers from './ScrollViewWithPickers';
 
 const propTypes = {
     /** A unique Onyx key identifying the form */
@@ -249,7 +250,7 @@ class Form extends React.Component {
     render() {
         return (
             <>
-                <ScrollView
+                <ScrollViewWithPickers
                     style={[styles.w100, styles.flex1]}
                     contentContainerStyle={styles.flexGrow1}
                     keyboardShouldPersistTaps="handled"
@@ -283,7 +284,7 @@ class Form extends React.Component {
                         />
                         )}
                     </View>
-                </ScrollView>
+                </ScrollViewWithPickers>
             </>
         );
     }

--- a/src/components/Picker/index.js
+++ b/src/components/Picker/index.js
@@ -151,12 +151,6 @@ class Picker extends PureComponent {
     render() {
         const hasError = !_.isEmpty(this.props.errorText);
 
-        let scrollViewRef;
-        if (this.context != null
-            && this.context.scrollViewRef != null) {
-            scrollViewRef = this.context.scrollViewRef;
-        }
-
         return (
             <>
                 <View
@@ -199,7 +193,7 @@ class Picker extends PureComponent {
                             }
                             this.props.innerRef(el);
                         }}
-                        scrollViewRef={scrollViewRef}
+                        scrollViewRef={this.context && this.context.scrollViewRef}
                     />
                 </View>
                 <FormHelpMessage message={this.props.errorText} />

--- a/src/components/Picker/index.js
+++ b/src/components/Picker/index.js
@@ -10,7 +10,7 @@ import Text from '../Text';
 import styles from '../../styles/styles';
 import themeColors from '../../styles/themes/default';
 import pickerStyles from './pickerStyles';
-import {ScrollViewWithPickersContext} from '../ScrollViewWithPickers';
+import {ScrollContext} from '../ScrollViewWithContext';
 
 const propTypes = {
     /** Picker label */
@@ -205,7 +205,7 @@ class Picker extends PureComponent {
 
 Picker.propTypes = propTypes;
 Picker.defaultProps = defaultProps;
-Picker.contextType = ScrollViewWithPickersContext;
+Picker.contextType = ScrollContext;
 
 // eslint-disable-next-line react/jsx-props-no-spreading
 export default React.forwardRef((props, ref) => <Picker {...props} innerRef={ref} key={props.inputID} />);

--- a/src/components/Picker/index.js
+++ b/src/components/Picker/index.js
@@ -10,6 +10,7 @@ import Text from '../Text';
 import styles from '../../styles/styles';
 import themeColors from '../../styles/themes/default';
 import pickerStyles from './pickerStyles';
+import {ScrollViewWithPickersContext} from '../ScrollViewWithPickers';
 
 const propTypes = {
     /** Picker label */
@@ -91,8 +92,8 @@ const defaultProps = {
             {...(size === 'small' ? {width: styles.pickerSmall.icon.width, height: styles.pickerSmall.icon.height} : {})}
         />
     ),
-    onBlur: () => {},
-    innerRef: () => {},
+    onBlur: () => { },
+    innerRef: () => { },
 };
 
 class Picker extends PureComponent {
@@ -149,6 +150,13 @@ class Picker extends PureComponent {
 
     render() {
         const hasError = !_.isEmpty(this.props.errorText);
+
+        let scrollViewRef;
+        if (this.context != null
+            && this.context.scrollViewRef != null) {
+            scrollViewRef = this.context.scrollViewRef;
+        }
+
         return (
             <>
                 <View
@@ -191,6 +199,7 @@ class Picker extends PureComponent {
                             }
                             this.props.innerRef(el);
                         }}
+                        scrollViewRef={scrollViewRef}
                     />
                 </View>
                 <FormHelpMessage message={this.props.errorText} />
@@ -201,6 +210,7 @@ class Picker extends PureComponent {
 
 Picker.propTypes = propTypes;
 Picker.defaultProps = defaultProps;
+Picker.contextType = ScrollViewWithPickersContext;
 
 // eslint-disable-next-line react/jsx-props-no-spreading
 export default React.forwardRef((props, ref) => <Picker {...props} innerRef={ref} key={props.inputID} />);

--- a/src/components/Picker/index.js
+++ b/src/components/Picker/index.js
@@ -194,6 +194,7 @@ class Picker extends PureComponent {
                             this.props.innerRef(el);
                         }}
                         scrollViewRef={this.context && this.context.scrollViewRef}
+                        scrollViewContentOffsetY={this.context && this.context.contentOffsetY}
                     />
                 </View>
                 <FormHelpMessage message={this.props.errorText} />

--- a/src/components/Picker/index.js
+++ b/src/components/Picker/index.js
@@ -92,8 +92,8 @@ const defaultProps = {
             {...(size === 'small' ? {width: styles.pickerSmall.icon.width, height: styles.pickerSmall.icon.height} : {})}
         />
     ),
-    onBlur: () => { },
-    innerRef: () => { },
+    onBlur: () => {},
+    innerRef: () => {},
 };
 
 class Picker extends PureComponent {

--- a/src/components/ScrollViewWithContext.js
+++ b/src/components/ScrollViewWithContext.js
@@ -9,13 +9,13 @@ const ScrollContext = React.createContext();
 const propTypes = ScrollView.propTypes;
 
 /*
-* <ScrollViewWithPickers /> is a wrapper around <ScrollView /> that provides a ref to the <ScrollView />.
-* <ScrollViewWithPickers /> can be used as a direct replacement for <ScrollView />
+* <ScrollViewWithContext /> is a wrapper around <ScrollView /> that provides a ref to the <ScrollView />.
+* <ScrollViewWithContext /> can be used as a direct replacement for <ScrollView />
 * if it contains one or more <Picker /> / <RNPickerSelect /> components.
 * Using this wrapper will automatically handle scrolling to the picker's <TextInput />
 * when the picker modal is opened
 */
-class ScrollViewWithScrollContext extends React.Component {
+class ScrollViewWithContext extends React.Component {
     constructor(props) {
         super(props);
 
@@ -56,7 +56,9 @@ class ScrollViewWithScrollContext extends React.Component {
         );
     }
 }
-ScrollViewWithScrollContext.propTypes = propTypes;
+ScrollViewWithContext.propTypes = propTypes;
 
-export default ScrollViewWithScrollContext;
-module.exports.ScrollViewWithPickersContext = ScrollContext;
+export default ScrollViewWithContext;
+export {
+    ScrollContext,
+};

--- a/src/components/ScrollViewWithPickers.js
+++ b/src/components/ScrollViewWithPickers.js
@@ -15,8 +15,10 @@ const propTypes = ScrollView.propTypes;
 * when the picker modal is opened
 */
 class ScrollViewWithPickers extends React.Component {
-    setScrollViewRef(ref) {
-        this.scrollViewRef = ref;
+    constructor(props) {
+        super(props);
+
+        this.scrollViewRef = React.createRef(null);
     }
 
     render() {
@@ -24,7 +26,7 @@ class ScrollViewWithPickers extends React.Component {
         const {children, ...propsWithoutChildren} = this.props;
         return (
             // eslint-disable-next-line react/jsx-props-no-spreading
-            <ScrollView {...propsWithoutChildren} ref={this.setScrollViewRef}>
+            <ScrollView {...propsWithoutChildren} ref={this.scrollViewRef}>
                 <ScrollViewWithPickersContext.Provider value={{scrollViewRef: this.scrollViewRef}}>
                     {children}
                 </ScrollViewWithPickersContext.Provider>

--- a/src/components/ScrollViewWithPickers.js
+++ b/src/components/ScrollViewWithPickers.js
@@ -1,4 +1,4 @@
-import React, {useRef} from 'react';
+import React from 'react';
 import {ScrollView} from 'react-native';
 
 // eslint-disable-next-line rulesdir/no-inline-named-export
@@ -14,18 +14,24 @@ const propTypes = ScrollView.propTypes;
 * Using this wrapper will automatically hadnle scrolling to the picker's <TextInput />
 * when the picker modal is opened
 */
-export default function ScrollViewWithPickers(props) {
-    // eslint-disable-next-line react/destructuring-assignment
-    const {children, ...restProps} = props;
-    const scrollViewRef = useRef(null);
+class ScrollViewWithPickers extends React.Component {
+    setScrollViewRef(ref) {
+        this.scrollViewRef = ref;
+    }
 
-    return (
-        // eslint-disable-next-line react/jsx-props-no-spreading
-        <ScrollView {...restProps} ref={scrollViewRef}>
-            <ScrollViewWithPickersContext.Provider value={{scrollViewRef}}>
-                {children}
-            </ScrollViewWithPickersContext.Provider>
-        </ScrollView>
-    );
+    render() {
+        // eslint-disable-next-line react/destructuring-assignment
+        const {children, ...propsWithoutChildren} = this.props;
+        return (
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            <ScrollView {...propsWithoutChildren} ref={this.setScrollViewRef}>
+                <ScrollViewWithPickersContext.Provider value={{scrollViewRef: this.scrollViewRef}}>
+                    {children}
+                </ScrollViewWithPickersContext.Provider>
+            </ScrollView>
+        );
+    }
 }
 ScrollViewWithPickers.propTypes = propTypes;
+
+export default ScrollViewWithPickers;

--- a/src/components/ScrollViewWithPickers.js
+++ b/src/components/ScrollViewWithPickers.js
@@ -23,7 +23,7 @@ class ScrollViewWithPickers extends React.Component {
         };
         this.scrollViewRef = React.createRef(null);
 
-        this.handleScroll = this.setContextScrollPosition.bind(this);
+        this.setContextScrollPosition = this.setContextScrollPosition.bind(this);
     }
 
     setContextScrollPosition(event) {

--- a/src/components/ScrollViewWithPickers.js
+++ b/src/components/ScrollViewWithPickers.js
@@ -11,7 +11,7 @@ const propTypes = ScrollView.propTypes;
 * <ScrollViewWithPickers /> is a wrapper around <ScrollView /> that provides a ref to the <ScrollView />.
 * <ScrollViewWithPickers /> can be used as a direct replacement for <ScrollView />
 * if it contains one or more <Picker /> / <RNPickerSelect /> components.
-* Using this wrapper will automatically hadnle scrolling to the picker's <TextInput />
+* Using this wrapper will automatically handle scrolling to the picker's <TextInput />
 * when the picker modal is opened
 */
 class ScrollViewWithPickers extends React.Component {

--- a/src/components/ScrollViewWithPickers.js
+++ b/src/components/ScrollViewWithPickers.js
@@ -43,6 +43,7 @@ class ScrollViewWithPickers extends React.Component {
                 ref={this.scrollViewRef}
                 onScroll={this.handleScroll}
                 scrollEventThrottle={scrollEventThrottle || 16}
+                scrollToOverflowEnabled
             >
                 <ScrollViewWithPickersContext.Provider
                     value={{

--- a/src/components/ScrollViewWithPickers.js
+++ b/src/components/ScrollViewWithPickers.js
@@ -1,0 +1,24 @@
+import React, {useRef} from 'react';
+import {ScrollView} from 'react-native';
+
+// eslint-disable-next-line rulesdir/no-inline-named-export
+export const ScrollViewWithPickersContext = React.createContext();
+
+// eslint-disable-next-line react/forbid-foreign-prop-types
+const propTypes = ScrollView.propTypes;
+
+export default function ScrollViewWithPickers(props) {
+    // eslint-disable-next-line react/destructuring-assignment
+    const {children, ...restProps} = props;
+    const scrollViewRef = useRef(null);
+
+    return (
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        <ScrollView {...restProps} ref={scrollViewRef}>
+            <ScrollViewWithPickersContext.Provider value={{scrollViewRef}}>
+                {children}
+            </ScrollViewWithPickersContext.Provider>
+        </ScrollView>
+    );
+}
+ScrollViewWithPickers.propTypes = propTypes;

--- a/src/components/ScrollViewWithPickers.js
+++ b/src/components/ScrollViewWithPickers.js
@@ -18,16 +18,38 @@ class ScrollViewWithPickers extends React.Component {
     constructor(props) {
         super(props);
 
+        this.state = {
+            contentOffsetY: 0,
+        };
         this.scrollViewRef = React.createRef(null);
+
+        this.handleScroll = this.handleScroll.bind(this);
+    }
+
+    handleScroll(event) {
+        if (this.props.onScroll) {
+            this.props.onScroll(event);
+        }
+        this.setState({contentOffsetY: event.nativeEvent.contentOffset.y});
     }
 
     render() {
         // eslint-disable-next-line react/destructuring-assignment
-        const {children, ...propsWithoutChildren} = this.props;
+        const {children, scrollEventThrottle, ...propsWithoutChildrenAndScrollEventThrottle} = this.props;
         return (
-            // eslint-disable-next-line react/jsx-props-no-spreading
-            <ScrollView {...propsWithoutChildren} ref={this.scrollViewRef}>
-                <ScrollViewWithPickersContext.Provider value={{scrollViewRef: this.scrollViewRef}}>
+            <ScrollView
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                {...propsWithoutChildrenAndScrollEventThrottle}
+                ref={this.scrollViewRef}
+                onScroll={this.handleScroll}
+                scrollEventThrottle={scrollEventThrottle || 16}
+            >
+                <ScrollViewWithPickersContext.Provider
+                    value={{
+                        scrollViewRef: this.scrollViewRef,
+                        contentOffsetY: this.state.contentOffsetY,
+                    }}
+                >
                     {children}
                 </ScrollViewWithPickersContext.Provider>
             </ScrollView>

--- a/src/components/ScrollViewWithPickers.js
+++ b/src/components/ScrollViewWithPickers.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import {ScrollView} from 'react-native';
 
-// eslint-disable-next-line rulesdir/no-inline-named-export
-export const ScrollViewWithPickersContext = React.createContext();
+const MIN_SMOOTH_SCROLL_EVENT_THROTTLE = 16;
+
+const ScrollContext = React.createContext();
 
 // eslint-disable-next-line react/forbid-foreign-prop-types
 const propTypes = ScrollView.propTypes;
@@ -14,7 +15,7 @@ const propTypes = ScrollView.propTypes;
 * Using this wrapper will automatically handle scrolling to the picker's <TextInput />
 * when the picker modal is opened
 */
-class ScrollViewWithPickers extends React.Component {
+class ScrollViewWithScrollContext extends React.Component {
     constructor(props) {
         super(props);
 
@@ -34,29 +35,28 @@ class ScrollViewWithPickers extends React.Component {
     }
 
     render() {
-        // eslint-disable-next-line react/destructuring-assignment
-        const {children, scrollEventThrottle, ...propsWithoutChildrenAndScrollEventThrottle} = this.props;
         return (
             <ScrollView
                 // eslint-disable-next-line react/jsx-props-no-spreading
-                {...propsWithoutChildrenAndScrollEventThrottle}
+                {...this.props}
                 ref={this.scrollViewRef}
                 onScroll={this.setContextScrollPosition}
-                scrollEventThrottle={scrollEventThrottle || 16}
+                scrollEventThrottle={this.props.scrollEventThrottle || MIN_SMOOTH_SCROLL_EVENT_THROTTLE}
                 scrollToOverflowEnabled
             >
-                <ScrollViewWithPickersContext.Provider
+                <ScrollContext.Provider
                     value={{
                         scrollViewRef: this.scrollViewRef,
                         contentOffsetY: this.state.contentOffsetY,
                     }}
                 >
-                    {children}
-                </ScrollViewWithPickersContext.Provider>
+                    {this.props.children}
+                </ScrollContext.Provider>
             </ScrollView>
         );
     }
 }
-ScrollViewWithPickers.propTypes = propTypes;
+ScrollViewWithScrollContext.propTypes = propTypes;
 
-export default ScrollViewWithPickers;
+export default ScrollViewWithScrollContext;
+module.exports.ScrollViewWithPickersContext = ScrollContext;

--- a/src/components/ScrollViewWithPickers.js
+++ b/src/components/ScrollViewWithPickers.js
@@ -23,10 +23,10 @@ class ScrollViewWithPickers extends React.Component {
         };
         this.scrollViewRef = React.createRef(null);
 
-        this.handleScroll = this.handleScroll.bind(this);
+        this.handleScroll = this.setContextScrollPosition.bind(this);
     }
 
-    handleScroll(event) {
+    setContextScrollPosition(event) {
         if (this.props.onScroll) {
             this.props.onScroll(event);
         }
@@ -41,7 +41,7 @@ class ScrollViewWithPickers extends React.Component {
                 // eslint-disable-next-line react/jsx-props-no-spreading
                 {...propsWithoutChildrenAndScrollEventThrottle}
                 ref={this.scrollViewRef}
-                onScroll={this.handleScroll}
+                onScroll={this.setContextScrollPosition}
                 scrollEventThrottle={scrollEventThrottle || 16}
                 scrollToOverflowEnabled
             >

--- a/src/components/ScrollViewWithPickers.js
+++ b/src/components/ScrollViewWithPickers.js
@@ -7,6 +7,13 @@ export const ScrollViewWithPickersContext = React.createContext();
 // eslint-disable-next-line react/forbid-foreign-prop-types
 const propTypes = ScrollView.propTypes;
 
+/*
+* <ScrollViewWithPickers /> is a wrapper around <ScrollView /> that provides a ref to the <ScrollView />.
+* <ScrollViewWithPickers /> can be used as a direct replacement for <ScrollView />
+* if it contains one or more <Picker /> / <RNPickerSelect /> components.
+* Using this wrapper will automatically hadnle scrolling to the picker's <TextInput />
+* when the picker modal is opened
+*/
 export default function ScrollViewWithPickers(props) {
     // eslint-disable-next-line react/destructuring-assignment
     const {children, ...restProps} = props;

--- a/src/pages/workspace/WorkspacePageWithSections.js
+++ b/src/pages/workspace/WorkspacePageWithSections.js
@@ -20,7 +20,7 @@ import withPolicy from './withPolicy';
 import {withNetwork} from '../../components/OnyxProvider';
 import networkPropTypes from '../../components/networkPropTypes';
 import FullPageNotFoundView from '../../components/BlockingViews/FullPageNotFoundView';
-import ScrollViewWithPickers from '../../components/ScrollViewWithPickers';
+import ScrollViewWithContext from '../../components/ScrollViewWithContext';
 
 const propTypes = {
     shouldSkipVBBACall: PropTypes.bool,
@@ -122,7 +122,7 @@ class WorkspacePageWithSections extends React.Component {
                     />
                     {this.props.shouldUseScrollView
                         ? (
-                            <ScrollViewWithPickers
+                            <ScrollViewWithContext
                                 keyboardShouldPersistTaps="handled"
                                 style={[styles.settingsPageBackground, styles.flex1, styles.w100]}
                             >
@@ -131,7 +131,7 @@ class WorkspacePageWithSections extends React.Component {
                                     {this.props.children(hasVBA, policyID, isUsingECard)}
 
                                 </View>
-                            </ScrollViewWithPickers>
+                            </ScrollViewWithContext>
                         )
                         : this.props.children(hasVBA, policyID, isUsingECard)}
                     {this.props.footer}

--- a/src/pages/workspace/WorkspacePageWithSections.js
+++ b/src/pages/workspace/WorkspacePageWithSections.js
@@ -68,7 +68,7 @@ const propTypes = {
 };
 
 const defaultProps = {
-    children: () => { },
+    children: () => {},
     user: {},
     reimbursementAccount: {},
     footer: null,

--- a/src/pages/workspace/WorkspacePageWithSections.js
+++ b/src/pages/workspace/WorkspacePageWithSections.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {View, ScrollView} from 'react-native';
+import {View} from 'react-native';
 import {withOnyx} from 'react-native-onyx';
 import lodashGet from 'lodash/get';
 import _ from 'underscore';
@@ -20,6 +20,7 @@ import withPolicy from './withPolicy';
 import {withNetwork} from '../../components/OnyxProvider';
 import networkPropTypes from '../../components/networkPropTypes';
 import FullPageNotFoundView from '../../components/BlockingViews/FullPageNotFoundView';
+import ScrollViewWithPickers from '../../components/ScrollViewWithPickers';
 
 const propTypes = {
     shouldSkipVBBACall: PropTypes.bool,
@@ -67,7 +68,7 @@ const propTypes = {
 };
 
 const defaultProps = {
-    children: () => {},
+    children: () => { },
     user: {},
     reimbursementAccount: {},
     footer: null,
@@ -121,7 +122,7 @@ class WorkspacePageWithSections extends React.Component {
                     />
                     {this.props.shouldUseScrollView
                         ? (
-                            <ScrollView
+                            <ScrollViewWithPickers
                                 keyboardShouldPersistTaps="handled"
                                 style={[styles.settingsPageBackground, styles.flex1, styles.w100]}
                             >
@@ -130,7 +131,7 @@ class WorkspacePageWithSections extends React.Component {
                                     {this.props.children(hasVBA, policyID, isUsingECard)}
 
                                 </View>
-                            </ScrollView>
+                            </ScrollViewWithPickers>
                         )
                         : this.props.children(hasVBA, policyID, isUsingECard)}
                     {this.props.footer}


### PR DESCRIPTION
- [x] Held on changes to our fork: https://github.com/Expensify/react-native-picker-select/pull/3

### Details
Implement a custom HOC that allows to automatically scroll `ScrollView` to `react-native-picker-select`'s TextInput.

Adds a `<ScrollViewWithPickers />` component which should be used instead of vanilla `ScrollView`. This adds a ref and passes it down to the `Picker` component via `ScrollViewWithPickersContext`.

`<Picker />` component is adjusted, so that `scrollViewRef` is passed to `RNPickerSelect`, if it's provided.

Relevant changes in `react-native-picker-select` library are implemented [here](https://github.com/Expensify/react-native-picker-select/pull/3)

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ #11391 
[Proposal](https://github.com/Expensify/App/issues/11391#issuecomment-1337227034)


### Tests
- [x] Click on "Unit" input in Workflows "Reimburse expenses screen" a few times, with different ScrollView `contentOffsets`
1. Go to a the workspace settings
2. Go to the "Reimburse expenses" setting
3. Under "Track Distance", tap on the input for "Unit"
4. For iOS, the entire unit field should be visible above the picker. For all other platforms, there should be no changes to the input or the picker (they will all have different pickers).


### Offline tests
None

### QA Steps
Same as tests above

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

Not needed, as this is (native) iOS specific

</details>

<details>
<summary>Mobile Web - Chrome</summary>

Not needed, as this is (native) iOS specific

</details>

<details>
<summary>Mobile Web - Safari</summary>

Not needed, as this is (native) iOS specific

</details>

<details>
<summary>Desktop</summary>

Not needed, as this is (native) iOS specific

</details>

<details>
<summary>iOS</summary>

iPhone 14 Pro:

https://user-images.githubusercontent.com/20173411/209147933-8723b639-d4fc-4329-a457-a786802fc670.mp4

iPhone 8:

https://user-images.githubusercontent.com/20173411/209148968-fea65339-83ca-4179-beba-b345a47a2b6e.mp4

</details>

<details>
<summary>Android</summary>

Not needed, as this is (native) iOS specific

</details>