### PR TITLE
fix: 15963 - Border line appears, then disappears, above the 1st search result

### DIFF
--- a/src/components/OptionRow.js
+++ b/src/components/OptionRow.js
@@ -93,6 +93,7 @@ class OptionRow extends Component {
         return this.state.isDisabled !== nextState.isDisabled
             || this.props.isDisabled !== nextProps.isDisabled
             || this.props.isSelected !== nextProps.isSelected
+            || this.props.shouldHaveOptionSeparator !== nextProps.shouldHaveOptionSeparator
             || this.props.showSelectedState !== nextProps.showSelectedState
             || this.props.showTitleTooltip !== nextProps.showTitleTooltip
             || !_.isEqual(this.props.option.icons, nextProps.option.icons)
@@ -102,11 +103,9 @@ class OptionRow extends Component {
             || this.props.option.descriptiveText !== nextProps.option.descriptiveText
             || this.props.option.brickRoadIndicator !== nextProps.option.brickRoadIndicator
             || this.props.option.shouldShowSubscript !== nextProps.option.shouldShowSubscript
-            || this.props.option.icons !== nextProps.option.icons
             || this.props.option.ownerEmail !== nextProps.option.ownerEmail
             || this.props.option.subtitle !== nextProps.option.subtitle
-            || this.props.option.pendingAction !== nextProps.option.pendingAction
-            || this.props.shouldHaveOptionSeparator !== nextProps.shouldHaveOptionSeparator;
+            || this.props.option.pendingAction !== nextProps.option.pendingAction;
     }
 
     componentDidUpdate(prevProps) {

--- a/src/components/OptionRow.js
+++ b/src/components/OptionRow.js
@@ -100,7 +100,8 @@ class OptionRow extends Component {
             || this.props.option.text !== nextProps.option.text
             || this.props.option.alternateText !== nextProps.option.alternateText
             || this.props.option.descriptiveText !== nextProps.option.descriptiveText
-            || this.props.option.brickRoadIndicator !== nextProps.option.brickRoadIndicator;
+            || this.props.option.brickRoadIndicator !== nextProps.option.brickRoadIndicator
+            || this.props.shouldHaveOptionSeparator !== nextProps.shouldHaveOptionSeparator;
     }
 
     componentDidUpdate(prevProps) {

--- a/src/components/OptionRow.js
+++ b/src/components/OptionRow.js
@@ -101,6 +101,11 @@ class OptionRow extends Component {
             || this.props.option.alternateText !== nextProps.option.alternateText
             || this.props.option.descriptiveText !== nextProps.option.descriptiveText
             || this.props.option.brickRoadIndicator !== nextProps.option.brickRoadIndicator
+            || this.props.option.shouldShowSubscript !== nextProps.option.shouldShowSubscript
+            || this.props.option.icons !== nextProps.option.icons
+            || this.props.option.ownerEmail !== nextProps.option.ownerEmail
+            || this.props.option.subtitle !== nextProps.option.subtitle
+            || this.props.option.pendingAction !== nextProps.option.pendingAction
             || this.props.shouldHaveOptionSeparator !== nextProps.shouldHaveOptionSeparator;
     }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

This PR added `this.props.shouldHaveOptionSeparator !== nextProps.shouldHaveOptionSeparator;` to the `shouldComponentUpdate` of `OptionRow`. This will remove the redundant border line above the first item in the pronoun search.

In addition, the PR also added some other props condition in `shouldComponentUpdate` that should make the item in `OptionRow` re-render, as suggested by the reviewer. The addition props being considered are `this.props.option.shouldShowSubscript`, `this.props.option.ownerEmail`, `this.props.option.subtitle`, `this.props.option.pendingAction`.

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/15963
PROPOSAL: https://github.com/Expensify/App/issues/15963#issuecomment-1469410712


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Navigate to Settings > Profile > Pronouns
2. Type Hi
3. Observe that the border doesn't show above the first result
4. Type Hir
5. Verify that the border still doesn't show above the first result

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

n/a

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
9. Upload an image via copy paste
10. Verify a modal appears displaying a preview of that image
--->

#### For the main issue
1. Navigate to Settings > Profile > Pronouns
2. Type Hi
3. Observe that the border doesn't show above the first result
4. Type Hir
5. Verify that the border still doesn't show above the first result


#### For the other pages that could be affected

##### PriorityModePage
1. Navigate to Settings > Preferences > Priority mode
6. Verify that the border doesn't show above the first item
7. Verify that there is no error occur

##### LanguagePage
1. Navigate to Settings > Preferences > Language
2. Verify that the border doesn't show above the first item
3. Verify that there is no error occur

##### ReportParticipantsPage
1. Navigate to a report with multiple participants
2. Click on the user list on the top to open Details page
3. Verify that the border doesn't show above the first item
8. Verify that there is no error occur

##### IOUConfirmationList
1. Go to a report
2. Choose `Request money` or `Send money`
3. Type in an amount and move to the confirmation page
4. Verify that there is no error occur

##### NewChatPage
1. Click the plus button in the LHN page, select `New chat`
2. Verify that the border doesn't show above the first item
3. Verify that there is no error occur

##### SearchPage
1. Click the search button in the LHN page
2. Verify that the border doesn't show above the first item
3. Verify that there is no error occur

##### IOUCurrencySelection
1. Go to a report
2. Choose `Request money` or `Send money`
3. Select the currency to enter currency selection page
4. Verify that the border doesn't show above the first item
9. Verify that there is no error occur

##### IOUParticipantsRequest
1. Click the plus button in the LHN page, select `Request money`
2. Type in an amount and proceed
3. Search for users
4. Verify that the border doesn't show above the first item
5. Verify that there is no error occur

##### IOUParticipantsSplit
1. Click the plus button in the LHN page, select `Split bill`
2. Type in an amount and proceed
3. Search for users
4. Verify that the border doesn't show above the first item
5. Verify that there is no error occur

##### YearPickerPage
1. Navigate to Settings > Profile > Personal details > Date of birth
2. Select year dropdown
3. Search for a year
4. Verify that the border doesn't show above the first item
5. Verify that there is no error occur

##### TimezoneSelectPage
1. Navigate to Settings > Profile > Timezone
2. Disable automatic timezone, then go to select time zone
3. Verify that the border doesn't show above the first item
4. Verify that there is no error occur

##### WorkspaceInvitePage
1. Go to a workspace
2. Select `Manage members` > `Invite`
3. Search for a user
4. Verify that the border doesn't show above the first item
5. Verify that there is no error occur

##### WorkspaceMembersPage
1. Go to a workspace
2. Select `Manage members`
3. Verify that the border doesn't show above the first item
4. Verify that there is no error occur

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://user-images.githubusercontent.com/113963320/226094178-18db0b8d-a574-427a-9ab7-7c86f9afc6da.mov

https://user-images.githubusercontent.com/113963320/226094181-79b6ad33-89b5-4872-aec7-024aa38af7ad.mov

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>

[android-chrome.webm](https://user-images.githubusercontent.com/113963320/226094175-0109103f-c9ad-4c0a-9630-987aa17c62b0.webm)

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

https://user-images.githubusercontent.com/113963320/226094171-2f8109e5-439b-487c-93c1-f25f4b001fe2.mov


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>

https://user-images.githubusercontent.com/113963320/226094148-b2e15884-b481-47f3-b816-15b9251eca08.mov

<!-- add screenshots or videos here -->

</details>


<details>
<summary>iOS</summary>


https://user-images.githubusercontent.com/113963320/226094647-0040ef39-5b86-478e-bf87-7b263eb0372e.mov


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>

[android-native.webm](https://user-images.githubusercontent.com/113963320/226094132-f5eb52ec-41d6-413e-9075-1e8865815da8.webm)

<!-- add screenshots or videos here -->

</details>
