### PR TITLE
[Fix] Bug: Entering 0 as a name causes problems

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -333,6 +333,7 @@ const CONST = {
         RESERVED_ROOM_NAMES: ['#admins', '#announce'],
         MAX_PREVIEW_AVATARS: 4,
         MAX_ROOM_NAME_LENGTH: 79,
+        MAX_WORKSPACE_NAME_LENGTH: 80,
         LAST_MESSAGE_TEXT_MAX_LENGTH: 200,
         OWNER_EMAIL_FAKE: '__FAKE__',
         DEFAULT_REPORT_NAME: 'Chat Report',

--- a/src/components/withLocalize.js
+++ b/src/components/withLocalize.js
@@ -16,6 +16,9 @@ const withLocalizePropTypes = {
     /** Returns translated string for given locale and phrase */
     translate: PropTypes.func.isRequired,
 
+    /** Returns translated string for given locale and phrase .Uses the locale that's updated by the Onyx subscriber */
+    translateLocal: PropTypes.func.isRequired,
+
     /** Formats number formatted according to locale and options */
     numberFormat: PropTypes.func.isRequired,
 
@@ -58,6 +61,7 @@ class LocaleContextProvider extends React.Component {
     getContextValue() {
         return {
             translate: this.translate.bind(this),
+            translateLocal: this.translateLocal,
             numberFormat: this.numberFormat.bind(this),
             datetimeToRelative: this.datetimeToRelative.bind(this),
             datetimeToCalendarTime: this.datetimeToCalendarTime.bind(this),
@@ -76,6 +80,16 @@ class LocaleContextProvider extends React.Component {
      */
     translate(phrase, variables) {
         return Localize.translate(this.props.preferredLocale, phrase, variables);
+    }
+
+    /**
+     * *
+     * @param {String|Array} phrase
+     * @param {Object} [variables]
+     * @returns {String}
+     */
+    translateLocal(phrase, variables) {
+        return Localize.translateLocal(phrase, variables);
     }
 
     /**

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -945,6 +945,8 @@ export default {
             nameInputLabel: 'Name',
             nameInputHelpText: 'This is the name you will see on your workspace.',
             nameIsRequiredError: 'You need to define a name for your workspace',
+            nameInvalidError: 'Invalid workspace name',
+            nameContainSpaceError: 'Workspace names can not contain spaces',
             currencyInputLabel: 'Default currency',
             currencyInputHelpText: 'All expenses on this workspace will be converted to this currency.',
             save: 'Save',

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -554,6 +554,8 @@ export default {
             lastNameLength: 'Last name shouldn\'t be longer than 50 characters',
             characterLimit: ({limit}) => `Exceeds the max length of ${limit} characters`,
             hasInvalidCharacter: ({invalidCharacter}) => `Please remove the ${invalidCharacter} from the name field.`,
+            nameInvalidError: ({name}) => `Invalid ${name}`,
+            nameRestrictedError: ({restrictedWord, name}) => `${restrictedWord} is not allowed in your ${name}`,
             comma: 'comma',
             semicolon: 'semicolon',
         },

--- a/src/libs/ValidationUtils.js
+++ b/src/libs/ValidationUtils.js
@@ -366,8 +366,19 @@ function findInvalidSymbols(valuesToBeValidated) {
 }
 
 /**
+ * Checks if a name includes a restricted Word
+ * @param {String} name
+ * @param {String} restrictedWord
+ * @returns {boolean}
+ */
+function hasRestrictedWord(name, restrictedWord) {
+    return new RegExp(restrictedWord, 'i').test(name);
+}
+
+/**
  * Checks if a name is valid by checking that:
- * - Equals to restricted words Expensify or Concierge or Zero
+ * - Includes a restricted words Expensify or Concierge
+ * - Equals to Zero
  * - It includes comma or semicolon which are not accepted
  * @param {String} name
  * @param {String} valuesToBeValidated
@@ -381,6 +392,7 @@ function isValidDisplayName(name, valuesToBeValidated, withRestrictedWords = fal
     }
     const value = valuesToBeValidated.trim();
     const invalidCharacter = findInvalidSymbols(valuesToBeValidated);
+    const restrictedWords = ['Expensify', 'Concierge'];
 
     // check if name equals to 0
     if (value === '0') {
@@ -397,17 +409,15 @@ function isValidDisplayName(name, valuesToBeValidated, withRestrictedWords = fal
         return [];
     }
 
-    // check if name equals to Expensify
-    if (value.toLowerCase() === 'expensify') {
-        return ['personalDetails.error.nameRestrictedError', {restrictedWord: 'Expensify', name}];
-    }
+    // check if name equals to Expensify or Concierge
+    const restrictedWordsErrors = _.compact(
+        _.map(
+            restrictedWords,
+            word => (hasRestrictedWord(value, word) ? ['personalDetails.error.nameRestrictedError', {restrictedWord: word, name}] : null),
+        ),
+    );
 
-    // check if name equals to Concierge
-    if (value.toLowerCase() === 'concierge') {
-        return ['personalDetails.error.nameRestrictedError', {restrictedWord: 'Concierge', name}];
-    }
-
-    return [];
+    return _.flatten(restrictedWordsErrors);
 }
 
 /**

--- a/src/libs/ValidationUtils.js
+++ b/src/libs/ValidationUtils.js
@@ -408,14 +408,31 @@ function isValidRoomName(roomName) {
 }
 
 /**
- * Checks if workspace name does not contain spaces
+ * Checks if workspace name is valid by checking that:
+ * - It's not empty or only contain spaces
+ * - It does not equal to zero
+ * - It does not contain spaces
  *
  * @param {String} workspaceName
- * @returns {Boolean}
+ * @returns {[String]}
  */
 
 function isValidWorkspaceName(workspaceName) {
-    return !/\s/.test(workspaceName.trim());
+    // Case Empty
+    if (!workspaceName || !workspaceName.trim().length) {
+        return ['workspace.editor.nameIsRequiredError'];
+    }
+
+    // Case Equals to Zero
+    if (workspaceName.trim() === '0') {
+        return ['workspace.editor.nameInvalidError'];
+    }
+
+    // Case contain Spaces
+    if (/\s/.test(workspaceName.trim())) {
+        return ['workspace.editor.nameContainSpaceError'];
+    }
+    return [];
 }
 
 /**

--- a/src/libs/ValidationUtils.js
+++ b/src/libs/ValidationUtils.js
@@ -351,20 +351,18 @@ function doesFailCharacterLimitAfterTrim(maxLength, valuesToBeValidated) {
 /**
  * Checks if input value includes comma or semicolon which are not accepted
  *
- * @param {String[]} valuesToBeValidated
- * @returns {String[]}
+ * @param {String} valuesToBeValidated
+ * @returns {String}
  */
 function findInvalidSymbols(valuesToBeValidated) {
-    return _.map(valuesToBeValidated, (value) => {
-        if (!value) {
-            return '';
-        }
-        let inValidSymbol = value.replace(/[,]+/g, '') !== value ? Localize.translateLocal('personalDetails.error.comma') : '';
-        if (_.isEmpty(inValidSymbol)) {
-            inValidSymbol = value.replace(/[;]+/g, '') !== value ? Localize.translateLocal('personalDetails.error.semicolon') : '';
-        }
-        return inValidSymbol;
-    });
+    if (!valuesToBeValidated) {
+        return '';
+    }
+    let inValidSymbol = valuesToBeValidated.replace(/[,]+/g, '') !== valuesToBeValidated ? Localize.translateLocal('personalDetails.error.comma') : '';
+    if (_.isEmpty(inValidSymbol)) {
+        inValidSymbol = valuesToBeValidated.replace(/[;]+/g, '') !== valuesToBeValidated ? Localize.translateLocal('personalDetails.error.semicolon') : '';
+    }
+    return inValidSymbol;
 }
 
 /**

--- a/src/libs/ValidationUtils.js
+++ b/src/libs/ValidationUtils.js
@@ -408,6 +408,17 @@ function isValidRoomName(roomName) {
 }
 
 /**
+ * Checks if workspace name does not contain spaces
+ *
+ * @param {String} workspaceName
+ * @returns {Boolean}
+ */
+
+function isValidWorkspaceName(workspaceName) {
+    return !/\s/.test(workspaceName.trim());
+}
+
+/**
  * Checks if tax ID consists of 9 digits
  *
  * @param {String} taxID
@@ -464,4 +475,5 @@ export {
     isValidTaxID,
     findInvalidSymbols,
     assignError,
+    isValidWorkspaceName,
 };

--- a/src/libs/ValidationUtils.js
+++ b/src/libs/ValidationUtils.js
@@ -371,9 +371,10 @@ function findInvalidSymbols(valuesToBeValidated) {
  * - It includes comma or semicolon which are not accepted
  * @param {String} name
  * @param {String} valuesToBeValidated
+ * @param {Boolean} withRestrictedWords - if true , we should validate restricted words
  * @returns {[string,Object]}
  */
-function isValidDisplayName(name, valuesToBeValidated) {
+function isValidDisplayName(name, valuesToBeValidated, withRestrictedWords = false) {
     if (!valuesToBeValidated || !valuesToBeValidated.trim().length) {
         // we can display an error if empty
         return [];
@@ -389,6 +390,11 @@ function isValidDisplayName(name, valuesToBeValidated) {
     // Check for invalid characters in name
     if (!_.isEmpty(invalidCharacter)) {
         return ['personalDetails.error.hasInvalidCharacter', {invalidCharacter}];
+    }
+
+    // we should validate restricted words if withRestrictedWord is set to true
+    if (!withRestrictedWords) {
+        return [];
     }
 
     // check if name equals to Expensify

--- a/src/libs/ValidationUtils.js
+++ b/src/libs/ValidationUtils.js
@@ -417,6 +417,22 @@ function isValidTaxID(taxID) {
     return taxID && CONST.REGEX.TAX_ID.test(taxID.replace(CONST.REGEX.NON_NUMERIC, ''));
 }
 
+/**
+ * @param {Object} errors
+ * @param {String} errorKey
+ * @param {Boolean} hasError
+ * @param {Array} errorCopy
+ * @returns {Object} - An object containing the errors for each inputID
+ */
+function assignError(errors, errorKey, hasError, errorCopy) {
+    const validateErrors = errors;
+    if (hasError) {
+        const [phrase, variables] = errorCopy;
+        validateErrors[errorKey] = Localize.translateLocal(phrase, variables);
+    }
+    return validateErrors;
+}
+
 export {
     meetsAgeRequirements,
     isValidAddress,
@@ -447,4 +463,5 @@ export {
     isValidRoomName,
     isValidTaxID,
     findInvalidSymbols,
+    assignError,
 };

--- a/src/libs/ValidationUtils.js
+++ b/src/libs/ValidationUtils.js
@@ -366,6 +366,45 @@ function findInvalidSymbols(valuesToBeValidated) {
 }
 
 /**
+ * Checks if a name is valid by checking that:
+ * - Equals to restricted words Expensify or Concierge or Zero
+ * - It includes comma or semicolon which are not accepted
+ * @param {String} name
+ * @param {String} valuesToBeValidated
+ * @returns {[string,Object]}
+ */
+function isValidDisplayName(name, valuesToBeValidated) {
+    if (!valuesToBeValidated || !valuesToBeValidated.trim().length) {
+        // we can display an error if empty
+        return [];
+    }
+    const value = valuesToBeValidated.trim();
+    const invalidCharacter = findInvalidSymbols(valuesToBeValidated);
+
+    // check if name equals to 0
+    if (value === '0') {
+        return ['personalDetails.error.nameInvalidError', {name}];
+    }
+
+    // Check for invalid characters in name
+    if (!_.isEmpty(invalidCharacter)) {
+        return ['personalDetails.error.hasInvalidCharacter', {invalidCharacter}];
+    }
+
+    // check if name equals to Expensify
+    if (value.toLowerCase() === 'expensify') {
+        return ['personalDetails.error.nameRestrictedError', {restrictedWord: 'Expensify', name}];
+    }
+
+    // check if name equals to Concierge
+    if (value.toLowerCase() === 'concierge') {
+        return ['personalDetails.error.nameRestrictedError', {restrictedWord: 'Concierge', name}];
+    }
+
+    return [];
+}
+
+/**
  * Checks if is one of the certain names which are reserved for default rooms
  * and should not be used for policy rooms.
  *
@@ -491,4 +530,5 @@ export {
     findInvalidSymbols,
     assignError,
     isValidWorkspaceName,
+    isValidDisplayName,
 };

--- a/src/pages/ReimbursementAccount/CompanyStep.js
+++ b/src/pages/ReimbursementAccount/CompanyStep.js
@@ -63,7 +63,7 @@ class CompanyStep extends React.Component {
     validate(values) {
         const errors = {};
 
-        if (!values.companyName) {
+        if (!values.companyName || values.companyName.trim() === '0') {
             errors.companyName = this.props.translate('bankAccount.error.companyName');
         }
 

--- a/src/pages/settings/Profile/DisplayNamePage.js
+++ b/src/pages/settings/Profile/DisplayNamePage.js
@@ -99,7 +99,7 @@ class DisplayNamePage extends Component {
      * @param {Object} errors
      * @param {String} errorKey
      * @param {Boolean} hasError
-     * @param {Array} errorCopy
+     * @param {Array<[phrase, variables]>} errorCopy
      * @returns {Object} - An object containing the errors for each inputID
      */
     assignError(errors, errorKey, hasError, errorCopy) {

--- a/src/pages/settings/Profile/DisplayNamePage.js
+++ b/src/pages/settings/Profile/DisplayNamePage.js
@@ -6,7 +6,6 @@ import withCurrentUserPersonalDetails, {withCurrentUserPersonalDetailsPropTypes,
 import ScreenWrapper from '../../../components/ScreenWrapper';
 import HeaderWithCloseButton from '../../../components/HeaderWithCloseButton';
 import withLocalize, {withLocalizePropTypes} from '../../../components/withLocalize';
-import * as Localize from '../../../libs/Localize';
 import ROUTES from '../../../ROUTES';
 import Form from '../../../components/Form';
 import ONYXKEYS from '../../../ONYXKEYS';

--- a/src/pages/settings/Profile/DisplayNamePage.js
+++ b/src/pages/settings/Profile/DisplayNamePage.js
@@ -90,21 +90,6 @@ class DisplayNamePage extends Component {
         return errors;
     }
 
-    /**
-     * @param {Object} errors
-     * @param {String} errorKey
-     * @param {Boolean} hasError
-     * @param {Array<[phrase, variables]>} errorCopy
-     * @returns {Object} - An object containing the errors for each inputID
-     */
-    assignError(errors, errorKey, hasError, errorCopy) {
-        const validateErrors = errors;
-        if (hasError) {
-            validateErrors[errorKey] = this.props.translateLocal(...errorCopy);
-        }
-        return validateErrors;
-    }
-
     render() {
         const currentUserDetails = this.props.currentUserPersonalDetails || {};
 

--- a/src/pages/settings/Profile/DisplayNamePage.js
+++ b/src/pages/settings/Profile/DisplayNamePage.js
@@ -84,8 +84,8 @@ class DisplayNamePage extends Component {
             CONST.FORM_CHARACTER_LIMIT,
             [values.firstName, values.lastName],
         );
-        this.assignError(errors, 'firstName', hasFirstNameError, characterLimitError);
-        this.assignError(errors, 'lastName', hasLastNameError, characterLimitError);
+        ValidationUtils.assignError(errors, 'firstName', hasFirstNameError, characterLimitError);
+        ValidationUtils.assignError(errors, 'lastName', hasLastNameError, characterLimitError);
 
         return errors;
     }

--- a/src/pages/settings/Profile/DisplayNamePage.js
+++ b/src/pages/settings/Profile/DisplayNamePage.js
@@ -57,7 +57,7 @@ class DisplayNamePage extends Component {
     validate(values) {
         const errors = {};
 
-        const firstNameValidation = ValidationUtils.isValidDisplayName('first name', values.firstName);
+        const firstNameValidation = ValidationUtils.isValidDisplayName('first name', values.firstName, true);
         const lastNameValidation = ValidationUtils.isValidDisplayName('last name', values.lastName);
 
         ValidationUtils.assignError(

--- a/src/pages/settings/Profile/DisplayNamePage.js
+++ b/src/pages/settings/Profile/DisplayNamePage.js
@@ -65,26 +65,26 @@ class DisplayNamePage extends Component {
             errors,
             'firstName',
             !_.isEmpty(firstNameInvalidCharacter),
-            this.props.translateLocal(
+            [
                 'personalDetails.error.hasInvalidCharacter',
                 {invalidCharacter: firstNameInvalidCharacter},
-            ),
+            ],
         );
         this.assignError(
             errors,
             'lastName',
             !_.isEmpty(lastNameInvalidCharacter),
-            this.props.translateLocal(
+            [
                 'personalDetails.error.hasInvalidCharacter',
                 {invalidCharacter: lastNameInvalidCharacter},
-            ),
+            ],
         );
         if (!_.isEmpty(errors)) {
             return errors;
         }
 
         // Check the character limit for first and last name
-        const characterLimitError = this.props.translateLocal('personalDetails.error.characterLimit', {limit: CONST.FORM_CHARACTER_LIMIT});
+        const characterLimitError = ['personalDetails.error.characterLimit', {limit: CONST.FORM_CHARACTER_LIMIT}];
         const [hasFirstNameError, hasLastNameError] = ValidationUtils.doesFailCharacterLimitAfterTrim(
             CONST.FORM_CHARACTER_LIMIT,
             [values.firstName, values.lastName],
@@ -99,13 +99,13 @@ class DisplayNamePage extends Component {
      * @param {Object} errors
      * @param {String} errorKey
      * @param {Boolean} hasError
-     * @param {String} errorCopy
+     * @param {Array} errorCopy
      * @returns {Object} - An object containing the errors for each inputID
      */
     assignError(errors, errorKey, hasError, errorCopy) {
         const validateErrors = errors;
         if (hasError) {
-            validateErrors[errorKey] = errorCopy;
+            validateErrors[errorKey] = this.props.translateLocal(...errorCopy);
         }
         return validateErrors;
     }

--- a/src/pages/settings/Profile/DisplayNamePage.js
+++ b/src/pages/settings/Profile/DisplayNamePage.js
@@ -57,28 +57,23 @@ class DisplayNamePage extends Component {
     validate(values) {
         const errors = {};
 
-        // Check for invalid characters in first and last name
-        const [firstNameInvalidCharacter, lastNameInvalidCharacter] = ValidationUtils.findInvalidSymbols(
-            [values.firstName, values.lastName],
-        );
-        this.assignError(
+        const firstNameValidation = ValidationUtils.isValidDisplayName('first name', values.firstName);
+        const lastNameValidation = ValidationUtils.isValidDisplayName('last name', values.lastName);
+
+        ValidationUtils.assignError(
             errors,
             'firstName',
-            !_.isEmpty(firstNameInvalidCharacter),
-            [
-                'personalDetails.error.hasInvalidCharacter',
-                {invalidCharacter: firstNameInvalidCharacter},
-            ],
+            !_.isEmpty(firstNameValidation),
+            firstNameValidation,
         );
-        this.assignError(
+
+        ValidationUtils.assignError(
             errors,
             'lastName',
-            !_.isEmpty(lastNameInvalidCharacter),
-            [
-                'personalDetails.error.hasInvalidCharacter',
-                {invalidCharacter: lastNameInvalidCharacter},
-            ],
+            !_.isEmpty(lastNameValidation),
+            lastNameValidation,
         );
+
         if (!_.isEmpty(errors)) {
             return errors;
         }

--- a/src/pages/settings/Profile/DisplayNamePage.js
+++ b/src/pages/settings/Profile/DisplayNamePage.js
@@ -66,7 +66,7 @@ class DisplayNamePage extends Component {
             errors,
             'firstName',
             !_.isEmpty(firstNameInvalidCharacter),
-            Localize.translateLocal(
+            this.props.translateLocal(
                 'personalDetails.error.hasInvalidCharacter',
                 {invalidCharacter: firstNameInvalidCharacter},
             ),
@@ -75,7 +75,7 @@ class DisplayNamePage extends Component {
             errors,
             'lastName',
             !_.isEmpty(lastNameInvalidCharacter),
-            Localize.translateLocal(
+            this.props.translateLocal(
                 'personalDetails.error.hasInvalidCharacter',
                 {invalidCharacter: lastNameInvalidCharacter},
             ),
@@ -85,7 +85,7 @@ class DisplayNamePage extends Component {
         }
 
         // Check the character limit for first and last name
-        const characterLimitError = Localize.translateLocal('personalDetails.error.characterLimit', {limit: CONST.FORM_CHARACTER_LIMIT});
+        const characterLimitError = this.props.translateLocal('personalDetails.error.characterLimit', {limit: CONST.FORM_CHARACTER_LIMIT});
         const [hasFirstNameError, hasLastNameError] = ValidationUtils.doesFailCharacterLimitAfterTrim(
             CONST.FORM_CHARACTER_LIMIT,
             [values.firstName, values.lastName],

--- a/src/pages/workspace/WorkspaceSettingsPage.js
+++ b/src/pages/workspace/WorkspaceSettingsPage.js
@@ -115,6 +115,7 @@ class WorkspaceSettingsPage extends React.Component {
                         >
                             <TextInput
                                 inputID="name"
+                                maxLength={80}
                                 label={this.props.translate('workspace.editor.nameInputLabel')}
                                 containerStyles={[styles.mt4]}
                                 defaultValue={this.props.policy.name}

--- a/src/pages/workspace/WorkspaceSettingsPage.js
+++ b/src/pages/workspace/WorkspaceSettingsPage.js
@@ -67,7 +67,6 @@ class WorkspaceSettingsPage extends React.Component {
 
         const workSpaceNameValidation = ValidationUtils.isValidWorkspaceName(values.name);
 
-        // Case Name is empty
         ValidationUtils.assignError(
             errors,
             'name',

--- a/src/pages/workspace/WorkspaceSettingsPage.js
+++ b/src/pages/workspace/WorkspaceSettingsPage.js
@@ -138,7 +138,7 @@ class WorkspaceSettingsPage extends React.Component {
                         >
                             <TextInput
                                 inputID="name"
-                                maxLength={80}
+                                maxLength={CONST.REPORT.MAX_WORKSPACE_NAME_LENGTH}
                                 label={this.props.translate('workspace.editor.nameInputLabel')}
                                 containerStyles={[styles.mt4]}
                                 defaultValue={this.props.policy.name}

--- a/src/pages/workspace/WorkspaceSettingsPage.js
+++ b/src/pages/workspace/WorkspaceSettingsPage.js
@@ -21,6 +21,7 @@ import withPolicy, {policyPropTypes, policyDefaultProps} from './withPolicy';
 import {withNetwork} from '../../components/OnyxProvider';
 import OfflineWithFeedback from '../../components/OfflineWithFeedback';
 import Form from '../../components/Form';
+import * as ValidationUtils from '../../libs/ValidationUtils';
 
 const propTypes = {
     ...policyPropTypes,
@@ -63,9 +64,31 @@ class WorkspaceSettingsPage extends React.Component {
 
     validate(values) {
         const errors = {};
-        if (!values.name || !values.name.trim().length) {
-            errors.name = this.props.translate('workspace.editor.nameIsRequiredError');
-        }
+
+        // Case Name is empty
+        ValidationUtils.assignError(
+            errors,
+            'name',
+            !values.name || !values.name.trim().length,
+            ['workspace.editor.nameIsRequiredError'],
+        );
+
+        // Case Name equals to 0
+        ValidationUtils.assignError(
+            errors,
+            'name',
+            values.name.trim() === '0',
+            ['workspace.editor.nameInvalidError'],
+        );
+
+        // Case Name have spaces
+        ValidationUtils.assignError(
+            errors,
+            'name',
+            !ValidationUtils.isValidWorkspaceName(values.name),
+            ['workspace.editor.nameContainSpaceError'],
+        );
+
         return errors;
     }
 

--- a/src/pages/workspace/WorkspaceSettingsPage.js
+++ b/src/pages/workspace/WorkspaceSettingsPage.js
@@ -65,28 +65,14 @@ class WorkspaceSettingsPage extends React.Component {
     validate(values) {
         const errors = {};
 
+        const workSpaceNameValidation = ValidationUtils.isValidWorkspaceName(values.name);
+
         // Case Name is empty
         ValidationUtils.assignError(
             errors,
             'name',
-            !values.name || !values.name.trim().length,
-            ['workspace.editor.nameIsRequiredError'],
-        );
-
-        // Case Name equals to 0
-        ValidationUtils.assignError(
-            errors,
-            'name',
-            values.name.trim() === '0',
-            ['workspace.editor.nameInvalidError'],
-        );
-
-        // Case Name have spaces
-        ValidationUtils.assignError(
-            errors,
-            'name',
-            !ValidationUtils.isValidWorkspaceName(values.name),
-            ['workspace.editor.nameContainSpaceError'],
+            !_.isEmpty(workSpaceNameValidation),
+            workSpaceNameValidation,
         );
 
         return errors;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ GH_LINK   
PROPOSAL: GH_LINK_ISSUE(COMMENT)


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for the expected offline behavior in the `Offline steps` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android / native
    - [ ] Android / Chrome
    - [ ] iOS / native
    - [ ] iOS / Safari
    - [ ] MacOS / Chrome / Safari
    - [ ] MacOS / Desktop
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [ ] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [ ] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [ ] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] I verified that if a function's arguments changed that all usages have also been updated correctly
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [ ] If any new file was added I verified that:
    - [ ] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [ ] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>
