### PR TITLE
fix long text cut in iOS single line input

### DIFF
--- a/src/components/RNTextInput.js
+++ b/src/components/RNTextInput.js
@@ -22,11 +22,6 @@ const RNTextInput = props => (
             }
             props.forwardedRef(ref);
         }}
-
-        // By default, align input to the left to override right alignment in RTL mode which is not yet supported in the App.
-        // eslint-disable-next-line react/jsx-props-no-multi-spaces
-        textAlign="left"
-
         // eslint-disable-next-line
         {...props}
     />

--- a/src/components/TextInput/BaseTextInput.js
+++ b/src/components/TextInput/BaseTextInput.js
@@ -285,7 +285,7 @@ class BaseTextInput extends Component {
                                             (!hasLabel || this.props.multiline) && styles.pv0,
                                             this.props.prefixCharacter && StyleUtils.getPaddingLeft(this.state.prefixWidth + styles.pl1.paddingLeft),
                                             this.props.secureTextEntry && styles.secureInput,
-                                            !this.props.multiline && {height: this.state.height},
+                                            !this.props.multiline && {height: this.state.height, lineHeight: null},
                                         ]}
                                         multiline={this.props.multiline}
                                         maxLength={this.props.maxLength}

--- a/src/components/TextInput/BaseTextInput.js
+++ b/src/components/TextInput/BaseTextInput.js
@@ -285,7 +285,7 @@ class BaseTextInput extends Component {
                                             (!hasLabel || this.props.multiline) && styles.pv0,
                                             this.props.prefixCharacter && StyleUtils.getPaddingLeft(this.state.prefixWidth + styles.pl1.paddingLeft),
                                             this.props.secureTextEntry && styles.secureInput,
-                                            !this.props.multiline && {height: this.state.height, lineHeight: null},
+                                            !this.props.multiline && {height: this.state.height, lineHeight: undefined},
                                         ]}
                                         multiline={this.props.multiline}
                                         maxLength={this.props.maxLength}

--- a/src/components/TextInput/BaseTextInput.js
+++ b/src/components/TextInput/BaseTextInput.js
@@ -285,6 +285,9 @@ class BaseTextInput extends Component {
                                             (!hasLabel || this.props.multiline) && styles.pv0,
                                             this.props.prefixCharacter && StyleUtils.getPaddingLeft(this.state.prefixWidth + styles.pl1.paddingLeft),
                                             this.props.secureTextEntry && styles.secureInput,
+
+                                            // Explicitly remove `lineHeight` from single line inputs so that long text doesn't disappear
+                                            // once it exceeds the input space (See https://github.com/Expensify/App/issues/13802)
                                             !this.props.multiline && {height: this.state.height, lineHeight: undefined},
                                         ]}
                                         multiline={this.props.multiline}


### PR DESCRIPTION
### Details
- remove textAlign="left"
- remove lineHeight when single line

### Fixed Issues
$ https://github.com/Expensify/App/issues/13802#issuecomment-1375016021
PROPOSAL: https://github.com/Expensify/App/issues/13802


### Tests
1. Login with any account.
2. Choose any single line TextInput, i.e. Settings -> Workspaces -> workspace -> General settings and focus on Name input.
3. Enter long text with multiple words, i.e. `Miroslav.stevanovic12345's Workspacelongnametest test`.
4. Blur text input by clicking Default currency picker or clicking Save button.
5. Verify that Name text is cut at the end position of input field. On iOS, `...` should be added at the end.

- [x] Verify that no errors appear in the JS console

### Offline tests
1. Login with any account.
2. Disable network
3. Choose any single line TextInput, i.e. Settings -> Workspaces -> workspace -> General settings and focus on Name input.
4. Enter long text with multiple words, i.e. `Miroslav.stevanovic12345's Workspacelongnametest test`.
5. Blur text input by clicking Default currency picker.
6. Verify that Name text is cut at the end position of input field. On iOS, `...` should be added at the end.

### QA Steps
1. Login with any account.
2. Choose any single line TextInput, i.e. Settings -> Workspaces -> workspace -> General settings and focus on Name input.
3. Enter long text with multiple words, i.e. `Miroslav.stevanovic12345's Workspacelongnametest test`.
4. Blur text input by clicking Default currency picker.
5. Verify that Name text is cut at the end position of input field. On iOS, `...` should be added at the end.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>


https://user-images.githubusercontent.com/97473779/212289941-c6f7727b-39cb-4f63-a14a-c83a60b37ec5.mov



</details>

<details>
<summary>Mobile Web - Chrome</summary>


https://user-images.githubusercontent.com/97473779/212290083-f8042b8b-363c-45c4-bbee-2d39405e3112.mp4



</details>

<details>
<summary>Mobile Web - Safari</summary>


https://user-images.githubusercontent.com/97473779/212290171-76a22c4a-18bd-4786-8184-0c7018e1f71e.mp4



</details>

<details>
<summary>Desktop</summary>


https://user-images.githubusercontent.com/97473779/212290447-b5369429-298b-4653-add8-3badb151538f.mov



</details>

<details open>
<summary>iOS</summary>


https://user-images.githubusercontent.com/97473779/212290500-920d7aec-299a-4b7a-8a90-b8940686eae4.mp4


While testing on iOS, I noticed that Save button blinks when open & close picker while showing keyboard. This is not related to this issue and can be handled in a separate issue.

</details>

<details>
<summary>Android</summary>


https://user-images.githubusercontent.com/97473779/212290542-0d428f32-0714-4539-841b-e27a8ca1dc9a.mp4



</details>
