### PR TITLE
Update attachment link URL replacing logic

### DIFF
--- a/src/components/HTMLEngineProvider/HTMLRenderers/ImageRenderer.js
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/ImageRenderer.js
@@ -1,35 +1,12 @@
 import React from 'react';
-import _ from 'underscore';
 import htmlRendererPropTypes from './htmlRendererPropTypes';
-import Config from '../../../CONFIG';
 import AttachmentModal from '../../AttachmentModal';
 import styles from '../../../styles/styles';
 import ThumbnailImage from '../../ThumbnailImage';
 import PressableWithoutFocus from '../../PressableWithoutFocus';
 import CONST from '../../../CONST';
 import {ShowContextMenuContext, showContextMenuForReport} from '../../ShowContextMenuContext';
-
-/**
- * Update the image URL so images can be accessed depending on the config environment
- *
- * @param {String} urlString
- * @returns {*|String}
- */
-function mapSource(urlString) {
-    // Attachments can come from either staging or prod, depending on the env they were uploaded by
-    // Both should be replaced and loaded from API ROOT of the current environment
-    const originsWeShouldReplace = [Config.EXPENSIFY.EXPENSIFY_URL, Config.EXPENSIFY.STAGING_EXPENSIFY_URL];
-
-    const originToReplace = _.find(originsWeShouldReplace, origin => urlString.startsWith(origin));
-    if (!originToReplace) {
-        return urlString;
-    }
-
-    return urlString.replace(
-        originToReplace,
-        Config.EXPENSIFY.URL_API_ROOT,
-    );
-}
+import replaceSourceOrigin from '../../../libs/replaceSourceOrigin';
 
 const ImageRenderer = (props) => {
     const htmlAttribs = props.tnode.attributes;
@@ -53,8 +30,8 @@ const ImageRenderer = (props) => {
     //
     const isAttachment = Boolean(htmlAttribs[CONST.ATTACHMENT_SOURCE_ATTRIBUTE]);
     const originalFileName = htmlAttribs['data-name'];
-    const previewSource = mapSource(htmlAttribs.src);
-    const source = mapSource(isAttachment
+    const previewSource = replaceSourceOrigin(htmlAttribs.src);
+    const source = replaceSourceOrigin(isAttachment
         ? htmlAttribs[CONST.ATTACHMENT_SOURCE_ATTRIBUTE]
         : htmlAttribs.src);
 

--- a/src/components/HTMLEngineProvider/HTMLRenderers/ImageRenderer.js
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/ImageRenderer.js
@@ -6,7 +6,7 @@ import ThumbnailImage from '../../ThumbnailImage';
 import PressableWithoutFocus from '../../PressableWithoutFocus';
 import CONST from '../../../CONST';
 import {ShowContextMenuContext, showContextMenuForReport} from '../../ShowContextMenuContext';
-import replaceSourceOrigin from '../../../libs/replaceSourceOrigin';
+import tryResolveUrlFromApiRoot from '../../../libs/tryResolveUrlFromApiRoot';
 
 const ImageRenderer = (props) => {
     const htmlAttribs = props.tnode.attributes;
@@ -30,8 +30,10 @@ const ImageRenderer = (props) => {
     //
     const isAttachment = Boolean(htmlAttribs[CONST.ATTACHMENT_SOURCE_ATTRIBUTE]);
     const originalFileName = htmlAttribs['data-name'];
-    const previewSource = replaceSourceOrigin(htmlAttribs.src);
-    const source = replaceSourceOrigin(isAttachment
+
+    // Files created/uploaded/hosted by App should resolve from API ROOT. Other URLs aren't modified
+    const previewSource = tryResolveUrlFromApiRoot(htmlAttribs.src);
+    const source = tryResolveUrlFromApiRoot(isAttachment
         ? htmlAttribs[CONST.ATTACHMENT_SOURCE_ATTRIBUTE]
         : htmlAttribs.src);
 

--- a/src/libs/fileDownload/getAttachmentDetails.js
+++ b/src/libs/fileDownload/getAttachmentDetails.js
@@ -1,5 +1,5 @@
 import CONST from '../../CONST';
-import Config from '../../CONFIG';
+import replaceSourceOrigin from '../replaceSourceOrigin';
 
 /**
  * Extract the thumbnail URL, source URL and the original filename from the HTML.
@@ -19,14 +19,9 @@ export default function getAttachmentName(html) {
             originalFileName: null,
         };
     }
-    const sourceURL = html.match(SOURCE_REGEX)[1].replace(
-        Config.EXPENSIFY.EXPENSIFY_URL,
-        Config.EXPENSIFY.URL_API_ROOT,
-    );
-    const previewSourceURL = (IS_IMAGE_TAG ? html.match(PREVIEW_SOURCE_REGEX)[1] : sourceURL).replace(
-        Config.EXPENSIFY.EXPENSIFY_URL,
-        Config.EXPENSIFY.URL_API_ROOT,
-    );
+    const sourceURL = replaceSourceOrigin(html.match(SOURCE_REGEX)[1]);
+    const imageURL = IS_IMAGE_TAG && replaceSourceOrigin(html.match(PREVIEW_SOURCE_REGEX)[1]);
+    const previewSourceURL = IS_IMAGE_TAG ? imageURL : sourceURL;
     const originalFileName = html.match(ORIGINAL_FILENAME_REGEX)[1];
 
     // Update the image URL so the images can be accessed depending on the config environment

--- a/src/libs/fileDownload/getAttachmentDetails.js
+++ b/src/libs/fileDownload/getAttachmentDetails.js
@@ -1,5 +1,5 @@
 import CONST from '../../CONST';
-import replaceSourceOrigin from '../replaceSourceOrigin';
+import tryResolveUrlFromApiRoot from '../tryResolveUrlFromApiRoot';
 
 /**
  * Extract the thumbnail URL, source URL and the original filename from the HTML.
@@ -19,8 +19,10 @@ export default function getAttachmentName(html) {
             originalFileName: null,
         };
     }
-    const sourceURL = replaceSourceOrigin(html.match(SOURCE_REGEX)[1]);
-    const imageURL = IS_IMAGE_TAG && replaceSourceOrigin(html.match(PREVIEW_SOURCE_REGEX)[1]);
+
+    // Files created/uploaded/hosted by App should resolve from API ROOT. Other URLs aren't modified
+    const sourceURL = tryResolveUrlFromApiRoot(html.match(SOURCE_REGEX)[1]);
+    const imageURL = IS_IMAGE_TAG && tryResolveUrlFromApiRoot(html.match(PREVIEW_SOURCE_REGEX)[1]);
     const previewSourceURL = IS_IMAGE_TAG ? imageURL : sourceURL;
     const originalFileName = html.match(ORIGINAL_FILENAME_REGEX)[1];
 

--- a/src/libs/replaceSourceOrigin.js
+++ b/src/libs/replaceSourceOrigin.js
@@ -1,0 +1,24 @@
+import _ from 'underscore';
+import Config from '../CONFIG';
+
+/**
+ * Update the URL so images/files can be accessed depending on the config environment
+ *
+ * @param {String} urlString
+ * @returns {String}
+ */
+export default function replaceSourceOrigin(urlString) {
+    // Attachments can come from either staging or prod, depending on the env they were uploaded by
+    // Both should be replaced and loaded from API ROOT of the current environment
+    const originsToReplace = [Config.EXPENSIFY.EXPENSIFY_URL, Config.EXPENSIFY.STAGING_EXPENSIFY_URL];
+
+    const originToReplace = _.find(originsToReplace, origin => urlString.startsWith(origin));
+    if (!originToReplace) {
+        return urlString;
+    }
+
+    return urlString.replace(
+        originToReplace,
+        Config.EXPENSIFY.URL_API_ROOT,
+    );
+}

--- a/src/libs/replaceSourceOrigin.js
+++ b/src/libs/replaceSourceOrigin.js
@@ -1,24 +1,21 @@
-import _ from 'underscore';
 import Config from '../CONFIG';
 
+// Absolute URLs (`/` or `//`) should be resolved from API ROOT
+// Legacy attachments can come from either staging or prod, depending on the env they were uploaded by
+// Both should be replaced and loaded from API ROOT of the current environment
+const ORIGINS_TO_REPLACE = ['/+', Config.EXPENSIFY.EXPENSIFY_URL, Config.EXPENSIFY.STAGING_EXPENSIFY_URL];
+
+// Anything starting with a match from ORIGINS_TO_REPLACE
+const ORIGIN_PATTERN = new RegExp(`^(${ORIGINS_TO_REPLACE.join('|')})`);
+
 /**
- * Update the URL so images/files can be accessed depending on the config environment
+ * Updates URLs, so they are accessed relative to URL_API_ROOT
+ * Matches: absolute, prod or staging URLs
+ * Unmatched URLs aren't modified
  *
- * @param {String} urlString
+ * @param {String} url
  * @returns {String}
  */
-export default function replaceSourceOrigin(urlString) {
-    // Attachments can come from either staging or prod, depending on the env they were uploaded by
-    // Both should be replaced and loaded from API ROOT of the current environment
-    const originsToReplace = [Config.EXPENSIFY.EXPENSIFY_URL, Config.EXPENSIFY.STAGING_EXPENSIFY_URL];
-
-    const originToReplace = _.find(originsToReplace, origin => urlString.startsWith(origin));
-    if (!originToReplace) {
-        return urlString;
-    }
-
-    return urlString.replace(
-        originToReplace,
-        Config.EXPENSIFY.URL_API_ROOT,
-    );
+export default function replaceSourceOrigin(url) {
+    return url.replace(ORIGIN_PATTERN, Config.EXPENSIFY.URL_API_ROOT);
 }

--- a/src/libs/tryResolveUrlFromApiRoot.js
+++ b/src/libs/tryResolveUrlFromApiRoot.js
@@ -9,13 +9,16 @@ const ORIGINS_TO_REPLACE = ['/+', Config.EXPENSIFY.EXPENSIFY_URL, Config.EXPENSI
 const ORIGIN_PATTERN = new RegExp(`^(${ORIGINS_TO_REPLACE.join('|')})`);
 
 /**
- * Updates URLs, so they are accessed relative to URL_API_ROOT
- * Matches: absolute, prod or staging URLs
- * Unmatched URLs aren't modified
+ * When possible resolve sources relative to API ROOT
+ * Updates applicable URLs, so they are accessed relative to URL_API_ROOT
+ * - Absolute URLs like `/{path}`, become: `https://{API_ROOT}/{path}`
+ * - Similarly for prod or staging URLs we replace the `https://www.expensify`
+ * or `https://staging.expensify` part, with `https://{API_ROOT}`
+ * - Unmatched URLs are returned with no modifications
  *
  * @param {String} url
  * @returns {String}
  */
-export default function replaceSourceOrigin(url) {
+export default function tryResolveUrlFromApiRoot(url) {
     return url.replace(ORIGIN_PATTERN, Config.EXPENSIFY.URL_API_ROOT);
 }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Update existing logic that changes URLs to resolve from API ROOT to handle more URL patterns.
URLs coming from these origins should be updated to resolve from API_ROOT
- staging
- prod
- absolute urls (URLs starting with a `/` that have no origin part)

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/14227   
PROPOSAL: https://github.com/Expensify/App/issues/14227#issuecomment-1399323823


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify staging and prod urls are resolved from API ROOT
    - Follow the steps from the issue description https://github.com/Expensify/App/issues/14227#issue-1529764776 in order to create attachment links from staging and prod. 
    - Inspect the Network tab or the HTML source (Chrome Dev tools -> Elements tab) to verify any attachment url (staging or prod) is resolved against the API ROOT of the current environment
- [ ] Verify absolute urls are resolved from API ROOT
    - At the moment the backend is not yet saving attachments using the absolute path, so we need to simulate the result
    - We need to inspect and modify Onyx data
    - Find an attachment action and modify the `html` of the message so that the `<img src="https://{env}.expensify.com/chat-attachments/{path}" />` part becomes `<img src="/chat-attachments/{path}" />`
        <details>
        <summary>Example</summary>
        In Chrome dev console:
       
        ```js
        Onyx.connect({ key: 'reportActions_71955477', callback: actions => {
            const action = actions[932];
            action.message[0].html = action.message[0].html.replace('https://staging.expensify.com/', '/');
            Onyx.merge('reportActions_71955477', { 932: action });
        }});
        ```
        </details>
    - Now refresh the browser. The (modified) attachment should resolve and load successfully from API ROOT
- [ ] Verify all attachment usages are covered. All these places should resolve the attachment from API ROOT
    - attachment thumbnail in chat message comments 
    - attachment preview modal
    - attachment download button
    - use different attachment types - image formats / document formats

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Expected Offline behavior
- Images that were seen recently should be visible and render instantly (from cache)
- Images that haven't been already loaded would be blank

Expected slow internet behavior
- Images that were seen recently should be visible and render instantly (from cache)
- Other images would display a spinner / loader animation for a while until they load

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify loading attachments still works
    - Follow the steps to from the issue description https://github.com/Expensify/App/issues/14227#issue-1529764776 in order to create attachment links from staging and prod. 
    - Inspect the Network tab or the HTML source (Chrome Dev tools -> Elements tab) to verify any attachment url (staging or prod) is resolved against the API ROOT of the current environment
    - Example: 
        1. Create attachment on PROD
        2. It would be saved with a `https://www.expensify.com/...` url
        3. Open staging web (and have Chrome dev tools open)
        4. See the same attachment 
        5. It should be resolved from `staging.expensify.com` 
- [ ] Upload different attachment types using staging and prod and verify they work
    - E.g. save a PDF, DOC, JPG, PNG on staging, save the same on prod. Verify they load successfully from both staging and prod
- [ ] Verify all attachment usages are covered. All these places should load and render successfully
    - attachment thumbnail in chat message comments 
    - attachment preview modal
    - attachment download button
    - use different attachment types - image formats / document formats

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->
<img width="1552" alt="Screenshot 2023-01-23 at 11 03 48" src="https://user-images.githubusercontent.com/12156624/214001270-119fbb22-b1e5-41cf-b72e-9ddd3f38a42b.png">

<img width="1436" alt="Screenshot 2023-01-23 at 11 04 37" src="https://user-images.githubusercontent.com/12156624/214001398-d15b87c4-195f-488e-86c8-9e64ae1b09af.png">
</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->
<img width="349" alt="Screenshot 2023-01-24 at 0 50 01" src="https://user-images.githubusercontent.com/12156624/214169764-5cb63a5e-e778-4605-8f45-15f533d763d6.png">

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->
<img width="516" alt="Screenshot 2023-01-23 at 11 06 45" src="https://user-images.githubusercontent.com/12156624/214001755-8526e78b-d60d-4ec7-8d93-a652e7ee65e5.png">

</details>

<details>
<summary>Desktop</summary>

<img width="1312" alt="Screenshot 2023-01-23 at 11 07 56" src="https://user-images.githubusercontent.com/12156624/214001971-813b988c-34f3-4ae8-8b50-3a3e4d31068d.png">

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->
<img width="516" alt="Screenshot 2023-01-23 at 11 13 18" src="https://user-images.githubusercontent.com/12156624/214002886-3a247ed8-0620-441b-a7a8-8d9d155a72de.png">

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->
<img width="349" alt="Screenshot 2023-01-24 at 0 51 52" src="https://user-images.githubusercontent.com/12156624/214170343-6434d70c-e478-445e-81ab-8141a5cc6e33.png">

</details>
