### PR TITLE
Ensure OpenReport is always called when deeplinking from an outside source

### DIFF
--- a/src/components/HTMLEngineProvider/HTMLRenderers/AnchorRenderer.js
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/AnchorRenderer.js
@@ -48,13 +48,6 @@ const AnchorRenderer = (props) => {
         // If we are handling a New Expensify link then we will assume this should be opened by the app internally. This ensures that the links are opened internally via react-navigation
         // instead of in a new tab or with a page refresh (which is the default behavior of an anchor tag)
         if (internalNewExpensifyPath) {
-            // If we're navigating to a report, we need to call OpenReport here since componentDidMount doesn't get called
-            // when we're deeplinking to a report from a different report (it never unmounts).
-            if (attrPath.startsWith('r/')) {
-                const reportID = attrPath.split('/')[1];
-                Report.openReport(reportID);
-            }
-
             Navigation.navigate(internalNewExpensifyPath);
             return;
         }

--- a/src/components/HTMLEngineProvider/HTMLRenderers/AnchorRenderer.js
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/AnchorRenderer.js
@@ -14,7 +14,6 @@ import styles from '../../../styles/styles';
 import Navigation from '../../../libs/Navigation/Navigation';
 import AnchorForCommentsOnly from '../../AnchorForCommentsOnly';
 import AnchorForAttachmentsOnly from '../../AnchorForAttachmentsOnly';
-import * as Report from '../../../libs/actions/Report';
 import * as Url from '../../../libs/Url';
 import ROUTES from '../../../ROUTES';
 

--- a/src/pages/home/ReportScreen.js
+++ b/src/pages/home/ReportScreen.js
@@ -125,14 +125,14 @@ class ReportScreen extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
-        if (getReportID(this.props.route) === prevProps.route.params.reportID) {
-            // If you already have a report open and are deeplinking to a new report on native,
-            // the ReportScreen never actually unmounts and the reportID in the route also doesn't change.
-            // Therefore, we need to compare if the existing reportID is the same as the one in the route
-            // before deciding that we shouldn't call OpenReport.
-            if (!this.props.report.reportID || this.props.report.reportID === getReportID(this.props.route)) {
-                return;
-            }
+        // If you already have a report open and are deeplinking to a new report on native,
+        // the ReportScreen never actually unmounts and the reportID in the route also doesn't change.
+        // Therefore, we need to compare if the existing reportID is the same as the one in the route
+        // before deciding that we shouldn't call OpenReport.
+        const onyxReportID = this.props.report.reportID;
+        const routeReportID = getReportID(this.props.route);
+        if (routeReportID === prevProps.route.params.reportID && (!onyxReportID || onyxReportID === routeReportID)) {
+            return;
         }
 
         this.fetchReportIfNeeded();

--- a/src/pages/home/ReportScreen.js
+++ b/src/pages/home/ReportScreen.js
@@ -126,7 +126,17 @@ class ReportScreen extends React.Component {
 
     componentDidUpdate(prevProps) {
         if (this.props.route.params.reportID === prevProps.route.params.reportID) {
-            return;
+            if (!this.props.report.reportID) {
+                return;
+            }
+
+            // If you already have a report open and are deeplinking to a new report on native,
+            // the ReportScreen never actually unmounts and the reportID in the route also doesn't change.
+            // Therefore, we need to compare if the existing reportID is the same as the one in the route
+            // before deciding that we shouldn't call OpenReport.
+            if (this.props.report.reportID === getReportID(this.props.route)) {
+                return;
+            }
         }
 
         this.fetchReportIfNeeded();
@@ -159,7 +169,7 @@ class ReportScreen extends React.Component {
         // It possible that we may not have the report object yet in Onyx yet e.g. we navigated to a URL for an accessible report that
         // is not stored locally yet. If props.report.reportID exists, then the report has been stored locally and nothing more needs to be done.
         // If it doesn't exist, then we fetch the report from the API.
-        if (this.props.report.reportID) {
+        if (this.props.report.reportID && this.props.report.reportID === getReportID(this.props.route)) {
             return;
         }
 

--- a/src/pages/home/ReportScreen.js
+++ b/src/pages/home/ReportScreen.js
@@ -125,16 +125,12 @@ class ReportScreen extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
-        if (this.props.route.params.reportID === prevProps.route.params.reportID) {
-            if (!this.props.report.reportID) {
-                return;
-            }
-
+        if (getReportID(this.props.route) === prevProps.route.params.reportID) {
             // If you already have a report open and are deeplinking to a new report on native,
             // the ReportScreen never actually unmounts and the reportID in the route also doesn't change.
             // Therefore, we need to compare if the existing reportID is the same as the one in the route
             // before deciding that we shouldn't call OpenReport.
-            if (this.props.report.reportID === getReportID(this.props.route)) {
+            if (!this.props.report.reportID || this.props.report.reportID === getReportID(this.props.route)) {
                 return;
             }
         }


### PR DESCRIPTION
### Details
This fixes an issue where scanning QR codes on Android would cause you to navigate to a "No Access" screen. This was due to a faulty condition in our `componentDidUpdate` logic in the ReportScreen that would prevent OpenReport from being called when you deeplinked to a report on Native platforms from outside the App.

This also makes it so I can get rid of a hack I added to get deeplinks within the App to work in the `AnchorRenderer`

### Fixed Issues
$ N/A


### Tests/QA

#### Deeplinking from within the App
1. Send yourself a link to a public report you're not already a member of on NewDot (from a different account).
2. Click on that link, and verify you can access the report.

#### Deeplinking from outside the App
1. Paste a link to a public report you're not already a member of to an outside source (e.g. Notes app, Contacts app, etc.)
2. Click on that link, and verify you can access the report.

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>


https://user-images.githubusercontent.com/31285285/225364775-3248a618-018f-435a-b8f3-f54fbe547339.mov



</details>

<details>
<summary>Mobile Web - Chrome</summary>


https://user-images.githubusercontent.com/31285285/225364796-3eda00ba-2e41-434e-bb50-67342b814fd8.mov



</details>

<details>
<summary>Mobile Web - Safari</summary>


https://user-images.githubusercontent.com/31285285/225364822-970de6ab-9400-40dd-acd5-90f5bee0336b.mov



</details>

<details>
<summary>Desktop</summary>


https://user-images.githubusercontent.com/31285285/225364851-3ed3ea55-6463-482e-ba1f-7cb434e55a41.mov



</details>

<details>
<summary>iOS</summary>


https://user-images.githubusercontent.com/31285285/225364869-f2b4e7f2-65eb-41d0-b77a-47bdf5467166.mp4



</details>

<details>
<summary>Android</summary>




https://user-images.githubusercontent.com/31285285/225364881-c2ed2f37-4b5f-4f79-96de-1671ea86bf94.mov




</details>
