### PR TITLE
show tooltip for emoji picker button on hover the outer part

### DIFF
--- a/src/components/EmojiPicker/EmojiPickerButton.js
+++ b/src/components/EmojiPicker/EmojiPickerButton.js
@@ -28,25 +28,25 @@ const defaultProps = {
 const EmojiPickerButton = (props) => {
     let emojiPopoverAnchor = null;
     return (
-        <Pressable
-            ref={el => emojiPopoverAnchor = el}
-            style={({hovered, pressed}) => ([
-                styles.chatItemEmojiButton,
-                StyleUtils.getButtonBackgroundColorStyle(getButtonState(hovered, pressed)),
-            ])}
-            disabled={props.isDisabled}
-            onPress={() => EmojiPickerAction.showEmojiPicker(props.onModalHide, props.onEmojiSelected, emojiPopoverAnchor)}
-            nativeID={props.nativeID}
-        >
-            {({hovered, pressed}) => (
-                <Tooltip text={props.translate('reportActionCompose.emoji')}>
+        <Tooltip containerStyles={[styles.alignSelfEnd]} text={props.translate('reportActionCompose.emoji')}>
+            <Pressable
+                ref={el => emojiPopoverAnchor = el}
+                style={({hovered, pressed}) => ([
+                    styles.chatItemEmojiButton,
+                    StyleUtils.getButtonBackgroundColorStyle(getButtonState(hovered, pressed)),
+                ])}
+                disabled={props.isDisabled}
+                onPress={() => EmojiPickerAction.showEmojiPicker(props.onModalHide, props.onEmojiSelected, emojiPopoverAnchor)}
+                nativeID={props.nativeID}
+            >
+                {({hovered, pressed}) => (
                     <Icon
                         src={Expensicons.Emoji}
                         fill={StyleUtils.getIconFillColor(getButtonState(hovered, pressed))}
                     />
-                </Tooltip>
-            )}
-        </Pressable>
+                )}
+            </Pressable>
+        </Tooltip>
     );
 };
 


### PR DESCRIPTION
### Details
- Wrap Pressable with Tooltip
- Apply style to Tooltip container for multiline responsive

### Fixed Issues
$ https://github.com/Expensify/App/issues/13455
PROPOSAL: https://github.com/Expensify/App/issues/13455#issuecomment-1349495976


### Tests
1. Login the app
2. Open any chat room
3. In composer, hover on the clickable area of emoji button but the outer part of emoji icon
4. Verify that Emoji tooltip shows

- [x] Verify that no errors appear in the JS console

### Offline tests
1. Login the app
2. Open any chat room
3. Disable network
4. In composer, hover on the clickable area of emoji button but the outer part of emoji icon
5. Verify that Emoji tooltip shows

### QA Steps
1. Login the app
2. Open any chat room
3. In composer, hover on the clickable area of emoji button but the outer part of emoji icon
4. Verify that Emoji tooltip shows

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>



https://user-images.githubusercontent.com/108292595/207830645-4e4bce30-ad90-4b41-a3d3-ca705fbac50e.mov


</details>

<details>
<summary>Mobile Web - Chrome</summary>

![mchrome](https://user-images.githubusercontent.com/108292595/207830692-0489617c-72a3-4bbf-b261-b2f44d544cf7.jpg)


</details>

<details>
<summary>Mobile Web - Safari</summary>

![msafari](https://user-images.githubusercontent.com/108292595/207830770-e5e08c72-5127-4c4f-9427-8e8c0f0504dd.png)


</details>

<details>
<summary>Desktop</summary>


https://user-images.githubusercontent.com/108292595/207830793-0858a6ef-6958-4d68-8b51-0aa86f49dd6d.mov



</details>

<details>
<summary>iOS</summary>

![ios](https://user-images.githubusercontent.com/108292595/207830837-ed616391-0e30-49f2-991b-d6566944ce21.png)


</details>

<details>
<summary>Android</summary>

![android](https://user-images.githubusercontent.com/108292595/207830919-1a0f6864-6989-4647-9801-77cfb23694c7.jpg)


</details>
