### PR TITLE
Add go back link to initial route on Not Found Page

### DIFF
--- a/src/components/BlockingViews/BlockingView.js
+++ b/src/components/BlockingViews/BlockingView.js
@@ -48,15 +48,15 @@ const BlockingView = props => (
         />
         <Text style={[styles.notFoundTextHeader]}>{props.title}</Text>
         <Text style={[styles.textAlignCenter]}>{props.subtitle}</Text>
-        {!!props.shouldShowBackHomeLink
-            && (
+        {props.shouldShowBackHomeLink
+            ? (
                 <TextLink
                     onPress={() => Navigation.navigate(ROUTES.REPORT)}
                     style={[styles.link, styles.mt2]}
                 >
                     {props.link}
                 </TextLink>
-            )}
+            ) : null}
     </View>
 );
 

--- a/src/components/BlockingViews/BlockingView.js
+++ b/src/components/BlockingViews/BlockingView.js
@@ -6,6 +6,9 @@ import variables from '../../styles/variables';
 import Icon from '../Icon';
 import Text from '../Text';
 import themeColors from '../../styles/themes/default';
+import TextLink from '../TextLink';
+import Navigation from '../../libs/Navigation/Navigation';
+import ROUTES from '../../ROUTES';
 
 const propTypes = {
     /** Expensicon for the page */
@@ -19,10 +22,18 @@ const propTypes = {
 
     /** Subtitle message below the title */
     subtitle: PropTypes.string.isRequired,
+
+    /** Link message below the subtitle */
+    link: PropTypes.string,
+
+    /** Whether we should show a go back home link */
+    shouldShowBackHomeLink: PropTypes.bool,
 };
 
 const defaultProps = {
     iconColor: themeColors.offline,
+    shouldShowBackHomeLink: false,
+    link: 'notFound.goBackHome',
 };
 
 const BlockingView = props => (
@@ -37,6 +48,15 @@ const BlockingView = props => (
         />
         <Text style={[styles.notFoundTextHeader]}>{props.title}</Text>
         <Text style={[styles.textAlignCenter]}>{props.subtitle}</Text>
+        {!!props.shouldShowBackHomeLink
+            && (
+                <TextLink
+                    onPress={() => Navigation.navigate(ROUTES.REPORT)}
+                    style={[styles.link, styles.mt2]}
+                >
+                    {props.link}
+                </TextLink>
+            )}
     </View>
 );
 

--- a/src/components/BlockingViews/FullPageNotFoundView.js
+++ b/src/components/BlockingViews/FullPageNotFoundView.js
@@ -31,6 +31,12 @@ const propTypes = {
     /** Whether we should show a close button */
     shouldShowCloseButton: PropTypes.bool,
 
+    /** Whether we should show a go back home link */
+    shouldShowBackHomeLink: PropTypes.bool,
+
+    /** The key in the translations file to use for the go back link */
+    linkKey: PropTypes.string,
+
     /** Method to trigger when pressing the back button of the header */
     onBackButtonPress: PropTypes.func,
 };
@@ -40,7 +46,9 @@ const defaultProps = {
     shouldShow: false,
     titleKey: 'notFound.notHere',
     subtitleKey: 'notFound.pageNotFound',
+    linkKey: 'notFound.goBackHome',
     shouldShowBackButton: true,
+    shouldShowBackHomeLink: false,
     shouldShowCloseButton: true,
     onBackButtonPress: () => Navigation.dismissModal(),
 };
@@ -61,6 +69,8 @@ const FullPageNotFoundView = (props) => {
                         icon={Expensicons.QuestionMark}
                         title={props.translate(props.titleKey)}
                         subtitle={props.translate(props.subtitleKey)}
+                        link={props.translate(props.linkKey)}
+                        shouldShowBackHomeLink={props.shouldShowBackHomeLink}
                     />
                 </View>
             </>

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -642,6 +642,7 @@ export default {
         notHere: "Hmm... it's not here",
         pageNotFound: 'That page is nowhere to be found.',
         noAccess: 'You don\'t have access to this chat',
+        goBackHome: 'Go back to Home page',
     },
     setPasswordPage: {
         enterPassword: 'Enter a password',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -641,6 +641,7 @@ export default {
         notHere: 'Hmm… no está aquí',
         pageNotFound: 'La página que buscas no existe.',
         noAccess: 'No tienes acceso a este chat',
+        goBackHome: 'Volver a la página principal',
     },
     setPasswordPage: {
         enterPassword: 'Escribe una contraseña',

--- a/src/pages/ErrorPage/NotFoundPage.js
+++ b/src/pages/ErrorPage/NotFoundPage.js
@@ -5,7 +5,7 @@ import FullPageNotFoundView from '../../components/BlockingViews/FullPageNotFoun
 // eslint-disable-next-line rulesdir/no-negated-variables
 const NotFoundPage = () => (
     <ScreenWrapper>
-        <FullPageNotFoundView shouldShow />
+        <FullPageNotFoundView shouldShow shouldShowBackHomeLink />
     </ScreenWrapper>
 );
 


### PR DESCRIPTION
### Details
We should have go back link if user get on Not Found Page, to make interaction faster and clear how to move to main page

### Fixed Issues
$ https://github.com/Expensify/App/issues/15719
$ https://github.com/Expensify/App/issues/15719#issuecomment-1461688018


### Tests
1. Open website
2. Type something in url to land on not existing page
3. Check that Link to go back exists
4. Clicking should move back to main screen

- [ ] Verify that no errors appear in the JS console

### Offline tests
This feature doesn't change or is impacted by offline mode.

### QA Steps
Same as above.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>


https://user-images.githubusercontent.com/28352309/224082462-810cdec1-fb97-4062-8c6a-0f167dc92e5d.mov


</details>

<details>
<summary>Mobile Web - Chrome</summary>


https://user-images.githubusercontent.com/28352309/224082496-ee12859b-17c1-4cef-86cd-26f9ff63447e.mov


</details>

<details>
<summary>Mobile Web - Safari</summary>


https://user-images.githubusercontent.com/28352309/224082521-76a08bdd-c62b-4c7f-ae69-597ae7790694.mov


</details>

<details>
<summary>Desktop</summary>


https://user-images.githubusercontent.com/28352309/224082545-4693735e-dee3-4c46-b0d2-cfa3f8ddf70d.mov


</details>

<details>
<summary>iOS</summary>


https://user-images.githubusercontent.com/28352309/224082570-56a6f958-076b-4851-a89d-7f489d135308.mov


</details>

<details>
<summary>Android</summary>


https://user-images.githubusercontent.com/28352309/224082593-c25cede3-28ae-4544-acfb-570e09a7f648.mov


</details>
