### PR TITLE
Fix/15373 last message in the report shows for a brief moment

### DIFF
--- a/src/components/AttachmentModal.js
+++ b/src/components/AttachmentModal.js
@@ -248,7 +248,6 @@ class AttachmentModal extends PureComponent {
         return (
             <>
                 <Modal
-                    statusBarTranslucent={false}
                     type={this.state.modalType}
                     onSubmit={this.submitAndClose}
                     onClose={() => this.setState({isModalOpen: false})}

--- a/src/components/AvatarCropModal/AvatarCropModal.js
+++ b/src/components/AvatarCropModal/AvatarCropModal.js
@@ -363,7 +363,6 @@ const AvatarCropModal = (props) => {
             isVisible={props.isVisible}
             type={CONST.MODAL.MODAL_TYPE.RIGHT_DOCKED}
             onModalHide={resetState}
-            statusBarTranslucent={false}
         >
             {props.isSmallScreenWidth && <HeaderGap />}
             <HeaderWithCloseButton

--- a/src/components/Modal/BaseModal.js
+++ b/src/components/Modal/BaseModal.js
@@ -139,7 +139,7 @@ class BaseModal extends PureComponent {
                             paddingBottom: safeAreaPaddingBottom,
                             paddingLeft: safeAreaPaddingLeft,
                             paddingRight: safeAreaPaddingRight,
-                        } = StyleUtils.getSafeAreaPadding(insets);
+                        } = StyleUtils.getSafeAreaPadding(insets, this.props.statusBarTranslucent);
 
                         const modalPaddingStyles = StyleUtils.getModalPaddingStyles({
                             safeAreaPaddingTop,

--- a/src/libs/getSafeAreaPaddingTop/index.android.js
+++ b/src/libs/getSafeAreaPaddingTop/index.android.js
@@ -1,0 +1,5 @@
+import {StatusBar} from 'react-native';
+
+export default function getSafeAreaPaddingTop() {
+    return StatusBar.currentHeight || 0;
+}

--- a/src/libs/getSafeAreaPaddingTop/index.android.js
+++ b/src/libs/getSafeAreaPaddingTop/index.android.js
@@ -1,5 +1,12 @@
 import {StatusBar} from 'react-native';
 
+/**
+ * Returns safe area padding top to use for a View
+ *
+ * @param {Object} insets
+ * @param {Boolean} statusBarTranslucent
+ * @returns {Number}
+ */
 export default function getSafeAreaPaddingTop(insets, statusBarTranslucent) {
     return (statusBarTranslucent && StatusBar.currentHeight) || 0;
 }

--- a/src/libs/getSafeAreaPaddingTop/index.android.js
+++ b/src/libs/getSafeAreaPaddingTop/index.android.js
@@ -1,5 +1,5 @@
 import {StatusBar} from 'react-native';
 
-export default function getSafeAreaPaddingTop() {
-    return StatusBar.currentHeight || 0;
+export default function getSafeAreaPaddingTop(insets, statusBarTranslucent) {
+    return (statusBarTranslucent && StatusBar.currentHeight) || 0;
 }

--- a/src/libs/getSafeAreaPaddingTop/index.js
+++ b/src/libs/getSafeAreaPaddingTop/index.js
@@ -1,3 +1,9 @@
+/**
+ * Takes safe area insets and returns padding top to use for a View
+ *
+ * @param {Object} insets
+ * @returns {Number}
+ */
 export default function getSafeAreaPaddingTop(insets) {
     return insets.top;
 }

--- a/src/libs/getSafeAreaPaddingTop/index.js
+++ b/src/libs/getSafeAreaPaddingTop/index.js
@@ -1,0 +1,3 @@
+export default function getSafeAreaPaddingTop(insets) {
+    return insets.top;
+}

--- a/src/styles/StyleUtils.js
+++ b/src/styles/StyleUtils.js
@@ -126,11 +126,12 @@ function getDefaultWorspaceAvatarColor(workspaceName) {
  * Takes safe area insets and returns padding to use for a View
  *
  * @param {Object} insets
+ * @param {boolean} statusBarTranslucent
  * @returns {Object}
  */
-function getSafeAreaPadding(insets) {
+function getSafeAreaPadding(insets, statusBarTranslucent) {
     return {
-        paddingTop: getSafeAreaPaddingTop(insets),
+        paddingTop: getSafeAreaPaddingTop(insets, statusBarTranslucent),
         paddingBottom: insets.bottom * variables.safeInsertPercentage,
         paddingLeft: insets.left * variables.safeInsertPercentage,
         paddingRight: insets.right * variables.safeInsertPercentage,

--- a/src/styles/StyleUtils.js
+++ b/src/styles/StyleUtils.js
@@ -126,7 +126,7 @@ function getDefaultWorspaceAvatarColor(workspaceName) {
  * Takes safe area insets and returns padding to use for a View
  *
  * @param {Object} insets
- * @param {boolean} statusBarTranslucent
+ * @param {Boolean} statusBarTranslucent
  * @returns {Object}
  */
 function getSafeAreaPadding(insets, statusBarTranslucent) {

--- a/src/styles/StyleUtils.js
+++ b/src/styles/StyleUtils.js
@@ -7,6 +7,7 @@ import colors from './colors';
 import positioning from './utilities/positioning';
 import styles from './styles';
 import * as ReportUtils from '../libs/ReportUtils';
+import getSafeAreaPaddingTop from '../libs/getSafeAreaPaddingTop';
 
 const workspaceColorOptions = [
     {backgroundColor: colors.blue200, fill: colors.blue700},
@@ -129,7 +130,7 @@ function getDefaultWorspaceAvatarColor(workspaceName) {
  */
 function getSafeAreaPadding(insets) {
     return {
-        paddingTop: insets.top,
+        paddingTop: getSafeAreaPaddingTop(insets),
         paddingBottom: insets.bottom * variables.safeInsertPercentage,
         paddingLeft: insets.left * variables.safeInsertPercentage,
         paddingRight: insets.right * variables.safeInsertPercentage,

--- a/src/styles/getModalStyles/index.android.js
+++ b/src/styles/getModalStyles/index.android.js
@@ -1,8 +1,0 @@
-import getBaseModalStyles from './getBaseModalStyles';
-
-// Only apply top padding on iOS since it's the only platform using SafeAreaView
-export default (type, windowDimensions, popoverAnchorPosition = {}, innerContainerStyle = {}) => ({
-    ...getBaseModalStyles(type, windowDimensions, popoverAnchorPosition, innerContainerStyle),
-    shouldAddTopSafeAreaMargin: false,
-    shouldAddTopSafeAreaPadding: false,
-});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/15373
$ https://github.com/Expensify/App/issues/15373#issuecomment-1452061630


### Tests

Sample password protected PDF: [password-protected.pdf](https://github.com/Expensify/App/files/11043319/password-protected.pdf)
Password: 1234


1. Sign in to NewExpensify Chrome on an Android
2. Select a chat
3. Send a password protected pdf
4. Click on password protected pdf
5. Click on blue hyperlink to "enter password"
6. As the keyboard slides up, verify that you will not see the chat behind.
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

Sample password protected PDF: [password-protected.pdf](https://github.com/Expensify/App/files/11043319/password-protected.pdf)
Password: 1234

1. Sign in to NewExpensify Chrome on an Android
2. Select a chat
3. Send a password protected pdf
4. Click on password protected pdf
5. Click on blue hyperlink to "enter password"
6. As the keyboard slides up, verify that you will not see the chat behind.
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/113963320/226530433-076bb9be-4a10-436e-8582-c5ab4840f225.mov


</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/113963320/226530404-3d130267-2977-4a4c-8f17-f9ab0b68cc43.mov

 
</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/113963320/226530388-7e96219c-f54a-432b-94bf-d8c8f9b2d5e1.mov


</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/113963320/226530374-72d2c505-1c16-46c4-a1a4-d3b5212f30af.mov


</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/113963320/226530360-023278bd-194e-4a4b-bbf0-a6b693f97ef2.mov


</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/113963320/226530346-03727faf-299a-4b5c-912f-607e8408c42f.mov


</details>
