### PR TITLE
Fix emoji reaction icon and copy

### DIFF
--- a/src/components/Reactions/MiniQuickEmojiReactions.js
+++ b/src/components/Reactions/MiniQuickEmojiReactions.js
@@ -84,7 +84,7 @@ const MiniQuickEmojiReactions = (props) => {
                 ref={ref}
                 onPress={openEmojiPicker}
                 isDelayButtonStateComplete={false}
-                tooltipText={props.translate('reportActionContextMenu.addEmojiReaction')}
+                tooltipText={props.translate('reportActionContextMenu.addReactionTooltip')}
             >
                 {({hovered, pressed}) => (
                     <Icon

--- a/src/components/Reactions/MiniQuickEmojiReactions.js
+++ b/src/components/Reactions/MiniQuickEmojiReactions.js
@@ -89,7 +89,7 @@ const MiniQuickEmojiReactions = (props) => {
                 {({hovered, pressed}) => (
                     <Icon
                         small
-                        src={Expensicons.Emoji}
+                        src={Expensicons.AddReaction}
                         fill={StyleUtils.getIconFillColor(getButtonState(hovered, pressed, false))}
                     />
                 )}

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -225,8 +225,7 @@ export default {
         editComment: 'Edit comment',
         deleteComment: 'Delete comment',
         deleteConfirmation: 'Are you sure you want to delete this comment?',
-        addEmojiReaction: 'Add emoji reaction',
-        addReactionTooltip: 'Add Reaction…',
+        addReactionTooltip: 'Add Reaction',
     },
     reportActionsView: {
         beginningOfArchivedRoomPartOne: 'You missed the party in ',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -224,8 +224,7 @@ export default {
         editComment: 'Editar commentario',
         deleteComment: 'Eliminar comentario',
         deleteConfirmation: '¿Estás seguro de que quieres eliminar este comentario?',
-        addEmojiReaction: 'Añadir una reacción emoji',
-        addReactionTooltip: 'Añadir una reacción…',
+        addReactionTooltip: 'Añadir una reacción',
     },
     reportActionsView: {
         beginningOfArchivedRoomPartOne: 'Te perdiste la fiesta en ',


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/15787
PROPOSAL: n/a


### Tests
Web/Desktop only
1. Open any conversation
2. Hover over a message
3. Make sure the emoji reaction icon has a `+` sign
4. Hover over the icon and make sure the copy says `Add Reaction`
5. Right click the message and hover the reaction button. 
6. Make sure the copy says `Add Reaction`
7. Add an emoji
8. Hover the add reaction button next to the reaction bubble on the message
9. Make sure the reaction icon has a `+` sign 
10. Make sure the copy says `Add Reaction`

Mobile / Mobile web
1. Open any conversation
2. Long press a message
3. Make sure the emoji reaction icon has a `+` sign

- [x] Verify that no errors appear in the JS console

### Offline tests
n/a

### QA Steps
Web/Desktop only
1. Open any conversation
2. Hover over a message
3. Make sure the emoji reaction icon has a `+` sign
4. Hover over the icon and make sure the copy says `Add Reaction`
5. Right click the message and hover the reaction button. 
6. Make sure the copy says `Add Reaction`
7. Add an emoji
8. Hover the add reaction button next to the reaction bubble on the message
9. Make sure the reaction icon has a `+` sign 
10. Make sure the copy says `Add Reaction`

Mobile / Mobile web
1. Open any conversation
2. Long press a message
3. Make sure the emoji reaction icon has a `+` sign

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>
<img width="544" alt="2023-03-09_14-20-04" src="https://user-images.githubusercontent.com/42391420/224162795-de31fa3a-93d1-49b4-9eed-749874d17bdc.png">

<img width="531" alt="2023-03-09_14-15-59" src="https://user-images.githubusercontent.com/42391420/224162807-efdd8899-5f55-42e0-9454-6ff2d2b51551.png">
<img width="482" alt="2023-03-09_14-16-06" src="https://user-images.githubusercontent.com/42391420/224162816-41999cc0-3d80-4f1a-b81a-de124585f19c.png">


</details>

<details>
<summary>Mobile Web - Chrome</summary>

<img width="447" alt="2023-03-09_14-53-26" src="https://user-images.githubusercontent.com/42391420/224168702-6bf8a4ec-78a1-4319-a6a0-8ba65ac1123c.png">
<img width="447" alt="2023-03-09_14-53-22" src="https://user-images.githubusercontent.com/42391420/224168704-955259ab-ecb8-4be8-a6b7-d0d07ac6f8e7.png">


</details>

<details>
<summary>Mobile Web - Safari</summary>
<img width="453" alt="2023-03-09_14-36-15" src="https://user-images.githubusercontent.com/42391420/224165505-5f8898d2-d6f0-4f3c-a262-5c37d08ee56d.png">

<img width="383" alt="2023-03-09_14-36-11" src="https://user-images.githubusercontent.com/42391420/224165510-46b7b44e-1f05-4e51-a298-a3ca31b0fdb0.png">


</details>

<details>
<summary>Desktop</summary>

<img width="1200" alt="2023-03-09_14-19-46" src="https://user-images.githubusercontent.com/42391420/224162769-08165157-7226-45ef-9175-281d60bafc47.png">
<img width="1200" alt="2023-03-09_14-19-51" src="https://user-images.githubusercontent.com/42391420/224162777-9d42ff6b-752f-4889-a60e-0b3497841e8f.png">
<img width="1200" alt="2023-03-09_14-19-56" src="https://user-images.githubusercontent.com/42391420/224162786-e2dbedbc-9dcd-4c83-be59-ed48dad993d2.png">


</details>

<details>
<summary>iOS</summary>

<img width="453" alt="2023-03-09_14-35-55" src="https://user-images.githubusercontent.com/42391420/224165475-b3a4f49e-41b0-4337-be97-44bba8abdd6b.png">
<img width="388" alt="2023-03-09_14-35-49" src="https://user-images.githubusercontent.com/42391420/224165484-38ceb9ad-faf7-45f4-8403-88b40fa24a6c.png">


</details>

<details>
<summary>Android</summary>

<img width="447" alt="2023-03-09_14-51-43" src="https://user-images.githubusercontent.com/42391420/224168408-49b9e037-6e7d-491c-b96e-1ea1a419ebfb.png">
<img width="447" alt="2023-03-09_14-51-37" src="https://user-images.githubusercontent.com/42391420/224168415-4ee0f55d-e24d-4f87-9ed4-85f93d7f42cd.png">



</details>
