### PR TITLE
apply dark theme throughout the app

### DIFF
--- a/android/app/src/main/java/com/expensify/chat/MainApplication.java
+++ b/android/app/src/main/java/com/expensify/chat/MainApplication.java
@@ -3,6 +3,7 @@ package com.expensify.chat;
 import android.content.Context;
 import android.database.CursorWindow;
 
+import androidx.appcompat.app.AppCompatDelegate;
 import androidx.multidex.MultiDexApplication;
 
 import com.expensify.chat.bootsplash.BootSplashPackage;
@@ -64,6 +65,7 @@ public class MainApplication extends MultiDexApplication implements ReactApplica
   @Override
   public void onCreate() {
       super.onCreate();
+      AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES);
       // If you opted-in for the New Architecture, we enable the TurboModule system
       ReactFeatureFlags.useTurboModules = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED;
       SoLoader.init(this, /* native exopackage */ false);

--- a/android/app/src/main/java/com/expensify/chat/MainApplication.java
+++ b/android/app/src/main/java/com/expensify/chat/MainApplication.java
@@ -65,7 +65,10 @@ public class MainApplication extends MultiDexApplication implements ReactApplica
   @Override
   public void onCreate() {
       super.onCreate();
+
+      // Use night (dark) mode so native UI defaults to dark theme.
       AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES);
+      
       // If you opted-in for the New Architecture, we enable the TurboModule system
       ReactFeatureFlags.useTurboModules = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED;
       SoLoader.init(this, /* native exopackage */ false);

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -4,7 +4,7 @@
     <style name="AppTheme" parent="BaseAppTheme"/>
 
     <!-- Base application theme. Applied to all Android versions -->
-    <style name="BaseAppTheme" parent="Theme.AppCompat.Light.NoActionBar">
+    <style name="BaseAppTheme" parent="Theme.AppCompat.NoActionBar">
         <item name="android:textColor">@color/dark</item>
         <item name="android:colorEdgeEffect">@color/gray4</item>
         <item name="android:statusBarColor">#061B09</item>

--- a/ios/NewExpensify/Info.plist
+++ b/ios/NewExpensify/Info.plist
@@ -111,6 +111,8 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 	</array>
+	<key>UIUserInterfaceStyle</key>
+	<string>Dark</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 </dict>

--- a/web/index.html
+++ b/web/index.html
@@ -23,6 +23,9 @@
         #root > div > div {
             height: 100% !important;
         }
+        :root {
+            color-scheme: dark;
+        }
         #drag-area {
             -webkit-app-region: drag;
         }


### PR DESCRIPTION
### Details
force dark theme on all platforms

### Fixed Issues
$ https://github.com/Expensify/App/issues/12914
PROPOSAL: https://github.com/Expensify/App/issues/12914#issuecomment-1364423999


### Tests
1. Login with any account
2. Go to any chat room
3. In composer, click the Emoji button
4. Verify that the scroll bar looks "well" in the dark mode

- [x] Verify that no errors appear in the JS console

### Offline tests
1. Login with any account
2. Go to any chat room
3. Disable network
4. In composer, click the Emoji button
5. Verify that the scroll bar looks "well" in the dark mode

### QA Steps
1. Login with any account
2. Go to any chat room
3. In composer, click the Emoji button
4. Verify that the scroll bar looks "well" in the dark mode

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

Chrome (Mac):
<img width="325" alt="chrome-mac" src="https://user-images.githubusercontent.com/97473779/209415126-845913eb-d5fa-4f13-9ea3-5d42f4a28f24.png">

Chrome (Windows) (thumb active):
![chrome-windows](https://user-images.githubusercontent.com/97473779/209415133-63caf9a5-66fc-4d8d-abc4-df1b88529221.png)

Chrome (Windows) (thumb inactive):
![chrome-windows1](https://user-images.githubusercontent.com/97473779/209415500-cd745730-9e11-4d18-b807-90a124fde3ed.png)

Firefox (Windows):
![firefox](https://user-images.githubusercontent.com/97473779/209415512-95cad98c-524f-44b3-8c0e-4ace144beabc.png)


Safari (Mac):
<img width="322" alt="safari" src="https://user-images.githubusercontent.com/97473779/209415142-b1a437c9-e1cd-495a-8fb2-893f0e8897e5.png">

</details>

<details>
<summary>Mobile Web - Chrome</summary>

![mchrome1](https://user-images.githubusercontent.com/97473779/209885156-67407600-dadb-442e-b04a-8cb26c37e41e.jpg)
![mchrome2](https://user-images.githubusercontent.com/97473779/209885162-1c5f33fb-1cd6-4e69-b321-8598bec462a5.jpg)


</details>

<details>
<summary>Mobile Web - Safari</summary>

![msafari1](https://user-images.githubusercontent.com/97473779/209885224-fcc116b4-7f0b-47cf-8e66-559c6a268925.png)
![msafari2](https://user-images.githubusercontent.com/97473779/209885238-5ea8cd79-a394-4ff4-b6c8-7ac609dafb07.png)


</details>

<details>
<summary>Desktop</summary>


https://user-images.githubusercontent.com/97473779/209885495-21e13c78-1ee2-48d0-aafc-0b424a6fe143.mov



</details>

<details>
<summary>iOS</summary>

![ios](https://user-images.githubusercontent.com/97473779/209411034-1ec8e08d-bac0-4816-ae44-64ca87574a61.png)
![ios2](https://user-images.githubusercontent.com/97473779/209414970-9b0bd45b-ba58-4873-a6e6-a796572cf162.png)


</details>

<details>
<summary>Android</summary>

![android1](https://user-images.githubusercontent.com/97473779/209414980-dc956bef-8e94-4ca1-87e8-0a46bfd8e8d2.jpg)
![android2](https://user-images.githubusercontent.com/97473779/209414987-5fdf1e3b-3b5f-4ef6-8c3f-4fecb6770c99.jpg)

</details>
