### PR TITLE
Allow individual options to have bold style

### DIFF
--- a/src/components/OptionRow.js
+++ b/src/components/OptionRow.js
@@ -80,7 +80,7 @@ const OptionRow = (props) => {
     const textStyle = props.optionIsFocused
         ? styles.sidebarLinkActiveText
         : styles.sidebarLinkText;
-    const textUnreadStyle = (props.boldStyle)
+    const textUnreadStyle = (props.boldStyle || props.option.boldStyle)
         ? [textStyle, styles.sidebarLinkTextBold] : [textStyle];
     const displayNameStyle = StyleUtils.combineStyles(styles.optionDisplayName, textUnreadStyle, props.style);
     const alternateTextStyle = StyleUtils.combineStyles(textStyle, styles.optionAlternateText, styles.textLabelSupporting, props.style);

--- a/src/components/optionPropTypes.js
+++ b/src/components/optionPropTypes.js
@@ -6,6 +6,9 @@ export default PropTypes.shape({
     // Text to display
     text: PropTypes.string,
 
+    /** Display the text of the option in bold font style */
+    boldStyle: PropTypes.bool,
+
     // Alternate text to display
     alternateText: PropTypes.string,
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
cc @tgolen since it looks like this was missed in your cleanup PR (that I helped review 🙃 )

### Details
Regression from https://github.com/Expensify/App/pull/13319/

### Fixed Issues
$ https://github.com/Expensify/App/issues/14154

### Tests
1. Navigate to Settings -> Profile -> Pronouns
2. Verify your current selected pronoun is in **bold**

<img width="349" alt="Screenshot 2023-01-10 at 3 28 30 PM" src="https://user-images.githubusercontent.com/3885503/211564299-88e0dd0b-c68f-4bd7-81af-ad22b93f9bf9.png">

3. Navigate to Settings -> Profile -> Timezone
4. Make sure you're not automatically updating timezone, then click "Timezone"
5. Verify your current selected timezone is in **bold**

<img width="365" alt="Screenshot 2023-01-10 at 3 30 37 PM" src="https://user-images.githubusercontent.com/3885503/211564510-df2b42f8-7363-479b-b7c7-26c080f1ba94.png">

Update each and make sure the newly selected items are now bold and the previously selected items are no longer bold

- [ ] Verify that no errors appear in the JS console

### Offline tests
Same steps above

### QA Steps
Same as all above steps

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<img width="349" alt="Screenshot 2023-01-10 at 3 28 30 PM" src="https://user-images.githubusercontent.com/3885503/211564812-783d3be2-25c0-4fed-a316-a7be6e32fbe7.png">

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<img width="385" alt="Screenshot 2023-01-10 at 3 49 47 PM" src="https://user-images.githubusercontent.com/3885503/211568575-19f72341-6ba6-4a71-89cf-a2e057ab4088.png">

</details>

<details>
<summary>Mobile Web - Safari</summary>

<img width="428" alt="Screenshot 2023-01-10 at 3 57 01 PM" src="https://user-images.githubusercontent.com/3885503/211570191-3a40dff0-7e66-4e1e-83cd-349700073079.png">

</details>

<details>
<summary>Desktop</summary>

<img width="487" alt="Screenshot 2023-01-10 at 3 57 53 PM" src="https://user-images.githubusercontent.com/3885503/211570388-dbb27c39-3d56-4b34-ba46-d4eb0ef09c8a.png">

</details>

<details>
<summary>iOS</summary>

<img width="430" alt="Screenshot 2023-01-10 at 3 55 56 PM" src="https://user-images.githubusercontent.com/3885503/211569956-644393a9-d212-473a-a57a-7d145a974ff4.png">

</details>

<details>
<summary>Android</summary>

<img width="385" alt="Screenshot 2023-01-10 at 3 43 53 PM" src="https://user-images.githubusercontent.com/3885503/211567737-f803a11d-4e35-4dd3-8523-dd062140ac6c.png">

</details>
