### PR TITLE
add Tooltips at appropriate locations in workspace/user section and update its text

### DIFF
--- a/src/pages/settings/InitialSettingsPage.js
+++ b/src/pages/settings/InitialSettingsPage.js
@@ -259,7 +259,7 @@ class InitialSettingsPage extends React.Component {
                             <View style={styles.w100}>
                                 <View style={styles.avatarSectionWrapper}>
                                     <Pressable style={[styles.mb3]} onPress={this.openProfileSettings}>
-                                        <Tooltip text={this.props.currentUserPersonalDetails.displayName}>
+                                        <Tooltip text={this.props.translate('common.profile')}>
                                             <OfflineWithFeedback
                                                 pendingAction={lodashGet(this.props.currentUserPersonalDetails, 'pendingFields.avatar', null)}
                                             >
@@ -273,11 +273,13 @@ class InitialSettingsPage extends React.Component {
                                     </Pressable>
 
                                     <Pressable style={[styles.mt1, styles.mw100]} onPress={this.openProfileSettings}>
-                                        <Text style={[styles.textHeadline]} numberOfLines={1}>
-                                            {this.props.currentUserPersonalDetails.displayName
-                                                ? this.props.currentUserPersonalDetails.displayName
-                                                : Str.removeSMSDomain(this.props.session.email)}
-                                        </Text>
+                                        <Tooltip text={this.props.translate('common.profile')}>
+                                            <Text style={[styles.textHeadline]} numberOfLines={1}>
+                                                {this.props.currentUserPersonalDetails.displayName
+                                                    ? this.props.currentUserPersonalDetails.displayName
+                                                    : Str.removeSMSDomain(this.props.session.email)}
+                                            </Text>
+                                        </Tooltip>
                                     </Pressable>
                                     {this.props.currentUserPersonalDetails.displayName && (
                                         <Text

--- a/src/pages/workspace/WorkspaceInitialPage.js
+++ b/src/pages/workspace/WorkspaceInitialPage.js
@@ -192,15 +192,17 @@ class WorkspaceInitialPage extends React.Component {
                                                 style={[styles.pRelative, styles.avatarLarge]}
                                                 onPress={this.openEditor}
                                             >
-                                                <Avatar
-                                                    containerStyles={styles.avatarLarge}
-                                                    imageStyles={[styles.avatarLarge, styles.alignSelfCenter]}
-                                                    source={this.props.policy.avatar ? this.props.policy.avatar : ReportUtils.getDefaultWorkspaceAvatar(policyName)}
-                                                    fallbackIcon={Expensicons.FallbackWorkspaceAvatar}
-                                                    size={CONST.AVATAR_SIZE.LARGE}
-                                                    name={policyName}
-                                                    type={CONST.ICON_TYPE_WORKSPACE}
-                                                />
+                                                <Tooltip text={this.props.translate('workspace.common.settings')}>
+                                                    <Avatar
+                                                        containerStyles={styles.avatarLarge}
+                                                        imageStyles={[styles.avatarLarge, styles.alignSelfCenter]}
+                                                        source={this.props.policy.avatar ? this.props.policy.avatar : ReportUtils.getDefaultWorkspaceAvatar(policyName)}
+                                                        fallbackIcon={Expensicons.FallbackWorkspaceAvatar}
+                                                        size={CONST.AVATAR_SIZE.LARGE}
+                                                        name={policyName}
+                                                        type={CONST.ICON_TYPE_WORKSPACE}
+                                                    />
+                                                </Tooltip>
                                             </Pressable>
                                             {!_.isEmpty(this.props.policy.name) && (
                                                 <Pressable
@@ -212,7 +214,7 @@ class WorkspaceInitialPage extends React.Component {
                                                     ]}
                                                     onPress={this.openEditor}
                                                 >
-                                                    <Tooltip text={this.props.policy.name}>
+                                                    <Tooltip text={this.props.translate('workspace.common.settings')}>
                                                         <Text
                                                             numberOfLines={1}
                                                             style={[


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
https://github.com/Expensify/App/issues/15451#issuecomment-1451637274

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/15451   
PROPOSAL: https://github.com/Expensify/App/issues/15451#issuecomment-1451637274

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Go to [new.expensify.com](http://new.expensify.com/)
2. Navigate to Settings
3. Hover over the User's Avatar & display name and verify that a Tooltip will be shown saying "Profile"
4. Navigate to Workspaces > Select any workspace
5. Hover our Workspace's Avatar & workspace name and verify that a Tooltip will be shown saying "General Settings" 

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Go to [new.expensify.com](http://new.expensify.com/)
2. Navigate to Settings
3. Hover over the User's Avatar & display name and verify that a Tooltip will be shown saying "Profile"
4. Navigate to Workspaces > Select any workspace
5. Hover our Workspace's Avatar & workspace name and verify that a Tooltip will be shown saying "General Settings" 

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>
<img width="381" alt="Screenshot 2023-03-07 at 10 09 02 PM" src="https://user-images.githubusercontent.com/71884990/223489107-61e5d816-3658-42c0-8643-89377aa6519e.png">
<img width="381" alt="Screenshot 2023-03-07 at 10 13 06 PM" src="https://user-images.githubusercontent.com/71884990/223489750-313f99b8-ab31-486c-89a7-b654c543bfac.png">

<img width="381" alt="Screenshot 2023-03-07 at 10 09 08 PM" src="https://user-images.githubusercontent.com/71884990/223489130-29a3d0ae-9bf7-4df7-972d-4f69f711b490.png">
<img width="381" alt="Screenshot 2023-03-07 at 10 09 07 PM" src="https://user-images.githubusercontent.com/71884990/223489136-97e0ca90-cbe9-441e-bbf2-e5e75aea15bb.png">

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>
N/A


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>
N/A
<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>
<img width="381" alt="Screenshot 2023-03-07 at 10 09 55 PM" src="https://user-images.githubusercontent.com/71884990/223489024-060b8eb7-b19b-4631-bfbe-096b06041677.png">
<img width="381" alt="Screenshot 2023-03-07 at 10 12 15 PM" src="https://user-images.githubusercontent.com/71884990/223489958-f0b0c95a-4106-4115-b1eb-948ad778291e.png">

<img width="381" alt="Screenshot 2023-03-07 at 10 09 42 PM" src="https://user-images.githubusercontent.com/71884990/223489058-9260cf14-50ac-487f-9904-3ecd93efe3cd.png">

<img width="381" alt="Screenshot 2023-03-07 at 10 09 45 PM" src="https://user-images.githubusercontent.com/71884990/223489055-67ac54a8-c58d-4d71-a035-3d472dff47ba.png">
<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>
N/A
<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>
N/A
<!-- add screenshots or videos here -->

</details>
