### PR TITLE
Find LHN lastActorDetails from global personal details rather than the participants list

### DIFF
--- a/src/libs/SidebarUtils.js
+++ b/src/libs/SidebarUtils.js
@@ -249,7 +249,7 @@ function getOptionData(reportID) {
         lastMessageTextFromReport = Str.htmlDecode(report ? report.lastMessageText : '');
     }
 
-    const lastActorDetails = personalDetails[report.lastActorEmail] || {displayName: Str.removeSMSDomain(report.lastActorEmail)};
+    const lastActorDetails = personalDetails[report.lastActorEmail] || null;
     let lastMessageText = hasMultipleParticipants && lastActorDetails && (lastActorDetails.login !== currentUserLogin.email)
         ? `${lastActorDetails.displayName}: `
         : '';

--- a/src/libs/SidebarUtils.js
+++ b/src/libs/SidebarUtils.js
@@ -216,9 +216,8 @@ function getOptionData(reportID) {
         isPolicyExpenseChat: false,
     };
 
-    const personalDetailMap = OptionsListUtils.getPersonalDetailsForLogins(report.participants, personalDetails);
-    const personalDetailList = _.values(personalDetailMap);
-    const personalDetail = personalDetailList[0] || {};
+    const participantPersonalDetailList = _.values(OptionsListUtils.getPersonalDetailsForLogins(report.participants, personalDetails));
+    const personalDetail = participantPersonalDetailList[0] || {};
 
     result.isChatRoom = ReportUtils.isChatRoom(report);
     result.isArchivedRoom = ReportUtils.isArchivedRoom(report);
@@ -237,11 +236,11 @@ function getOptionData(reportID) {
     result.tooltipText = ReportUtils.getReportParticipantsTitle(report.participants || []);
     result.hasOutstandingIOU = report.hasOutstandingIOU;
 
-    const hasMultipleParticipants = personalDetailList.length > 1 || result.isChatRoom || result.isPolicyExpenseChat;
+    const hasMultipleParticipants = participantPersonalDetailList.length > 1 || result.isChatRoom || result.isPolicyExpenseChat;
     const subtitle = ReportUtils.getChatRoomSubtitle(report, policies);
 
     // We only create tooltips for the first 10 users or so since some reports have hundreds of users, causing performance to degrade.
-    const displayNamesWithTooltips = ReportUtils.getDisplayNamesWithTooltips((personalDetailList || []).slice(0, 10), hasMultipleParticipants);
+    const displayNamesWithTooltips = ReportUtils.getDisplayNamesWithTooltips((participantPersonalDetailList || []).slice(0, 10), hasMultipleParticipants);
 
     let lastMessageTextFromReport = '';
     if (ReportUtils.isReportMessageAttachment({text: report.lastMessageText, html: report.lastMessageHtml})) {
@@ -250,7 +249,7 @@ function getOptionData(reportID) {
         lastMessageTextFromReport = Str.htmlDecode(report ? report.lastMessageText : '');
     }
 
-    const lastActorDetails = personalDetailMap[report.lastActorEmail] || null;
+    const lastActorDetails = personalDetails[report.lastActorEmail] || null;
     let lastMessageText = hasMultipleParticipants && lastActorDetails && (lastActorDetails.login !== currentUserLogin.email)
         ? `${lastActorDetails.displayName}: `
         : '';
@@ -296,9 +295,9 @@ function getOptionData(reportID) {
     const reportName = ReportUtils.getReportName(report, policies);
     result.text = reportName;
     result.subtitle = subtitle;
-    result.participantsList = personalDetailList;
+    result.participantsList = participantPersonalDetailList;
     result.icons = ReportUtils.getIcons(report, personalDetails, policies, personalDetail.avatar);
-    result.searchText = OptionsListUtils.getSearchText(report, reportName, personalDetailList, result.isChatRoom || result.isPolicyExpenseChat);
+    result.searchText = OptionsListUtils.getSearchText(report, reportName, participantPersonalDetailList, result.isChatRoom || result.isPolicyExpenseChat);
     result.displayNamesWithTooltips = displayNamesWithTooltips;
 
     return result;

--- a/src/libs/SidebarUtils.js
+++ b/src/libs/SidebarUtils.js
@@ -249,7 +249,7 @@ function getOptionData(reportID) {
         lastMessageTextFromReport = Str.htmlDecode(report ? report.lastMessageText : '');
     }
 
-    const lastActorDetails = personalDetails[report.lastActorEmail] || null;
+    const lastActorDetails = personalDetails[report.lastActorEmail] || {displayName: Str.removeSMSDomain(report.lastActorEmail)};
     let lastMessageText = hasMultipleParticipants && lastActorDetails && (lastActorDetails.login !== currentUserLogin.email)
         ? `${lastActorDetails.displayName}: `
         : '';


### PR DESCRIPTION
cc @tgolen 

### Details
We were unnecessarily grabbing personal details from the list of participants in the report. So if a user was removed from the report this would mean we would not be able to find their personal details. At the same time we already had the global `personalDetails` map in scope. So, just use that instead.

### Fixed Issues
$ https://github.com/Expensify/App/issues/13858   

### Tests
1. Sign in with User A
2. Go to Settings > Workspaces > New workspace
3. Go to Manage members and invite User B
4. Sign out and sign in with User B
5. Send a message to the invited workspace room
6. Sign out and sign in with User A again
7. Observe the last message on LHN with the user's name (e.g. User B: Hello)
8. Go to Settings > Workspace > Manage members
9. Remove User B
10. Make sure the last message in LHN still has the user's name (e.g. User B: Hello)

- [ ] Verify that no errors appear in the JS console

### Offline tests
1. Open up your workspace members like from the steps above
2. Go offline
3. Remove the user, you will see them optimistically crossed off: 
<img width="413" alt="Screenshot 2023-01-04 at 5 57 22 PM" src="https://user-images.githubusercontent.com/4741899/210684821-17fe0d3e-e359-4815-81e5-a39875d50c45.png">

4. Make sure you still see their name next to their message in the announce room: 
<img width="408" alt="Screenshot 2023-01-04 at 5 57 38 PM" src="https://user-images.githubusercontent.com/4741899/210684899-63e65cb3-c113-4d5f-a1d7-60586fe9b159.png">

### QA Steps
- Same as both sets of test steps above.

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://user-images.githubusercontent.com/4741899/210685497-5268c759-84bc-4266-9a32-6bf7dc94864f.mp4

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<img width="482" alt="Screenshot 2023-01-04 at 6 09 20 PM" src="https://user-images.githubusercontent.com/4741899/210685647-70b7371c-6743-4446-933a-baa737a26737.png">

</details>

<details>
<summary>Mobile Web - Safari</summary>

<img width="407" alt="Screenshot 2023-01-04 at 6 09 04 PM" src="https://user-images.githubusercontent.com/4741899/210685690-82338971-987f-497b-81eb-247378224f36.png">

</details>

<details>
<summary>Desktop</summary>

<img width="448" alt="Screenshot 2023-01-04 at 6 11 09 PM" src="https://user-images.githubusercontent.com/4741899/210685789-97e109e1-fbeb-45f4-9ecf-ead86554f4ef.png">

</details>

<details>
<summary>iOS</summary>

<img width="482" alt="Screenshot 2023-01-04 at 6 09 20 PM" src="https://user-images.githubusercontent.com/4741899/210685703-c1475ef8-0c93-4979-871a-8e2cda73cc35.png">

</details>

<details>
<summary>Android</summary>

<img width="485" alt="Screenshot 2023-01-04 at 6 08 58 PM" src="https://user-images.githubusercontent.com/4741899/210685655-009808fd-5b7b-4dab-a271-17f50c86665a.png">

</details>
