### PR TITLE
Update use of allPolicies variable and push notification subscription to fix inconsistency in deep link routing

### DIFF
--- a/src/libs/Notification/PushNotification/index.native.js
+++ b/src/libs/Notification/PushNotification/index.native.js
@@ -5,7 +5,7 @@ import lodashGet from 'lodash/get';
 import Log from '../../Log';
 import NotificationType from './NotificationType';
 import PushNotification from '.';
-import * as Report from '../../../libs/actions/Report';
+import * as Report from '../../actions/Report';
 
 const notificationEventActionMap = {};
 
@@ -110,11 +110,11 @@ function register(accountID) {
     Log.info(`[PUSH_NOTIFICATIONS] Subscribing to notifications for account ID ${accountID}`);
     UrbanAirship.setNamedUser(accountID.toString());
 
-    // When the user logged out and then logged in with a different account 
+    // When the user logged out and then logged in with a different account
     // while the app is still in background, we must resubscribe to the report
     // push notification in order to render the report click behaviour correctly
     PushNotification.init();
-    Report.subscribeToReportCommentPushNotifications();   
+    Report.subscribeToReportCommentPushNotifications();
 }
 
 /**

--- a/src/libs/Notification/PushNotification/index.native.js
+++ b/src/libs/Notification/PushNotification/index.native.js
@@ -4,6 +4,8 @@ import {UrbanAirship, EventType, iOS} from 'urbanairship-react-native';
 import lodashGet from 'lodash/get';
 import Log from '../../Log';
 import NotificationType from './NotificationType';
+import PushNotification from '.';
+import Report from '.';
 
 const notificationEventActionMap = {};
 
@@ -107,6 +109,12 @@ function register(accountID) {
     // Regardless of the user's opt-in status, we still want to receive silent push notifications.
     Log.info(`[PUSH_NOTIFICATIONS] Subscribing to notifications for account ID ${accountID}`);
     UrbanAirship.setNamedUser(accountID.toString());
+
+    // When the user logged out and then logged in with a different account 
+    // while the app is still in background, we must resubscribe to the report
+    // push notification in order to render the report click behaviour correctly
+    PushNotification.init();
+    Report.subscribeToReportCommentPushNotifications();   
 }
 
 /**

--- a/src/libs/Notification/PushNotification/index.native.js
+++ b/src/libs/Notification/PushNotification/index.native.js
@@ -5,7 +5,7 @@ import lodashGet from 'lodash/get';
 import Log from '../../Log';
 import NotificationType from './NotificationType';
 import PushNotification from '.';
-import Report from '.';
+import * as Report from '../../../libs/actions/Report';
 
 const notificationEventActionMap = {};
 

--- a/src/libs/actions/Policy.js
+++ b/src/libs/actions/Policy.js
@@ -1027,4 +1027,5 @@ export {
     openWorkspaceMembersPage,
     openWorkspaceInvitePage,
     removeWorkspace,
+    allPolicies
 };

--- a/src/libs/actions/Policy.js
+++ b/src/libs/actions/Policy.js
@@ -1027,5 +1027,5 @@ export {
     openWorkspaceMembersPage,
     openWorkspaceInvitePage,
     removeWorkspace,
-    allPolicies
+    allPolicies,
 };

--- a/src/libs/actions/Policy.js
+++ b/src/libs/actions/Policy.js
@@ -1027,5 +1027,4 @@ export {
     openWorkspaceMembersPage,
     openWorkspaceInvitePage,
     removeWorkspace,
-    allPolicies,
 };

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -65,11 +65,17 @@ function subscribeToReportCommentPushNotifications() {
             if (Navigation.getActiveRoute().slice(1, 2) === ROUTES.REPORT && !Navigation.isActiveRoute(`r/${reportID}`)) {
                 Navigation.goBack();
             }
-            Navigation.navigate(ROUTES.getReportRoute(reportID));
+            Navigation.isDrawerReady()
+                .then(() => {
+                    Navigation.navigate(ROUTES.getReportRoute(reportID));
+                })
         } else {
             // Navigation container is not yet ready, use deeplinking to open to correct report instead
             Navigation.setDidTapNotification();
-            Linking.openURL(`${CONST.DEEPLINK_BASE_URL}${ROUTES.getReportRoute(reportID)}`);
+            Navigation.isDrawerReady()
+                .then(() => {
+                    Linking.openURL(`${CONST.DEEPLINK_BASE_URL}${ROUTES.getReportRoute(reportID)}`);
+                });
         }
     });
 }

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -68,7 +68,7 @@ function subscribeToReportCommentPushNotifications() {
             Navigation.isDrawerReady()
                 .then(() => {
                     Navigation.navigate(ROUTES.getReportRoute(reportID));
-                })
+                });
         } else {
             // Navigation container is not yet ready, use deeplinking to open to correct report instead
             Navigation.setDidTapNotification();

--- a/src/libs/actions/Welcome.js
+++ b/src/libs/actions/Welcome.js
@@ -65,7 +65,6 @@ Onyx.connect({
     },
 });
 
-const allPolicies = {};
 Onyx.connect({
     key: ONYXKEYS.COLLECTION.POLICY,
     callback: (val, key) => {
@@ -73,7 +72,7 @@ Onyx.connect({
             return;
         }
 
-        allPolicies[key] = {...allPolicies[key], ...val};
+        Policy.allPolicies[key] = {...Policy.allPolicies[key], ...val};
     },
 });
 
@@ -120,7 +119,7 @@ function show({routes, showCreateMenu}) {
 
         // If user is not already an admin of a free policy and we are not navigating them to their workspace or creating a new workspace via workspace/new then
         // we will show the create menu.
-        if (!Policy.isAdminOfFreePolicy(allPolicies) && !isDisplayingWorkspaceRoute) {
+        if (!Policy.isAdminOfFreePolicy(Policy.allPolicies) && !isDisplayingWorkspaceRoute) {
             showCreateMenu();
         }
     });

--- a/src/libs/actions/Welcome.js
+++ b/src/libs/actions/Welcome.js
@@ -65,14 +65,20 @@ Onyx.connect({
     },
 });
 
+const allPolicies = {};
 Onyx.connect({
     key: ONYXKEYS.COLLECTION.POLICY,
     callback: (val, key) => {
-        if (!val || !key) {
+        if (!key) {
             return;
         }
 
-        Policy.allPolicies[key] = {...Policy.allPolicies[key], ...val};
+        if (val === null || val === undefined) {
+            delete allPolicies[key];
+            return;
+        }
+
+        allPolicies[key] = {...allPolicies[key], ...val};
     },
 });
 
@@ -119,7 +125,7 @@ function show({routes, showCreateMenu}) {
 
         // If user is not already an admin of a free policy and we are not navigating them to their workspace or creating a new workspace via workspace/new then
         // we will show the create menu.
-        if (!Policy.isAdminOfFreePolicy(Policy.allPolicies) && !isDisplayingWorkspaceRoute) {
+        if (!Policy.isAdminOfFreePolicy(allPolicies) && !isDisplayingWorkspaceRoute) {
             showCreateMenu();
         }
     });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
- Currently, logging out from an account with workspaces and then login to a new account will not open the FAB modal as default. To make the FAB modal always opened for a new account regardless of the previous state of the app, delete the duplicated `allPolicies` variable in https://github.com/Expensify/App/blob/df900108b413826dd7c4b0e51ab6cf8092223289/src/libs/actions/Welcome.js#L68-L78
and reuse the same variable in https://github.com/Expensify/App/blob/21486cd0173aca0f3ac2d9991c9898063af8fb54/src/libs/actions/Policy.js#L18
- Currently, navigating to a deeplink from push notification may cause inconsistency due to overlapping navigation with the default navigation (last accessed report) of the app. To make the push notification always open the correct report, add the use of `Navigation.isDrawerReady()` before navigating in https://github.com/Expensify/App/blob/a59825caa19d1e3217e8d59db864dbe2f3bd386d/src/libs/actions/Report.js#L72-L82
- Currently, the device push notification listener is not working when user logout, keep app in background and login again. When such scenario happens, clicking a push notification will open the app but will not open the correct report, which also cause inconsistency. To miltigate this issue, add the subscription logic in the `register()` function like in https://github.com/Expensify/App/pull/14588/files#diff-24c7a3c4dd0b7b7cb20e0e8cb485e27259b55286e6395fc6ae92727c7bb8741f
This function is then called each time the user try to login to the app, but the logic will only be triggered for _new_ user logging in the app only (logged in users are not affected)

### Fixed Issues
<!---
  1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/13691
https://github.com/Expensify/App/issues/13691#issuecomment-1384218222
https://github.com/Expensify/App/issues/13691#issuecomment-1384218945


### Tests
1. Open the app
2. Register with a new email
3. Go back to home screen
4. Perform 1 of the following 
  4.1. Keep the app in background
  4.2. Kill the app in background
5. Go to mailbox and click the magic sign-in link to access the set password page. Set a password and proceed
6. Verify that the FAB modal is opened after signing in
7. Select _New workspace_ to create a new workspace
8. Wait for the Notification from the support team member
9. Perform 1 of the following 
  9.1. Keep the app in background
  9.2. Kill the app in background
10. Tap the notification
11. Verify that the app navigates to the correct channel #admins

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
1. Open the app
2. Register with a new email
3. Go back to home screen
4. Perform 1 of the following 
  4.1. Keep the app in background
  4.2. Kill the app in background
5. Go to mailbox and click the magic sign-in link to access the set password page. Set a password and proceed
6. Disable the internet
7. Verify that the FAB modal is opened after signing in
8. Enable the internet
9. Select _New workspace_ to create a new workspace
10. Wait for the Notification from the support team member
11. Disable the internet
12. Perform 1 of the following 
  12.1. Keep the app in background
  12.2. Kill the app in background
13. Tap the notification
14. Verify that the app navigates to the correct channel #admins

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
6. Upload an image via copy paste
7. Verify a modal appears displaying a preview of that image
--->
1. Open the app
2. Register with a new email
3. Go back to home screen
4. Perform 1 of the following 
  4.1. Keep the app in background
  4.2. Kill the app in background
5. Go to mailbox and click the magic sign-in link to access the set password page. Set a password and proceed
6. Verify that the FAB modal is opened after signing in
7. Select _New workspace_ to create a new workspace
8. Wait for the Notification from the support team member
9. Perform 1 of the following 
  9.1. Keep the app in background
  9.2. Kill the app in background
10. Tap the notification
11. Verify that the app navigates to the correct channel #admins

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/113963320/214908780-5ae73c5a-297f-4610-8125-e7f865c5097b.mp4


</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/113963320/215100351-5ff4cbaa-3d8d-40a6-b692-7506044b03ea.mp4


</details>

<details>
<summary>Mobile Web - Safari</summary>


https://user-images.githubusercontent.com/113963320/214905840-e19a485a-1033-4daf-b789-371ff050176f.mp4



</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/113963320/215014902-09da2142-2a5c-4b7a-95cf-ddc148f0583d.mp4


</details>

<details>
<summary>iOS</summary>

https://user-images.githubusercontent.com/113963320/214866143-512c619d-100c-405d-a7ba-c81d6bdaf683.mov

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/113963320/214831559-a38bdddc-d2c1-4e76-b09b-1c787783719c.mp4


</details>
