### PR TITLE
fix tooltip position changes after closing fab menu

### DIFF
--- a/src/components/FloatingActionButton.js
+++ b/src/components/FloatingActionButton.js
@@ -1,5 +1,7 @@
 import React, {PureComponent} from 'react';
-import {Pressable, Animated, Easing} from 'react-native';
+import {
+    Pressable, Animated, Easing, View,
+} from 'react-native';
 import PropTypes from 'prop-types';
 import Icon from './Icon';
 import * as Expensicons from './Icon/Expensicons';
@@ -72,22 +74,24 @@ class FloatingActionButton extends PureComponent {
 
         return (
             <Tooltip absolute text={this.props.translate('common.new')}>
-                <AnimatedPressable
-                    ref={el => this.fabPressable = el}
-                    accessibilityLabel={this.props.accessibilityLabel}
-                    accessibilityRole={this.props.accessibilityRole}
-                    onPress={(e) => {
+                <View style={styles.floatingActionButtonContainer}>
+                    <AnimatedPressable
+                        ref={el => this.fabPressable = el}
+                        accessibilityLabel={this.props.accessibilityLabel}
+                        accessibilityRole={this.props.accessibilityRole}
+                        onPress={(e) => {
                         // Drop focus to avoid blue focus ring.
-                        this.fabPressable.blur();
-                        this.props.onPress(e);
-                    }}
-                    style={[
-                        styles.floatingActionButton,
-                        StyleUtils.getAnimatedFABStyle(rotate, backgroundColor),
-                    ]}
-                >
-                    <AnimatedIcon src={Expensicons.Plus} fill={fill} />
-                </AnimatedPressable>
+                            this.fabPressable.blur();
+                            this.props.onPress(e);
+                        }}
+                        style={[
+                            styles.floatingActionButton,
+                            StyleUtils.getAnimatedFABStyle(rotate, backgroundColor),
+                        ]}
+                    >
+                        <AnimatedIcon src={Expensicons.Plus} fill={fill} />
+                    </AnimatedPressable>
+                </View>
             </Tooltip>
         );
     }

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -998,16 +998,19 @@ const styles = {
         },
     },
 
-    floatingActionButton: {
-        backgroundColor: themeColors.success,
+    floatingActionButtonContainer: {
         position: 'absolute',
-        height: variables.componentSizeLarge,
-        width: variables.componentSizeLarge,
         right: 20,
 
         // The bottom of the floating action button should align with the bottom of the compose box.
         // The value should be equal to the height + marginBottom + marginTop of chatItemComposeSecondaryRow
         bottom: 25,
+    },
+
+    floatingActionButton: {
+        backgroundColor: themeColors.success,
+        height: variables.componentSizeLarge,
+        width: variables.componentSizeLarge,
         borderRadius: 999,
         alignItems: 'center',
         justifyContent: 'center',


### PR DESCRIPTION
### Details
wrap AnimatedPressable with View and move position related styles into parent container so that rotate is applied to only button and parent container position is always fixed regardless of rotation.

### Fixed Issues
$ https://github.com/Expensify/App/issues/13638
PROPOSAL: https://github.com/Expensify/App/issues/13638#issuecomment-1355552704


### Tests
1. Login with any account
2. Hover over Fab icon
3. Verify that tooltip shows
4. Click on it to open
5. Click on it again to close
6. Verify that tooltip shows again and its position stays the same

- [x] Verify that no errors appear in the JS console

### Offline tests
1. Login with any account
2. Disable network
3. Hover over Fab icon
4. Verify that tooltip shows
5. Click on it to open
6. Click on it again to close
7. Verify that tooltip shows again and its position stays the same

### QA Steps
1. Login with any account
2. Hover over Fab icon
3. Verify that tooltip shows
4. Click on it to open
5. Click on it again to close
6. Verify that tooltip shows again and its position stays the same

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>


https://user-images.githubusercontent.com/97473779/208190142-935e0033-27b3-4a34-aa9e-39c581ecb936.mov



</details>

<details>
<summary>Mobile Web - Chrome</summary>


https://user-images.githubusercontent.com/97473779/208190198-195d7c05-2e65-484e-aac8-6bd928bcc8ac.mp4



</details>

<details>
<summary>Mobile Web - Safari</summary>


https://user-images.githubusercontent.com/97473779/208192124-463fa7db-1156-44e6-a1dd-5b97c9fab427.mp4



</details>

<details>
<summary>Desktop</summary>


https://user-images.githubusercontent.com/97473779/208192164-78124f98-fe74-4e57-a6b0-9df60d970100.mov



</details>

<details>
<summary>iOS</summary>


https://user-images.githubusercontent.com/97473779/208192206-7ecfb217-d6c0-4103-8e0d-b90d25469c82.mp4



</details>

<details>
<summary>Android</summary>


https://user-images.githubusercontent.com/97473779/208192226-f99fe27e-8f81-4065-9210-e9b18e4e74af.mp4



</details>
