### PR TITLE
fix/16425: Using localize in new date picker

### DIFF
--- a/src/components/NewDatePicker/index.js
+++ b/src/components/NewDatePicker/index.js
@@ -9,8 +9,10 @@ import styles from '../../styles/styles';
 import * as Expensicons from '../Icon/Expensicons';
 import {propTypes as datePickerPropTypes, defaultProps as defaultDatePickerProps} from './datePickerPropTypes';
 import KeyboardShortcut from '../../libs/KeyboardShortcut';
+import withLocalize, {withLocalizePropTypes} from '../withLocalize';
 
 const propTypes = {
+    ...withLocalizePropTypes,
     ...datePickerPropTypes,
 };
 
@@ -127,7 +129,7 @@ class NewDatePicker extends React.Component {
                         label={this.props.label}
                         value={this.props.value || ''}
                         defaultValue={this.defaultValue}
-                        placeholder={this.props.placeholder || CONST.DATE.MOMENT_FORMAT_STRING}
+                        placeholder={this.props.placeholder || this.props.translate('common.dateFormat')}
                         errorText={this.props.errorText}
                         containerStyles={this.props.containerStyles}
                         textInputContainerStyles={this.state.isPickerVisible ? [styles.borderColorFocus] : []}
@@ -162,7 +164,8 @@ class NewDatePicker extends React.Component {
 NewDatePicker.propTypes = propTypes;
 NewDatePicker.defaultProps = datePickerDefaultProps;
 
-export default React.forwardRef((props, ref) => (
+export default
+withLocalize(React.forwardRef((props, ref) => (
     /* eslint-disable-next-line react/jsx-props-no-spreading */
     <NewDatePicker {...props} innerRef={ref} />
-));
+)));

--- a/src/components/NewDatePicker/index.js
+++ b/src/components/NewDatePicker/index.js
@@ -164,8 +164,7 @@ class NewDatePicker extends React.Component {
 NewDatePicker.propTypes = propTypes;
 NewDatePicker.defaultProps = datePickerDefaultProps;
 
-export default
-withLocalize(React.forwardRef((props, ref) => (
+export default withLocalize(React.forwardRef((props, ref) => (
     /* eslint-disable-next-line react/jsx-props-no-spreading */
     <NewDatePicker {...props} innerRef={ref} />
 )));


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Using localize in new date picker so that it can be displayed correctly in both English and Spainese
### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/16425
PROPOSAL: https://github.com/Expensify/App/issues/16425#issuecomment-1481039970


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Change the language to Spanish
2. Go to settings > Personal Information > Date of Birth and see that the date format is AAAA-MM-DD
3. Change the language to English
2. Go to settings > Personal Information > Date of Birth and see that the date format is YYYY-MM-DD

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
Same above
### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
4. Verify a modal appears displaying a preview of that image
--->
1. Change the language to Spanish
2. Go to settings > Personal Information > Date of Birth and see that the date format is AAAA-MM-DD
3. Change the language to English
2. Go to settings > Personal Information > Date of Birth and see that the date format is YYYY-MM-DD
- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>
<img width="1440" alt="Screen Shot 2023-03-23 at 23 38 22" src="https://user-images.githubusercontent.com/113963320/227274043-9b1dacc2-2105-4d10-af3a-b32f7278c1e4.png">
<img width="1440" alt="Screen Shot 2023-03-23 at 23 38 42" src="https://user-images.githubusercontent.com/113963320/227274058-d262f3bc-2a93-45c1-9628-57b56eb43083.png">

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>
<img width="315" alt="Screen Shot 2023-03-23 at 23 39 53" src="https://user-images.githubusercontent.com/113963320/227274112-165262cd-3446-4f77-a83f-a0b7bf7f11f6.png">
<img width="312" alt="Screen Shot 2023-03-23 at 23 40 11" src="https://user-images.githubusercontent.com/113963320/227274135-3ce74f16-92f2-474c-8553-755eabfa7f05.png">

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>
<img width="310" alt="Screen Shot 2023-03-23 at 23 39 10" src="https://user-images.githubusercontent.com/113963320/227274172-e3b234e2-e4ed-4000-af32-894703fd9fb6.png">
<img width="314" alt="Screen Shot 2023-03-23 at 23 39 38" src="https://user-images.githubusercontent.com/113963320/227274213-d26fb445-4f91-43d2-aafc-4f934bece163.png">

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>
<img width="1202" alt="Screen Shot 2023-03-23 at 23 41 52" src="https://user-images.githubusercontent.com/113963320/227274624-a594dc90-56c1-4fb5-8323-0f5dbd3400d1.png">
<img width="1190" alt="Screen Shot 2023-03-23 at 23 42 13" src="https://user-images.githubusercontent.com/113963320/227274636-368762f4-4bae-432f-93cf-26b69ea10a51.png">

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->
<img width="432" alt="Screen Shot 2023-03-24 at 00 04 14" src="https://user-images.githubusercontent.com/113963320/227280518-a20592bd-91fd-42ee-9f35-bb6020e7dad7.png">

<img width="402" alt="Screen Shot 2023-03-24 at 00 04 32" src="https://user-images.githubusercontent.com/113963320/227280543-7d6b7e7c-325f-4152-8cf9-8ac1fd40c5ef.png">
</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->
<img width="344" alt="Screen Shot 2023-03-24 at 00 20 46" src="https://user-images.githubusercontent.com/113963320/227286055-6ba6a511-8427-423e-8e95-2cf358a055c8.png">
<img width="386" alt="Screen Shot 2023-03-24 at 00 21 38" src="https://user-images.githubusercontent.com/113963320/227286065-c6dee821-52e1-4792-856a-0cc222e593f2.png">

</details>
