### PR TITLE
fix header button's margin and tooltip position issue

### DIFF
--- a/src/components/HeaderWithCloseButton.js
+++ b/src/components/HeaderWithCloseButton.js
@@ -139,6 +139,7 @@ class HeaderWithCloseButton extends Component {
                 ]}
                 >
                     {this.props.shouldShowBackButton && (
+                    <View style={[styles.mr2]}>
                         <Tooltip text={this.props.translate('common.back')}>
                             <Pressable
                                 onPress={() => {
@@ -152,6 +153,7 @@ class HeaderWithCloseButton extends Component {
                                 <Icon src={Expensicons.BackArrow} />
                             </Pressable>
                         </Tooltip>
+                    </View>
                     )}
                     <Header
                         title={this.props.title}

--- a/src/components/HeaderWithCloseButton.js
+++ b/src/components/HeaderWithCloseButton.js
@@ -180,7 +180,7 @@ class HeaderWithCloseButton extends Component {
                         <Tooltip text={this.props.translate('getAssistancePage.questionMarkButtonTooltip')}>
                             <Pressable
                                 onPress={() => Navigation.navigate(ROUTES.getGetAssistanceRoute(this.props.guidesCallTaskID))}
-                                style={[styles.touchableButtonImage, styles.mr0]}
+                                style={[styles.touchableButtonImage]}
                                 accessibilityRole="button"
                                 accessibilityLabel={this.props.translate('getAssistancePage.questionMarkButtonTooltip')}
                             >
@@ -193,7 +193,6 @@ class HeaderWithCloseButton extends Component {
                             <ThreeDotsMenu
                                 menuItems={this.props.threeDotsMenuItems}
                                 onIconPress={this.props.onThreeDotsButtonPress}
-                                iconStyles={[styles.mr0]}
                                 anchorPosition={this.props.threeDotsAnchorPosition}
                             />
                         )}
@@ -203,7 +202,7 @@ class HeaderWithCloseButton extends Component {
                         <Tooltip text={this.props.translate('common.close')}>
                             <Pressable
                                 onPress={this.props.onCloseButtonPress}
-                                style={[styles.touchableButtonImage, styles.mr0]}
+                                style={[styles.touchableButtonImage]}
                                 accessibilityRole="button"
                                 accessibilityLabel={this.props.translate('common.close')}
                             >

--- a/src/components/OfflineWithFeedback.js
+++ b/src/components/OfflineWithFeedback.js
@@ -107,7 +107,7 @@ const OfflineWithFeedback = (props) => {
                     <Tooltip text={props.translate('common.close')}>
                         <Pressable
                             onPress={props.onClose}
-                            style={[styles.touchableButtonImage, styles.mr0]}
+                            style={[styles.touchableButtonImage]}
                             accessibilityRole="button"
                             accessibilityLabel={props.translate('common.close')}
                         >

--- a/src/components/VideoChatButtonAndMenu/BaseVideoChatButtonAndMenu.js
+++ b/src/components/VideoChatButtonAndMenu/BaseVideoChatButtonAndMenu.js
@@ -118,7 +118,7 @@ class BaseVideoChatButtonAndMenu extends Component {
                                 }
                                 this.toggleVideoChatMenu();
                             }}
-                            style={[styles.touchableButtonImage, styles.mr0]}
+                            style={[styles.touchableButtonImage]}
                         >
                             <Icon
                                 src={Expensicons.Phone}

--- a/src/pages/home/HeaderView.js
+++ b/src/pages/home/HeaderView.js
@@ -156,7 +156,7 @@ const HeaderView = (props) => {
                             <Tooltip text={props.report.isPinned ? props.translate('common.unPin') : props.translate('common.pin')}>
                                 <Pressable
                                     onPress={() => Report.togglePinnedState(props.report)}
-                                    style={[styles.touchableButtonImage, styles.mr0]}
+                                    style={[styles.touchableButtonImage]}
                                 >
                                     <Icon src={Expensicons.Pin} fill={props.report.isPinned ? themeColors.heading : themeColors.icon} />
                                 </Pressable>

--- a/src/pages/iou/IOUModal.js
+++ b/src/pages/iou/IOUModal.js
@@ -379,14 +379,16 @@ class IOUModal extends Component {
                 >
                     {this.state.currentStepIndex > 0
                         && (
-                        <Tooltip text={this.props.translate('common.back')}>
-                            <TouchableOpacity
-                                onPress={this.navigateToPreviousStep}
-                                style={[styles.touchableButtonImage]}
-                            >
-                                <Icon src={Expensicons.BackArrow} />
-                            </TouchableOpacity>
-                        </Tooltip>
+                        <View style={[styles.mr2]}>
+                            <Tooltip text={this.props.translate('common.back')}>
+                                <TouchableOpacity
+                                    onPress={this.navigateToPreviousStep}
+                                    style={[styles.touchableButtonImage]}
+                                >
+                                    <Icon src={Expensicons.BackArrow} />
+                                </TouchableOpacity>
+                            </Tooltip>
+                        </View>
                         )}
                     <Header title={this.getTitleForStep()} />
                     <View style={[styles.reportOptions, styles.flexRow, styles.pr5]}>

--- a/src/pages/iou/IOUModal.js
+++ b/src/pages/iou/IOUModal.js
@@ -379,21 +379,21 @@ class IOUModal extends Component {
                 >
                     {this.state.currentStepIndex > 0
                         && (
-                            <Tooltip text={this.props.translate('common.back')}>
-                                <TouchableOpacity
-                                    onPress={this.navigateToPreviousStep}
-                                    style={[styles.touchableButtonImage]}
-                                >
-                                    <Icon src={Expensicons.BackArrow} />
-                                </TouchableOpacity>
-                            </Tooltip>
+                        <Tooltip text={this.props.translate('common.back')}>
+                            <TouchableOpacity
+                                onPress={this.navigateToPreviousStep}
+                                style={[styles.touchableButtonImage]}
+                            >
+                                <Icon src={Expensicons.BackArrow} />
+                            </TouchableOpacity>
+                        </Tooltip>
                         )}
                     <Header title={this.getTitleForStep()} />
                     <View style={[styles.reportOptions, styles.flexRow, styles.pr5]}>
                         <Tooltip text={this.props.translate('common.close')}>
                             <TouchableOpacity
                                 onPress={() => Navigation.dismissModal()}
-                                style={[styles.touchableButtonImage, styles.mr0]}
+                                style={[styles.touchableButtonImage]}
                                 accessibilityRole="button"
                                 accessibilityLabel={this.props.translate('common.close')}
                             >

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -537,7 +537,6 @@ const styles = {
         alignItems: 'center',
         height: variables.componentSizeNormal,
         justifyContent: 'center',
-        marginRight: 8,
         width: variables.componentSizeNormal,
     },
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
https://github.com/Expensify/App/issues/14043#issuecomment-1373175647
Fixing the tooltip not being centred for header close buttons and  setting margin-right value to 0 for download button

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/14043   
PROPOSAL: https://github.com/Expensify/App/issues/14043#issuecomment-1373175647


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Go to settings > Preferences (you can check any page with a back button)
2. Hover over the < icon 
3. Verify the tooltip is in center as shown in the screenshot
<img width="373" alt="Screenshot 2023-01-07 at 7 47 17 PM" src="https://user-images.githubusercontent.com/71884990/211155331-35566251-0905-4aac-8077-40a37ac7adf2.png">

---
1. Go to settings > workspaces 
2. Click on a workspace
3. Verify the header looks the same 

---

1. Go to a chat 
2. Send an attachment
3. Open it
4. Verify the download button doesn't has margin at right

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
6. Upload an image via copy paste
7. Verify a modal appears displaying a preview of that image
--->


1. Go to settings > Preferences (you can check any page with a back button)
3. Hover over the < icon 
4. Verify the tooltip is in center as shown in the screenshot
<img width="373" alt="Screenshot 2023-01-07 at 7 47 17 PM" src="https://user-images.githubusercontent.com/71884990/211155331-35566251-0905-4aac-8077-40a37ac7adf2.png">

---

1. Go to settings > workspaces 
2. Click on a workspace
3. Verify the header looks the same 

<img width="373" alt="Screenshot 2023-01-07 at 7 53 24 PM" src="https://user-images.githubusercontent.com/71884990/211155501-8e2c56f1-56b9-40cd-a37b-c33f7164515e.png">

---
1. Go to a chat 
2. Send an attachment
3. Open it
4. Verify the download button doesn't has margin at right
<img width="220" alt="Screenshot 2023-01-07 at 7 59 02 PM" src="https://user-images.githubusercontent.com/71884990/211155716-7a4c2d58-4dac-4764-b8f4-1ae9b3f402a4.png">

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>
<img width="373" alt="Screenshot 2023-01-07 at 7 47 17 PM" src="https://user-images.githubusercontent.com/71884990/211155794-8b4c244d-8375-4ef2-afe6-41f29b460a04.png">


![image](https://user-images.githubusercontent.com/71884990/211146140-8d2153da-a21e-43d4-8abc-8d25b7c80c85.png)

![image](https://user-images.githubusercontent.com/71884990/211146221-94720f8a-ea2a-4b85-9bca-bb64dbe5c8c4.png)


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>
<img width="341" alt="Screenshot 2023-01-07 at 8 06 28 PM" src="https://user-images.githubusercontent.com/71884990/211156275-ca9bc033-6e80-4daf-95ec-2eb5f6c22eeb.png">

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>
<img width="356" alt="Screenshot 2023-01-07 at 8 08 33 PM" src="https://user-images.githubusercontent.com/71884990/211156155-5ff63d72-872f-4a01-b61b-95e43028fd90.png">

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>
<img width="365" alt="Screenshot 2023-01-07 at 8 02 57 PM" src="https://user-images.githubusercontent.com/71884990/211155927-320b3c2e-b745-47c9-a230-a310a66e101f.png">

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>
<img width="356" alt="Screenshot 2023-01-07 at 8 11 14 PM" src="https://user-images.githubusercontent.com/71884990/211156269-d64aed93-27b7-4f23-95a5-90e27f4d4e6a.png">

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

![image](https://user-images.githubusercontent.com/71884990/211146291-ebd7d02e-fdc5-4252-8934-18aa439c6998.png)

![image](https://user-images.githubusercontent.com/71884990/211146376-94ff75bd-b694-4f67-95c2-b099ab3393b6.png)


</details>
