### PR TITLE
Added an option to use absolute position for tooltips

### DIFF
--- a/src/components/ContextMenuItem.js
+++ b/src/components/ContextMenuItem.js
@@ -75,7 +75,7 @@ class ContextMenuItem extends Component {
         return (
             this.props.isMini
                 ? (
-                    <Tooltip text={text}>
+                    <Tooltip text={text} teleport={false}>
                         <Pressable
                             focusable
                             accessibilityLabel={text}

--- a/src/components/Tooltip/TooltipRenderedOnPageBody.js
+++ b/src/components/Tooltip/TooltipRenderedOnPageBody.js
@@ -41,11 +41,15 @@ const propTypes = {
 
     /** Maximum number of lines to show in tooltip */
     numberOfLines: PropTypes.number.isRequired,
+
+    /** Whether to teleport the tooltip through the portal */
+    teleport: PropTypes.bool,
 };
 
 const defaultProps = {
     shiftHorizontal: 0,
     shiftVertical: 0,
+    teleport: true,
 };
 
 // Props will change frequently.
@@ -117,34 +121,44 @@ class TooltipRenderedOnPageBody extends React.PureComponent {
             this.state.tooltipTextWidth,
             this.props.shiftHorizontal,
             this.props.shiftVertical,
+            this.props.teleport,
         );
+
+        const child = (
+            <Animated.View
+                onLayout={this.measureTooltip}
+                style={[tooltipWrapperStyle, animationStyle]}
+            >
+                <Text numberOfLines={this.props.numberOfLines} style={tooltipTextStyle}>
+                    <Text
+                        style={tooltipTextStyle}
+                        ref={(ref) => {
+                            // Once the text for the tooltip first renders, update the width of the tooltip dynamically to fit the width of the text.
+                            // Note that we can't have this code in componentDidMount because the ref for the text won't be set until after the first render
+                            if (this.textRef) {
+                                return;
+                            }
+
+                            this.textRef = ref;
+                            this.updateTooltipTextWidth();
+                        }}
+                    >
+                        {this.props.text}
+                    </Text>
+                </Text>
+                <View style={pointerWrapperStyle}>
+                    <View style={pointerStyle} />
+                </View>
+            </Animated.View>
+        );
+
+        if (!this.props.teleport) {
+            return child;
+        }
+
         return (
             <Portal>
-                <Animated.View
-                    onLayout={this.measureTooltip}
-                    style={[tooltipWrapperStyle, animationStyle]}
-                >
-                    <Text numberOfLines={this.props.numberOfLines} style={tooltipTextStyle}>
-                        <Text
-                            style={tooltipTextStyle}
-                            ref={(ref) => {
-                                // Once the text for the tooltip first renders, update the width of the tooltip dynamically to fit the width of the text.
-                                // Note that we can't have this code in componentDidMount because the ref for the text won't be set until after the first render
-                                if (this.textRef) {
-                                    return;
-                                }
-
-                                this.textRef = ref;
-                                this.updateTooltipTextWidth();
-                            }}
-                        >
-                            {this.props.text}
-                        </Text>
-                    </Text>
-                    <View style={pointerWrapperStyle}>
-                        <View style={pointerStyle} />
-                    </View>
-                </Animated.View>
+                {child}
             </Portal>
         );
     }

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -181,7 +181,12 @@ class Tooltip extends PureComponent {
             });
         }
         return (
-            <>
+            <Hoverable
+                absolute={this.props.absolute}
+                containerStyles={this.props.containerStyles}
+                onHoverIn={this.showTooltip}
+                onHoverOut={this.hideTooltip}
+            >
                 {this.state.isRendered && (
                     <TooltipRenderedOnPageBody
                         animation={this.animation}
@@ -195,17 +200,11 @@ class Tooltip extends PureComponent {
                         text={this.props.text}
                         maxWidth={this.props.maxWidth}
                         numberOfLines={this.props.numberOfLines}
+                        teleport={this.props.teleport}
                     />
                 )}
-                <Hoverable
-                    absolute={this.props.absolute}
-                    containerStyles={this.props.containerStyles}
-                    onHoverIn={this.showTooltip}
-                    onHoverOut={this.hideTooltip}
-                >
-                    {child}
-                </Hoverable>
-            </>
+                {child}
+            </Hoverable>
         );
     }
 }

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -180,13 +180,9 @@ class Tooltip extends PureComponent {
                 focusable: true,
             });
         }
-        return (
-            <Hoverable
-                absolute={this.props.absolute}
-                containerStyles={this.props.containerStyles}
-                onHoverIn={this.showTooltip}
-                onHoverOut={this.hideTooltip}
-            >
+
+        const childWithTooltip = (
+            <>
                 {this.state.isRendered && (
                     <TooltipRenderedOnPageBody
                         animation={this.animation}
@@ -203,8 +199,25 @@ class Tooltip extends PureComponent {
                         teleport={this.props.teleport}
                     />
                 )}
-                {child}
-            </Hoverable>
+                <Hoverable
+                    absolute={this.props.absolute}
+                    containerStyles={this.props.containerStyles}
+                    onHoverIn={this.showTooltip}
+                    onHoverOut={this.hideTooltip}
+                >
+                    {child}
+                </Hoverable>
+            </>
+        );
+
+        if (this.props.teleport) {
+            return childWithTooltip;
+        }
+
+        return (
+            <View>
+                {childWithTooltip}
+            </View>
         );
     }
 }

--- a/src/components/Tooltip/tooltipPropTypes.js
+++ b/src/components/Tooltip/tooltipPropTypes.js
@@ -32,6 +32,9 @@ const propTypes = {
 
     /** Maximum number of lines to show in tooltip */
     numberOfLines: PropTypes.number,
+
+    /** Whether to teleport the tooltip through the portal */
+    teleport: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -42,6 +45,7 @@ const defaultProps = {
     text: '',
     maxWidth: variables.sideBarWidth,
     numberOfLines: CONST.TOOLTIP_MAX_LINES,
+    teleport: true,
 };
 
 export {

--- a/src/styles/getTooltipStyles.js
+++ b/src/styles/getTooltipStyles.js
@@ -27,6 +27,7 @@ const POINTER_WIDTH = 12;
  * @param {Number} [manualShiftHorizontal] - Any additional amount to manually shift the tooltip to the left or right.
  *                                         A positive value shifts it to the right,
  *                                         and a negative value shifts it to the left.
+ * @param {Boolean} useFixedPosition - Whether to use position fixed or position absolute.
  * @returns {Number}
  */
 function computeHorizontalShift(windowWidth, xOffset, componentWidth, tooltipWidth, manualShiftHorizontal) {
@@ -84,6 +85,7 @@ export default function getTooltipStyles(
     tooltipTextWidth,
     manualShiftHorizontal = 0,
     manualShiftVertical = 0,
+    useFixedPosition = true,
 ) {
     // Determine if the tooltip should display below the wrapped component.
     // If a tooltip will try to render within GUTTER_WIDTH logical pixels of the top of the screen,
@@ -117,7 +119,7 @@ export default function getTooltipStyles(
             }],
         },
         tooltipWrapperStyle: {
-            position: 'fixed',
+            position: useFixedPosition ? 'fixed' : 'absolute',
             backgroundColor: themeColors.heading,
             borderRadius: variables.componentBorderRadiusSmall,
             ...tooltipVerticalPadding,
@@ -136,10 +138,10 @@ export default function getTooltipStyles(
             top: shouldShowBelow
 
                 // We need to shift the tooltip down below the component. So shift the tooltip down (+) by...
-                ? (yOffset + componentHeight + POINTER_HEIGHT + manualShiftVertical)
+                ? ((useFixedPosition ? yOffset : 0) + componentHeight + POINTER_HEIGHT + manualShiftVertical)
 
                 // We need to shift the tooltip up above the component. So shift the tooltip up (-) by...
-                : ((yOffset - (tooltipHeight + POINTER_HEIGHT)) + manualShiftVertical),
+                : (((useFixedPosition ? yOffset : 0) - (tooltipHeight + POINTER_HEIGHT)) + manualShiftVertical),
 
             // Next, we'll position it horizontally.
             // we will use xOffset to position the tooltip relative to the Wrapped Component
@@ -153,7 +155,7 @@ export default function getTooltipStyles(
             //      so the tooltip's center lines up with the center of the wrapped component.
             //   3) Add the horizontal shift (left or right) computed above to keep it out of the gutters.
             //   4) Lastly, add the manual horizontal shift passed in as a parameter.
-            left: xOffset + ((componentWidth / 2) - (tooltipWidth / 2)) + horizontalShift + manualShiftHorizontal,
+            left: (useFixedPosition ? xOffset : 0) + ((componentWidth / 2) - (tooltipWidth / 2)) + horizontalShift + manualShiftHorizontal,
 
             opacity,
         },
@@ -164,7 +166,7 @@ export default function getTooltipStyles(
             overflow: 'hidden',
         },
         pointerWrapperStyle: {
-            position: 'fixed',
+            position: useFixedPosition ? 'fixed' : 'absolute',
 
             // By default, the pointer's top-left will align with the top-left of the tooltip wrapper.
             //

--- a/src/styles/getTooltipStyles.js
+++ b/src/styles/getTooltipStyles.js
@@ -27,7 +27,6 @@ const POINTER_WIDTH = 12;
  * @param {Number} [manualShiftHorizontal] - Any additional amount to manually shift the tooltip to the left or right.
  *                                         A positive value shifts it to the right,
  *                                         and a negative value shifts it to the left.
- * @param {Boolean} useFixedPosition - Whether to use position fixed or position absolute.
  * @returns {Number}
  */
 function computeHorizontalShift(windowWidth, xOffset, componentWidth, tooltipWidth, manualShiftHorizontal) {
@@ -70,6 +69,7 @@ function computeHorizontalShift(windowWidth, xOffset, componentWidth, tooltipWid
  *                                         and a negative value shifts it to the left.
  * @param {Number} [manualShiftVertical] - Any additional amount to manually shift the tooltip up or down.
  *                                       A positive value shifts it down, and a negative value shifts it up.
+ * @param {Boolean} useFixedPosition - Whether to use position fixed or position absolute.
  * @returns {Object}
  */
 export default function getTooltipStyles(


### PR DESCRIPTION
@francoisl @mollfpr

Tagging you since you are familiar with the tooltip and the addresed behaviour in this PR

### Details
I have added an option so we can render tooltips as they are without being ported to the `<body>` (using `<Portal />` or `ReactDOM.createPortal`)
With the current code the tooltips are positioned using a fixed position on the viewport and this may create problems especially on scroll.
With this PR we have the option to use absolute positioning where the tooltips gets attached to their corresponding elements instead of the document body.

### Fixed Issues
https://github.com/Expensify/App/issues/14127
This PR does not fix the issue but makes it less annoying.

#### Before

https://user-images.githubusercontent.com/16493223/211208102-bc23cb56-b1c7-4be5-90f9-dc4d93545f19.mp4



#### After


https://user-images.githubusercontent.com/16493223/211208110-b52a2ba0-b04b-40dc-aaa0-285fc6069026.mp4



### Tests
1. Go to any report
2. Click on the copy to clipboard
3. Scroll to the top
4. Verify that the tooltip remains attached to the "copy to clipboard" button and not stuck in the screen

- [ ] Verify that no errors appear in the JS console

### Offline tests
n/a

### QA Steps
1. Go to any report
2. Click on the copy to clipboard
3. Scroll to the top
4. Verify that the tooltip remains attached to the "copy to clipboard" button and not stuck in the screen

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android / native
    - [X] Android / Chrome
    - [X] iOS / native
    - [X] iOS / Safari
    - [X] MacOS / Chrome / Safari
    - [X] MacOS / Desktop
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
    - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [X] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If a new component is created I verified that:
    - [X] A similar component doesn't exist in the codebase
    - [X] All props are defined accurately and each prop has a `/** comment above it */`
    - [X] The file is named correctly
    - [X] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [X] The only data being stored in the state is data necessary for rendering and nothing else
    - [X] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [X] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [X] All JSX used for rendering exists in the render method
    - [X] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>

</details>

<details>
<summary>Mobile Web - Safari</summary>

[<!-- add screenshots or videos here -->
](https://user-images.githubusercontent.com/16493223/211208110-b52a2ba0-b04b-40dc-aaa0-285fc6069026.mp4)
</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>
