### PR TITLE
Use Image instead of ImageBackground

### DIFF
--- a/src/pages/home/report/ReportActionItemCreated.js
+++ b/src/pages/home/report/ReportActionItemCreated.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Pressable, ImageBackground, View} from 'react-native';
+import {Pressable, View, Image} from 'react-native';
 import lodashGet from 'lodash/get';
 import {withOnyx} from 'react-native-onyx';
 import PropTypes from 'prop-types';
@@ -52,12 +52,11 @@ const ReportActionItemCreated = (props) => {
             onClose={() => Report.navigateToConciergeChatAndDeleteReport(props.report.reportID)}
         >
             <View style={StyleUtils.getReportWelcomeContainerStyle(props.isSmallScreenWidth)}>
-                <View pointerEvents="none" style={StyleUtils.getReportWelcomeBackgroundImageViewStyle(props.isSmallScreenWidth)}>
-                    <ImageBackground
-                        source={EmptyStateBackgroundImage}
-                        style={StyleUtils.getReportWelcomeBackgroundImageStyle(props.isSmallScreenWidth)}
-                    />
-                </View>
+                <Image
+                    source={EmptyStateBackgroundImage}
+                    style={StyleUtils.getReportWelcomeBackgroundImageStyle(props.isSmallScreenWidth)}
+                />
+                <View pointerEvents="none" style={StyleUtils.getReportWelcomeBackgroundImageViewStyle(props.isSmallScreenWidth)} />
                 <View
                     accessibilityLabel="Chat welcome message"
                     style={styles.p5}

--- a/src/pages/home/report/ReportActionItemCreated.js
+++ b/src/pages/home/report/ReportActionItemCreated.js
@@ -56,10 +56,9 @@ const ReportActionItemCreated = (props) => {
                     source={EmptyStateBackgroundImage}
                     style={StyleUtils.getReportWelcomeBackgroundImageStyle(props.isSmallScreenWidth)}
                 />
-                <View pointerEvents="none" style={StyleUtils.getReportWelcomeBackgroundImageViewStyle(props.isSmallScreenWidth)} />
                 <View
                     accessibilityLabel="Chat welcome message"
-                    style={styles.p5}
+                    style={[styles.p5, StyleUtils.getReportWelcomeTopMarginStyle(props.isSmallScreenWidth)]}
                 >
                     <Pressable
                         onPress={() => ReportUtils.navigateToDetailsPage(props.report)}

--- a/src/pages/home/report/ReportActionItemCreated.js
+++ b/src/pages/home/report/ReportActionItemCreated.js
@@ -53,6 +53,7 @@ const ReportActionItemCreated = (props) => {
         >
             <View style={StyleUtils.getReportWelcomeContainerStyle(props.isSmallScreenWidth)}>
                 <Image
+                    pointerEvents="none"
                     source={EmptyStateBackgroundImage}
                     style={StyleUtils.getReportWelcomeBackgroundImageStyle(props.isSmallScreenWidth)}
                 />

--- a/src/styles/StyleUtils.js
+++ b/src/styles/StyleUtils.js
@@ -696,7 +696,7 @@ function getReportWelcomeBackgroundImageStyle(isSmallScreenWidth) {
 }
 
 /**
- * Gets the correct size for the empty state background image view based on screen dimensions
+ * Gets the correct top margin size for the chat welcome message based on screen dimensions
  *
  * @param {Boolean} isSmallScreenWidth
  * @returns {Object}

--- a/src/styles/StyleUtils.js
+++ b/src/styles/StyleUtils.js
@@ -701,15 +701,15 @@ function getReportWelcomeBackgroundImageStyle(isSmallScreenWidth) {
  * @param {Boolean} isSmallScreenWidth
  * @returns {Object}
  */
-function getReportWelcomeBackgroundImageViewStyle(isSmallScreenWidth) {
+function getReportWelcomeTopMarginStyle(isSmallScreenWidth) {
     if (isSmallScreenWidth) {
         return {
-            height: CONST.EMPTY_STATE_BACKGROUND.SMALL_SCREEN.VIEW_HEIGHT,
+            marginTop: CONST.EMPTY_STATE_BACKGROUND.SMALL_SCREEN.VIEW_HEIGHT,
         };
     }
 
     return {
-        height: CONST.EMPTY_STATE_BACKGROUND.WIDE_SCREEN.VIEW_HEIGHT,
+        marginTop: CONST.EMPTY_STATE_BACKGROUND.WIDE_SCREEN.VIEW_HEIGHT,
     };
 }
 
@@ -773,6 +773,6 @@ export {
     fade,
     getHorizontalStackedAvatarBorderStyle,
     getReportWelcomeBackgroundImageStyle,
-    getReportWelcomeBackgroundImageViewStyle,
+    getReportWelcomeTopMarginStyle,
     getReportWelcomeContainerStyle,
 };

--- a/src/styles/StyleUtils.js
+++ b/src/styles/StyleUtils.js
@@ -684,12 +684,14 @@ function getReportWelcomeBackgroundImageStyle(isSmallScreenWidth) {
         return {
             height: CONST.EMPTY_STATE_BACKGROUND.SMALL_SCREEN.IMAGE_HEIGHT,
             width: '100%',
+            position: 'absolute',
         };
     }
 
     return {
         height: CONST.EMPTY_STATE_BACKGROUND.WIDE_SCREEN.IMAGE_HEIGHT,
         width: '100%',
+        position: 'absolute',
     };
 }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

I couldn't pinpoint the root cause of the original issue. The issue seems to stem from the `ImageBackground` RN component. This PR replaces `ImageBackground` with `Image`.

In the original code, `ImageBackground` was contained inside [this `View` component](https://github.com/Expensify/App/blob/571e051557a31af8b48289ad169f7665bf3ab3a9/src/pages/home/report/ReportActionItemCreated.js#L55), which also acted as a filler to push [this `View` component](https://github.com/Expensify/App/blob/571e051557a31af8b48289ad169f7665bf3ab3a9/src/pages/home/report/ReportActionItemCreated.js#L61) down.

In the original code, `ImageBackground` overflew its [parent `View` component](https://github.com/Expensify/App/blob/571e051557a31af8b48289ad169f7665bf3ab3a9/src/pages/home/report/ReportActionItemCreated.js#L55). This overflew part behaved differently depending on the platform. On laptop and mobile Safari and mobile Chrome, this overflew part covered [the `View` component](https://github.com/Expensify/App/blob/571e051557a31af8b48289ad169f7665bf3ab3a9/src/pages/home/report/ReportActionItemCreated.js#L61) which contains avatars and welcome texts.

Instead of using `ImageBackground`, this PR uses `Image` RN component with its `position` set to `absolute`. By putting this `Image` before other sibling components in the code, `Image` goes behind just like what `ImageBackground` does.

The [`View` component ](https://github.com/Expensify/App/blob/571e051557a31af8b48289ad169f7665bf3ab3a9/src/pages/home/report/ReportActionItemCreated.js#L55)which originally contained `ImageBackground` still needs to be there, as it also acts as a filler to position avatars and welcome texts correctly.

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/15237


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

#### Mobile Safari and Mobile Chrome
1. Go to NewDot and sign in with any account
2. Create a new chat room
3. Zoom in and zoom out
4. Check if the avatars and welcome messages (`This is the beginning of your chat history...) are not covered by background illustration

- [ ] Verify that no errors appear in the JS console

_*You cannot zoom in or zoom out on NewDot on Chrome on Android device. You can use Chrome on iPhone to test zoom in and zoom out interactions._

#### Laptop Chrome and Safari, Desktop, Android and Safari Native
1. Go to NewDot and sign in with any account
2. Create a new chat room
3. Check if the avatars and welcome messages (`This is the beginning of your chat history...) are not covered by background illustration

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Same as above

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
6. Upload an image via copy paste
7. Verify a modal appears displaying a preview of that image
--->

Same as above

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

Chrome
<img width="1840" alt="Screenshot 2023-02-22 at 3 20 19 PM" src="https://user-images.githubusercontent.com/98560306/220789592-3b339587-d788-4e61-b191-35c6d0405738.png">

Safari
<img width="1840" alt="Screenshot 2023-02-22 at 3 19 37 PM" src="https://user-images.githubusercontent.com/98560306/220789608-339c2b5b-3c39-4ddb-a8fe-de5afa541097.png">

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->
![Screenshot_1677111062](https://user-images.githubusercontent.com/98560306/220792951-335c93d3-2873-4541-9363-2ba125e25423.png)

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/98560306/220789644-b6ad41c0-1d7c-4999-a4eb-87a3ee0f024e.mp4

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->
<img width="1312" alt="Screenshot 2023-02-22 at 3 52 48 PM" src="https://user-images.githubusercontent.com/98560306/220790499-d379d7be-dbd2-4227-83d0-fe6baf9fa13f.png">

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

![Simulator Screen Shot - iPhone 14 - 2023-02-22 at 15 50 27](https://user-images.githubusercontent.com/98560306/220790278-232e4965-55bc-4872-be66-bfef2cdc4aa7.png)

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->
![Screenshot_1677109868](https://user-images.githubusercontent.com/98560306/220790234-099355ed-cc58-4357-8ff4-46faa42da059.png)

</details>
