### PR TITLE
fix: selected month while navigating to year list

### DIFF
--- a/src/components/CalendarPicker/calendarPickerPropTypes.js
+++ b/src/components/CalendarPicker/calendarPickerPropTypes.js
@@ -15,11 +15,17 @@ const propTypes = {
     /** Default year to be set in the calendar picker. Used with navigation to set the correct year after going back to the view with calendar */
     selectedYear: PropTypes.string,
 
+    /** Default month to be set in the calendar picker. Used to keep last selected month after going back to the view with calendar */
+    selectedMonth: PropTypes.number,
+
     /** A function that is called when the date changed inside the calendar component */
     onChanged: PropTypes.func,
 
     /** A function called when the date is selected */
     onSelected: PropTypes.func,
+
+    /** A function called when the year picker is opened */
+    onYearPickerOpen: PropTypes.func,
 };
 
 const defaultProps = {
@@ -27,8 +33,10 @@ const defaultProps = {
     minDate: moment().year(CONST.CALENDAR_PICKER.MIN_YEAR).toDate(),
     maxDate: moment().year(CONST.CALENDAR_PICKER.MAX_YEAR).toDate(),
     selectedYear: null,
+    selectedMonth: null,
     onChanged: () => {},
     onSelected: () => {},
+    onYearPickerOpen: () => {},
 };
 
 export {propTypes, defaultProps};

--- a/src/components/CalendarPicker/index.js
+++ b/src/components/CalendarPicker/index.js
@@ -25,6 +25,9 @@ class CalendarPicker extends React.PureComponent {
         if (props.selectedYear) {
             currentDateView = moment(currentDateView).set('year', props.selectedYear).toDate();
         }
+        if (props.selectedMonth != null) {
+            currentDateView = moment(currentDateView).set('month', props.selectedMonth).toDate();
+        }
         if (props.maxDate < currentDateView) {
             currentDateView = props.maxDate;
         } else if (props.minDate > currentDateView) {
@@ -68,6 +71,7 @@ class CalendarPicker extends React.PureComponent {
         const maxYear = moment(this.props.maxDate).year();
         const currentYear = this.state.currentDateView.getFullYear();
         Navigation.navigate(ROUTES.getYearSelectionRoute(minYear, maxYear, currentYear, Navigation.getActiveRoute()));
+        this.props.onYearPickerOpen(this.state.currentDateView);
     }
 
     /**

--- a/src/components/NewDatePicker/index.js
+++ b/src/components/NewDatePicker/index.js
@@ -24,12 +24,14 @@ class NewDatePicker extends React.Component {
 
         this.state = {
             isPickerVisible: false,
+            selectedMonth: null,
             selectedDate: moment(props.value || props.defaultValue || undefined).toDate(),
         };
 
         this.setDate = this.setDate.bind(this);
         this.showPicker = this.showPicker.bind(this);
         this.hidePicker = this.hidePicker.bind(this);
+        this.setCurrentSelectedMonth = this.setCurrentSelectedMonth.bind(this);
 
         this.opacity = new Animated.Value(0);
 
@@ -57,6 +59,15 @@ class NewDatePicker extends React.Component {
             return;
         }
         this.unsubscribeEscapeKey();
+    }
+
+    /**
+     * Updates selected month when year picker is opened.
+     * This is used to keep the last visible month in the calendar when going back from year picker screen.
+     * @param {Date} currentDateView
+     */
+    setCurrentSelectedMonth(currentDateView) {
+        this.setState({selectedMonth: currentDateView.getMonth()});
     }
 
     /**
@@ -149,7 +160,9 @@ class NewDatePicker extends React.Component {
                             maxDate={this.props.maxDate}
                             value={this.state.selectedDate}
                             onSelected={this.setDate}
+                            selectedMonth={this.state.selectedMonth}
                             selectedYear={this.props.selectedYear}
+                            onYearPickerOpen={this.setCurrentSelectedMonth}
                         />
                     </Animated.View>
                     )


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This PR fix stores the last selected month when the year list page opens.
This fix doesn't change the current behaviour in the native iOS and Android apps.

### Fixed Issues

$ #16358 
PROPOSAL: https://github.com/Expensify/App/issues/16358#issuecomment-1482759631


### Tests
1. Open settings > profile > personal details > date of birth > date of birth input
2. Change the month by using left or right arrows
3. Press year to select the new year from the list
4. Ensure the month is the same as was before selected.

- [x] Verify that no errors appear in the JS console

### Offline tests
No offline tests required.

### QA Steps
1. Open settings > profile > personal details > date of birth > date of birth input
2. Change the month by using left or right arrows
3. Press year to select the new year from the list
4. Ensure the month is the same as was before selected.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>


https://user-images.githubusercontent.com/24796318/227559027-3f0d876f-431d-46ef-9574-3bd4ecaebdb0.mov



</details>

<details>
<summary>Mobile Web - Chrome</summary>



https://user-images.githubusercontent.com/24796318/227572977-4513268b-0a5c-48fd-b54f-04773016bbe6.mov





</details>

<details>
<summary>Mobile Web - Safari</summary>


https://user-images.githubusercontent.com/24796318/227572130-78f34236-9e6b-4da9-82ae-335502e42596.mov



</details>

<details>
<summary>Desktop</summary>


https://user-images.githubusercontent.com/24796318/227570893-45841651-af63-4eaf-8857-bb2afb9ad387.mov



</details>

<details>
<summary>iOS</summary>


https://user-images.githubusercontent.com/24796318/227571808-731dee85-531a-4ccf-b93e-69106a3729c6.mov



</details>

<details>
<summary>Android</summary>


https://user-images.githubusercontent.com/24796318/227571576-4f2d280a-6fb5-4e8b-9ee8-298a73eeec9f.mov



</details>
