### PR TITLE
Fix the edit comment input getting focus when long-pressing on Android

### DIFF
--- a/src/libs/focusTextInputAfterAnimation/index.android.js
+++ b/src/libs/focusTextInputAfterAnimation/index.android.js
@@ -1,5 +1,5 @@
 /**
- * For native Android devices, if an input is focused while an animation is happening, then they keyboard is not displayed. Delaying the focus until after the animation is done will ensure
+ * For native Android devices, if an input is focused while an animation is happening, then the keyboard is not displayed. Delaying the focus until after the animation is done will ensure
  * that the keyboard opens properly.
  *
  * @param {Object} inputRef

--- a/src/libs/focusTextInputAfterAnimation/index.android.js
+++ b/src/libs/focusTextInputAfterAnimation/index.android.js
@@ -1,0 +1,17 @@
+/**
+ * For native Android devices, if an input is focused while an animation is happening, then they keyboard is not displayed. Delaying the focus until after the animation is done will ensure
+ * that the keyboard opens properly.
+ *
+ * @param {Object} inputRef
+ * @param {Number} animationLength you must use your best guess as to what a good animationLength is. It can't be too short, or the animation won't be finished. It can't be too long or
+ *      the user will notice that it feels sluggish
+ */
+const focusTextInputAfterAnimation = (inputRef, animationLength = 0) => {
+    // This setTimeout is necessary because there are some animations that are just impossible to listen to in order to determine when they are finished (like when items are added to
+    // a FlatList).
+    setTimeout(() => {
+        inputRef.focus();
+    }, animationLength);
+};
+
+export default focusTextInputAfterAnimation;

--- a/src/libs/focusTextInputAfterAnimation/index.js
+++ b/src/libs/focusTextInputAfterAnimation/index.js
@@ -1,6 +1,6 @@
 /**
  * This library is a no-op for all platforms except for Android and will immediately focus the given input without any delays. This is important for native iOS clients because
- * text inputs can only be focused from user interactions and wrapping the focus() inside a setTimeout breaks that use case since it's not longer triggered from a user interaction.
+ * text inputs can only be focused from user interactions and wrapping the focus() inside a setTimeout breaks that use case since it's no longer triggered from a user interaction.
  *
  * @param {Object} inputRef
  */

--- a/src/libs/focusTextInputAfterAnimation/index.js
+++ b/src/libs/focusTextInputAfterAnimation/index.js
@@ -1,0 +1,11 @@
+/**
+ * This library is a no-op for all platforms except for Android and will immediately focus the given input without any delays. This is important for native iOS clients because
+ * text inputs can only be focused from user interactions and wrapping the focus() inside a setTimeout breaks that use case since it's not longer triggered from a user interaction.
+ *
+ * @param {Object} inputRef
+ */
+const focusTextInputAfterAnimation = (inputRef) => {
+    inputRef.focus();
+};
+
+export default focusTextInputAfterAnimation;

--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -33,6 +33,7 @@ import * as ReportUtils from '../../../libs/ReportUtils';
 import OfflineWithFeedback from '../../../components/OfflineWithFeedback';
 import * as ReportActions from '../../../libs/actions/ReportActions';
 import reportPropTypes from '../../reportPropTypes';
+import focusTextInputAfterAnimation from '../../../libs/focusTextInputAfterAnimation';
 
 const propTypes = {
     /** Report for this action */
@@ -95,7 +96,9 @@ class ReportActionItem extends Component {
         }
 
         // Only focus the input when user edits a message, skip it for existing drafts being edited of the report.
-        this.textInput.focus();
+        // There is an animation when the comment is hidden and the edit form is shown, and there can be bugs on different mobile platforms
+        // if the input is given focus in the middle of that animation which can prevent the keyboard from opening.
+        focusTextInputAfterAnimation(this.textInput, 100);
     }
 
     checkIfContextMenuActive() {

--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -98,7 +98,7 @@ class ReportActionItem extends Component {
         // Only focus the input when user edits a message, skip it for existing drafts being edited of the report.
         // There is an animation when the comment is hidden and the edit form is shown, and there can be bugs on different mobile platforms
         // if the input is given focus in the middle of that animation which can prevent the keyboard from opening.
-        focusTextInputAfterAnimation(this.textInput, 10);
+        focusTextInputAfterAnimation(this.textInput, 100);
     }
 
     checkIfContextMenuActive() {

--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -98,7 +98,7 @@ class ReportActionItem extends Component {
         // Only focus the input when user edits a message, skip it for existing drafts being edited of the report.
         // There is an animation when the comment is hidden and the edit form is shown, and there can be bugs on different mobile platforms
         // if the input is given focus in the middle of that animation which can prevent the keyboard from opening.
-        focusTextInputAfterAnimation(this.textInput, 100);
+        focusTextInputAfterAnimation(this.textInput, 10);
     }
 
     checkIfContextMenuActive() {


### PR DESCRIPTION
### Fixed Issues
$ https://github.com/Expensify/App/issues/11048


### Tests
Mobile platforms:
1. Go into a chat where you sent a message
2. Long-press on the message and select edit
3. Verify that the keyboard is open and you can edit the comment

Non-mobile platforms:
1. Go into a chat where you sent a messages
2. Hover over the messages and click on the edit button in the context menu
3. Verify that the edit comment button has focus and you can edit it

- [ ] Verify that no errors appear in the JS console

### Offline tests
Same as above. There should be no difference in behavior

### QA Steps
Same as above.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/1228807/207700874-d892b78b-e226-4079-94b9-7157dbb5bbb4.mp4


</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/1228807/207700901-4dd05d69-92dd-43c6-bf26-7618107f404e.mp4


</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/1228807/207700925-570114db-a534-42b1-b181-8ba1d595aabe.mp4


</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/1228807/207700946-8acf3c6a-375b-4ff6-918a-a616b06a988f.mp4


</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/1228807/207700962-84cba813-d9c4-4ea8-adf3-924480f98440.mp4


</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/1228807/207700987-81408c04-3668-4812-89d2-64fde75620fc.mp4


</details>
