### PR TITLE
Fixes width/height extraction with respect to exif orientation tag

### DIFF
--- a/patches/react-native-fast-image+8.6.3.patch
+++ b/patches/react-native-fast-image+8.6.3.patch
@@ -34,7 +34,7 @@ index 0000000..6ea9042
 +        bitmapOptions.inJustDecodeBounds = true;
 +        BitmapFactory.decodeStream(source, null, bitmapOptions);
 +        source.reset();
-+        int orientation = Integer.parseInt(new ExifInterface(source).getAttribute(ExifInterface.TAG_ORIENTATION));
++        int orientation = new ExifInterface(source).getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_UNDEFINED);
 +        if (orientation == ExifInterface.ORIENTATION_ROTATE_90 || orientation == ExifInterface.ORIENTATION_ROTATE_270 ) {
 +            int tmpHeight = bitmapOptions.outHeight;
 +            int tmpWidth = bitmapOptions.outWidth;

--- a/patches/react-native-fast-image+8.6.3.patch
+++ b/patches/react-native-fast-image+8.6.3.patch
@@ -1,9 +1,9 @@
 diff --git a/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/BitmapSizeDecoder.java b/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/BitmapSizeDecoder.java
 new file mode 100644
-index 0000000..f97ed67
+index 0000000..2bd58b8
 --- /dev/null
 +++ b/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/BitmapSizeDecoder.java
-@@ -0,0 +1,43 @@
+@@ -0,0 +1,44 @@
 +package com.dylanvann.fastimage;
 +
 +import android.graphics.BitmapFactory;
@@ -33,23 +33,25 @@ index 0000000..f97ed67
 +        BitmapFactory.Options bitmapOptions = new BitmapFactory.Options();
 +        bitmapOptions.inJustDecodeBounds = true;
 +        BitmapFactory.decodeStream(source, null, bitmapOptions);
-+        // BitmapFactory#decodeStream leaves stream's position where ever it was after reading the encoded data 
++
++        // BitmapFactory#decodeStream leaves stream's position where ever it was after reading the encoded data
 +        // https://developer.android.com/reference/android/graphics/BitmapFactory#decodeStream(java.io.InputStream)
 +        // so we need to rewind the stream to be able to read image header with exif values
 +        source.reset();
++
 +        int orientation = new ExifInterface(source).getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_UNDEFINED);
-+        if (orientation == ExifInterface.ORIENTATION_ROTATE_90 || orientation == ExifInterface.ORIENTATION_ROTATE_270 ) {
-+            int tmpHeight = bitmapOptions.outHeight;
++        if (orientation == ExifInterface.ORIENTATION_ROTATE_90 || orientation == ExifInterface.ORIENTATION_ROTATE_270) {
 +            int tmpWidth = bitmapOptions.outWidth;
++            bitmapOptions.outWidth = bitmapOptions.outHeight;
 +            bitmapOptions.outHeight = tmpWidth;
-+            bitmapOptions.outWidth = tmpHeight;
 +        }
 +        return new SimpleResource(bitmapOptions);
 +    }
 +}
+\ No newline at end of file
 diff --git a/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/BitmapSizeTranscoder.java b/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/BitmapSizeTranscoder.java
 new file mode 100644
-index 0000000..5287e17
+index 0000000..7d208d1
 --- /dev/null
 +++ b/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/BitmapSizeTranscoder.java
 @@ -0,0 +1,23 @@
@@ -228,7 +230,7 @@ index 34fcf89..1339f5c 100644
  
 diff --git a/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/Size.java b/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/Size.java
 new file mode 100644
-index 0000000..8b8ec3d
+index 0000000..2fe8a47
 --- /dev/null
 +++ b/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/Size.java
 @@ -0,0 +1,6 @@
@@ -268,7 +270,7 @@ diff --git a/node_modules/react-native-fast-image/ios/FastImage/FFFastImageView.
 index f710081..391ef92 100644
 --- a/node_modules/react-native-fast-image/ios/FastImage/FFFastImageView.m
 +++ b/node_modules/react-native-fast-image/ios/FastImage/FFFastImageView.m
-@@ -54,7 +54,6 @@
+@@ -54,7 +54,6 @@ - (void) setOnFastImageError: (RCTDirectEventBlock)onFastImageError {
  - (void) setOnFastImageLoadStart: (RCTDirectEventBlock)onFastImageLoadStart {
      if (_source && !self.hasSentOnLoadStart) {
          _onFastImageLoadStart = onFastImageLoadStart;
@@ -276,7 +278,7 @@ index f710081..391ef92 100644
          self.hasSentOnLoadStart = YES;
      } else {
          _onFastImageLoadStart = onFastImageLoadStart;
-@@ -188,7 +187,18 @@
+@@ -188,7 +187,18 @@ - (void) reloadImage {
          }
  
          if (self.onFastImageLoadStart) {

--- a/patches/react-native-fast-image+8.6.3.patch
+++ b/patches/react-native-fast-image+8.6.3.patch
@@ -1,9 +1,9 @@
 diff --git a/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/BitmapSizeDecoder.java b/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/BitmapSizeDecoder.java
 new file mode 100644
-index 0000000..6ea9042
+index 0000000..f97ed67
 --- /dev/null
 +++ b/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/BitmapSizeDecoder.java
-@@ -0,0 +1,40 @@
+@@ -0,0 +1,43 @@
 +package com.dylanvann.fastimage;
 +
 +import android.graphics.BitmapFactory;
@@ -33,6 +33,9 @@ index 0000000..6ea9042
 +        BitmapFactory.Options bitmapOptions = new BitmapFactory.Options();
 +        bitmapOptions.inJustDecodeBounds = true;
 +        BitmapFactory.decodeStream(source, null, bitmapOptions);
++        // BitmapFactory#decodeStream leaves stream's position where ever it was after reading the encoded data 
++        // https://developer.android.com/reference/android/graphics/BitmapFactory#decodeStream(java.io.InputStream)
++        // so we need to rewind the stream to be able to read image header with exif values
 +        source.reset();
 +        int orientation = Integer.parseInt(new ExifInterface(source).getAttribute(ExifInterface.TAG_ORIENTATION));
 +        if (orientation == ExifInterface.ORIENTATION_ROTATE_90 || orientation == ExifInterface.ORIENTATION_ROTATE_270 ) {

--- a/patches/react-native-fast-image+8.6.3.patch
+++ b/patches/react-native-fast-image+8.6.3.patch
@@ -38,7 +38,7 @@ index 0000000..f97ed67
 +        // so we need to rewind the stream to be able to read image header with exif values
 +        source.reset();
 +        int orientation = new ExifInterface(source).getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_UNDEFINED);
-+        if (orientation == ExifInterface.ORIENTATION_ROTATE_90 || orientation == ExifInterface.ORIENTATION_ROTATE_270 ) {
++        if (orientation == ExifInterface.ORIENTATION_ROTATE_90 || orientation == ExifInterface.ORIENTATION_ROTATE_270) {
 +            int tmpHeight = bitmapOptions.outHeight;
 +            int tmpWidth = bitmapOptions.outWidth;
 +            bitmapOptions.outHeight = tmpWidth;

--- a/patches/react-native-fast-image+8.6.3.patch
+++ b/patches/react-native-fast-image+8.6.3.patch
@@ -1,15 +1,16 @@
 diff --git a/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/BitmapSizeDecoder.java b/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/BitmapSizeDecoder.java
 new file mode 100644
-index 0000000..03ad017
+index 0000000..6ea9042
 --- /dev/null
 +++ b/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/BitmapSizeDecoder.java
-@@ -0,0 +1,31 @@
+@@ -0,0 +1,40 @@
 +package com.dylanvann.fastimage;
 +
 +import android.graphics.BitmapFactory;
 +
 +import androidx.annotation.NonNull;
 +import androidx.annotation.Nullable;
++import androidx.exifinterface.media.ExifInterface;
 +
 +import com.bumptech.glide.load.Options;
 +import com.bumptech.glide.load.ResourceDecoder;
@@ -32,13 +33,21 @@ index 0000000..03ad017
 +        BitmapFactory.Options bitmapOptions = new BitmapFactory.Options();
 +        bitmapOptions.inJustDecodeBounds = true;
 +        BitmapFactory.decodeStream(source, null, bitmapOptions);
++        source.reset();
++        int orientation = Integer.parseInt(new ExifInterface(source).getAttribute(ExifInterface.TAG_ORIENTATION));
++        if (orientation == ExifInterface.ORIENTATION_ROTATE_90 || orientation == ExifInterface.ORIENTATION_ROTATE_270 ) {
++            int tmpHeight = bitmapOptions.outHeight;
++            int tmpWidth = bitmapOptions.outWidth;
++            bitmapOptions.outHeight = tmpWidth;
++            bitmapOptions.outWidth = tmpHeight;
++        }
 +        return new SimpleResource(bitmapOptions);
 +    }
 +}
 \ No newline at end of file
 diff --git a/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/BitmapSizeTranscoder.java b/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/BitmapSizeTranscoder.java
 new file mode 100644
-index 0000000..7d208d1
+index 0000000..5287e17
 --- /dev/null
 +++ b/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/BitmapSizeTranscoder.java
 @@ -0,0 +1,23 @@
@@ -217,7 +226,7 @@ index 34fcf89..1339f5c 100644
  
 diff --git a/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/Size.java b/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/Size.java
 new file mode 100644
-index 0000000..2fe8a47
+index 0000000..8b8ec3d
 --- /dev/null
 +++ b/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/Size.java
 @@ -0,0 +1,6 @@
@@ -257,7 +266,7 @@ diff --git a/node_modules/react-native-fast-image/ios/FastImage/FFFastImageView.
 index f710081..391ef92 100644
 --- a/node_modules/react-native-fast-image/ios/FastImage/FFFastImageView.m
 +++ b/node_modules/react-native-fast-image/ios/FastImage/FFFastImageView.m
-@@ -54,7 +54,6 @@ - (void) setOnFastImageError: (RCTDirectEventBlock)onFastImageError {
+@@ -54,7 +54,6 @@
  - (void) setOnFastImageLoadStart: (RCTDirectEventBlock)onFastImageLoadStart {
      if (_source && !self.hasSentOnLoadStart) {
          _onFastImageLoadStart = onFastImageLoadStart;
@@ -265,7 +274,7 @@ index f710081..391ef92 100644
          self.hasSentOnLoadStart = YES;
      } else {
          _onFastImageLoadStart = onFastImageLoadStart;
-@@ -188,7 +187,18 @@ - (void) reloadImage {
+@@ -188,7 +187,18 @@
          }
  
          if (self.onFastImageLoadStart) {

--- a/patches/react-native-fast-image+8.6.3.patch
+++ b/patches/react-native-fast-image+8.6.3.patch
@@ -44,7 +44,6 @@ index 0000000..6ea9042
 +        return new SimpleResource(bitmapOptions);
 +    }
 +}
-\ No newline at end of file
 diff --git a/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/BitmapSizeTranscoder.java b/node_modules/react-native-fast-image/android/src/main/java/com/dylanvann/fastimage/BitmapSizeTranscoder.java
 new file mode 100644
 index 0000000..5287e17


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. @mountiny @0xmiroslav  -->
### Details

Expensify uses react-native-fast-image and added a patch to be able to get dimensions of the image displayed in the component on an onLoad event. But this method doesn't work correctly with images that have an exif property of image orientation. In such cases image is displayed properly (rotated according to the exif orientation flag) but dimensions returned from react-native-fast-image component are wrong (width/height swapped).  
To resolve this propblem we should add an exif reader to get orientation tag and correct dimensions in such cases.

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/14448
$ https://github.com/Expensify/App/issues/14448#issuecomment-1422330478


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Launch the app
2. Login with any account
3. Go to any chat
4. Tap on plus button
5. Select Add Attachment
6. Select Take a photo
7. Take a photo and send it

- [x] Verify that no errors appear in the JS console
- [x] Picture should be displayed in full size
- [x]  upload image from iOS camera and preview in android
- [x] upload image from iOS gallery and preview in android
- [x] upload image from web and preview in android
- [x] upload image from android camera and preview in all platforms
- [x] upload image from android gallery and preview in all platforms

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

1. Go to a chat with previously uploaded pictures
2.  Pictures should be displayed in full size

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Launch the app
2. Login with any account
3. Go to any chat
4. Tap on plus button
5. Select Add Attachment
7. Select Take a photo
8. Take a photo and send it

- [x] Verify that no errors appear in the JS console
- [x] Picture should be displayed in full size
- [x]  upload image from iOS camera and preview in android
- [x] upload image from iOS gallery and preview in android
- [x] upload image from web and preview in android
- [x] upload image from android camera and preview in all platforms
- [x] upload image from android gallery and preview in all platforms

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->
<img width="970" alt="image" src="https://user-images.githubusercontent.com/3872759/217951395-dfaf539c-b659-47e8-aa70-9f30faa512ce.png">

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->
![Screenshot_20230210_030608_Chrome](https://user-images.githubusercontent.com/3872759/217952321-23964136-80c2-42ee-b07c-2c7dbcc111cd.jpeg)


</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->
![screen_web_ios](https://user-images.githubusercontent.com/3872759/218060692-270715a0-6e85-445a-aaf8-392563cdd684.jpg)


</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->
<img width="1201" alt="image" src="https://user-images.githubusercontent.com/3872759/217950849-80efff54-41e2-4f6a-9a34-b7b0657db41c.png">

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->
![screen_ios](https://user-images.githubusercontent.com/3872759/218060781-ceff2da8-4ebb-46bc-960b-13769ab435e1.jpg)


</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->
![Screenshot_20230210_040127_New Expensify](https://user-images.githubusercontent.com/3872759/217958796-33f5ffb5-4925-4558-9ae4-c7dc213b9d8f.jpeg)


</details>
