### PR TITLE
[No QA] Fix #15965 - Remove desktop app deep link on quit

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -406,7 +406,13 @@ const mainWindow = (() => {
                 browserWindow.webContents.send(ELECTRON_EVENTS.BLUR);
             });
 
-            app.on('before-quit', () => quitting = true);
+            app.on('before-quit', () => {
+                // Adding __DEV__ check because we only want to remove it on dev version
+                if (__DEV__) {
+                    app.removeAsDefaultProtocolClient('new-expensify');
+                }
+                quitting = true;
+            });
             app.on('activate', () => {
                 if (expectedUpdateVersion && app.getVersion() !== expectedUpdateVersion) {
                     return;

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -16,7 +16,7 @@ const {machineId} = require('node-machine-id');
 const ELECTRON_EVENTS = require('./ELECTRON_EVENTS');
 const checkForUpdates = require('../src/libs/checkForUpdates');
 const CONFIG = require('../src/CONFIG').default;
-const CONST = require('../src/CONST');
+const CONST = require('../src/CONST').default;
 const Localize = require('../src/libs/Localize');
 
 const port = process.env.PORT || 8080;
@@ -80,6 +80,8 @@ let downloadedVersion;
 // because the only way code can be shared between the main and renderer processes at runtime is via the context bridge
 // So we track preferredLocale separately via ELECTRON_EVENTS.LOCALE_UPDATED
 let preferredLocale = CONST.DEFAULT_LOCALE;
+
+const appProtocol = CONST.DEEPLINK_BASE_URL.replace('://', '');
 
 const quitAndInstallWithUpdate = () => {
     if (!downloadedVersion) {
@@ -268,7 +270,7 @@ const mainWindow = (() => {
              * when the app is bundled electron-builder will take care of it.
              */
             if (__DEV__) {
-                app.setAsDefaultProtocolClient('new-expensify');
+                app.setAsDefaultProtocolClient(appProtocol);
             }
 
             browserWindow = new BrowserWindow({
@@ -407,10 +409,10 @@ const mainWindow = (() => {
             });
 
             app.on('before-quit', () => {
-                // Adding __DEV__ check because we only want to remove it on dev version
+                // Adding __DEV__ check because we want links to be handled by dev app only while it's running
                 // https://github.com/Expensify/App/issues/15965#issuecomment-1483182952
                 if (__DEV__) {
-                    app.removeAsDefaultProtocolClient('new-expensify');
+                    app.removeAsDefaultProtocolClient(appProtocol);
                 }
                 quitting = true;
             });

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -408,6 +408,7 @@ const mainWindow = (() => {
 
             app.on('before-quit', () => {
                 // Adding __DEV__ check because we only want to remove it on dev version
+                // https://github.com/Expensify/App/issues/15965#issuecomment-1483182952
                 if (__DEV__) {
                     app.removeAsDefaultProtocolClient('new-expensify');
                 }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR adds a callback to the Electron app when it is about to quit. The callback un-registers the electron app as default protocol client.

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/15965  
PROPOSAL: https://github.com/Expensify/App/issues/15965#issuecomment-1483182952


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Install the New Expensify Desktop app on your machine.
2. Start the local electron app by running `npm run desktop`.
3. Open any web browser and enter: `new-expensify://test`.
4. Verify that the browser shows a prompt mentioning `Open with Electron App`.
5. Close the local Electron app and re-enter `new-expensify://test` in the browser.
6. Verify that the browser shows a prompt mentioning `Open with New Expensify App`.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image


1. Install the New Expensify Desktop app on your machine.
2. Start the local electron app by running `npm run desktop`.
3. Open any web browser and enter: `new-expensify://test`.
4. Verify that the browser shows a prompt mentioning `Open with Electron App`.
5. Close the local Electron app and re-enter `new-expensify://test` in the browser.
6. Verify that the browser shows a prompt mentioning `Open with New Expensify App`.

- [x] Verify that no errors appear in the JS console
--->
No QA
### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->
<img width="1504" alt="Screenshot 2023-03-29 at 2 36 03 AM" src="https://user-images.githubusercontent.com/30054992/228372571-ecf322f0-0fc5-4242-8f94-5dc6bc142574.png">

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->
<img width="451" alt="Screenshot 2023-03-29 at 2 36 32 AM" src="https://user-images.githubusercontent.com/30054992/228372628-60bf45ab-1615-4bd6-8173-350b0f147b5e.png">

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->
<img width="458" alt="Screenshot 2023-03-29 at 2 36 52 AM" src="https://user-images.githubusercontent.com/30054992/228372737-d306d9f9-4c66-43e6-9f1e-6446a1ac83a2.png">

</details>

<details>
<summary>Desktop</summary>
<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/30054992/228371727-0adb0c32-6600-4a9f-bfc0-6db2dd09806e.mp4

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->
<img width="458" alt="Screenshot 2023-03-29 at 2 37 07 AM" src="https://user-images.githubusercontent.com/30054992/228372769-788f6c8e-ed10-4e3b-8952-32a75d4febc5.png">

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->
<img width="456" alt="Screenshot 2023-03-29 at 2 37 25 AM" src="https://user-images.githubusercontent.com/30054992/228372812-f0406a63-d97e-4e8a-9471-f75ea83fb712.png">

</details>
