### PR TITLE
Fix label fonts

### DIFF
--- a/src/components/AutoUpdateTime.js
+++ b/src/components/AutoUpdateTime.js
@@ -89,7 +89,7 @@ class AutoUpdateTime extends PureComponent {
     render() {
         return (
             <View style={[styles.mb6, styles.detailsPageSectionContainer]}>
-                <Text style={[styles.formLabel, styles.mb2]} numberOfLines={1}>
+                <Text style={[styles.textLabelSupporting, styles.mb2]} numberOfLines={1}>
                     {this.props.translate('detailsPage.localTime')}
                 </Text>
                 <Text numberOfLines={1}>

--- a/src/components/IOUConfirmationList.js
+++ b/src/components/IOUConfirmationList.js
@@ -203,7 +203,7 @@ class IOUConfirmationList extends Component {
                 }));
 
             sections.push({
-                title: this.props.translate('common.to').toUpperCase(),
+                title: this.props.translate('common.to'),
                 data: formattedParticipants,
                 shouldShow: true,
                 indexOffset: 0,

--- a/src/components/OptionsList/BaseOptionsList.js
+++ b/src/components/OptionsList/BaseOptionsList.js
@@ -190,7 +190,7 @@ class BaseOptionsList extends Component {
                 // we need to know the heights of all list items up-front in order to synchronously compute the layout of any given list item.
                 // So be aware that if you adjust the content of the section header (for example, change the font size), you may need to adjust this explicit height as well.
                 <View style={styles.optionsListSectionHeader}>
-                    <Text style={[styles.p5, styles.textMicroBold, styles.colorHeading, styles.textUppercase]}>
+                    <Text style={[styles.p5, styles.textLabelSupporting]}>
                         {title}
                     </Text>
                 </View>

--- a/src/components/TestToolMenu.js
+++ b/src/components/TestToolMenu.js
@@ -37,7 +37,7 @@ const defaultProps = {
 
 const TestToolMenu = props => (
     <>
-        <Text style={[styles.formLabel]} numberOfLines={1}>
+        <Text style={[styles.textLabelSupporting, styles.mb2, styles.mt6]} numberOfLines={1}>
             Test Preferences
         </Text>
 

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -146,8 +146,8 @@ export default {
         openLinkInBrowser: 'open this link in your browser',
     },
     iOUConfirmationList: {
-        whoPaid: 'WHO PAID?',
-        whoWasThere: 'WHO WAS THERE?',
+        whoPaid: 'Who paid?',
+        whoWasThere: 'Who was there?',
         whatsItFor: 'What\'s it for?',
     },
     iOUCurrencySelection: {

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -152,7 +152,7 @@ export default {
     },
     iOUCurrencySelection: {
         selectCurrency: 'Select a currency',
-        allCurrencies: 'ALL CURRENCIES',
+        allCurrencies: 'All currencies',
     },
     optionsSelector: {
         nameEmailOrPhoneNumber: 'Name, email, or phone number',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -146,8 +146,8 @@ export default {
         openLinkInBrowser: 'abrir este enlace en tu navegador',
     },
     iOUConfirmationList: {
-        whoPaid: '¿QUIÉN PAGO?',
-        whoWasThere: '¿QUIÉN ASISTIÓ?',
+        whoPaid: '¿Quién pago?',
+        whoWasThere: '¿Quién asistió?',
         whatsItFor: '¿Para qué es?',
     },
     iOUCurrencySelection: {

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -152,7 +152,7 @@ export default {
     },
     iOUCurrencySelection: {
         selectCurrency: 'Selecciona una moneda',
-        allCurrencies: 'TODAS LAS MONEDAS',
+        allCurrencies: 'Todas las monedas',
     },
     optionsSelector: {
         nameEmailOrPhoneNumber: 'Nombre, email o número de teléfono',

--- a/src/pages/DetailsPage.js
+++ b/src/pages/DetailsPage.js
@@ -151,7 +151,7 @@ class DetailsPage extends React.PureComponent {
                                 )}
                                 {details.login ? (
                                     <View style={[styles.mb6, styles.detailsPageSectionContainer, styles.w100]}>
-                                        <Text style={[styles.formLabel, styles.mb2]} numberOfLines={1}>
+                                        <Text style={[styles.textLabelSupporting, styles.mb2]} numberOfLines={1}>
                                             {this.props.translate(isSMSLogin
                                                 ? 'common.phoneNumber'
                                                 : 'common.email')}
@@ -169,7 +169,7 @@ class DetailsPage extends React.PureComponent {
                                 ) : null}
                                 {pronouns ? (
                                     <View style={[styles.mb6, styles.detailsPageSectionContainer]}>
-                                        <Text style={[styles.formLabel, styles.mb2]} numberOfLines={1}>
+                                        <Text style={[styles.textLabelSupporting, styles.mb2]} numberOfLines={1}>
                                             {this.props.translate('profilePage.preferredPronouns')}
                                         </Text>
                                         <Text numberOfLines={1}>

--- a/src/pages/iou/steps/IOUParticipantsPage/IOUParticipantsSplit.js
+++ b/src/pages/iou/steps/IOUParticipantsPage/IOUParticipantsSplit.js
@@ -213,7 +213,7 @@ class IOUParticipantsSplit extends Component {
             <SafeAreaConsumer>
                 {({safeAreaPaddingBottomStyle}) => (
                     <View style={[styles.flex1, styles.w100, (this.props.participants.length > 0 ? safeAreaPaddingBottomStyle : {})]}>
-                        <Text style={[styles.formLabel, styles.pt3, styles.ph5]}>
+                        <Text style={[styles.textLabelSupporting, styles.pt3, styles.ph5]}>
                             {this.props.translate('common.to')}
                         </Text>
                         <OptionsSelector

--- a/src/pages/settings/Payments/PaymentsPage/BasePaymentsPage.js
+++ b/src/pages/settings/Payments/PaymentsPage/BasePaymentsPage.js
@@ -299,7 +299,7 @@ class BasePaymentsPage extends React.Component {
                     </>
                 )}
                 <Text
-                    style={[styles.ph5, styles.mt6, styles.formLabel]}
+                    style={[styles.ph5, styles.mt6, styles.textLabelSupporting]}
                 >
                     {this.props.translate('paymentsPage.paymentMethodsTitle')}
                 </Text>

--- a/src/pages/settings/Payments/TransferBalancePage.js
+++ b/src/pages/settings/Payments/TransferBalancePage.js
@@ -212,7 +212,7 @@ class TransferBalancePage extends React.Component {
                         ))}
                     </View>
                     <Text
-                        style={[styles.p5, styles.textStrong, styles.textLabel, styles.justifyContentStart]}
+                        style={[styles.p5, styles.textLabelSupporting, styles.justifyContentStart]}
                     >
                         {this.props.translate('transferAmountPage.whichAccount')}
                     </Text>
@@ -233,8 +233,7 @@ class TransferBalancePage extends React.Component {
                             style={[
                                 styles.mt5,
                                 styles.mb3,
-                                styles.textStrong,
-                                styles.textLabel,
+                                styles.textLabelSupporting,
                                 styles.justifyContentStart,
                             ]}
                         >

--- a/src/pages/settings/PreferencesPage.js
+++ b/src/pages/settings/PreferencesPage.js
@@ -66,7 +66,7 @@ const PreferencesPage = (props) => {
             />
             <ScrollView style={styles.flex1} contentContainerStyle={styles.p5}>
                 <View style={[styles.settingsPageBody, styles.mb6]}>
-                    <Text style={[styles.formLabel]} numberOfLines={1}>
+                    <Text style={[styles.textLabelSupporting, styles.mb2]} numberOfLines={1}>
                         {props.translate('common.notifications')}
                     </Text>
                     <View style={[styles.flexRow, styles.mb6, styles.justifyContentBetween]}>

--- a/src/pages/settings/Profile/LoginField.js
+++ b/src/pages/settings/Profile/LoginField.js
@@ -97,7 +97,7 @@ class LoginField extends Component {
                                 interactive={Boolean(!this.props.login.partnerUserID)}
                                 onPress={this.props.login.partnerUserID ? () => { } : () => Navigation.navigate(ROUTES.getSettingsAddLoginRoute(this.props.type))}
                                 shouldShowRightIcon={Boolean(!this.props.login.partnerUserID)}
-                                style={[styles.colorMuted]}
+                                style={[!this.props.login.partnerUserID && styles.colorMuted]}
                             />
                         </View>
                     ) : (

--- a/src/pages/settings/Profile/LoginField.js
+++ b/src/pages/settings/Profile/LoginField.js
@@ -97,7 +97,7 @@ class LoginField extends Component {
                                 interactive={Boolean(!this.props.login.partnerUserID)}
                                 onPress={this.props.login.partnerUserID ? () => { } : () => Navigation.navigate(ROUTES.getSettingsAddLoginRoute(this.props.type))}
                                 shouldShowRightIcon={Boolean(!this.props.login.partnerUserID)}
-                                style={[!this.props.login.partnerUserID && styles.colorMuted]}
+                                style={[styles.colorMuted]}
                             />
                         </View>
                     ) : (

--- a/src/pages/settings/Profile/LoginField.js
+++ b/src/pages/settings/Profile/LoginField.js
@@ -97,7 +97,7 @@ class LoginField extends Component {
                                 interactive={Boolean(!this.props.login.partnerUserID)}
                                 onPress={this.props.login.partnerUserID ? () => { } : () => Navigation.navigate(ROUTES.getSettingsAddLoginRoute(this.props.type))}
                                 shouldShowRightIcon={Boolean(!this.props.login.partnerUserID)}
-                                style={[styles.pushToPageEmptyItemLabel]}
+                                style={[!this.props.login.partnerUserID && styles.colorMuted]}
                             />
                         </View>
                     ) : (

--- a/src/stories/Composer.stories.js
+++ b/src/stories/Composer.stories.js
@@ -50,7 +50,7 @@ const Default = (args) => {
                     ]}
                     nativeID={CONST.REPORT.DROP_NATIVE_ID}
                 >
-                    <Text style={[styles.mb2, styles.formLabel]}>Entered Comment (Drop Enabled)</Text>
+                    <Text style={[styles.mb2, styles.textLabelSupporting]}>Entered Comment (Drop Enabled)</Text>
                     <Text>{comment}</Text>
                 </View>
                 <View
@@ -62,7 +62,7 @@ const Default = (args) => {
                         styles.flex1,
                     ]}
                 >
-                    <Text style={[styles.mb2, styles.formLabel]}>Rendered Comment</Text>
+                    <Text style={[styles.mb2, styles.textLabelSupporting]}>Rendered Comment</Text>
                     {Boolean(renderedHTML) && <RenderHTML html={renderedHTML} />}
                     {pastedFile && (
                         <View style={styles.mv3}>

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -894,15 +894,6 @@ const styles = {
         lineHeight: 16,
     },
 
-    formLabel: {
-        fontFamily: fontFamily.EXP_NEUE_BOLD,
-        fontWeight: fontWeightBold,
-        color: themeColors.heading,
-        fontSize: variables.fontSizeLabel,
-        lineHeight: variables.lineHeightLarge,
-        marginBottom: 8,
-    },
-
     formHelp: {
         color: themeColors.textSupporting,
         fontSize: variables.fontSizeLabel,

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -2849,12 +2849,6 @@ const styles = {
         paddingRight: 18,
     },
 
-    pushToPageEmptyItemLabel: {
-        color: themeColors.textSupporting,
-        fontSize: variables.fontSizeNormal,
-        maxWidth: 240,
-    },
-
     deeplinkWrapperContainer: {
         padding: 20,
         flex: 1,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

### Fixed Issues
$ https://github.com/Expensify/App/issues/14208

### Tests
1. Navigate to the following pages and confirm that the labels style (font, text color and size) looks the same as the image below:

- **Notifications** and **Test Preferences** in `Settings > Preferences`
- **Email**, **Preferred pronouns** and **Local time** in `Chat header > user details`
- **All currencies** in `+ > Request money > Currency symbol`
- **Recents** and **Contacts** in `+ > Request money > Enter amount > Select participants`
- **To** in `+ > Request money > Enter amount > Select participants > Confirm page`
- **Who paid?** and **Who was there?** in `+ > Split bill > Enter amount > Select participants > Confirm page`

<img width="486" alt="example" src="https://user-images.githubusercontent.com/22219519/212177728-56abfb51-ce84-4ae2-a42f-cad4b67e9902.png">

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
Same as tests

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

![web-preferencesPage](https://user-images.githubusercontent.com/22219519/212178016-4c34758c-071b-4028-894f-c9d218756ed8.png)
![web-detailsPage](https://user-images.githubusercontent.com/22219519/212178017-844b30b4-5dc5-458a-abf1-48e267693fa7.png)
![web-currencySelection](https://user-images.githubusercontent.com/22219519/212178018-41ab2209-d6c2-4272-a8b0-f3efcb4d0e5e.png)
![web-recents](https://user-images.githubusercontent.com/22219519/212178020-350619fd-3c62-42bf-bf39-ca9c59469ac3.png)
![web-requestPage](https://user-images.githubusercontent.com/22219519/212178022-13702774-f379-4c74-ae9d-4c5a16f8744e.png)
![web-split](https://user-images.githubusercontent.com/22219519/212178023-e9beebfa-1ef6-4cb3-8cbd-3cf823d9db0f.png)


</details>

<details>
<summary>Mobile Web - Chrome</summary>

![chrome-preferences](https://user-images.githubusercontent.com/22219519/212178098-38164dbb-7fdb-4678-b9c3-0f05e688ff50.png)
![chrome-details](https://user-images.githubusercontent.com/22219519/212178102-918be01a-b23b-40e4-b201-a4d00782ca03.png)
![chrome-currency](https://user-images.githubusercontent.com/22219519/212178103-cbd38777-7d7f-4039-8be5-5cb6ffac52d1.png)
![chrome-recents](https://user-images.githubusercontent.com/22219519/212178105-bb155e61-abea-4981-a791-4e78090d61f7.png)
![chrome-split](https://user-images.githubusercontent.com/22219519/212178109-130baa21-ce05-40d2-93ba-3a1afa1e73c5.png)
![chrome-request](https://user-images.githubusercontent.com/22219519/212178113-7e6c5af2-06dc-404c-9a82-ccb040f88913.png)


</details>

<details>
<summary>Mobile Web - Safari</summary>

![safari-preferences](https://user-images.githubusercontent.com/22219519/212178153-3f904cd9-76ee-44da-ae1b-51a4473907e2.png)
![safari-details](https://user-images.githubusercontent.com/22219519/212178156-0f7445cd-516c-4ddf-979f-f48aaa180019.png)
![safari-currency](https://user-images.githubusercontent.com/22219519/212178158-9ad7b9f5-cdac-4945-af7c-599f14eccfad.png)
![safari-request](https://user-images.githubusercontent.com/22219519/212178160-e857225a-efb9-4746-a5f7-09b9d82da3a7.png)
![safari-split](https://user-images.githubusercontent.com/22219519/212178164-c03fc6be-c5af-4b77-b428-90cd25db9437.png)


</details>

<details>
<summary>Desktop</summary>

![desktop-detailsPage](https://user-images.githubusercontent.com/22219519/212178198-d849bbdf-30bd-40b5-877b-ad835a702b6f.png)
![desktop-currencySelection](https://user-images.githubusercontent.com/22219519/212178200-83fccbae-f22b-4f0e-99ad-46344e029882.png)
![desktop-recents](https://user-images.githubusercontent.com/22219519/212178201-fa182d37-5871-432b-97ee-7d6646fbbded.png)
![desktop-requestPage](https://user-images.githubusercontent.com/22219519/212178206-e5366fde-4c6c-4071-8e4f-e731563542bb.png)
![desktop-preferencesPage](https://user-images.githubusercontent.com/22219519/212178207-9e6e013c-8f6f-4e37-87a7-7553902bf173.png)
![desktop-split](https://user-images.githubusercontent.com/22219519/212178208-4402198f-d46d-453d-be91-fc87bfc22ca3.png)


</details>

<details>
<summary>iOS</summary>

![ios-preferences](https://user-images.githubusercontent.com/22219519/212178238-c9297eab-3a26-46c9-b72e-fd281bb7fd10.png)
![ios-details](https://user-images.githubusercontent.com/22219519/212178240-71493de1-4cb7-4082-9629-13237d8a39e7.png)
![ios-currency](https://user-images.githubusercontent.com/22219519/212178242-29e385b4-cd46-4b40-b4d4-b36eafa96770.png)
![ios-request](https://user-images.githubusercontent.com/22219519/212178245-9250fe1f-3e09-4335-b671-6f05618e6c6c.png)
![ios-recents](https://user-images.githubusercontent.com/22219519/212178246-a07987a7-871d-4979-9c05-963e3f7ad163.png)
![ios-split](https://user-images.githubusercontent.com/22219519/212178247-621d2300-4514-4d39-8fb3-db463bd11ae7.png)


</details>

<details>
<summary>Android</summary>

![android-request](https://user-images.githubusercontent.com/22219519/212178275-9497210f-016a-42b0-b26d-45bca6ee8200.png)
![android-recents](https://user-images.githubusercontent.com/22219519/212178278-38f7cc02-0ef5-479f-8ce2-5f8c825ceb2c.png)
![android-split](https://user-images.githubusercontent.com/22219519/212178279-4a7c6725-7b47-43b3-9945-f3f16863e47c.png)
![android-currency](https://user-images.githubusercontent.com/22219519/212178281-85889f34-29c8-4c8b-8515-da957ae56e3f.png)
![android-details](https://user-images.githubusercontent.com/22219519/212178283-6307ff14-a630-4f78-8d28-31daa72949c2.png)
![android-preferences](https://user-images.githubusercontent.com/22219519/212178285-6826c3f6-1e31-4242-952f-59339a526e93.png)


</details>
