### PR TITLE
Add tiny padding-bottom to button text

### DIFF
--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -487,7 +487,7 @@ const styles = {
         marginRight: 22,
 
         // Align vertically with the Button text
-        paddingBottom: 2,
+        paddingBottom: 1,
     },
 
     buttonConfirm: {

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -373,6 +373,7 @@ const styles = {
         // It is needed to unset the Lineheight. We don't need it for buttons as button always contains single line of text.
         // It allows to vertically center the text.
         lineHeight: undefined,
+        paddingBottom: 1,
     },
 
     buttonSmall: {

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -373,6 +373,8 @@ const styles = {
         // It is needed to unset the Lineheight. We don't need it for buttons as button always contains single line of text.
         // It allows to vertically center the text.
         lineHeight: undefined,
+
+        // Add 1px to the Button text to give optical vertical alignment.
         paddingBottom: 1,
     },
 

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -488,6 +488,7 @@ const styles = {
 
         // Align vertically with the Button text
         paddingBottom: 1,
+        paddingTop: 1,
     },
 
     buttonConfirm: {

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -485,6 +485,9 @@ const styles = {
 
     buttonCTAIcon: {
         marginRight: 22,
+
+        // Align vertically with the Button text
+        paddingBottom: 2,
     },
 
     buttonConfirm: {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Adds 1px padding-bottom to the button text to achieve the vertical optical alignment and also adds 1px for both padding-bottom and padding-top to the button left icon to align it along with the button text (otherwise it will look a bit misaligned with the change to the button text, more details [here](https://github.com/Expensify/App/issues/13682)).

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/13682

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Go to settings > manage members
1. Verify the invite and remove button text are vertically aligned 

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

Same as `Test` steps

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->


- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

<img width="923" alt="Screenshot 2022-12-27 at 17 14 11" src="https://user-images.githubusercontent.com/6829422/209735528-6f34d8a6-b04f-41a2-96c0-f69d4321e4df.png">

<img width="923" alt="Screenshot 2022-12-27 at 17 14 37" src="https://user-images.githubusercontent.com/6829422/209735533-564c296e-34e8-4f47-ae5d-5fc6aadca8e3.png">

<img width="923" alt="Screenshot 2022-12-27 at 18 04 22" src="https://user-images.githubusercontent.com/6829422/209857535-a94496de-715e-4b0a-b718-053c11ec87c0.png">

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

<img width="354" alt="Screenshot 2022-12-27 at 17 17 17" src="https://user-images.githubusercontent.com/6829422/209735657-c7b02567-129d-4f3f-a5c0-ea4ccb2c4f8a.png">

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

<img width="420" alt="Screenshot 2022-12-27 at 17 19 08" src="https://user-images.githubusercontent.com/6829422/209735722-0883e72d-2171-40f2-89e0-f6043e75209b.png">


</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

<img width="1202" alt="Screenshot 2022-12-27 at 17 21 07" src="https://user-images.githubusercontent.com/6829422/209735833-ff526fda-a313-4489-8636-80cb4a79a5c7.png">


</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

<img width="426" alt="Screenshot 2022-12-27 at 17 22 03" src="https://user-images.githubusercontent.com/6829422/209735916-ecb69f23-9e39-4cc6-8631-bc65a40984e6.png">

<img width="436" alt="Screenshot 2022-12-27 at 17 22 28" src="https://user-images.githubusercontent.com/6829422/209735919-724abaa0-4710-4708-9062-daa72ccb2ff1.png">

<img width="427" alt="Screenshot 2022-12-27 at 17 22 15" src="https://user-images.githubusercontent.com/6829422/209735920-e373df67-6990-44ee-a10f-7a6de3348cbd.png">


</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

<img width="352" alt="Screenshot 2022-12-27 at 17 25 09" src="https://user-images.githubusercontent.com/6829422/209736037-617eea93-19dd-41c8-8ffa-471f39f2802a.png">

<img width="360" alt="Screenshot 2022-12-27 at 17 24 30" src="https://user-images.githubusercontent.com/6829422/209736046-1c9bbb04-0112-493c-af26-c78b42aaeb38.png">


</details>
