### PR TITLE
Add a generic error in failureData of AddComment

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -1134,6 +1134,6 @@ export default {
         },
     },
     report: {
-        genericCreateFailureMessage: '',
-    }
+        genericAddCommentFailureMessage: 'Unexpected error while posting the comment, please try again later',
+    },
 };

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -1133,4 +1133,7 @@ export default {
             message: 'We couldn\'t look for an update. Please check again in a bit!',
         },
     },
+    report: {
+        genericCreateFailureMessage: '',
+    }
 };

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -1135,4 +1135,7 @@ export default {
             message: 'No hemos podido comprobar si existe una actualización. Inténtalo de nuevo más tarde!',
         },
     },
+    report: {
+        genericAddCommentFailureMessage: 'Error inesperado al agregar el comentario, por favor inténtalo más tarde',
+    },
 };

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -19,6 +19,7 @@ import * as ReportUtils from '../ReportUtils';
 import DateUtils from '../DateUtils';
 import * as ReportActionsUtils from '../ReportActionsUtils';
 import * as OptionsListUtils from '../OptionsListUtils';
+import * as Localize from '../Localize';
 
 let currentUserEmail;
 let currentUserAccountID;
@@ -268,7 +269,11 @@ function addActions(reportID, text = '', file) {
         {
             onyxMethod: CONST.ONYX.METHOD.MERGE,
             key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`,
-            value: _.mapObject(optimisticReportActions, () => null),
+            value: _.mapObject(optimisticReportActions, (action) => {
+                // eslint-disable-next-line no-param-reassign
+                action.errors = {[DateUtils.getMicroseconds()]: Localize.translateLocal('iou.error.genericCreateFailureMessage')};
+                return action;
+            }),
         },
     ];
 

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -271,7 +271,7 @@ function addActions(reportID, text = '', file) {
             key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`,
             value: _.mapObject(optimisticReportActions, (action) => {
                 // eslint-disable-next-line no-param-reassign
-                action.errors = {[DateUtils.getMicroseconds()]: Localize.translateLocal('iou.error.genericCreateFailureMessage')};
+                action.errors = {[DateUtils.getMicroseconds()]: Localize.translateLocal('report.genericAddCommentFailureMessage')};
                 return action;
             }),
         },

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -269,11 +269,7 @@ function addActions(reportID, text = '', file) {
         {
             onyxMethod: CONST.ONYX.METHOD.MERGE,
             key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`,
-            value: _.mapObject(optimisticReportActions, (action) => {
-                // eslint-disable-next-line no-param-reassign
-                action.errors = {[DateUtils.getMicroseconds()]: Localize.translateLocal('report.genericAddCommentFailureMessage')};
-                return action;
-            }),
+            value: _.mapObject(optimisticReportActions, action => ({...action, errors: {[DateUtils.getMicroseconds()]: Localize.translateLocal('report.genericAddCommentFailureMessage')}})),
         },
     ];
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/14735
PROPOSAL: GH_LINK_ISSUE(COMMENT)


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- Modify the backend so that AddComment throws an unexpected error (I just added a call to an unexisting function right after `} elseif ($command === 'AddComment') {`)
- Send a comment
- Check the comment shows with opacity, with the RBR dot and message and with the X in it
- Check the LHN also has a red dot
- Click on the X check it clears the comment, the error and the red dots

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
- Same, but go offline before posting the comment and go online afterwards

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

I don't think this can be QAed since there's not a good way to force an error in the server, but for web, we have a possible workaround:
- Block a user from talking to Concierge (ping us to do this)
- Go to the Concierge chat with the blocked user
- Inspect element and find the <textarea> of the composer and remove the disabled attribute
![image](https://user-images.githubusercontent.com/521248/216451210-10eda281-dad9-4983-965d-a27a50572d07.png)
- Type something and hit enter to submit
- Check the comment shows with opacity, with the RBR dot and message and with the X in it
- Check the LHN also has a red dot
- Click on the X check it clears the comment, the error and the red dots

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/521248/216435735-8358166b-2b72-4e9d-9bda-0b510e780f60.png">
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/521248/216435754-e366c032-b0b0-4092-b8f6-2b812352bb4d.png">


</details>

<details>
<summary>Mobile Web - Chrome</summary>

<img width="398" alt="image" src="https://user-images.githubusercontent.com/521248/216437026-ef597ca5-b417-459c-b79a-7fe4ddf3eccc.png">
<img width="414" alt="image" src="https://user-images.githubusercontent.com/521248/216437066-a646f46c-0795-4f5c-b1fe-c658c5c8e681.png">
<img width="399" alt="image" src="https://user-images.githubusercontent.com/521248/216437096-6bde4b39-523a-485a-8b21-bc7aef88ef39.png">


</details>

<details>
<summary>Mobile Web - Safari</summary>

<img width="478" alt="image" src="https://user-images.githubusercontent.com/521248/216449198-e8d29060-d4f6-4691-b4af-0b2d1852f8a7.png">
<img width="422" alt="image" src="https://user-images.githubusercontent.com/521248/216449181-090f652b-568d-4ab4-9fe6-748dbaf7b10b.png">
<img width="439" alt="image" src="https://user-images.githubusercontent.com/521248/216449220-7697bef8-bead-485e-a408-e10c526a4e84.png">


</details>

<details>
<summary>Desktop</summary>

<img width="1211" alt="image" src="https://user-images.githubusercontent.com/521248/216450019-1b0fb10b-56ca-4ecc-b7d9-207830ba5b6f.png">
<img width="1211" alt="image" src="https://user-images.githubusercontent.com/521248/216450044-9cfc365c-ec02-49fd-9d0d-1d8f5b70693b.png">


</details>

<details>
<summary>iOS</summary>

<img width="452" alt="image" src="https://user-images.githubusercontent.com/521248/216444424-2e6fa90b-faca-4194-9dd0-056cb944e19c.png">
<img width="445" alt="image" src="https://user-images.githubusercontent.com/521248/216444409-779c4235-5da1-42fd-86ea-61ab364f256c.png">
<img width="455" alt="image" src="https://user-images.githubusercontent.com/521248/216444444-3f6441a5-d495-4426-ba5c-92b10990fcfd.png">


</details>

<details>
<summary>Android</summary>

<img width="453" alt="image" src="https://user-images.githubusercontent.com/521248/216448577-826d71d7-974a-441e-bce7-8711925483a7.png">
<img width="474" alt="image" src="https://user-images.githubusercontent.com/521248/216448598-3bd7b5c3-0fc6-4d9b-a0ee-223ddad47c1e.png">
<img width="436" alt="image" src="https://user-images.githubusercontent.com/521248/216448623-ffda6c69-5705-4517-882a-4c376df2aac8.png">


</details>
