### PR TITLE
Update ShortLivedToken naming convention 

### DIFF
--- a/src/libs/Navigation/AppNavigator/PublicScreens.js
+++ b/src/libs/Navigation/AppNavigator/PublicScreens.js
@@ -3,7 +3,7 @@ import {createStackNavigator} from '@react-navigation/stack';
 import SignInPage from '../../../pages/signin/SignInPage';
 import SetPasswordPage from '../../../pages/SetPasswordPage';
 import ValidateLoginPage from '../../../pages/ValidateLoginPage';
-import LogInWithShortLivedTokenPage from '../../../pages/LogInWithShortLivedTokenPage';
+import LogInWithShortLivedAuthTokenPage from '../../../pages/LogInWithShortLivedAuthTokenPage';
 import ConciergePage from '../../../pages/ConciergePage';
 import SCREENS from '../../../SCREENS';
 import defaultScreenOptions from './defaultScreenOptions';
@@ -20,7 +20,7 @@ const PublicScreens = () => (
         <RootStack.Screen
             name={SCREENS.TRANSITION_FROM_OLD_DOT}
             options={defaultScreenOptions}
-            component={LogInWithShortLivedTokenPage}
+            component={LogInWithShortLivedAuthTokenPage}
         />
         <RootStack.Screen
             name="ValidateLogin"

--- a/src/libs/actions/Session/index.js
+++ b/src/libs/actions/Session/index.js
@@ -266,13 +266,13 @@ function signIn(password, twoFactorAuthCode) {
  * Uses a short lived authToken to continue a user's session from OldDot
  *
  * @param {String} email
- * @param {String} shortLivedToken
+ * @param {String} shortLivedAuthToken
  * @param {String} exitTo
  */
-function signInWithShortLivedToken(email, shortLivedToken) {
+function signInWithShortLivedAuthToken(email, shortLivedAuthToken) {
     Onyx.merge(ONYXKEYS.ACCOUNT, {...CONST.DEFAULT_ACCOUNT_DATA, isLoading: true});
 
-    createTemporaryLogin(shortLivedToken, email)
+    createTemporaryLogin(shortLivedAuthToken, email)
         .then((response) => {
             if (response.jsonCode !== CONST.JSON_CODE.SUCCESS) {
                 return;
@@ -507,7 +507,7 @@ export {
     beginSignIn,
     updatePasswordAndSignin,
     signIn,
-    signInWithShortLivedToken,
+    signInWithShortLivedAuthToken,
     signOut,
     signOutAndRedirectToSignIn,
     resendValidationLink,

--- a/src/pages/LogInWithShortLivedAuthTokenPage.js
+++ b/src/pages/LogInWithShortLivedAuthTokenPage.js
@@ -9,8 +9,8 @@ const propTypes = {
     route: PropTypes.shape({
         /** Each parameter passed via the URL */
         params: PropTypes.shape({
-            /** Short lived token to sign in a user */
-            shortLivedToken: PropTypes.string,
+            /** Short lived authToken to sign in a user */
+            shortLivedAuthToken: PropTypes.string,
 
             /** The email of the transitioning user */
             email: PropTypes.string,
@@ -18,11 +18,11 @@ const propTypes = {
     }).isRequired,
 };
 
-class LogInWithShortLivedTokenPage extends Component {
+class LogInWithShortLivedAuthTokenPage extends Component {
     componentDidMount() {
         const email = lodashGet(this.props, 'route.params.email', '');
-        const shortLivedToken = lodashGet(this.props, 'route.params.shortLivedToken', '');
-        Session.signInWithShortLivedToken(email, shortLivedToken);
+        const shortLivedAuthToken = lodashGet(this.props, 'route.params.shortLivedAuthToken', '');
+        Session.signInWithShortLivedAuthToken(email, shortLivedAuthToken);
     }
 
     render() {
@@ -30,6 +30,6 @@ class LogInWithShortLivedTokenPage extends Component {
     }
 }
 
-LogInWithShortLivedTokenPage.propTypes = propTypes;
+LogInWithShortLivedAuthTokenPage.propTypes = propTypes;
 
-export default LogInWithShortLivedTokenPage;
+export default LogInWithShortLivedAuthTokenPage;


### PR DESCRIPTION

### Details
Updating naming conventions for consistency. 

cc: @Beamanator as we discussed this [here](https://github.com/Expensify/App/pull/13456#pullrequestreview-1220418485)


### Fixed Issues

$ N/A discussed in https://github.com/Expensify/App/pull/13456

### Tests
1. Log into an account on oldDot and create a new Free policy 
2. Confirm you're automatically logged into newDot as that user 
3. Log out of the account on NewDot
4. Back in OldDot, click on the name of the free policy you created in step 1 
5. Confirm you're logged back into newDot and that you land on the workspace page 
6. Navigate to the `/pricing` page on oldDot and selected `Free` 
7. Confirm you're logged back into newDot and that you land on the workspace page of a **new** workspace 

- [ ] Verify that no errors appear in the JS console

### Offline tests
N/A This action can only be taken while online. If you try this while offline in oldDot you get the following error:
![image](https://user-images.githubusercontent.com/16747822/208199627-a29ff48e-a813-4fed-920b-2f1dc9f86631.png)

### QA Steps
1. Log into an account on oldDot and create a new Free policy 
2. Confirm you're automatically logged into newDot as that user 
3. Log out of the account on NewDot
4. Back in OldDot, click on the name of the free policy you created in step 1 
5. Confirm you're logged back into newDot and that you land on the workspace page 
6. Navigate to the `/pricing` page on oldDot and selected `Free` 
7. Confirm you're logged back into newDot and that you land on the workspace page of a **new** workspace 

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos

AFAIK this can only be tested on web. The last PR that updated this logic (https://github.com/Expensify/App/pull/8855) doesn't appear to have platform-specific tests.

### Web 

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>
