### PR TITLE
Refactor tooltip

### DIFF
--- a/src/components/Hoverable/hoverablePropTypes.js
+++ b/src/components/Hoverable/hoverablePropTypes.js
@@ -19,9 +19,6 @@ const propTypes = {
 
     /** Function that executes when the mouse leaves the children. */
     onHoverOut: PropTypes.func,
-
-    // If the mouse clicks outside, should we dismiss hover?
-    resetsOnClickOutside: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -29,7 +26,6 @@ const defaultProps = {
     containerStyles: [],
     onHoverIn: () => {},
     onHoverOut: () => {},
-    resetsOnClickOutside: false,
 };
 
 export {

--- a/src/components/Hoverable/index.js
+++ b/src/components/Hoverable/index.js
@@ -72,10 +72,6 @@ class Hoverable extends Component {
         if (!this.state.isHovered) {
             return;
         }
-        if (this.props.resetsOnClickOutside) {
-            this.setIsHovered(false);
-            return;
-        }
         if (this.wrapperView && !this.wrapperView.contains(event.target)) {
             this.setIsHovered(false);
         }
@@ -93,8 +89,24 @@ class Hoverable extends Component {
                         ref(el);
                     }
                 },
-                onMouseEnter: () => this.setIsHovered(true),
-                onMouseLeave: () => this.setIsHovered(false),
+                onMouseEnter: (el) => {
+                    this.setIsHovered(true);
+
+                    // Call the original onMouseEnter, if any
+                    const {onMouseEnter} = this.props.children;
+                    if (_.isFunction(onMouseEnter)) {
+                        onMouseEnter(el);
+                    }
+                },
+                onMouseLeave: (el) => {
+                    this.setIsHovered(false);
+
+                    // Call the original onMouseLeave, if any
+                    const {onMouseLeave} = this.props.children;
+                    if (_.isFunction(onMouseLeave)) {
+                        onMouseLeave(el);
+                    }
+                },
             });
         }
         return (

--- a/src/components/Modal/BaseModal.js
+++ b/src/components/Modal/BaseModal.js
@@ -8,6 +8,7 @@ import * as StyleUtils from '../../styles/StyleUtils';
 import themeColors from '../../styles/themes/default';
 import {propTypes as modalPropTypes, defaultProps as modalDefaultProps} from './modalPropTypes';
 import * as Modal from '../../libs/actions/Modal';
+import DomUtils from '../../libs/DomUtils';
 import getModalStyles from '../../styles/getModalStyles';
 import variables from '../../styles/variables';
 
@@ -90,6 +91,7 @@ class BaseModal extends PureComponent {
                 // Note: Escape key on web/desktop will trigger onBackButtonPress callback
                 // eslint-disable-next-line react/jsx-props-no-multi-spaces
                 onBackButtonPress={this.props.onClose}
+                onModalWillShow={DomUtils.blurActiveElement}
                 onModalShow={() => {
                     if (this.props.shouldSetModalVisibility) {
                         Modal.setModalVisibility(true);

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -155,7 +155,6 @@ class Tooltip extends PureComponent {
             <View
                 ref={el => this.wrapperView = el}
                 style={this.props.containerStyles}
-                onFocus={this.showTooltip}
                 onBlur={this.hideTooltip}
                 focusable
             >
@@ -172,15 +171,6 @@ class Tooltip extends PureComponent {
                     const {ref} = this.props.children;
                     if (_.isFunction(ref)) {
                         ref(el);
-                    }
-                },
-                onFocus: (el) => {
-                    this.showTooltip();
-
-                    // Call the original onFocus, if any
-                    const {onFocus} = this.props.children;
-                    if (_.isFunction(onFocus)) {
-                        onFocus(el);
                     }
                 },
                 onBlur: (el) => {

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -7,6 +7,7 @@ import withWindowDimensions from '../withWindowDimensions';
 import {propTypes, defaultProps} from './tooltipPropTypes';
 import TooltipSense from './TooltipSense';
 import makeCancellablePromise from '../../libs/MakeCancellablePromise';
+import * as Browser from '../../libs/Browser';
 
 class Tooltip extends PureComponent {
     constructor(props) {
@@ -79,6 +80,12 @@ class Tooltip extends PureComponent {
      * Display the tooltip in an animation.
      */
     showTooltip() {
+        // On mWeb we do not show Tooltips as there are no way to hide them besides blurring.
+        // That's due to that fact that on mWeb there is no MouseLeave events.
+        if (Browser.isMobile()) {
+            return;
+        }
+
         if (!this.state.isRendered) {
             this.setState({isRendered: true});
         }

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -63,7 +63,7 @@ class Tooltip extends PureComponent {
     getWrapperPosition() {
         return new Promise(((resolve) => {
             // Make sure the wrapper is mounted before attempting to measure it.
-            if (this.wrapperView) {
+            if (this.wrapperView && _.isFunction(this.wrapperView.measureInWindow)) {
                 this.wrapperView.measureInWindow((x, y, width, height) => resolve({
                     x, y, width, height,
                 }));
@@ -148,6 +148,9 @@ class Tooltip extends PureComponent {
             <View
                 ref={el => this.wrapperView = el}
                 style={this.props.containerStyles}
+                onFocus={this.showTooltip}
+                onBlur={this.hideTooltip}
+                focusable
             >
                 {this.props.children}
             </View>
@@ -156,15 +159,33 @@ class Tooltip extends PureComponent {
         if (this.props.absolute && React.isValidElement(this.props.children)) {
             child = React.cloneElement(React.Children.only(this.props.children), {
                 ref: (el) => {
-                    // Keep your own reference
                     this.wrapperView = el;
 
                     // Call the original ref, if any
                     const {ref} = this.props.children;
-                    if (typeof ref === 'function') {
+                    if (_.isFunction(ref)) {
                         ref(el);
                     }
                 },
+                onFocus: (el) => {
+                    this.showTooltip();
+
+                    // Call the original onFocus, if any
+                    const {onFocus} = this.props.children;
+                    if (_.isFunction(onFocus)) {
+                        onFocus(el);
+                    }
+                },
+                onBlur: (el) => {
+                    this.hideTooltip();
+
+                    // Call the original onBlur, if any
+                    const {onBlur} = this.props.children;
+                    if (_.isFunction(onBlur)) {
+                        onBlur(el);
+                    }
+                },
+                focusable: true,
             });
         }
         return (
@@ -189,7 +210,6 @@ class Tooltip extends PureComponent {
                     containerStyles={this.props.containerStyles}
                     onHoverIn={this.showTooltip}
                     onHoverOut={this.hideTooltip}
-                    resetsOnClickOutside
                 >
                     {child}
                 </Hoverable>

--- a/src/libs/DomUtils/index.js
+++ b/src/libs/DomUtils/index.js
@@ -1,0 +1,7 @@
+function blurActiveElement() {
+    document.activeElement.blur();
+}
+
+export default {
+    blurActiveElement,
+};

--- a/src/libs/DomUtils/index.native.js
+++ b/src/libs/DomUtils/index.native.js
@@ -1,0 +1,5 @@
+function blurActiveElement() {}
+
+export default {
+    blurActiveElement,
+};

--- a/src/libs/Navigation/NavigationRoot.js
+++ b/src/libs/Navigation/NavigationRoot.js
@@ -8,6 +8,7 @@ import AppNavigator from './AppNavigator';
 import FullScreenLoadingIndicator from '../../components/FullscreenLoadingIndicator';
 import themeColors from '../../styles/themes/default';
 import styles from '../../styles/styles';
+import DomUtils from '../DomUtils';
 import Log from '../Log';
 
 // https://reactnavigation.org/docs/themes
@@ -44,6 +45,12 @@ function parseAndLogRoute(state) {
     } else {
         Log.info('Navigating to route', false, {path: currentPath});
     }
+
+    // Clicking a button that does navigation will stay active even if it's out of view
+    // and it's tooltip will stay visible.
+    // We blur the element manually to fix that (especially for Safari).
+    // More info: https://github.com/Expensify/App/issues/13146
+    DomUtils.blurActiveElement();
 
     Navigation.setIsNavigationReady();
 }


### PR DESCRIPTION
@francoisl @mollfpr

### Details
Refactored the tooltips and achieved natural tooltip behaviour.
- Show tooltip on hover in ~or focus~ 
- Hide tooltip on hover out or blur


### Fixed Issues
$ https://github.com/Expensify/App/issues/13146   
PROPOSAL: https://github.com/Expensify/App/issues/13146#issuecomment-1372902581


### Tests

1. Login to any account
2. Open any chat (or any page that contain the context menu actions (copy to clipboard))
3. Click the copy to clipboard button
4. On Web and Desktop: Verify that before clicking you see "Copy to clipboard" tooltip and after clicking you see "Copied!" tooltip
5. On Native and mWeb: Verify that the button still works and no tooltip is shown

- [X] Verify that no errors appear in the JS console

**Important**: on Web, the test must be done on Safari (Chrome is already working fine).

### Offline tests
n/a

### QA Steps

1. Login to any account
2. Open any chat (or any page that contain the context menu actions (copy to clipboard))
3. Click the copy to clipboard button
4. On Web: Verify that before clicking you see "Copy to clipboard" tooltip and after clicking you see "Copied!" tooltip
5. On Native and mWeb: Verify that the button still works and no tooltip is shown

- [X] Verify that no errors appear in the JS console

**Important**: on Web, the test must be done on Safari (Chrome is already working fine).

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android / native
    - [X] Android / Chrome
    - [X] iOS / native
    - [X] iOS / Safari
    - [X] MacOS / Chrome / Safari
    - [X] MacOS / Desktop
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
    - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [X] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If a new component is created I verified that:
    - [X] A similar component doesn't exist in the codebase
    - [X] All props are defined accurately and each prop has a `/** comment above it */`
    - [X] The file is named correctly
    - [X] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [X] The only data being stored in the state is data necessary for rendering and nothing else
    - [X] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [X] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [X] All JSX used for rendering exists in the render method
    - [X] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>



https://user-images.githubusercontent.com/16493223/210907897-66476e50-0d18-4ba3-80db-2e0bb85d9c41.mp4


</details>

<details>
<summary>Mobile Web - Chrome</summary>



https://user-images.githubusercontent.com/16493223/210907937-940a1c7b-f124-4aba-afc5-8707524779ed.mp4


</details>

<details>
<summary>Mobile Web - Safari</summary>


https://user-images.githubusercontent.com/16493223/210908003-ffe73e7d-a5a8-4adf-bf1b-afc7ab99af3c.mp4



</details>

<details>
<summary>Desktop</summary>


https://user-images.githubusercontent.com/16493223/210908025-9e7f9cfd-a944-4a4e-9037-64f84f9b8112.mp4


</details>

<details>
<summary>iOS</summary>



https://user-images.githubusercontent.com/16493223/210908098-357104ed-721f-41f8-b3cd-8bdf3ca1bab4.mp4


</details>

<details>
<summary>Android</summary>



https://user-images.githubusercontent.com/16493223/210908433-3fd639f1-d5f8-42e3-9bb7-9e6d68012ab8.mp4


</details>
