### PR TITLE
Filter out assigned guides from the policy members

### DIFF
--- a/src/libs/PolicyUtils.js
+++ b/src/libs/PolicyUtils.js
@@ -1,5 +1,6 @@
 import _ from 'underscore';
 import lodashGet from 'lodash/get';
+import Str from 'expensify-common/lib/str';
 import CONST from '../CONST';
 import ONYXKEYS from '../ONYXKEYS';
 
@@ -75,10 +76,19 @@ function shouldShowPolicy(policy, isOffline) {
     );
 }
 
+/**
+ * @param {string} email
+ * @returns {boolean}
+ */
+function isAssignedGuide(email) {
+    return Str.extractEmailDomain(email) === CONST.EMAIL.GUIDES_DOMAIN;
+}
+
 export {
     hasPolicyMemberError,
     hasPolicyError,
     hasCustomUnitsError,
     getPolicyBrickRoadIndicatorStatus,
     shouldShowPolicy,
+    isAssignedGuide,
 };

--- a/src/libs/PolicyUtils.js
+++ b/src/libs/PolicyUtils.js
@@ -80,8 +80,9 @@ function shouldShowPolicy(policy, isOffline) {
  * @param {string} email
  * @returns {boolean}
  */
-function isAssignedGuide(email) {
-    return Str.extractEmailDomain(email) === CONST.EMAIL.GUIDES_DOMAIN;
+function isExpensifyTeam(email) {
+    const emailDomain = Str.extractEmailDomain(email);
+    return emailDomain === CONST.EXPENSIFY_PARTNER_NAME || emailDomain === CONST.EMAIL.GUIDES_DOMAIN;
 }
 
 export {
@@ -90,5 +91,5 @@ export {
     hasCustomUnitsError,
     getPolicyBrickRoadIndicatorStatus,
     shouldShowPolicy,
-    isAssignedGuide,
+    isExpensifyTeam,
 };

--- a/src/pages/workspace/WorkspaceMembersPage.js
+++ b/src/pages/workspace/WorkspaceMembersPage.js
@@ -325,7 +325,6 @@ class WorkspaceMembersPage extends React.Component {
             || this.isKeywordMatch(member.firstName, searchValue)
             || this.isKeywordMatch(member.lastName, searchValue));
 
-        // eslint-disable-next-line arrow-body-style
         data = _.reject(data, (member) => {
             // If this policy is owned by Expensify then show all support (expensify.com or team.expensify.com) emails
             if (PolicyUtils.isExpensifyTeam(lodashGet(this.props.policy, 'owner'))) {

--- a/src/pages/workspace/WorkspaceMembersPage.js
+++ b/src/pages/workspace/WorkspaceMembersPage.js
@@ -324,7 +324,7 @@ class WorkspaceMembersPage extends React.Component {
             || this.isKeywordMatch(member.phoneNumber, searchValue)
             || this.isKeywordMatch(member.firstName, searchValue)
             || this.isKeywordMatch(member.lastName, searchValue));
-            
+
         // eslint-disable-next-line arrow-body-style
         data = _.reject(data, (member) => {
             // If this policy is owned by Expensify then show all support (expensify.com or team.expensify.com) emails

--- a/src/pages/workspace/WorkspaceMembersPage.js
+++ b/src/pages/workspace/WorkspaceMembersPage.js
@@ -330,10 +330,15 @@ class WorkspaceMembersPage extends React.Component {
             || this.isKeywordMatch(member.lastName, searchValue));
         // eslint-disable-next-line arrow-body-style
         data = _.reject(data, (member) => {
+            // If this policy is owned by Expensify then show all support (expensify.com or team.expensify.com) emails
+            if (PolicyUtils.isExpensifyTeam(lodashGet(this.props.policy, 'owner'))) {
+                return;
+            }
+
             // We don't want to show guides as policy members unless the user is not a guide. Some customers get confused when they
             // see random people added to their policy, but guides having access to the policies help set them up.
-            const isCurrentUserAssignedGuide = PolicyUtils.isAssignedGuide(this.props.currentUserPersonalDetails.login);
-            return !isCurrentUserAssignedGuide && PolicyUtils.isAssignedGuide(member.login);
+            const isCurrentUserExpensifyTeam = PolicyUtils.isExpensifyTeam(this.props.currentUserPersonalDetails.login);
+            return !isCurrentUserExpensifyTeam && PolicyUtils.isExpensifyTeam(member.login);
         });
 
         const policyID = lodashGet(this.props.route, 'params.policyID');

--- a/src/pages/workspace/WorkspaceMembersPage.js
+++ b/src/pages/workspace/WorkspaceMembersPage.js
@@ -332,7 +332,6 @@ class WorkspaceMembersPage extends React.Component {
         data = _.reject(data, (member) => {
             // We don't want to show guides as policy members unless the user is not a guide. Some customers get confused when they
             // see random people added to their policy, but guides having access to the policies help set them up.
-            // eslint-disable-next-line implicit-arrow-linebreak
             const isCurrentUserAssignedGuide = PolicyUtils.isAssignedGuide(this.props.currentUserPersonalDetails.login);
             return !isCurrentUserAssignedGuide && PolicyUtils.isAssignedGuide(member.login);
         });


### PR DESCRIPTION
### Details

Customers are confused about seeing guides in their workspaces so we are filtering them out.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/266480

### Tests

1. Login as a non guide that has a guide (`@team.expensify.com` user) in their policy
2. Navigate to `/workspace/[policy id]/members`
3. Verify the guide is not visible in the policy members list 
4. Login as the guide and verify that they can see the `@team.expensify.com` users in any assigned policies
5. Login as `expensify.com` and verify they can also see the `@team.expensify.com` users or `@expensify.com` users in any policies.

- [ ] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps

Same as tests, but internal I think.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<img width="1507" alt="2023-03-21_07-32-44" src="https://user-images.githubusercontent.com/32969087/226693924-61d5b39a-b1ae-439e-b07e-fac6204e215f.png">

</details>

<details>
<summary>Mobile Web - Chrome</summary>

![2023-03-21_08-33-18](https://user-images.githubusercontent.com/32969087/226707881-81cb0dc3-3934-4cdf-beb5-c1f63cf4bfcc.png)

</details>

<details>
<summary>Mobile Web - Safari</summary>

![2023-03-21_07-37-59](https://user-images.githubusercontent.com/32969087/226694917-d2b2ff09-ecbe-4ca5-96e3-80e471aca5a8.png)

</details>

<details>
<summary>Desktop</summary>

![2023-03-21_08-19-12](https://user-images.githubusercontent.com/32969087/226704705-dd90a126-19c7-45f9-b2c3-622aba061fdc.png)

</details>

<details>
<summary>iOS</summary>

![2023-03-21_07-37-01](https://user-images.githubusercontent.com/32969087/226694793-1b47a169-9b1e-4994-8011-076faa28e3a1.png)

</details>

<details>
<summary>Android</summary>

![2023-03-21_07-51-36](https://user-images.githubusercontent.com/32969087/226698301-8ad20882-5124-4034-9e4a-4a4615ae7624.png)

</details>
