### PR TITLE
fix: get last actor details from last report action if not present in personal details

### DIFF
--- a/src/libs/SidebarUtils.js
+++ b/src/libs/SidebarUtils.js
@@ -253,7 +253,7 @@ function getOptionData(reportID) {
     // If the last actor's details are not currently saved in Onyx Collection,
     // then try to get that from the last report action.
     let lastActorDetails = personalDetails[report.lastActorEmail] || null;
-    if (!lastActorDetails && lastReportActions[report.reportID]) {
+    if (!lastActorDetails && lastReportActions[report.reportID] && lastReportActions[report.reportID].actionName !== CONST.REPORT.ACTIONS.TYPE.CREATED) {
         const lastActorDisplayName = lodashGet(lastReportActions[report.reportID], 'person[0].text');
         lastActorDetails = lastActorDisplayName ? {
             displayName: lastActorDisplayName,

--- a/src/libs/SidebarUtils.js
+++ b/src/libs/SidebarUtils.js
@@ -1,5 +1,6 @@
 import Onyx from 'react-native-onyx';
 import _ from 'underscore';
+import lodashGet from 'lodash/get';
 import lodashOrderBy from 'lodash/orderBy';
 import Str from 'expensify-common/lib/str';
 import ONYXKEYS from '../ONYXKEYS';
@@ -249,7 +250,16 @@ function getOptionData(reportID) {
         lastMessageTextFromReport = Str.htmlDecode(report ? report.lastMessageText : '');
     }
 
-    const lastActorDetails = personalDetails[report.lastActorEmail] || null;
+    // If the last actor details is not in currently saved in the existing details in Onyx,
+    // then we need to get them from the last report info
+    let lastActorDetails = personalDetails[report.lastActorEmail] || null;
+    if (!lastActorDetails && lastReportActions[report.reportID]) {
+        const lastActorDisplayName = lodashGet(lastReportActions[report.reportID], 'person[0].text');
+        lastActorDetails = lastActorDisplayName ? {
+            displayName: lastActorDisplayName,
+            login: lastReportActions[report.reportID].actorEmail,
+        } : null;
+    }
     let lastMessageText = hasMultipleParticipants && lastActorDetails && (lastActorDetails.login !== currentUserLogin.email)
         ? `${lastActorDetails.displayName}: `
         : '';

--- a/src/libs/SidebarUtils.js
+++ b/src/libs/SidebarUtils.js
@@ -250,14 +250,14 @@ function getOptionData(reportID) {
         lastMessageTextFromReport = Str.htmlDecode(report ? report.lastMessageText : '');
     }
 
-    // If the last actor details is not in currently saved in the existing details in Onyx,
-    // then we need to get them from the last report info
+    // If the last actor's details are not currently saved in Onyx Collection,
+    // then try to get that from the last report action.
     let lastActorDetails = personalDetails[report.lastActorEmail] || null;
     if (!lastActorDetails && lastReportActions[report.reportID]) {
         const lastActorDisplayName = lodashGet(lastReportActions[report.reportID], 'person[0].text');
         lastActorDetails = lastActorDisplayName ? {
             displayName: lastActorDisplayName,
-            login: lastReportActions[report.reportID].actorEmail,
+            login: report.lastActorEmail,
         } : null;
     }
     let lastMessageText = hasMultipleParticipants && lastActorDetails && (lastActorDetails.login !== currentUserLogin.email)


### PR DESCRIPTION
### Details

There are instances* where users in a group/channel do not have information about each other saved in the Onyx collection. When that happens, the last message in a chat from those users will not appear in LHN with the user name, only the content.

The fix for this problem was adding a fallback to the last actor email in the `lastReportActions`. The `lastReportAction` was already used below to get a possible archive reason, so it's available and contains the necessary info without having to refetch the data for that specific user.

\* The instances consists for example of inviting to a workspace 2 users who never spoken before. When one of these users talk in the `#announce` chat, the other user will not get the preview with the user name.
 
### Fixed Issues
$ https://github.com/Expensify/App/issues/15711 
https://github.com/Expensify/App/issues/15711#issuecomment-1461680412


### Tests
1. Create a workspace
2. Invite members to that workspace that never interacted with each other
3. Switch to one of these accounts
4. Send a message to the `#announce` channel
5. Switch to the other account that was invited and check that the sender name appears in the preview of the last message of the chat

- [X] Verify that no errors appear in the JS console

### Offline tests

Should work as before, so not applicable in this case.

### QA Steps

1. Create a workspace
2. Invite members to that workspace that never interacted with each other
3. Switch to one of these accounts
4. Send a message to the `#announce` channel
5. Switch to the other account that was invited and check that the sender name appears in the preview of the last message of the chat

- [X] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android / native
    - [X] Android / Chrome
    - [X] iOS / native
    - [X] iOS / Safari
    - [X] MacOS / Chrome / Safari
    - [X] MacOS / Desktop
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [X] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [X] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If a new component is created I verified that:
    - [X] A similar component doesn't exist in the codebase
    - [X] All props are defined accurately and each prop has a `/** comment above it */`
    - [X] The file is named correctly
    - [X] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [X] The only data being stored in the state is data necessary for rendering and nothing else
    - [X] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [X] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [X] All JSX used for rendering exists in the render method
    - [X] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [X] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://user-images.githubusercontent.com/25725586/224763186-9ef432cd-ecd3-487a-b9bf-4371cfb0bf1c.mp4

</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://user-images.githubusercontent.com/25725586/224763293-7d4e6277-6572-4724-a527-5d9032ffb887.mp4

</details>

<details>
<summary>Mobile Web - Safari</summary>

https://user-images.githubusercontent.com/25725586/224763293-7d4e6277-6572-4724-a527-5d9032ffb887.mp4

</details>

<details>
<summary>Desktop</summary>

https://user-images.githubusercontent.com/25725586/224763356-4b6b8bc1-e3f7-4907-9fcd-c2bb21294793.mp4

</details>

<details>
<summary>iOS</summary>

https://user-images.githubusercontent.com/25725586/224763421-8a1579ec-b548-48ee-b739-55dc7d4910d8.mp4

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>
