### PR TITLE
Fix focus border for Dropdown Menu Buttons

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -108,6 +108,9 @@ const propTypes = {
 
     /** Id to use for this button */
     nativeID: PropTypes.string,
+
+    /** Whether to use a rounded border on tab selection */
+    useRoundedFocusBorder: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -139,6 +142,7 @@ const defaultProps = {
     shouldRemoveLeftBorderRadius: false,
     shouldEnableHapticFeedback: false,
     nativeID: '',
+    useRoundedFocusBorder: true,
 };
 
 class Button extends Component {
@@ -256,7 +260,7 @@ class Button extends Component {
                 style={[
                     this.props.isDisabled ? {...styles.cursorDisabled, ...styles.noSelect} : {},
                     ...StyleUtils.parseStyleAsArray(this.props.style),
-                    styles.buttonContainer,
+                    this.props.useRoundedFocusBorder ? styles.buttonContainer : [],
                 ]}
                 nativeID={this.props.nativeID}
             >

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -108,7 +108,6 @@ const propTypes = {
 
     /** Id to use for this button */
     nativeID: PropTypes.string,
-
 };
 
 const defaultProps = {
@@ -257,8 +256,8 @@ class Button extends Component {
                 style={[
                     this.props.isDisabled ? {...styles.cursorDisabled, ...styles.noSelect} : {},
                     styles.buttonContainer,
-                    this.props.shouldRemoveRightBorderRadius ? styles.noRightBorderRadius : [],
-                    this.props.shouldRemoveLeftBorderRadius ? styles.shouldRemoveLeftBorderRadius : [],
+                    this.props.shouldRemoveRightBorderRadius ? styles.noRightBorderRadius : undefined,
+                    this.props.shouldRemoveLeftBorderRadius ? styles.noLeftBorderRadius : undefined,
                     ...StyleUtils.parseStyleAsArray(this.props.style),
                 ]}
                 nativeID={this.props.nativeID}

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -109,8 +109,6 @@ const propTypes = {
     /** Id to use for this button */
     nativeID: PropTypes.string,
 
-    /** Whether to use a rounded border on tab selection */
-    useRoundedFocusBorder: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -142,7 +140,6 @@ const defaultProps = {
     shouldRemoveLeftBorderRadius: false,
     shouldEnableHapticFeedback: false,
     nativeID: '',
-    useRoundedFocusBorder: true,
 };
 
 class Button extends Component {
@@ -259,8 +256,10 @@ class Button extends Component {
                 disabled={this.props.isLoading || this.props.isDisabled}
                 style={[
                     this.props.isDisabled ? {...styles.cursorDisabled, ...styles.noSelect} : {},
+                    styles.buttonContainer,
+                    this.props.shouldRemoveRightBorderRadius ? styles.noRightBorderRadius : [],
+                    this.props.shouldRemoveLeftBorderRadius ? styles.shouldRemoveLeftBorderRadius : [],
                     ...StyleUtils.parseStyleAsArray(this.props.style),
-                    this.props.useRoundedFocusBorder ? styles.buttonContainer : [],
                 ]}
                 nativeID={this.props.nativeID}
             >

--- a/src/components/ButtonWithDropdown.js
+++ b/src/components/ButtonWithDropdown.js
@@ -40,17 +40,16 @@ const ButtonWithDropdown = props => (
             isDisabled={props.isDisabled}
             isLoading={props.isLoading}
             shouldRemoveRightBorderRadius
-            style={[styles.flex1]}
-            useRoundedFocusBorder={false}
+            style={[styles.flex1, styles.pr0]}
             pressOnEnter
         />
         <Button
             success
             isDisabled={props.isDisabled}
-            style={[styles.buttonDropdown]}
+            innerStyles={[styles.buttonDropdown]}
+            style={[styles.pl0]}
             onPress={props.onDropdownPress}
             shouldRemoveLeftBorderRadius
-            useRoundedFocusBorder={false}
             ContentComponent={() => (
                 <Icon src={Expensicons.DownArrow} fill={themeColors.textLight} />
             )}

--- a/src/components/ButtonWithDropdown.js
+++ b/src/components/ButtonWithDropdown.js
@@ -43,10 +43,10 @@ const ButtonWithDropdown = props => (
             style={[styles.flex1, styles.pr0]}
             pressOnEnter
         />
+        <View style={styles.buttonDivider} />
         <Button
             success
             isDisabled={props.isDisabled}
-            innerStyles={[styles.buttonDropdown]}
             style={[styles.pl0]}
             onPress={props.onDropdownPress}
             shouldRemoveLeftBorderRadius

--- a/src/components/ButtonWithDropdown.js
+++ b/src/components/ButtonWithDropdown.js
@@ -41,6 +41,7 @@ const ButtonWithDropdown = props => (
             isLoading={props.isLoading}
             shouldRemoveRightBorderRadius
             style={[styles.flex1]}
+            useRoundedFocusBorder={false}
             pressOnEnter
         />
         <Button
@@ -49,6 +50,7 @@ const ButtonWithDropdown = props => (
             style={[styles.buttonDropdown]}
             onPress={props.onDropdownPress}
             shouldRemoveLeftBorderRadius
+            useRoundedFocusBorder={false}
             ContentComponent={() => (
                 <Icon src={Expensicons.DownArrow} fill={themeColors.textLight} />
             )}

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -458,9 +458,11 @@ const styles = {
         borderWidth: 0,
     },
 
-    buttonDropdown: {
-        borderLeftWidth: 1,
-        borderColor: themeColors.textLight,
+    buttonDivider: {
+        width: 1,
+        alignSelf: 'stretch',
+        backgroundColor: themeColors.textLight,
+        marginVertical: 1,
     },
 
     noRightBorderRadius: {

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -334,6 +334,14 @@ const styles = {
         opacity: 1,
     },
 
+    pr0: {
+        paddingRight: 0,
+    },
+
+    pl0: {
+        paddingLeft: 0,
+    },
+
     textDanger: {
         color: themeColors.danger,
     },


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

https://user-images.githubusercontent.com/38015950/208527975-5bd77421-ba79-419e-bbe6-c0362920b939.mov


WEB / DESKTOP ONLY: 

Fixes the blue focus border around dropdown menu buttons when using tab to select. Also separates the line divider so that it does not change color when clicking on either side of the button.

This should not affect other kinds of buttons.

https://user-images.githubusercontent.com/38015950/208506103-0ca5328d-cc76-4ebd-9030-58584ef11644.mov



### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/13687


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console
- [x] Open an IOU where you owe money > click to open the modal > find the drop-down pay button
- [x] Use the tab to select through options until you are focused on the drop-down button 
- [x] Ensure that border focus style is correct visually for both left and right sides (see description)

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console
- [ ] Same as Tests

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] iOS / native
    - [x] Android / native
    - [x] iOS / Safari
    - [x] Android / Chrome
    - [x] MacOS / Chrome
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/38015950/208525932-f61ecbdf-4717-4c55-9264-efe37c82e87b.mov


</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->
<img width="200" alt="image" src="https://user-images.githubusercontent.com/38015950/208526391-88841671-00b5-4b22-b109-ad615ef7cca9.png">

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->
<img width="200" alt="image" src="https://user-images.githubusercontent.com/38015950/208526919-d51ee107-6854-423b-bdbe-ad26d892e162.png">



</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/38015950/208527506-ee204cae-8772-44e4-851d-cab01f07b133.mov


</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->
<img width="620" alt="image" src="https://user-images.githubusercontent.com/38015950/208526662-866096ea-9592-4cae-b02e-daed00f2640c.png">

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->
<img width="551" alt="image" src="https://user-images.githubusercontent.com/38015950/208526614-2316f4b1-2eb1-49e6-83d3-9b785165aa07.png">



</details>
