### PR TITLE
Display error message for symbols in legal name

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -823,6 +823,7 @@ const CONST = {
         PHONE_E164_PLUS: /^\+?[1-9]\d{1,14}$/,
         PHONE_WITH_SPECIAL_CHARS: /^\s*(?:\+?(\d{1,3}))?[-. (]*(\d{3})[-. )]*(\d{3})[-. ]*(\d{4})(?: *x(\d+))?\s*$/,
         ALPHABETIC_CHARS: /[a-zA-Z]+/,
+        ALPHABETIC_CHARS_ONLY: /^[a-zA-Z ]*$/,
         POSITIVE_INTEGER: /^\d+$/,
         NON_ALPHA_NUMERIC: /[^A-Za-z0-9+]/g,
         PO_BOX: /\b[P|p]?(OST|ost)?\.?\s*[O|o|0]?(ffice|FFICE)?\.?\s*[B|b][O|o|0]?[X|x]?\.?\s+[#]?(\d+)\b/,

--- a/src/CONST.js
+++ b/src/CONST.js
@@ -823,7 +823,7 @@ const CONST = {
         PHONE_E164_PLUS: /^\+?[1-9]\d{1,14}$/,
         PHONE_WITH_SPECIAL_CHARS: /^\s*(?:\+?(\d{1,3}))?[-. (]*(\d{3})[-. )]*(\d{3})[-. ]*(\d{4})(?: *x(\d+))?\s*$/,
         ALPHABETIC_CHARS: /[a-zA-Z]+/,
-        ALPHABETIC_CHARS_ONLY: /^[a-zA-Z ]*$/,
+        ALPHABETIC_CHARS_WITH_NUMBER: /^[a-zA-Z0-9 ]*$/,
         POSITIVE_INTEGER: /^\d+$/,
         NON_ALPHA_NUMERIC: /[^A-Za-z0-9+]/g,
         PO_BOX: /\b[P|p]?(OST|ost)?\.?\s*[O|o|0]?(ffice|FFICE)?\.?\s*[B|b][O|o|0]?[X|x]?\.?\s+[#]?(\d+)\b/,

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -622,7 +622,7 @@ export default {
         error: {
             dateShouldBeBefore: ({dateString}) => `Date should be before ${dateString}.`,
             dateShouldBeAfter: ({dateString}) => `Date should be after ${dateString}.`,
-            hasInvalidCharacter: 'Name can only include include letters and numbers.',
+            hasInvalidCharacter: 'Name can only include letters and numbers.',
         },
     },
     resendValidationForm: {

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -622,7 +622,7 @@ export default {
         error: {
             dateShouldBeBefore: ({dateString}) => `Date should be before ${dateString}.`,
             dateShouldBeAfter: ({dateString}) => `Date should be after ${dateString}.`,
-            hasInvalidCharacter: 'Name contains unsupported character.',
+            hasInvalidCharacter: 'Name can only include include letters and numbers.',
         },
     },
     resendValidationForm: {

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -622,6 +622,7 @@ export default {
         error: {
             dateShouldBeBefore: ({dateString}) => `Date should be before ${dateString}.`,
             dateShouldBeAfter: ({dateString}) => `Date should be after ${dateString}.`,
+            hasInvalidCharacter: 'Name contains unsupported character.',
         },
     },
     resendValidationForm: {

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -621,7 +621,7 @@ export default {
         error: {
             dateShouldBeBefore: ({dateString}) => `La fecha debe ser anterior a ${dateString}.`,
             dateShouldBeAfter: ({dateString}) => `La fecha debe ser posterior a ${dateString}.`,
-            hasInvalidCharacter: 'El nombre contiene un carácter no admitido.',
+            hasInvalidCharacter: 'El nombre solo puede contener letras y números.',
         },
     },
     resendValidationForm: {

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -621,6 +621,7 @@ export default {
         error: {
             dateShouldBeBefore: ({dateString}) => `La fecha debe ser anterior a ${dateString}.`,
             dateShouldBeAfter: ({dateString}) => `La fecha debe ser posterior a ${dateString}.`,
+            hasInvalidCharacter: 'El nombre contiene un carácter no admitido.',
         },
     },
     resendValidationForm: {

--- a/src/libs/ValidationUtils.js
+++ b/src/libs/ValidationUtils.js
@@ -359,6 +359,16 @@ function isValidDisplayName(name) {
 }
 
 /**
+ * Checks that the provided legal name doesn't contain special characters
+ *
+ * @param {String} name
+ * @returns {Boolean}
+ */
+function isValidLegalName(name) {
+    return CONST.REGEX.ALPHABETIC_CHARS_ONLY.test(name);
+}
+
+/**
  * Checks if the provided string includes any of the provided reserved words
  *
  * @param {String} value
@@ -449,5 +459,6 @@ export {
     isValidTaxID,
     isValidValidateCode,
     isValidDisplayName,
+    isValidLegalName,
     doesContainReservedWord,
 };

--- a/src/libs/ValidationUtils.js
+++ b/src/libs/ValidationUtils.js
@@ -365,7 +365,7 @@ function isValidDisplayName(name) {
  * @returns {Boolean}
  */
 function isValidLegalName(name) {
-    return CONST.REGEX.ALPHABETIC_CHARS_ONLY.test(name);
+    return CONST.REGEX.ALPHABETIC_CHARS_WITH_NUMBER.test(name);
 }
 
 /**

--- a/src/pages/settings/Profile/PersonalDetails/LegalNamePage.js
+++ b/src/pages/settings/Profile/PersonalDetails/LegalNamePage.js
@@ -66,14 +66,14 @@ class LegalNamePage extends Component {
     validate(values) {
         const errors = {};
 
-        if (!ValidationUtils.isValidDisplayName(values.legalFirstName)) {
-            errors.legalFirstName = this.props.translate('personalDetails.error.hasInvalidCharacter');
+        if (!ValidationUtils.isValidLegalName(values.legalFirstName)) {
+            errors.legalFirstName = this.props.translate('privatePersonalDetails.error.hasInvalidCharacter');
         } else if (_.isEmpty(values.legalFirstName)) {
             errors.legalFirstName = this.props.translate('common.error.fieldRequired');
         }
 
-        if (!ValidationUtils.isValidDisplayName(values.legalLastName)) {
-            errors.legalLastName = this.props.translate('personalDetails.error.hasInvalidCharacter');
+        if (!ValidationUtils.isValidLegalName(values.legalLastName)) {
+            errors.legalLastName = this.props.translate('privatePersonalDetails.error.hasInvalidCharacter');
         } else if (_.isEmpty(values.legalLastName)) {
             errors.legalLastName = this.props.translate('common.error.fieldRequired');
         }


### PR DESCRIPTION
@sobitneupane @PauloGasparSv PR is ready for review

### Details
When we use special chars and symbols for legal name at that time server side api will remove all symbols and not store legal name within db so legal name become clear if such chars used.

Also form does not show error in ui when user enter special chars or symbols within first name and last name fields for legal name. So within this pr we implemented functionality to show error to user when special chars used for legal name.  

So now user can enter a-zA-Z0-9 and Space chars within legal name fields. e.g. "Paulo 1st" or "John the 2nd" etc.

**Note:** _Within recorded video I did not show number while entering first and last legal name but user can also use 0-9 chars within it._

### Fixed Issues
$ https://github.com/Expensify/App/issues/15741
PROPOSAL: https://github.com/Expensify/App/issues/15741#issuecomment-1467022286

### Tests
1. Navigate to Settings -> Profile -> Personal details
2. Navigate to the Legal name page or Legal last name
3. Enter one a symbol (like *-+) at the beginning or anywhere within Legal first name or last name fields.
4. Verify that **when special symbols entered it will show error as "Name contains unsupported characters"** as shown in video.

- [x] Verify that no errors appear in the JS console

### Offline tests
1. Navigate to Settings -> Profile -> Personal details
2. Navigate to the Legal name page or Legal last name
3. Enter one a symbol (like *-+) at the beginning or anywhere within Legal first name or last name fields.
4. Verify that **when special symbols entered it will show error as "Name contains unsupported characters"** as shown in video.

### QA Steps
1. Navigate to Settings -> Profile -> Personal details
2. Navigate to the Legal name page or Legal last name
3. Enter one a symbol (like *-+) at the beginning or anywhere within Legal first name or last name fields.
4. Verify that **when special symbols entered it will show error as "Name contains unsupported characters"** as shown in video.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://user-images.githubusercontent.com/7823358/225327773-17edc061-8c4d-40f7-a400-2087e35551f1.mp4

</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://user-images.githubusercontent.com/7823358/225327943-4b94d69e-14ed-4923-87fd-8860bb0dd3b0.mp4

</details>

<details>
<summary>Mobile Web - Safari</summary>

https://user-images.githubusercontent.com/7823358/225328039-557e28ca-d015-48f1-87cc-b090d384649f.mov

</details>

<details>
<summary>Desktop</summary>

https://user-images.githubusercontent.com/7823358/225328167-290d9783-5de3-4cd0-8043-0ed6986b1b19.mp4

</details>

<details>
<summary>iOS</summary>

https://user-images.githubusercontent.com/7823358/225328232-5c8ac3f4-793b-4720-af4d-a731bc3a8df7.mov

</details>

<details>
<summary>Android</summary>

https://user-images.githubusercontent.com/7823358/225328334-4cc2f7ce-c5bf-4296-aaa4-e34f6735c205.mp4

</details>
