### PR TITLE
fix: The app crashes when the user is logged into multiple tabs and logs out of one of the tabs #15321

### DIFF
--- a/src/components/OnyxProvider.js
+++ b/src/components/OnyxProvider.js
@@ -6,7 +6,7 @@ import ComposeProviders from './ComposeProviders';
 
 // Set up any providers for individual keys. This should only be used in cases where many components will subscribe to
 // the same key (e.g. FlatList renderItem components)
-const [withNetwork, NetworkProvider] = createOnyxContext(ONYXKEYS.NETWORK);
+const [withNetwork, NetworkProvider] = createOnyxContext(ONYXKEYS.NETWORK, {});
 const [withPersonalDetails, PersonalDetailsProvider] = createOnyxContext(ONYXKEYS.PERSONAL_DETAILS);
 const [withCurrentDate, CurrentDateProvider] = createOnyxContext(ONYXKEYS.CURRENT_DATE);
 const [withReportActionsDrafts, ReportActionsDraftsProvider] = createOnyxContext(ONYXKEYS.COLLECTION.REPORT_ACTIONS_DRAFTS);

--- a/src/components/createOnyxContext.js
+++ b/src/components/createOnyxContext.js
@@ -38,7 +38,6 @@ export default (onyxKeyName, defaultValue) => {
 
                     if (propsToPass[propName] === undefined && defaultValue) {
                         propsToPass[propName] = defaultValue;
-                        //propsToPass[propName] = propsToPass[propName] || {};
                     }
                     return (
                         // eslint-disable-next-line react/jsx-props-no-spreading

--- a/src/components/createOnyxContext.js
+++ b/src/components/createOnyxContext.js
@@ -9,7 +9,7 @@ const propTypes = {
     children: PropTypes.node.isRequired,
 };
 
-export default (onyxKeyName) => {
+export default (onyxKeyName, defaultValue) => {
     const Context = createContext();
     const Provider = props => (
         <Context.Provider value={props[onyxKeyName]}>
@@ -35,6 +35,11 @@ export default (onyxKeyName) => {
                         ...props,
                         [propName]: transformValue ? transformValue(value, props) : value,
                     };
+
+                    if (propsToPass[propName] === undefined && defaultValue) {
+                        propsToPass[propName] = defaultValue;
+                        //propsToPass[propName] = propsToPass[propName] || {};
+                    }
                     return (
                         // eslint-disable-next-line react/jsx-props-no-spreading
                         <WrappedComponent {...propsToPass} ref={ref} />

--- a/tests/unit/NetworkTest.js
+++ b/tests/unit/NetworkTest.js
@@ -33,7 +33,7 @@ beforeEach(() => {
     HttpUtils.cancelPendingRequests();
     PersistedRequests.clear();
     NetworkStore.checkRequiredData();
-    
+
     // Wait for any Log command to finish and Onyx to fully clear
     jest.advanceTimersByTime(CONST.NETWORK.PROCESS_REQUEST_DELAY_MS);
     return waitForPromisesToResolve()

--- a/tests/unit/NetworkTest.js
+++ b/tests/unit/NetworkTest.js
@@ -33,6 +33,7 @@ beforeEach(() => {
     HttpUtils.cancelPendingRequests();
     PersistedRequests.clear();
     NetworkStore.checkRequiredData();
+    
     // Wait for any Log command to finish and Onyx to fully clear
     jest.advanceTimersByTime(CONST.NETWORK.PROCESS_REQUEST_DELAY_MS);
     return waitForPromisesToResolve()

--- a/tests/unit/NetworkTest.js
+++ b/tests/unit/NetworkTest.js
@@ -33,7 +33,6 @@ beforeEach(() => {
     HttpUtils.cancelPendingRequests();
     PersistedRequests.clear();
     NetworkStore.checkRequiredData();
-
     // Wait for any Log command to finish and Onyx to fully clear
     jest.advanceTimersByTime(CONST.NETWORK.PROCESS_REQUEST_DELAY_MS);
     return waitForPromisesToResolve()


### PR DESCRIPTION
PR for `App`

<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
The currennt code does not have default value in `createOnyxContext `. This may the app to crash when an important Onyx key is deleted. In this PR, I added a new `defaultValue` for `createOnyxContext`, if the value of the OnyxKey is undefined then we'll fallback to that defaultValue.

Regarding the issue, I added the default value `{}` for the `network` property. By doing this, if the `network` value is deleted from Onyx, the app will not crash since it is using the default value.

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/15321
$ https://github.com/Expensify/App/issues/15321#issuecomment-1441602988


### Tests

1. Open the app in the browser
2. Open another tab in the same browser
3. Log out from one of the tabs 
4. Verify that in other tab the app is not crashed and logged out to the login page.

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Open the app in the browser
2. Open another tab in the same browser
3. Disable the internet
3. Log out from one of the tabs 
4. Verify that in other tab the app is not crashed and logged out to the login page.

### QA Steps

1. Open the app in the browser
2. Open another tab in the same browser
3. Log out from one of the tabs 
4. Verify that in other tab the app is not crashed and logged out to the login page.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://user-images.githubusercontent.com/113963320/221806394-0158a8ce-42e4-496e-808a-f51f174465e8.mov

</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://user-images.githubusercontent.com/113963320/221826952-1511fa8b-f72f-43d0-8eaf-61563bf1b41f.mp4
</details>

<details>
<summary>Mobile Web - Safari</summary>

https://user-images.githubusercontent.com/113963320/221822738-82d0e2db-305b-41f5-9a74-22ea408a9aca.mp4
</details>

<details>
<summary>Desktop</summary>

https://user-images.githubusercontent.com/113963320/221823234-9ce9e7df-10ee-4c36-9940-f5fb59038222.mov
</details>

<details>
<summary>iOS</summary>

https://user-images.githubusercontent.com/113963320/221815380-d3961cc1-6fdc-48e4-b763-d289263d21d4.mp4

</details>

<details>
<summary>Android</summary>

https://user-images.githubusercontent.com/113963320/221823777-efebea4c-a362-4044-95f3-bcb53f7d686d.webm
</details>
