### PR TITLE
localize payment method description on payments page

### DIFF
--- a/src/libs/PaymentUtils.js
+++ b/src/libs/PaymentUtils.js
@@ -25,31 +25,23 @@ function hasExpensifyPaymentMethod(cardList = [], bankAccountList = []) {
     return validBankAccount || validDebitCard;
 }
 
-function formatPaymentMethod(accountType, account) {
-    let formattedPaymentMethod = {};
+/**
+ * Get the PaymentMethod description
+ * @param {String} accountType
+ * @param {Object} account
+ * @returns {String}
+ */
+function getPaymentMethodDescription(accountType, account) {
     if (accountType === CONST.PAYMENT_METHODS.PAYPAL) {
-        formattedPaymentMethod = {
-            title: 'PayPal.me',
-            icon: account.icon,
-            description: account.username,
-            type: CONST.PAYMENT_METHODS.PAYPAL,
-        };
-    } else if (accountType === CONST.PAYMENT_METHODS.BANK_ACCOUNT) {
-        formattedPaymentMethod = {
-            title: account.addressName,
-            icon: account.icon,
-            description: `${Localize.translateLocal('paymentMethodList.accountLastFour')} ${account.accountNumber.slice(-4)}`,
-            type: CONST.PAYMENT_METHODS.BANK_ACCOUNT,
-        };
-    } else if (accountType === CONST.PAYMENT_METHODS.DEBIT_CARD) {
-        formattedPaymentMethod = {
-            title: account.addressName,
-            icon: account.icon,
-            description: `${Localize.translateLocal('paymentMethodList.cardLastFour')} ${account.cardNumber.slice(-4)}`,
-            type: CONST.PAYMENT_METHODS.DEBIT_CARD,
-        };
+        return account.username;
     }
-    return formattedPaymentMethod;
+    if (accountType === CONST.PAYMENT_METHODS.BANK_ACCOUNT) {
+        return `${Localize.translateLocal('paymentMethodList.accountLastFour')} ${account.accountNumber.slice(-4)}`;
+    }
+    if (accountType === CONST.PAYMENT_METHODS.DEBIT_CARD) {
+        return `${Localize.translateLocal('paymentMethodList.cardLastFour')} ${account.cardNumber.slice(-4)}`;
+    }
+    return '';
 }
 
 /**
@@ -71,7 +63,7 @@ function formatPaymentMethods(bankAccountList, cardList, payPalMeData = null) {
         const {icon, iconSize} = getBankIcon(lodashGet(bankAccount, 'accountData.additionalData.bankName', ''));
         combinedPaymentMethods.push({
             ...bankAccount,
-            description: formatPaymentMethod(bankAccount.accountType, bankAccount.accountData).description,
+            description: getPaymentMethodDescription(bankAccount.accountType, bankAccount.accountData),
             icon,
             iconSize,
             errors: bankAccount.errors,
@@ -83,7 +75,7 @@ function formatPaymentMethods(bankAccountList, cardList, payPalMeData = null) {
         const {icon, iconSize} = getBankIcon(lodashGet(card, 'accountData.bank', ''), true);
         combinedPaymentMethods.push({
             ...card,
-            description: formatPaymentMethod(card.accountType, card.accountData).description,
+            description: getPaymentMethodDescription(card.accountType, card.accountData),
             icon,
             iconSize,
             errors: card.errors,
@@ -94,7 +86,7 @@ function formatPaymentMethods(bankAccountList, cardList, payPalMeData = null) {
     if (!_.isEmpty(payPalMeData)) {
         combinedPaymentMethods.push({
             ...payPalMeData,
-            description: formatPaymentMethod(payPalMeData.accountType, payPalMeData.accountData).description,
+            description: getPaymentMethodDescription(payPalMeData.accountType, payPalMeData.accountData),
             icon: Expensicons.PayPal,
         });
     }
@@ -117,7 +109,7 @@ function calculateWalletTransferBalanceFee(currentBalance, methodType) {
 
 export {
     hasExpensifyPaymentMethod,
-    formatPaymentMethod,
+    getPaymentMethodDescription,
     formatPaymentMethods,
     calculateWalletTransferBalanceFee,
 };

--- a/src/libs/PaymentUtils.js
+++ b/src/libs/PaymentUtils.js
@@ -4,6 +4,7 @@ import BankAccount from './models/BankAccount';
 import * as Expensicons from '../components/Icon/Expensicons';
 import getBankIcon from '../components/Icon/BankIcons';
 import CONST from '../CONST';
+import * as Localize from './Localize';
 
 /**
  * Check to see if user has either a debit card or personal bank account added
@@ -22,6 +23,33 @@ function hasExpensifyPaymentMethod(cardList = [], bankAccountList = []) {
     const validDebitCard = _.some(cardList, card => lodashGet(card, 'accountData.additionalData.isP2PDebitCard', false));
 
     return validBankAccount || validDebitCard;
+}
+
+function formatPaymentMethod(accountType, account) {
+    let formattedPaymentMethod = {};
+    if (accountType === CONST.PAYMENT_METHODS.PAYPAL) {
+        formattedPaymentMethod = {
+            title: 'PayPal.me',
+            icon: account.icon,
+            description: account.username,
+            type: CONST.PAYMENT_METHODS.PAYPAL,
+        };
+    } else if (accountType === CONST.PAYMENT_METHODS.BANK_ACCOUNT) {
+        formattedPaymentMethod = {
+            title: account.addressName,
+            icon: account.icon,
+            description: `${Localize.translateLocal('paymentMethodList.accountLastFour')} ${account.accountNumber.slice(-4)}`,
+            type: CONST.PAYMENT_METHODS.BANK_ACCOUNT,
+        };
+    } else if (accountType === CONST.PAYMENT_METHODS.DEBIT_CARD) {
+        formattedPaymentMethod = {
+            title: account.addressName,
+            icon: account.icon,
+            description: `${Localize.translateLocal('paymentMethodList.cardLastFour')} ${account.cardNumber.slice(-4)}`,
+            type: CONST.PAYMENT_METHODS.DEBIT_CARD,
+        };
+    }
+    return formattedPaymentMethod;
 }
 
 /**
@@ -43,6 +71,7 @@ function formatPaymentMethods(bankAccountList, cardList, payPalMeData = null) {
         const {icon, iconSize} = getBankIcon(lodashGet(bankAccount, 'accountData.additionalData.bankName', ''));
         combinedPaymentMethods.push({
             ...bankAccount,
+            description: formatPaymentMethod(bankAccount.accountType, bankAccount.accountData).description,
             icon,
             iconSize,
             errors: bankAccount.errors,
@@ -54,6 +83,7 @@ function formatPaymentMethods(bankAccountList, cardList, payPalMeData = null) {
         const {icon, iconSize} = getBankIcon(lodashGet(card, 'accountData.bank', ''), true);
         combinedPaymentMethods.push({
             ...card,
+            description: formatPaymentMethod(card.accountType, card.accountData).description,
             icon,
             iconSize,
             errors: card.errors,
@@ -64,6 +94,7 @@ function formatPaymentMethods(bankAccountList, cardList, payPalMeData = null) {
     if (!_.isEmpty(payPalMeData)) {
         combinedPaymentMethods.push({
             ...payPalMeData,
+            description: formatPaymentMethod(payPalMeData.accountType, payPalMeData.accountData).description,
             icon: Expensicons.PayPal,
         });
     }
@@ -86,6 +117,7 @@ function calculateWalletTransferBalanceFee(currentBalance, methodType) {
 
 export {
     hasExpensifyPaymentMethod,
+    formatPaymentMethod,
     formatPaymentMethods,
     calculateWalletTransferBalanceFee,
 };

--- a/src/libs/PaymentUtils.js
+++ b/src/libs/PaymentUtils.js
@@ -26,7 +26,6 @@ function hasExpensifyPaymentMethod(cardList = [], bankAccountList = []) {
 }
 
 /**
- * Get the PaymentMethod description
  * @param {String} accountType
  * @param {Object} account
  * @returns {String}

--- a/src/libs/PaymentUtils.js
+++ b/src/libs/PaymentUtils.js
@@ -26,7 +26,7 @@ function hasExpensifyPaymentMethod(cardList = [], bankAccountList = []) {
 }
 
 /**
- * @param {String} accountType
+ * @param {String} [accountType] - one of {'bankAccount', 'debitCard', 'payPalMe'}
  * @param {Object} account
  * @returns {String}
  */

--- a/src/pages/settings/Payments/PaymentsPage/BasePaymentsPage.js
+++ b/src/pages/settings/Payments/PaymentsPage/BasePaymentsPage.js
@@ -194,35 +194,12 @@ class BasePaymentsPage extends React.Component {
 
         // The delete/default menu
         if (accountType) {
-            let formattedSelectedPaymentMethod;
-            if (accountType === CONST.PAYMENT_METHODS.PAYPAL) {
-                formattedSelectedPaymentMethod = {
-                    title: 'PayPal.me',
-                    icon: account.icon,
-                    description: account.username,
-                    type: CONST.PAYMENT_METHODS.PAYPAL,
-                };
-            } else if (accountType === CONST.PAYMENT_METHODS.BANK_ACCOUNT) {
-                formattedSelectedPaymentMethod = {
-                    title: account.addressName,
-                    icon: account.icon,
-                    description: `${this.props.translate('paymentMethodList.accountLastFour')} ${account.accountNumber.slice(-4)}`,
-                    type: CONST.PAYMENT_METHODS.BANK_ACCOUNT,
-                };
-            } else if (accountType === CONST.PAYMENT_METHODS.DEBIT_CARD) {
-                formattedSelectedPaymentMethod = {
-                    title: account.addressName,
-                    icon: account.icon,
-                    description: `${this.props.translate('paymentMethodList.cardLastFour')} ${account.cardNumber.slice(-4)}`,
-                    type: CONST.PAYMENT_METHODS.DEBIT_CARD,
-                };
-            }
             this.setState({
                 isSelectedPaymentMethodDefault: isDefault,
                 shouldShowDefaultDeleteMenu: true,
                 selectedPaymentMethod: account,
                 selectedPaymentMethodType: accountType,
-                formattedSelectedPaymentMethod,
+                formattedSelectedPaymentMethod: PaymentUtils.formatPaymentMethod(accountType, account),
                 methodID,
             });
             this.setPositionAddPaymentMenu(position);

--- a/src/pages/settings/Payments/PaymentsPage/BasePaymentsPage.js
+++ b/src/pages/settings/Payments/PaymentsPage/BasePaymentsPage.js
@@ -194,12 +194,35 @@ class BasePaymentsPage extends React.Component {
 
         // The delete/default menu
         if (accountType) {
+            let formattedSelectedPaymentMethod;
+            if (accountType === CONST.PAYMENT_METHODS.PAYPAL) {
+                formattedSelectedPaymentMethod = {
+                    title: 'PayPal.me',
+                    icon: account.icon,
+                    description: PaymentUtils.getPaymentMethodDescription(accountType, account),
+                    type: CONST.PAYMENT_METHODS.PAYPAL,
+                };
+            } else if (accountType === CONST.PAYMENT_METHODS.BANK_ACCOUNT) {
+                formattedSelectedPaymentMethod = {
+                    title: account.addressName,
+                    icon: account.icon,
+                    description: PaymentUtils.getPaymentMethodDescription(accountType, account),
+                    type: CONST.PAYMENT_METHODS.BANK_ACCOUNT,
+                };
+            } else if (accountType === CONST.PAYMENT_METHODS.DEBIT_CARD) {
+                formattedSelectedPaymentMethod = {
+                    title: account.addressName,
+                    icon: account.icon,
+                    description: PaymentUtils.getPaymentMethodDescription(accountType, account),
+                    type: CONST.PAYMENT_METHODS.DEBIT_CARD,
+                };
+            }
             this.setState({
                 isSelectedPaymentMethodDefault: isDefault,
                 shouldShowDefaultDeleteMenu: true,
                 selectedPaymentMethod: account,
                 selectedPaymentMethodType: accountType,
-                formattedSelectedPaymentMethod: PaymentUtils.formatPaymentMethod(accountType, account),
+                formattedSelectedPaymentMethod,
                 methodID,
             });
             this.setPositionAddPaymentMenu(position);


### PR DESCRIPTION
### Details
Add custom `description` key with localized description to payment method data

### Fixed Issues
$ https://github.com/Expensify/App/issues/15333
PROPOSAL: https://github.com/Expensify/App/issues/15333#issuecomment-1440238083


### Tests
Same as QA Steps

NOTE: I was not able to add debit card as payment method so only tested bank account and paypal.

- [ ] Verify that no errors appear in the JS console

### Offline tests
Same as QA Steps

### QA Steps
1. Login with any account
2. Add a bank account with plaid on staging
3. Change the language to Spanish
4. Open the payments page
5. Verify that payment method description (`Account ending in xxxx`) is translated into Spanish

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<img width="1205" alt="web" src="https://user-images.githubusercontent.com/115748623/221827719-f78e4433-c1d2-4730-96c1-1a61967c4724.png">


</details>

<details>
<summary>Mobile Web - Chrome</summary>

![mchrome](https://user-images.githubusercontent.com/115748623/221827756-f48e429a-f05f-4404-847c-23b14a510aa0.png)


</details>

<details>
<summary>Mobile Web - Safari</summary>

![msafari](https://user-images.githubusercontent.com/115748623/221827789-ff60f4c1-1805-49a0-8cbf-05650f31c519.png)


</details>

<details>
<summary>Desktop</summary>

<img width="1192" alt="desktop" src="https://user-images.githubusercontent.com/115748623/221827815-eedb7f7b-2a6f-4e6d-ada4-ef2593b02836.png">


</details>

<details>
<summary>iOS</summary>

![ios](https://user-images.githubusercontent.com/115748623/221827846-00e11c6d-1865-47dd-b413-1c40156573a0.png)

https://user-images.githubusercontent.com/115748623/222755712-74828842-9516-45b8-9563-159fd02e928d.mov

</details>

<details>
<summary>Android</summary>

![android](https://user-images.githubusercontent.com/115748623/221827862-2dbeba34-f558-42a5-8a0e-7c3c549c94a2.png)


</details>
