### PR TITLE
Preferences follow up

### DIFF
--- a/src/libs/actions/App.js
+++ b/src/libs/actions/App.js
@@ -86,6 +86,7 @@ function setLocale(locale) {
     API.write('UpdatePreferredLocale', {
         value: locale,
     }, {optimisticData});
+    Navigation.navigate(ROUTES.SETTINGS_PREFERENCES);
 }
 
 function setSidebarLoaded() {

--- a/src/libs/actions/App.js
+++ b/src/libs/actions/App.js
@@ -52,6 +52,12 @@ Onyx.connect({
     callback: policies => allPolicies = policies,
 });
 
+let preferredLocale;
+Onyx.connect({
+    key: ONYXKEYS.NVP_PREFERRED_LOCALE,
+    callback: val => preferredLocale = val,
+});
+
 /**
  * @param {Array} policies
  * @return {Array<String>} array of policy ids
@@ -68,6 +74,10 @@ function getNonOptimisticPolicyIDs(policies) {
 * @param {String} locale
 */
 function setLocale(locale) {
+    if(locale == preferredLocale) {
+        return;
+    }
+
     // If user is not signed in, change just locally.
     if (!currentUserAccountID) {
         Onyx.merge(ONYXKEYS.NVP_PREFERRED_LOCALE, locale);
@@ -86,6 +96,13 @@ function setLocale(locale) {
     API.write('UpdatePreferredLocale', {
         value: locale,
     }, {optimisticData});
+}
+
+/**
+* @param {String} locale
+*/
+function setLocaleAndNavigate(locale) {
+    setLocale(locale);
     Navigation.navigate(ROUTES.SETTINGS_PREFERENCES);
 }
 
@@ -271,6 +288,7 @@ function openProfile() {
 
 export {
     setLocale,
+    setLocaleAndNavigate,
     setSidebarLoaded,
     setUpPoliciesAndNavigate,
     openProfile,

--- a/src/libs/actions/App.js
+++ b/src/libs/actions/App.js
@@ -74,7 +74,7 @@ function getNonOptimisticPolicyIDs(policies) {
 * @param {String} locale
 */
 function setLocale(locale) {
-    if(locale == preferredLocale) {
+    if (locale === preferredLocale) {
         return;
     }
 

--- a/src/pages/settings/Preferences/LanguagePage.js
+++ b/src/pages/settings/Preferences/LanguagePage.js
@@ -47,14 +47,7 @@ const LanguagePage = (props) => {
             />
             <OptionsList
                 sections={[{data: localesToLanguages}]}
-                onSelectRow={
-                    (language) => {
-                        if (language.value !== props.preferredLocale) {
-                            App.setLocale(language.value);
-                        }
-                        Navigation.navigate(ROUTES.SETTINGS_PREFERENCES);
-                    }
-                }
+                onSelectRow={language => App.setLocale(language.value)}
                 hideSectionHeaders
                 optionHoveredStyle={
                     {

--- a/src/pages/settings/Preferences/LanguagePage.js
+++ b/src/pages/settings/Preferences/LanguagePage.js
@@ -47,7 +47,7 @@ const LanguagePage = (props) => {
             />
             <OptionsList
                 sections={[{data: localesToLanguages}]}
-                onSelectRow={language => App.setLocale(language.value)}
+                onSelectRow={language => App.setLocaleAndNavigate(language.value)}
                 hideSectionHeaders
                 optionHoveredStyle={
                     {

--- a/src/pages/settings/Preferences/PreferencesPage.js
+++ b/src/pages/settings/Preferences/PreferencesPage.js
@@ -46,7 +46,7 @@ const PreferencesPage = (props) => {
     const priorityModes = props.translate('priorityModePage.priorityModes');
     const languages = props.translate('languagePage.languages');
 
-    // If we are in the staging environment then we enable additional test features
+    // Enable additional test features in the staging or dev environments
     const shouldShowTestToolMenu = _.contains([CONST.ENVIRONMENT.STAGING, CONST.ENVIRONMENT.DEV], props.environment);
 
     return (

--- a/src/pages/settings/Preferences/PreferencesPage.js
+++ b/src/pages/settings/Preferences/PreferencesPage.js
@@ -45,6 +45,9 @@ const defaultProps = {
 const PreferencesPage = (props) => {
     const priorityModes = props.translate('priorityModePage.priorityModes');
     const languages = props.translate('languagePage.languages');
+    
+    // If we are in the staging environment then we enable additional test features
+    const shouldShowTestToolMenu = _.contains([CONST.ENVIRONMENT.STAGING, CONST.ENVIRONMENT.DEV], props.environment);
 
     return (
         <ScreenWrapper includeSafeAreaPaddingBottom={false}>
@@ -84,16 +87,7 @@ const PreferencesPage = (props) => {
                         description={props.translate('languagePage.language')}
                         onPress={() => Navigation.navigate(ROUTES.SETTINGS_LANGUAGE)}
                     />
-
-                    {/* If we are in the staging environment then we enable additional test features */}
-                    {
-                        _.contains([CONST.ENVIRONMENT.STAGING, CONST.ENVIRONMENT.DEV], props.environment)
-                        && (
-                            <View style={[styles.mh8, styles.mt6]}>
-                                <TestToolMenu />
-                            </View>
-                        )
-                    }
+                    {shouldShowTestToolMenu && <View style={[styles.mh8, styles.mt6]}><TestToolMenu /></View>}
                 </View>
             </ScrollView>
         </ScreenWrapper>

--- a/src/pages/settings/Preferences/PreferencesPage.js
+++ b/src/pages/settings/Preferences/PreferencesPage.js
@@ -45,7 +45,7 @@ const defaultProps = {
 const PreferencesPage = (props) => {
     const priorityModes = props.translate('priorityModePage.priorityModes');
     const languages = props.translate('languagePage.languages');
-    
+
     // If we are in the staging environment then we enable additional test features
     const shouldShowTestToolMenu = _.contains([CONST.ENVIRONMENT.STAGING, CONST.ENVIRONMENT.DEV], props.environment);
 


### PR DESCRIPTION
cc @Beamanator 

### Details
This is a follow-up PR with 2 tiny little changes asked for [this PR](https://github.com/Expensify/App/pull/14591#issuecomment-1418680460)

### Fixed Issues
https://github.com/Expensify/App/pull/14591#issuecomment-1418680460


### Tests and QA Steps
1. Go to Settings -> Preferences -> Language
2. Change the language
3. Verify it works as expected
4. Log out
5. On the sign in page, change the language from the small language picker
6. Verify that it works as expected.

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://user-images.githubusercontent.com/18078393/216957181-fa2f43a8-65b6-4c48-8ba5-821436a66dc6.mov


</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://user-images.githubusercontent.com/18078393/216957217-0ff57c93-17a3-4fca-8244-ddb314428b1e.mov


</details>

<details>
<summary>Mobile Web - Safari</summary>

https://user-images.githubusercontent.com/18078393/216957253-b4d77b46-0336-4278-bbb4-967059bb04a7.mov


</details>

<details>
<summary>Desktop</summary>

https://user-images.githubusercontent.com/18078393/216957288-872a8f2e-910b-44ac-ab4a-60a339a4261a.mov


</details>

<details>
<summary>iOS</summary>

https://user-images.githubusercontent.com/18078393/216957322-5a92c750-180f-4ede-86c6-a86ba0c572a5.mov


</details>

<details>
<summary>Android</summary>

https://user-images.githubusercontent.com/18078393/216957354-0051eb8a-5bf8-40b3-b54f-89e8f0ade8d5.mov


</details>
