### PR TITLE
Revert "replace onModalHide with onDismiss for the web"

### DIFF
--- a/src/components/Modal/BaseModal.js
+++ b/src/components/Modal/BaseModal.js
@@ -16,15 +16,11 @@ const propTypes = {
 
     /** The ref to the modal container */
     forwardedRef: PropTypes.func,
-
-    /** Ensure that callback and trap deactivation are in the same loop on the web platform */
-    shouldUseOnDismiss: PropTypes.bool,
 };
 
 const defaultProps = {
     ...modalDefaultProps,
     forwardedRef: () => {},
-    shouldUseOnDismiss: false,
 };
 
 class BaseModal extends PureComponent {
@@ -113,8 +109,7 @@ class BaseModal extends PureComponent {
                     this.props.onModalShow();
                 }}
                 propagateSwipe={this.props.propagateSwipe}
-                onDismiss={this.props.shouldUseOnDismiss ? this.hideModal : () => {}}
-                onModalHide={!this.props.shouldUseOnDismiss ? this.hideModal : () => {}}
+                onModalHide={this.hideModal}
                 onSwipeComplete={this.props.onClose}
                 swipeDirection={swipeDirection}
                 isVisible={this.props.isVisible}

--- a/src/components/Modal/index.web.js
+++ b/src/components/Modal/index.web.js
@@ -29,7 +29,6 @@ const Modal = (props) => {
         <BaseModal
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...props}
-            shouldUseOnDismiss={props.fullscreen}
             onModalHide={hideModal}
             onModalShow={showModal}
         >


### PR DESCRIPTION
The PR which we revert PR introduced a [regression](https://github.com/Expensify/App/issues/15559). We want to revert it because this has an impact on all modals, since the changes apply to BaseModal component. 

Reverts Expensify/App#15298

### Fixed Issues
$ https://github.com/Expensify/App/issues/15559