### PR TITLE
fix "LHN - Workspace badge is not fully visible/missing for some Room chats"

### DIFF
--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1222,7 +1222,7 @@ const styles = {
         minWidth: 'auto',
         flexBasis: 'auto',
         flexGrow: 0,
-        flexShrink: 0,
+        flexShrink: 1,
     },
 
     displayNameTooltipEllipsis: {
@@ -2839,7 +2839,8 @@ const styles = {
         borderRadius: 10,
         overflow: 'hidden',
         paddingVertical: 2,
-        flexShrink: 1,
+        flexShrink: 0,
+        maxWidth: 180,
         fontSize: variables.fontSizeSmall,
         ...spacing.ph2,
     },

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -2840,7 +2840,7 @@ const styles = {
         overflow: 'hidden',
         paddingVertical: 2,
         flexShrink: 0,
-        maxWidth: 180,
+        maxWidth: variables.badgeMaxWidth,
         fontSize: variables.fontSizeSmall,
         ...spacing.ph2,
     },

--- a/src/styles/variables.js
+++ b/src/styles/variables.js
@@ -98,4 +98,5 @@ export default {
     modalTopBigIconHeight: 244,
     modalWordmarkWidth: 154,
     modalWordmarkHeight: 34,
+    badgeMaxWidth: 180,
 };


### PR DESCRIPTION
### Details
- set flexShrink to display name
- remove flexShrink from workspace name (badge)
- set maxWidth (180px) to badge

### Fixed Issues
$ https://github.com/Expensify/App/issues/14491
PROPOSAL: https://github.com/Expensify/App/issues/14491#issuecomment-1439212081


### Tests
Same as QA step

- [x] Verify that no errors appear in the JS console

### Offline tests
Same as QA step

### QA Steps
1. Login with any account
2. Create new workspace if not exists
3. Update workspace name to "PR testing"
4. Go to Create new room page
5. Put "00--00--00--00--00--00--00--00--00" on room name
6. Select workspace - "PR testing"
7. Save room and go back to LHN
8. Verify that workspace (PR testing) badge is fully visible on "00--00--00--00--00--00--00--00--00" room

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<img width="1218" alt="web1" src="https://user-images.githubusercontent.com/108292595/221053415-eef08859-2153-41ed-874a-655f7daa7b3f.png">
<img width="1218" alt="web2" src="https://user-images.githubusercontent.com/108292595/221053436-04a2457f-0f2d-4302-a7da-bbddf2cb4cb8.png">


</details>

<details>
<summary>Mobile Web - Chrome</summary>

<img width="428" alt="mchrome1" src="https://user-images.githubusercontent.com/108292595/221053471-0efedd4d-8ac9-4a2b-857e-48a15b39e201.png">
<img width="428" alt="mchrome2" src="https://user-images.githubusercontent.com/108292595/221053495-e29dc1c0-c3f7-42e8-8a2e-e4db0f6d7d85.png">


</details>

<details>
<summary>Mobile Web - Safari</summary>

![msafari11](https://user-images.githubusercontent.com/108292595/221053523-043aa867-47e5-4aac-a3e5-18739082ae73.png)
![msafari12](https://user-images.githubusercontent.com/108292595/221053542-d26ceab8-18dd-4396-b304-de2afd04590e.png)
![msafari2](https://user-images.githubusercontent.com/108292595/221053570-4b2697ce-3d71-4723-9250-798c33aac086.png)



</details>

<details>
<summary>Desktop</summary>

<img width="1196" alt="desktop1" src="https://user-images.githubusercontent.com/108292595/221053602-d049afd1-683c-4470-8389-2ac0610fd4be.png">
<img width="1196" alt="desktop2" src="https://user-images.githubusercontent.com/108292595/221053621-08ed7389-5618-4add-9bf0-bcc6d932bab5.png">


</details>

<details>
<summary>iOS</summary>

![ios1](https://user-images.githubusercontent.com/108292595/221053650-56d92e02-cf13-4a11-b132-1fd60f42bbe0.png)
![ios2](https://user-images.githubusercontent.com/108292595/221053666-ffcaac17-47dd-41b1-a85c-1fc90df14ac1.png)


</details>

<details>
<summary>Android</summary>

![android1](https://user-images.githubusercontent.com/108292595/221053700-45f3df23-6c6d-42ae-b816-e84cf66c6989.jpg)
![android2](https://user-images.githubusercontent.com/108292595/221053714-5d5e0079-4585-469f-a3d6-493211fbf385.jpg)


</details>
