### PR TITLE
On workspace delete, do cleanup / cascade delete

### DIFF
--- a/src/libs/ReportUtils.js
+++ b/src/libs/ReportUtils.js
@@ -1186,7 +1186,7 @@ function getChatByParticipants(newParticipantList) {
  * @param {String} policyID
  * @returns {Array}
  */
-function getPolicyReports(policyID) {
+function getAllPolicyReports(policyID) {
     return _.filter(allReports, report => report && report.policyID === policyID);
 }
 
@@ -1264,7 +1264,7 @@ export {
     buildOptimisticReportAction,
     shouldReportBeInOptionList,
     getChatByParticipants,
-    getPolicyReports,
+    getAllPolicyReports,
     getIOUReportActionMessage,
     getDisplayNameForParticipant,
     isIOUReport,

--- a/src/libs/ReportUtils.js
+++ b/src/libs/ReportUtils.js
@@ -1183,6 +1183,15 @@ function getChatByParticipants(newParticipantList) {
 }
 
 /**
+ * Get policy reports
+ * @param {String} policyID
+ * @returns {Array}
+ */
+function getPolicyReports(policyID) {
+    return _.filter(allReports, report => report && report.policyID === policyID);
+}
+
+/**
 * Returns true if Chronos is one of the chat participants (1:1)
 * @param {Object} report
 * @returns {Boolean}
@@ -1256,6 +1265,7 @@ export {
     buildOptimisticReportAction,
     shouldReportBeInOptionList,
     getChatByParticipants,
+    getPolicyReports,
     getIOUReportActionMessage,
     getDisplayNameForParticipant,
     isIOUReport,

--- a/src/libs/ReportUtils.js
+++ b/src/libs/ReportUtils.js
@@ -1183,7 +1183,6 @@ function getChatByParticipants(newParticipantList) {
 }
 
 /**
- * Get policy reports
  * @param {String} policyID
  * @returns {Array}
  */

--- a/src/libs/actions/Policy.js
+++ b/src/libs/actions/Policy.js
@@ -22,8 +22,17 @@ Onyx.connect({
         if (!key) {
             return;
         }
-
         if (val === null || val === undefined) {
+            const policyID = key.replace(ONYXKEYS.COLLECTION.POLICY, '');
+            const policyReports = ReportUtils.getPolicyReports(policyID);
+            const cleanUpMergeQueries = {};
+            const cleanUpSetQueries = {};
+            _.each(policyReports, ({reportID}) => {
+                cleanUpMergeQueries[`${ONYXKEYS.COLLECTION.REPORT}${reportID}`] = {hasDraft: false};
+                cleanUpSetQueries[`${ONYXKEYS.COLLECTION.REPORT_DRAFT_COMMENT}${reportID}`] = null;
+            });
+            Onyx.mergeCollection(ONYXKEYS.COLLECTION.REPORT, cleanUpMergeQueries);
+            Onyx.multiSet(cleanUpSetQueries);
             delete allPolicies[key];
             return;
         }

--- a/src/libs/actions/Policy.js
+++ b/src/libs/actions/Policy.js
@@ -23,6 +23,9 @@ Onyx.connect({
             return;
         }
         if (val === null || val === undefined) {
+            // If we are deleting a policy, we have to check every report linked to that policy
+            // and unset the draft indicator (pencil icon) alognside removing any draft comments
+            // More info: https://github.com/Expensify/App/issues/14260
             const policyID = key.replace(ONYXKEYS.COLLECTION.POLICY, '');
             const policyReports = ReportUtils.getPolicyReports(policyID);
             const cleanUpMergeQueries = {};

--- a/src/libs/actions/Policy.js
+++ b/src/libs/actions/Policy.js
@@ -27,7 +27,7 @@ Onyx.connect({
             // and unset the draft indicator (pencil icon) alongside removing any draft comments. Clearing these values will keep the newly archived chats from being displayed in the LHN.
             // More info: https://github.com/Expensify/App/issues/14260
             const policyID = key.replace(ONYXKEYS.COLLECTION.POLICY, '');
-            const policyReports = ReportUtils.getPolicyReports(policyID);
+            const policyReports = ReportUtils.getAllPolicyReports(policyID);
             const cleanUpMergeQueries = {};
             const cleanUpSetQueries = {};
             _.each(policyReports, ({reportID}) => {

--- a/src/libs/actions/Policy.js
+++ b/src/libs/actions/Policy.js
@@ -24,7 +24,7 @@ Onyx.connect({
         }
         if (val === null || val === undefined) {
             // If we are deleting a policy, we have to check every report linked to that policy
-            // and unset the draft indicator (pencil icon) alognside removing any draft comments
+            // and unset the draft indicator (pencil icon) alongside removing any draft comments. Clearing these values will keep the newly archived chats from being displayed in the LHN.
             // More info: https://github.com/Expensify/App/issues/14260
             const policyID = key.replace(ONYXKEYS.COLLECTION.POLICY, '');
             const policyReports = ReportUtils.getPolicyReports(policyID);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
If we are deleting a workspace perform clean up queries

### Fixed Issues
$ https://github.com/Expensify/App/issues/14260   
PROPOSAL: https://github.com/Expensify/App/issues/14260#issuecomment-1385632796


### Tests
1. Create a workspace
2. (device A) Go to one of the workspace reports (such as the admins room or announce room)
3. (device A) Type any message
4. (device A) Verify that you see the pencil icon on LHN
5. (device B) Delete the same workspace
6. (device A) Verify that you no longer see the pencil icon on LHN

- [ ] Verify that no errors appear in the JS console

### Offline tests
n/a

### QA Steps
1. Create a workspace
2. (device A) Go to one of the workspace reports (such as the admins room or announce room)
3. (device A) Type any message
4. (device A) Verify that you see the pencil icon on LHN
5. (device B) Delete the same workspace
6. (device A) Verify that you no longer see the pencil icon on LHN

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android / native
    - [X] Android / Chrome
    - [X] iOS / native
    - [X] iOS / Safari
    - [X] MacOS / Chrome / Safari
    - [X] MacOS / Desktop
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [X] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [X] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If a new component is created I verified that:
    - [X] A similar component doesn't exist in the codebase
    - [X] All props are defined accurately and each prop has a `/** comment above it */`
    - [X] The file is named correctly
    - [X] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [X] The only data being stored in the state is data necessary for rendering and nothing else
    - [X] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [X] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [X] All JSX used for rendering exists in the render method
    - [X] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>


https://user-images.githubusercontent.com/16493223/213022809-38025198-28db-469c-b4d6-df6f8d871c53.mp4



</details>

<details>
<summary>Mobile Web - Chrome</summary>


https://user-images.githubusercontent.com/16493223/213022827-0f5f084a-b765-4725-9575-41cc7862efed.mp4



</details>

<details>
<summary>Mobile Web - Safari</summary>


https://user-images.githubusercontent.com/16493223/213023116-50291cf1-7ac0-43b9-b489-9f99470c25a6.mp4



</details>

<details>
<summary>Desktop</summary>


https://user-images.githubusercontent.com/16493223/213023127-8d277207-5a13-45f6-a08a-d24d6a4789f7.mp4



</details>

<details>
<summary>iOS</summary>



https://user-images.githubusercontent.com/16493223/213023452-93f1d98f-00cb-4c19-b88f-07d9d8838e68.mp4


</details>

<details>
<summary>Android</summary>



https://user-images.githubusercontent.com/16493223/213023471-db53b32b-dd38-4477-8f6d-a0081b4e026f.mp4


</details>
