### PR TITLE
EditComposer: On blur ignore modal

### DIFF
--- a/patches/react-native-modal+13.0.1.patch
+++ b/patches/react-native-modal+13.0.1.patch
@@ -11,7 +11,7 @@ index b63bcfc..bd6419e 100644
      buildPanResponder: () => void;
      getAccDistancePerDirection: (gestureState: PanResponderGestureState) => number;
 diff --git a/node_modules/react-native-modal/dist/modal.js b/node_modules/react-native-modal/dist/modal.js
-index 80f4e75..fe028ab 100644
+index 80f4e75..b6e8e9d 100644
 --- a/node_modules/react-native-modal/dist/modal.js
 +++ b/node_modules/react-native-modal/dist/modal.js
 @@ -75,6 +75,13 @@ export class ReactNativeModal extends React.Component {
@@ -28,6 +28,15 @@ index 80f4e75..fe028ab 100644
          this.shouldPropagateSwipe = (evt, gestureState) => {
              return typeof this.props.propagateSwipe === 'function'
                  ? this.props.propagateSwipe(evt, gestureState)
+@@ -418,7 +425,7 @@ export class ReactNativeModal extends React.Component {
+             }
+             // If there's no custom backdrop, handle presses with
+             // TouchableWithoutFeedback
+-            return (React.createElement(TouchableWithoutFeedback, { onPress: onBackdropPress }, backdropWrapper));
++            return (React.createElement(TouchableWithoutFeedback, { nativeID: 'modalBackdrop', onPress: onBackdropPress }, backdropWrapper));
+         };
+         const { animationIn, animationOut } = buildAnimations(extractAnimationFromProps(props));
+         this.animationIn = animationIn;
 @@ -454,9 +461,15 @@ export class ReactNativeModal extends React.Component {
              this.open();
          }

--- a/src/CONST.js
+++ b/src/CONST.js
@@ -400,6 +400,8 @@ const CONST = {
         FULL_COMPOSER_MIN_LINES: 3,
     },
     MODAL: {
+        // Defined on react-native-modal (as a patch)
+        BACKDROP_NATIVE_ID: 'modalBackdrop',
         MODAL_TYPE: {
             CONFIRM: 'confirm',
             CENTERED: 'centered',

--- a/src/pages/home/report/ReportActionItemMessageEdit.js
+++ b/src/pages/home/report/ReportActionItemMessageEdit.js
@@ -260,15 +260,19 @@ class ReportActionItemMessageEdit extends React.Component {
                         onBlur={(event) => {
                             this.setState({isFocused: false});
                             const relatedTargetId = lodashGet(event, 'nativeEvent.relatedTarget.id');
+                            const relatedTargetIdsToIgnore = [
+                                this.saveButtonID,
+                                this.cancelButtonID,
+                                this.emojiButtonID,
+                                this.messageEditInput,
+                                CONST.MODAL.BACKDROP_NATIVE_ID,
+                            ];
 
                             // Return to prevent re-render when save/cancel button is pressed which cancels the onPress event by re-rendering
-                            if (_.contains([this.saveButtonID, this.cancelButtonID, this.emojiButtonID], relatedTargetId)) {
+                            if (_.contains(relatedTargetIdsToIgnore, relatedTargetId)) {
                                 return;
                             }
 
-                            if (this.messageEditInput === relatedTargetId) {
-                                return;
-                            }
                             openReportActionComposeViewWhenClosingMessageEdit(this.props.isSmallScreenWidth);
                         }}
                         selection={this.state.selection}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Early return if the related target of the Edit Composer blur event is the modal.

### Fixed Issues
$ https://github.com/Expensify/App/issues/15105   
PROPOSAL: https://github.com/Expensify/App/issues/15105#issuecomment-1452240699


### Tests
1. Login to any account
2. Go to any chat
3. Long press on any message that you sent
4. Select "Edit comment"
4. Long press on any other message that you sent
5. Verify that none of the options have a blue frame

- [ ] Verify that no errors appear in the JS console

### Offline tests
n/a

### QA Steps
1. Login to any account
2. Go to any chat
3. Long press on any message that you sent
4. Select "Edit comment"
4. Long press on any other message that you sent
5. Verify that none of the options have a blue frame

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android / native
    - [X] Android / Chrome
    - [X] iOS / native
    - [X] iOS / Safari
    - [X] MacOS / Chrome / Safari
    - [X] MacOS / Desktop
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [X] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [X] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If a new component is created I verified that:
    - [X] A similar component doesn't exist in the codebase
    - [X] All props are defined accurately and each prop has a `/** comment above it */`
    - [X] The file is named correctly
    - [X] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [X] The only data being stored in the state is data necessary for rendering and nothing else
    - [X] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [X] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [X] All JSX used for rendering exists in the render method
    - [X] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [X] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>


https://user-images.githubusercontent.com/16493223/226777308-7e406d69-a817-4f62-973e-96513ccfba90.mp4


</details>

<details>
<summary>Mobile Web - Chrome</summary>


https://user-images.githubusercontent.com/16493223/226777296-5172f6ca-de08-4ac9-b8ca-0f754a6d1126.mp4


</details>

<details>
<summary>Mobile Web - Safari</summary>


https://user-images.githubusercontent.com/16493223/226777273-3ceb8066-fbc8-428e-85d9-1bb9d60f4c98.mp4


</details>

<details>
<summary>Desktop</summary>


https://user-images.githubusercontent.com/16493223/226777263-db7383b4-241a-4766-8af6-0eddfb847c8f.mp4


</details>

<details>
<summary>iOS</summary>


https://user-images.githubusercontent.com/16493223/226777246-b09dd171-0795-4f9a-983c-6060705f3e2e.mp4


</details>

<details>
<summary>Android</summary>


https://user-images.githubusercontent.com/16493223/226777047-f775bd9a-e293-46ee-996a-8755e4a025cc.mp4


</details>
