### PR TITLE
Make padding above avatar consistent

### DIFF
--- a/src/pages/DetailsPage.js
+++ b/src/pages/DetailsPage.js
@@ -120,7 +120,7 @@ class DetailsPage extends React.PureComponent {
                 >
                     {details ? (
                         <ScrollView>
-                            <View style={styles.pageWrapper}>
+                            <View style={[styles.pageWrapper, styles.pt0]}>
                                 <AttachmentModal
                                     headerTitle={isSMSLogin ? this.props.toLocalPhone(details.displayName) : details.displayName}
                                     sourceURL={details.avatar}

--- a/src/pages/DetailsPage.js
+++ b/src/pages/DetailsPage.js
@@ -120,7 +120,7 @@ class DetailsPage extends React.PureComponent {
                 >
                     {details ? (
                         <ScrollView>
-                            <View style={[styles.pageWrapper, styles.pt0]}>
+                            <View style={styles.avatarSectionWrapper}>
                                 <AttachmentModal
                                     headerTitle={isSMSLogin ? this.props.toLocalPhone(details.displayName) : details.displayName}
                                     sourceURL={details.avatar}

--- a/src/pages/settings/InitialSettingsPage.js
+++ b/src/pages/settings/InitialSettingsPage.js
@@ -246,7 +246,7 @@ class InitialSettingsPage extends React.Component {
                 />
                 <ScrollView style={[styles.settingsPageBackground]}>
                     <View style={styles.w100}>
-                        <View style={[styles.pageWrapper, styles.pt0]}>
+                        <View style={styles.avatarSectionWrapper}>
                             <Pressable style={[styles.mb3]} onPress={this.openProfileSettings}>
                                 <Tooltip text={this.props.currentUserPersonalDetails.displayName}>
                                     <OfflineWithFeedback

--- a/src/pages/settings/InitialSettingsPage.js
+++ b/src/pages/settings/InitialSettingsPage.js
@@ -246,7 +246,7 @@ class InitialSettingsPage extends React.Component {
                 />
                 <ScrollView style={[styles.settingsPageBackground]}>
                     <View style={styles.w100}>
-                        <View style={styles.pageWrapper}>
+                        <View style={[styles.pageWrapper, styles.pt0]}>
                             <Pressable style={[styles.mb3]} onPress={this.openProfileSettings}>
                                 <Tooltip text={this.props.currentUserPersonalDetails.displayName}>
                                     <OfflineWithFeedback

--- a/src/pages/workspace/WorkspaceInitialPage.js
+++ b/src/pages/workspace/WorkspaceInitialPage.js
@@ -183,7 +183,7 @@ class WorkspaceInitialPage extends React.Component {
                             errorRowStyles={[styles.ph6, styles.pv2]}
                         >
                             <View style={[styles.flex1]}>
-                                <View style={styles.pageWrapper}>
+                                <View style={[styles.pageWrapper, styles.pt0]}>
                                     <View style={[styles.settingsPageBody, styles.alignItemsCenter]}>
                                         <Pressable
                                             disabled={this.hasPolicyCreationError()}

--- a/src/pages/workspace/WorkspaceInitialPage.js
+++ b/src/pages/workspace/WorkspaceInitialPage.js
@@ -215,7 +215,6 @@ class WorkspaceInitialPage extends React.Component {
                                                 style={[
                                                     styles.alignSelfCenter,
                                                     styles.mt4,
-                                                    styles.mb6,
                                                     styles.w100,
                                                 ]}
                                                 onPress={this.openEditor}

--- a/src/pages/workspace/WorkspaceInitialPage.js
+++ b/src/pages/workspace/WorkspaceInitialPage.js
@@ -183,7 +183,7 @@ class WorkspaceInitialPage extends React.Component {
                             errorRowStyles={[styles.ph6, styles.pv2]}
                         >
                             <View style={[styles.flex1]}>
-                                <View style={[styles.pageWrapper, styles.pt0]}>
+                                <View style={styles.avatarSectionWrapper}>
                                     <View style={[styles.settingsPageBody, styles.alignItemsCenter]}>
                                         <Pressable
                                             disabled={this.hasPolicyCreationError()}

--- a/src/pages/workspace/WorkspaceSettingsPage.js
+++ b/src/pages/workspace/WorkspaceSettingsPage.js
@@ -80,7 +80,7 @@ class WorkspaceSettingsPage extends React.Component {
                     <Form
                         formID={ONYXKEYS.FORMS.WORKSPACE_SETTINGS_FORM}
                         submitButtonText={this.props.translate('workspace.editor.save')}
-                        style={[styles.mh5, styles.mt5, styles.flexGrow1]}
+                        style={[styles.mh5, styles.flexGrow1]}
                         validate={this.validate}
                         onSubmit={this.submit}
                         enabledWhenOffline

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -2038,6 +2038,13 @@ const styles = {
         padding: 20,
     },
 
+    avatarSectionWrapper: {
+        width: '100%',
+        alignItems: 'center',
+        paddingHorizontal: 20,
+        paddingBottom: 20,
+    },
+
     selectCircle: {
         width: variables.componentSizeSmall,
         height: variables.componentSizeSmall,


### PR DESCRIPTION
cc @shawnborton 

### Details
Removes extra padding above the avatar on the following pages
- Initial settings page
- Initial workspace page
- Workspace general settings page
- User details page

![padding](https://user-images.githubusercontent.com/6833644/213291161-9adb2191-d451-4595-91d8-67228374d0ac.png)

### Fixed Issues
$ https://github.com/Expensify/App/issues/14182

### Tests
Verify that there is no additional padding on the following pages

- Settings
- Settings > Workspaces > {Workspace}
- Settings > Workspaces > {Worspace} > General settings
- Any chat > User details (click their avatar)

### Offline tests
None

### QA Steps
Same as Tests

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->
![Screenshot 2023-01-18 at 4 07 56 PM](https://user-images.githubusercontent.com/6833644/213295233-ba858d1d-ad6f-44cb-93e9-afcec20eff3c.png)

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->
![Screenshot_20230118-160648](https://user-images.githubusercontent.com/6833644/213295203-13420fdb-3b59-4db0-8fc3-e98ca44a89ad.png)

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->
![IMG_A06B11390434-1](https://user-images.githubusercontent.com/6833644/213291822-0e80638c-d677-4aac-a96a-6e61b3d0896d.jpeg)

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->
![Screenshot 2023-01-18 at 4 10 42 PM](https://user-images.githubusercontent.com/6833644/213295514-2d7c4691-bb96-425f-bb3b-f0f8f5fbd62d.png)

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->
![IMG_1447A6F4A97A-1](https://user-images.githubusercontent.com/6833644/213291415-4d4b5715-37db-496d-8dc3-945e00d52abf.jpeg)

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->
![Screenshot_20230118-160411](https://user-images.githubusercontent.com/6833644/213295073-85683970-83c2-4190-97c2-d95cbe61b445.png)

</details>
