### PR TITLE
Fix Attachment download links for non-previewable items

### DIFF
--- a/src/components/AnchorForAttachmentsOnly/BaseAnchorForAttachmentsOnly.js
+++ b/src/components/AnchorForAttachmentsOnly/BaseAnchorForAttachmentsOnly.js
@@ -22,7 +22,9 @@ const propTypes = {
     onPressOut: PropTypes.func,
 
     /** If a file download is happening */
-    download: PropTypes.bool,
+    download: PropTypes.shape({
+        isDownloading: PropTypes.bool.isRequired,
+    }),
 
     ...anchorForAttachmentsOnlyPropTypes,
 };
@@ -30,7 +32,7 @@ const propTypes = {
 const defaultProps = {
     onPressIn: undefined,
     onPressOut: undefined,
-    download: false,
+    download: {isDownloading: false},
     ...anchorForAttachmentsOnlyDefaultProps,
 };
 

--- a/src/components/HTMLEngineProvider/HTMLRenderers/AnchorRenderer.js
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/AnchorRenderer.js
@@ -16,6 +16,7 @@ import AnchorForCommentsOnly from '../../AnchorForCommentsOnly';
 import AnchorForAttachmentsOnly from '../../AnchorForAttachmentsOnly';
 import * as Url from '../../../libs/Url';
 import ROUTES from '../../../ROUTES';
+import tryResolveUrlFromApiRoot from '../../../libs/tryResolveUrlFromApiRoot';
 
 const AnchorRenderer = (props) => {
     const htmlAttribs = props.tnode.attributes;
@@ -77,7 +78,7 @@ const AnchorRenderer = (props) => {
     if (isAttachment) {
         return (
             <AnchorForAttachmentsOnly
-                source={attrHref}
+                source={tryResolveUrlFromApiRoot(attrHref)}
                 displayName={displayName}
             />
         );


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Update attachment download links to be downloaded relative to the current API in use
Attachments uploaded on PROD but accessed from STAGING would be downloaded from STAGING api (and vice versa)

Only the download links are modified, so we don't break any existing functionality. 
E.g. comments with plain links to staging or prod won't be converted, pressing them should open the link in a new window and it will load in the intended environment

<details>
<summary><strong>The PR also fixes a small problem observed on DEV</strong></summary>

1. Pressing a download link on dev opens it in new tab (instead of initiating download)
2. The original tab would print a CORS error in the console (because we send a request directly from localhost to the API (instead of letting it happen through the dev proxy server))

https://user-images.githubusercontent.com/12156624/227621728-6df43979-edbf-4a71-978a-1a2e51b9b82c.mp4

</details>

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
4. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/16327
PROPOSAL: https://github.com/Expensify/App/issues/16327#issuecomment-1477596282 (option 3 at the end)


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
5. Verify a modal appears displaying a preview of that image
--->

#### Preparation steps

1. Use the **actual** App to upload a non-preview attachment 
    - e.g. go to new.staging.expensify.com and upload something that does not have a preview (like mp4)

#### Web (and mobile web)

_Local DEV by default uses a proxy server so attachments should be resolved from it_

- [ ] Verify downloading attachments work
    1. Press the download button
    2. A popup should prompt you to save the attachment locally 

#### Desktop / iOS / Android

_Use the "staging toggle" from preferences to toggle between environments (on DEV)_

- [ ] STAGING TO PROD
    1. Use new.staging.expensify.com to upload an non-preview attachment
    2. On DEV set the "staging toggle" to use PROD (this is the default state)
    3. Go and download the attachment 
        - the attachment should be downloaded from PROD (because you are on PROD)
        - on Desktop you can use the web inspector and the Network tab to see that a request is actually sent to `www.expensify`
        - on other platforms it's not as easy to verify because Flipper is broken

- [ ] PROD TO STAGING
    1. Use new.expensify.com to upload an non-preview attachment
    2. On DEV set the "staging toggle" to ON
    3. Go and download the attachment 
        - the attachment should be downloaded from PROD (because you are on PROD)
        - on Desktop you can use the web inspector and the Network tab to see that a request is actually sent to `taging.expensify`
        - on other platforms it's not as easy to verify because Flipper is broken

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

N/A - Downloading files is not possible while offline

Pressing the download button while offline has some weird behavior opening a new window, but it's not introduced in this PR

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
5. Upload an image via copy paste
6. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

#### on STAGING

1. From PROD new.expensify.com - upload a non-preview attachment (like an mp4 file)
2. Return to STAGING and try to access the attachment
3. Attachment should be resolved and downloaded from STAGING 
    - you can only verify this on web and desktop by using the web inspector and the Network tab
    - Go to the Network tab, then press the attachment download link, see a request designated to `staging.expensify.com/chat-attachments/...` 
    - For other platform simply verify that downloading works

#### on PROD

After the PR is merged to PROD the App should work this way

1. From STAGING staging.new.expensify.com - upload a non-preview attachment (like an mp4 file)
2. Return to PROD and try to access the attachment
3. Attachment should be resolved and downloaded from PROD 
    - you can only verify this on web and desktop by using the web inspector and the Network tab
    - Go to the Network tab, then press the attachment download link, see a request designated to `www.expensify.com/chat-attachments/...` 
    - For other platform simply verify that downloading works

_You can also use the "staging toggle" from Preferences for this test._
_1. On staging -> go to Preferences and switch the toggle so you use PROD_
_2. Refresh the Browser (because rendered report links are not always re-rendered after switching)_
_3. Go to a non-preview attachment uploaded on STAGING_
_4. Press to download it - similary to above, the network tab should show that the attachment is resolved from PROD `www.expensify` (because we've switched to PROD)_

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->
https://user-images.githubusercontent.com/12156624/227620360-e8e58639-8209-4392-b4fa-85418f546775.mp4

<img width="1552" alt="Screenshot 2023-03-27 at 12 30 49" src="https://user-images.githubusercontent.com/12156624/227902999-aaa04b70-5613-4481-ba91-b0db0e1565ba.png">

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->
![image](https://user-images.githubusercontent.com/12156624/227894200-12a04089-f0d8-4071-a6bb-7e887e0548fe.png)

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->
<img width="513" alt="Screenshot 2023-03-27 at 12 31 28" src="https://user-images.githubusercontent.com/12156624/227902833-b0c9e1a3-77df-44c9-9510-b1c904f40826.png">

<img width="513" alt="Screenshot 2023-03-27 at 12 31 41" src="https://user-images.githubusercontent.com/12156624/227902864-fe1b4607-87ff-4143-a47e-1f1f1bea9b26.png">

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->
<img width="1440" alt="Screenshot 2023-03-27 at 12 22 56" src="https://user-images.githubusercontent.com/12156624/227902925-fbfac7f1-0590-46cf-836c-7bc074973248.png">


</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->
<img width="513" alt="Screenshot 2023-03-27 at 12 36 31" src="https://user-images.githubusercontent.com/12156624/227904301-3083bbc4-bdc1-4df5-9d28-469563394ea8.png">

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->
![image](https://user-images.githubusercontent.com/12156624/227902608-e357767f-7f0e-4870-9714-d3fcaf1cf0f9.png)

![image](https://user-images.githubusercontent.com/12156624/227904242-2587c658-568c-477a-9426-f4e9b02da603.png)

</details>
