### PR TITLE
Use policyName sent back with public rooms for people who aren't in the workspace

### DIFF
--- a/src/libs/ReportUtils.js
+++ b/src/libs/ReportUtils.js
@@ -281,10 +281,17 @@ function isArchivedRoom(report) {
  * @param {Object} report
  * @param {String} report.policyID
  * @param {String} report.oldPolicyName
+ * @param {String} report.policyName
  * @param {Object} policies must have Onyxkey prefix (i.e 'policy_') for keys
  * @returns {String}
  */
 function getPolicyName(report, policies) {
+    // Public rooms send back the policy name with the reportSummary,
+    // since they can also be accessed by people who aren't in the workspace
+    if (report.policyName) {
+        return report.policyName;
+    }
+
     if (_.isEmpty(policies)) {
         return Localize.translateLocal('workspace.common.unavailable');
     }


### PR DESCRIPTION
Needs https://github.com/Expensify/Web-Expensify/pull/36595

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/Expensify/issues/263074

### Tests
1. Create a new workspace, save the reportID of the #announce room.
2. `./script/sql.sh` and run the following query to update the visibility rNVP to be "public_announce":
    `INSERT INTO reportNameValuePairs (reportID, name, value) VALUES (<reportID>, "visibility", "public_announce");`
3. Sign out of the account that created the workspace, and sign into a different account that isn't in the workspace.
4. Navigate to the #announce room (i.e. `localhost:8080/r/<reportID`)
5. Verify that the policyName appears in the subtitle in the header of the report screen.

### QA Steps
**_REQUIRES RING3_**
1. Create a new workspace, save the reportID for of the #announce room.
2. `./script/sql.sh` and run the following query to update the visibility rNVP to be "public_announce":
    `INSERT INTO reportNameValuePairs (reportID, name, value) VALUES (<reportID>, "visibility", "public_announce");`
3. Sign out of the account that created the workspace, and sign into a different account that isn't in the workspace.
4. Navigate to the #announce room (i.e. `staging.new.expensify.com/r/<reportID`)
5. Verify that the policyName appears in the subtitle in the header of the report screen.

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<img width="1709" alt="Screenshot 2023-02-27 at 6 53 40 PM" src="https://user-images.githubusercontent.com/31285285/221741911-b725fcfc-3324-4874-a6eb-c53a2d75e453.png">

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<img width="386" alt="Screenshot 2023-02-27 at 7 15 19 PM" src="https://user-images.githubusercontent.com/31285285/221744483-51bd0d05-1030-47b1-a45c-afd58a0f0fab.png">
<img width="378" alt="Screenshot 2023-02-27 at 7 15 15 PM" src="https://user-images.githubusercontent.com/31285285/221744484-6694c950-342d-4984-81b4-0f48251fae02.png">


</details>

<details>
<summary>Mobile Web - Safari</summary>

<img width="480" alt="Screenshot 2023-02-27 at 7 05 59 PM" src="https://user-images.githubusercontent.com/31285285/221743211-2e082e6b-365b-406a-aed8-5f6d09357fc7.png">

<img width="481" alt="Screenshot 2023-02-27 at 7 06 04 PM" src="https://user-images.githubusercontent.com/31285285/221743215-e67bc8ee-7175-4b48-ad83-41676747087e.png">


</details>

<details>
<summary>Desktop</summary>

<img width="1197" alt="Screenshot 2023-02-27 at 7 04 18 PM" src="https://user-images.githubusercontent.com/31285285/221743001-cd027ef5-0725-4520-be12-04367ac69b40.png">

</details>

<details>
<summary>iOS</summary>

<img width="470" alt="Screenshot 2023-02-27 at 7 05 04 PM" src="https://user-images.githubusercontent.com/31285285/221743058-37ed6c16-4616-4cbb-904c-dc6b5330911c.png">

<img width="482" alt="Screenshot 2023-02-27 at 7 05 12 PM" src="https://user-images.githubusercontent.com/31285285/221743067-776d54ce-c2af-46f1-9d87-ee40990c37ed.png">

</details>

<details>
<summary>Android</summary>

<img width="382" alt="Screenshot 2023-02-27 at 7 14 49 PM" src="https://user-images.githubusercontent.com/31285285/221744419-cbd4fe2f-befa-46c3-a221-5bf8b73207fb.png">
<img width="385" alt="Screenshot 2023-02-27 at 7 14 53 PM" src="https://user-images.githubusercontent.com/31285285/221744420-2744e1f1-fdcc-4ed9-a568-d91dc48d954f.png">



</details>
