### PR TITLE
Update feedback message when the link to get a magic code is resent

### DIFF
--- a/src/pages/signin/ValidateCodeForm/BaseValidateCodeForm.js
+++ b/src/pages/signin/ValidateCodeForm/BaseValidateCodeForm.js
@@ -70,6 +70,7 @@ class BaseValidateCodeForm extends React.Component {
             formError: {},
             validateCode: props.credentials.validateCode || '',
             twoFactorAuthCode: '',
+            linkSent: false,
         };
     }
 
@@ -131,6 +132,9 @@ class BaseValidateCodeForm extends React.Component {
         }
         this.setState({formError: {}});
         User.resendValidateCode(this.props.credentials.login, true);
+
+        // Give feedback to the user to let them know the email was sent so they don't spam the button.
+        this.setState({linkSent: true});
     }
 
     /**
@@ -212,15 +216,21 @@ class BaseValidateCodeForm extends React.Component {
                             autoFocus
                         />
                         <View style={[styles.changeExpensifyLoginLinkContainer]}>
-                            <TouchableOpacity
-                                style={[styles.mt2]}
-                                onPress={this.resendValidateCode}
-                                underlayColor={themeColors.componentBG}
-                            >
-                                <Text style={[styles.link]}>
-                                    {this.props.translate('validateCodeForm.magicCodeNotReceived')}
+                            {this.state.linkSent ? (
+                                <Text style={[styles.mt2]}>
+                                    {this.props.account.message}
                                 </Text>
-                            </TouchableOpacity>
+                            ) : (
+                                <TouchableOpacity
+                                    style={[styles.mt2]}
+                                    onPress={this.resendValidateCode}
+                                    underlayColor={themeColors.componentBG}
+                                >
+                                    <Text style={[styles.link]}>
+                                        {this.props.translate('validateCodeForm.magicCodeNotReceived')}
+                                    </Text>
+                                </TouchableOpacity>
+                            )}
                         </View>
                     </View>
                 )}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/264822


### Tests
1. Go to the login page and enter an Expensify email (since passwordless is not enabled for other domains)
2. When the prompt to enter the magic code shows up, click on "Didn't receive a magic code? right"
3. Once the email is sent, the link message should get updated to the image below and it should be non-clickable:
<img width="335" alt="Monosnap New Expensify 2023-02-28 15-52-33" src="https://user-images.githubusercontent.com/6474442/221978052-a071ce61-da44-49fc-bc04-d95343045cfd.png">

4. Repeat the process with an account that is not under the beta, instead of asking for magic code, it should ask for the password and clicking `Forgot?` should take you to the following screen:
<img width="329" alt="Monosnap New Expensify 2023-02-28 16-06-50" src="https://user-images.githubusercontent.com/6474442/221979896-4d5ba737-f0ea-4a3c-8ddc-10ca85da3473.png">

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A, you can't log in without internet.

### QA Steps
1. Go to the login page and enter an Expensify email (since passwordless is not enabled for other domains)
2. When the prompt to enter the magic code shows up, click on "Didn't receive a magic code? right"
3. Once the email is sent, the link message should get updated to the image below and it should be non-clickable:
<img width="335" alt="Monosnap New Expensify 2023-02-28 15-52-33" src="https://user-images.githubusercontent.com/6474442/221978052-a071ce61-da44-49fc-bc04-d95343045cfd.png">

4. Repeat the process with an account that is not under the beta, instead of asking for magic code, it should ask for the password and clicking `Forgot?` should take you to the following screen:
<img width="329" alt="Monosnap New Expensify 2023-02-28 16-06-50" src="https://user-images.githubusercontent.com/6474442/221979896-4d5ba737-f0ea-4a3c-8ddc-10ca85da3473.png">

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<img width="335" alt="Monosnap New Expensify 2023-02-28 15-52-33" src="https://user-images.githubusercontent.com/6474442/221980813-636765e4-6a2d-460a-97a3-7a57b52a1fae.png">

</details>

<details>
<summary>Mobile Web - Chrome</summary>

![image](https://user-images.githubusercontent.com/6474442/221991011-a938b9f6-4d99-4b4e-9079-07a4b206d7f3.png)

</details>

<details>
<summary>Mobile Web - Safari</summary>

![image](https://user-images.githubusercontent.com/6474442/221986055-5d325d6d-849f-4619-8a1c-a2657c9770f2.png)

</details>

<details>
<summary>Desktop</summary>

<img width="335" alt="Monosnap New Expensify 2023-02-28 15-52-33" src="https://user-images.githubusercontent.com/6474442/221980813-636765e4-6a2d-460a-97a3-7a57b52a1fae.png">

</details>

<details>
<summary>iOS</summary>

![image](https://user-images.githubusercontent.com/6474442/221985771-99f0ea4e-9462-4b7f-ac47-0d39be32e345.png)

</details>

<details>
<summary>Android</summary>

![image](https://user-images.githubusercontent.com/6474442/221992168-0a840e6d-72ad-49fb-8976-ea7dca12630d.png)

</details>
