### PR TITLE
Update CODEOWNERS so that we don't accidentally deploy a new version of react-native-onyx

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,5 @@
 # Every PR gets a review from an internal Expensify engineer
 * @Expensify/pullerbear
+
+# Tim reviews all changes to package.json to ensure we don't roll out SQLite Onyx until we are ready
+package.json @tgolen


### PR DESCRIPTION
# Problem
`react-native-onyx` has had [this PR](https://github.com/Expensify/react-native-onyx/pull/211) merged to `main` which adds SQLite support, but we are not ready to deploy it to App yet.

# Solution
I will review all PRs with changes to `package.json` to ensure it doesn't get deployed.

### Tests
None

### Offline tests
None

### QA Steps
Internal QA:
1. Create a PR that modifies `package.json`
2. Verify that I am assigned to it for review

### PR Author Checklist
Checklist doesn't apply to any of the changes in this PR

### Screenshots/Videos
Screenshots don't apply to this PR