### PR TITLE
[HOLD] Revert "Merge pull request #15646 from tienifr/fix/15438-maintain-whi…

### DIFF
--- a/src/components/DisplayNames/index.js
+++ b/src/components/DisplayNames/index.js
@@ -71,7 +71,7 @@ class DisplayNames extends PureComponent {
             // No need for any complex text-splitting, just return a simple Text component
             return (
                 <Text
-                    style={[...this.props.textStyles, (this.props.numberOfLines === 1 ? styles.pre : styles.preWrap)]}
+                    style={this.props.textStyles}
                     numberOfLines={this.props.numberOfLines}
                 >
                     {this.props.fullTitle}
@@ -100,7 +100,7 @@ class DisplayNames extends PureComponent {
                             >
                                 {/*  // We need to get the refs to all the names which will be used to correct
                                     the horizontal position of the tooltip */}
-                                <Text ref={el => this.childRefs[index] = el} style={[...this.props.textStyles, styles.preWrap]}>
+                                <Text ref={el => this.childRefs[index] = el} style={this.props.textStyles}>
                                     {displayName}
                                 </Text>
                             </Tooltip>

--- a/src/components/HTMLEngineProvider/BaseHTMLEngineProvider.js
+++ b/src/components/HTMLEngineProvider/BaseHTMLEngineProvider.js
@@ -44,10 +44,6 @@ const customHTMLElementModels = {
         tagName: 'email-comment',
         mixedUAStyles: {whiteSpace: 'normal'},
     }),
-    strong: defaultHTMLElementModels.span.extend({
-        tagName: 'strong',
-        mixedUAStyles: {whiteSpace: 'pre'},
-    }),
 };
 
 const defaultViewProps = {style: [styles.alignItemsStart, styles.userSelectText]};

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -34,7 +34,7 @@ const Header = props => (
             </Text>
             {/* If there's no subtitle then display a fragment to avoid an empty space which moves the main title */}
             {_.isString(props.subtitle)
-                ? Boolean(props.subtitle) && <Text style={[styles.mutedTextLabel, styles.pre]} numberOfLines={1}>{props.subtitle}</Text>
+                ? Boolean(props.subtitle) && <Text style={[styles.mutedTextLabel]} numberOfLines={1}>{props.subtitle}</Text>
                 : props.subtitle}
         </View>
         {props.shouldShowEnvironmentBadge && (

--- a/src/components/LHNOptionsList/OptionRowLHN.js
+++ b/src/components/LHNOptionsList/OptionRowLHN.js
@@ -68,13 +68,13 @@ const OptionRowLHN = (props) => {
         : styles.sidebarLinkText;
     const textUnreadStyle = optionItem.isUnread
         ? [textStyle, styles.sidebarLinkTextBold] : [textStyle];
-    const displayNameStyle = StyleUtils.combineStyles([styles.optionDisplayName, styles.optionDisplayNameCompact, styles.pre, ...textUnreadStyle], props.style);
+    const displayNameStyle = StyleUtils.combineStyles([styles.optionDisplayName, styles.optionDisplayNameCompact, ...textUnreadStyle], props.style);
     const textPillStyle = props.isFocused
         ? [styles.ml1, StyleUtils.getBackgroundColorWithOpacityStyle(themeColors.icon, 0.5)]
         : [styles.ml1];
     const alternateTextStyle = StyleUtils.combineStyles(props.viewMode === CONST.OPTION_MODE.COMPACT
-        ? [textStyle, styles.optionAlternateText, styles.pre, styles.textLabelSupporting, styles.optionAlternateTextCompact, styles.ml2]
-        : [textStyle, styles.optionAlternateText, styles.pre, styles.textLabelSupporting], props.style);
+        ? [textStyle, styles.optionAlternateText, styles.textLabelSupporting, styles.optionAlternateTextCompact, styles.ml2]
+        : [textStyle, styles.optionAlternateText, styles.textLabelSupporting], props.style);
     const contentContainerStyles = props.viewMode === CONST.OPTION_MODE.COMPACT
         ? [styles.flex1, styles.flexRow, styles.overflowHidden, optionRowStyles.compactContentContainerStyles]
         : [styles.flex1];

--- a/src/components/MenuItem.js
+++ b/src/components/MenuItem.js
@@ -58,7 +58,6 @@ const MenuItem = (props) => {
         (props.icon ? styles.ml3 : undefined),
         (props.shouldShowBasicTitle ? undefined : styles.textStrong),
         (props.interactive && props.disabled ? {...styles.disabledText, ...styles.userSelectNone} : undefined),
-        styles.pre,
     ], props.style);
     const descriptionTextStyle = StyleUtils.combineStyles([
         styles.textLabelSupporting,

--- a/src/components/OptionRow.js
+++ b/src/components/OptionRow.js
@@ -118,8 +118,8 @@ class OptionRow extends Component {
             : styles.sidebarLinkText;
         const textUnreadStyle = (this.props.boldStyle || this.props.option.boldStyle)
             ? [textStyle, styles.sidebarLinkTextBold] : [textStyle];
-        const displayNameStyle = StyleUtils.combineStyles(styles.optionDisplayName, textUnreadStyle, this.props.style, styles.pre);
-        const alternateTextStyle = StyleUtils.combineStyles(textStyle, styles.optionAlternateText, styles.textLabelSupporting, this.props.style, styles.pre);
+        const displayNameStyle = StyleUtils.combineStyles(styles.optionDisplayName, textUnreadStyle, this.props.style);
+        const alternateTextStyle = StyleUtils.combineStyles(textStyle, styles.optionAlternateText, styles.textLabelSupporting, this.props.style);
         const contentContainerStyles = [styles.flex1];
         const sidebarInnerRowStyle = StyleSheet.flatten([
             styles.chatLinkRowPressable,

--- a/src/pages/DetailsPage.js
+++ b/src/pages/DetailsPage.js
@@ -147,7 +147,7 @@ class DetailsPage extends React.PureComponent {
                                     )}
                                 </AttachmentModal>
                                 {details.displayName && (
-                                    <Text style={[styles.textHeadline, styles.mb6, styles.pre]} numberOfLines={1}>
+                                    <Text style={[styles.textHeadline, styles.mb6]} numberOfLines={1}>
                                         {isSMSLogin ? this.props.toLocalPhone(details.displayName) : details.displayName}
                                     </Text>
                                 )}

--- a/src/pages/ReportDetailsPage.js
+++ b/src/pages/ReportDetailsPage.js
@@ -139,7 +139,7 @@ class ReportDetailsPage extends Component {
                                             displayNamesWithTooltips={displayNamesWithTooltips}
                                             tooltipEnabled
                                             numberOfLines={1}
-                                            textStyles={[styles.textHeadline, styles.mb2, styles.textAlignCenter, styles.pre]}
+                                            textStyles={[styles.textHeadline, styles.mb2, styles.textAlignCenter]}
                                             shouldUseFullTitle={isChatRoom || isPolicyExpenseChat}
                                         />
                                     </View>
@@ -149,7 +149,6 @@ class ReportDetailsPage extends Component {
                                             styles.optionAlternateText,
                                             styles.textLabelSupporting,
                                             styles.mb2,
-                                            styles.pre,
                                         ]}
                                         numberOfLines={1}
                                     >

--- a/src/pages/ReportSettingsPage.js
+++ b/src/pages/ReportSettingsPage.js
@@ -192,7 +192,7 @@ class ReportSettingsPage extends Component {
                                                     <Text style={[styles.textLabelSupporting, styles.lh16, styles.mb1]} numberOfLines={1}>
                                                         {this.props.translate('newRoomPage.roomName')}
                                                     </Text>
-                                                    <Text numberOfLines={1} style={[styles.optionAlternateText, styles.pre]}>
+                                                    <Text numberOfLines={1} style={[styles.optionAlternateText]}>
                                                         {this.props.report.reportName}
                                                     </Text>
                                                 </View>
@@ -213,7 +213,7 @@ class ReportSettingsPage extends Component {
                                 <Text style={[styles.textLabelSupporting, styles.lh16, styles.mb1]} numberOfLines={1}>
                                     {this.props.translate('workspace.common.workspace')}
                                 </Text>
-                                <Text numberOfLines={1} style={[styles.optionAlternateText, styles.pre]}>
+                                <Text numberOfLines={1} style={[styles.optionAlternateText]}>
                                     {linkedWorkspace.name}
                                 </Text>
                             </View>

--- a/src/pages/home/HeaderView.js
+++ b/src/pages/home/HeaderView.js
@@ -123,7 +123,7 @@ const HeaderView = (props) => {
                                     displayNamesWithTooltips={displayNamesWithTooltips}
                                     tooltipEnabled
                                     numberOfLines={1}
-                                    textStyles={[styles.headerText, styles.pre]}
+                                    textStyles={[styles.headerText, styles.textNoWrap]}
                                     shouldUseFullTitle={isChatRoom || isPolicyExpenseChat}
                                 />
                                 {(isChatRoom || isPolicyExpenseChat) && (
@@ -132,7 +132,6 @@ const HeaderView = (props) => {
                                             styles.sidebarLinkText,
                                             styles.optionAlternateText,
                                             styles.textLabelSupporting,
-                                            styles.pre,
                                         ]}
                                         numberOfLines={1}
                                     >

--- a/src/pages/home/report/ParticipantLocalTime.js
+++ b/src/pages/home/report/ParticipantLocalTime.js
@@ -65,7 +65,6 @@ class ParticipantLocalTime extends PureComponent {
                     style={[
                         styles.chatItemComposeSecondaryRowSubText,
                         styles.chatItemComposeSecondaryRowOffset,
-                        styles.pre,
                     ]}
                     numberOfLines={1}
                 >

--- a/src/pages/home/report/ReportActionItemFragment.js
+++ b/src/pages/home/report/ReportActionItemFragment.js
@@ -140,7 +140,7 @@ const ReportActionItemFragment = (props) => {
                 <Tooltip text={props.tooltipText}>
                     <Text
                         numberOfLines={props.isSingleLine ? 1 : undefined}
-                        style={[styles.chatItemMessageHeaderSender, (props.isSingleLine ? styles.pre : styles.preWrap)]}
+                        style={[styles.chatItemMessageHeaderSender]}
                     >
                         {Str.htmlDecode(props.fragment.text)}
                     </Text>

--- a/src/pages/settings/InitialSettingsPage.js
+++ b/src/pages/settings/InitialSettingsPage.js
@@ -274,7 +274,7 @@ class InitialSettingsPage extends React.Component {
 
                                     <Pressable style={[styles.mt1, styles.mw100]} onPress={this.openProfileSettings}>
                                         <Tooltip text={this.props.translate('common.profile')}>
-                                            <Text style={[styles.textHeadline, styles.pre]} numberOfLines={1}>
+                                            <Text style={[styles.textHeadline]} numberOfLines={1}>
                                                 {this.props.currentUserPersonalDetails.displayName
                                                     ? this.props.currentUserPersonalDetails.displayName
                                                     : Str.removeSMSDomain(this.props.session.email)}

--- a/src/pages/workspace/WorkspaceInitialPage.js
+++ b/src/pages/workspace/WorkspaceInitialPage.js
@@ -220,7 +220,6 @@ class WorkspaceInitialPage extends React.Component {
                                                             style={[
                                                                 styles.textHeadline,
                                                                 styles.alignSelfCenter,
-                                                                styles.pre,
                                                             ]}
                                                         >
                                                             {this.props.policy.name}

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -323,7 +323,6 @@ const styles = {
 
     textHeadline: {
         ...headlineFont,
-        ...whiteSpace.preWrap,
         color: themeColors.heading,
         fontSize: variables.fontSizeXLarge,
     },
@@ -2915,7 +2914,6 @@ const styles = {
         flexShrink: 0,
         maxWidth: variables.badgeMaxWidth,
         fontSize: variables.fontSizeSmall,
-        ...whiteSpace.pre,
         ...spacing.ph2,
     },
 

--- a/src/styles/utilities/whiteSpace/index.js
+++ b/src/styles/utilities/whiteSpace/index.js
@@ -5,7 +5,4 @@ export default {
     preWrap: {
         whiteSpace: 'pre-wrap',
     },
-    pre: {
-        whiteSpace: 'pre',
-    },
 };


### PR DESCRIPTION
…te-space-in-display-name"

This reverts commit 5a0c876fabbccf8279eb5483c92997f565633267, reversing changes made to 80ad4132102d03798abc4ac1c0d08696a507db36.

### Details
Reverts https://github.com/Expensify/App/pull/15646 to solve deploy blockers

### Fixed Issues
$ https://github.com/Expensify/App/issues/16376
$ https://github.com/Expensify/App/issues/16371   
PROPOSAL: N/a


### Tests
1. Create a new group chat with 8 users
2. _Verify_ the names in the header do not overflow
- [x] Verify that no errors appear in the JS console

### Offline tests
Same as tests

### QA Steps
1. Create a new group chat with 8 users
2. _Verify_ the names in the header do not overflow
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<img width="660" alt="image" src="https://user-images.githubusercontent.com/22447860/226970568-eb3ded56-5f02-44fa-b995-490c3dc3e984.png">

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<img width="525" alt="image" src="https://user-images.githubusercontent.com/22447860/226973513-f1c2902f-5970-4e6f-8ec6-1138472ab19b.png">
</details>

<details>
<summary>Mobile Web - Safari</summary>

<img width="420" alt="image" src="https://user-images.githubusercontent.com/22447860/226973146-cd174c76-adb2-4a81-8770-85d4750a89f6.png">
</details>

<details>
<summary>Desktop</summary>

<img width="831" alt="image" src="https://user-images.githubusercontent.com/22447860/226970667-48c98dca-42ca-484d-8d2c-f0d51ec62ebf.png">
</details>

<details>
<summary>iOS</summary>

<img width="414" alt="image" src="https://user-images.githubusercontent.com/22447860/226972795-74473aaf-1c2a-46ec-ae8c-9dd18b3f40e7.png">

</details>

<details>
<summary>Android</summary>

<img width="508" alt="image" src="https://user-images.githubusercontent.com/22447860/226973349-06afad29-f962-4bb0-be01-028930dfa3af.png">
</details>
