### PR TITLE
Use else-ifs to establish precedence for room name validations

### DIFF
--- a/src/pages/ReportSettingsPage.js
+++ b/src/pages/ReportSettingsPage.js
@@ -90,22 +90,18 @@ class ReportSettingsPage extends Component {
             return errors;
         }
 
-        // Show error if the room name already exists
-        if (ValidationUtils.isExistingRoomName(values.newRoomName, this.props.reports, this.props.report.policyID)) {
-            errors.newRoomName = this.props.translate('newRoomPage.roomAlreadyExistsError');
-        }
-
-        // We error if the user doesn't enter a room name or left blank
+        // The following validations are ordered by precedence.
+        // First priority: We error if the user doesn't enter a room name or left blank
         if (!values.newRoomName || values.newRoomName === CONST.POLICY.ROOM_PREFIX) {
             errors.newRoomName = this.props.translate('newRoomPage.pleaseEnterRoomName');
-        }
-
-        // Certain names are reserved for default rooms and should not be used for policy rooms.
-        if (ValidationUtils.isReservedRoomName(values.newRoomName)) {
+        } else if (ValidationUtils.isReservedRoomName(values.newRoomName)) {
+            // Second priority: Certain names are reserved for default rooms and should not be used for policy rooms.
             errors.newRoomName = this.props.translate('newRoomPage.roomNameReservedError');
-        }
-
-        if (!ValidationUtils.isValidRoomName(values.newRoomName)) {
+        } else if (ValidationUtils.isExistingRoomName(values.newRoomName, this.props.reports, this.props.report.policyID)) {
+            // Third priority: Show error if the room name already exists
+            errors.newRoomName = this.props.translate('newRoomPage.roomAlreadyExistsError');
+        } else if (!ValidationUtils.isValidRoomName(values.newRoomName)) {
+            // Fourth priority: We error if the room name has invalid characters
             errors.newRoomName = this.props.translate('newRoomPage.roomNameInvalidError');
         }
 

--- a/src/pages/workspace/WorkspaceNewRoomPage.js
+++ b/src/pages/workspace/WorkspaceNewRoomPage.js
@@ -81,22 +81,18 @@ class WorkspaceNewRoomPage extends React.Component {
     validate(values) {
         const errors = {};
 
-        // We error if the user doesn't enter a room name or left blank
+        // The following validations are ordered by precedence.
+        // First priority: We error if the user doesn't enter a room name or left blank
         if (!values.roomName || values.roomName === CONST.POLICY.ROOM_PREFIX) {
             errors.roomName = this.props.translate('newRoomPage.pleaseEnterRoomName');
-        }
-
-        // We error if the room name already exists.
-        if (ValidationUtils.isExistingRoomName(values.roomName, this.props.reports, values.policyID)) {
-            errors.roomName = this.props.translate('newRoomPage.roomAlreadyExistsError');
-        }
-
-        // Certain names are reserved for default rooms and should not be used for policy rooms.
-        if (ValidationUtils.isReservedRoomName(values.roomName)) {
+        } else if (ValidationUtils.isReservedRoomName(values.roomName)) {
+            // Second priority: Certain names are reserved for default rooms and should not be used for policy rooms.
             errors.roomName = this.props.translate('newRoomPage.roomNameReservedError');
-        }
-
-        if (!ValidationUtils.isValidRoomName(values.roomName)) {
+        } else if (ValidationUtils.isExistingRoomName(values.roomName, this.props.reports, values.policyID)) {
+            // Third priority: We error if the room name already exists.
+            errors.roomName = this.props.translate('newRoomPage.roomAlreadyExistsError');
+        } else if (!ValidationUtils.isValidRoomName(values.roomName)) {
+            // Fourth priority: We error if the room name has invalid characters
             errors.roomName = this.props.translate('newRoomPage.roomNameInvalidError');
         }
 


### PR DESCRIPTION
cc @puneetlath @fedirjh 

### Details
Update the validation code to use `else-ifs` so we can more clearly establish the precedence for which validation errors get shown.

### Fixed Issues
$ https://github.com/Expensify/App/issues/14010   


### Tests
1. Login with account that has policyRooms beta enabled
2. Click FAB -> New Room
3. Don't input anything and just click "Create Room" button
4. Make sure "Please enter a room name message shows below Room Name input field
5. Type in `#admins`, make sure "A room on this workspace already uses this name" error shows

===

5. Create a room
6. Go to that room in the LHN
7. Go to the room settings page
8. Do the same steps as above.

- [ ] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
- Repeat the steps as above, but while offline, ensure the behavior is the same

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
- Conduct both the steps in Tests and Offline Tests above.
- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<img width="373" alt="Screenshot 2023-01-06 at 11 20 20 AM" src="https://user-images.githubusercontent.com/4741899/211084159-415c9f9d-dfc4-48af-8165-b2cb31fa6f8a.png">


</details>

<details>
<summary>Mobile Web - Chrome</summary>

<img width="419" alt="Screenshot 2023-01-06 at 11 29 20 AM" src="https://user-images.githubusercontent.com/4741899/211085538-1bfdfeb3-f57a-4267-b816-1e85c79789bb.png">

</details>

<details>
<summary>Mobile Web - Safari</summary>

<img width="467" alt="Screenshot 2023-01-06 at 11 21 09 AM" src="https://user-images.githubusercontent.com/4741899/211084292-4d17d286-d7ac-4d52-be66-528bc16ffd51.png">


</details>

<details>
<summary>Desktop</summary>

<img width="360" alt="Screenshot 2023-01-06 at 11 22 51 AM" src="https://user-images.githubusercontent.com/4741899/211084497-ad176ffd-d92e-45e8-a05d-6c2dd5990544.png">


</details>

<details>
<summary>iOS</summary>

<img width="455" alt="Screenshot 2023-01-06 at 11 22 17 AM" src="https://user-images.githubusercontent.com/4741899/211084425-35c2179d-a047-4061-bc80-bc28bf205bec.png">


</details>

<details>
<summary>Android</summary>
<img width="440" alt="Screenshot 2023-01-06 at 11 26 58 AM" src="https://user-images.githubusercontent.com/4741899/211085513-a8d030f8-f93c-446d-96ba-abcedf7e4ed3.png">


</details>
