### PR TITLE
Feature: Track downloads status

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -772,7 +772,6 @@ const CONST = {
         EMOJI_SUGGESTIONS: /:[a-zA-Z0-9_+-]{1,40}$/,
         AFTER_FIRST_LINE_BREAK: /\n.*/g,
         CODE_2FA: /^\d{6}$/,
-
         ATTACHMENT_ID: /chat-attachments\/(\d+)/,
     },
 

--- a/src/CONST.js
+++ b/src/CONST.js
@@ -772,6 +772,8 @@ const CONST = {
         EMOJI_SUGGESTIONS: /:[a-zA-Z0-9_+-]{1,40}$/,
         AFTER_FIRST_LINE_BREAK: /\n.*/g,
         CODE_2FA: /^\d{6}$/,
+
+        ATTACHMENT_ID: /chat-attachments\/(\d+)/,
     },
 
     PRONOUNS: {

--- a/src/ONYXKEYS.js
+++ b/src/ONYXKEYS.js
@@ -98,6 +98,7 @@ export default {
         POLICY: 'policy_',
         REPORT_IS_COMPOSER_FULL_SIZE: 'reportIsComposerFullSize_',
         POLICY_MEMBER_LIST: 'policyMemberList_',
+        DOWNLOAD: 'download_',
     },
 
     // Indicates which locale should be used

--- a/src/components/AnchorForAttachmentsOnly/BaseAnchorForAttachmentsOnly.js
+++ b/src/components/AnchorForAttachmentsOnly/BaseAnchorForAttachmentsOnly.js
@@ -6,6 +6,7 @@ import {
     propTypes as anchorForAttachmentsOnlyPropTypes,
     defaultProps as anchorForAttachmentsOnlyDefaultProps,
 } from './anchorForAttachmentsOnlyPropTypes';
+import CONST from '../../CONST';
 import ONYXKEYS from '../../ONYXKEYS';
 import AttachmentView from '../AttachmentView';
 import * as Download from '../../libs/actions/Download';
@@ -33,7 +34,7 @@ class BaseAnchorForAttachmentsOnly extends React.Component {
     render() {
         const sourceURL = this.props.source;
         const sourceURLWithAuth = addEncryptedAuthTokenToURL(sourceURL);
-        const sourceID = (sourceURL.match(/chat-attachments\/(\d+)/) || [])[1];
+        const sourceID = (sourceURL.match(CONST.REGEX.ATTACHMENT_ID) || [])[1];
         const fileName = this.props.displayName;
 
         const isDownloading = this.props.download && this.props.download.isDownloading;
@@ -84,7 +85,7 @@ BaseAnchorForAttachmentsOnly.defaultProps = defaultProps;
 export default withOnyx({
     download: {
         key: ({source}) => {
-            const sourceID = (source.match(/chat-attachments\/(\d+)/) || [])[1];
+            const sourceID = (source.match(CONST.REGEX.ATTACHMENT_ID) || [])[1];
             return `${ONYXKEYS.COLLECTION.DOWNLOAD}${sourceID}`;
         },
     },

--- a/src/components/AnchorForAttachmentsOnly/BaseAnchorForAttachmentsOnly.js
+++ b/src/components/AnchorForAttachmentsOnly/BaseAnchorForAttachmentsOnly.js
@@ -30,55 +30,54 @@ const defaultProps = {
     ...anchorForAttachmentsOnlyDefaultProps,
 };
 
-class BaseAnchorForAttachmentsOnly extends React.Component {
-    render() {
-        const sourceURL = this.props.source;
-        const sourceURLWithAuth = addEncryptedAuthTokenToURL(sourceURL);
-        const sourceID = (sourceURL.match(CONST.REGEX.ATTACHMENT_ID) || [])[1];
-        const fileName = this.props.displayName;
+const BaseAnchorForAttachmentsOnly = (props) => {
+    const sourceURL = props.source;
+    const sourceURLWithAuth = addEncryptedAuthTokenToURL(sourceURL);
+    const sourceID = (sourceURL.match(CONST.REGEX.ATTACHMENT_ID) || [])[1];
+    const fileName = props.displayName;
 
-        const isDownloading = this.props.download && this.props.download.isDownloading;
+    const isDownloading = props.download && props.download.isDownloading;
 
-        return (
-            <ShowContextMenuContext.Consumer>
-                {({
-                    anchor,
-                    reportID,
-                    action,
-                    checkIfContextMenuActive,
-                }) => (
-                    <Pressable
-                        style={this.props.style}
-                        onPress={() => {
-                            if (isDownloading) {
-                                return;
-                            }
-                            Download.setDownload(sourceID, true);
-                            fileDownload(sourceURLWithAuth, fileName).then(() => Download.setDownload(sourceID, false));
-                        }}
-                        onPressIn={this.props.onPressIn}
-                        onPressOut={this.props.onPressOut}
-                        onLongPress={event => showContextMenuForReport(
-                            event,
-                            anchor,
-                            reportID,
-                            action,
-                            checkIfContextMenuActive,
-                        )}
-                    >
-                        <AttachmentView
-                            sourceURL={sourceURLWithAuth}
-                            file={{name: fileName}}
-                            shouldShowDownloadIcon
-                            shouldShowLoadingSpinnerIcon={isDownloading}
-                        />
-                    </Pressable>
-                )}
-            </ShowContextMenuContext.Consumer>
-        );
-    }
-}
+    return (
+        <ShowContextMenuContext.Consumer>
+            {({
+                anchor,
+                reportID,
+                action,
+                checkIfContextMenuActive,
+            }) => (
+                <Pressable
+                    style={props.style}
+                    onPress={() => {
+                        if (isDownloading) {
+                            return;
+                        }
+                        Download.setDownload(sourceID, true);
+                        fileDownload(sourceURLWithAuth, fileName).then(() => Download.setDownload(sourceID, false));
+                    }}
+                    onPressIn={props.onPressIn}
+                    onPressOut={props.onPressOut}
+                    onLongPress={event => showContextMenuForReport(
+                        event,
+                        anchor,
+                        reportID,
+                        action,
+                        checkIfContextMenuActive,
+                    )}
+                >
+                    <AttachmentView
+                        sourceURL={sourceURLWithAuth}
+                        file={{name: fileName}}
+                        shouldShowDownloadIcon
+                        shouldShowLoadingSpinnerIcon={isDownloading}
+                    />
+                </Pressable>
+            )}
+        </ShowContextMenuContext.Consumer>
+    );
+};
 
+BaseAnchorForAttachmentsOnly.displayName = 'BaseAnchorForAttachmentsOnly';
 BaseAnchorForAttachmentsOnly.propTypes = propTypes;
 BaseAnchorForAttachmentsOnly.defaultProps = defaultProps;
 

--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -102,6 +102,7 @@ class AuthScreens extends React.Component {
 
         App.openApp();
         App.setUpPoliciesAndNavigate(this.props.session);
+        App.clearDownloads();
         Timing.end(CONST.TIMING.HOMEPAGE_INITIAL_RENDER);
 
         const searchShortcutConfig = CONST.KEYBOARD_SHORTCUTS.SEARCH;

--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -28,6 +28,7 @@ import * as ModalStackNavigators from './ModalStackNavigators';
 import SCREENS from '../../../SCREENS';
 import defaultScreenOptions from './defaultScreenOptions';
 import * as App from '../../actions/App';
+import * as Download from '../../actions/Download';
 import * as Session from '../../actions/Session';
 
 let currentUserEmail;
@@ -102,7 +103,7 @@ class AuthScreens extends React.Component {
 
         App.openApp();
         App.setUpPoliciesAndNavigate(this.props.session);
-        App.clearDownloads();
+        Download.clearDownloads();
         Timing.end(CONST.TIMING.HOMEPAGE_INITIAL_RENDER);
 
         const searchShortcutConfig = CONST.KEYBOARD_SHORTCUTS.SEARCH;

--- a/src/libs/actions/App.js
+++ b/src/libs/actions/App.js
@@ -169,6 +169,22 @@ function reconnectApp() {
 }
 
 /**
+ * Clear downloads
+ */
+function clearDownloads() {
+    const connectionID = Onyx.connect({
+        key: ONYXKEYS.COLLECTION.DOWNLOAD,
+        waitForCollectionCallback: true,
+        callback: (records) => {
+            Onyx.disconnect(connectionID);
+            const downloads = {};
+            _.each(_.keys(records), recordKey => downloads[recordKey] = null);
+            Onyx.multiSet(downloads);
+        },
+    });
+}
+
+/**
  * This action runs when the Navigator is ready and the current route changes
  *
  * currentPath should be the path as reported by the NavigationContainer
@@ -277,4 +293,5 @@ export {
     openProfile,
     openApp,
     reconnectApp,
+    clearDownloads,
 };

--- a/src/libs/actions/App.js
+++ b/src/libs/actions/App.js
@@ -179,7 +179,9 @@ function clearDownloads() {
             Onyx.disconnect(connectionID);
             const downloads = {};
             _.each(_.keys(records), recordKey => downloads[recordKey] = null);
-            Onyx.multiSet(downloads);
+            if (!_.isEmpty(downloads)) {
+                Onyx.multiSet(downloads);
+            }
         },
     });
 }

--- a/src/libs/actions/App.js
+++ b/src/libs/actions/App.js
@@ -169,24 +169,6 @@ function reconnectApp() {
 }
 
 /**
- * Clear downloads
- */
-function clearDownloads() {
-    const connectionID = Onyx.connect({
-        key: ONYXKEYS.COLLECTION.DOWNLOAD,
-        waitForCollectionCallback: true,
-        callback: (records) => {
-            Onyx.disconnect(connectionID);
-            const downloads = {};
-            _.each(_.keys(records), recordKey => downloads[recordKey] = null);
-            if (!_.isEmpty(downloads)) {
-                Onyx.multiSet(downloads);
-            }
-        },
-    });
-}
-
-/**
  * This action runs when the Navigator is ready and the current route changes
  *
  * currentPath should be the path as reported by the NavigationContainer
@@ -295,5 +277,4 @@ export {
     openProfile,
     openApp,
     reconnectApp,
-    clearDownloads,
 };

--- a/src/libs/actions/Download.js
+++ b/src/libs/actions/Download.js
@@ -19,10 +19,10 @@ function clearDownloads() {
         waitForCollectionCallback: true,
         callback: (records) => {
             Onyx.disconnect(connectionID);
-            const downloads = {};
-            _.each(_.keys(records), recordKey => downloads[recordKey] = null);
-            if (!_.isEmpty(downloads)) {
-                Onyx.multiSet(downloads);
+            const downloadsToDelete = {};
+            _.each(_.keys(records), recordKey => downloadsToDelete[recordKey] = null);
+            if (!_.isEmpty(downloadsToDelete)) {
+                Onyx.multiSet(downloadsToDelete);
             }
         },
     });

--- a/src/libs/actions/Download.js
+++ b/src/libs/actions/Download.js
@@ -1,3 +1,4 @@
+import _ from 'underscore';
 import Onyx from 'react-native-onyx';
 import ONYXKEYS from '../../ONYXKEYS';
 
@@ -12,7 +13,22 @@ function setDownload(sourceID, isDownloading) {
     return Onyx.merge(`${ONYXKEYS.COLLECTION.DOWNLOAD}${sourceID}`, {isDownloading});
 }
 
+function clearDownloads() {
+    const connectionID = Onyx.connect({
+        key: ONYXKEYS.COLLECTION.DOWNLOAD,
+        waitForCollectionCallback: true,
+        callback: (records) => {
+            Onyx.disconnect(connectionID);
+            const downloads = {};
+            _.each(_.keys(records), recordKey => downloads[recordKey] = null);
+            if (!_.isEmpty(downloads)) {
+                Onyx.multiSet(downloads);
+            }
+        },
+    });
+}
+
 export {
-    // eslint-disable-next-line import/prefer-default-export
     setDownload,
+    clearDownloads,
 };

--- a/src/libs/actions/Download.js
+++ b/src/libs/actions/Download.js
@@ -3,7 +3,7 @@ import Onyx from 'react-native-onyx';
 import ONYXKEYS from '../../ONYXKEYS';
 
 /**
- * Immediate indication whether the an attachment is being downloaded.
+ * Sets whether the an attachment is being downloaded.
  *
  * @param {String} sourceID
  * @param {Boolean} isDownloading

--- a/src/libs/actions/Download.js
+++ b/src/libs/actions/Download.js
@@ -1,0 +1,18 @@
+import Onyx from 'react-native-onyx';
+import ONYXKEYS from '../../ONYXKEYS';
+
+/**
+ * Immediate indication whether the an attachment is being downloaded.
+ *
+ * @param {String} sourceID
+ * @param {Boolean} isDownloading
+ * @returns {Promise}
+ */
+function setDownload(sourceID, isDownloading) {
+    return Onyx.merge(`${ONYXKEYS.COLLECTION.DOWNLOAD}${sourceID}`, {isDownloading});
+}
+
+export {
+    // eslint-disable-next-line import/prefer-default-export
+    setDownload,
+};

--- a/src/libs/actions/Download.js
+++ b/src/libs/actions/Download.js
@@ -3,7 +3,7 @@ import Onyx from 'react-native-onyx';
 import ONYXKEYS from '../../ONYXKEYS';
 
 /**
- * Sets whether the an attachment is being downloaded.
+ * Set whether an attachment is being downloaded so that a spinner can be shown.
  *
  * @param {String} sourceID
  * @param {Boolean} isDownloading

--- a/src/pages/home/report/ContextMenu/ContextMenuActions.js
+++ b/src/pages/home/report/ContextMenu/ContextMenuActions.js
@@ -53,7 +53,7 @@ export default [
             const attachmentDetails = getAttachmentDetails(html);
             const {originalFileName, sourceURL} = attachmentDetails;
             const sourceURLWithAuth = addEncryptedAuthTokenToURL(sourceURL);
-            const sourceID = (sourceURL.match(/chat-attachments\/(\d+)/) || [])[1];
+            const sourceID = (sourceURL.match(CONST.REGEX.ATTACHMENT_ID) || [])[1];
             Download.setDownload(sourceID, true);
             fileDownload(sourceURLWithAuth, originalFileName).then(() => Download.setDownload(sourceID, false));
             if (closePopover) {

--- a/src/pages/home/report/ContextMenu/ContextMenuActions.js
+++ b/src/pages/home/report/ContextMenu/ContextMenuActions.js
@@ -4,6 +4,7 @@ import Str from 'expensify-common/lib/str';
 import lodashGet from 'lodash/get';
 import * as Expensicons from '../../../../components/Icon/Expensicons';
 import * as Report from '../../../../libs/actions/Report';
+import * as Download from '../../../../libs/actions/Download';
 import Clipboard from '../../../../libs/Clipboard';
 import * as ReportUtils from '../../../../libs/ReportUtils';
 import ReportActionComposeFocusManager from '../../../../libs/ReportActionComposeFocusManager';
@@ -50,10 +51,11 @@ export default [
             const message = _.last(lodashGet(reportAction, 'message', [{}]));
             const html = lodashGet(message, 'html', '');
             const attachmentDetails = getAttachmentDetails(html);
-            const {originalFileName} = attachmentDetails;
-            let {sourceURL} = attachmentDetails;
-            sourceURL = addEncryptedAuthTokenToURL(sourceURL);
-            fileDownload(sourceURL, originalFileName);
+            const {originalFileName, sourceURL} = attachmentDetails;
+            const sourceURLWithAuth = addEncryptedAuthTokenToURL(sourceURL);
+            const sourceID = (sourceURL.match(/chat-attachments\/(\d+)/) || [])[1];
+            Download.setDownload(sourceID, true);
+            fileDownload(sourceURLWithAuth, originalFileName).then(() => Download.setDownload(sourceID, false));
             if (closePopover) {
                 hideContextMenu(true, ReportActionComposeFocusManager.focus);
             }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Added download collection to onyx so we can track downloads status

### Fixed Issues
$ https://github.com/Expensify/App/issues/14237   
PROPOSAL: https://github.com/Expensify/App/issues/14237#issuecomment-1384669144


### Tests
1. Login to any account
2. Send any attachment that does not have a preview (e.g. mp4, mp3)
3. Open context menu
4. Click on download
5. Verify that you see a download spinner on the attachmnet widget
6. Wait for download to complete
7. Verify that you no longer see the download spinner on the attachmnet widget

- [ ] Verify that no errors appear in the JS console

### Offline tests
n/a

### QA Steps
1. Login to any account
2. Send any attachment that does not have a preview (e.g. mp4, mp3)
3. Open context menu
4. Click on download
5. Verify that you see a download spinner on the attachmnet widget
6. Wait for download to complete
7. Verify that you no longer see the download spinner on the attachmnet widget

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android / native
    - [X] Android / Chrome
    - [X] iOS / native
    - [X] iOS / Safari
    - [X] MacOS / Chrome / Safari
    - [X] MacOS / Desktop
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [X] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [X] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If a new component is created I verified that:
    - [X] A similar component doesn't exist in the codebase
    - [X] All props are defined accurately and each prop has a `/** comment above it */`
    - [X] The file is named correctly
    - [X] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [X] The only data being stored in the state is data necessary for rendering and nothing else
    - [X] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [X] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [X] All JSX used for rendering exists in the render method
    - [X] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>


https://user-images.githubusercontent.com/16493223/213801267-f858d3ce-e375-4e7f-ace2-0c7143355211.mp4



</details>

<details>
<summary>Mobile Web - Chrome</summary>


https://user-images.githubusercontent.com/16493223/213801317-579555be-68ec-4f45-8326-590479057c29.mp4



</details>

<details>
<summary>Mobile Web - Safari</summary>


https://user-images.githubusercontent.com/16493223/213801344-1b86d1bc-f2b9-4f52-8dcd-b21b4afef08d.mp4



</details>

<details>
<summary>Desktop</summary>



https://user-images.githubusercontent.com/16493223/213801486-d0e150c8-3b8c-4431-a665-d4f430fb0be0.mp4


</details>

<details>
<summary>iOS</summary>


https://user-images.githubusercontent.com/16493223/213801566-c661cf9c-5dbb-4da1-8f30-d404d793006b.mp4



</details>

<details>
<summary>Android</summary>


https://user-images.githubusercontent.com/16493223/213801623-5267f576-417a-4194-841b-b59f62cad7ec.mp4



</details>
