### PR TITLE
[No QA] Revert "Update CODEOWNERS so that we don't accidentally deploy a new version of react-native-onyx"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,2 @@
 # Every PR gets a review from an internal Expensify engineer
 * @Expensify/pullerbear
-
-# Tim reviews all changes to package.json to ensure we don't roll out SQLite Onyx until we are ready
-package.json @tgolen


### PR DESCRIPTION
Reverts Expensify/App#13952

We are rolling out the SQLite upgrade today, so it's no longer necessary for me to review these PRs.

No testing or checklists required since this change doesn't affect the App code