### PR TITLE
Only show call button in Concierge and assistance page for eligible users

### DIFF
--- a/src/components/VideoChatButtonAndMenu/BaseVideoChatButtonAndMenu.js
+++ b/src/components/VideoChatButtonAndMenu/BaseVideoChatButtonAndMenu.js
@@ -16,8 +16,6 @@ import themeColors from '../../styles/themes/default';
 import withWindowDimensions, {windowDimensionsPropTypes} from '../withWindowDimensions';
 import withLocalize, {withLocalizePropTypes} from '../withLocalize';
 import compose from '../../libs/compose';
-import Navigation from '../../libs/Navigation/Navigation';
-import ROUTES from '../../ROUTES';
 import Tooltip from '../Tooltip';
 import {propTypes as videoChatButtonAndMenuPropTypes, defaultProps} from './videoChatButtonAndMenuPropTypes';
 

--- a/src/components/VideoChatButtonAndMenu/BaseVideoChatButtonAndMenu.js
+++ b/src/components/VideoChatButtonAndMenu/BaseVideoChatButtonAndMenu.js
@@ -112,8 +112,8 @@ class BaseVideoChatButtonAndMenu extends Component {
                                 this.videoChatButton.blur();
 
                                 // If this is the Concierge chat, we'll open the modal for requesting a setup call instead
-                                if (this.props.isConcierge) {
-                                    Navigation.navigate(ROUTES.getRequestCallRoute(CONST.GUIDES_CALL_TASK_IDS.CONCIERGE_DM));
+                                if (this.props.isConcierge && this.props.guideCalendarLink) {
+                                    Linking.openURL(this.props.guideCalendarLink);
                                     return;
                                 }
                                 this.toggleVideoChatMenu();

--- a/src/components/VideoChatButtonAndMenu/videoChatButtonAndMenuPropTypes.js
+++ b/src/components/VideoChatButtonAndMenu/videoChatButtonAndMenuPropTypes.js
@@ -3,10 +3,14 @@ import PropTypes from 'prop-types';
 const propTypes = {
     /** If this is the Concierge chat, we'll open the modal for requesting a setup call instead of showing popover menu */
     isConcierge: PropTypes.bool,
+
+    /** URL to the assigned guide's appointment booking calendar */
+    guideCalendarLink: PropTypes.string,
 };
 
 const defaultProps = {
     isConcierge: false,
+    guideCalendarLink: null,
 };
 
 export {propTypes, defaultProps};

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -978,7 +978,7 @@ export default {
         subtitle: 'We\'re here to clear your path to greatness!',
         description: 'Choose from the support options below:',
         chatWithConcierge: 'Chat with Concierge',
-        requestSetupCall: 'Request a setup call',
+        scheduleSetupCall: 'Schedule a setup call',
         questionMarkButtonTooltip: 'Get assistance from our team',
         exploreHelpDocs: 'Explore help docs',
     },

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -980,7 +980,7 @@ export default {
         subtitle: '¡Estamos aquí para ayudarte!',
         description: 'Elige una de las siguientes opciones:',
         chatWithConcierge: 'Chatear con Concierge',
-        requestSetupCall: 'Llámame por teléfono',
+        scheduleSetupCall: 'Concertar una llamada',
         questionMarkButtonTooltip: 'Obtén ayuda de nuestro equipo',
         exploreHelpDocs: 'Explorar la documentación de ayuda',
     },

--- a/src/pages/home/HeaderView.js
+++ b/src/pages/home/HeaderView.js
@@ -3,6 +3,7 @@ import React from 'react';
 import {View, Pressable} from 'react-native';
 import PropTypes from 'prop-types';
 import lodashGet from 'lodash/get';
+import {withOnyx} from 'react-native-onyx';
 import styles from '../../styles/styles';
 import themeColors from '../../styles/themes/default';
 import Icon from '../../components/Icon';
@@ -25,6 +26,7 @@ import Tooltip from '../../components/Tooltip';
 import variables from '../../styles/variables';
 import colors from '../../styles/colors';
 import reportPropTypes from '../reportPropTypes';
+import ONYXKEYS from '../../ONYXKEYS';
 
 const propTypes = {
     /** Toggles the navigationMenu open and closed */
@@ -66,10 +68,11 @@ const HeaderView = (props) => {
     const subtitle = ReportUtils.getChatRoomSubtitle(props.report, props.policies);
     const isConcierge = participants.length === 1 && _.contains(participants, CONST.EMAIL.CONCIERGE);
     const isAutomatedExpensifyAccount = (participants.length === 1 && ReportUtils.hasExpensifyEmails(participants));
+    const guideCalendarLink = lodashGet(props.account, 'guideCalendarLink');
 
     // We hide the button when we are chatting with an automated Expensify account since it's not possible to contact
     // these users via alternative means. It is possible to request a call with Concierge so we leave the option for them.
-    const shouldShowCallButton = isConcierge || !isAutomatedExpensifyAccount;
+    const shouldShowCallButton = (isConcierge && guideCalendarLink) || !isAutomatedExpensifyAccount;
     const avatarTooltip = isChatRoom ? undefined : _.pluck(displayNamesWithTooltips, 'tooltip');
     const shouldShowSubscript = isPolicyExpenseChat && !props.report.isOwnPolicyExpenseChat && !ReportUtils.isArchivedRoom(props.report);
     const icons = ReportUtils.getIcons(props.report, props.personalDetails, props.policies);
@@ -152,7 +155,7 @@ const HeaderView = (props) => {
                                 <IOUBadge iouReportID={props.report.iouReportID} />
                             )}
 
-                            {shouldShowCallButton && <VideoChatButtonAndMenu isConcierge={isConcierge} />}
+                            {shouldShowCallButton && <VideoChatButtonAndMenu isConcierge={isConcierge} guideCalendarLink={guideCalendarLink} />}
                             <Tooltip text={props.report.isPinned ? props.translate('common.unPin') : props.translate('common.pin')}>
                                 <Pressable
                                     onPress={() => Report.togglePinnedState(props.report)}
@@ -175,4 +178,10 @@ HeaderView.defaultProps = defaultProps;
 export default compose(
     withWindowDimensions,
     withLocalize,
+    withOnyx({
+        account: {
+            key: ONYXKEYS.ACCOUNT,
+            selector: account => account && ({guideCalendarLink: account.guideCalendarLink}),
+        },
+    }),
 )(HeaderView);


### PR DESCRIPTION
~Hold until https://github.com/Expensify/Web-Expensify/pull/36149 is deployed to production~

### Changes
- Only show the Call button in Concierge and the Get Assistance page for people eligible for Guide calls (i.e. have a guide assigned)
- When clicking the button/option, open the Guide's calendar appointment booking link instead of the call modal

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/255964   

### Tests
For Expensify internal engineers:
1. If you haven't set up any guides locally yet, follow this [SO post](https://stackoverflowteams.com/c/expensify/questions/14339)
2. Make sure your guide accounts all have a `expensify_googleCalendarLink` NVP set. If not, set it with anything as the value (doesn't necessarily need to be a valid Google Calendar link)
3. Follow the QA steps below

- [x] Verify that no errors appear in the JS console

### Offline tests
Receiving the updated assigned guide's calendar link after creating or deleting a workspace requires being online. While offline, a workspace can be optimistically created or deleted, but the client won't receive the updated Guide's calendar link value until coming back online.

### QA Steps
1. Create a new account
2. Open the chat with Concierge
3. Make sure you don't see the Phone 📞 icon in the top bar
4. Create a workspace
5. Close the left-hand panel, make sure the phone icon appears in the top bar of the Concierge chat (it can take a few seconds)
6. Click the button, make sure it opens a new tab on a Google calendar appointment booking page (if not, make sure your popup blocker didn't get triggered). Close that page without booking an appointment
7. Open your Workspace
8. Click the "Get Assistance from our team" question mark icon in the top
    <img width="373" alt="image" src="https://user-images.githubusercontent.com/2229301/214179801-1244daf0-16f6-4137-9c13-5e9c2e6eef18.png">
1. Make sure you see a "Schedule a setup call" option on the page
    <img width="378" alt="image" src="https://user-images.githubusercontent.com/2229301/214180003-83af1d42-3883-4122-b7d9-118f85320c35.png">
1. Click the option, make sure it opens a new tab on a Google calendar appointment booking page
2. Delete your workspace
3. Go back to the Concierge chat, make sure the phone icon is no longer present

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

- New account without guide + creation of a workspace showing a guide being assigned (for test purposes, the Guide's appointment booking page is simply google.com)

    https://user-images.githubusercontent.com/2229301/214180277-48eebf35-bff8-4904-aee5-2e81ffdf0999.mov


</details>

<details>
<summary>Mobile Web - Chrome</summary>


https://user-images.githubusercontent.com/2229301/214192562-5d2b83c3-5044-4d84-a51c-bad3e44e174f.mov



</details>

<details>
<summary>Mobile Web - Safari</summary>


https://user-images.githubusercontent.com/2229301/214185988-ac47f2f7-8938-4a61-95bd-bcef4cd5742e.mov

https://user-images.githubusercontent.com/2229301/214186102-e0565a25-44a8-4cc2-9f00-24205f9f74df.mov



</details>

<details>
<summary>Desktop</summary>


https://user-images.githubusercontent.com/2229301/214191233-002bb096-74d5-4065-aa1f-27462aab106b.mov



</details>

<details>
<summary>iOS</summary>


https://user-images.githubusercontent.com/2229301/214190223-3cd46eec-bcde-4bd9-9377-30c5eab017b7.mov



</details>

<details>
<summary>Android</summary>


https://user-images.githubusercontent.com/2229301/214192442-f9b0abad-8c0f-4035-8630-3599c8f28cc4.mov



</details>
