### PR TITLE
Ignore close action for archived workspace chats

### DIFF
--- a/src/libs/ReportActionsUtils.js
+++ b/src/libs/ReportActionsUtils.js
@@ -79,6 +79,11 @@ function filterReportActionsForDisplay(reportActions) {
             return false;
         }
 
+        // Ignore closed action here since we're already displaying a footer that explains why the report was closed
+        if (reportAction.actionName === CONST.REPORT.ACTIONS.TYPE.CLOSED) {
+            return false;
+        }
+
         // All other actions are displayed except deleted, non-pending actions
         const isDeleted = isDeletedAction(reportAction);
         const isPending = !_.isEmpty(reportAction.pendingAction);

--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -170,10 +170,6 @@ class ReportActionItem extends Component {
     }
 
     render() {
-        // Ignore closed action here since we're already displaying a footer that explains why the report was closed
-        if (this.props.action.actionName === CONST.REPORT.ACTIONS.TYPE.CLOSED) {
-            return null;
-        }
         if (this.props.action.actionName === CONST.REPORT.ACTIONS.TYPE.CREATED) {
             return <ReportActionItemCreated reportID={this.props.report.reportID} />;
         }

--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -170,6 +170,10 @@ class ReportActionItem extends Component {
     }
 
     render() {
+        // Ignore closed action here since we're already displaying a footer that explains why the report was closed
+        if (this.props.action.actionName === CONST.REPORT.ACTIONS.TYPE.CLOSED) {
+            return null;
+        }
         if (this.props.action.actionName === CONST.REPORT.ACTIONS.TYPE.CREATED) {
             return <ReportActionItemCreated reportID={this.props.report.reportID} />;
         }

--- a/tests/unit/ReportActionsUtilsTest.js
+++ b/tests/unit/ReportActionsUtilsTest.js
@@ -74,7 +74,31 @@ describe('ReportActionsUtils', () => {
                     message: [{html: 'Hello world'}],
                 },
                 {
-                    actionName: CONST.REPORT.ACTIONS.TYPE.CLOSED,
+                    actionName: CONST.REPORT.ACTIONS.TYPE.CREATED,
+                    message: [{html: 'Hello world'}],
+                },
+                {
+                    actionName: CONST.REPORT.ACTIONS.TYPE.IOU,
+                    message: [{html: 'Hello world'}],
+                },
+                {
+                    actionName: CONST.REPORT.ACTIONS.TYPE.RENAMED,
+                    message: [{html: 'Hello world'}],
+                },
+                {
+                    actionName: 'REIMBURSED',
+                    message: [{html: 'Hello world'}],
+                },
+            ];
+            const result = ReportActionsUtils.filterReportActionsForDisplay(input);
+            input.pop();
+            expect(result).toStrictEqual(input);
+        });
+
+        it('should filter out closed actions', () => {
+            const input = [
+                {
+                    actionName: CONST.REPORT.ACTIONS.TYPE.ADDCOMMENT,
                     message: [{html: 'Hello world'}],
                 },
                 {
@@ -90,7 +114,7 @@ describe('ReportActionsUtils', () => {
                     message: [{html: 'Hello world'}],
                 },
                 {
-                    actionName: 'REIMBURSED',
+                    actionName: CONST.REPORT.ACTIONS.TYPE.CLOSED,
                     message: [{html: 'Hello world'}],
                 },
             ];


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Ignore the close action that was originally generated for OldDot (more details [here](https://expensify.slack.com/archives/C01GTK53T8Q/p1672259353511219)), since we're already displaying the footer when a chat report is closed.

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/13839

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Create a Workspace chat (Go to Settings > Workspaces > New workspace)
2. Delete it
3. Open the archived workspace chat 
4. Verify the message "You closed this report" doesn't appear (just the footer explaining why the workspace chate is no longer active).

- [ ] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
5. Upload an image via copy paste
6. Verify a modal appears displaying a preview of that image
--->

Same as `Test` steps.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.


### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

<img width="809" alt="Screenshot 2022-12-29 at 13 04 12" src="https://user-images.githubusercontent.com/6829422/209997794-f849b0ad-2a4e-4185-af97-5f13af1106e4.png">

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

<img width="357" alt="Screenshot 2022-12-29 at 13 06 37" src="https://user-images.githubusercontent.com/6829422/209997826-3aa0ac0b-524c-497b-8f0d-044e6754b462.png">


</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

<img width="438" alt="Screenshot 2022-12-29 at 13 04 43" src="https://user-images.githubusercontent.com/6829422/209997837-1dbbcf3e-9a45-4280-8786-d8ba6b249265.png">


</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

<img width="1201" alt="Screenshot 2022-12-29 at 13 08 33" src="https://user-images.githubusercontent.com/6829422/209997911-4089603f-f978-41aa-ae7c-92fff2d7e071.png">

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

<img width="425" alt="Screenshot 2022-12-29 at 13 07 00" src="https://user-images.githubusercontent.com/6829422/209997857-aa4b29e3-3e5e-4aac-9467-3b8e2295f834.png">


</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

<img width="357" alt="Screenshot 2022-12-29 at 13 14 57" src="https://user-images.githubusercontent.com/6829422/209999493-7a418373-1e94-4cd4-be77-726b6534bec9.png">

</details>
