### PR TITLE
Remove in-app password requirement for passwordless users

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -377,8 +377,8 @@ export default {
     addSecondaryLoginPage: {
         addPhoneNumber: 'Add phone number',
         addEmailAddress: 'Add email address',
-        enterPreferredPhoneNumberToSendValidationLink: 'Enter your preferred phone number and password to send a validation link.',
-        enterPreferredEmailToSendValidationLink: 'Enter your preferred email address and password to send a validation link.',
+        enterPreferredPhoneNumberToSendValidationLink: 'Enter your preferred phone number to send a validation link.',
+        enterPreferredEmailToSendValidationLink: 'Enter your preferred email address to send a validation link.',
         sendValidation: 'Send validation',
     },
     initialSettingsPage: {

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -377,8 +377,8 @@ export default {
     addSecondaryLoginPage: {
         addPhoneNumber: 'Agregar número de teléfono',
         addEmailAddress: 'Agregar dirección de email',
-        enterPreferredPhoneNumberToSendValidationLink: 'Escribe tu número de teléfono y contraseña para recibir el enlace de validación.',
-        enterPreferredEmailToSendValidationLink: 'Escribe tu email y contraseña para recibir el enlace de validación.',
+        enterPreferredPhoneNumberToSendValidationLink: 'Escribe tu número de teléfono para recibir el enlace de validación.',
+        enterPreferredEmailToSendValidationLink: 'Escribe tu email para recibir el enlace de validación.',
         sendValidation: 'Enviar validación',
     },
     initialSettingsPage: {

--- a/src/pages/settings/Payments/AddDebitCardPage.js
+++ b/src/pages/settings/Payments/AddDebitCardPage.js
@@ -21,12 +21,16 @@ import ONYXKEYS from '../../../ONYXKEYS';
 import AddressSearch from '../../../components/AddressSearch';
 import * as ComponentUtils from '../../../libs/ComponentUtils';
 import Form from '../../../components/Form';
+import Permissions from '../../../libs/Permissions';
 
 const propTypes = {
     /* Onyx Props */
     formData: PropTypes.shape({
         setupComplete: PropTypes.bool,
     }),
+
+    /** List of betas available to current user */
+    betas: PropTypes.arrayOf(PropTypes.string),
 
     ...withLocalizePropTypes,
 };
@@ -35,6 +39,7 @@ const defaultProps = {
     formData: {
         setupComplete: false,
     },
+    betas: [],
 };
 
 class DebitCardPage extends Component {
@@ -95,7 +100,7 @@ class DebitCardPage extends Component {
             errors.addressState = this.props.translate('addDebitCardPage.error.addressState');
         }
 
-        if (!values.password || _.isEmpty(values.password.trim())) {
+        if (!Permissions.canUsePasswordlessLogins(this.props.betas) && (!values.password || _.isEmpty(values.password.trim()))) {
             errors.password = this.props.translate('addDebitCardPage.error.password');
         }
 
@@ -176,15 +181,17 @@ class DebitCardPage extends Component {
                             />
                         </View>
                     </View>
-                    <View style={[styles.mt4]}>
-                        <TextInput
-                            inputID="password"
-                            label={this.props.translate('addDebitCardPage.expensifyPassword')}
-                            textContentType="password"
-                            autoCompleteType={ComponentUtils.PASSWORD_AUTOCOMPLETE_TYPE}
-                            secureTextEntry
-                        />
-                    </View>
+                    {!Permissions.canUsePasswordlessLogins(this.props.betas) && (
+                        <View style={[styles.mt4]}>
+                            <TextInput
+                                inputID="password"
+                                label={this.props.translate('addDebitCardPage.expensifyPassword')}
+                                textContentType="password"
+                                autoCompleteType={ComponentUtils.PASSWORD_AUTOCOMPLETE_TYPE}
+                                secureTextEntry
+                            />
+                        </View>
+                    )}
                     <CheckboxWithLabel
                         inputID="acceptedTerms"
                         LabelComponent={() => (
@@ -211,6 +218,9 @@ export default compose(
     withOnyx({
         formData: {
             key: ONYXKEYS.FORMS.ADD_DEBIT_CARD_FORM,
+        },
+        betas: {
+            key: ONYXKEYS.BETAS,
         },
     }),
 )(DebitCardPage);

--- a/src/pages/settings/Payments/PaymentsPage/BasePaymentsPage.js
+++ b/src/pages/settings/Payments/PaymentsPage/BasePaymentsPage.js
@@ -465,7 +465,7 @@ class BasePaymentsPage extends React.Component {
                                     // https://github.com/Expensify/App/issues/7768#issuecomment-1044879541
                                     InteractionManager.runAfterInteractions(() => {
                                         this.setState({
-                                            shouldShowPasswordPrompt: true,
+                                            shouldShowPasswordPrompt: !Permissions.canUsePasswordlessLogins(this.props.betas),
                                             passwordButtonText: this.props.translate('paymentsPage.setDefaultConfirmation'),
                                         });
                                     });

--- a/src/pages/settings/Payments/PaymentsPage/BasePaymentsPage.js
+++ b/src/pages/settings/Payments/PaymentsPage/BasePaymentsPage.js
@@ -299,7 +299,7 @@ class BasePaymentsPage extends React.Component {
         LayoutAnimation.configureNext(LayoutAnimation.create(50, LayoutAnimation.Types.easeInEaseOut, LayoutAnimation.Properties.opacity));
     }
 
-    makeDefaultPaymentMethod(password) {
+    makeDefaultPaymentMethod(password = '') {
         // Find the previous default payment method so we can revert if the MakeDefaultPaymentMethod command errors
         const paymentMethods = PaymentUtils.formatPaymentMethods(
             this.props.bankAccountList,

--- a/src/pages/settings/Payments/PaymentsPage/BasePaymentsPage.js
+++ b/src/pages/settings/Payments/PaymentsPage/BasePaymentsPage.js
@@ -464,10 +464,14 @@ class BasePaymentsPage extends React.Component {
                                     // InteractionManager fires after the currently running animation is completed.
                                     // https://github.com/Expensify/App/issues/7768#issuecomment-1044879541
                                     InteractionManager.runAfterInteractions(() => {
-                                        this.setState({
-                                            shouldShowPasswordPrompt: !Permissions.canUsePasswordlessLogins(this.props.betas),
-                                            passwordButtonText: this.props.translate('paymentsPage.setDefaultConfirmation'),
-                                        });
+                                        if (Permissions.canUsePasswordlessLogins(this.props.betas)) {
+                                            this.makeDefaultPaymentMethod();
+                                        } else {
+                                            this.setState({
+                                                shouldShowPasswordPrompt: true,
+                                                passwordButtonText: this.props.translate('paymentsPage.setDefaultConfirmation'),
+                                            });
+                                        }
                                     });
                                 }}
                                 text={this.props.translate('paymentsPage.setDefaultConfirmation')}


### PR DESCRIPTION
### Details

Conditionally removes the password requirement for for in app actions when the user is on the passwordless beta. 


### Fixed Issues

$ (https://github.com/Expensify/Expensify/issues/261738
PROPOSAL: N/A internal 

### Tests

**Debit Card**
1. Log into New Expensify with an account that is on the passwordless beta 
2. Navigate to Settings > Payments > Add Payment Method > Debit Card
3. Confirm that you do **not** see a field for the `Expensify Password` in the debit card form 
4. Fill out the form with any details but use the card number `4242424242424242`
5. Confirm you can successfully add the card 

**Default Payment**
1. Log into New Expensify with an account that is on the expensifyWallet and passwordless betas
2. Navigate to Settings > Payments > Add Payment Method 
3. Add either 2 personal bank accounts, a personal bank account and a debit card, or two debit cards 
4. Click on the bank account or debit card that is not the default payment method 
5. Select `Make default payment method` in the resulting pop up
6. Confirm you're **not** prompted to enter your password
7. Confirm your default payment method is updated 
 
**Secondary Login**
1. Log into New Expensify with an account that is on passwordless beta and does not have a secondary login 
8. Navigate to Settings > Profile > Contact Method and select whichever option does not have a login already (e.g. Phone number)
9. Confirm the resulting view has the copy `Enter your preferred phone number to send a validation link` (or `Enter your preferred email to send a validation link` and that there is **no** password prompt 
10. Enter the login you want to add as a secondary login and confirm it's added in an unvalidated state successfully. 

- [x] Verify that no errors appear in the JS console

### Offline tests
No change to current behavior 

### QA Steps

**Debit Card**
1. Log into New Expensify with an account that is on the passwordless beta 
2. Navigate to Settings > Payments > Add Payment Method > Debit Card
3. Confirm that you do **not** see a field for the `Expensify Password` in the debit card form 
4. Fill out the form with any details but use the card number `4242424242424242`
5. Confirm you can successfully add the card 

**Default Payment**
1. Log into New Expensify with an account that is on the expensifyWallet and passwordless betas
2. Navigate to Settings > Payments > Add Payment Method 
3. Add either 2 personal bank accounts, a personal bank account and a debit card, or two debit cards 
4. Click on the bank account or debit card that is not the default payment method 
5. Select `Make default payment method` in the resulting pop up
6. Confirm you're **not** prompted to enter your password
7. Confirm your default payment method is updated 

**Secondary Login**
1. Log into New Expensify with an account that is on passwordless beta and does not have a secondary login 
2. Navigate to Settings > Profile > Contact Method and select whichever option does not have a login already (e.g. Phone number)
3. Confirm the resulting view has the copy `Enter your preferred phone number to send a validation link` (or `Enter your preferred email to send a validation link` and that there is **no** password prompt 
4. Enter the login you want to add as a secondary login and confirm it's added in an unvalidated state successfully. 

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

**Debit Card**

https://user-images.githubusercontent.com/16747822/220746257-cc0882f1-980e-44f6-9c7b-638e15718039.mov

**Default Payment**

https://user-images.githubusercontent.com/16747822/220746213-2b897a50-de0a-4695-855d-34c2fda5ad5d.mov

**Secondary Login**

https://user-images.githubusercontent.com/16747822/220746236-cb7b6220-0da9-4ecf-aae8-6f2313053e2d.mov

</details>

<details>
<summary>Mobile Web - Chrome</summary>

**Debit Card**

https://user-images.githubusercontent.com/16747822/220804429-78f51f59-6889-4ea5-bbe4-e0e6d1325b4f.mov

**Default Payment Method**

https://user-images.githubusercontent.com/16747822/220804458-92dfe416-54e2-44a7-99d9-be7431f5fffe.mov

**Secondary Login**

https://user-images.githubusercontent.com/16747822/220804475-471c8b03-c42a-4a50-9db3-a972b6ee0988.mov

</details>

<details>
<summary>Mobile Web - Safari</summary>

**Debit Card**

https://user-images.githubusercontent.com/16747822/220801643-d48fb16a-8d4c-40ec-8d73-dc862b213058.mp4

**Default Payment Method**

https://user-images.githubusercontent.com/16747822/220801664-44699cf7-92b7-42ca-89a6-71ad63900d31.mp4

**Secondary Login**

https://user-images.githubusercontent.com/16747822/220801674-8472c440-c670-49f7-93a2-9efe36bd04b5.mp4

</details>

<details>
<summary>Desktop</summary>

**Debit Card**

https://user-images.githubusercontent.com/16747822/220798349-76bcfa00-9ef4-41e7-a9cf-2ff077d99805.mov

**Default Payment Method**

https://user-images.githubusercontent.com/16747822/220798343-577d0fd9-ad8f-49ff-9b3c-a62eec577c82.mov

**Secondary Login**

https://user-images.githubusercontent.com/16747822/220798360-c14981d5-6396-483d-8543-ab451f822666.mov

</details>

<details>
<summary>iOS</summary>

**Debit Card**

https://user-images.githubusercontent.com/16747822/220801583-d1e4777e-e7a7-4716-aac7-4e617a0ff766.mp4

**Default Payment Method**

https://user-images.githubusercontent.com/16747822/220801555-3c429bed-78cc-455e-843a-ba4f67572f04.mp4

**Secondary Login**

https://user-images.githubusercontent.com/16747822/220801614-d182fa04-6e72-4b6d-b6fa-edd3376b2209.mp4

</details>

<details>
<summary>Android</summary>

**Debit Card**

https://user-images.githubusercontent.com/16747822/220804331-c1ca7e3f-703d-409c-8fe6-317e26a76ef3.mov

**Default Payment Method**

https://user-images.githubusercontent.com/16747822/220804368-0f899a4f-788b-4c63-9a8c-025fb49fd0a1.mov

**Secondary Login**

https://user-images.githubusercontent.com/16747822/220804404-cdb7ccd1-07a3-482b-a3db-972dbdc3d54d.mov

</details>
