### PR TITLE
Previous PR

### DIFF
--- a/src/components/CalendarPicker/index.js
+++ b/src/components/CalendarPicker/index.js
@@ -18,8 +18,8 @@ class CalendarPicker extends React.PureComponent {
     constructor(props) {
         super(props);
 
-        this.monthNames =_.map(moment.localeData(props.preferredLocale).months(), month => month.replace(/^\w/, c => c.toUpperCase()));
-        this.daysOfWeek = _.map(moment.localeData(props.preferredLocale).weekdays(), day => day.toUpperCase());
+        this.monthNames = moment.localeData(props.preferredLocale).months();
+        this.daysOfWeek = moment.localeData(props.preferredLocale).weekdays();
 
         let currentDateView = props.value;
         if (props.selectedYear) {

--- a/src/components/CalendarPicker/index.js
+++ b/src/components/CalendarPicker/index.js
@@ -18,8 +18,8 @@ class CalendarPicker extends React.PureComponent {
     constructor(props) {
         super(props);
 
-        this.monthNames = moment.localeData(props.preferredLocale).months();
-        this.daysOfWeek = moment.localeData(props.preferredLocale).weekdays();
+        this.monthNames =_.map(moment.localeData(props.preferredLocale).months(), month => month.replace(/^\w/, c => c.toUpperCase()));
+        this.daysOfWeek = _.map(moment.localeData(props.preferredLocale).weekdays(), day => day.toUpperCase());
 
         let currentDateView = props.value;
         if (props.selectedYear) {

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -905,7 +905,7 @@ export default {
         },
     },
     reimbursementAccountLoadingAnimation: {
-        oneMoment: 'One Moment',
+        oneMoment: 'One moment',
         explanationLine: 'We’re taking a look at your information. You will be able to continue with next steps shortly.',
     },
     session: {

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -55,7 +55,7 @@ export default {
         invite: 'Invitar',
         here: 'aquí',
         date: 'Fecha',
-        dob: 'Fecha de Nacimiento',
+        dob: 'Fecha de nacimiento',
         currentYear: 'Año actual',
         currentMonth: 'Mes actual',
         ssnLast4: 'Últimos 4 dígitos de su SSN',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -69,7 +69,7 @@ export default {
         stateOrProvince: 'Estado / Provincia',
         country: 'País',
         zip: 'Código postal',
-        zipPostCode: 'Código Postal',
+        zipPostCode: 'Código postal',
         whatThis: '¿Qué es esto?',
         iAcceptThe: 'Acepto los ',
         remove: 'Eliminar',
@@ -906,7 +906,7 @@ export default {
         },
     },
     reimbursementAccountLoadingAnimation: {
-        oneMoment: 'Un Momento',
+        oneMoment: 'Un momento',
         explanationLine: 'Estamos verificando tu información y podrás continuar con los siguientes pasos en unos momentos.',
     },
     session: {

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -143,7 +143,7 @@ export default {
         notAllowedExtension: 'Los archivos adjuntos deben ser de uno de los siguientes tipos: ',
     },
     avatarCropModal: {
-        title: 'Editar Foto',
+        title: 'Editar foto',
         description: 'Arrastra, haz zoom y rota tu imagen para que quede como te gusta.',
     },
     composer: {

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -55,7 +55,7 @@ export default {
         invite: 'Invitar',
         here: 'aquí',
         date: 'Fecha',
-        dob: 'Fecha de nacimiento',
+        dob: 'Fecha de Nacimiento',
         currentYear: 'Año actual',
         currentMonth: 'Mes actual',
         ssnLast4: 'Últimos 4 dígitos de su SSN',


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
### Details
We want to convert some capital characters to lowercase and capitalization for months and days in Spanish.

### Fixed Issues
#16403 
PROPOSAL: https://github.com/Expensify/App/issues/16403#issuecomment-1481348542
### Tests

1. Go to the Personal detail -> Date of birth  verify word (Fecha de nacimiento)
2. Open date of birth picker in Spanish verify (Month name, including days)
3. Go to the Home Address and verify word 'Código postal'.
4. Go to the Profile add new profile and verify word 'Editar foto'.
5. Go to the Workspace-> Connect bank account, verify header words in both language (One moment,Un momento)


### Offline tests

Same as above


### QA Steps
Same as above

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos

<details>

<summary>Web</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/56740856/227703254-d2f00d90-396e-4dfb-99c2-7cdeda8ba35b.mp4


![Screenshot_49](https://user-images.githubusercontent.com/56740856/227703626-becc6d4f-c48f-4ae2-a35a-f704d8bbff43.png)
![Screenshot_51](https://user-images.githubusercontent.com/56740856/227703629-205d4d5a-a096-4f3e-ada6-f30dad42a00b.png)
![Screenshot_53](https://user-images.githubusercontent.com/56740856/227703630-b4d248e3-0be7-45b3-bcce-369b832f24dd.png)
![Screenshot_54](https://user-images.githubusercontent.com/56740856/227703632-6157a9f7-54b2-4e81-9dcd-556b98c4b21c.png)
![Screenshot_55](https://user-images.githubusercontent.com/56740856/227703634-aa3ec46b-db9d-4fd5-addd-4c09f2461f2e.png)

</details>

<details>
<summary>Mobile Web - Chrome</summary>

Uploading Screen Recording 2023
<img width="372" alt="Screenshot 2023-03-27 at 10 48 30 PM" src="https://user-images.githubusercontent.com/56740856/228037982-14efc5ea-7a8c-4f45-89cd-9d4f2aed41ba.png">



https://user-images.githubusercontent.com/56740856/228038992-d8b155e6-ccd1-470c-8782-561219e9235d.mov



<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>



</details>

<details>
<summary>Desktop</summary>
<img width="1196" alt="Screenshot 2023-03-27 at 10 39 46 PM" src="https://user-images.githubusercontent.com/56740856/228034784-23dcbcec-5b7b-440b-ba15-ccdab7591144.png">
<img width="1202" alt="Screenshot 2023-03-27 at 10 38 28 PM" src="https://user-images.githubusercontent.com/56740856/228034798-9b4be39d-d583-4fc4-9f35-f2dd49bee626.png">

https://user-images.githubusercontent.com/56740856/228034811-5a73fedd-9cf2-405e-8512-68fcf219099a.mov

<img width="1195" alt="Screenshot 2023-03-27 at 10 39 01 PM" src="https://user-images.githubusercontent.com/56740856/228034815-eeedcd24-8154-4ec2-a1c4-8ba1cc5cb761.png">

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<img width="332" alt="Screenshot 2023-03-27 at 10 45 45 PM" src="https://user-images.githubusercontent.com/56740856/228037439-eee79e20-ed65-4042-813e-4ce20a8afd09.png">
<img width="339" alt="Screenshot 2023-03-27 at 10 45 56 PM" src="https://user-images.githubusercontent.com/56740856/228037447-6a2faee1-440e-438b-84db-b64a57b29970.png">
<img width="333" alt="Screenshot 2023-03-27 at 10 47 17 PM" src="https://user-images.githubusercontent.com/56740856/228037456-2c4afc92-e2c1-42ae-a1e7-eb255f85c6ca.png">

https://user-images.githubusercontent.com/56740856/228037468-b0ba84f3-51c5-4d68-a15c-23867ef08b7b.mov



<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>

<img width="489" alt="Screenshot 2023-03-27 at 11 01 59 PM" src="https://user-images.githubusercontent.com/56740856/228036750-cdc1ae9b-e2e9-4b5f-83ac-78a495d200bb.png">
<img width="371" alt="Screenshot 2023-03-27 at 11 02 19 PM" src="https://user-images.githubusercontent.com/56740856/228036762-599cdcd8-828e-4507-bace-91ee0ab1d4bf.png">

https://user-images.githubusercontent.com/56740856/228036776-8b29c9bc-f535-4eeb-9607-2194d4954c1f.mov

<img width="368" alt="Screenshot 2023-03-27 at 11 02 44 PM" src="https://user-images.githubusercontent.com/56740856/228036795-fc7fc9ba-644c-46c4-8d68-12088065c71e.png">


<!-- add screenshots or videos here -->

</details>
