### PR TITLE
Hook Localize HOC into the `currentUserPersonalDetails`

### DIFF
--- a/src/components/withLocalize.js
+++ b/src/components/withLocalize.js
@@ -46,12 +46,24 @@ const localeProviderPropTypes = {
     /** The user's preferred locale e.g. 'en', 'es-ES' */
     preferredLocale: PropTypes.string,
 
-    /* Actual content wrapped by this component */
+    /** Actual content wrapped by this component */
     children: PropTypes.node.isRequired,
+
+    /** The current user's personalDetails */
+    currentUserPersonalDetails: PropTypes.shape({
+
+        /** Timezone of the current user */
+        timezone: PropTypes.shape({
+
+            /** Value of the selected timezone */
+            selected: PropTypes.string,
+        }),
+    }),
 };
 
 const localeProviderDefaultProps = {
     preferredLocale: CONST.DEFAULT_LOCALE,
+    currentUserPersonalDetails: {},
 };
 
 class LocaleContextProvider extends React.Component {

--- a/src/components/withLocalize.js
+++ b/src/components/withLocalize.js
@@ -1,6 +1,8 @@
 import React, {createContext, forwardRef} from 'react';
 import PropTypes from 'prop-types';
 import {withOnyx} from 'react-native-onyx';
+import lodashGet from 'lodash/get';
+
 import getComponentDisplayName from '../libs/getComponentDisplayName';
 import ONYXKEYS from '../ONYXKEYS';
 import * as Localize from '../libs/Localize';
@@ -9,6 +11,8 @@ import * as LocalePhoneNumber from '../libs/LocalePhoneNumber';
 import * as NumberFormatUtils from '../libs/NumberFormatUtils';
 import * as LocaleDigitUtils from '../libs/LocaleDigitUtils';
 import CONST from '../CONST';
+import compose from '../libs/compose';
+import withCurrentUserPersonalDetails from './withCurrentUserPersonalDetails';
 
 const LocaleContext = createContext(null);
 
@@ -105,6 +109,7 @@ class LocaleContextProvider extends React.Component {
             this.props.preferredLocale,
             datetime,
             includeTimezone,
+            lodashGet(this.props, 'currentUserPersonalDetails.timezone.selected'),
         );
     }
 
@@ -152,11 +157,14 @@ class LocaleContextProvider extends React.Component {
 LocaleContextProvider.propTypes = localeProviderPropTypes;
 LocaleContextProvider.defaultProps = localeProviderDefaultProps;
 
-const Provider = withOnyx({
-    preferredLocale: {
-        key: ONYXKEYS.NVP_PREFERRED_LOCALE,
-    },
-})(LocaleContextProvider);
+const Provider = compose(
+    withCurrentUserPersonalDetails,
+    withOnyx({
+        preferredLocale: {
+            key: ONYXKEYS.NVP_PREFERRED_LOCALE,
+        },
+    }),
+)(LocaleContextProvider);
 
 Provider.displayName = 'withOnyx(LocaleContextProvider)';
 

--- a/src/libs/DateUtils.js
+++ b/src/libs/DateUtils.js
@@ -49,6 +49,7 @@ function getLocalMomentFromDatetime(locale, datetime, currentSelectedTimezone = 
     if (!datetime) {
         return moment.tz(currentSelectedTimezone);
     }
+
     return moment.utc(datetime).tz(currentSelectedTimezone);
 }
 
@@ -63,11 +64,12 @@ function getLocalMomentFromDatetime(locale, datetime, currentSelectedTimezone = 
  * @param {String} locale
  * @param {String} datetime
  * @param {Boolean} includeTimeZone
+ * @param {String} [currentSelectedTimezone]
  *
  * @returns {String}
  */
-function datetimeToCalendarTime(locale, datetime, includeTimeZone = false) {
-    const date = getLocalMomentFromDatetime(locale, datetime);
+function datetimeToCalendarTime(locale, datetime, includeTimeZone = false, currentSelectedTimezone) {
+    const date = getLocalMomentFromDatetime(locale, datetime, currentSelectedTimezone);
     const tz = includeTimeZone ? ' [UTC]Z' : '';
 
     const todayAt = Localize.translate(locale, 'common.todayAt');


### PR DESCRIPTION
### Details

The Localize HOC uses methods that depend on a subscription here:

https://github.com/Expensify/App/blob/17edc8253c992391c6937e9ba788679b898e99aa/src/libs/DateUtils.js#L27-L33

However, when the timezone updates connected component will not re-render to recalculate the time. We could fix this in a naive way by subscribing to the personalDetails with `withCurrentUserPersonalDetails` in either the `ReportActionItemDate` component or `withLocalize()`. If we do nothing else, that fixes the issue. However, to make the dependency more obvious I am now passing the selected timezone to the method that gets called here:

https://github.com/Expensify/App/blob/17edc8253c992391c6937e9ba788679b898e99aa/src/components/withLocalize.js#L119-L126

Where it is optionally passed here:

https://github.com/Expensify/App/blob/17edc8253c992391c6937e9ba788679b898e99aa/src/libs/DateUtils.js#L67-L72

### Fixed Issues
$ https://github.com/Expensify/App/issues/14436

### Tests

Same as QA

- [ ] Verify that no errors appear in the JS console

### Offline tests

These steps can be tested while offline and the behavior should be the same as if we are online.

### QA Steps

1. Navigate to any chat and note the time of a comment
2. Navigate to `/settings/profile/timezone`
3. De-select `Automatically determine your location.`
4. Modify the timezone
5. Verify that the chat has updated with the correct timezone.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

![2023-01-20_12-20-24](https://user-images.githubusercontent.com/32969087/213815496-8832fc06-44b4-4bb2-bd47-5d453835ac21.png)

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<img width="405" alt="2023-01-20_12-35-24" src="https://user-images.githubusercontent.com/32969087/213817477-00b7d6d5-3bb1-4d52-832b-0fc2e3c74229.png">

</details>

<details>
<summary>Mobile Web - Safari</summary>

<img width="438" alt="2023-01-20_12-26-40" src="https://user-images.githubusercontent.com/32969087/213816389-0054322d-33eb-4689-bc81-a090ea07aa69.png">

</details>

<details>
<summary>Desktop</summary>

![2023-01-20_12-30-13](https://user-images.githubusercontent.com/32969087/213816878-4fdde5eb-ddf6-4802-a9f3-437467a6fd49.png)

</details>

<details>
<summary>iOS</summary>

<img width="438" alt="2023-01-20_12-24-54" src="https://user-images.githubusercontent.com/32969087/213816181-3f18745f-8b5e-4744-9ec2-b7867beb26de.png">

</details>

<details>
<summary>Android</summary>

<img width="405" alt="2023-01-20_12-32-32" src="https://user-images.githubusercontent.com/32969087/213817162-e95f4f57-96a6-4377-a327-7c1f1a6378cc.png">

</details>
