### PR TITLE
Conditionally require password for adding a debit card

### DIFF
--- a/src/pages/settings/Payments/AddDebitCardPage.js
+++ b/src/pages/settings/Payments/AddDebitCardPage.js
@@ -21,12 +21,16 @@ import ONYXKEYS from '../../../ONYXKEYS';
 import AddressSearch from '../../../components/AddressSearch';
 import * as ComponentUtils from '../../../libs/ComponentUtils';
 import Form from '../../../components/Form';
+import Permissions from '../../../libs/Permissions';
 
 const propTypes = {
     /* Onyx Props */
     formData: PropTypes.shape({
         setupComplete: PropTypes.bool,
     }),
+
+    /** List of betas available to current user */
+    betas: PropTypes.arrayOf(PropTypes.string),
 
     ...withLocalizePropTypes,
 };
@@ -95,7 +99,7 @@ class DebitCardPage extends Component {
             errors.addressState = this.props.translate('addDebitCardPage.error.addressState');
         }
 
-        if (!values.password || _.isEmpty(values.password.trim())) {
+        if (!Permissions.canUsePasswordlessLogins(this.props.betas) && (!values.password || _.isEmpty(values.password.trim()))) {
             errors.password = this.props.translate('addDebitCardPage.error.password');
         }
 
@@ -176,15 +180,17 @@ class DebitCardPage extends Component {
                             />
                         </View>
                     </View>
-                    <View style={[styles.mt4]}>
-                        <TextInput
-                            inputID="password"
-                            label={this.props.translate('addDebitCardPage.expensifyPassword')}
-                            textContentType="password"
-                            autoCompleteType={ComponentUtils.PASSWORD_AUTOCOMPLETE_TYPE}
-                            secureTextEntry
-                        />
-                    </View>
+                    {!Permissions.canUsePolicyRooms(this.props.betas) &&
+                        <View style={[styles.mt4]}>
+                            <TextInput
+                                inputID="password"
+                                label={this.props.translate('addDebitCardPage.expensifyPassword')}
+                                textContentType="password"
+                                autoCompleteType={ComponentUtils.PASSWORD_AUTOCOMPLETE_TYPE}
+                                secureTextEntry
+                            />
+                        </View>
+                    }
                     <CheckboxWithLabel
                         inputID="acceptedTerms"
                         LabelComponent={() => (
@@ -211,6 +217,9 @@ export default compose(
     withOnyx({
         formData: {
             key: ONYXKEYS.FORMS.ADD_DEBIT_CARD_FORM,
+        },
+        betas: {
+            key: ONYXKEYS.BETAS,
         },
     }),
 )(DebitCardPage);

--- a/src/pages/settings/Payments/AddDebitCardPage.js
+++ b/src/pages/settings/Payments/AddDebitCardPage.js
@@ -39,6 +39,7 @@ const defaultProps = {
     formData: {
         setupComplete: false,
     },
+    betas: [],
 };
 
 class DebitCardPage extends Component {
@@ -180,7 +181,7 @@ class DebitCardPage extends Component {
                             />
                         </View>
                     </View>
-                    {!Permissions.canUsePolicyRooms(this.props.betas) &&
+                    {!Permissions.canUsePolicyRooms(this.props.betas) && (
                         <View style={[styles.mt4]}>
                             <TextInput
                                 inputID="password"
@@ -190,7 +191,7 @@ class DebitCardPage extends Component {
                                 secureTextEntry
                             />
                         </View>
-                    }
+                    )}
                     <CheckboxWithLabel
                         inputID="acceptedTerms"
                         LabelComponent={() => (

--- a/src/pages/settings/Payments/AddDebitCardPage.js
+++ b/src/pages/settings/Payments/AddDebitCardPage.js
@@ -181,7 +181,7 @@ class DebitCardPage extends Component {
                             />
                         </View>
                     </View>
-                    {!Permissions.canUsePolicyRooms(this.props.betas) && (
+                    {!Permissions.canUsePasswordlessLogins(this.props.betas) && (
                         <View style={[styles.mt4]}>
                             <TextInput
                                 inputID="password"


### PR DESCRIPTION
### Details
Removes password requirement for adding a debit card if user is passwordless 

### Fixed Issues

Originally for https://github.com/Expensify/Expensify/issues/261738 but reverted in https://github.com/Expensify/App/pull/15217
PROPOSAL: N/A

### Tests
1. Log into new Expensify with an account that is on the passwordless beta 
2. Navigate to Settings > Payments > Add Payment Method > Debit Card
3. Confirm that you do **not** see a field for the `Expensify Password` in the debit card form 
4. Fill out the form with any details but use the card number `4242424242424242`
5. Confirm you can successfully add the card 
6. Log into new Expensify with an account that is **not** on the passwordless beta 
7. Navigate to Settings > Payments > Add Payment Method > Debit Card
8. Confirm you do see the field for the `Expensify Password` in the form 
9. Fill everything out except the password 
10. Try to submit the form and confirm you're unable to do so and receive an error

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A behavior is the same as online tests

### QA Steps
1. Log into new Expensify with an account that is on the passwordless beta 
2. Navigate to Settings > Payments > Add Payment Method > Debit Card
3. Confirm that you do **not** see a field for the `Expensify Password` in the debit card form 
4. Fill out the form with any details but use the card number `4242424242424242`
5. Confirm you can successfully add the card 
6. Log into new Expensify with an account that is **not** on the passwordless beta 
7. Navigate to Settings > Payments > Add Payment Method > Debit Card
8. Confirm you do see the field for the `Expensify Password` in the form 
9. Fill everything out except the password 
10. Try to submit the form and confirm you're unable to do so and receive an error

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    -[x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

**Passwordless**

https://user-images.githubusercontent.com/16747822/218627556-9125070f-cdc4-47ef-a7c6-97249922563a.mov

**Not Passwordless**

https://user-images.githubusercontent.com/16747822/218627589-656feee6-504e-4de2-bc36-cb18f5b1e5c4.mov

</details>

<details>
<summary>Mobile Web - Chrome</summary>

**Passwordless**

![mweb-chrome-passwordless](https://user-images.githubusercontent.com/16747822/218633027-8cb3cb4a-3172-400e-bd56-1ee0b03eb47b.gif)

**Not Passwordless**

![mweb-chrome-notpasswordless](https://user-images.githubusercontent.com/16747822/218633052-3b8a80e4-a638-4b5c-8451-f255b8f88830.gif)

</details>

<details>
<summary>Mobile Web - Safari</summary>

**Passwordless**

https://user-images.githubusercontent.com/16747822/218630236-5c638523-651d-4116-82bf-ae6e2978abcf.mp4

**Not Passwordless**

https://user-images.githubusercontent.com/16747822/218630261-5aa57321-3f48-4c81-9842-c3e4756f2b62.mp4

</details>

<details>
<summary>Desktop</summary>

**Passwordless**

https://user-images.githubusercontent.com/16747822/218628119-a5f20932-be1d-42a9-bb0e-d161c8f14448.mov

**Not Passwordless**

https://user-images.githubusercontent.com/16747822/218628164-1efd4336-e374-4d16-8e7c-4e77ebda81bb.mov

</details>

<details>
<summary>iOS</summary>

**Passwordless**

https://user-images.githubusercontent.com/16747822/218630133-f97ae6e6-c8a5-4ba5-8c5d-fa67b543804b.mp4

**Not Passwordless**

https://user-images.githubusercontent.com/16747822/218630186-8aa01a9c-8300-4b4e-b303-d57787965563.mp4

</details>

<details>
<summary>Android</summary>

**Passwordless**

![android-passwordless](https://user-images.githubusercontent.com/16747822/218814232-c416c15b-b315-447c-beb1-c6f163a8878a.gif)

**Not Passwordless**

![android-nonpasswordless](https://user-images.githubusercontent.com/16747822/218814285-a4dd0bc0-0d6a-4205-b3de-1dba04094a95.gif)

</details>
