### PR TITLE
Add better support for non-US cities in address autocomplete by pulling in postal_town

### DIFF
--- a/src/components/AddressSearch.js
+++ b/src/components/AddressSearch.js
@@ -105,8 +105,8 @@ const AddressSearch = (props) => {
         const {
             street_number: streetNumber,
             route: streetName,
-            locality: locality,
-            sublocality: sublocality,
+            locality,
+            sublocality,
             postal_town: postalTown,
             postal_code: zipCode,
             administrative_area_level_1: state,
@@ -132,9 +132,10 @@ const AddressSearch = (props) => {
 
         const values = {
             street: props.value ? props.value.trim() : '',
+
             // When locality is not returned, many countries return the city as postalTown (e.g. 5 New Street
-            // Square, London), otherwise as sublocality (e.g. 384 Court Street Brooklyn). If postalTown is 
-            // returned, the sublocality will be a city subdivision so shouldn't take precedence (e.g. 
+            // Square, London), otherwise as sublocality (e.g. 384 Court Street Brooklyn). If postalTown is
+            // returned, the sublocality will be a city subdivision so shouldn't take precedence (e.g.
             // Salagatan, Upssala, Sweden).
             city: locality || postalTown || sublocality,
             zipCode,

--- a/src/components/AddressSearch.js
+++ b/src/components/AddressSearch.js
@@ -105,8 +105,9 @@ const AddressSearch = (props) => {
         const {
             street_number: streetNumber,
             route: streetName,
-            locality: city,
-            sublocality: cityFallback, // Some locations only return sublocality instead of locality
+            locality: locality,
+            sublocality: sublocality,
+            postal_town: postalTown,
             postal_code: zipCode,
             administrative_area_level_1: state,
             country,
@@ -115,6 +116,7 @@ const AddressSearch = (props) => {
             route: 'long_name',
             locality: 'long_name',
             sublocality: 'long_name',
+            postal_town: 'long_name',
             postal_code: 'long_name',
             administrative_area_level_1: 'short_name',
             country: 'short_name',
@@ -130,7 +132,10 @@ const AddressSearch = (props) => {
 
         const values = {
             street: props.value ? props.value.trim() : '',
-            city: city || cityFallback,
+            // When locality is not returned, many (non-US) countries return the city as
+            // postalTown, otherwise as sublocality. If postalTown is returned, the
+            // sublocality will be a city subdivision so wouldn't be appropriate.
+            city: locality || postalTown || sublocality,
             zipCode,
             state,
             country: '',

--- a/src/components/AddressSearch.js
+++ b/src/components/AddressSearch.js
@@ -132,9 +132,10 @@ const AddressSearch = (props) => {
 
         const values = {
             street: props.value ? props.value.trim() : '',
-            // When locality is not returned, many (non-US) countries return the city as
-            // postalTown, otherwise as sublocality. If postalTown is returned, the
-            // sublocality will be a city subdivision so wouldn't be appropriate.
+            // When locality is not returned, many countries return the city as postalTown (e.g. 5 New Street
+            // Square, London), otherwise as sublocality (e.g. 384 Court Street Brooklyn). If postalTown is 
+            // returned, the sublocality will be a city subdivision so shouldn't take precedence (e.g. 
+            // Salagatan, Upssala, Sweden).
             city: locality || postalTown || sublocality,
             zipCode,
             state,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Pull in the postal_town parameter from address autocomplete, to support certain non-US addresses where that component is used to denote the city. 

I have replaced the `cityFallback` and `city` variables with their original names from the Autocomplete API in order to make their sources when we're using them later to generate the actual city name.

There are a few test addresses I've used to ensure the correct new fallback order (`locality || postalTown || sublocality`):

- 5 New Street Square, **London** (address within a city, `postal_town` is the one to use)
- Main St, **Huby**, York (address in a small town, where `postal_town` and `locality` are both available, but `locality` is the town name, and so should be used for the "City" field)
- Salagatan, **Uppsala**, Sweden (address in a city, where `sublocality` would return a city subdivision, so `postal_town` needs to take precedence here)

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ #16392    
PROPOSAL: [#16392 (comment)](https://github.com/Expensify/App/issues/16392#issuecomment-1480885123)


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

For each of these addresses:

- 5 New Street Square, **London**
- Main St, **Huby**, York
- Salagatan, **Uppsala**, Sweden
- 384 Court Street **Brooklyn**

1. Go to Settings -> Personal details -> Home Address
2. In Address line 1 type the address and select the first result
3. Ensure that the city field is filled in with the relevant string (in bold above)

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

N/A as autocomplete won't work offline.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
4. Upload an image via copy paste
5. Verify a modal appears displaying a preview of that image
--->

Same tests as above.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://user-images.githubusercontent.com/27287420/227999169-c770d884-5599-4f10-873c-f26df2ab237a.mp4

</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://user-images.githubusercontent.com/27287420/227998395-185c5ac7-02c6-4b6c-a317-16ffbbd4f1e6.mp4

</details>

<details>
<summary>Mobile Web - Safari</summary>

https://user-images.githubusercontent.com/27287420/227996590-5c6a7502-392e-4155-8467-07a8bbffc502.mp4

</details>

<details>
<summary>Desktop</summary>

https://user-images.githubusercontent.com/27287420/227996673-f885eb4d-ac18-4725-adde-de73a25c5f7f.mp4

</details>

<details>
<summary>iOS</summary>

https://user-images.githubusercontent.com/27287420/227996646-723bf37f-a282-4067-96e9-958c0e7130ff.mp4

</details>

<details>
<summary>Android</summary>

https://user-images.githubusercontent.com/27287420/227997307-78d93c39-5d8f-42c7-be72-e2858f564ad8.mp4

</details>
