### PR TITLE
Fix workspace list empty state not showing immediate

### DIFF
--- a/src/libs/PolicyUtils.js
+++ b/src/libs/PolicyUtils.js
@@ -61,8 +61,8 @@ function getPolicyBrickRoadIndicatorStatus(policy, policyMembers) {
  * Note: Using a local ONYXKEYS.NETWORK subscription will cause a delay in
  * updating the screen. Passing the offline status from the component.
  * @param {Object} policy
- * @param {boolean} isOffline
- * @returns {boolean}
+ * @param {Boolean} isOffline
+ * @returns {Boolean}
  */
 function shouldShowPolicy(policy, isOffline) {
     return policy

--- a/src/libs/PolicyUtils.js
+++ b/src/libs/PolicyUtils.js
@@ -54,9 +54,29 @@ function getPolicyBrickRoadIndicatorStatus(policy, policyMembers) {
     return '';
 }
 
+/**
+ * Check if the policy can be display
+ * If offline always show the delete pending policy.
+ * If online show the delete pending policy only if it has an error.
+ * @param {Object} policy
+ * @param {boolean} isOffline
+ * @returns {boolean}
+ */
+function shouldShowPolicy(policy, isOffline) {
+    return policy
+    && policy.type === CONST.POLICY.TYPE.FREE
+    && policy.role === CONST.POLICY.ROLE.ADMIN
+    && (
+        isOffline
+        || policy.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE
+        || !_.isEmpty(policy.errors)
+    );
+}
+
 export {
     hasPolicyMemberError,
     hasPolicyError,
     hasCustomUnitsError,
     getPolicyBrickRoadIndicatorStatus,
+    shouldShowPolicy,
 };

--- a/src/libs/PolicyUtils.js
+++ b/src/libs/PolicyUtils.js
@@ -59,7 +59,7 @@ function getPolicyBrickRoadIndicatorStatus(policy, policyMembers) {
  * If offline, always show the policy pending deletion.
  * If online, show the policy pending deletion only if there is an error.
  * Note: Using a local ONYXKEYS.NETWORK subscription will cause a delay in
- * updating the screen pass the offline status from the component.
+ * updating the screen. Passing the offline status from the component.
  * @param {Object} policy
  * @param {boolean} isOffline
  * @returns {boolean}

--- a/src/libs/PolicyUtils.js
+++ b/src/libs/PolicyUtils.js
@@ -58,6 +58,8 @@ function getPolicyBrickRoadIndicatorStatus(policy, policyMembers) {
  * Check if the policy can be displayed
  * If offline, always show the policy pending deletion.
  * If online, show the policy pending deletion only if there is an error.
+ * Note: Using a local ONYXKEYS.NETWORK subscription will cause a delay in
+ * updating the screen pass the offline status from the component.
  * @param {Object} policy
  * @param {boolean} isOffline
  * @returns {boolean}

--- a/src/libs/PolicyUtils.js
+++ b/src/libs/PolicyUtils.js
@@ -55,9 +55,9 @@ function getPolicyBrickRoadIndicatorStatus(policy, policyMembers) {
 }
 
 /**
- * Check if the policy can be display
- * If offline always show the delete pending policy.
- * If online show the delete pending policy only if it has an error.
+ * Check if the policy can be displayed
+ * If offline, always show the policy pending deletion.
+ * If online, show the policy pending deletion only if there is an error.
  * @param {Object} policy
  * @param {boolean} isOffline
  * @returns {boolean}

--- a/src/pages/settings/InitialSettingsPage.js
+++ b/src/pages/settings/InitialSettingsPage.js
@@ -130,10 +130,7 @@ class InitialSettingsPage extends React.Component {
      */
     getDefaultMenuItems() {
         const policiesAvatars = _.chain(this.props.policies)
-            .filter(policy => policy
-                && policy.type === CONST.POLICY.TYPE.FREE
-                && policy.role === CONST.POLICY.ROLE.ADMIN
-                && policy.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE)
+            .filter(policy => PolicyUtils.shouldShowPolicy(policy, this.props.network.isOffline))
             .sortBy(policy => policy.name)
             .pluck('avatar')
             .value();

--- a/src/pages/workspace/WorkspacesListPage.js
+++ b/src/pages/workspace/WorkspacesListPage.js
@@ -23,6 +23,7 @@ import Permissions from '../../libs/Permissions';
 import Button from '../../components/Button';
 import FixedFooter from '../../components/FixedFooter';
 import BlockingView from '../../components/BlockingViews/BlockingView';
+import {withNetwork} from '../../components/OnyxProvider';
 
 const propTypes = {
     /* Onyx Props */
@@ -115,7 +116,7 @@ class WorkspacesListPage extends Component {
      */
     getWorkspaces() {
         return _.chain(this.props.policies)
-            .filter(policy => policy && policy.type === CONST.POLICY.TYPE.FREE && policy.role === CONST.POLICY.ROLE.ADMIN)
+            .filter(policy => PolicyUtils.shouldShowPolicy(policy, this.props.network.isOffline))
             .map(policy => ({
                 title: policy.name,
                 icon: policy.avatar ? policy.avatar : Expensicons.Building,
@@ -208,6 +209,7 @@ WorkspacesListPage.defaultProps = defaultProps;
 
 export default compose(
     withLocalize,
+    withNetwork(),
     withOnyx({
         policies: {
             key: ONYXKEYS.COLLECTION.POLICY,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Fixed the issue of Workspace - the welcome message does not appear immediately after deleting the workspace.
Changes - While online filter out all the delete pending policy if it not have an error.

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/13615   
PROPOSAL: https://github.com/Expensify/App/issues/13615#issuecomment-1363886220


### Tests
1. Login with any account.
2. Go to Settings -> Workspace (you should have only one workspace, if more than one delete them).
3. Click on workspace to navigate to workspace detail page.
4. Click on 3 dot and click on "Delete workspace".
5. Confirm the modal to delete the workspace.
6. It will navigate to workspace list page.
7. Verify welcome message (empty list message) appear immediately. 
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
1. Login with any account.
2. Go to Settings -> Workspace (you should have only one workspace, if more than one delete them).
3. Disable the internet connection in the device.
4. Click on workspace to navigate to workspace detail page.
5. Click on 3 dot and click on "Delete workspace".
6. Confirm the modal to delete the workspace.
7. It will navigate to workspace list page.
8. Verify the workspace is now displayed with a strikethrough indicating it will be deleted when back online.
9. Enable the internet connection in the device. 
10. Verify welcome message (empty list message) appear immediately. 

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Login with any account.
2. Go to Settings -> Workspace (you should have only one workspace, if more than one delete them).
3. Click on workspace to navigate to workspace detail page.
4. Click on 3 dot and click on "Delete workspace".
5. Confirm the modal to delete the workspace.
6. It will navigate to workspace list page.
7. Verify welcome message (empty list message) appear immediately. 

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->
https://user-images.githubusercontent.com/114683042/211206506-f82abcb9-35a8-437e-9143-c30a4985bd05.mov
</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->
https://user-images.githubusercontent.com/114683042/211207119-4ae716dd-1eb8-46d0-b8ce-74d3b7a317d2.mov
</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->
https://user-images.githubusercontent.com/114683042/211207464-a1273aa0-1cf0-4fb4-8cfd-0f9601f71684.mov
</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->
https://user-images.githubusercontent.com/114683042/211207154-1f8dd4f4-6a35-49f3-85b4-6cc9ff18583b.mov
</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->
https://user-images.githubusercontent.com/114683042/211207438-2afaa4b7-ff50-49c9-98f5-56e25beefb7a.mov
</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->
https://user-images.githubusercontent.com/114683042/211207172-ae33e6b3-8394-4e04-a07b-ba38bc603375.mov
</details>
