### PR TITLE
Emoji Category Shortcuts Bar Tooltip

### DIFF
--- a/assets/emojis.js
+++ b/assets/emojis.js
@@ -77,7 +77,7 @@ const emojis = [
     {
         code: 'smileysAndEmotion',
         header: true,
-        icon: Smiley
+        icon: Smiley,
     },
     {
         name: 'grinning',
@@ -6975,7 +6975,7 @@ const emojis = [
     {
         code: 'animalsAndNature',
         header: true,
-        icon: AnimalsAndNature
+        icon: AnimalsAndNature,
     },
     {
         name: 'monkey_face',
@@ -8149,7 +8149,7 @@ const emojis = [
     {
         code: 'foodAndDrink',
         header: true,
-        icon: FoodAndDrink
+        icon: FoodAndDrink,
     },
     {
         name: 'grapes',
@@ -9327,7 +9327,7 @@ const emojis = [
     {
         code: 'travelAndPlaces',
         header: true,
-        icon: TravelAndPlaces
+        icon: TravelAndPlaces,
     },
     {
         name: 'earth_africa',
@@ -11447,7 +11447,7 @@ const emojis = [
     {
         code: 'activities',
         header: true,
-        icon: Activities
+        icon: Activities,
     },
     {
         name: 'jack_o_lantern',
@@ -12285,7 +12285,7 @@ const emojis = [
     {
         code: 'objects',
         header: true,
-        icon: Objects
+        icon: Objects,
     },
     {
         name: 'eyeglasses',
@@ -14615,7 +14615,7 @@ const emojis = [
     {
         code: 'symbols',
         header: true,
-        icon: Symbols
+        icon: Symbols,
     },
     {
         name: 'atm',
@@ -16606,7 +16606,7 @@ const emojis = [
     {
         code: 'flags',
         header: true,
-        icon: Flags
+        icon: Flags,
     },
     {
         name: 'checkered_flag',

--- a/assets/emojis.js
+++ b/assets/emojis.js
@@ -1,3 +1,12 @@
+import Smiley from './images/emoji.svg';
+import AnimalsAndNature from './images/emojiCategoryIcons/plant.svg';
+import FoodAndDrink from './images/emojiCategoryIcons/hamburger.svg';
+import TravelAndPlaces from './images/emojiCategoryIcons/plane.svg';
+import Activities from './images/emojiCategoryIcons/soccer-ball.svg';
+import Objects from './images/emojiCategoryIcons/light-bulb.svg';
+import Symbols from './images/emojiCategoryIcons/peace-sign.svg';
+import Flags from './images/emojiCategoryIcons/flag.svg';
+
 /*
  * This list is generated from the code here https://github.com/github/gemoji/blob/master/db/emoji.json
  * Each code is then converted to hex by replacing the "U+" with "0x"
@@ -68,6 +77,7 @@ const emojis = [
     {
         code: 'smileysAndEmotion',
         header: true,
+        icon: Smiley
     },
     {
         name: 'grinning',
@@ -6965,6 +6975,7 @@ const emojis = [
     {
         code: 'animalsAndNature',
         header: true,
+        icon: AnimalsAndNature
     },
     {
         name: 'monkey_face',
@@ -8138,6 +8149,7 @@ const emojis = [
     {
         code: 'foodAndDrink',
         header: true,
+        icon: FoodAndDrink
     },
     {
         name: 'grapes',
@@ -9315,6 +9327,7 @@ const emojis = [
     {
         code: 'travelAndPlaces',
         header: true,
+        icon: TravelAndPlaces
     },
     {
         name: 'earth_africa',
@@ -11434,6 +11447,7 @@ const emojis = [
     {
         code: 'activities',
         header: true,
+        icon: Activities
     },
     {
         name: 'jack_o_lantern',
@@ -12271,6 +12285,7 @@ const emojis = [
     {
         code: 'objects',
         header: true,
+        icon: Objects
     },
     {
         name: 'eyeglasses',
@@ -14600,6 +14615,7 @@ const emojis = [
     {
         code: 'symbols',
         header: true,
+        icon: Symbols
     },
     {
         name: 'atm',
@@ -16590,6 +16606,7 @@ const emojis = [
     {
         code: 'flags',
         header: true,
+        icon: Flags
     },
     {
         name: 'checkered_flag',

--- a/src/components/EmojiPicker/CategoryShortcutBar.js
+++ b/src/components/EmojiPicker/CategoryShortcutBar.js
@@ -21,7 +21,10 @@ const propTypes = {
     onPress: PropTypes.func.isRequired,
 
     /** The emojis consisting emoji code and indices that the icons should link to */
-    headerEmojis: PropTypes.arrayOf(PropTypes.number).isRequired,
+    headerEmojis: PropTypes.arrayOf(PropTypes.shape({
+        code: PropTypes.string.isRequired,
+        index: PropTypes.number.isRequired,
+    })).isRequired,
 };
 
 const CategoryShortcutBar = (props) => {

--- a/src/components/EmojiPicker/CategoryShortcutBar.js
+++ b/src/components/EmojiPicker/CategoryShortcutBar.js
@@ -17,7 +17,7 @@ const propTypes = {
     })).isRequired,
 };
 
-const CategoryShortcutBar = (props) => (
+const CategoryShortcutBar = props => (
     <View style={[styles.pt2, styles.ph4, styles.flexRow]}>
         {_.map(props.headerEmojis, (headerEmoji, i) => (
             <CategoryShortcutButton

--- a/src/components/EmojiPicker/CategoryShortcutBar.js
+++ b/src/components/EmojiPicker/CategoryShortcutBar.js
@@ -3,15 +3,6 @@ import PropTypes from 'prop-types';
 import {View} from 'react-native';
 import _ from 'underscore';
 import styles from '../../styles/styles';
-import FrequentlyUsed from '../../../assets/images/history.svg';
-import Smiley from '../../../assets/images/emoji.svg';
-import AnimalsAndNature from '../../../assets/images/emojiCategoryIcons/plant.svg';
-import FoodAndDrink from '../../../assets/images/emojiCategoryIcons/hamburger.svg';
-import TravelAndPlaces from '../../../assets/images/emojiCategoryIcons/plane.svg';
-import Activities from '../../../assets/images/emojiCategoryIcons/soccer-ball.svg';
-import Objects from '../../../assets/images/emojiCategoryIcons/light-bulb.svg';
-import Symbols from '../../../assets/images/emojiCategoryIcons/peace-sign.svg';
-import Flags from '../../../assets/images/emojiCategoryIcons/flag.svg';
 import CategoryShortcutButton from './CategoryShortcutButton';
 import getOperatingSystem from '../../libs/getOperatingSystem';
 import CONST from '../../CONST';
@@ -24,23 +15,16 @@ const propTypes = {
     headerEmojis: PropTypes.arrayOf(PropTypes.shape({
         code: PropTypes.string.isRequired,
         index: PropTypes.number.isRequired,
+        icon: PropTypes.func.isRequired,
     })).isRequired,
 };
 
 const CategoryShortcutBar = (props) => {
-    const icons = [Smiley, AnimalsAndNature, FoodAndDrink, TravelAndPlaces, Activities, Objects, Symbols, Flags];
-
-    // If the user has frequently used emojis, there will be 9 headers, otherwise there will be 8
-    // Or for Windows OS there will be 8 headers, otherwise there will be 7
-    if (props.headerEmojis.length === 9 || (getOperatingSystem() === CONST.OS.WINDOWS && props.headerEmojis.length === 8)) {
-        icons.unshift(FrequentlyUsed);
-    }
-
     return (
         <View style={[styles.pt2, styles.ph4, styles.flexRow]}>
             {_.map(props.headerEmojis, (headerEmoji, i) => (
                 <CategoryShortcutButton
-                    icon={icons[i]}
+                    icon={headerEmoji.icon}
                     onPress={() => props.onPress(headerEmoji.index)}
                     key={`categoryShortcut${i}`}
                     code={headerEmoji.code}

--- a/src/components/EmojiPicker/CategoryShortcutBar.js
+++ b/src/components/EmojiPicker/CategoryShortcutBar.js
@@ -20,8 +20,8 @@ const propTypes = {
     /** The function to call when an emoji is selected */
     onPress: PropTypes.func.isRequired,
 
-    /** The indices that the icons should link to */
-    headerIndices: PropTypes.arrayOf(PropTypes.number).isRequired,
+    /** The emojis consisting emoji code and indices that the icons should link to */
+    headerEmojis: PropTypes.arrayOf(PropTypes.number).isRequired,
 };
 
 const CategoryShortcutBar = (props) => {
@@ -29,17 +29,18 @@ const CategoryShortcutBar = (props) => {
 
     // If the user has frequently used emojis, there will be 9 headers, otherwise there will be 8
     // Or for Windows OS there will be 8 headers, otherwise there will be 7
-    if (props.headerIndices.length === 9 || (getOperatingSystem() === CONST.OS.WINDOWS && props.headerIndices.length === 8)) {
+    if (props.headerEmojis.length === 9 || (getOperatingSystem() === CONST.OS.WINDOWS && props.headerEmojis.length === 8)) {
         icons.unshift(FrequentlyUsed);
     }
 
     return (
         <View style={[styles.pt2, styles.ph4, styles.flexRow]}>
-            {_.map(props.headerIndices, (headerIndex, i) => (
+            {_.map(props.headerEmojis, (headerEmoji, i) => (
                 <CategoryShortcutButton
                     icon={icons[i]}
-                    onPress={() => props.onPress(headerIndex)}
+                    onPress={() => props.onPress(headerEmoji.index)}
                     key={`categoryShortcut${i}`}
+                    code={headerEmoji.code}
                 />
             ))}
         </View>

--- a/src/components/EmojiPicker/CategoryShortcutBar.js
+++ b/src/components/EmojiPicker/CategoryShortcutBar.js
@@ -4,8 +4,6 @@ import {View} from 'react-native';
 import _ from 'underscore';
 import styles from '../../styles/styles';
 import CategoryShortcutButton from './CategoryShortcutButton';
-import getOperatingSystem from '../../libs/getOperatingSystem';
-import CONST from '../../CONST';
 
 const propTypes = {
     /** The function to call when an emoji is selected */
@@ -19,20 +17,19 @@ const propTypes = {
     })).isRequired,
 };
 
-const CategoryShortcutBar = (props) => {
-    return (
-        <View style={[styles.pt2, styles.ph4, styles.flexRow]}>
-            {_.map(props.headerEmojis, (headerEmoji, i) => (
-                <CategoryShortcutButton
-                    icon={headerEmoji.icon}
-                    onPress={() => props.onPress(headerEmoji.index)}
-                    key={`categoryShortcut${i}`}
-                    code={headerEmoji.code}
-                />
-            ))}
-        </View>
-    );
-};
+const CategoryShortcutBar = (props) => (
+    <View style={[styles.pt2, styles.ph4, styles.flexRow]}>
+        {_.map(props.headerEmojis, (headerEmoji, i) => (
+            <CategoryShortcutButton
+                icon={headerEmoji.icon}
+                onPress={() => props.onPress(headerEmoji.index)}
+                key={`categoryShortcut${i}`}
+                code={headerEmoji.code}
+            />
+        ))}
+    </View>
+);
+
 CategoryShortcutBar.propTypes = propTypes;
 CategoryShortcutBar.displayName = 'CategoryShortcutBar';
 

--- a/src/components/EmojiPicker/CategoryShortcutButton.js
+++ b/src/components/EmojiPicker/CategoryShortcutButton.js
@@ -33,7 +33,6 @@ class CategoryShortcutButton extends PureComponent {
 
     render() {
         return (
-            
             <Pressable
                 onPress={this.props.onPress}
                 onHoverIn={() => this.setState({isHighlighted: true})}
@@ -44,7 +43,7 @@ class CategoryShortcutButton extends PureComponent {
                     this.state.isHighlighted && styles.emojiItemHighlighted,
                 ])}
             >
-                <Tooltip text={this.props.translate(`emojiPicker.headers.${this.props.code}`)}>
+                <Tooltip text={this.props.translate(`emojiPicker.headers.${this.props.code}`)} shiftVertical={-8}>
                     <View style={styles.alignSelfCenter}>
                         <Icon
                             fill={themeColors.icon}

--- a/src/components/EmojiPicker/CategoryShortcutButton.js
+++ b/src/components/EmojiPicker/CategoryShortcutButton.js
@@ -2,6 +2,8 @@ import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {Pressable, View} from 'react-native';
 import Icon from '../Icon';
+import Tooltip from '../Tooltip';
+import withLocalize, { withLocalizePropTypes } from '../withLocalize';
 import variables from '../../styles/variables';
 import styles from '../../styles/styles';
 import * as StyleUtils from '../../styles/StyleUtils';
@@ -9,11 +11,16 @@ import getButtonState from '../../libs/getButtonState';
 import themeColors from '../../styles/themes/default';
 
 const propTypes = {
+    /** The emoji code of the category header */
+    code: PropTypes.string.isRequired,
+
     /** The icon representation of the category that this button links to */
     icon: PropTypes.func.isRequired,
 
     /** The function to call when an emoji is selected */
     onPress: PropTypes.func.isRequired,
+
+    ...withLocalizePropTypes
 };
 
 class CategoryShortcutButton extends PureComponent {
@@ -26,6 +33,7 @@ class CategoryShortcutButton extends PureComponent {
 
     render() {
         return (
+            
             <Pressable
                 onPress={this.props.onPress}
                 onHoverIn={() => this.setState({isHighlighted: true})}
@@ -36,18 +44,20 @@ class CategoryShortcutButton extends PureComponent {
                     this.state.isHighlighted && styles.emojiItemHighlighted,
                 ])}
             >
-                <View style={styles.alignSelfCenter}>
-                    <Icon
-                        fill={themeColors.icon}
-                        src={this.props.icon}
-                        height={variables.iconSizeNormal}
-                        width={variables.iconSizeNormal}
-                    />
-                </View>
+                <Tooltip text={this.props.translate(`emojiPicker.headers.${code}`)}>
+                    <View style={styles.alignSelfCenter}>
+                        <Icon
+                            fill={themeColors.icon}
+                            src={this.props.icon}
+                            height={variables.iconSizeNormal}
+                            width={variables.iconSizeNormal}
+                        />
+                    </View>
+                </Tooltip>
             </Pressable>
         );
     }
 }
 CategoryShortcutButton.propTypes = propTypes;
 
-export default CategoryShortcutButton;
+export default withLocalize(CategoryShortcutButton);

--- a/src/components/EmojiPicker/CategoryShortcutButton.js
+++ b/src/components/EmojiPicker/CategoryShortcutButton.js
@@ -46,6 +46,7 @@ class CategoryShortcutButton extends PureComponent {
                 <Tooltip
                     containerStyles={[styles.flex1, styles.alignSelfStretch, styles.alignItemsCenter, styles.justifyContentCenter]}
                     text={this.props.translate(`emojiPicker.headers.${this.props.code}`)}
+                    shiftVertical={-2}
                 >
                     <Icon
                         fill={themeColors.icon}

--- a/src/components/EmojiPicker/CategoryShortcutButton.js
+++ b/src/components/EmojiPicker/CategoryShortcutButton.js
@@ -33,27 +33,31 @@ class CategoryShortcutButton extends PureComponent {
 
     render() {
         return (
-            <Pressable
-                onPress={this.props.onPress}
-                onHoverIn={() => this.setState({isHighlighted: true})}
-                onHoverOut={() => this.setState({isHighlighted: false})}
-                style={({pressed}) => ([
-                    StyleUtils.getButtonBackgroundColorStyle(getButtonState(false, pressed)),
-                    styles.categoryShortcutButton,
-                    this.state.isHighlighted && styles.emojiItemHighlighted,
-                ])}
-            >
+            <View style={[styles.categoryShortcutButton, this.state.isHighlighted && styles.emojiItemHighlighted,]}>
                 <Tooltip text={this.props.translate(`emojiPicker.headers.${this.props.code}`)} shiftVertical={-8}>
-                    <View style={styles.alignSelfCenter}>
-                        <Icon
-                            fill={themeColors.icon}
-                            src={this.props.icon}
-                            height={variables.iconSizeNormal}
-                            width={variables.iconSizeNormal}
-                        />
-                    </View>
+                    <Pressable
+                        onPress={this.props.onPress}
+                        onHoverIn={() => this.setState({isHighlighted: true})}
+                        onHoverOut={() => this.setState({isHighlighted: false})}
+                        style={({pressed}) => ([
+                            StyleUtils.getButtonBackgroundColorStyle(getButtonState(false, pressed)),
+                            
+                        ])}
+                    >
+                        
+                            <View style={styles.alignSelfCenter}>
+                                <Icon
+                                    fill={themeColors.icon}
+                                    src={this.props.icon}
+                                    height={variables.iconSizeNormal}
+                                    width={variables.iconSizeNormal}
+                                />
+                            </View>
+                        
+                    </Pressable>
                 </Tooltip>
-            </Pressable>
+            </View>
+            
         );
     }
 }

--- a/src/components/EmojiPicker/CategoryShortcutButton.js
+++ b/src/components/EmojiPicker/CategoryShortcutButton.js
@@ -1,6 +1,6 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {Pressable, View} from 'react-native';
+import {Pressable} from 'react-native';
 import Icon from '../Icon';
 import Tooltip from '../Tooltip';
 import withLocalize, {withLocalizePropTypes} from '../withLocalize';

--- a/src/components/EmojiPicker/CategoryShortcutButton.js
+++ b/src/components/EmojiPicker/CategoryShortcutButton.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {Pressable, View} from 'react-native';
 import Icon from '../Icon';
 import Tooltip from '../Tooltip';
-import withLocalize, { withLocalizePropTypes } from '../withLocalize';
+import withLocalize, {withLocalizePropTypes} from '../withLocalize';
 import variables from '../../styles/variables';
 import styles from '../../styles/styles';
 import * as StyleUtils from '../../styles/StyleUtils';
@@ -20,7 +20,7 @@ const propTypes = {
     /** The function to call when an emoji is selected */
     onPress: PropTypes.func.isRequired,
 
-    ...withLocalizePropTypes
+    ...withLocalizePropTypes,
 };
 
 class CategoryShortcutButton extends PureComponent {

--- a/src/components/EmojiPicker/CategoryShortcutButton.js
+++ b/src/components/EmojiPicker/CategoryShortcutButton.js
@@ -46,7 +46,7 @@ class CategoryShortcutButton extends PureComponent {
                 <Tooltip
                     containerStyles={[styles.flex1, styles.alignSelfStretch, styles.alignItemsCenter, styles.justifyContentCenter]}
                     text={this.props.translate(`emojiPicker.headers.${this.props.code}`)}
-                    shiftVertical={-2}
+                    shiftVertical={-4}
                 >
                     <Icon
                         fill={themeColors.icon}

--- a/src/components/EmojiPicker/CategoryShortcutButton.js
+++ b/src/components/EmojiPicker/CategoryShortcutButton.js
@@ -33,7 +33,7 @@ class CategoryShortcutButton extends PureComponent {
 
     render() {
         return (
-            <View style={[styles.categoryShortcutButton, this.state.isHighlighted && styles.emojiItemHighlighted,]}>
+            <View style={[styles.categoryShortcutButton, this.state.isHighlighted && styles.emojiItemHighlighted]}>
                 <Tooltip text={this.props.translate(`emojiPicker.headers.${this.props.code}`)} shiftVertical={-8}>
                     <Pressable
                         onPress={this.props.onPress}
@@ -41,23 +41,19 @@ class CategoryShortcutButton extends PureComponent {
                         onHoverOut={() => this.setState({isHighlighted: false})}
                         style={({pressed}) => ([
                             StyleUtils.getButtonBackgroundColorStyle(getButtonState(false, pressed)),
-                            
                         ])}
                     >
-                        
-                            <View style={styles.alignSelfCenter}>
-                                <Icon
-                                    fill={themeColors.icon}
-                                    src={this.props.icon}
-                                    height={variables.iconSizeNormal}
-                                    width={variables.iconSizeNormal}
-                                />
-                            </View>
-                        
+                        <View style={styles.alignSelfCenter}>
+                            <Icon
+                                fill={themeColors.icon}
+                                src={this.props.icon}
+                                height={variables.iconSizeNormal}
+                                width={variables.iconSizeNormal}
+                            />
+                        </View>
                     </Pressable>
                 </Tooltip>
             </View>
-            
         );
     }
 }

--- a/src/components/EmojiPicker/CategoryShortcutButton.js
+++ b/src/components/EmojiPicker/CategoryShortcutButton.js
@@ -33,27 +33,28 @@ class CategoryShortcutButton extends PureComponent {
 
     render() {
         return (
-            <View style={[styles.categoryShortcutButton, this.state.isHighlighted && styles.emojiItemHighlighted]}>
-                <Tooltip text={this.props.translate(`emojiPicker.headers.${this.props.code}`)} shiftVertical={-8}>
-                    <Pressable
-                        onPress={this.props.onPress}
-                        onHoverIn={() => this.setState({isHighlighted: true})}
-                        onHoverOut={() => this.setState({isHighlighted: false})}
-                        style={({pressed}) => ([
-                            StyleUtils.getButtonBackgroundColorStyle(getButtonState(false, pressed)),
-                        ])}
-                    >
-                        <View style={styles.alignSelfCenter}>
-                            <Icon
-                                fill={themeColors.icon}
-                                src={this.props.icon}
-                                height={variables.iconSizeNormal}
-                                width={variables.iconSizeNormal}
-                            />
-                        </View>
-                    </Pressable>
+            <Pressable
+                onPress={this.props.onPress}
+                onHoverIn={() => this.setState({isHighlighted: true})}
+                onHoverOut={() => this.setState({isHighlighted: false})}
+                style={({pressed}) => ([
+                    StyleUtils.getButtonBackgroundColorStyle(getButtonState(false, pressed)),
+                    styles.categoryShortcutButton,
+                    this.state.isHighlighted && styles.emojiItemHighlighted,
+                ])}
+            >
+                <Tooltip
+                    containerStyles={[styles.flex1, styles.alignSelfStretch, styles.alignItemsCenter, styles.justifyContentCenter]}
+                    text={this.props.translate(`emojiPicker.headers.${this.props.code}`)}
+                >
+                    <Icon
+                        fill={themeColors.icon}
+                        src={this.props.icon}
+                        height={variables.iconSizeNormal}
+                        width={variables.iconSizeNormal}
+                    />
                 </Tooltip>
-            </View>
+            </Pressable>
         );
     }
 }

--- a/src/components/EmojiPicker/CategoryShortcutButton.js
+++ b/src/components/EmojiPicker/CategoryShortcutButton.js
@@ -44,7 +44,7 @@ class CategoryShortcutButton extends PureComponent {
                     this.state.isHighlighted && styles.emojiItemHighlighted,
                 ])}
             >
-                <Tooltip text={this.props.translate(`emojiPicker.headers.${code}`)}>
+                <Tooltip text={this.props.translate(`emojiPicker.headers.${this.props.code}`)}>
                     <View style={styles.alignSelfCenter}>
                         <Icon
                             fill={themeColors.icon}

--- a/src/components/EmojiPicker/EmojiPickerMenu/index.js
+++ b/src/components/EmojiPicker/EmojiPickerMenu/index.js
@@ -490,7 +490,7 @@ class EmojiPickerMenu extends Component {
                 )}
                 {!isFiltered && (
                     <CategoryShortcutBar
-                        headerIndices={this.headerIndices}
+                        headerEmojis={this.headerEmojis}
                         onPress={this.scrollToHeader}
                     />
                 )}

--- a/src/components/EmojiPicker/EmojiPickerMenu/index.js
+++ b/src/components/EmojiPicker/EmojiPickerMenu/index.js
@@ -64,13 +64,15 @@ class EmojiPickerMenu extends Component {
             ? EmojiUtils.mergeEmojisWithFrequentlyUsedEmojis(emojis.slice(0, flagHeaderIndex), this.props.frequentlyUsedEmojis)
             : EmojiUtils.mergeEmojisWithFrequentlyUsedEmojis(emojis, this.props.frequentlyUsedEmojis);
 
-        // This is the actual header index starting at the first emoji and counting each one
-        this.headerIndices = EmojiUtils.getHeaderIndices(this.emojis);
+        // Get the header emojis along with the code and index.
+        // index is the actual header index starting at the first emoji and counting each one
+        this.headerEmojis = EmojiUtils.getHeaderEmojis(this.emojis);
 
         // This is the indices of each header's Row
         // The positions are static, and are calculated as index/numColumns (8 in our case)
         // This is because each row of 8 emojis counts as one index to the flatlist
-        this.headerRowIndices = _.map(this.headerIndices, headerIndex => Math.floor(headerIndex / CONST.EMOJI_NUM_PER_ROW));
+        this.headerRowIndices = _.map(this.headerEmojis, (headerEmoji) => Math.floor(headerEmoji.index / CONST.EMOJI_NUM_PER_ROW));
+
 
         this.filterEmojis = _.debounce(this.filterEmojis.bind(this), 300);
         this.highlightAdjacentEmoji = this.highlightAdjacentEmoji.bind(this);

--- a/src/components/EmojiPicker/EmojiPickerMenu/index.js
+++ b/src/components/EmojiPicker/EmojiPickerMenu/index.js
@@ -64,7 +64,7 @@ class EmojiPickerMenu extends Component {
             ? EmojiUtils.mergeEmojisWithFrequentlyUsedEmojis(emojis.slice(0, flagHeaderIndex), this.props.frequentlyUsedEmojis)
             : EmojiUtils.mergeEmojisWithFrequentlyUsedEmojis(emojis, this.props.frequentlyUsedEmojis);
 
-        // Get the header emojis along with the code and index.
+        // Get the header emojis along with the code, index and icon.
         // index is the actual header index starting at the first emoji and counting each one
         this.headerEmojis = EmojiUtils.getHeaderEmojis(this.emojis);
 

--- a/src/components/EmojiPicker/EmojiPickerMenu/index.js
+++ b/src/components/EmojiPicker/EmojiPickerMenu/index.js
@@ -71,8 +71,7 @@ class EmojiPickerMenu extends Component {
         // This is the indices of each header's Row
         // The positions are static, and are calculated as index/numColumns (8 in our case)
         // This is because each row of 8 emojis counts as one index to the flatlist
-        this.headerRowIndices = _.map(this.headerEmojis, (headerEmoji) => Math.floor(headerEmoji.index / CONST.EMOJI_NUM_PER_ROW));
-
+        this.headerRowIndices = _.map(this.headerEmojis, headerEmoji => Math.floor(headerEmoji.index / CONST.EMOJI_NUM_PER_ROW));
 
         this.filterEmojis = _.debounce(this.filterEmojis.bind(this), 300);
         this.highlightAdjacentEmoji = this.highlightAdjacentEmoji.bind(this);

--- a/src/components/EmojiPicker/EmojiPickerMenu/index.native.js
+++ b/src/components/EmojiPicker/EmojiPickerMenu/index.native.js
@@ -153,7 +153,7 @@ class EmojiPickerMenu extends Component {
             <View style={styles.emojiPickerContainer}>
                 <View>
                     <CategoryShortcutBar
-                        headerIndices={this.headerIndices}
+                        headerEmojis={this.headerEmojis}
                         onPress={this.scrollToHeader}
                     />
                 </View>

--- a/src/components/EmojiPicker/EmojiPickerMenu/index.native.js
+++ b/src/components/EmojiPicker/EmojiPickerMenu/index.native.js
@@ -51,7 +51,7 @@ class EmojiPickerMenu extends Component {
 
         this.emojis = EmojiUtils.mergeEmojisWithFrequentlyUsedEmojis(emojis, this.props.frequentlyUsedEmojis);
 
-        // Get the header emojis along with the code and index.
+        // Get the header emojis along with the code, index and icon.
         // index is the actual header index starting at the first emoji and counting each one
         this.headerEmojis = EmojiUtils.getHeaderEmojis(this.emojis);
 

--- a/src/components/EmojiPicker/EmojiPickerMenu/index.native.js
+++ b/src/components/EmojiPicker/EmojiPickerMenu/index.native.js
@@ -55,11 +55,10 @@ class EmojiPickerMenu extends Component {
         // index is the actual header index starting at the first emoji and counting each one
         this.headerEmojis = EmojiUtils.getHeaderEmojis(this.emojis);
 
-
         // This is the indices of each header's Row
         // The positions are static, and are calculated as index/numColumns (8 in our case)
         // This is because each row of 8 emojis counts as one index to the flatlist
-        this.headerRowIndices = _.map(this.headerEmojis, (headerEmoji) => Math.floor(headerEmoji.index / CONST.EMOJI_NUM_PER_ROW));
+        this.headerRowIndices = _.map(this.headerEmojis, headerEmoji => Math.floor(headerEmoji.index / CONST.EMOJI_NUM_PER_ROW));
 
         this.renderItem = this.renderItem.bind(this);
         this.isMobileLandscape = this.isMobileLandscape.bind(this);

--- a/src/components/EmojiPicker/EmojiPickerMenu/index.native.js
+++ b/src/components/EmojiPicker/EmojiPickerMenu/index.native.js
@@ -51,13 +51,15 @@ class EmojiPickerMenu extends Component {
 
         this.emojis = EmojiUtils.mergeEmojisWithFrequentlyUsedEmojis(emojis, this.props.frequentlyUsedEmojis);
 
-        // This is the actual header index starting at the first emoji and counting each one
-        this.headerIndices = EmojiUtils.getHeaderIndices(this.emojis);
+        // Get the header emojis along with the code and index.
+        // index is the actual header index starting at the first emoji and counting each one
+        this.headerEmojis = EmojiUtils.getHeaderEmojis(this.emojis);
+
 
         // This is the indices of each header's Row
         // The positions are static, and are calculated as index/numColumns (8 in our case)
         // This is because each row of 8 emojis counts as one index to the flatlist
-        this.headerRowIndices = _.map(this.headerIndices, headerIndex => Math.floor(headerIndex / CONST.EMOJI_NUM_PER_ROW));
+        this.headerRowIndices = _.map(this.headerEmojis, (headerEmoji) => Math.floor(headerEmoji.index / CONST.EMOJI_NUM_PER_ROW));
 
         this.renderItem = this.renderItem.bind(this);
         this.isMobileLandscape = this.isMobileLandscape.bind(this);

--- a/src/libs/EmojiUtils.js
+++ b/src/libs/EmojiUtils.js
@@ -5,6 +5,7 @@ import Str from 'expensify-common/lib/str';
 import CONST from '../CONST';
 import * as User from './actions/User';
 import emojisTrie from './EmojiTrie';
+import FrequentlyUsed from './../../assets/images/history.svg';
 
 /**
  * Get the unicode code of an emoji in base 16.
@@ -92,7 +93,7 @@ function getHeaderEmojis(emojis) {
         if (!emoji.header) {
             return;
         }
-        headerIndices.push({code: emoji.code, index});
+        headerIndices.push({code: emoji.code, index, icon: emoji.icon});
     });
     return headerIndices;
 }
@@ -149,6 +150,7 @@ function mergeEmojisWithFrequentlyUsedEmojis(emojis, frequentlyUsedEmojis = []) 
     let allEmojis = [{
         header: true,
         code: 'frequentlyUsed',
+        icon: FrequentlyUsed
     }];
 
     allEmojis = allEmojis.concat(frequentlyUsedEmojis, emojis);

--- a/src/libs/EmojiUtils.js
+++ b/src/libs/EmojiUtils.js
@@ -83,7 +83,7 @@ function containsOnlyEmojis(message) {
 }
 
 /**
- * Get the header indices based on the max emojis per row
+ * Get the header emojis with their code, icon and index
  * @param {Object[]} emojis
  * @returns {Object[]}
  */

--- a/src/libs/EmojiUtils.js
+++ b/src/libs/EmojiUtils.js
@@ -5,7 +5,7 @@ import Str from 'expensify-common/lib/str';
 import CONST from '../CONST';
 import * as User from './actions/User';
 import emojisTrie from './EmojiTrie';
-import FrequentlyUsed from './../../assets/images/history.svg';
+import FrequentlyUsed from '../../assets/images/history.svg';
 
 /**
  * Get the unicode code of an emoji in base 16.
@@ -150,7 +150,7 @@ function mergeEmojisWithFrequentlyUsedEmojis(emojis, frequentlyUsedEmojis = []) 
     let allEmojis = [{
         header: true,
         code: 'frequentlyUsed',
-        icon: FrequentlyUsed
+        icon: FrequentlyUsed,
     }];
 
     allEmojis = allEmojis.concat(frequentlyUsedEmojis, emojis);

--- a/src/libs/EmojiUtils.js
+++ b/src/libs/EmojiUtils.js
@@ -84,15 +84,15 @@ function containsOnlyEmojis(message) {
 /**
  * Get the header indices based on the max emojis per row
  * @param {Object[]} emojis
- * @returns {Number[]}
+ * @returns {Object[]}
  */
-function getHeaderIndices(emojis) {
+function getHeaderEmojis(emojis) {
     const headerIndices = [];
     _.each(emojis, (emoji, index) => {
         if (!emoji.header) {
             return;
         }
-        headerIndices.push(index);
+        headerIndices.push({code: emoji.code, index});
     });
     return headerIndices;
 }
@@ -246,7 +246,7 @@ function suggestEmojis(text, limit = 5) {
 }
 
 export {
-    getHeaderIndices,
+    getHeaderEmojis,
     mergeEmojisWithFrequentlyUsedEmojis,
     addToFrequentlyUsedEmojis,
     containsOnlyEmojis,

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1534,9 +1534,8 @@ const styles = {
     categoryShortcutButton: {
         flex: 1,
         borderRadius: 8,
-        paddingTop: 2,
-        paddingBottom: 2,
         height: CONST.EMOJI_PICKER_ITEM_HEIGHT,
+        alignItems: 'center',
         justifyContent: 'center',
     },
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/15108   
PROPOSAL: https://github.com/Expensify/App/issues/15108#issuecomment-1440483855


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

**For Desktop and Web**

1. Open the app
2. Go to any chat
3. Click on the Emoji Icon
4. Hover over the category icons
5. Ensure that you are able to see the Tooltip
6. You can change the language and confirm that the tooltip shows up in the selected language.
7. Click on the Emoji Category Icon, and confirm it scrolls to the correct category
8. Attempt the steps 3-6 on a new account to see that `Frequently Used` category is not shown and still the steps work fine.

**For mWeb and Mobile Apps**

1. Open the app
2. Go to any chat
3. Click on the Emoji Icon
4. Click on the Emoji Category Icon, and confirm it scrolls to the correct category
5. Attempt the steps 2-4 on a new account to see that `Frequently Used` category is not shown and still the steps work fine.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
NA

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
10. Upload an image via copy paste
11. Verify a modal appears displaying a preview of that image
--->

**For Desktop and Web**

1. Open the app
2. Go to any chat
3. Click on the Emoji Icon
4. Hover over the category icons
5. Ensure that you are able to see the Tooltip
6. You can change the language and confirm that the tooltip shows up in the selected language.
7. Click on the Emoji Category Icon, and confirm it scrolls to the correct category
8. Attempt the steps 3-6 on a new account to see that `Frequently Used` category is not shown and still the steps work fine.

**For mWeb and Mobile Apps**

1. Open the app
2. Go to any chat
3. Click on the Emoji Icon
4. Click on the Emoji Category Icon, and confirm it scrolls to the correct category
5. Attempt the steps 2-4 on a new account to see that `Frequently Used` category is not shown and still the steps work fine.



- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<img width="1498" alt="Screenshot 2023-02-27 at 11 27 12 PM" src="https://user-images.githubusercontent.com/57435789/221661209-4e4c177b-19cf-4c01-bad8-41c819b63c85.png">

**v1**
https://user-images.githubusercontent.com/57435789/221661937-ba95e97f-1c3b-48a5-a057-21796e0356f0.mp4

**v2**

https://user-images.githubusercontent.com/57435789/222346542-4f509bd4-77db-4c71-80df-21a7ae131814.mp4

**v3**

<img width="1198" alt="Screenshot 2023-03-02 at 12 59 02 PM" src="https://user-images.githubusercontent.com/57435789/222360576-844d04c0-e26d-4a30-a1ec-3f2c0f0190ee.png">

**v4 with 4px padding**

<img width="475" alt="Screenshot 2023-03-02 at 7 05 31 PM" src="https://user-images.githubusercontent.com/57435789/222443794-5cfd9c8e-3cb0-47fd-a9f4-a097a5cb44e2.png">

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<img width="358" alt="Screenshot 2023-02-28 at 12 26 11 AM" src="https://user-images.githubusercontent.com/57435789/221661427-583b499d-30e7-4cf4-b40b-ae6f3ebe6004.png">

</details>

<details>
<summary>Mobile Web - Safari</summary>

<img width="435" alt="Screenshot 2023-02-28 at 12 44 14 AM" src="https://user-images.githubusercontent.com/57435789/221661525-3852ec3c-fca6-49f0-afae-ebcaff2f4e72.png">

</details>

<details>
<summary>Desktop</summary>

<img width="1194" alt="Screenshot 2023-02-27 at 11 29 44 PM" src="https://user-images.githubusercontent.com/57435789/221661610-381119c7-b5c6-4969-a241-32c8b2134930.png">

**v1**
https://user-images.githubusercontent.com/57435789/221662042-4ef1cfeb-6943-4df7-8764-2acfa55183b8.mp4

**v2**

https://user-images.githubusercontent.com/57435789/222346208-3adbf0c9-a0cd-498b-9fe6-baff5f6a6ebb.mp4

**v3**
<img width="1198" alt="Screenshot 2023-03-02 at 12 59 02 PM" src="https://user-images.githubusercontent.com/57435789/222360628-dd93cbb2-118a-4427-ab35-42cc7e3eb554.png">

**v4 with 4px padding**

<img width="1193" alt="Screenshot 2023-03-02 at 7 05 54 PM" src="https://user-images.githubusercontent.com/57435789/222443849-793e6297-1c8c-4c77-bc35-98bba650b5f5.png">


</details>

<details>
<summary>iOS</summary>

<img width="417" alt="Screenshot 2023-02-28 at 1 27 19 AM" src="https://user-images.githubusercontent.com/57435789/221669690-d5e05978-e72f-4d19-998c-395489267e5c.png">

</details>

<details>
<summary>Android</summary>

<img width="370" alt="Screenshot 2023-02-27 at 11 50 04 PM" src="https://user-images.githubusercontent.com/57435789/221661697-c8604606-02c2-4158-b317-78c37ea22ee1.png">

</details>