### PR TITLE
Remove beta flag for i18n

### DIFF
--- a/src/components/LocalePicker.js
+++ b/src/components/LocalePicker.js
@@ -7,7 +7,6 @@ import * as App from '../libs/actions/App';
 import withLocalize, {withLocalizePropTypes} from './withLocalize';
 import ONYXKEYS from '../ONYXKEYS';
 import CONST from '../CONST';
-import Permissions from '../libs/Permissions';
 import * as Localize from '../libs/Localize';
 import Picker from './Picker';
 import styles from '../styles/styles';
@@ -42,28 +41,22 @@ const localesToLanguages = {
     },
 };
 
-const LocalePicker = (props) => {
-    if (!Permissions.canUseInternationalization(props.betas)) {
-        return null;
-    }
+const LocalePicker = (props) => (
+    <Picker
+        label={props.size === 'normal' ? props.translate('languagePage.language') : null}
+        onInputChange={(locale) => {
+            if (locale === props.preferredLocale) {
+                return;
+            }
 
-    return (
-        <Picker
-            label={props.size === 'normal' ? props.translate('languagePage.language') : null}
-            onInputChange={(locale) => {
-                if (locale === props.preferredLocale) {
-                    return;
-                }
-
-                App.setLocale(locale);
-            }}
-            items={_.values(localesToLanguages)}
-            size={props.size}
-            value={props.preferredLocale}
-            containerStyles={props.size === 'small' ? [styles.pickerContainerSmall] : []}
-        />
-    );
-};
+            App.setLocale(locale);
+        }}
+        items={_.values(localesToLanguages)}
+        size={props.size}
+        value={props.preferredLocale}
+        containerStyles={props.size === 'small' ? [styles.pickerContainerSmall] : []}
+    />
+);
 
 LocalePicker.defaultProps = defaultProps;
 LocalePicker.propTypes = propTypes;

--- a/src/components/LocalePicker.js
+++ b/src/components/LocalePicker.js
@@ -18,16 +18,12 @@ const propTypes = {
     /** Indicates size of a picker component and whether to render the label or not */
     size: PropTypes.oneOf(['normal', 'small']),
 
-    /** Beta features list */
-    betas: PropTypes.arrayOf(PropTypes.string),
-
     ...withLocalizePropTypes,
 };
 
 const defaultProps = {
     preferredLocale: CONST.DEFAULT_LOCALE,
     size: 'normal',
-    betas: [],
 };
 
 const localesToLanguages = {
@@ -41,7 +37,7 @@ const localesToLanguages = {
     },
 };
 
-const LocalePicker = (props) => (
+const LocalePicker = props => (
     <Picker
         label={props.size === 'normal' ? props.translate('languagePage.language') : null}
         onInputChange={(locale) => {
@@ -67,9 +63,6 @@ export default compose(
     withOnyx({
         preferredLocale: {
             key: ONYXKEYS.NVP_PREFERRED_LOCALE,
-        },
-        betas: {
-            key: ONYXKEYS.BETAS,
         },
     }),
 )(LocalePicker);

--- a/src/libs/Permissions.js
+++ b/src/libs/Permissions.js
@@ -47,14 +47,6 @@ function canUseDefaultRooms(betas) {
  * @param {Array<String>} betas
  * @returns {Boolean}
  */
-function canUseInternationalization(betas) {
-    return _.contains(betas, CONST.BETAS.INTERNATIONALIZATION) || canUseAllBetas(betas);
-}
-
-/**
- * @param {Array<String>} betas
- * @returns {Boolean}
- */
 function canUseIOUSend(betas) {
     return _.contains(betas, CONST.BETAS.IOU_SEND) || canUseAllBetas(betas);
 }
@@ -107,7 +99,6 @@ export default {
     canUseIOU,
     canUsePayWithExpensify,
     canUseDefaultRooms,
-    canUseInternationalization,
     canUseIOUSend,
     canUseWallet,
     canUseCommentLinking,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Beta flags are bound to the account. On sign in page, there's no beta flag fetched from the server yet, so we don't want to hide the `LocalePicker` behind the i18n beta flag. Checked with the team [here](https://expensify.slack.com/archives/C03TQ48KC/p1676412182155769) about deleting the flag.

### Fixed Issues
$ https://github.com/Expensify/App/issues/14986


### Tests and QA Steps
1. Open Sign in page in incognito window on web, or fresh install on native
2. Verify that Locale picker exists at the bottom right corner and it works as expected.

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<img width="583" alt="web" src="https://user-images.githubusercontent.com/18078393/219068444-ee370929-b270-4ecf-8fb9-1023d3cb0245.png">

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<img width="393" alt="android chrome" src="https://user-images.githubusercontent.com/18078393/219068513-4107a060-eadc-4271-b1f3-3b809952e691.png">

</details>

<details>
<summary>Mobile Web - Safari</summary>

<img width="440" alt="ios safari" src="https://user-images.githubusercontent.com/18078393/219068605-e0248a83-48d9-434d-8a14-1b16cef5e9d0.png">

</details>

<details>
<summary>Desktop</summary>

<img width="722" alt="desktop" src="https://user-images.githubusercontent.com/18078393/219068829-4b7a11d8-eb0e-4294-adf6-c56aa6665858.png">

</details>

<details>
<summary>iOS</summary>

<img width="450" alt="ios native" src="https://user-images.githubusercontent.com/18078393/219068655-f3007ef0-58b1-4bc2-be19-0bf426167e5b.png">

</details>

<details>
<summary>Android</summary>

<img width="404" alt="Screenshot 2023-02-15 at 17 15 49" src="https://user-images.githubusercontent.com/18078393/219068944-408ede77-72d7-4d6d-a0be-e0e032f36f6a.png">

</details>
