### PR TITLE
Account for markdown using debounced comment counter

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -402,6 +402,7 @@ const CONST = {
         SHOW_LOADING_SPINNER_DEBOUNCE_TIME: 250,
         TOOLTIP_SENSE: 1000,
         TRIE_INITIALIZATION: 'trie_initialization',
+        COMMENT_LENGTH_DEBOUNCE_TIME: 500,
     },
     PRIORITY_MODE: {
         GSD: 'gsd',

--- a/src/components/ExceededCommentLength.js
+++ b/src/components/ExceededCommentLength.js
@@ -1,27 +1,62 @@
-import React from 'react';
+import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
+import {debounce} from 'lodash';
 import CONST from '../CONST';
+import * as ReportUtils from '../libs/ReportUtils';
 import Text from './Text';
 import styles from '../styles/styles';
 
 const propTypes = {
-    /** The current length of the comment */
-    commentLength: PropTypes.number.isRequired,
+    /** Text Comment */
+    comment: PropTypes.string.isRequired,
+
+    /** Update UI on parent when comment length is exceeded */
+    onExceededMaxCommentLength: PropTypes.func.isRequired,
 };
 
-const ExceededCommentLength = (props) => {
-    if (props.commentLength <= CONST.MAX_COMMENT_LENGTH) {
-        return null;
+class ExceededCommentLength extends PureComponent {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            commentLength: 0,
+        };
+
+        // By debouncing, we defer the calculation until there is a break in typing
+        this.updateCommentLength = debounce(this.updateCommentLength.bind(this), CONST.TIMING.COMMENT_LENGTH_DEBOUNCE_TIME);
     }
 
-    return (
-        <Text style={[styles.textMicro, styles.textDanger, styles.chatItemComposeSecondaryRow, styles.mlAuto, styles.pl2]}>
-            {`${props.commentLength}/${CONST.MAX_COMMENT_LENGTH}`}
-        </Text>
-    );
-};
+    componentDidMount() {
+        this.updateCommentLength();
+    }
+
+    componentDidUpdate(prevProps) {
+        if (prevProps.comment === this.props.comment) {
+            return;
+        }
+
+        this.updateCommentLength();
+    }
+
+    updateCommentLength() {
+        const commentLength = ReportUtils.getCommentLength(this.props.comment);
+        this.setState({commentLength});
+        this.props.onExceededMaxCommentLength(commentLength > CONST.MAX_COMMENT_LENGTH);
+    }
+
+    render() {
+        if (this.state.commentLength <= CONST.MAX_COMMENT_LENGTH) {
+            return null;
+        }
+
+        return (
+            <Text style={[styles.textMicro, styles.textDanger, styles.chatItemComposeSecondaryRow, styles.mlAuto, styles.pl2]}>
+                {`${this.state.commentLength}/${CONST.MAX_COMMENT_LENGTH}`}
+            </Text>
+        );
+    }
+}
 
 ExceededCommentLength.propTypes = propTypes;
-ExceededCommentLength.displayName = 'ExceededCommentLength';
 
 export default ExceededCommentLength;

--- a/src/libs/ReportUtils.js
+++ b/src/libs/ReportUtils.js
@@ -775,6 +775,15 @@ function hasReportNameError(report) {
 }
 
 /**
+ * @param {String} text
+ * @returns {String}
+ */
+function getParsedComment(text) {
+    const parser = new ExpensiMark();
+    return text.length < CONST.MAX_MARKUP_LENGTH ? parser.replace(text) : text;
+}
+
+/**
  * @param {String} [text]
  * @param {File} [file]
  * @returns {Object}
@@ -783,7 +792,7 @@ function buildOptimisticAddCommentReportAction(text, file) {
     // For comments shorter than 10k chars, convert the comment from MD into HTML because that's how it is stored in the database
     // For longer comments, skip parsing and display plaintext for performance reasons. It takes over 40s to parse a 100k long string!!
     const parser = new ExpensiMark();
-    const commentText = text.length < CONST.MAX_MARKUP_LENGTH ? parser.replace(text) : text;
+    const commentText = getParsedComment(text);
     const isAttachment = _.isEmpty(text) && file !== undefined;
     const attachmentInfo = isAttachment ? file : {};
     const htmlForNewComment = isAttachment ? 'Uploading Attachment...' : commentText;
@@ -1425,13 +1434,13 @@ function getNewMarkerReportActionID(report, sortedAndFilteredReportActions) {
 }
 
 /**
- * Replace code points > 127 with C escape sequences, and return the resulting string's overall length
- * Used for compatibility with the backend auth validator for AddComment
+ * Performs the markdown conversion, and replaces code points > 127 with C escape sequences
+ * Used for compatibility with the backend auth validator for AddComment, and to account for MD in comments
  * @param {String} textComment
- * @returns {Number}
+ * @returns {Number} The comment's total length as seen from the backend
  */
 function getCommentLength(textComment) {
-    return textComment.replace(/[^ -~]/g, '\\u????').length;
+    return getParsedComment(textComment).replace(/[^ -~]/g, '\\u????').trim().length;
 }
 
 /**

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -132,6 +132,7 @@ class ReportActionCompose extends React.Component {
         this.getInputPlaceholder = this.getInputPlaceholder.bind(this);
         this.getIOUOptions = this.getIOUOptions.bind(this);
         this.addAttachment = this.addAttachment.bind(this);
+        this.setExceededMaxCommentLength = this.setExceededMaxCommentLength.bind(this);
         this.comment = props.comment;
 
         // React Native will retain focus on an input for native devices but web/mWeb behave differently so we have some focus management
@@ -153,6 +154,7 @@ class ReportActionCompose extends React.Component {
 
             // If we are on a small width device then don't show last 3 items from conciergePlaceholderOptions
             conciergePlaceholderRandomIndex: _.random(this.props.translate('reportActionCompose.conciergePlaceholderOptions').length - (this.props.isSmallScreenWidth ? 4 : 1)),
+            hasExceededMaxCommentLength: false,
         };
     }
 
@@ -300,6 +302,16 @@ class ReportActionCompose extends React.Component {
             maxLines = CONST.COMPOSER.MAX_LINES_FULL;
         }
         this.setState({maxLines});
+    }
+
+    /**
+     * Updates the composer when the comment length is exceeded
+     * Shows red borders and prevents the comment from being sent
+     *
+     * @param {Boolean} hasExceededMaxCommentLength
+     */
+    setExceededMaxCommentLength(hasExceededMaxCommentLength) {
+        this.setState({hasExceededMaxCommentLength});
     }
 
     isEmptyChat() {
@@ -513,8 +525,7 @@ class ReportActionCompose extends React.Component {
         const isComposeDisabled = this.props.isDrawerOpen && this.props.isSmallScreenWidth;
         const isBlockedFromConcierge = ReportUtils.chatIncludesConcierge(this.props.report) && User.isBlockedFromConcierge(this.props.blockedFromConcierge);
         const inputPlaceholder = this.getInputPlaceholder();
-        const encodedCommentLength = ReportUtils.getCommentLength(this.comment);
-        const hasExceededMaxCommentLength = encodedCommentLength > CONST.MAX_COMMENT_LENGTH;
+        const hasExceededMaxCommentLength = this.state.hasExceededMaxCommentLength;
 
         return (
             <View style={[
@@ -709,7 +720,7 @@ class ReportActionCompose extends React.Component {
                 >
                     {!this.props.isSmallScreenWidth && <OfflineIndicator containerStyles={[styles.chatItemComposeSecondaryRow]} />}
                     <ReportTypingIndicator reportID={this.props.reportID} />
-                    <ExceededCommentLength commentLength={encodedCommentLength} />
+                    <ExceededCommentLength comment={this.comment} onExceededMaxCommentLength={this.setExceededMaxCommentLength} />
                 </View>
                 {this.state.isDraggingOver && <ReportDropUI />}
             </View>

--- a/src/pages/home/report/ReportActionItemMessageEdit.js
+++ b/src/pages/home/report/ReportActionItemMessageEdit.js
@@ -69,6 +69,7 @@ class ReportActionItemMessageEdit extends React.Component {
         this.triggerSaveOrCancel = this.triggerSaveOrCancel.bind(this);
         this.onSelectionChange = this.onSelectionChange.bind(this);
         this.addEmojiToTextBox = this.addEmojiToTextBox.bind(this);
+        this.setExceededMaxCommentLength = this.setExceededMaxCommentLength.bind(this);
         this.saveButtonID = 'saveButton';
         this.cancelButtonID = 'cancelButton';
         this.emojiButtonID = 'emojiButton';
@@ -84,6 +85,7 @@ class ReportActionItemMessageEdit extends React.Component {
                 end: draftMessage.length,
             },
             isFocused: false,
+            hasExceededMaxCommentLength: false,
         };
     }
 
@@ -94,6 +96,16 @@ class ReportActionItemMessageEdit extends React.Component {
      */
     onSelectionChange(e) {
         this.setState({selection: e.nativeEvent.selection});
+    }
+
+    /**
+     * Updates the composer when the comment length is exceeded
+     * Shows red borders and prevents the comment from being sent
+     *
+     * @param {Boolean} hasExceededMaxCommentLength
+     */
+    setExceededMaxCommentLength(hasExceededMaxCommentLength) {
+        this.setState({hasExceededMaxCommentLength});
     }
 
     /**
@@ -217,8 +229,7 @@ class ReportActionItemMessageEdit extends React.Component {
     }
 
     render() {
-        const draftLength = ReportUtils.getCommentLength(this.state.draft);
-        const hasExceededMaxCommentLength = draftLength > CONST.MAX_COMMENT_LENGTH;
+        const hasExceededMaxCommentLength = this.state.hasExceededMaxCommentLength;
         return (
             <View style={styles.chatItemMessage}>
                 <View
@@ -290,7 +301,7 @@ class ReportActionItemMessageEdit extends React.Component {
                         onPress={this.publishDraft}
                         text={this.props.translate('common.saveChanges')}
                     />
-                    <ExceededCommentLength commentLength={draftLength} />
+                    <ExceededCommentLength comment={this.state.draft} onExceededMaxCommentLength={this.setExceededMaxCommentLength} />
                 </View>
             </View>
         );


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

Combined with https://github.com/Expensify/App/pull/14752, this PR completes the synchronisation of comment length  counting with the backend.

An overview of the changes are:
1. Include the markdown transformation in the `getCommentLength` function.
2. Defer counting until there is a 500ms break in typing to avoid performance issues.
3. Abstract the logic to a pure component so calculating occurs once per pause when the comment changes.

When comment length is exceeded, the `ExceededCommentLength` component calls `setExceededCommentLength` on the parent composer components.  This applies the state `hasExceededMaxCommentLength` to the composer which in turn displays the red borders and prevents the message from being sent.

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/14268
PROPOSAL: https://github.com/Expensify/App/issues/14268#issuecomment-1425649894


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [X] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

Use the following sequence of `*b*` characters for completing each test:

```
*b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b**b*
```

#### Test 1 - Attempt sending MD that exceeds the limit

1. Paste the above `*b*` characters into the composer and remove any surrounding backticks and spaces.
2. Confirm that the comment exceeds the limit and is not sendable.

#### Test 2 - Attempt sending MD that does not exceed the limit

1. Paste the `*b*` characters into the composer and remove any surrounding backticks and spaces.
2. Confirm that the comment counter displays as 15012, and that the length is exceeded.
3. Remove one `*b*` sequence from the comment.  The comment should now be sendable.
4. Send the comment and confirm that the delivered message consists only of `b` characters formatted in bold.

#### Test 3 - Confirm composer counts the HTML length of the Markdown:

1. Paste the `*b*` sequence above into the composer and remove any surrounding backticks and spaces.
2. Add additional `*b*` characters.
3. Confirm that for each additional `*b*` sequence, the character counter increases by 18.

#### Test 4 - Confirm comment is not counted until a break in typing (debounce functionality):

1. Paste the `*b*` characters above into the composer and remove any surrounding backticks and spaces.
2. Continue typing a sentence, or add several characters of your choosing without pausing.
3. Pause and observe that the character counter only updates after you stop.
4. Continue typing, and confirm that the character counter only updates after a pause in typing.

Repeat the above tests for editing a comment.  Confirm that comments exceeding the limit cannot be sent by pressing enter, or by clicking the send button.

- [X] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android / native
    - [X] Android / Chrome
    - [X] iOS / native
    - [X] iOS / Safari
    - [X] MacOS / Chrome / Safari
    - [X] MacOS / Desktop
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [X] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [X] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If a new component is created I verified that:
    - [X] A similar component doesn't exist in the codebase
    - [X] All props are defined accurately and each prop has a `/** comment above it */`
    - [X] The file is named correctly
    - [X] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [X] The only data being stored in the state is data necessary for rendering and nothing else
    - [X] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [X] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [X] All JSX used for rendering exists in the render method
    - [X] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [X] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://user-images.githubusercontent.com/1311325/221374695-40dafc05-17af-4b3a-8a8c-38c6af7379d7.mp4

</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://user-images.githubusercontent.com/1311325/221375850-d9752d13-702d-40a0-91a3-8cc7375233d6.mp4

</details>

<details>
<summary>Mobile Web - Safari</summary>

https://user-images.githubusercontent.com/1311325/221374751-49be7751-4e1a-4c6d-9fe6-ae5c2c8b15be.mp4

</details>

<details>
<summary>Desktop</summary>

https://user-images.githubusercontent.com/1311325/221374789-88121858-44be-48ae-8dbf-ee89382f619b.mp4

</details>

<details>
<summary>iOS</summary>

https://user-images.githubusercontent.com/1311325/221374818-f43b1682-86e5-43f8-ad5b-23a4379815c2.mp4

</details>

<details>
<summary>Android</summary>

https://user-images.githubusercontent.com/1311325/221375824-208be9f0-3e62-4b42-97d7-eec7370bbb16.mp4

</details>