### PR TITLE
fix-15877: add disabled state styles to Picker

### DIFF
--- a/src/components/Picker/Picker.js
+++ b/src/components/Picker/Picker.js
@@ -78,12 +78,16 @@ const propTypes = {
 
     /** Additional events passed to the core Picker for specific platforms such as web */
     additionalPickerEvents: PropTypes.func,
+
+    /** Hint text that appears below the picker */
+    hintText: PropTypes.string,
 };
 
 const defaultProps = {
     label: '',
     isDisabled: false,
     errorText: '',
+    hintText: '',
     containerStyles: [],
     backgroundColor: undefined,
     inputID: undefined,
@@ -172,6 +176,27 @@ class Picker extends PureComponent {
     render() {
         const hasError = !_.isEmpty(this.props.errorText);
 
+        if (this.props.isDisabled) {
+            return (
+                <View>
+                    {this.props.label && (
+                        <Text style={[styles.textLabelSupporting, styles.mb1]} numberOfLines={1}>
+                            {this.props.label}
+                        </Text>
+                    )}
+                    <Text numberOfLines={1}>
+                        {this.props.value}
+                    </Text>
+                    {this.props.hintText
+                    && (
+                        <Text style={[styles.textLabel, styles.colorMuted, styles.mt2]}>
+                            {this.props.hintText}
+                        </Text>
+                    )}
+                </View>
+            );
+        }
+
         return (
             <>
                 <View
@@ -230,6 +255,12 @@ class Picker extends PureComponent {
                     />
                 </View>
                 <FormHelpMessage message={this.props.errorText} />
+                {this.props.hintText
+                    && (
+                        <Text style={[styles.textLabel, styles.colorMuted, styles.mt2]}>
+                            {this.props.hintText}
+                        </Text>
+                    )}
             </>
         );
     }

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -1023,6 +1023,7 @@ export default {
             nameIsRequiredError: 'You need to define a name for your workspace.',
             currencyInputLabel: 'Default currency',
             currencyInputHelpText: 'All expenses on this workspace will be converted to this currency.',
+            currencyInputDisabledText: 'The default currency cannot be changed because this workspace is linked to a business bank account.',
             save: 'Save',
             genericFailureMessage: 'An error occurred updating the workspace, please try again.',
             avatarUploadFailureMessage: 'An error occurred uploading the avatar, please try again.',

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -1023,7 +1023,7 @@ export default {
             nameIsRequiredError: 'You need to define a name for your workspace.',
             currencyInputLabel: 'Default currency',
             currencyInputHelpText: 'All expenses on this workspace will be converted to this currency.',
-            currencyInputDisabledText: 'The default currency cannot be changed because this workspace is linked to a business bank account.',
+            currencyInputDisabledText: 'The default currency can\'t be changed because this workspace is linked to a USD bank account.',
             save: 'Save',
             genericFailureMessage: 'An error occurred updating the workspace, please try again.',
             avatarUploadFailureMessage: 'An error occurred uploading the avatar, please try again.',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -1024,6 +1024,7 @@ export default {
             nameIsRequiredError: 'Debes definir un nombre para tu espacio de trabajo.',
             currencyInputLabel: 'Moneda por defecto',
             currencyInputHelpText: 'Todas los gastos en este espacio de trabajo serán convertidos a esta moneda.',
+            currencyInputDisabledText: 'La moneda predeterminada no se puede cambiar porque este espacio de trabajo está vinculado a una cuenta bancaria comercial.',
             save: 'Guardar',
             genericFailureMessage: 'Se produjo un error al guardar el espacio de trabajo. Por favor, inténtalo de nuevo.',
             avatarUploadFailureMessage: 'No se pudo subir el avatar. Por favor, inténtalo de nuevo.',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -1024,7 +1024,7 @@ export default {
             nameIsRequiredError: 'Debes definir un nombre para tu espacio de trabajo.',
             currencyInputLabel: 'Moneda por defecto',
             currencyInputHelpText: 'Todas los gastos en este espacio de trabajo serán convertidos a esta moneda.',
-            currencyInputDisabledText: 'La moneda predeterminada no se puede cambiar porque este espacio de trabajo está vinculado a una cuenta bancaria comercial.',
+            currencyInputDisabledText: 'La moneda predeterminada no se puede cambiar porque este espacio de trabajo está vinculado a una cuenta bancaria en USD.',
             save: 'Guardar',
             genericFailureMessage: 'Se produjo un error al guardar el espacio de trabajo. Por favor, inténtalo de nuevo.',
             avatarUploadFailureMessage: 'No se pudo subir el avatar. Por favor, inténtalo de nuevo.',

--- a/src/pages/workspace/WorkspaceSettingsPage.js
+++ b/src/pages/workspace/WorkspaceSettingsPage.js
@@ -6,7 +6,6 @@ import lodashGet from 'lodash/get';
 import ONYXKEYS from '../../ONYXKEYS';
 import withLocalize, {withLocalizePropTypes} from '../../components/withLocalize';
 import styles from '../../styles/styles';
-import Text from '../../components/Text';
 import compose from '../../libs/compose';
 import * as Policy from '../../libs/actions/Policy';
 import * as Expensicons from '../../components/Icon/Expensicons';
@@ -136,11 +135,9 @@ class WorkspaceSettingsPage extends React.Component {
                                     items={this.getCurrencyItems()}
                                     isDisabled={hasVBA}
                                     defaultValue={this.props.policy.outputCurrency}
+                                    hintText={this.props.translate('workspace.editor.currencyInputHelpText')}
                                 />
                             </View>
-                            <Text style={[styles.textLabel, styles.colorMuted, styles.mt2]}>
-                                {this.props.translate('workspace.editor.currencyInputHelpText')}
-                            </Text>
                         </OfflineWithFeedback>
                     </Form>
                 )}

--- a/src/pages/workspace/WorkspaceSettingsPage.js
+++ b/src/pages/workspace/WorkspaceSettingsPage.js
@@ -135,7 +135,11 @@ class WorkspaceSettingsPage extends React.Component {
                                     items={this.getCurrencyItems()}
                                     isDisabled={hasVBA}
                                     defaultValue={this.props.policy.outputCurrency}
-                                    hintText={this.props.translate('workspace.editor.currencyInputHelpText')}
+                                    hintText={
+                                        hasVBA
+                                            ? this.props.translate('workspace.editor.currencyInputDisabledText')
+                                            : this.props.translate('workspace.editor.currencyInputHelpText')
+                                    }
                                 />
                             </View>
                         </OfflineWithFeedback>

--- a/src/stories/Picker.stories.js
+++ b/src/stories/Picker.stories.js
@@ -31,6 +31,7 @@ const Default = Template.bind({});
 Default.args = {
     label: 'Default picker',
     name: 'Default',
+    hintText: 'Default hint text',
     items: [
         {
             label: 'Orange',
@@ -48,6 +49,7 @@ PickerWithValue.args = {
     label: 'Picker with defined value',
     name: 'Picker with defined value',
     value: 'apple',
+    hintText: 'Picker with hint text',
     items: [
         {
             label: 'Orange',
@@ -64,6 +66,7 @@ const ErrorStory = Template.bind({});
 ErrorStory.args = {
     label: 'Picker with error',
     name: 'PickerWithError',
+    hintText: 'Picker hint text',
     errorText: 'This field has an error.',
     items: [
         {
@@ -81,7 +84,9 @@ const Disabled = Template.bind({});
 Disabled.args = {
     label: 'Picker disabled',
     name: 'Disabled',
+    value: 'orange',
     isDisabled: true,
+    hintText: 'Picker hint text',
     items: [
         {
             label: 'Orange',


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR adds correct Picker styles for the disabled state as suggested by @shawnborton [here](https://github.com/Expensify/App/issues/15877#issuecomment-1476700892).

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/15877 
PROPOSAL: https://github.com/Expensify/App/issues/15877#issuecomment-1476800668


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Launch the app
2. Log in with expensifail account which has Control policy
3. Go to Settings - Workspace - Tap on Avatar
4. Check Workspace Settings
5. Verify that the default currency field is disabled and has styles matching [this](https://github.com/Expensify/App/issues/15877#issuecomment-1476700892) comment.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Launch the app
2. Log in with expensifail account which has Control policy
3. Go to Settings - Workspace - Tap on Avatar
4. Check Workspace Settings
5. Verify that the default currency field is disabled and has styles matching [this](https://github.com/Expensify/App/issues/15877#issuecomment-1476700892) comment.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>


<img width="1512" alt="Screenshot 2023-03-23 at 8 12 20 PM" src="https://user-images.githubusercontent.com/30054992/227254831-89906751-cedf-4544-a1f4-0b9e44d2d53a.png">


**Storybook**

<img width="750" alt="Screenshot 2023-03-24 at 7 38 17 PM" src="https://user-images.githubusercontent.com/30054992/227555967-48ee0731-df22-41fb-b3e8-eeedf4429bc0.png">

<img width="750" alt="Screenshot 2023-03-24 at 7 38 26 PM" src="https://user-images.githubusercontent.com/30054992/227555976-a9c8eb05-2305-4475-b2fb-0a1dc5be3518.png">

<img width="750" alt="Screenshot 2023-03-24 at 7 38 33 PM" src="https://user-images.githubusercontent.com/30054992/227555979-22774560-c70d-4c95-a600-198b0c77b920.png">

<img width="750" alt="Screenshot 2023-03-24 at 7 38 40 PM" src="https://user-images.githubusercontent.com/30054992/227555984-b52842d4-d189-46c4-951e-2917381d280b.png">

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<img width="371" alt="Screenshot 2023-03-23 at 8 21 33 PM" src="https://user-images.githubusercontent.com/30054992/227254996-ef891e9e-9f3b-4af9-adb5-0c27cacba54c.png">

</details>

<details>
<summary>Mobile Web - Safari</summary>

<img width="349" alt="Screenshot 2023-03-23 at 8 17 27 PM" src="https://user-images.githubusercontent.com/30054992/227255114-33c98379-c621-4b63-92f0-23eb5d37b996.png">

</details>

<details>
<summary>Desktop</summary>

<img width="1196" alt="Screenshot 2023-03-23 at 8 15 16 PM" src="https://user-images.githubusercontent.com/30054992/227255216-7df25a59-a071-4827-8033-e540fff1d4c2.png">

</details>

<details>
<summary>iOS</summary>

<img width="349" alt="Screenshot 2023-03-23 at 8 21 00 PM" src="https://user-images.githubusercontent.com/30054992/227255326-594c2fd8-42f2-44e4-9e67-de311cf1398a.png">

</details>

<details>
<summary>Android</summary>

<img width="371" alt="Screenshot 2023-03-23 at 8 26 20 PM" src="https://user-images.githubusercontent.com/30054992/227255395-51e6d187-439a-4d82-9e49-d40efc1b1efd.png">

</details>
