### PR TITLE
Load PDF worker from blob source

### DIFF
--- a/config/webpack/webpack.common.js
+++ b/config/webpack/webpack.common.js
@@ -142,6 +142,13 @@ const webpackConfig = ({envFile = '.env', platform = 'web'}) => ({
                 ],
             },
 
+            // We are importing this worker as a string by using asset/source otherwise it will default to loading via an HTTPS request later.
+            // This causes issues if we have gone offline before the pdfjs web worker is set up as we won't be able to load it from the server.
+            {
+                test: new RegExp('node_modules/pdfjs-dist/legacy/build/pdf.worker.js'),
+                type: 'asset/source',
+            },
+
             // Rule for react-native-web-webview
             {
                 test: /postMock.html$/,

--- a/src/components/PDFView/index.js
+++ b/src/components/PDFView/index.js
@@ -1,7 +1,8 @@
 import _ from 'underscore';
 import React, {Component} from 'react';
 import {View, Dimensions} from 'react-native';
-import {Document, Page} from 'react-pdf/dist/esm/entry.webpack';
+import {Document, Page, pdfjs} from 'react-pdf/dist/esm/entry.webpack';
+import pdfWorkerSource from 'pdfjs-dist/legacy/build/pdf.worker';
 import FullScreenLoadingIndicator from '../FullscreenLoadingIndicator';
 import styles from '../../styles/styles';
 import variables from '../../styles/variables';
@@ -27,6 +28,9 @@ class PDFView extends Component {
         this.initiatePasswordChallenge = this.initiatePasswordChallenge.bind(this);
         this.attemptPDFLoad = this.attemptPDFLoad.bind(this);
         this.toggleKeyboardOnSmallScreens = this.toggleKeyboardOnSmallScreens.bind(this);
+
+        const workerBlob = new Blob([pdfWorkerSource], {type: 'text/javascript'});
+        pdfjs.GlobalWorkerOptions.workerSrc = URL.createObjectURL(workerBlob);
     }
 
     componentDidUpdate(prevProps) {


### PR DESCRIPTION
This is a second attempt for https://github.com/Expensify/App/pull/13546

We ran into some [CSP issues with that](https://github.com/Expensify/App/issues/13665) ([now resolved](https://github.com/Expensify/Cloudflare-Workers/pull/56)) so this should be working now on staging and production.

### Details

When someone goes offline before opening the attachment modal they are unable to load the web workers script via HTTPS. This fix allows loading the worker source as a string in the bundle so it can be used later even if we are offline.

### Fixed Issues

$ https://github.com/Expensify/App/issues/12512

### Tests

Same as QA.

**Note:** Use a VALID PDF i.e. something that normally works fine while we are online.

I would recommend sending yourself a valid PDF to an iOS and Android device + hosting the local web version via NGROK then test selecting the attachment with the internet disabled (i.e. Wi-Fi disabled).

- [x] Verify that no errors appear in the JS console

### Offline tests

This is related to offline behavior so QA is the same.

### QA Steps

1. Open any chat in the new dot
1. Go offline
1. Click ➕ in composer -> Add Attachments
1. Select a **_VALID_** PDF attachment
1. Verify that a preview shows and there is no "Failed to load PDF file" text 

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

![2022-12-12_14-45-27](https://user-images.githubusercontent.com/32969087/207198829-b3db9e61-1587-4f59-8774-5e76dd152c99.png)

</details>

<details>
<summary>Mobile Web - Chrome</summary>

Works. But looks messed up atm and is missing the submit button.

![Screenshot_20221212-151035_Chrome](https://user-images.githubusercontent.com/32969087/207201923-77aa85b7-c660-4808-a935-9678d8aa3004.jpg)

</details>

<details>
<summary>Mobile Web - Safari</summary>

![image_123986672 (1)](https://user-images.githubusercontent.com/32969087/207202259-b952f632-9b1c-4f0e-8b28-24d97f9ef85c.JPG)

</details>

<details>
<summary>Desktop</summary>

![2022-12-12_15-07-48](https://user-images.githubusercontent.com/32969087/207201309-4a5de562-e108-4ed8-a1ce-b060d3a85817.png)

</details>

<details>
<summary>iOS</summary>

N/A as this platform is not touched in this PR

</details>

<details>
<summary>Android</summary>

N/A as this platform is not touched in this PR

</details>