### PR TITLE
Skip call for deactivateLabel when autofill text exists

### DIFF
--- a/src/components/TextInput/BaseTextInput.js
+++ b/src/components/TextInput/BaseTextInput.js
@@ -132,7 +132,7 @@ class BaseTextInput extends Component {
 
         // If the text has been supplied by Chrome autofill, the value state is not synced with the value
         // as Chrome doesn't trigger a change event. When there is autofill text, don't deactivate label.
-        const textWasAutoFilled = this.input.matches(':-internal-autofill-selected');
+        const textWasAutoFilled = this.input.matches && this.input.matches(':-internal-autofill-selected');
         if (!textWasAutoFilled) {
             this.deactivateLabel();
         }

--- a/src/components/TextInput/BaseTextInput.js
+++ b/src/components/TextInput/BaseTextInput.js
@@ -132,8 +132,8 @@ class BaseTextInput extends Component {
 
         // If the text has been supplied by Chrome autofill, the value state is not synced with the value
         // as Chrome doesn't trigger a change event. When there is autofill text, don't deactivate label.
-        const textWasAutoFilled = this.input.matches && this.input.matches(':-internal-autofill-selected');
-        if (!textWasAutoFilled) {
+        const textWasAutoFilledOnChrome = this.input.matches && this.input.matches(':-webkit-autofill');
+        if (!textWasAutoFilledOnChrome) {
             this.deactivateLabel();
         }
     }

--- a/src/components/TextInput/BaseTextInput.js
+++ b/src/components/TextInput/BaseTextInput.js
@@ -129,6 +129,13 @@ class BaseTextInput extends Component {
     onBlur(event) {
         if (this.props.onBlur) { this.props.onBlur(event); }
         this.setState({isFocused: false});
+
+        // If the text has been supplied by Chrome autofill, the value state is not synced with the value
+        // as Chrome doesn't trigger a change event. When there is autofill text, don't deactivate label.
+        const textWasAutoFilled = this.input.matches(':-internal-autofill-selected');
+        if (!textWasAutoFilled) {
+            this.deactivateLabel();
+        }
     }
 
     /**

--- a/src/components/TextInput/BaseTextInput.js
+++ b/src/components/TextInput/BaseTextInput.js
@@ -129,7 +129,6 @@ class BaseTextInput extends Component {
     onBlur(event) {
         if (this.props.onBlur) { this.props.onBlur(event); }
         this.setState({isFocused: false});
-        this.deactivateLabel();
     }
 
     /**


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

<!--
In `BaseTextInput` (which is used inside `TextInput`), `deactivateLabel` is invoked twice when `blur` event happens.
- `blur` event -> `onBlur` handler -> `deactivateLabel`
- `blur` event -> `onBlur` handler -> new `isFocused` state value is set to `false` -> `componentDidUpdate` -> `deactivateLabel`
-->

When a `blur` event is fired, `deactivateLabel` method is invoked inside `onBlur` event handler.

`deactivateLabel` method determines if the position of input label should be really updated based on the current input value. If there is already text, it does not deactivate (i.e. move the input label down closer to the input field).

For `deactivateLabel` to properly determine its course of action, the `value` state value should be synced to the text inputted in the text field. This is usually fine, as the `value` state value is updated in the `onChangeText` callback as the user types, deletes or pastes texts into the field.

However, the `onChangeText` callback is not invoked when the text value is autofilled by Chrome (ex. for username and password). This results in the `value` state not synced with the text displayed in the text field.

When the `value` state value is empty but the text field is not for this reason, `deactivateLabel` thinks it should move the label down to indicate deactivation state, making the label overlap with the displayed input text.

The straight forward solution to this problem is to make sure the `value` is synced with the displayed text when the input is autofilled by Chrome. However, there is no solution for this at this moment.

This is not React Native specific problem. [When autofilling a text, Chrome doesn't trigger a change event or even register the text value with the input element until user performs some kind of action WITHIN the page](https://stackoverflow.com/questions/55244590/autofill-does-not-trigger-onchange#:~:text=Chrome%20doesn%27t%20set%20the%20value%20of%20the%20inputs%20until%20there%20has%20been%20user%20interaction%20with%20the%20page.%20This%20can%20be%20clicking%20on%20the%20page%2C%20or%20even%20typing%20random%20things%20into%20the%20console.) (ex. clicking on somewhere on the page). In other words, when you cause a `blur` event without any direct user interaction WITHIN the website, the `value` state is not updated. This is why this issue only happens when the user clicks outside the website (ex. url bar or outside Chrome window itself). Triggering an arbitrary event programmatically doesn't work either.

The workaround for this issue is to check for the existence of a sudo selector that Chrome internally use. When this selector is present, `deactivateLabel` should not be invoked. After the user edits the autofilled text, this selector is removed. However, because this is an internal selector, we don't know when this selector might change.

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/14801


### Tests / Offline Tests / QA Steps
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

Check the issue has been fixed
1. Open Chrome on laptop
2. Follow [this](https://github.com/Expensify/App/issues/14801#issuecomment-1429937519) and [this](https://github.com/Expensify/App/issues/14801#issuecomment-1430600211) instructions to make sure Chrome can save and autofill your username
3. Logout from New Expensify if you're logged in
4. Go to sign in page and wait for the username to be autofilled by Chrome
5. Click anywhere outside the website (URL Bar, Share Button, or outside Chrome window)
6. Check the text input label `Phone or email` is not overlapped with the text that is autofilled by Chrome
7. Verify that no errors appear in the JS console

Check this PR didn't break the normal behavior

8. Delete the username that is autofilled by Chrome
9. Click outside the text field to remove the focus from the field
10. Check the label `Phone or email` moves a little bit downward to indicate inactive state.

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [ ] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/98560306/219135420-e62bc1af-5c08-42f7-99ed-212762205284.mov

https://user-images.githubusercontent.com/98560306/219136145-8a62b89a-ac7f-4b4a-b695-a7caddc84a94.mov

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

[android chrome.webm](https://user-images.githubusercontent.com/98560306/219135501-fd4fcb0f-19d4-432f-8549-420a13525f12.webm)

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/98560306/219135562-84ae4b76-93ab-46c9-a7b4-38a806dcce0e.mp4

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/98560306/219195483-1ca8a3c6-fe60-4ee2-9daa-e3dd7b8d3818.mov

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->


https://user-images.githubusercontent.com/98560306/219135711-5526c8fb-0d41-4c30-b50d-611f072f262f.mp4


</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

[android native.webm](https://user-images.githubusercontent.com/98560306/219135752-f62242b2-b993-4a63-8065-8baa4dd11616.webm)

</details>
