### PR TITLE
close modal when opening new page using keyboard shortcut

### DIFF
--- a/src/components/KeyboardShortcutsModal.js
+++ b/src/components/KeyboardShortcutsModal.js
@@ -14,6 +14,7 @@ import withLocalize, {withLocalizePropTypes} from './withLocalize';
 import compose from '../libs/compose';
 import KeyboardShortcut from '../libs/KeyboardShortcut';
 import * as KeyboardShortcutsActions from '../libs/actions/KeyboardShortcuts';
+import * as ModalActions from '../libs/actions/Modal';
 import ONYXKEYS from '../ONYXKEYS';
 
 const propTypes = {
@@ -35,6 +36,7 @@ class KeyboardShortcutsModal extends React.Component {
     componentDidMount() {
         const shortcutConfig = CONST.KEYBOARD_SHORTCUTS.SHORTCUT_MODAL;
         this.unsubscribeShortcutModal = KeyboardShortcut.subscribe(shortcutConfig.shortcutKey, () => {
+            ModalActions.close();
             KeyboardShortcutsActions.showKeyboardShortcutModal();
         }, shortcutConfig.descriptionKey, shortcutConfig.modifiers, true);
     }

--- a/src/components/Modal/BaseModal.js
+++ b/src/components/Modal/BaseModal.js
@@ -33,7 +33,7 @@ class BaseModal extends PureComponent {
     componentDidMount() {
         if (!this.props.isVisible) { return; }
 
-        // to handle case of modal already visible when mounted, i.e. PopoverReportActionContextMenu
+        // To handle closing any modal already visible when this modal is mounted, i.e. PopoverReportActionContextMenu
         Modal.setCloseModal(this.props.onClose);
     }
 

--- a/src/components/Modal/BaseModal.js
+++ b/src/components/Modal/BaseModal.js
@@ -50,7 +50,7 @@ class BaseModal extends PureComponent {
         // we don't want to call the onModalHide on unmount
         this.hideModal(this.props.isVisible);
 
-        // to handle case of modal unmounted with visible state
+        // To prevent closing any modal already unmounted when this modal still remains as visible state
         Modal.setCloseModal(null);
     }
 

--- a/src/components/Modal/BaseModal.js
+++ b/src/components/Modal/BaseModal.js
@@ -32,7 +32,9 @@ class BaseModal extends PureComponent {
 
     componentDidMount() {
         if (!this.props.isVisible) { return; }
-        Modal.setModalClose(this.props.onClose);
+
+        // to handle case of modal already visible when mounted, i.e. PopoverReportActionContextMenu
+        Modal.setCloseModal(this.props.onClose);
     }
 
     componentDidUpdate(prevProps) {
@@ -41,15 +43,15 @@ class BaseModal extends PureComponent {
         }
 
         Modal.willAlertModalBecomeVisible(this.props.isVisible);
-        Modal.setModalClose(this.props.isVisible ? this.props.onClose : null);
+        Modal.setCloseModal(this.props.isVisible ? this.props.onClose : null);
     }
 
     componentWillUnmount() {
         // we don't want to call the onModalHide on unmount
         this.hideModal(this.props.isVisible);
 
-        // we don't want to call the onClose on unmount
-        Modal.setModalClose(null);
+        // to handle case of modal unmounted with visible state
+        Modal.setCloseModal(null);
     }
 
     /**

--- a/src/components/Modal/BaseModal.js
+++ b/src/components/Modal/BaseModal.js
@@ -30,17 +30,26 @@ class BaseModal extends PureComponent {
         this.hideModal = this.hideModal.bind(this);
     }
 
+    componentDidMount() {
+        if (!this.props.isVisible) { return; }
+        Modal.setModalClose(this.props.onClose);
+    }
+
     componentDidUpdate(prevProps) {
         if (prevProps.isVisible === this.props.isVisible) {
             return;
         }
 
         Modal.willAlertModalBecomeVisible(this.props.isVisible);
+        Modal.setModalClose(this.props.isVisible ? this.props.onClose : null);
     }
 
     componentWillUnmount() {
         // we don't want to call the onModalHide on unmount
         this.hideModal(this.props.isVisible);
+
+        // we don't want to call the onClose on unmount
+        Modal.setModalClose(null);
     }
 
     /**

--- a/src/components/Popover/index.js
+++ b/src/components/Popover/index.js
@@ -1,42 +1,20 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import {createPortal} from 'react-dom';
-import {withOnyx} from 'react-native-onyx';
-import {propTypes as popoverPropTypes, defaultProps as popoverDefaultProps} from './popoverPropTypes';
+import {propTypes, defaultProps} from './popoverPropTypes';
 import CONST from '../../CONST';
 import Modal from '../Modal';
 import withWindowDimensions from '../withWindowDimensions';
-import compose from '../../libs/compose';
-import ONYXKEYS from '../../ONYXKEYS';
-
-const propTypes = {
-    isShortcutsModalOpen: PropTypes.bool,
-    ...popoverPropTypes,
-};
-
-const defaultProps = {
-    isShortcutsModalOpen: false,
-    ...popoverDefaultProps,
-};
 
 /*
  * This is a convenience wrapper around the Modal component for a responsive Popover.
  * On small screen widths, it uses BottomDocked modal type, and a Popover type on wide screen widths.
  */
 const Popover = (props) => {
-    if (props.isShortcutsModalOpen && props.isVisible) {
-        // There are modals that can show up on top of these pop-overs, for example, the keyboard shortcut menu,
-        // if that happens, close the pop-over as if we were clicking outside.
-        props.onClose();
-        return null;
-    }
-
     if (!props.fullscreen && !props.isSmallScreenWidth) {
         return createPortal(
             <Modal
                 // eslint-disable-next-line react/jsx-props-no-spreading
                 {...props}
-                isVisible={props.isVisible && !props.isShortcutsModalOpen}
                 type={CONST.MODAL.MODAL_TYPE.POPOVER}
                 popoverAnchorPosition={props.anchorPosition}
                 animationInTiming={props.disableAnimation ? 1 : props.animationInTiming}
@@ -50,7 +28,6 @@ const Popover = (props) => {
         <Modal
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...props}
-            isVisible={props.isVisible && !props.isShortcutsModalOpen}
             type={props.isSmallScreenWidth ? CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED : CONST.MODAL.MODAL_TYPE.POPOVER}
             popoverAnchorPosition={props.isSmallScreenWidth ? undefined : props.anchorPosition}
             fullscreen={props.isSmallScreenWidth ? true : props.fullscreen}
@@ -64,9 +41,4 @@ Popover.propTypes = propTypes;
 Popover.defaultProps = defaultProps;
 Popover.displayName = 'Popover';
 
-export default compose(
-    withWindowDimensions,
-    withOnyx({
-        isShortcutsModalOpen: {key: ONYXKEYS.IS_SHORTCUTS_MODAL_OPEN},
-    }),
-)(Popover);
+export default withWindowDimensions(Popover);

--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -115,9 +115,11 @@ class AuthScreens extends React.Component {
         // the chat switcher, or new group chat
         // based on the key modifiers pressed and the operating system
         this.unsubscribeSearchShortcut = KeyboardShortcut.subscribe(searchShortcutConfig.shortcutKey, () => {
+            Modal.close();
             Navigation.navigate(ROUTES.SEARCH);
         }, searchShortcutConfig.descriptionKey, searchShortcutConfig.modifiers, true);
         this.unsubscribeGroupShortcut = KeyboardShortcut.subscribe(groupShortcutConfig.shortcutKey, () => {
+            Modal.close();
             Navigation.navigate(ROUTES.NEW_GROUP);
         }, groupShortcutConfig.descriptionKey, groupShortcutConfig.modifiers, true);
     }

--- a/src/libs/actions/Modal.js
+++ b/src/libs/actions/Modal.js
@@ -1,6 +1,22 @@
 import Onyx from 'react-native-onyx';
 import ONYXKEYS from '../../ONYXKEYS';
 
+let closeModal;
+
+/**
+ * Allows other parts of the app to call modal close function
+ *
+ * @param {Function} [onClose]
+ */
+function setModalClose(onClose) {
+    closeModal = onClose;
+}
+
+function close() {
+    if (!closeModal) { return; }
+    closeModal();
+}
+
 /**
  * Allows other parts of the app to know when a modal has been opened or closed
  *
@@ -21,6 +37,8 @@ function willAlertModalBecomeVisible(isVisible) {
 }
 
 export {
+    setModalClose,
+    close,
     setModalVisibility,
     willAlertModalBecomeVisible,
 };

--- a/src/libs/actions/Modal.js
+++ b/src/libs/actions/Modal.js
@@ -8,7 +8,7 @@ let closeModal;
  *
  * @param {Function} [onClose]
  */
-function setModalClose(onClose) {
+function setCloseModal(onClose) {
     closeModal = onClose;
 }
 
@@ -37,7 +37,7 @@ function willAlertModalBecomeVisible(isVisible) {
 }
 
 export {
-    setModalClose,
+    setCloseModal,
     close,
     setModalVisibility,
     willAlertModalBecomeVisible,


### PR DESCRIPTION
### Details
- close any open modal on pressing shortcut keys of search, new group pages and keyboard shortcut modal
- removing existing close popover logic when keyboard shortcut modal is open (introduced in #13956)

### Fixed Issues
$ https://github.com/Expensify/App/issues/14889
PROPOSAL: https://github.com/Expensify/App/issues/14889#issuecomment-1436124583


### Tests
Same as QA step

- [x] Verify that no errors appear in the JS console

### Offline tests
Same as QA step

### QA Steps
1. Login with any account
2. Navigate to Settings ->Payments
3. Click on "Add payment method"
4. Press (CTRL+K) on the keyboard
5. Verify that payment method modal closes while opening Search page

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://user-images.githubusercontent.com/108292595/220960097-f9ffc194-a4fc-4a48-ab38-dded389a38ec.mov

</details>

<details>
<summary>Mobile Web - Chrome</summary>



<img width="336" alt="mchrome" src="https://user-images.githubusercontent.com/108292595/220960865-6814a713-69f3-4d96-9913-7f87ae35ced0.png">



</details>

<details>
<summary>Mobile Web - Safari</summary>

![msafari](https://user-images.githubusercontent.com/108292595/220960272-cdddcd28-c3a1-4f09-812a-5b6c2c296bbd.png)


</details>

<details>
<summary>Desktop</summary>


https://user-images.githubusercontent.com/108292595/220960318-10aad7b8-8c84-4a5e-8c05-2ab12e4a4175.mov



</details>

<details>
<summary>iOS</summary>

![ios](https://user-images.githubusercontent.com/108292595/220960354-7b7a2f89-aae8-4b99-b3b8-5a110fc30fa8.png)


</details>

<details>
<summary>Android</summary>

<img width="342" alt="android" src="https://user-images.githubusercontent.com/108292595/220960389-137011c9-ae01-4d72-bc72-01f6e53e8285.png">


</details>

NOTE: The main videos are in web, desktop. Other platforms are just app-working screenshot since keyboard shortcut is not available.