### PR TITLE
ArrowKeyFocusManager: Do not capture events targeting textarea nodes

### DIFF
--- a/src/components/ArrowKeyFocusManager.js
+++ b/src/components/ArrowKeyFocusManager.js
@@ -48,7 +48,7 @@ class ArrowKeyFocusManager extends Component {
             }
 
             this.props.onFocusedIndexChanged(newFocusedIndex);
-        }, arrowUpConfig.descriptionKey, arrowUpConfig.modifiers, true);
+        }, arrowUpConfig.descriptionKey, arrowUpConfig.modifiers, true, false, 0, true, ['TEXTAREA']);
 
         this.unsubscribeArrowDownKey = KeyboardShortcut.subscribe(arrowDownConfig.shortcutKey, () => {
             if (this.props.maxIndex < 0) {
@@ -66,7 +66,7 @@ class ArrowKeyFocusManager extends Component {
             }
 
             this.props.onFocusedIndexChanged(newFocusedIndex);
-        }, arrowDownConfig.descriptionKey, arrowDownConfig.modifiers, true);
+        }, arrowDownConfig.descriptionKey, arrowDownConfig.modifiers, true, false, 0, true, ['TEXTAREA']);
     }
 
     componentWillUnmount() {

--- a/src/libs/KeyboardShortcut/index.js
+++ b/src/libs/KeyboardShortcut/index.js
@@ -75,8 +75,8 @@ function bindHandlerToKeydownEvent(event) {
 
     // Loop over all the callbacks
     _.every(eventHandlers[displayName], (callback) => {
-        // Early return for excludeNodes
-        if (_.contains(callback.excludeNodes, event.target.nodeName)) {
+        // Early return for excludedNodes
+        if (_.contains(callback.excludedNodes, event.target.nodeName)) {
             return true;
         }
 
@@ -150,10 +150,10 @@ function getPlatformEquivalentForKeys(keys) {
  * @param {Boolean|Function} [shouldBubble] Should the event bubble?
  * @param {Number} [priority] The position the callback should take in the stack. 0 means top priority, and 1 means less priority than the most recently added.
  * @param {Boolean} [shouldPreventDefault] Should call event.preventDefault after callback?
- * @param {Array<String>} [excludeNodes] Do not capture key events targeting excluded nodes (i.e. do not prevent default and let the event bubble)
+ * @param {Array<String>} [excludedNodes] Do not capture key events targeting excluded nodes (i.e. do not prevent default and let the event bubble)
  * @returns {Function} clean up method
  */
-function subscribe(key, callback, descriptionKey, modifiers = 'shift', captureOnInputs = false, shouldBubble = false, priority = 0, shouldPreventDefault = true, excludeNodes = []) {
+function subscribe(key, callback, descriptionKey, modifiers = 'shift', captureOnInputs = false, shouldBubble = false, priority = 0, shouldPreventDefault = true, excludedNodes = []) {
     const platformAdjustedModifiers = getPlatformEquivalentForKeys(modifiers);
     const displayName = getDisplayName(key, platformAdjustedModifiers);
     if (!_.has(eventHandlers, displayName)) {
@@ -167,7 +167,7 @@ function subscribe(key, callback, descriptionKey, modifiers = 'shift', captureOn
         captureOnInputs,
         shouldPreventDefault,
         shouldBubble,
-        excludeNodes,
+        excludedNodes,
     });
 
     if (descriptionKey) {

--- a/src/libs/KeyboardShortcut/index.js
+++ b/src/libs/KeyboardShortcut/index.js
@@ -75,6 +75,11 @@ function bindHandlerToKeydownEvent(event) {
 
     // Loop over all the callbacks
     _.every(eventHandlers[displayName], (callback) => {
+        // Early return for excludeNodes
+        if (_.contains(callback.excludeNodes, event.target.nodeName)) {
+            return true;
+        }
+
         // If configured to do so, prevent input text control to trigger this event
         if (!callback.captureOnInputs && (
             event.target.nodeName === 'INPUT'
@@ -145,9 +150,10 @@ function getPlatformEquivalentForKeys(keys) {
  * @param {Boolean|Function} [shouldBubble] Should the event bubble?
  * @param {Number} [priority] The position the callback should take in the stack. 0 means top priority, and 1 means less priority than the most recently added.
  * @param {Boolean} [shouldPreventDefault] Should call event.preventDefault after callback?
+ * @param {Array<String>} [excludeNodes] Do not capture key events targeting excluded nodes (i.e. do not prevent default and let the event bubble)
  * @returns {Function} clean up method
  */
-function subscribe(key, callback, descriptionKey, modifiers = 'shift', captureOnInputs = false, shouldBubble = false, priority = 0, shouldPreventDefault = true) {
+function subscribe(key, callback, descriptionKey, modifiers = 'shift', captureOnInputs = false, shouldBubble = false, priority = 0, shouldPreventDefault = true, excludeNodes = []) {
     const platformAdjustedModifiers = getPlatformEquivalentForKeys(modifiers);
     const displayName = getDisplayName(key, platformAdjustedModifiers);
     if (!_.has(eventHandlers, displayName)) {
@@ -161,6 +167,7 @@ function subscribe(key, callback, descriptionKey, modifiers = 'shift', captureOn
         captureOnInputs,
         shouldPreventDefault,
         shouldBubble,
+        excludeNodes,
     });
 
     if (descriptionKey) {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Do not capture the arrow up/down key events if the targeted node is a textarea.

### Fixed Issues
$ https://github.com/Expensify/App/issues/15075   
PROPOSAL: https://github.com/Expensify/App/issues/15075#issuecomment-1427867312


### Tests
1. Login to any account
2. Create a workspace if you don't have any
3. Go to workspace invite page (Settings -> Workspaces -> _any_ workspace -> Manage members -> Click Invite button)
4.  - Android/iOS/mWeb:
        1. Verify that the page works normally and not broken
    - Web/Desktop:
        1. Focus/Click on the personal message text area
        2. Press arrow up/down keys
        3. Verify that the cursor on the text area moves on arrow key presses

- [ ] Verify that no errors appear in the JS console

### Offline tests
n/a

### QA Steps
1. Login to any account
2. Create a workspace if you don't have any
3. Go to workspace invite page (Settings -> Workspaces -> _any_ workspace -> Manage members -> Click Invite button)
4.  - Android/iOS/mWeb:
        1. Verify that the page works normally and not broken
    - Web/Desktop:
        1. Focus/Click on the personal message text area
        2. Press arrow up/down keys
        3. Verify that the cursor on the text area moves on arrow key presses

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android / native
    - [X] Android / Chrome
    - [X] iOS / native
    - [X] iOS / Safari
    - [X] MacOS / Chrome / Safari
    - [X] MacOS / Desktop
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [X] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [X] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If a new component is created I verified that:
    - [X] A similar component doesn't exist in the codebase
    - [X] All props are defined accurately and each prop has a `/** comment above it */`
    - [X] The file is named correctly
    - [X] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [X] The only data being stored in the state is data necessary for rendering and nothing else
    - [X] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [X] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [X] All JSX used for rendering exists in the render method
    - [X] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>


https://user-images.githubusercontent.com/16493223/219012363-3706c002-bb8f-429f-b22d-5fe2d8b6700a.mp4


</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://user-images.githubusercontent.com/16493223/219012382-bd5716d6-e147-4922-84d7-0ae95ddf2605.mp4



</details>

<details>
<summary>Mobile Web - Safari</summary>


https://user-images.githubusercontent.com/16493223/219012401-abd51a19-d120-4f27-a6ae-62e99b96364b.mp4


</details>

<details>
<summary>Desktop</summary>

https://user-images.githubusercontent.com/16493223/219012514-ca236a4b-eea8-4976-8bf0-56ea463a5676.mp4



</details>

<details>
<summary>iOS</summary>

https://user-images.githubusercontent.com/16493223/219012531-5de35801-7f0b-45ff-a571-e113a8cc0224.mp4



</details>

<details>
<summary>Android</summary>

https://user-images.githubusercontent.com/16493223/219012547-765012b5-f222-46a4-b191-504bd316f44e.mp4



</details>
