### PR TITLE
Change right icon for the help site

### DIFF
--- a/src/pages/GetAssistancePage.js
+++ b/src/pages/GetAssistancePage.js
@@ -55,6 +55,7 @@ const GetAssistancePage = (props) => {
             onPress: () => Linking.openURL(guideCalendarLink),
             icon: Expensicons.Phone,
             shouldShowRightIcon: true,
+            iconRight: Expensicons.NewWindow,
             wrapperStyle: [styles.cardMenuItem],
         });
     }

--- a/src/pages/GetAssistancePage.js
+++ b/src/pages/GetAssistancePage.js
@@ -59,6 +59,7 @@ const GetAssistancePage = props => (
                         onPress: () => Link.openExternalLink(CONST.NEWHELP_URL),
                         icon: Expensicons.QuestionMark,
                         shouldShowRightIcon: true,
+                        iconRight: Expensicons.NewWindow,
                         wrapperStyle: [styles.cardMenuItem],
                     },
                 ]}

--- a/src/pages/settings/InitialSettingsPage.js
+++ b/src/pages/settings/InitialSettingsPage.js
@@ -175,6 +175,8 @@ class InitialSettingsPage extends React.Component {
                 translationKey: 'initialSettingsPage.help',
                 icon: Expensicons.QuestionMark,
                 action: () => { Link.openExternalLink(CONST.NEWHELP_URL); },
+                shouldShowRightIcon: true,
+                iconRight: Expensicons.NewWindow,
             },
             {
                 translationKey: 'initialSettingsPage.about',
@@ -203,6 +205,7 @@ class InitialSettingsPage extends React.Component {
                 iconStyles={item.iconStyles}
                 iconFill={item.iconFill}
                 shouldShowRightIcon
+                iconRight={item.iconRight}
                 badgeText={this.getWalletBalance(isPaymentItem)}
                 fallbackIcon={item.fallbackIcon}
                 brickRoadIndicator={item.brickRoadIndicator}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
We want to reflect the correct UX for the action of the help site button which opens in a new browser tab. Context [here](https://expensify.slack.com/archives/C02QSAC6BJ8/p1674793823367609?thread_ts=1674753336.977669&cid=C02QSAC6BJ8).

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/Expensify/issues/258498

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Open the Settings menu
2. Verify the "Help" item has the correct icon to open an external resource (see screenshots).
4. Open the menu of an existing workspace.
5. Open the Get assistance page (Click on the "?" icon at the top of the page)
6. Verify the "Explore help docs" item it also has the correct icon to open an external resource (see screenshots).

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Same as `Test` steps.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->
<img width="1128" alt="Screenshot 2023-01-27 at 16 31 53" src="https://user-images.githubusercontent.com/6829422/215205869-5d4fb14e-eea7-467c-8766-506513e25411.png">

<img width="1037" alt="Screenshot 2023-02-03 at 18 59 44" src="https://user-images.githubusercontent.com/6829422/216736654-f75c66f5-a2f7-4bd2-9cb5-d54b04413fd1.png">

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->
<img width="364" alt="Screenshot 2023-01-27 at 16 47 57" src="https://user-images.githubusercontent.com/6829422/215207495-954d932e-3a73-4152-8f2c-162c62ace92b.png">

<img width="366" alt="Screenshot 2023-02-03 at 19 01 56" src="https://user-images.githubusercontent.com/6829422/216736755-56b57797-1a0c-45b9-9315-36ddd53d939d.png">


</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->
<img width="424" alt="Screenshot 2023-01-27 at 16 47 01" src="https://user-images.githubusercontent.com/6829422/215207575-a6eb3873-f41e-47a8-807a-99bbcdb28fb6.png">

<img width="412" alt="Screenshot 2023-02-03 at 19 01 02" src="https://user-images.githubusercontent.com/6829422/216736715-48d4c235-2f63-47aa-8170-ae7d1262f0f3.png">


</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->
<img width="1201" alt="Screenshot 2023-01-27 at 16 51 11" src="https://user-images.githubusercontent.com/6829422/215208320-7e10ec30-ab11-4db3-9345-8955aa109a7e.png">

<img width="1205" alt="Screenshot 2023-02-03 at 19 04 01" src="https://user-images.githubusercontent.com/6829422/216736881-6a0e55c2-a1bb-4215-b0bb-6f940645064e.png">

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->
<img width="424" alt="Screenshot 2023-01-27 at 16 43 33" src="https://user-images.githubusercontent.com/6829422/215206259-f0e8589a-1a03-4ea3-ae81-8a36bab702d9.png">

<img width="425" alt="Screenshot 2023-02-03 at 19 05 31" src="https://user-images.githubusercontent.com/6829422/216736986-79354b26-c716-4e8f-b4b7-66434ab958ba.png">

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

<img width="355" alt="Screenshot 2023-01-27 at 16 57 46" src="https://user-images.githubusercontent.com/6829422/215210663-0c7640d8-cb15-4591-828a-9826de14efd0.png">

<img width="365" alt="Screenshot 2023-02-03 at 19 13 40" src="https://user-images.githubusercontent.com/6829422/216737420-cad5fb36-5681-4b71-84fd-9debe78217d7.png">

</details>
