### PR TITLE
Add Placeholder text and No results found message on Pronouns Search Page

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -348,6 +348,7 @@ export default {
     pronounsPage: {
         pronouns: 'Pronouns',
         isShownOnProfile: 'Your pronouns are shown on your profile.',
+        placeholderText: 'Search to see options',
     },
     contacts: {
         contactMethod: 'Contact method',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -347,6 +347,7 @@ export default {
     pronounsPage: {
         pronouns: 'Pronombres',
         isShownOnProfile: 'Tus pronombres se muestran en tu perfil.',
+        placeholderText: 'Buscar para ver opciones',
     },
     contacts: {
         contactMethod: 'Método de contacto',

--- a/src/pages/settings/Profile/PronounsPage.js
+++ b/src/pages/settings/Profile/PronounsPage.js
@@ -106,6 +106,7 @@ class PronounsPage extends Component {
 
     render() {
         const filteredPronounsList = this.getFilteredPronouns();
+        const headerMessage = this.state.searchValue.trim() && !filteredPronounsList.length ? this.props.translate('common.noResultsFound') : '';
 
         return (
             <ScreenWrapper includeSafeAreaPaddingBottom={false}>
@@ -122,6 +123,8 @@ class PronounsPage extends Component {
                         </Text>
                         <OptionsSelector
                             textInputLabel={this.props.translate('pronounsPage.pronouns')}
+                            placeholderText={this.props.translate('pronounsPage.placeholderText')}
+                            headerMessage={headerMessage}
                             sections={[{data: filteredPronounsList}]}
                             value={this.state.searchValue}
                             onSelectRow={this.updatePronouns}


### PR DESCRIPTION
@jasperhuangg @sobitneupane  PR is ready for review.

### Details
Within pronouns search page _Placeholder text_ and _No results found_ message not there. So in this PR we added **Placeholder text** and **No results found** message on Pronoun Search page.

### Fixed Issues
$ https://github.com/Expensify/App/issues/15779  
PROPOSAL: https://github.com/Expensify/App/issues/15779#issuecomment-1481235866

### Tests
1. Open the app in any device
2. Open settings
3. Open profile
4. Open Pronouns
5. **Verify that Placeholder text should be there** in search field.
6. Search term which does not exists eg: Test  **Verify that it shows _No results found_ message**.
8. Repeat this test for English and Spanish both

- [x] Verify that no errors appear in the JS console

### Offline tests
1. Open the app in any device
2. Open settings
3. Open profile
4. Open Pronouns
5. **Verify that Placeholder text should be there** in search field.
6. Search term which does not exists eg: Test  **Verify that it shows _No results found_ message**.
8. Repeat this test for English and Spanish both

### QA Steps
1. Open the app in any device
2. Open settings
3. Open profile
4. Open Pronouns
5. **Verify that Placeholder text should be there** in search field.
6. Search term which does not exists eg: Test  **Verify that it shows _No results found_ message**.
8. Repeat this test for English and Spanish both

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

#### EN

https://user-images.githubusercontent.com/7823358/228118398-3580bbc2-fca3-4368-b8ef-23f0a16f6e98.mov

####  ES

https://user-images.githubusercontent.com/7823358/228118425-5376a3d5-4902-48b6-b3d2-005d042311c2.mov

</details>

<details>
<summary>Mobile Web - Chrome</summary>

####  EN

https://user-images.githubusercontent.com/7823358/228118495-1189ad47-5e2d-4043-8a30-0d85138486dd.mov

####  ES

https://user-images.githubusercontent.com/7823358/228118519-b999a1ed-993b-4518-ba55-ced5fd9f57fa.mov

</details>

<details>
<summary>Mobile Web - Safari</summary>

####  EN

https://user-images.githubusercontent.com/7823358/228118552-01cd1087-5cc2-4148-82db-23db231efea5.mov

####  ES

https://user-images.githubusercontent.com/7823358/228118886-27d0bafd-f1e8-46d0-86af-22a511037430.mov

</details>

<details>
<summary>Desktop</summary>

####  EN

https://user-images.githubusercontent.com/7823358/228118719-bd394376-6b9f-45c2-a0a1-db9f4bb57d60.mov

####  ES

https://user-images.githubusercontent.com/7823358/228118649-bad8dc38-e21c-4a59-b458-84bef604c21c.mov

</details>

<details>
<summary>iOS</summary>

####  EN

https://user-images.githubusercontent.com/7823358/228119067-c3dcef30-9364-4fa1-8075-ed9132d89fed.mov

####  ES

https://user-images.githubusercontent.com/7823358/228119102-0cbd4465-5a5e-4b6e-a393-5e9d785d6f44.mov

</details>

<details>
<summary>Android</summary>

####  EN

https://user-images.githubusercontent.com/7823358/228119131-1dd31639-062c-4d6e-806b-b048311da159.mov

####  ES

https://user-images.githubusercontent.com/7823358/228119175-2c38345b-5f25-4c0a-8f44-90b2c245d4ed.mov

</details>
