### PR TITLE
Fix picker translation

### DIFF
--- a/src/pages/ReportSettingsPage.js
+++ b/src/pages/ReportSettingsPage.js
@@ -52,20 +52,6 @@ const propTypes = {
 class ReportSettingsPage extends Component {
     constructor(props) {
         super(props);
-        this.notificationPreferencesOptions = {
-            default: {
-                value: CONST.REPORT.NOTIFICATION_PREFERENCE.ALWAYS,
-                label: this.props.translate('notificationPreferences.immediately'),
-            },
-            daily: {
-                value: CONST.REPORT.NOTIFICATION_PREFERENCE.DAILY,
-                label: this.props.translate('notificationPreferences.daily'),
-            },
-            mute: {
-                value: CONST.REPORT.NOTIFICATION_PREFERENCE.MUTE,
-                label: this.props.translate('notificationPreferences.mute'),
-            },
-        };
 
         this.roomNameInputRef = null;
 
@@ -76,6 +62,14 @@ class ReportSettingsPage extends Component {
 
         this.resetToPreviousName = this.resetToPreviousName.bind(this);
         this.validateAndUpdatePolicyRoomName = this.validateAndUpdatePolicyRoomName.bind(this);
+    }
+
+    getNotificationPreferenceOptions() {
+        return [
+            {value: CONST.REPORT.NOTIFICATION_PREFERENCE.ALWAYS, label: this.props.translate('notificationPreferences.immediately')},
+            {value: CONST.REPORT.NOTIFICATION_PREFERENCE.DAILY, label: this.props.translate('notificationPreferences.daily')},
+            {value: CONST.REPORT.NOTIFICATION_PREFERENCE.MUTE, label: this.props.translate('notificationPreferences.mute')},
+        ];
     }
 
     /**
@@ -166,7 +160,7 @@ class ReportSettingsPage extends Component {
                                         notificationPreference,
                                     );
                                 }}
-                                items={_.values(this.notificationPreferencesOptions)}
+                                items={this.getNotificationPreferenceOptions()}
                                 value={this.props.report.notificationPreference}
                             />
                         </View>

--- a/src/pages/workspace/reimburse/WorkspaceReimburseView.js
+++ b/src/pages/workspace/reimburse/WorkspaceReimburseView.js
@@ -81,17 +81,6 @@ class WorkspaceReimburseView extends React.Component {
             outputCurrency: lodashGet(props, 'policy.outputCurrency', ''),
         };
 
-        this.unitItems = [
-            {
-                label: this.props.translate('workspace.reimburse.kilometers'),
-                value: 'km',
-            },
-            {
-                label: this.props.translate('workspace.reimburse.miles'),
-                value: 'mi',
-            },
-        ];
-
         this.debounceUpdateOnCursorMove = this.debounceUpdateOnCursorMove.bind(this);
         this.updateRateValueDebounced = _.debounce(this.updateRateValue.bind(this), 1000);
         this.updatedValue = this.state.unitRateValue;
@@ -128,6 +117,13 @@ class WorkspaceReimburseView extends React.Component {
 
     getUnitRateValue(customUnitRate) {
         return this.getRateDisplayValue(lodashGet(customUnitRate, 'rate', 0) / CONST.POLICY.CUSTOM_UNIT_RATE_BASE_OFFSET);
+    }
+
+    getUnitItems() {
+        return [
+            {label: this.props.translate('workspace.reimburse.kilometers'), value: 'km'},
+            {label: this.props.translate('workspace.reimburse.miles'), value: 'mi'},
+        ];
     }
 
     getRateDisplayValue(value) {
@@ -283,7 +279,7 @@ class WorkspaceReimburseView extends React.Component {
                             <View style={[styles.unitCol]}>
                                 <Picker
                                     label={this.props.translate('workspace.reimburse.trackDistanceUnit')}
-                                    items={this.unitItems}
+                                    items={this.getUnitItems()}
                                     value={this.state.unitValue}
                                     onInputChange={value => this.setUnit(value)}
                                 />


### PR DESCRIPTION
### Details
Makes sure that picker dropdown options are translated.

### Fixed Issues
$ https://github.com/Expensify/App/issues/13685

### Tests
1. Log into the same account in two different tabs, A and B
2. On tab A, navigate to `Settings > Preferences`
3. On tab B, navigate to `Workspace > Reimburse expenses`
4. Note that the value for `Track distance > Unit` is in the selected language
5. On tab A, change the language
6. On tab B, verify that the value for `Track distance > Unit` is translated accordingly
7. On tab B, navigate to a policy room, e.g. `#admins`
8. Tap the chat header and navigate to `Settings`
9. Note that the `Notify me about new messages` value is in the selected language
10. On tab A, change the language
11. On tab B, verify that the value for `Notify me about new messages` is translated accordingly

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
Same as test steps

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://user-images.githubusercontent.com/22219519/208523897-c3a97ec6-6c45-4b14-8066-b489a5e20685.mov

</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://user-images.githubusercontent.com/22219519/208523925-ce251c69-4d4e-468c-8abb-a6d561c27022.mov

</details>

<details>
<summary>Mobile Web - Safari</summary>

https://user-images.githubusercontent.com/22219519/208523947-05e0aadc-b4a2-4be6-ac6b-2c2011f11a6b.mov

</details>

<details>
<summary>Desktop</summary>

https://user-images.githubusercontent.com/22219519/208523967-3e3d305f-a18f-493a-b190-46fecbe1a1a5.mov

</details>

<details>
<summary>iOS</summary>

https://user-images.githubusercontent.com/22219519/208523997-e5339ac6-9254-4759-8e9c-955d560a5be3.mov

</details>

<details>
<summary>Android</summary>

https://user-images.githubusercontent.com/22219519/208524022-a6afe040-844b-4ce4-8abc-b899f5dd7c09.mov

</details>
