### PR TITLE
fix: tab behaviour in selecting from emoji menu and fix console error

### DIFF
--- a/src/components/EmojiPicker/CategoryShortcutButton.js
+++ b/src/components/EmojiPicker/CategoryShortcutButton.js
@@ -44,6 +44,7 @@ class CategoryShortcutButton extends PureComponent {
                 ])}
             >
                 <Tooltip
+                    focusable={false}
                     containerStyles={[styles.flex1, styles.alignSelfStretch, styles.alignItemsCenter, styles.justifyContentCenter]}
                     text={this.props.translate(`emojiPicker.headers.${this.props.code}`)}
                     shiftVertical={-4}

--- a/src/components/EmojiPicker/EmojiPickerMenu/index.js
+++ b/src/components/EmojiPicker/EmojiPickerMenu/index.js
@@ -88,6 +88,7 @@ class EmojiPickerMenu extends Component {
 
         this.currentScrollOffset = 0;
         this.firstNonHeaderIndex = 0;
+        this.isShiftKeyPressed = false;
 
         this.state = {
             filteredEmojis: this.emojis,
@@ -166,9 +167,24 @@ class EmojiPickerMenu extends Component {
                 return;
             }
 
-            // Let the tab logic and enter logic execute the default behavior,
-            // necessary for tab cycling and pressing enter on the focused element
+            // Handles the logic regarding tab focus logic when passing from the
+            // emoji list to the header list
+            if (keyBoardEvent.key === 'Tab' && this.isShiftKeyPressed) {
+                if (this.state.highlightedIndex <= this.firstNonHeaderIndex) {
+                    this.setState({highlightedIndex: -1});
+                }
+                return;
+            }
+
+            // Saves the shift key press state so that it can be used to handle the
+            // tab focus logic
+            if (keyBoardEvent.key === 'Shift') {
+                this.isShiftKeyPressed = true;
+            }
+
+            // Save the key and return so that the default behaviour can be executed
             if (keyBoardEvent.key === 'Tab' || keyBoardEvent.key === 'Shift' || keyBoardEvent.key === 'Enter') {
+                this.previousKey = keyBoardEvent.key;
                 return;
             }
 
@@ -182,9 +198,17 @@ class EmojiPickerMenu extends Component {
             }
         };
 
+        this.keyUpHandler = (keyBoardEvent) => {
+            if (keyBoardEvent.key !== 'Shift') {
+                return;
+            }
+            this.isShiftKeyPressed = false;
+        };
+
         // Keyboard events are not bubbling on TextInput in RN-Web, Bubbling was needed for this event to trigger
         // event handler attached to document root. To fix this, trigger event handler in Capture phase.
         document.addEventListener('keydown', this.keyDownHandler, true);
+        document.addEventListener('keyup', this.keyUpHandler, true);
 
         // Re-enable pointer events and hovering over EmojiPickerItems when the mouse moves
         this.mouseMoveHandler = () => {
@@ -219,6 +243,7 @@ class EmojiPickerMenu extends Component {
             return;
         }
 
+        document.removeEventListener('keyup', this.keyUpHandler, true);
         document.removeEventListener('keydown', this.keyDownHandler, true);
         document.removeEventListener('mousemove', this.mouseMoveHandler);
     }

--- a/src/components/EmojiPicker/EmojiPickerMenu/index.js
+++ b/src/components/EmojiPicker/EmojiPickerMenu/index.js
@@ -474,7 +474,7 @@ class EmojiPickerMenu extends Component {
                 onFocus={() => this.setState({highlightedIndex: index})}
                 onBlur={() => this.setState(prevState => ({
                     // Only clear the highlighted index if the highlighted index is the same,
-                    // meaning that the focus changed to a element that is not an emoji item.
+                    // meaning that the focus changed to an element that is not an emoji item.
                     highlightedIndex: prevState.highlightedIndex === index ? -1 : prevState.highlightedIndex,
                 }))}
                 isFocused={isEmojiFocused}

--- a/src/components/EmojiPicker/EmojiPickerMenu/index.js
+++ b/src/components/EmojiPicker/EmojiPickerMenu/index.js
@@ -88,7 +88,6 @@ class EmojiPickerMenu extends Component {
 
         this.currentScrollOffset = 0;
         this.firstNonHeaderIndex = 0;
-        this.isShiftKeyPressed = false;
 
         this.state = {
             filteredEmojis: this.emojis,
@@ -167,24 +166,9 @@ class EmojiPickerMenu extends Component {
                 return;
             }
 
-            // Handles the logic regarding tab focus logic when passing from the
-            // emoji list to the header list
-            if (keyBoardEvent.key === 'Tab' && this.isShiftKeyPressed) {
-                if (this.state.highlightedIndex <= this.firstNonHeaderIndex) {
-                    this.setState({highlightedIndex: -1});
-                }
-                return;
-            }
-
-            // Saves the shift key press state so that it can be used to handle the
-            // tab focus logic
-            if (keyBoardEvent.key === 'Shift') {
-                this.isShiftKeyPressed = true;
-            }
-
-            // Save the key and return so that the default behaviour can be executed
+            // Return if the key is related to any tab cycling event so that the default logic
+            // can be executed.
             if (keyBoardEvent.key === 'Tab' || keyBoardEvent.key === 'Shift' || keyBoardEvent.key === 'Enter') {
-                this.previousKey = keyBoardEvent.key;
                 return;
             }
 
@@ -198,17 +182,9 @@ class EmojiPickerMenu extends Component {
             }
         };
 
-        this.keyUpHandler = (keyBoardEvent) => {
-            if (keyBoardEvent.key !== 'Shift') {
-                return;
-            }
-            this.isShiftKeyPressed = false;
-        };
-
         // Keyboard events are not bubbling on TextInput in RN-Web, Bubbling was needed for this event to trigger
         // event handler attached to document root. To fix this, trigger event handler in Capture phase.
         document.addEventListener('keydown', this.keyDownHandler, true);
-        document.addEventListener('keyup', this.keyUpHandler, true);
 
         // Re-enable pointer events and hovering over EmojiPickerItems when the mouse moves
         this.mouseMoveHandler = () => {
@@ -243,7 +219,6 @@ class EmojiPickerMenu extends Component {
             return;
         }
 
-        document.removeEventListener('keyup', this.keyUpHandler, true);
         document.removeEventListener('keydown', this.keyDownHandler, true);
         document.removeEventListener('mousemove', this.mouseMoveHandler);
     }
@@ -496,6 +471,11 @@ class EmojiPickerMenu extends Component {
                 }}
                 emoji={emojiCode}
                 onFocus={() => this.setState({highlightedIndex: index})}
+                onBlur={() => this.setState(prevState => ({
+                    // Only clear the highlighted index if the highlighted index is the same,
+                    // meaning that the focus changed to a element that is not an emoji item.
+                    highlightedIndex: prevState.highlightedIndex === index ? -1 : prevState.highlightedIndex,
+                }))}
                 isFocused={isEmojiFocused}
                 isHighlighted={index === this.state.highlightedIndex}
                 isUsingKeyboardMovement={this.state.isUsingKeyboardMovement}

--- a/src/components/EmojiPicker/EmojiPickerMenu/index.js
+++ b/src/components/EmojiPicker/EmojiPickerMenu/index.js
@@ -457,6 +457,8 @@ class EmojiPickerMenu extends Component {
             ? types[this.props.preferredSkinTone]
             : code;
 
+        const isEmojiFocused = index === this.state.highlightedIndex && this.state.isUsingKeyboardMovement;
+
         return (
             <EmojiPickerMenuItem
                 onPress={emoji => this.addToFrequentAndSelectEmoji(emoji, item)}
@@ -469,7 +471,7 @@ class EmojiPickerMenu extends Component {
                 }}
                 emoji={emojiCode}
                 onFocus={() => this.setState({highlightedIndex: index})}
-                isFocused={index === this.state.highlightedIndex && this.state.isUsingKeyboardMovement}
+                isFocused={isEmojiFocused}
                 isHighlighted={index === this.state.highlightedIndex}
                 isUsingKeyboardMovement={this.state.isUsingKeyboardMovement}
             />

--- a/src/components/EmojiPicker/EmojiPickerMenu/index.js
+++ b/src/components/EmojiPicker/EmojiPickerMenu/index.js
@@ -169,6 +169,7 @@ class EmojiPickerMenu extends Component {
             // Return if the key is related to any tab cycling event so that the default logic
             // can be executed.
             if (keyBoardEvent.key === 'Tab' || keyBoardEvent.key === 'Shift' || keyBoardEvent.key === 'Enter') {
+                this.setState({isUsingKeyboardMovement: true});
                 return;
             }
 

--- a/src/components/EmojiPicker/EmojiPickerMenu/index.js
+++ b/src/components/EmojiPicker/EmojiPickerMenu/index.js
@@ -166,6 +166,12 @@ class EmojiPickerMenu extends Component {
                 return;
             }
 
+            // Let the tab logic and enter logic execute the default behavior,
+            // necessary for tab cycling and pressing enter on the focused element
+            if (keyBoardEvent.key === 'Tab' || keyBoardEvent.key === 'Shift' || keyBoardEvent.key === 'Enter') {
+                return;
+            }
+
             // We allow typing in the search box if any key is pressed apart from Arrow keys.
             if (this.searchInput && !this.searchInput.isFocused()) {
                 this.setState({selectTextOnFocus: false});
@@ -462,6 +468,8 @@ class EmojiPickerMenu extends Component {
                     this.setState({highlightedIndex: -1});
                 }}
                 emoji={emojiCode}
+                onFocus={() => this.setState({highlightedIndex: index})}
+                isFocused={index === this.state.highlightedIndex && this.state.isUsingKeyboardMovement}
                 isHighlighted={index === this.state.highlightedIndex}
                 isUsingKeyboardMovement={this.state.isUsingKeyboardMovement}
             />

--- a/src/components/EmojiPicker/EmojiPickerMenuItem.js
+++ b/src/components/EmojiPicker/EmojiPickerMenuItem.js
@@ -22,6 +22,9 @@ const propTypes = {
     /** Handles what to do when the pressable is focused */
     onFocus: PropTypes.func,
 
+    /** Handles what to do when the pressable is blurred */
+    onBlur: PropTypes.func,
+
     /** Whether this menu item is currently highlighted or not */
     isHighlighted: PropTypes.bool,
 
@@ -63,6 +66,7 @@ class EmojiPickerMenuItem extends PureComponent {
                 onHoverIn={this.props.onHoverIn}
                 onHoverOut={this.props.onHoverOut}
                 onFocus={this.props.onFocus}
+                onBlur={this.props.onBlur}
                 ref={ref => this.ref = ref}
                 style={({
                     pressed,
@@ -89,6 +93,7 @@ EmojiPickerMenuItem.defaultProps = {
     onHoverIn: () => {},
     onHoverOut: () => {},
     onFocus: () => {},
+    onBlur: () => {},
 };
 
 // Significantly speeds up re-renders of the EmojiPickerMenu's FlatList

--- a/src/components/EmojiPicker/EmojiPickerMenuItem.js
+++ b/src/components/EmojiPicker/EmojiPickerMenuItem.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {Pressable} from 'react-native';
 import styles from '../../styles/styles';
@@ -32,40 +32,56 @@ const propTypes = {
     isUsingKeyboardMovement: PropTypes.bool,
 };
 
-const EmojiPickerMenuItem = (props) => {
-    const ref = React.createRef();
+class EmojiPickerMenuItem extends PureComponent {
+    constructor(props) {
+        super(props);
 
-    React.useEffect(() => {
-        if (!props.isFocused) {
+        this.ref = null;
+    }
+
+    componentDidMount() {
+        if (!this.props.isFocused) {
             return;
         }
-        ref.current.focus();
-    }, [props.isFocused]);
+        this.ref.focus();
+    }
 
-    return (
-        <Pressable
-            onPress={() => props.onPress(props.emoji)}
-            onHoverIn={props.onHoverIn}
-            onHoverOut={props.onHoverOut}
-            onFocus={props.onFocus}
-            ref={ref}
-            style={({
-                pressed,
-            }) => ([
-                StyleUtils.getButtonBackgroundColorStyle(getButtonState(false, pressed)),
-                props.isHighlighted && props.isUsingKeyboardMovement ? styles.emojiItemKeyboardHighlighted : {},
-                props.isHighlighted && !props.isUsingKeyboardMovement ? styles.emojiItemHighlighted : {},
-                styles.emojiItem,
-            ])}
-        >
-            <Text style={[styles.emojiText]}>
-                {props.emoji}
-            </Text>
-        </Pressable>
-    );
-};
+    componentDidUpdate(prevProps) {
+        if (prevProps.isFocused === this.props.isFocused) {
+            return;
+        }
+        if (!this.props.isFocused) {
+            return;
+        }
+        this.ref.focus();
+    }
+
+    render() {
+        return (
+            <Pressable
+                onPress={() => this.props.onPress(this.props.emoji)}
+                onHoverIn={this.props.onHoverIn}
+                onHoverOut={this.props.onHoverOut}
+                onFocus={this.props.onFocus}
+                ref={ref => this.ref = ref}
+                style={({
+                    pressed,
+                }) => ([
+                    StyleUtils.getButtonBackgroundColorStyle(getButtonState(false, pressed)),
+                    this.props.isHighlighted && this.props.isUsingKeyboardMovement ? styles.emojiItemKeyboardHighlighted : {},
+                    this.props.isHighlighted && !this.props.isUsingKeyboardMovement ? styles.emojiItemHighlighted : {},
+                    styles.emojiItem,
+                ])}
+            >
+                <Text style={[styles.emojiText]}>
+                    {this.props.emoji}
+                </Text>
+            </Pressable>
+        );
+    }
+}
+
 EmojiPickerMenuItem.propTypes = propTypes;
-EmojiPickerMenuItem.displayName = 'EmojiPickerMenuItem';
 EmojiPickerMenuItem.defaultProps = {
     isHighlighted: false,
     isFocused: false,

--- a/src/components/EmojiPicker/EmojiPickerMenuItem.js
+++ b/src/components/EmojiPicker/EmojiPickerMenuItem.js
@@ -19,40 +19,60 @@ const propTypes = {
     /** Handles what to do when the hover is out */
     onHoverOut: PropTypes.func,
 
+    /** Handles what to do when the pressable is focused */
+    onFocus: PropTypes.func,
+
     /** Whether this menu item is currently highlighted or not */
     isHighlighted: PropTypes.bool,
+
+    /** Whether this menu item is currently focused or not */
+    isFocused: PropTypes.bool,
 
     /** Whether the emoji is highlighted by the keyboard/mouse */
     isUsingKeyboardMovement: PropTypes.bool,
 };
 
-const EmojiPickerMenuItem = props => (
-    <Pressable
-        onPress={() => props.onPress(props.emoji)}
-        onHoverIn={props.onHoverIn}
-        onHoverOut={props.onHoverOut}
-        style={({
-            pressed,
-        }) => ([
-            StyleUtils.getButtonBackgroundColorStyle(getButtonState(false, pressed)),
-            props.isHighlighted && props.isUsingKeyboardMovement ? styles.emojiItemKeyboardHighlighted : {},
-            props.isHighlighted && !props.isUsingKeyboardMovement ? styles.emojiItemHighlighted : {},
-            styles.emojiItem,
-        ])}
-    >
-        <Text style={[styles.emojiText]}>
-            {props.emoji}
-        </Text>
-    </Pressable>
+const EmojiPickerMenuItem = (props) => {
+    const ref = React.createRef();
 
-);
+    React.useEffect(() => {
+        if (!props.isFocused) {
+            return;
+        }
+        ref.current.focus();
+    }, [props.isFocused]);
+
+    return (
+        <Pressable
+            onPress={() => props.onPress(props.emoji)}
+            onHoverIn={props.onHoverIn}
+            onHoverOut={props.onHoverOut}
+            onFocus={props.onFocus}
+            ref={ref}
+            style={({
+                pressed,
+            }) => ([
+                StyleUtils.getButtonBackgroundColorStyle(getButtonState(false, pressed)),
+                props.isHighlighted && props.isUsingKeyboardMovement ? styles.emojiItemKeyboardHighlighted : {},
+                props.isHighlighted && !props.isUsingKeyboardMovement ? styles.emojiItemHighlighted : {},
+                styles.emojiItem,
+            ])}
+        >
+            <Text style={[styles.emojiText]}>
+                {props.emoji}
+            </Text>
+        </Pressable>
+    );
+};
 EmojiPickerMenuItem.propTypes = propTypes;
 EmojiPickerMenuItem.displayName = 'EmojiPickerMenuItem';
 EmojiPickerMenuItem.defaultProps = {
     isHighlighted: false,
+    isFocused: false,
     isUsingKeyboardMovement: false,
     onHoverIn: () => {},
     onHoverOut: () => {},
+    onFocus: () => {},
 };
 
 // Significantly speeds up re-renders of the EmojiPickerMenu's FlatList


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

Fixes the tab cycling behaviour in the emoji menu (supports Tab and Shift+Tab) and removes a console error that happened when using it. Using arrow keys should work similar to before.

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/16348
https://github.com/Expensify/App/issues/16348#issuecomment-1479616603


### Tests

1. Enter the app using the browser or desktop
2. Open a chat and open the emoji menu
3. Try to select an emoji with arrow keys and the tab key (or Shift+Tab to go back)
4. Verify you can select the emojis by pressing enter once focused.

- [X] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Not applicable

### QA Steps

1. Enter the app using the browser or desktop
2. Open a chat and open the emoji menu
3. Try to select an emoji with arrow keys and the tab key (or Shift+Tab to go back)
4. Verify you can select the emojis by pressing enter once focused.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android / native
    - [X] Android / Chrome
    - [X] iOS / native
    - [X] iOS / Safari
    - [X] MacOS / Chrome / Safari
    - [X] MacOS / Desktop
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [X] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [X] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If a new component is created I verified that:
    - [X] A similar component doesn't exist in the codebase
    - [X] All props are defined accurately and each prop has a `/** comment above it */`
    - [X] The file is named correctly
    - [X] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [X] The only data being stored in the state is data necessary for rendering and nothing else
    - [X] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [X] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [X] All JSX used for rendering exists in the render method
    - [X] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [X] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://user-images.githubusercontent.com/25725586/226987444-45504792-8719-4770-b276-48448f49ef3e.mp4

</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://user-images.githubusercontent.com/25725586/226987523-0dc0a598-5dcd-48fe-8481-b853f4f18f45.mov

</details>

<details>
<summary>Mobile Web - Safari</summary>

https://user-images.githubusercontent.com/25725586/226987634-66c57fb8-c7c8-457a-a4e8-b87ee27ba279.mp4

</details>

<details>
<summary>Desktop</summary>

https://user-images.githubusercontent.com/25725586/226987906-356eef93-e449-4f41-84b2-f45a8dfe5370.mp4

</details>

<details>
<summary>iOS</summary>

https://user-images.githubusercontent.com/25725586/226987976-629e8671-48ad-4871-bb14-f54560d159ae.mov

</details>

<details>
<summary>Android</summary>

https://user-images.githubusercontent.com/25725586/226988034-c239bbcb-4593-4b54-aced-a63b79697e28.mov

</details>
