### PR TITLE
fix: Message actions popover not showing after open app download links page and go back

### DIFF
--- a/src/Expensify.js
+++ b/src/Expensify.js
@@ -24,6 +24,8 @@ import * as User from './libs/actions/User';
 import NetworkConnection from './libs/NetworkConnection';
 import Navigation from './libs/Navigation/Navigation';
 import DeeplinkWrapper from './components/DeeplinkWrapper';
+import PopoverReportActionContextMenu from './pages/home/report/ContextMenu/PopoverReportActionContextMenu';
+import * as ReportActionContextMenu from './pages/home/report/ContextMenu/ReportActionContextMenu';
 
 // This lib needs to be imported, but it has nothing to export since all it contains is an Onyx connection
 // eslint-disable-next-line no-unused-vars
@@ -189,6 +191,9 @@ class Expensify extends PureComponent {
                 {!this.state.isSplashShown && (
                     <>
                         <GrowlNotification ref={Growl.growlRef} />
+                        <PopoverReportActionContextMenu
+                            ref={ReportActionContextMenu.contextMenuRef}
+                        />
                         {/* We include the modal for showing a new update at the top level so the option is always present. */}
                         {this.props.updateAvailable ? <UpdateAppModal /> : null}
                         {this.props.screenShareRequest ? (

--- a/src/libs/Navigation/AppNavigator/MainDrawerNavigator.js
+++ b/src/libs/Navigation/AppNavigator/MainDrawerNavigator.js
@@ -14,6 +14,8 @@ import SidebarScreen from '../../../pages/home/sidebar/SidebarScreen';
 import BaseDrawerNavigator from './BaseDrawerNavigator';
 import * as ReportUtils from '../../ReportUtils';
 import reportPropTypes from '../../../pages/reportPropTypes';
+import * as ReportActionContextMenu from '../../../pages/home/report/ContextMenu/ReportActionContextMenu';
+import PopoverReportActionContextMenu from '../../../pages/home/report/ContextMenu/PopoverReportActionContextMenu';
 
 const propTypes = {
     /** Available reports that would be displayed in this navigator */
@@ -80,26 +82,31 @@ class MainDrawerNavigator extends Component {
         // This way routing information is updated (if needed) based on the initial report ID resolved.
         // This is usually needed after login/create account and re-launches
         return (
-            <BaseDrawerNavigator
-                drawerContent={({navigation, state}) => {
-                    // This state belongs to the drawer so it should always have the ReportScreen as it's initial (and only) route
-                    const reportIDFromRoute = lodashGet(state, ['routes', 0, 'params', 'reportID']);
-                    return (
-                        <SidebarScreen
-                            navigation={navigation}
-                            reportIDFromRoute={reportIDFromRoute}
-                        />
-                    );
-                }}
-                screens={[
-                    {
-                        name: SCREENS.REPORT,
-                        component: ReportScreen,
-                        initialParams: this.initialParams,
-                    },
-                ]}
-                isMainScreen
-            />
+            <>
+                <PopoverReportActionContextMenu
+                    ref={ReportActionContextMenu.contextMenuRef}
+                />
+                <BaseDrawerNavigator
+                    drawerContent={({navigation, state}) => {
+                        // This state belongs to the drawer so it should always have the ReportScreen as it's initial (and only) route
+                        const reportIDFromRoute = lodashGet(state, ['routes', 0, 'params', 'reportID']);
+                        return (
+                            <SidebarScreen
+                                navigation={navigation}
+                                reportIDFromRoute={reportIDFromRoute}
+                            />
+                        );
+                    }}
+                    screens={[
+                        {
+                            name: SCREENS.REPORT,
+                            component: ReportScreen,
+                            initialParams: this.initialParams,
+                        },
+                    ]}
+                    isMainScreen
+                />
+            </>
         );
     }
 }

--- a/src/libs/Navigation/AppNavigator/MainDrawerNavigator.js
+++ b/src/libs/Navigation/AppNavigator/MainDrawerNavigator.js
@@ -14,8 +14,6 @@ import SidebarScreen from '../../../pages/home/sidebar/SidebarScreen';
 import BaseDrawerNavigator from './BaseDrawerNavigator';
 import * as ReportUtils from '../../ReportUtils';
 import reportPropTypes from '../../../pages/reportPropTypes';
-import * as ReportActionContextMenu from '../../../pages/home/report/ContextMenu/ReportActionContextMenu';
-import PopoverReportActionContextMenu from '../../../pages/home/report/ContextMenu/PopoverReportActionContextMenu';
 
 const propTypes = {
     /** Available reports that would be displayed in this navigator */
@@ -82,31 +80,26 @@ class MainDrawerNavigator extends Component {
         // This way routing information is updated (if needed) based on the initial report ID resolved.
         // This is usually needed after login/create account and re-launches
         return (
-            <>
-                <PopoverReportActionContextMenu
-                    ref={ReportActionContextMenu.contextMenuRef}
-                />
-                <BaseDrawerNavigator
-                    drawerContent={({navigation, state}) => {
-                        // This state belongs to the drawer so it should always have the ReportScreen as it's initial (and only) route
-                        const reportIDFromRoute = lodashGet(state, ['routes', 0, 'params', 'reportID']);
-                        return (
-                            <SidebarScreen
-                                navigation={navigation}
-                                reportIDFromRoute={reportIDFromRoute}
-                            />
-                        );
-                    }}
-                    screens={[
-                        {
-                            name: SCREENS.REPORT,
-                            component: ReportScreen,
-                            initialParams: this.initialParams,
-                        },
-                    ]}
-                    isMainScreen
-                />
-            </>
+            <BaseDrawerNavigator
+                drawerContent={({navigation, state}) => {
+                    // This state belongs to the drawer so it should always have the ReportScreen as it's initial (and only) route
+                    const reportIDFromRoute = lodashGet(state, ['routes', 0, 'params', 'reportID']);
+                    return (
+                        <SidebarScreen
+                            navigation={navigation}
+                            reportIDFromRoute={reportIDFromRoute}
+                        />
+                    );
+                }}
+                screens={[
+                    {
+                        name: SCREENS.REPORT,
+                        component: ReportScreen,
+                        initialParams: this.initialParams,
+                    },
+                ]}
+                isMainScreen
+            />
         );
     }
 }

--- a/src/pages/home/report/ContextMenu/PopoverReportActionContextMenu.js
+++ b/src/pages/home/report/ContextMenu/PopoverReportActionContextMenu.js
@@ -116,8 +116,8 @@ class PopoverReportActionContextMenu extends React.Component {
      * @param {String} draftMessage - ReportAction Draftmessage
      * @param {Function} [onShow] - Run a callback when Menu is shown
      * @param {Function} [onHide] - Run a callback when Menu is hidden
-     * @param {Boolean} isArchivedRoom - isArchivedRoom
-     * @param {Boolean} isChronosReport - isChronosReport
+     * @param {Boolean} isArchivedRoom - Whether the provided report is an archived room
+     * @param {Boolean} isChronosReport - Flag to check if the chat participant is Chronos
      */
     showContextMenu(
         type,

--- a/src/pages/home/report/ContextMenu/PopoverReportActionContextMenu.js
+++ b/src/pages/home/report/ContextMenu/PopoverReportActionContextMenu.js
@@ -311,8 +311,8 @@ class PopoverReportActionContextMenu extends React.Component {
                         reportID={this.state.reportID}
                         reportAction={this.state.reportAction}
                         draftMessage={this.state.reportActionDraftMessage}
-                        isArchivedRoom={this.props.isArchivedRoom}
-                        isChronosReport={this.props.isChronosReport}
+                        isArchivedRoom={this.state.isArchivedRoom}
+                        isChronosReport={this.state.isChronosReport}
                         anchor={this.contextMenuTargetNode}
                     />
                 </PopoverWithMeasuredContent>

--- a/src/pages/home/report/ContextMenu/PopoverReportActionContextMenu.js
+++ b/src/pages/home/report/ContextMenu/PopoverReportActionContextMenu.js
@@ -3,7 +3,6 @@ import {
     Dimensions,
 } from 'react-native';
 import _ from 'underscore';
-import PropTypes from 'prop-types';
 import lodashGet from 'lodash/get';
 import * as Report from '../../../../libs/actions/Report';
 import withLocalize, {withLocalizePropTypes} from '../../../../components/withLocalize';
@@ -12,18 +11,7 @@ import BaseReportActionContextMenu from './BaseReportActionContextMenu';
 import ConfirmModal from '../../../../components/ConfirmModal';
 
 const propTypes = {
-    /** Flag to check if the chat participant is Chronos */
-    isChronosReport: PropTypes.bool,
-
-    /** Whether the provided report is an archived room */
-    isArchivedRoom: PropTypes.bool,
-
     ...withLocalizePropTypes,
-};
-
-const defaultProps = {
-    isChronosReport: false,
-    isArchivedRoom: false,
 };
 
 class PopoverReportActionContextMenu extends React.Component {
@@ -48,6 +36,8 @@ class PopoverReportActionContextMenu extends React.Component {
                 horizontal: 0,
                 vertical: 0,
             },
+            isArchivedRoom: false,
+            isChronosReport: false,
         };
         this.onPopoverShow = () => {};
         this.onPopoverHide = () => {};
@@ -126,6 +116,8 @@ class PopoverReportActionContextMenu extends React.Component {
      * @param {String} draftMessage - ReportAction Draftmessage
      * @param {Function} [onShow] - Run a callback when Menu is shown
      * @param {Function} [onHide] - Run a callback when Menu is hidden
+     * @param {Boolean} isArchivedRoom - isArchivedRoom
+     * @param {Boolean} isChronosReport - isChronosReport
      */
     showContextMenu(
         type,
@@ -137,6 +129,8 @@ class PopoverReportActionContextMenu extends React.Component {
         draftMessage,
         onShow = () => {},
         onHide = () => {},
+        isArchivedRoom,
+        isChronosReport,
     ) {
         const nativeEvent = event.nativeEvent || {};
         this.contextMenuAnchor = contextMenuAnchor;
@@ -167,6 +161,8 @@ class PopoverReportActionContextMenu extends React.Component {
                 selection,
                 isPopoverVisible: true,
                 reportActionDraftMessage: draftMessage,
+                isArchivedRoom,
+                isChronosReport,
             });
         });
     }
@@ -239,8 +235,8 @@ class PopoverReportActionContextMenu extends React.Component {
                 selection={this.state.selection}
                 reportID={this.state.reportID}
                 reportAction={this.state.reportAction}
-                isArchivedRoom={this.props.isArchivedRoom}
-                isChronosReport={this.props.isChronosReport}
+                isArchivedRoom={this.state.isArchivedRoom}
+                isChronosReport={this.state.isChronosReport}
                 anchor={this.contextMenuTargetNode}
             />
         );
@@ -269,6 +265,8 @@ class PopoverReportActionContextMenu extends React.Component {
             reportAction: {},
             isDeleteCommentConfirmModalVisible: false,
             shouldSetModalVisibilityForDeleteConfirmation: true,
+            isArchivedRoom: false,
+            isChronosReport: false,
         });
     }
 
@@ -336,6 +334,5 @@ class PopoverReportActionContextMenu extends React.Component {
 }
 
 PopoverReportActionContextMenu.propTypes = propTypes;
-PopoverReportActionContextMenu.defaultProps = defaultProps;
 
 export default withLocalize(PopoverReportActionContextMenu);

--- a/src/pages/home/report/ContextMenu/ReportActionContextMenu.js
+++ b/src/pages/home/report/ContextMenu/ReportActionContextMenu.js
@@ -14,8 +14,8 @@ const contextMenuRef = React.createRef();
  * @param {String} draftMessage - ReportAction Draftmessage
  * @param {Function} [onShow=() => {}] - Run a callback when Menu is shown
  * @param {Function} [onHide=() => {}] - Run a callback when Menu is hidden
- * @param {Boolean} isArchivedRoom - isArchivedRoom
- * @param {Boolean} isChronosReport - isChronosReport
+ * @param {Boolean} isArchivedRoom - Whether the provided report is an archived room
+ * @param {Boolean} isChronosReport - Flag to check if the chat participant is Chronos
  */
 function showContextMenu(
     type,

--- a/src/pages/home/report/ContextMenu/ReportActionContextMenu.js
+++ b/src/pages/home/report/ContextMenu/ReportActionContextMenu.js
@@ -14,6 +14,8 @@ const contextMenuRef = React.createRef();
  * @param {String} draftMessage - ReportAction Draftmessage
  * @param {Function} [onShow=() => {}] - Run a callback when Menu is shown
  * @param {Function} [onHide=() => {}] - Run a callback when Menu is hidden
+ * @param {Boolean} isArchivedRoom - isArchivedRoom
+ * @param {Boolean} isChronosReport - isChronosReport
  */
 function showContextMenu(
     type,
@@ -25,6 +27,8 @@ function showContextMenu(
     draftMessage = '',
     onShow = () => {},
     onHide = () => {},
+    isArchivedRoom = false,
+    isChronosReport = false,
 ) {
     if (!contextMenuRef.current) {
         return;
@@ -39,6 +43,8 @@ function showContextMenu(
         draftMessage,
         onShow,
         onHide,
+        isArchivedRoom,
+        isChronosReport,
     );
 }
 

--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -133,6 +133,8 @@ class ReportActionItem extends Component {
             this.props.draftMessage,
             undefined,
             this.checkIfContextMenuActive,
+            ReportUtils.isArchivedRoom(this.props.report),
+            ReportUtils.chatIncludesChronos(this.props.report),
         );
     }
 

--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -12,8 +12,6 @@ import withWindowDimensions, {windowDimensionsPropTypes} from '../../../componen
 import {withDrawerPropTypes} from '../../../components/withDrawerState';
 import * as ReportScrollManager from '../../../libs/ReportScrollManager';
 import withLocalize, {withLocalizePropTypes} from '../../../components/withLocalize';
-import * as ReportActionContextMenu from './ContextMenu/ReportActionContextMenu';
-import PopoverReportActionContextMenu from './ContextMenu/PopoverReportActionContextMenu';
 import Performance from '../../../libs/Performance';
 import {withNetwork} from '../../../components/OnyxProvider';
 import * as EmojiPickerAction from '../../../libs/actions/EmojiPickerAction';
@@ -370,11 +368,6 @@ class ReportActionsView extends React.Component {
                             isLoadingMoreReportActions={this.props.report.isLoadingMoreReportActions}
                             loadMoreChats={this.loadMoreChats}
                             newMarkerReportActionID={this.state.newMarkerReportActionID}
-                        />
-                        <PopoverReportActionContextMenu
-                            ref={ReportActionContextMenu.contextMenuRef}
-                            isArchivedRoom={ReportUtils.isArchivedRoom(this.props.report)}
-                            isChronosReport={ReportUtils.chatIncludesChronos(this.props.report)}
                         />
                     </>
                 )}

--- a/src/pages/settings/AppDownloadLinks.js
+++ b/src/pages/settings/AppDownloadLinks.js
@@ -17,7 +17,6 @@ import withWindowDimensions, {windowDimensionsPropTypes} from '../../components/
 import * as DeviceCapabilities from '../../libs/DeviceCapabilities';
 import * as ReportActionContextMenu from '../home/report/ContextMenu/ReportActionContextMenu';
 import * as ContextMenuActions from '../home/report/ContextMenu/ContextMenuActions';
-import PopoverReportActionContextMenu from '../home/report/ContextMenu/PopoverReportActionContextMenu';
 
 const propTypes = {
     ...withLocalizePropTypes,
@@ -81,9 +80,6 @@ const AppDownloadLinksPage = (props) => {
                 onCloseButtonPress={() => Navigation.dismissModal(true)}
             />
             <ScrollView style={[styles.mt5]}>
-                <PopoverReportActionContextMenu
-                    ref={ReportActionContextMenu.contextMenuRef}
-                />
                 {_.map(menuItems, item => (
                     <PressableWithSecondaryInteraction
                         key={item.translationKey}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Escalate `PopoverReportActionContextMenu` to [Expensify.js (https://github.com/Expensify/App/blob/main/src/Expensify.js) to become an app-wide component, thus avoiding race conditions when using the app-wide `ReportActionContextMenu.showContextMenu` method

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/14131   
https://github.com/Expensify/App/issues/14131#issuecomment-1381298507


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Open any chat room.
2. Right click/Long press on any message to open actions popover. (Popover will be display)
3. Go to Settings => About => App download links.
4. Dismiss/close modal on outside click.
5. Try to right click on any message to open actions popover/modal.
6. Verify that the actions popover/modal shows correctly

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
1. Turn off the internet
2. Open any chat room.
3. Right click/Long press on any message to open actions popover. (Popover will be display)
4. Go to Settings => About => App download links.
5. Dismiss/close modal on outside click.
6. Try to right click on any message to open actions popover/modal.
7. Verify that the actions popover/modal shows correctly

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Open any chat room.
2. Right click/Long press on any message to open actions popover. (Popover will be display)
3. Go to Settings => About => App download links.
4. Dismiss/close modal on outside click.
5. Try to right click on any message to open actions popover/modal.
6. Verify that the actions popover/modal shows correctly

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/113963320/213670370-6155d3d1-f294-4509-b8a3-140b624ea132.mov


</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/113963320/213669161-1f2b6b64-1047-42c5-9037-52fcc0add485.mov

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/113963320/213670333-cdbfee10-5e0e-402f-9f6f-c26ab07d0853.mov


</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/113963320/213678369-d9aaa0ab-0eb3-4e5a-8b21-38cdf1e73e04.mov

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/113963320/213678274-7cc674c0-4af5-4864-afec-87d0ced04162.mov

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/113963320/213703377-e8c6c8ca-9418-4274-baa9-6265a2a63f57.mp4


</details>
