### PR TITLE
Revert "Make optimistic reportActions appear last"

### DIFF
--- a/src/libs/ReportActionsUtils.js
+++ b/src/libs/ReportActionsUtils.js
@@ -41,19 +41,8 @@ function isDeletedAction(reportAction) {
 }
 
 /**
- * @param {Object} reportAction
- * @returns {Boolean}
- */
-function isOptimisticAction(reportAction) {
-    return lodashGet(reportAction, 'pendingAction') === CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD;
-}
-
-/**
- * Sort an array of reportActions by:
- *
- * - Finalized actions always are "later" than optimistic actions
- * - then sort by created timestamp
- * - then sort by reportActionID. This gives us a stable order even in the case of multiple reportActions created on the same millisecond
+ * Sort an array of reportActions by their created timestamp first, and reportActionID second
+ * This gives us a stable order even in the case of multiple reportActions created on the same millisecond
  *
  * @param {Array} reportActions
  * @param {Boolean} shouldSortInDescendingOrder
@@ -68,11 +57,6 @@ function getSortedReportActions(reportActions, shouldSortInDescendingOrder = fal
     return _.chain(reportActions)
         .compact()
         .sort((first, second) => {
-            // First, make sure that optimistic reportActions appear at the end
-            if (isOptimisticAction(second) && !isOptimisticAction(first)) {
-                return -1 * invertedMultiplier;
-            }
-
             // First sort by timestamp
             if (first.created !== second.created) {
                 return (first.created < second.created ? -1 : 1) * invertedMultiplier;

--- a/src/libs/ReportUtils.js
+++ b/src/libs/ReportUtils.js
@@ -21,7 +21,6 @@ import linkingConfig from './Navigation/linkingConfig';
 import * as defaultAvatars from '../components/Icon/DefaultAvatars';
 import isReportMessageAttachment from './isReportMessageAttachment';
 import * as defaultWorkspaceAvatars from '../components/Icon/WorkspaceDefaultAvatars';
-import * as CollectionUtils from './CollectionUtils';
 
 let sessionEmail;
 Onyx.connect({
@@ -70,21 +69,6 @@ Onyx.connect({
     key: ONYXKEYS.COLLECTION.REPORT,
     waitForCollectionCallback: true,
     callback: val => allReports = val,
-});
-
-const lastReportActions = {};
-Onyx.connect({
-    key: ONYXKEYS.COLLECTION.REPORT_ACTIONS,
-    callback: (actions, key) => {
-        if (!key || !actions) {
-            return;
-        }
-        const reportID = CollectionUtils.extractCollectionItemID(key);
-        lastReportActions[reportID] = _.find(
-            ReportActionsUtils.getSortedReportActionsForDisplay(_.toArray(actions)),
-            reportAction => reportAction.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE,
-        );
-    },
 });
 
 let doesDomainHaveApprovedAccountant;
@@ -448,31 +432,6 @@ function canShowReportRecipientLocalTime(personalDetails, report) {
         && reportRecipientTimezone
         && reportRecipientTimezone.selected
         && isReportParticipantValidated);
-}
-
-/**
- * Gets the last message text from the report.
- * Looks at reportActions data as the "best source" for information, because the front-end may have optimistic reportActions that the server is not yet aware of.
- * If reportActions are not loaded for the report, then there can't be any optimistic reportActions, and the lastMessageText rNVP will be accurate as a fallback.
- *
- * @param {Object} report
- * @returns {String}
- */
-function getLastMessageText(report) {
-    if (!report) {
-        return '';
-    }
-
-    const lastReportAction = lastReportActions[report.reportID];
-    let lastReportActionText = report.lastMessageText;
-    let lastReportActionHtml = report.lastMessageHtml;
-    if (lastReportAction && lastReportAction.actionName === CONST.REPORT.ACTIONS.TYPE.ADDCOMMENT) {
-        lastReportActionText = lodashGet(lastReportAction, 'message[0].text', report.lastMessageText);
-        lastReportActionHtml = lodashGet(lastReportAction, 'message[0].html', report.lastMessageHtml);
-    }
-    return isReportMessageAttachment({text: lastReportActionText, html: lastReportActionHtml})
-        ? `[${Localize.translateLocal('common.attachment')}]`
-        : Str.htmlDecode(lastReportActionText);
 }
 
 /**
@@ -1715,7 +1674,6 @@ export {
     isIOUOwnedByCurrentUser,
     getIOUTotal,
     canShowReportRecipientLocalTime,
-    getLastMessageText,
     formatReportLastMessageText,
     chatIncludesConcierge,
     isPolicyExpenseChat,

--- a/tests/unit/ReportActionsUtilsTest.js
+++ b/tests/unit/ReportActionsUtilsTest.js
@@ -6,15 +6,7 @@ describe('ReportActionsUtils', () => {
         const cases = [
             [
                 [
-                    // This is the lowest created timestamp, but because it's an optimistic action it should appear last
-                    {
-                        created: '2022-11-09 20:00:00.000',
-                        reportActionID: '395268342',
-                        actionName: CONST.REPORT.ACTIONS.TYPE.ADDCOMMENT,
-                        pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD,
-                    },
-
-                    // This is the highest created timestamp, so should appear 2nd-to-last
+                    // This is the highest created timestamp, so should appear last
                     {
                         created: '2022-11-09 22:27:01.825',
                         reportActionID: '8401445780099176',
@@ -68,12 +60,6 @@ describe('ReportActionsUtils', () => {
                         created: '2022-11-09 22:27:01.825',
                         reportActionID: '8401445780099176',
                         actionName: CONST.REPORT.ACTIONS.TYPE.ADDCOMMENT,
-                    },
-                    {
-                        created: '2022-11-09 20:00:00.000',
-                        reportActionID: '395268342',
-                        actionName: CONST.REPORT.ACTIONS.TYPE.ADDCOMMENT,
-                        pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD,
                     },
                 ],
             ],


### PR DESCRIPTION
Reverts Expensify/App#15942

### Fixed Issues
$ https://github.com/Expensify/App/issues/16563

### Tests
1. Send a message with multiple lines
1. Confirm that in you LHN the row does not expand

Second set of tests

1. Create a new Workpace
1. Navigate to the #admins chat and send a message
1. Confirm the message is shown under the CREATED action.

- [x] Verify that no errors appear in the JS console

### Offline tests
All the tests are offline tests 😉 

### QA Steps
Same as tests

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.


### Screenshots/Videos
<details>
<summary>Web</summary>

<img width="1393" alt="image" src="https://user-images.githubusercontent.com/36083550/227992197-3f9421d5-a876-435a-a44b-fba653f9bb8d.png">


</details>

<details>
<summary>Mobile Web - Chrome</summary>

<img width="436" alt="image" src="https://user-images.githubusercontent.com/36083550/227992264-699b02ff-b3f1-4564-b5de-86db35399cd8.png">


</details>

<details>
<summary>Mobile Web - Safari</summary>

<img width="460" alt="image" src="https://user-images.githubusercontent.com/36083550/227992453-8c6cad14-bbbf-4806-9305-26d50929531a.png">


</details>

<details>
<summary>Desktop</summary>

<img width="1393" alt="image" src="https://user-images.githubusercontent.com/36083550/227992197-3f9421d5-a876-435a-a44b-fba653f9bb8d.png">

</details>

<details>
<summary>iOS</summary>
<img width="472" alt="image" src="https://user-images.githubusercontent.com/36083550/227992611-5d88dd99-8234-4420-8e72-4b59b4afc674.png">

<img width="454" alt="image" src="https://user-images.githubusercontent.com/36083550/227992646-14406fc6-6a54-4e84-9d08-0737eaa62f36.png">


</details>

<details>
<summary>Android</summary>

<img width="446" alt="image" src="https://user-images.githubusercontent.com/36083550/227992673-e6e3633b-80aa-4833-9b8e-c8a3b1d0d20c.png">

<img width="449" alt="image" src="https://user-images.githubusercontent.com/36083550/227992716-50870104-a3b0-443e-a26e-aee3803a2d69.png">



</details>
