### PR TITLE
fix: Timezone changes to some 1st option in the list while pressing the enter key

### DIFF
--- a/src/components/OptionsList/BaseOptionsList.js
+++ b/src/components/OptionsList/BaseOptionsList.js
@@ -121,6 +121,9 @@ class BaseOptionsList extends Component {
 
             // Add section items
             for (let i = 0; i < section.data.length; i++) {
+                if (i > 0 && this.props.shouldHaveOptionSeparator) {
+                    offset += variables.optionRowBorderTopWidth;
+                }
                 flatArray.push({length: optionHeight, offset});
                 offset += optionHeight;
             }

--- a/src/components/OptionsList/BaseOptionsList.js
+++ b/src/components/OptionsList/BaseOptionsList.js
@@ -121,11 +121,12 @@ class BaseOptionsList extends Component {
 
             // Add section items
             for (let i = 0; i < section.data.length; i++) {
+                let totalOptionHeight = optionHeight;
                 if (i > 0 && this.props.shouldHaveOptionSeparator) {
-                    offset += variables.borderTopWidth;
+                    totalOptionHeight += variables.borderTopWidth;
                 }
-                flatArray.push({length: optionHeight, offset});
-                offset += optionHeight;
+                flatArray.push({length: totalOptionHeight, offset});
+                offset += totalOptionHeight;
             }
 
             // Add the section footer

--- a/src/components/OptionsList/BaseOptionsList.js
+++ b/src/components/OptionsList/BaseOptionsList.js
@@ -122,7 +122,7 @@ class BaseOptionsList extends Component {
             // Add section items
             for (let i = 0; i < section.data.length; i++) {
                 if (i > 0 && this.props.shouldHaveOptionSeparator) {
-                    offset += variables.optionRowBorderTopWidth;
+                    offset += variables.borderTopWidth;
                 }
                 flatArray.push({length: optionHeight, offset});
                 offset += optionHeight;

--- a/src/components/OptionsList/BaseOptionsList.js
+++ b/src/components/OptionsList/BaseOptionsList.js
@@ -104,7 +104,6 @@ class BaseOptionsList extends Component {
      * @returns {Array<Object>}
      */
     buildFlatSectionArray() {
-        const optionHeight = variables.optionRowHeight;
         let offset = 0;
 
         // Start with just an empty list header
@@ -121,12 +120,12 @@ class BaseOptionsList extends Component {
 
             // Add section items
             for (let i = 0; i < section.data.length; i++) {
-                let totalOptionHeight = optionHeight;
+                let fullOptionHeight = variables.optionRowHeight;
                 if (i > 0 && this.props.shouldHaveOptionSeparator) {
-                    totalOptionHeight += variables.borderTopWidth;
+                    fullOptionHeight += variables.borderTopWidth;
                 }
-                flatArray.push({length: totalOptionHeight, offset});
-                offset += totalOptionHeight;
+                flatArray.push({length: fullOptionHeight, offset});
+                offset += fullOptionHeight;
             }
 
             // Add the section footer

--- a/src/components/OptionsSelector/BaseOptionsSelector.js
+++ b/src/components/OptionsSelector/BaseOptionsSelector.js
@@ -2,7 +2,7 @@ import _ from 'underscore';
 import lodashGet from 'lodash/get';
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import {View} from 'react-native';
+import {View, InteractionManager} from 'react-native';
 import Button from '../Button';
 import FixedFooter from '../FixedFooter';
 import OptionsList from '../OptionsList';
@@ -86,6 +86,10 @@ class BaseOptionsSelector extends Component {
             true,
         );
 
+        InteractionManager.runAfterInteractions(() => {
+            this.scrollToIndex(this.state.focusedIndex, false);
+        });
+
         if (!this.props.autoFocus) {
             return;
         }
@@ -95,8 +99,6 @@ class BaseOptionsSelector extends Component {
         } else {
             this.textInput.focus();
         }
-
-        this.scrollToIndex(this.state.focusedIndex, false);
     }
 
     componentDidUpdate(prevProps) {

--- a/src/components/OptionsSelector/BaseOptionsSelector.js
+++ b/src/components/OptionsSelector/BaseOptionsSelector.js
@@ -39,14 +39,7 @@ class BaseOptionsSelector extends Component {
         this.relatedTarget = null;
 
         const allOptions = this.flattenSections();
-
-        let focusedIndex = this.props.shouldTextInputAppearBelowOptions ? allOptions.length : 0;
-
-        const initialFocusedIndex = _.findIndex(allOptions, option => option.keyForList === this.props.initialFocusedOptionKey);
-
-        if (initialFocusedIndex >= 0) {
-            focusedIndex = initialFocusedIndex;
-        }
+        const focusedIndex = this.getInitialFocusedIndex(allOptions);
 
         this.state = {
             allOptions,
@@ -144,6 +137,20 @@ class BaseOptionsSelector extends Component {
         if (this.unsubscribeCTRLEnter) {
             this.unsubscribeCTRLEnter();
         }
+    }
+
+    /**
+     * @param {Array<Object>} allOptions
+     * @returns {Number}
+     */
+    getInitialFocusedIndex(allOptions) {
+        const initialFocusedIndex = _.findIndex(allOptions, option => option.keyForList === this.props.initialFocusedOptionKey);
+
+        if (initialFocusedIndex >= 0) {
+            return initialFocusedIndex;
+        }
+
+        return this.props.shouldTextInputAppearBelowOptions ? allOptions.length : 0;
     }
 
     /**

--- a/src/components/OptionsSelector/BaseOptionsSelector.js
+++ b/src/components/OptionsSelector/BaseOptionsSelector.js
@@ -86,6 +86,8 @@ class BaseOptionsSelector extends Component {
             true,
         );
 
+        this.scrollToIndex(this.state.focusedIndex, false);
+
         if (!this.props.autoFocus) {
             return;
         }

--- a/src/components/OptionsSelector/BaseOptionsSelector.js
+++ b/src/components/OptionsSelector/BaseOptionsSelector.js
@@ -142,13 +142,18 @@ class BaseOptionsSelector extends Component {
      * @returns {Number}
      */
     getInitiallyFocusedIndex(allOptions) {
+        const defaultIndex = this.props.shouldTextInputAppearBelowOptions ? allOptions.length : 0;
+        if (_.isUndefined(this.props.initiallyFocusedOptionKey)) {
+            return defaultIndex;
+        }
+
         const indexOfInitiallyFocusedOption = _.findIndex(allOptions, option => option.keyForList === this.props.initiallyFocusedOptionKey);
 
         if (indexOfInitiallyFocusedOption >= 0) {
             return indexOfInitiallyFocusedOption;
         }
 
-        return this.props.shouldTextInputAppearBelowOptions ? allOptions.length : 0;
+        return defaultIndex;
     }
 
     /**

--- a/src/components/OptionsSelector/BaseOptionsSelector.js
+++ b/src/components/OptionsSelector/BaseOptionsSelector.js
@@ -39,7 +39,7 @@ class BaseOptionsSelector extends Component {
         this.relatedTarget = null;
 
         const allOptions = this.flattenSections();
-        const focusedIndex = this.getInitialFocusedIndex(allOptions);
+        const focusedIndex = this.getInitiallyFocusedIndex(allOptions);
 
         this.state = {
             allOptions,
@@ -141,11 +141,11 @@ class BaseOptionsSelector extends Component {
      * @param {Array<Object>} allOptions
      * @returns {Number}
      */
-    getInitialFocusedIndex(allOptions) {
-        const initialFocusedIndex = _.findIndex(allOptions, option => option.keyForList === this.props.initialFocusedOptionKey);
+    getInitiallyFocusedIndex(allOptions) {
+        const indexOfInitiallyFocusedOption = _.findIndex(allOptions, option => option.keyForList === this.props.initiallyFocusedOptionKey);
 
-        if (initialFocusedIndex >= 0) {
-            return initialFocusedIndex;
+        if (indexOfInitiallyFocusedOption >= 0) {
+            return indexOfInitiallyFocusedOption;
         }
 
         return this.props.shouldTextInputAppearBelowOptions ? allOptions.length : 0;

--- a/src/components/OptionsSelector/BaseOptionsSelector.js
+++ b/src/components/OptionsSelector/BaseOptionsSelector.js
@@ -42,10 +42,10 @@ class BaseOptionsSelector extends Component {
 
         let focusedIndex = this.props.shouldTextInputAppearBelowOptions ? allOptions.length : 0;
 
-        const focusedOptionIndex = _.findIndex(allOptions, option => option.text === this.props.focusedValue);
+        const initialFocusedIndex = _.findIndex(allOptions, option => option.keyForList === this.props.initialFocusedOptionKey);
 
-        if (focusedOptionIndex >= 0) {
-            focusedIndex = focusedOptionIndex;
+        if (initialFocusedIndex >= 0) {
+            focusedIndex = initialFocusedIndex;
         }
 
         this.state = {

--- a/src/components/OptionsSelector/BaseOptionsSelector.js
+++ b/src/components/OptionsSelector/BaseOptionsSelector.js
@@ -2,7 +2,7 @@ import _ from 'underscore';
 import lodashGet from 'lodash/get';
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import {View, InteractionManager} from 'react-native';
+import {View} from 'react-native';
 import Button from '../Button';
 import FixedFooter from '../FixedFooter';
 import OptionsList from '../OptionsList';
@@ -85,10 +85,6 @@ class BaseOptionsSelector extends Component {
             CTRLEnterConfig.modifiers,
             true,
         );
-
-        InteractionManager.runAfterInteractions(() => {
-            this.scrollToIndex(this.state.focusedIndex, false);
-        });
 
         if (!this.props.autoFocus) {
             return;
@@ -286,7 +282,13 @@ class BaseOptionsSelector extends Component {
                 showTitleTooltip={this.props.showTitleTooltip}
                 isDisabled={this.props.isDisabled}
                 shouldHaveOptionSeparator={this.props.shouldHaveOptionSeparator}
-                onLayout={this.props.onLayout}
+                onLayout={() => {
+                    this.scrollToIndex(this.state.focusedIndex, false);
+
+                    if (this.props.onLayout) {
+                        this.props.onLayout();
+                    }
+                }}
             />
         ) : <FullScreenLoadingIndicator />;
         return (

--- a/src/components/OptionsSelector/BaseOptionsSelector.js
+++ b/src/components/OptionsSelector/BaseOptionsSelector.js
@@ -39,9 +39,18 @@ class BaseOptionsSelector extends Component {
         this.relatedTarget = null;
 
         const allOptions = this.flattenSections();
+
+        let focusedIndex = this.props.shouldTextInputAppearBelowOptions ? allOptions.length : 0;
+
+        const focusedOptionIndex = _.findIndex(allOptions, option => option.text === this.props.focusedValue);
+
+        if (focusedOptionIndex >= 0) {
+            focusedIndex = focusedOptionIndex;
+        }
+
         this.state = {
             allOptions,
-            focusedIndex: this.props.shouldTextInputAppearBelowOptions ? allOptions.length : 0,
+            focusedIndex,
         };
     }
 
@@ -93,6 +102,8 @@ class BaseOptionsSelector extends Component {
         } else {
             this.textInput.focus();
         }
+
+        this.scrollToIndex(this.state.focusedIndex, false);
     }
 
     componentDidUpdate(prevProps) {
@@ -175,8 +186,9 @@ class BaseOptionsSelector extends Component {
      * Scrolls to the focused index within the SectionList
      *
      * @param {Number} index
+     * @param {Boolean} animated
      */
-    scrollToIndex(index) {
+    scrollToIndex(index, animated = true) {
         const option = this.state.allOptions[index];
         if (!this.list || !option) {
             return;
@@ -195,7 +207,7 @@ class BaseOptionsSelector extends Component {
             }
         }
 
-        this.list.scrollToLocation({sectionIndex: adjustedSectionIndex, itemIndex});
+        this.list.scrollToLocation({sectionIndex: adjustedSectionIndex, itemIndex, animated});
     }
 
     /**

--- a/src/components/OptionsSelector/optionsSelectorPropTypes.js
+++ b/src/components/OptionsSelector/optionsSelectorPropTypes.js
@@ -27,9 +27,6 @@ const propTypes = {
     /** Value in the search input field */
     value: PropTypes.string.isRequired,
 
-    /** Key of the option that we should focus on when first opening the options list */
-    initialFocusedOptionKey: PropTypes.string,
-
     /** Callback fired when text changes */
     onChangeText: PropTypes.func.isRequired,
 
@@ -92,6 +89,9 @@ const propTypes = {
 
     /** Whether to show a line separating options in list */
     shouldHaveOptionSeparator: PropTypes.bool,
+
+    /** Key of the option that we should focus on when first opening the options list */
+    initialFocusedOptionKey: PropTypes.string,
 };
 
 const defaultProps = {
@@ -116,6 +116,7 @@ const defaultProps = {
     disableArrowKeysActions: false,
     isDisabled: false,
     shouldHaveOptionSeparator: false,
+    initialFocusedOptionKey: undefined,
 };
 
 export {propTypes, defaultProps};

--- a/src/components/OptionsSelector/optionsSelectorPropTypes.js
+++ b/src/components/OptionsSelector/optionsSelectorPropTypes.js
@@ -91,7 +91,7 @@ const propTypes = {
     shouldHaveOptionSeparator: PropTypes.bool,
 
     /** Key of the option that we should focus on when first opening the options list */
-    initialFocusedOptionKey: PropTypes.string,
+    initiallyFocusedOptionKey: PropTypes.string,
 };
 
 const defaultProps = {
@@ -116,7 +116,7 @@ const defaultProps = {
     disableArrowKeysActions: false,
     isDisabled: false,
     shouldHaveOptionSeparator: false,
-    initialFocusedOptionKey: undefined,
+    initiallyFocusedOptionKey: undefined,
 };
 
 export {propTypes, defaultProps};

--- a/src/components/OptionsSelector/optionsSelectorPropTypes.js
+++ b/src/components/OptionsSelector/optionsSelectorPropTypes.js
@@ -27,6 +27,9 @@ const propTypes = {
     /** Value in the search input field */
     value: PropTypes.string.isRequired,
 
+    /** Value of the option that we should focused on when first opening the options page */
+    focusedValue: PropTypes.string,
+
     /** Callback fired when text changes */
     onChangeText: PropTypes.func.isRequired,
 

--- a/src/components/OptionsSelector/optionsSelectorPropTypes.js
+++ b/src/components/OptionsSelector/optionsSelectorPropTypes.js
@@ -27,8 +27,8 @@ const propTypes = {
     /** Value in the search input field */
     value: PropTypes.string.isRequired,
 
-    /** Value of the option that we should focused on when first opening the options page */
-    focusedValue: PropTypes.string,
+    /** Key of the option that we should focus on when first opening the options list */
+    initialFocusedOptionKey: PropTypes.string,
 
     /** Callback fired when text changes */
     onChangeText: PropTypes.func.isRequired,

--- a/src/pages/settings/Profile/TimezoneSelectPage.js
+++ b/src/pages/settings/Profile/TimezoneSelectPage.js
@@ -61,9 +61,6 @@ class TimezoneSelectPage extends Component {
      */
     saveSelectedTimezone({text}) {
         PersonalDetails.updateSelectedTimezone(text);
-        this.setState({
-            timezoneInputText: text,
-        });
     }
 
     /**
@@ -93,7 +90,7 @@ class TimezoneSelectPage extends Component {
                     optionHoveredStyle={styles.hoveredComponentBG}
                     sections={[{data: this.state.timezoneOptions, indexOffset: 0}]}
                     shouldHaveOptionSeparator
-                    focusedValue={this.state.timezoneInputText}
+                    initialFocusedOptionKey={this.currentSelectedTimezone}
                 />
             </ScreenWrapper>
         );

--- a/src/pages/settings/Profile/TimezoneSelectPage.js
+++ b/src/pages/settings/Profile/TimezoneSelectPage.js
@@ -90,7 +90,7 @@ class TimezoneSelectPage extends Component {
                     optionHoveredStyle={styles.hoveredComponentBG}
                     sections={[{data: this.state.timezoneOptions, indexOffset: 0}]}
                     shouldHaveOptionSeparator
-                    initialFocusedOptionKey={this.currentSelectedTimezone}
+                    initiallyFocusedOptionKey={this.currentSelectedTimezone}
                 />
             </ScreenWrapper>
         );

--- a/src/pages/settings/Profile/TimezoneSelectPage.js
+++ b/src/pages/settings/Profile/TimezoneSelectPage.js
@@ -61,6 +61,9 @@ class TimezoneSelectPage extends Component {
      */
     saveSelectedTimezone({text}) {
         PersonalDetails.updateSelectedTimezone(text);
+        this.setState({
+            timezoneInputText: text,
+        });
     }
 
     /**
@@ -88,8 +91,9 @@ class TimezoneSelectPage extends Component {
                     onChangeText={this.filterShownTimezones}
                     onSelectRow={this.saveSelectedTimezone}
                     optionHoveredStyle={styles.hoveredComponentBG}
-                    sections={[{data: this.state.timezoneOptions}]}
+                    sections={[{data: this.state.timezoneOptions, indexOffset: 0}]}
                     shouldHaveOptionSeparator
+                    focusedValue={this.state.timezoneInputText}
                 />
             </ScreenWrapper>
         );

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1788,7 +1788,7 @@ const styles = {
     },
 
     borderTop: {
-        borderTopWidth: 1,
+        borderTopWidth: variables.optionRowBorderTopWidth,
         borderColor: themeColors.border,
     },
 

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1788,7 +1788,7 @@ const styles = {
     },
 
     borderTop: {
-        borderTopWidth: variables.optionRowBorderTopWidth,
+        borderTopWidth: variables.borderTopWidth,
         borderColor: themeColors.border,
     },
 

--- a/src/styles/variables.js
+++ b/src/styles/variables.js
@@ -71,6 +71,7 @@ export default {
     popoverMenuShadow: '0px 4px 12px 0px rgba(0, 0, 0, 0.06)',
     optionRowHeight: 64,
     optionRowHeightCompact: 52,
+    optionRowBorderTopWidth: 1,
     optionsListSectionHeaderHeight: getValueUsingPixelRatio(54, 60),
     overlayOpacity: 0.6,
     lineHeightSmall: getValueUsingPixelRatio(14, 16),

--- a/src/styles/variables.js
+++ b/src/styles/variables.js
@@ -71,7 +71,6 @@ export default {
     popoverMenuShadow: '0px 4px 12px 0px rgba(0, 0, 0, 0.06)',
     optionRowHeight: 64,
     optionRowHeightCompact: 52,
-    optionRowBorderTopWidth: 1,
     optionsListSectionHeaderHeight: getValueUsingPixelRatio(54, 60),
     overlayOpacity: 0.6,
     lineHeightSmall: getValueUsingPixelRatio(14, 16),
@@ -88,4 +87,5 @@ export default {
     checkboxLabelActiveOpacity: 0.7,
     avatarChatSpacing: 12,
     chatInputSpacing: 52, // 40 + avatarChatSpacing
+    borderTopWidth: 1,
 };


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
- Fix the missing focus style (it should have background color)
- When going to the options list, initially focus on the item that was selected before, and make it visible in the list

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/14314   
https://github.com/Expensify/App/issues/14314#issuecomment-1398626471


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Login with any account
2. Go to Settings -> Profile and click on timezone
3. Change timezone to some other regions and go back
4. Again click on timezone
5. Verify that the timezone selected before is visible in the list, and have the focus style (background color)
6. Hit the enter key
7. Verify that the timezone remains the same as was selected before and does not change to any arbitrary region

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

1. Turn the network off
2. Repeat the steps in `Tests`

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Login with any account
2. Go to Settings -> Profile and click on timezone
3. Change timezone to some other regions and go back
4. Again click on timezone
5. Verify that the timezone selected before is visible in the list, and have the focus style (background color)
6. Hit the enter key
7. Verify that the timezone remains the same as was selected before and does not change to any arbitrary region

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/113963320/214080463-043e4633-4187-43a4-9b8c-615227093dad.mov

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/113963320/214080876-b8cd6da8-cb33-4391-802a-c7e2b0f9982c.mov

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/113963320/214081066-c1720e13-5781-4610-993b-4571d56f16b0.mov

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/113963320/214081432-93b76410-87c1-4794-b9a1-013f9ec0616c.mov


</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->
https://user-images.githubusercontent.com/113963320/214087918-bbbdf15f-68da-4798-9b0e-4c875535689e.mov

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/113963320/214089174-1d6d2339-112f-4e59-9de7-0e6c657ce2c9.mp4


</details>
