### PR TITLE
fix error message style issue on OfflineWithFeedback

### DIFF
--- a/src/components/OfflineWithFeedback.js
+++ b/src/components/OfflineWithFeedback.js
@@ -103,7 +103,7 @@ const OfflineWithFeedback = (props) => {
             )}
             {(props.shouldShowErrorMessages && hasErrors) && (
                 <View style={StyleUtils.combineStyles(styles.offlineFeedback.error, props.errorRowStyles)}>
-                    <DotIndicatorMessage messages={props.errors} type="error" />
+                    <DotIndicatorMessage style={[styles.flex1]} messages={props.errors} type="error" />
                     <Tooltip text={props.translate('common.close')}>
                         <Pressable
                             onPress={props.onClose}


### PR DESCRIPTION
### Details
fix error message style issue on OfflineWithFeedback

### Fixed Issues
$ https://github.com/Expensify/App/issues/13505
$ https://github.com/Expensify/App/issues/13510
PROPOSAL: https://github.com/Expensify/App/issues/13505#issuecomment-1345372819

### Tests
1. Login with the same account on 2 different devices
2. On device A, go to Settings -> Workspaces -> select workspace
3. Now on device B, go to the same workspace and delete it
4. Immediately delete the same workspace on device A
5. Verify that error style is not broken: The text error message does NOT extend beyond the screen

-----

2. Login with any account
3. Click on the green + button
4. Click on the "New Chat" option
5. Create a new chat with an invalid phone number (5555555555555)
6. Verify the user is navigated to the conversation
7. The text of the error message should be centered

- [x] Verify that no errors appear in the JS console

### Offline tests
1. Login with the same account on 2 different devices
2. Make network offline
3. On device A, go to Settings -> Workspaces -> select workspace
4. Now on device B, go to the same workspace and delete it
5. Immediately delete the same workspace on device A
7. Verify that error style is not broken: The text error message does NOT extend beyond the screen

### QA Steps
1. Login with the same account on 2 different devices
2. On device A, go to Settings -> Workspaces -> select workspace
3. Now on device B, go to the same workspace and delete it
4. Immediately delete the same workspace on device A
5. Verify that error style is not broken: The text error message does NOT extend beyond the screen

-----

1. Go to URL https://staging.new.expensify.com/
2. Login with any account
3. Click on the green + button
4. Click on the "New Chat" option
5. Create a new chat with an invalid phone number (5555555555555)
6. Verify the user is navigated to the conversation
8. The text of the error message should be centered

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product was added in all `src/languages/*` files
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

![web](https://user-images.githubusercontent.com/108292595/207163827-404af002-dc6b-4371-ae02-5954b1b99ffc.png)


</details>

<details>
<summary>Mobile Web - Chrome</summary>

<img width="372" alt="mchrome" src="https://user-images.githubusercontent.com/108292595/207163858-59e82399-afbd-4526-ae65-5593fc87c818.png">


</details>

<details>
<summary>Mobile Web - Safari</summary>

<img width="341" alt="msafari" src="https://user-images.githubusercontent.com/108292595/207163908-05cff000-30e0-4ccb-836b-ac83493b2c9d.png">

</details>

<details>
<summary>Desktop</summary>

<img width="1192" alt="desktop" src="https://user-images.githubusercontent.com/108292595/207163932-2a40b51b-b39b-4d89-affa-e03287a2951d.png">


</details>

<details>
<summary>iOS</summary>

![ios](https://user-images.githubusercontent.com/108292595/207163957-df22fbb3-96be-44f5-bf5a-0490a11337db.png)


</details>

<details>
<summary>Android</summary>


![android](https://user-images.githubusercontent.com/108292595/207163977-eaed1171-60f7-4fe6-9f19-3e7322662315.png)

</details>
