### PR TITLE
[Refactor] Report Settings Page to use Form component

### DIFF
--- a/src/ONYXKEYS.js
+++ b/src/ONYXKEYS.js
@@ -173,6 +173,7 @@ export default {
         PROFILE_SETTINGS_FORM: 'profileSettingsForm',
         DISPLAY_NAME_FORM: 'displayNameForm',
         NEW_ROOM_FORM: 'newRoomForm',
+        ROOM_SETTINGS_FORM: 'roomSettingsForm',
     },
 
     // Whether we should show the compose input or not

--- a/src/pages/ReportSettingsPage.js
+++ b/src/pages/ReportSettingsPage.js
@@ -100,7 +100,7 @@ class ReportSettingsPage extends Component {
 
         // When the report name is not changed, skip the form submission. Added check here to keep the code clean
         if (values.newRoomName === this.props.report.reportName) {
-            return false;
+            return errors;
         }
 
         // Show error if the room name already exists

--- a/src/pages/ReportSettingsPage.js
+++ b/src/pages/ReportSettingsPage.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import {View, ScrollView, Keyboard} from 'react-native';
+import {View, Keyboard} from 'react-native';
 import {withOnyx} from 'react-native-onyx';
 import _ from 'underscore';
 import lodashGet from 'lodash/get';
@@ -22,6 +22,7 @@ import * as ValidationUtils from '../libs/ValidationUtils';
 import OfflineWithFeedback from '../components/OfflineWithFeedback';
 import reportPropTypes from './reportPropTypes';
 import withReportOrNavigateHome from './home/report/withReportOrNavigateHome';
+import Form from '../components/Form';
 
 const propTypes = {
     /** Route params */
@@ -144,7 +145,12 @@ class ReportSettingsPage extends Component {
                     onBackButtonPress={Navigation.goBack}
                     onCloseButtonPress={Navigation.dismissModal}
                 />
-                <ScrollView style={styles.flex1} contentContainerStyle={styles.p5} keyboardShouldPersistTaps="handled">
+                <Form
+                    formID={ONYXKEYS.FORMS.ROOM_SETTINGS_FORM}
+                    submitButtonText={this.props.translate('common.save')}
+                    style={[styles.mh5, styles.mt5, styles.flexGrow1]}
+                    enabledWhenOffline
+                >
                     <View>
                         <View style={[styles.mt2]}>
                             <Picker
@@ -238,7 +244,7 @@ class ReportSettingsPage extends Component {
                             </Text>
                         </View>
                     )}
-                </ScrollView>
+                </Form>
             </ScreenWrapper>
         );
     }

--- a/src/pages/ReportSettingsPage.js
+++ b/src/pages/ReportSettingsPage.js
@@ -53,10 +53,6 @@ class ReportSettingsPage extends Component {
     constructor(props) {
         super(props);
 
-        this.state = {
-            newRoomName: this.props.report.reportName,
-        };
-
         this.validate = this.validate.bind(this);
         this.validateAndUpdatePolicyRoomName = this.validateAndUpdatePolicyRoomName.bind(this);
     }
@@ -165,7 +161,7 @@ class ReportSettingsPage extends Component {
                                                     {this.props.translate('newRoomPage.roomName')}
                                                 </Text>
                                                 <Text numberOfLines={1} style={[styles.optionAlternateText]}>
-                                                    {this.state.newRoomName}
+                                                    {this.props.report.reportName}
                                                 </Text>
                                             </View>
                                         )

--- a/src/pages/ReportSettingsPage.js
+++ b/src/pages/ReportSettingsPage.js
@@ -54,7 +54,7 @@ class ReportSettingsPage extends Component {
         super(props);
 
         this.validate = this.validate.bind(this);
-        this.validateAndUpdatePolicyRoomName = this.validateAndUpdatePolicyRoomName.bind(this);
+        this.updatePolicyRoomName = this.updatePolicyRoomName.bind(this);
     }
 
     getNotificationPreferenceOptions() {
@@ -68,7 +68,7 @@ class ReportSettingsPage extends Component {
     /**
      * @param {Object} values - form input values passed by the Form component
      */
-    validateAndUpdatePolicyRoomName(values) {
+    updatePolicyRoomName(values) {
         Keyboard.dismiss();
 
         // When the room name has not changed, skip the Form submission
@@ -128,7 +128,7 @@ class ReportSettingsPage extends Component {
                     submitButtonText={this.props.translate('common.save')}
                     style={[styles.mh5, styles.mt5, styles.flexGrow1]}
                     validate={this.validate}
-                    onSubmit={this.validateAndUpdatePolicyRoomName}
+                    onSubmit={this.updatePolicyRoomName}
                     isSubmitButtonVisible={shouldShowRoomName && !shouldDisableRename}
                     enabledWhenOffline
                 >

--- a/src/pages/ReportSettingsPage.js
+++ b/src/pages/ReportSettingsPage.js
@@ -15,7 +15,6 @@ import HeaderWithCloseButton from '../components/HeaderWithCloseButton';
 import ScreenWrapper from '../components/ScreenWrapper';
 import withLocalize, {withLocalizePropTypes} from '../components/withLocalize';
 import Text from '../components/Text';
-import Button from '../components/Button';
 import RoomNameInput from '../components/RoomNameInput';
 import Picker from '../components/Picker';
 import * as ValidationUtils from '../libs/ValidationUtils';
@@ -152,6 +151,7 @@ class ReportSettingsPage extends Component {
                     submitButtonText={this.props.translate('common.save')}
                     style={[styles.mh5, styles.mt5, styles.flexGrow1]}
                     validate={this.validate}
+                    isSubmitButtonVisible={shouldShowRoomName && !shouldDisableRename}
                     enabledWhenOffline
                 >
                     <View>
@@ -201,18 +201,6 @@ class ReportSettingsPage extends Component {
                                                 />
                                             )}
                                     </View>
-                                    {!shouldDisableRename && (
-                                        <Button
-                                            large
-                                            success={!shouldDisableRename}
-                                            text={this.props.translate('common.save')}
-                                            onPress={this.validateAndUpdatePolicyRoomName}
-                                            style={[styles.ml2, styles.mnw25]}
-                                            textStyles={[styles.label]}
-                                            innerStyles={[styles.saveButtonPadding]}
-                                            isDisabled={shouldDisableRename}
-                                        />
-                                    )}
                                 </View>
                             </OfflineWithFeedback>
                         </View>

--- a/src/pages/ReportSettingsPage.js
+++ b/src/pages/ReportSettingsPage.js
@@ -60,7 +60,7 @@ class ReportSettingsPage extends Component {
 
         this.validate = this.validate.bind(this);
         this.resetToPreviousName = this.resetToPreviousName.bind(this);
-        this.validateAndUpdatePolicyRoomName = this.validateAndUpdatePolicyRoomName.bind(this);
+        this.submit = this.submit.bind(this);
     }
 
     getNotificationPreferenceOptions() {
@@ -80,12 +80,12 @@ class ReportSettingsPage extends Component {
         Report.clearPolicyRoomNameErrors(this.props.report.reportID);
     }
 
-    validateAndUpdatePolicyRoomName() {
-        if (!this.validate()) {
-            return;
-        }
+    /**
+     * @param {Object} values - form input values passed by the Form component
+     */
+    submit(values) {
         Keyboard.dismiss();
-        Report.updatePolicyRoomName(this.props.report, this.state.newRoomName);
+        Report.updatePolicyRoomName(this.props.report, values.newRoomName);
     }
 
     /**
@@ -151,6 +151,7 @@ class ReportSettingsPage extends Component {
                     submitButtonText={this.props.translate('common.save')}
                     style={[styles.mh5, styles.mt5, styles.flexGrow1]}
                     validate={this.validate}
+                    onSubmit={this.submit}
                     isSubmitButtonVisible={shouldShowRoomName && !shouldDisableRename}
                     enabledWhenOffline
                 >

--- a/src/pages/ReportSettingsPage.js
+++ b/src/pages/ReportSettingsPage.js
@@ -70,6 +70,11 @@ class ReportSettingsPage extends Component {
      */
     validateAndUpdatePolicyRoomName(values) {
         Keyboard.dismiss();
+
+        // When the room name has not changed, skip the Form submission
+        if (values.newRoomName === this.props.report.reportName) {
+            return;
+        }
         Report.updatePolicyRoomName(this.props.report, values.newRoomName);
     }
 
@@ -81,6 +86,7 @@ class ReportSettingsPage extends Component {
         const errors = {};
 
         // When the report name is not changed, skip the form submission. Added check here to keep the code clean
+        // We should skip validation hence we return an empty errors and we skip Form submission on the onSubmit method
         if (values.newRoomName === this.props.report.reportName) {
             return errors;
         }

--- a/src/pages/ReportSettingsPage.js
+++ b/src/pages/ReportSettingsPage.js
@@ -174,7 +174,6 @@ class ReportSettingsPage extends Component {
                                                 <RoomNameInput
                                                     inputID="newRoomName"
                                                     defaultValue={this.props.report.reportName}
-                                                    disabled={shouldDisableRename}
                                                 />
                                             )}
                                     </View>

--- a/src/pages/ReportSettingsPage.js
+++ b/src/pages/ReportSettingsPage.js
@@ -85,7 +85,6 @@ class ReportSettingsPage extends Component {
     validate(values) {
         const errors = {};
 
-        // When the report name is not changed, skip the form submission. Added check here to keep the code clean
         // We should skip validation hence we return an empty errors and we skip Form submission on the onSubmit method
         if (values.newRoomName === this.props.report.reportName) {
             return errors;

--- a/src/pages/ReportSettingsPage.js
+++ b/src/pages/ReportSettingsPage.js
@@ -61,6 +61,7 @@ class ReportSettingsPage extends Component {
             errors: {},
         };
 
+        this.validate = this.validate.bind(this);
         this.resetToPreviousName = this.resetToPreviousName.bind(this);
         this.validateAndUpdatePolicyRoomName = this.validateAndUpdatePolicyRoomName.bind(this);
     }

--- a/src/pages/ReportSettingsPage.js
+++ b/src/pages/ReportSettingsPage.js
@@ -54,8 +54,6 @@ class ReportSettingsPage extends Component {
     constructor(props) {
         super(props);
 
-        this.roomNameInputRef = null;
-
         this.state = {
             newRoomName: this.props.report.reportName,
             errors: {},
@@ -197,11 +195,9 @@ class ReportSettingsPage extends Component {
                                         )
                                             : (
                                                 <RoomNameInput
-                                                    ref={el => this.roomNameInputRef = el}
-                                                    value={this.state.newRoomName}
+                                                    inputID="newRoomName"
+                                                    defaultValue={this.props.report.reportName}
                                                     policyID={linkedWorkspace && linkedWorkspace.id}
-                                                    errorText={this.state.errors.newRoomName}
-                                                    onChangeText={newRoomName => this.clearErrorAndSetValue('newRoomName', newRoomName)}
                                                     disabled={shouldDisableRename}
                                                 />
                                             )}

--- a/src/pages/ReportSettingsPage.js
+++ b/src/pages/ReportSettingsPage.js
@@ -59,7 +59,7 @@ class ReportSettingsPage extends Component {
 
         this.validate = this.validate.bind(this);
         this.resetToPreviousName = this.resetToPreviousName.bind(this);
-        this.submit = this.submit.bind(this);
+        this.validateAndUpdatePolicyRoomName = this.validateAndUpdatePolicyRoomName.bind(this);
     }
 
     getNotificationPreferenceOptions() {
@@ -82,7 +82,7 @@ class ReportSettingsPage extends Component {
     /**
      * @param {Object} values - form input values passed by the Form component
      */
-    submit(values) {
+    validateAndUpdatePolicyRoomName(values) {
         Keyboard.dismiss();
         Report.updatePolicyRoomName(this.props.report, values.newRoomName);
     }
@@ -136,7 +136,7 @@ class ReportSettingsPage extends Component {
                     submitButtonText={this.props.translate('common.save')}
                     style={[styles.mh5, styles.mt5, styles.flexGrow1]}
                     validate={this.validate}
-                    onSubmit={this.submit}
+                    onSubmit={this.validateAndUpdatePolicyRoomName}
                     isSubmitButtonVisible={shouldShowRoomName && !shouldDisableRename}
                     enabledWhenOffline
                 >

--- a/src/pages/ReportSettingsPage.js
+++ b/src/pages/ReportSettingsPage.js
@@ -197,7 +197,6 @@ class ReportSettingsPage extends Component {
                                                 <RoomNameInput
                                                     inputID="newRoomName"
                                                     defaultValue={this.props.report.reportName}
-                                                    policyID={linkedWorkspace && linkedWorkspace.id}
                                                     disabled={shouldDisableRename}
                                                 />
                                             )}

--- a/src/pages/ReportSettingsPage.js
+++ b/src/pages/ReportSettingsPage.js
@@ -55,7 +55,6 @@ class ReportSettingsPage extends Component {
 
         this.state = {
             newRoomName: this.props.report.reportName,
-            errors: {},
         };
 
         this.validate = this.validate.bind(this);
@@ -116,20 +115,6 @@ class ReportSettingsPage extends Component {
         }
 
         return errors;
-    }
-
-    /**
-     * @param {String} inputKey
-     * @param {String} value
-     */
-    clearErrorAndSetValue(inputKey, value) {
-        this.setState(prevState => ({
-            [inputKey]: value,
-            errors: {
-                ...prevState.errors,
-                [inputKey]: '',
-            },
-        }));
     }
 
     render() {

--- a/src/pages/ReportSettingsPage.js
+++ b/src/pages/ReportSettingsPage.js
@@ -58,7 +58,6 @@ class ReportSettingsPage extends Component {
         };
 
         this.validate = this.validate.bind(this);
-        this.resetToPreviousName = this.resetToPreviousName.bind(this);
         this.validateAndUpdatePolicyRoomName = this.validateAndUpdatePolicyRoomName.bind(this);
     }
 
@@ -68,15 +67,6 @@ class ReportSettingsPage extends Component {
             {value: CONST.REPORT.NOTIFICATION_PREFERENCE.DAILY, label: this.props.translate('notificationPreferences.daily')},
             {value: CONST.REPORT.NOTIFICATION_PREFERENCE.MUTE, label: this.props.translate('notificationPreferences.mute')},
         ];
-    }
-
-    /**
-     * When the user dismisses the error updating the policy room name,
-     * reset the report name to the previously saved name and clear errors.
-     */
-    resetToPreviousName() {
-        this.setState({newRoomName: this.props.report.reportName});
-        Report.clearPolicyRoomNameErrors(this.props.report.reportID);
     }
 
     /**
@@ -165,7 +155,7 @@ class ReportSettingsPage extends Component {
                             <OfflineWithFeedback
                                 pendingAction={lodashGet(this.props.report, 'pendingFields.reportName', null)}
                                 errors={lodashGet(this.props.report, 'errorFields.reportName', null)}
-                                onClose={this.resetToPreviousName}
+                                onClose={() => Report.clearPolicyRoomNameErrors(this.props.report.reportID)}
                             >
                                 <View style={[styles.flexRow]}>
                                     <View style={[styles.flex3]}>

--- a/src/pages/ReportSettingsPage.js
+++ b/src/pages/ReportSettingsPage.js
@@ -90,31 +90,34 @@ class ReportSettingsPage extends Component {
         Report.updatePolicyRoomName(this.props.report, this.state.newRoomName);
     }
 
-    validate() {
+    /**
+     * @param {Object} values - form input values passed by the Form component
+     * @returns {Boolean}
+     */
+    validate(values) {
         const errors = {};
 
         // When the report name is not changed, skip the form submission. Added check here to keep the code clean
-        if (this.state.newRoomName === this.props.report.reportName) {
+        if (values.newRoomName === this.props.report.reportName) {
             return false;
         }
 
         // Show error if the room name already exists
-        if (ValidationUtils.isExistingRoomName(this.state.newRoomName, this.props.reports, this.props.report.policyID)) {
+        if (ValidationUtils.isExistingRoomName(values.newRoomName, this.props.reports, this.props.report.policyID)) {
             errors.newRoomName = this.props.translate('newRoomPage.roomAlreadyExistsError');
         }
 
         // We error if the user doesn't enter a room name or left blank
-        if (!this.state.newRoomName || this.state.newRoomName === CONST.POLICY.ROOM_PREFIX) {
+        if (!values.newRoomName || values.newRoomName === CONST.POLICY.ROOM_PREFIX) {
             errors.newRoomName = this.props.translate('newRoomPage.pleaseEnterRoomName');
         }
 
         // Certain names are reserved for default rooms and should not be used for policy rooms.
-        if (ValidationUtils.isReservedRoomName(this.state.newRoomName)) {
+        if (ValidationUtils.isReservedRoomName(values.newRoomName)) {
             errors.newRoomName = this.props.translate('newRoomPage.roomNameReservedError');
         }
 
-        this.setState({errors});
-        return _.isEmpty(errors);
+        return errors;
     }
 
     /**
@@ -149,6 +152,7 @@ class ReportSettingsPage extends Component {
                     formID={ONYXKEYS.FORMS.ROOM_SETTINGS_FORM}
                     submitButtonText={this.props.translate('common.save')}
                     style={[styles.mh5, styles.mt5, styles.flexGrow1]}
+                    validate={this.validate}
                     enabledWhenOffline
                 >
                     <View>


### PR DESCRIPTION
@puneetlath, @mollfpr 

### Details

- Refactor the Report Settings Page form to use Form.js.

### Fixed Issues
$ #13915
https://github.com/Expensify/App/issues/13915#issuecomment-1368255827

### Tests / QA Steps
#### Test 1

1. Open Any room
2. Go to settings of that room and try saving the name without any change
3. Verify you don't see any error

#### Test 2

1. Choose Any Room
2. Go to settings of that room
3. Clear the room name input and click Save
4. Verify that this error occur : `Please enter a room name`
5. Enter used room name and verify that this error occur : `A room with this name already exists`
6. Verify that this error occur at bottom ; `Please fix the errors in the form before continuing.`
7. Click on `fix the errors` and verify that the room name input is focused
8. Enter a valid room name and click save then close settings screen
9. Room Updated successfully
10. Verify that this text appears on the chat body : `You renamed this room from #old to #new`

- [ ]   UI looks as it did before the refactor
- [x]   Values can be added and edited
- [x]   Errors are highlighted correctly (input border)
- [x]   Error messages show up correctly
- [ ]   Draft values are saved properly
- [x]   Form alerts are displayed correctly
- [x]   Clicking the fix the errors link focuses the first input with error
- [x]   No duplicate submission of the form occurs (when it's already submitting)
- [x]   Verify that no errors appear in the JS console

### Offline tests

#### Test 1

1. Choose Room go to settings
2. Change the room name 
3. Click Save
4. Verified that the form can be submitted and the button is enabled

#### Test 2

1. Open account in offline browser
2. Open same account on another online browser
3. Add new room on the online browser name it to `newRoomTest` and then close the browser
4. Go back to offline browser and continue there
5. Open an existing room and go to setting
6. Change the room name to `newRoomTest`
7. Click Save and verified that the form can be submitted and the button is enabled
8. Verify that the room header on the chat page changed to `#newRoomTest`
9. Now go from offline to online (same browser)
10. Verify that there is red Dot Indicator appears on chat header
11. Go to settings of that room
12. Verify that this error occur `A room with this name already exists.`
13. Click close button of that error and verify that the error dismissed
14. Verify that room name input holds the old room name value

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://user-images.githubusercontent.com/36869046/210188166-cf93d31b-824d-41ad-9b56-e1f327cb9cc4.mov

</details>

<details>
<summary>Mobile Web - Chrome</summary>

![Screenshot_1672623572](https://user-images.githubusercontent.com/36869046/210190046-808f46f5-c47e-4aff-9df6-1f4d41493a4a.png)

![Screenshot_1672623582](https://user-images.githubusercontent.com/36869046/210190047-d1fa2ffa-674f-4af3-b670-45bb9bbc5f64.png)

https://user-images.githubusercontent.com/36869046/210190051-dea082d9-88e2-4b15-8113-88858af35945.mov

</details>

<details>
<summary>Mobile Web - Safari</summary>

https://user-images.githubusercontent.com/36869046/210190411-18b475a7-8a9b-44e5-a030-11de5b4ac87a.mp4

</details>

<details>
<summary>Desktop</summary>

https://user-images.githubusercontent.com/36869046/210188230-b8c0842b-509a-47cb-8978-9986c1b130d7.mov

</details>

<details>
<summary>iOS</summary>

https://user-images.githubusercontent.com/36869046/210188514-49b0f110-bff5-4098-a6b3-db6a2a74ed93.mp4

</details>

<details>
<summary>Android</summary>

https://user-images.githubusercontent.com/36869046/210189435-e28cafc7-c367-4f95-82f2-811696e7f592.mov

</details>
