### PR TITLE
[PROD QA] Navigate to Concierge chat from Statement

### DIFF
--- a/src/components/WalletStatementModal/index.js
+++ b/src/components/WalletStatementModal/index.js
@@ -32,14 +32,16 @@ class WalletStatementModal extends React.Component {
             return;
         }
 
+        if (e.data.type === 'CONCIERGE_NAVIGATE') {
+            Report.navigateToConciergeChat();
+        }
+
         if (e.data.type === 'STATEMENT_NAVIGATE' && e.data.url) {
             const iouRoutes = [ROUTES.IOU_REQUEST, ROUTES.IOU_SEND, ROUTES.IOU_BILL];
             const navigateToIOURoute = _.find(iouRoutes, iouRoute => e.data.url.includes(iouRoute));
             if (navigateToIOURoute) {
                 Navigation.navigate(navigateToIOURoute);
             }
-        } else if (e.data.type === 'CONCIERGE_NAVIGATE') {
-            Report.navigateToConciergeChat();
         }
     }
 

--- a/src/components/WalletStatementModal/index.js
+++ b/src/components/WalletStatementModal/index.js
@@ -11,6 +11,7 @@ import styles from '../../styles/styles';
 import FullScreenLoadingIndicator from '../FullscreenLoadingIndicator';
 import ROUTES from '../../ROUTES';
 import Navigation from '../../libs/Navigation/Navigation';
+import * as Report from '../../libs/actions/Report';
 
 class WalletStatementModal extends React.Component {
     constructor(props) {
@@ -27,13 +28,18 @@ class WalletStatementModal extends React.Component {
      * @param {MessageEvent} e
      */
     navigate(e) {
-        if (!e.data || e.data.type !== 'STATEMENT_NAVIGATE' || !e.data.url) {
+        if (!e.data || !e.data.type || (e.data.type !== 'STATEMENT_NAVIGATE' && e.data.type !== 'CONCIERGE_NAVIGATE')) {
             return;
         }
-        const iouRoutes = [ROUTES.IOU_REQUEST, ROUTES.IOU_SEND, ROUTES.IOU_BILL];
-        const navigateToIOURoute = _.find(iouRoutes, iouRoute => e.data.url.includes(iouRoute));
-        if (navigateToIOURoute) {
-            Navigation.navigate(navigateToIOURoute);
+
+        if (e.data.type === 'STATEMENT_NAVIGATE' && e.data.url) {
+            const iouRoutes = [ROUTES.IOU_REQUEST, ROUTES.IOU_SEND, ROUTES.IOU_BILL];
+            const navigateToIOURoute = _.find(iouRoutes, iouRoute => e.data.url.includes(iouRoute));
+            if (navigateToIOURoute) {
+                Navigation.navigate(navigateToIOURoute);
+            }
+        } else if (e.data.type === 'CONCIERGE_NAVIGATE') {
+            Report.navigateToConciergeChat();
         }
     }
 

--- a/src/components/WalletStatementModal/index.native.js
+++ b/src/components/WalletStatementModal/index.native.js
@@ -31,6 +31,11 @@ class WalletStatementModal extends React.Component {
             return;
         }
 
+        if (type === 'CONCIERGE_NAVIGATE') {
+            this.webview.stopLoading();
+            Report.navigateToConciergeChat();
+        }
+
         if (type === 'STATEMENT_NAVIGATE' && url) {
             const iouRoutes = [ROUTES.IOU_REQUEST, ROUTES.IOU_SEND, ROUTES.IOU_BILL];
             const navigateToIOURoute = _.find(iouRoutes, iouRoute => url.includes(iouRoute));
@@ -38,10 +43,6 @@ class WalletStatementModal extends React.Component {
                 this.webview.stopLoading();
                 Navigation.navigate(navigateToIOURoute);
             }
-        } else if (type === 'CONCIERGE_NAVIGATE') {
-            this.webview.stopLoading();
-            Navigation.navigate(navigateToIOURoute);
-            Report.navigateToConciergeChat();
         }
     }
 

--- a/src/components/WalletStatementModal/index.native.js
+++ b/src/components/WalletStatementModal/index.native.js
@@ -8,6 +8,7 @@ import ONYXKEYS from '../../ONYXKEYS';
 import compose from '../../libs/compose';
 import {walletStatementPropTypes, walletStatementDefaultProps} from './WalletStatementModalPropTypes';
 import FullScreenLoadingIndicator from '../FullscreenLoadingIndicator';
+import * as Report from '../../libs/actions/Report';
 import Navigation from '../../libs/Navigation/Navigation';
 import ROUTES from '../../ROUTES';
 
@@ -22,18 +23,25 @@ class WalletStatementModal extends React.Component {
     /**
      * Handles in-app navigation for webview links
      *
-     * @param {Object} params
+     * @param {String} params.type
      * @param {String} params.url
      */
-    navigate({url}) {
-        if (!this.webview || !url) {
+    navigate({type, url}) {
+        if (!this.webview || (type !== 'STATEMENT_NAVIGATE' && type !== 'CONCIERGE_NAVIGATE')) {
             return;
         }
-        const iouRoutes = [ROUTES.IOU_REQUEST, ROUTES.IOU_SEND, ROUTES.IOU_BILL];
-        const navigateToIOURoute = _.find(iouRoutes, iouRoute => url.includes(iouRoute));
-        if (navigateToIOURoute) {
+
+        if (type === 'STATEMENT_NAVIGATE' && url) {
+            const iouRoutes = [ROUTES.IOU_REQUEST, ROUTES.IOU_SEND, ROUTES.IOU_BILL];
+            const navigateToIOURoute = _.find(iouRoutes, iouRoute => url.includes(iouRoute));
+            if (navigateToIOURoute) {
+                this.webview.stopLoading();
+                Navigation.navigate(navigateToIOURoute);
+            }
+        } else if (type === 'CONCIERGE_NAVIGATE') {
             this.webview.stopLoading();
             Navigation.navigate(navigateToIOURoute);
+            Report.navigateToConciergeChat();
         }
     }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/11097


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

Difficult to test on platforms besides web unless you're on production since there is no way to access the statement on NewDot without modifying the URL

1. Access the statement using the URL http://localhost:8080/statements/202201/
2. You should see something like this
<img width="376" alt="Screen Shot 2022-10-03 at 3 26 01 PM" src="https://user-images.githubusercontent.com/30609178/193513491-7544d818-e3fe-4173-bc47-484311a15155.png">
3. Click on the concierge email and ensure that it redirects you to the concierge chat
<img width="1132" alt="Screen Shot 2022-10-03 at 3 26 32 PM" src="https://user-images.githubusercontent.com/30609178/193513568-e50059f0-6537-40e5-9437-3f7df2ae8560.png">

To test on other devices, this is what I do: https://github.com/Expensify/App/blob/9489c1bf7aa6e26780b4ef513cf167f2fe9adb42/src/pages/home/sidebar/SidebarScreen/FloatingActionButtonAndPopover.js#L172-L176

Update to 
`onSelected: () => Navigation.navigate(ROUTES.getWalletStatementWithDateRoute('202211')),`

This will override the new chat button to open up the statement for November, 2022


### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
No QA

INTERNAL QA - PROD QA ONLY
1. On a mobile device, go to your Concierge chat (on your expensify account). 
2. You should see a message link this - click on the link
<img width="819" alt="Screen Shot 2022-10-03 at 3 35 04 PM" src="https://user-images.githubusercontent.com/30609178/193514728-86f0c627-5b24-4de1-bee6-58ba38c7fd95.png">
3. On the statement page, click on the Concierge email address
4. It should open up the chat with Concierge in NewDot

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.


### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/30609178/211116167-a62aa238-e076-40b8-ba48-45aab532a309.mov


</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/30609178/211117246-1350b239-13c2-4f7a-bae9-1220757e7640.mov



</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->
Running into SSL errors (will test on prod)
</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/30609178/211117330-db44651a-ef61-460c-a20f-78b1b5ecbbdb.mov


</details>

<details>
<summary>iOS</summary>
Running into SSL errors (will test on prod)
<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>
x
<!-- add screenshots or videos here -->

</details>
