### PR TITLE
Swap dimensions when image is rotated on native devices

### DIFF
--- a/src/components/ImageView/index.native.js
+++ b/src/components/ImageView/index.native.js
@@ -66,15 +66,15 @@ class ImageView extends PureComponent {
         if (!this.props.url) {
             return;
         }
-        ImageSize.getSize(this.props.url).then(({width, height, rotation}) => {
+        ImageSize.getSize(this.props.url).then(({width, height}) => {
             let imageWidth = width;
             let imageHeight = height;
             const containerWidth = Math.round(this.props.windowWidth);
             const containerHeight = Math.round(this.state.containerHeight);
 
-            // On specific Android devices, the dimensions are sometimes returned to us flipped here, with `rotation` set to 90 degrees.
-            // Swap them back to make sure the image fits nicely in the container. On iOS, the rotation is always undefined, so this does not apply.
-            if (rotation === 90 && imageWidth > imageHeight) {
+            // On certain Android devices, the dimensions are sometimes returned to us flipped here. Swap them to make sure
+            // the image uses all the container space available.
+            if (imageWidth > imageHeight) {
                 [imageWidth, imageHeight] = [imageHeight, imageWidth];
             }
 

--- a/src/components/ImageView/index.native.js
+++ b/src/components/ImageView/index.native.js
@@ -72,6 +72,13 @@ class ImageView extends PureComponent {
             const containerWidth = Math.round(this.props.windowWidth);
             const containerHeight = Math.round(this.state.containerHeight);
 
+            // On Android, the dimensions are sometimes returned to us flipped here. Swap them back to make sure the image fits nicely in the container. This has no effect on iOS.
+            if (imageWidth > imageHeight) {
+                const swap = imageHeight;
+                imageHeight = imageWidth;
+                imageWidth = swap;
+            }
+
             const aspectRatio = Math.min(containerHeight / imageHeight, containerWidth / imageWidth);
 
             imageHeight *= aspectRatio;

--- a/src/components/ImageView/index.native.js
+++ b/src/components/ImageView/index.native.js
@@ -74,7 +74,7 @@ class ImageView extends PureComponent {
 
             // On specific Android devices, the dimensions are sometimes returned to us flipped here, with `rotation` set to 90 degrees.
             // Swap them back to make sure the image fits nicely in the container. On iOS, the rotation is always undefined, so this does not apply.
-            if ((rotation === 90 || rotation === 270) && imageWidth > imageHeight) {
+            if ((rotation === 90 || rotation === 270)) {
                 [imageWidth, imageHeight] = [imageHeight, imageWidth];
             }
 

--- a/src/components/ImageView/index.native.js
+++ b/src/components/ImageView/index.native.js
@@ -66,17 +66,16 @@ class ImageView extends PureComponent {
         if (!this.props.url) {
             return;
         }
-        ImageSize.getSize(this.props.url).then(({width, height}) => {
+        ImageSize.getSize(this.props.url).then(({width, height, rotation}) => {
             let imageWidth = width;
             let imageHeight = height;
             const containerWidth = Math.round(this.props.windowWidth);
             const containerHeight = Math.round(this.state.containerHeight);
 
-            // On Android, the dimensions are sometimes returned to us flipped here. Swap them back to make sure the image fits nicely in the container. This has no effect on iOS.
-            if (imageWidth > imageHeight) {
-                const swap = imageHeight;
-                imageHeight = imageWidth;
-                imageWidth = swap;
+            // On specific Android devices, the dimensions are sometimes returned to us flipped here, with `rotation` set to 90 degrees.
+            // Swap them back to make sure the image fits nicely in the container. On iOS, the rotation is always undefined, so this does not apply.
+            if (rotation === 90 && imageWidth > imageHeight) {
+                [imageWidth, imageHeight] = [imageHeight, imageWidth];
             }
 
             const aspectRatio = Math.min(containerHeight / imageHeight, containerWidth / imageWidth);

--- a/src/components/ImageView/index.native.js
+++ b/src/components/ImageView/index.native.js
@@ -74,7 +74,7 @@ class ImageView extends PureComponent {
 
             // On specific Android devices, the dimensions are sometimes returned to us flipped here, with `rotation` set to 90 degrees.
             // Swap them back to make sure the image fits nicely in the container. On iOS, the rotation is always undefined, so this does not apply.
-            if ((rotation === 90 || rotation === 270)) {
+            if (rotation === 90 || rotation === 270) {
                 [imageWidth, imageHeight] = [imageHeight, imageWidth];
             }
 

--- a/src/components/ImageView/index.native.js
+++ b/src/components/ImageView/index.native.js
@@ -66,15 +66,15 @@ class ImageView extends PureComponent {
         if (!this.props.url) {
             return;
         }
-        ImageSize.getSize(this.props.url).then(({width, height}) => {
+        ImageSize.getSize(this.props.url).then(({width, height, rotation}) => {
             let imageWidth = width;
             let imageHeight = height;
             const containerWidth = Math.round(this.props.windowWidth);
             const containerHeight = Math.round(this.state.containerHeight);
 
-            // On certain Android devices, the dimensions are sometimes returned to us flipped here. Swap them to make sure
-            // the image uses all the container space available.
-            if (imageWidth > imageHeight) {
+            // On specific Android devices, the dimensions are sometimes returned to us flipped here, with `rotation` set to 90 degrees.
+            // Swap them back to make sure the image fits nicely in the container. On iOS, the rotation is always undefined, so this does not apply.
+            if ((rotation === 90 || rotation === 270) && imageWidth > imageHeight) {
                 [imageWidth, imageHeight] = [imageHeight, imageWidth];
             }
 


### PR DESCRIPTION
### Details
- Fix attachment previews that look "small" (don't use all the available space) on Android.


### Fixed Issues
$ https://github.com/Expensify/App/issues/13300  


### Tests
On native devices (Android, iOS, mWeb Chrome & Safari):
1. Open any chat
2. In the compose box, click the `+` button > `📎  Add attachment` > `📸 Take photo`
3. Take a photo in portrait mode
4. On the "Send attachment" preview page, make sure the image uses all the available width space and isn't unnecessarily squished
5. Repeat with a photo taken in landscape mode, make sure the preview also doesn't look squished.
6. Download the following two images and drag-and-drop them in any chat
<img height="100" alt="208204571-007b5229-cc34-410a-81df-0c4dc52faa64" src="https://user-images.githubusercontent.com/2229301/208213654-22494b7d-0a7d-4602-9c58-c02072802781.png">&nbsp;&nbsp;&nbsp;<img height="100" src="https://user-images.githubusercontent.com/2229301/208213656-c12cfb6b-ae26-46fe-a86f-f7fa0ba3cdae.png">
7. After the images are added to the chat, open them back by clicking on them
8. Make sure the images don't look unnecessarily sized down

- [x] Verify that no errors appear in the JS console

### Offline tests
The same steps below apply while offline - we allow taking a photo as an attachment while offline.

### QA Steps
On native devices (Android, iOS, mWeb Chrome & Safari):
1. Open any chat
2. In the compose box, click the `+` button > `📎  Add attachment` > `📸 Take photo`
3. Take a photo in portrait mode
4. On the "Send attachment" preview page, make sure the image uses all the available width space and isn't unnecessarily squished
5. Repeat with a photo taken in landscape mode, make sure the preview also doesn't look squished.
6. Download the following two images and drag-and-drop them in any chat
<img height="100" alt="208204571-007b5229-cc34-410a-81df-0c4dc52faa64" src="https://user-images.githubusercontent.com/2229301/208213654-22494b7d-0a7d-4602-9c58-c02072802781.png">&nbsp;&nbsp;&nbsp;<img height="100" src="https://user-images.githubusercontent.com/2229301/208213656-c12cfb6b-ae26-46fe-a86f-f7fa0ba3cdae.png">
7. After the images are added to the chat, open them back by clicking on them
8. Make sure the images don't look unnecessarily sized down

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/2229301/207479207-898c2ce8-c44c-4aa7-b86c-2adf4426acdd.png">


</details>

<details>
<summary>Mobile Web - Chrome</summary>

<table>
<tr>
	<td>Portrait photo
	<td>Landscape photo
<tr>
	<td><img width="735" alt="image" src="https://user-images.githubusercontent.com/2229301/207479828-cdd9ad04-1a97-4e70-8d3e-3b9e9d45fd69.png">
	<td><img width="735" alt="image" src="https://user-images.githubusercontent.com/2229301/207479877-51dfa3e8-c83f-4f03-82c9-78feddc4a866.png">
</table>

</details>

<details>
<summary>Mobile Web - Safari</summary>

<img width="413" alt="image" src="https://user-images.githubusercontent.com/2229301/207482608-9e9fb96f-48f9-418e-b215-d9e347ee3254.png">


</details>

<details>
<summary>Desktop</summary>

<img width="1200" alt="image" src="https://user-images.githubusercontent.com/2229301/207484905-d2b2c277-35f3-4497-8318-42a64cea8ef3.png">

</details>

<details>
<summary>iOS</summary>

<img width="413" alt="image" src="https://user-images.githubusercontent.com/2229301/207482670-dd65ec78-21df-49fe-8785-0a5c4cb1ee53.png">


</details>

<details>
<summary>Android</summary>

<table>
<tr>
	<td>Device
	<td>Portrait photo
	<td>Landscape photo
	<td>Wide image from a chat
	<td>Tall image from a chat
<tr>
	<td>Pixel 3a AVD
	<td><img width="735" alt="Screenshot 2022-12-13 at 4 45 36 PM" src="https://user-images.githubusercontent.com/2229301/207476960-e53e7153-3935-49df-a660-27bae19dec15.png">
	<td><img width="735" alt="Screenshot 2022-12-13 at 4 45 53 PM" src="https://user-images.githubusercontent.com/2229301/207476962-736b021e-195d-4165-8a02-71fa147acee8.png">
	<td><img width="568" alt="image" src="https://user-images.githubusercontent.com/2229301/208214284-f23235b2-d36b-4806-b105-70d411d8aaa1.png">
	<td><img width="568" alt="image" src="https://user-images.githubusercontent.com/2229301/208214262-4815b4d9-ea01-4dad-a867-d4ab7c83578f.png">
<tr>
	<td>Pixel 6 Pro AVD
	<td>
<img width="735" alt="Screenshot 2022-12-13 at 4 46 12 PM" src="https://user-images.githubusercontent.com/2229301/207477051-7a27bb0b-3542-4636-9a34-ee511b035f09.png">
	<td><img width="735" alt="Screenshot 2022-12-13 at 4 46 37 PM" src="https://user-images.githubusercontent.com/2229301/207477053-968a67d4-6aef-47b3-94ab-df9baaf76d18.png">
	<td><img width="568" alt="image" src="https://user-images.githubusercontent.com/2229301/208214277-28831c8b-75c9-4bf0-9eb5-9cc81127349d.png">
	<td><img width="568" alt="image" src="https://user-images.githubusercontent.com/2229301/208214250-f53605ac-7b70-43ed-8e26-d6d52d4ba8a1.png">
<tr>
	<td>Pixel 6 (physical)
	<td><img src="https://user-images.githubusercontent.com/2229301/207477178-bf02ce9c-8fb3-4776-aad4-54018f4324a9.png">
	<td><img src="https://user-images.githubusercontent.com/2229301/207477170-0186ce2b-0921-4a37-b543-3e7954afd913.png">
	<td><img src="https://user-images.githubusercontent.com/2229301/208214019-8adeaef7-0fcc-4a05-b817-0664f4162251.png">
	<td><img src="https://user-images.githubusercontent.com/2229301/208214120-ec81544f-6e47-4d35-8069-6ba8c54f2c6e.png">
</table>


</details>
