### PR TITLE
replace onModalHide with onDismiss for the web

### DIFF
--- a/src/components/Modal/BaseModal.js
+++ b/src/components/Modal/BaseModal.js
@@ -32,7 +32,6 @@ class BaseModal extends PureComponent {
         super(props);
 
         this.hideModal = this.hideModal.bind(this);
-        this.onDismiss = this.onDismiss.bind(this);
     }
 
     componentDidUpdate(prevProps) {

--- a/src/components/Modal/BaseModal.js
+++ b/src/components/Modal/BaseModal.js
@@ -46,14 +46,6 @@ class BaseModal extends PureComponent {
     componentWillUnmount() {
         // we don't want to call the onModalHide on unmount
         this.hideModal(this.props.isVisible);
-        this.onDismiss(this.props.isVisible);
-    }
-
-    onDismiss(callHideCallback = true) {
-        if (!callHideCallback) {
-            return;
-        }
-        this.props.onDismiss();
     }
 
     /**

--- a/src/components/Modal/BaseModal.js
+++ b/src/components/Modal/BaseModal.js
@@ -14,17 +14,17 @@ import variables from '../../styles/variables';
 const propTypes = {
     ...modalPropTypes,
 
-    /** replace onModalHide with onDismiss for the web */
-    isWeb: PropTypes.bool,
-
     /** The ref to the modal container */
     forwardedRef: PropTypes.func,
+
+    /** Ensure that callback and trap deactivation are in the same loop on the web platform */
+    onDismiss: PropTypes.func,
 };
 
 const defaultProps = {
     ...modalDefaultProps,
-    isWeb: false,
     forwardedRef: () => {},
+    onDismiss: () => {},
 };
 
 class BaseModal extends PureComponent {
@@ -32,6 +32,7 @@ class BaseModal extends PureComponent {
         super(props);
 
         this.hideModal = this.hideModal.bind(this);
+        this.onDismiss = this.onDismiss.bind(this);
     }
 
     componentDidUpdate(prevProps) {
@@ -45,6 +46,14 @@ class BaseModal extends PureComponent {
     componentWillUnmount() {
         // we don't want to call the onModalHide on unmount
         this.hideModal(this.props.isVisible);
+        this.onDismiss(this.props.isVisible);
+    }
+
+    onDismiss(callHideCallback = true) {
+        if (!callHideCallback) {
+            return;
+        }
+        this.props.onDismiss();
     }
 
     /**
@@ -102,8 +111,8 @@ class BaseModal extends PureComponent {
                     this.props.onModalShow();
                 }}
                 propagateSwipe={this.props.propagateSwipe}
-                onModalHide={!this.props.isWeb ? this.hideModal : () => {}}
-                onDismiss={this.props.isWeb ? this.hideModal : () => {}}
+                onModalHide={this.hideModal}
+                onDismiss={this.onDismiss}
                 onSwipeComplete={this.props.onClose}
                 swipeDirection={swipeDirection}
                 isVisible={this.props.isVisible}

--- a/src/components/Modal/BaseModal.js
+++ b/src/components/Modal/BaseModal.js
@@ -14,12 +14,16 @@ import variables from '../../styles/variables';
 const propTypes = {
     ...modalPropTypes,
 
+    /** replace onModalHide with onDismiss for the web */
+    isWeb: PropTypes.bool,
+
     /** The ref to the modal container */
     forwardedRef: PropTypes.func,
 };
 
 const defaultProps = {
     ...modalDefaultProps,
+    isWeb: false,
     forwardedRef: () => {},
 };
 
@@ -98,7 +102,8 @@ class BaseModal extends PureComponent {
                     this.props.onModalShow();
                 }}
                 propagateSwipe={this.props.propagateSwipe}
-                onModalHide={this.hideModal}
+                onModalHide={!this.props.isWeb ? this.hideModal : () => {}}
+                onDismiss={this.props.isWeb ? this.hideModal : () => {}}
                 onSwipeComplete={this.props.onClose}
                 swipeDirection={swipeDirection}
                 isVisible={this.props.isVisible}

--- a/src/components/Modal/BaseModal.js
+++ b/src/components/Modal/BaseModal.js
@@ -18,13 +18,13 @@ const propTypes = {
     forwardedRef: PropTypes.func,
 
     /** Ensure that callback and trap deactivation are in the same loop on the web platform */
-    useOnDismiss: PropTypes.bool,
+    shouldUseOnDismiss: PropTypes.bool,
 };
 
 const defaultProps = {
     ...modalDefaultProps,
     forwardedRef: () => {},
-    useOnDismiss: false,
+    shouldUseOnDismiss: false,
 };
 
 class BaseModal extends PureComponent {
@@ -102,8 +102,8 @@ class BaseModal extends PureComponent {
                     this.props.onModalShow();
                 }}
                 propagateSwipe={this.props.propagateSwipe}
-                onDismiss={this.props.useOnDismiss ? this.hideModal : () => {}}
-                onModalHide={!this.props.useOnDismiss ? this.hideModal : () => {}}
+                onDismiss={this.props.shouldUseOnDismiss ? this.hideModal : () => {}}
+                onModalHide={!this.props.shouldUseOnDismiss ? this.hideModal : () => {}}
                 onSwipeComplete={this.props.onClose}
                 swipeDirection={swipeDirection}
                 isVisible={this.props.isVisible}

--- a/src/components/Modal/BaseModal.js
+++ b/src/components/Modal/BaseModal.js
@@ -18,13 +18,13 @@ const propTypes = {
     forwardedRef: PropTypes.func,
 
     /** Ensure that callback and trap deactivation are in the same loop on the web platform */
-    onDismiss: PropTypes.func,
+    useOnDismiss: PropTypes.bool,
 };
 
 const defaultProps = {
     ...modalDefaultProps,
     forwardedRef: () => {},
-    onDismiss: () => {},
+    useOnDismiss: false,
 };
 
 class BaseModal extends PureComponent {
@@ -111,8 +111,8 @@ class BaseModal extends PureComponent {
                     this.props.onModalShow();
                 }}
                 propagateSwipe={this.props.propagateSwipe}
-                onModalHide={this.hideModal}
-                onDismiss={this.onDismiss}
+                onDismiss={this.props.useOnDismiss ? this.hideModal : () => {}}
+                onModalHide={!this.props.useOnDismiss ? this.hideModal : () => {}}
                 onSwipeComplete={this.props.onClose}
                 swipeDirection={swipeDirection}
                 isVisible={this.props.isVisible}

--- a/src/components/Modal/index.web.js
+++ b/src/components/Modal/index.web.js
@@ -29,8 +29,8 @@ const Modal = (props) => {
         <BaseModal
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...props}
-            isWeb
-            onModalHide={hideModal}
+            onDismiss={hideModal}
+            onModalHide={() => {}}
             onModalShow={showModal}
         >
             {props.children}

--- a/src/components/Modal/index.web.js
+++ b/src/components/Modal/index.web.js
@@ -29,7 +29,7 @@ const Modal = (props) => {
         <BaseModal
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...props}
-            useOnDismiss={props.fullscreen}
+            shouldUseOnDismiss={props.fullscreen}
             onModalHide={hideModal}
             onModalShow={showModal}
         >

--- a/src/components/Modal/index.web.js
+++ b/src/components/Modal/index.web.js
@@ -29,6 +29,7 @@ const Modal = (props) => {
         <BaseModal
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...props}
+            isWeb
             onModalHide={hideModal}
             onModalShow={showModal}
         >

--- a/src/components/Modal/index.web.js
+++ b/src/components/Modal/index.web.js
@@ -29,8 +29,8 @@ const Modal = (props) => {
         <BaseModal
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...props}
-            onDismiss={hideModal}
-            onModalHide={() => {}}
+            useOnDismiss={props.fullscreen}
+            onModalHide={hideModal}
             onModalShow={showModal}
         >
             {props.children}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/14848
PROPOSAL: https://github.com/Expensify/App/issues/14848#issuecomment-1428032631


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Open a report that has historical messages.
2. Press the edit message icon.
3. Press the emoji icon in the edit composer to open the emoji modal.
4. Exit the emoji model by pressing outside.
5. The edit composer will highlight.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Open a report that has historical messages.
2. Press the edit message icon.
3. Press the emoji icon in the edit composer to open the emoji modal.
4. Exit the emoji model by pressing outside.
5. The edit composer will highlight.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://user-images.githubusercontent.com/8579651/220151584-e785212e-ae81-4e44-8ba8-bb4ff2563f35.mp4

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://user-images.githubusercontent.com/8579651/220151708-b6f1f3b5-62fd-4441-9a08-5907d9fef651.mp4

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

https://user-images.githubusercontent.com/8579651/220151794-d91fff46-a604-4f31-94a5-ac4c87d7d23e.mp4

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>

https://user-images.githubusercontent.com/8579651/220151857-f2a5cb12-9823-477e-b377-bfaa66d0b589.mp4

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

https://user-images.githubusercontent.com/8579651/221166110-e1a8a932-5577-4ea8-b508-6426f217e4a1.mp4

<!-- https://user-images.githubusercontent.com/8579651/220151888-2df48c96-3b1d-46de-9fa7-abb5cd2fdc8a.mp4
-->

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>

https://user-images.githubusercontent.com/8579651/220151914-7dcf123c-7796-4d2e-8f1d-a4a18a2981b2.mp4

<!-- add screenshots or videos here -->

</details>
