### PR TITLE
adjust horizontal padding in empty workspace view

### DIFF
--- a/src/components/BlockingViews/BlockingView.js
+++ b/src/components/BlockingViews/BlockingView.js
@@ -27,7 +27,7 @@ const defaultProps = {
 
 const BlockingView = props => (
     <View
-        style={[styles.flex1, styles.alignItemsCenter, styles.justifyContentCenter]}
+        style={[styles.flex1, styles.alignItemsCenter, styles.justifyContentCenter, styles.ph10]}
     >
         <Icon
             src={props.icon}
@@ -36,7 +36,7 @@ const BlockingView = props => (
             height={variables.iconSizeSuperLarge}
         />
         <Text style={[styles.notFoundTextHeader]}>{props.title}</Text>
-        <Text style={[styles.w70, styles.textAlignCenter]}>{props.subtitle}</Text>
+        <Text style={[styles.textAlignCenter]}>{props.subtitle}</Text>
     </View>
 );
 

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1905,6 +1905,7 @@ const styles = {
         fontSize: variables.fontSizeXLarge,
         marginTop: 20,
         marginBottom: 8,
+        textAlign: 'center',
     },
 
     notFoundTextBody: {

--- a/src/styles/utilities/spacing.js
+++ b/src/styles/utilities/spacing.js
@@ -290,6 +290,10 @@ export default {
         paddingHorizontal: 32,
     },
 
+    ph10: {
+        paddingHorizontal: 40,
+    },
+
     pr0: {
         paddingRight: 0,
     },


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
- add 40px horizontal padding to wrapper
- set text align center to title
- remove 70% width in subtitle

### Fixed Issues
$ https://github.com/Expensify/App/issues/14564
PROPOSAL: https://github.com/Expensify/App/issues/14564#issuecomment-1409292824


### Tests
1. Login with any account
2. If language is English, switch to Spanish in Settings -> Preferences
3. Go to Settings -> Workspaces
4. Delete all workspaces if they present
5. Verify that title is centered and welcome message is NOT very close to the edge of the page

- [x] Verify that no errors appear in the JS console

### Offline tests
1. Login with any account
2. If language is English, switch to Spanish in Settings -> Preferences
3. Go to Settings -> Workspaces
4. Delete all workspaces if they present
5. Disable network
6. Verify that title is centered and welcome message is NOT very close to the edge of the page

### QA Steps
1. Login with any account
2. If language is English, switch to Spanish in Settings -> Preferences
3. Go to Settings -> Workspaces
4. Delete all workspaces if they present
5. Verify that title is centered and welcome message is NOT very close to the edge of the page

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<img width="1179" alt="web" src="https://user-images.githubusercontent.com/108292595/216013848-4f393d55-99a6-4274-9dc7-4907e0ed76f3.png">


</details>

<details>
<summary>Mobile Web - Chrome</summary>

![mchrome](https://user-images.githubusercontent.com/108292595/216013782-a9d40f44-91fa-489e-ba9d-49c5a26938af.png)


</details>

<details>
<summary>Mobile Web - Safari</summary>

![msafari](https://user-images.githubusercontent.com/108292595/216013757-3dc0ec49-acc6-4f25-b698-281bfd930a67.png)


</details>

<details>
<summary>Desktop</summary>

<img width="1197" alt="desktop" src="https://user-images.githubusercontent.com/108292595/216013651-f9f89d6b-1599-4cf1-b778-a184fda73f2f.png">


</details>

<details>
<summary>iOS</summary>

![ios](https://user-images.githubusercontent.com/108292595/216013692-d25c6dc0-b453-40d8-9243-8f4490fe9c78.png)


</details>

<details>
<summary>Android</summary>

![android](https://user-images.githubusercontent.com/108292595/216013597-99bea8e5-dd3b-4955-9453-4aeb2c0c7ba5.png)


</details>
