### PR TITLE
feat: person handle

### DIFF
--- a/src/libs/ReportUtils.js
+++ b/src/libs/ReportUtils.js
@@ -417,7 +417,7 @@ function getPersonHandle(displayName, primaryLogin, viewerDomain) {
 
     if (primaryLogin) {
         const [username, domain] = primaryLogin.split('@');
-        if (CONST.REGEX.POSITIVE_INTEGER.test(username.replace('+', ''))) {
+        if (CONST.REGEX.POSITIVE_INTEGER.test(username.replace('+', '')) && displayName !== username) {
             handle = username.replace('+', '');
         } else if (isPublicEmail != null && !isPublicEmail && formattedViewerDomain === domain) {
             handle = username;

--- a/src/libs/ReportUtils.js
+++ b/src/libs/ReportUtils.js
@@ -406,14 +406,13 @@ function getPersonHandle(displayName, primaryLogin, viewerDomain) {
 
     const isPublicEmail = primaryLogin
         && formattedViewerDomain
-        && _.some(PUBLIC_DOMAINS, d => primaryLogin.includes(d))
-        && primaryLogin.includes(formattedViewerDomain);
+        && _.some(PUBLIC_DOMAINS, d => primaryLogin.includes(d));
 
     if (primaryLogin) {
-        const [username, domain] = primaryLogin.split('@');
+        const [username, currentDomain] = primaryLogin.split('@');
         if (CONST.REGEX.POSITIVE_INTEGER.test(username.replace('+', ''))) {
             handle = username.replace('+', '');
-        } else if (isPublicEmail != null && !isPublicEmail && formattedViewerDomain === domain) {
+        } else if (isPublicEmail != null && !isPublicEmail && formattedViewerDomain === currentDomain) {
             handle = username;
         } else {
             handle = primaryLogin;

--- a/src/libs/ReportUtils.js
+++ b/src/libs/ReportUtils.js
@@ -402,24 +402,24 @@ function getRoomWelcomeMessage(report, policiesMap) {
 /**
  * Function to get the handle of a person based on their display name, primary login, and viewer domain.
  * @param {String} displayName the display name of the person
- * @param {String} primaryLogin the primary login of the person, in the format of "username@domain"
- * @param {String} viewerDomain the domain of the viewer
+ * @param {String} primaryLogin the primary login of the person, in the format of "username@domain.com"
+ * @param {String} viewerDomain the domain of the viewer in the format of "+@domain.com"
  * @returns {String | null} the handle of the person, in the format of "@username", or null if no handle can be determined
  */
 function getPersonHandle(displayName, primaryLogin, viewerDomain) {
     let handle = null;
 
-    const formattedViewerDomain = viewerDomain && viewerDomain.startsWith('+@') ? viewerDomain.slice(2) : undefined;
+    const normalizedViewerDomain = viewerDomain && viewerDomain.startsWith('+@') ? viewerDomain.slice(2) : undefined;
 
     const isPublicEmail = primaryLogin
-        && formattedViewerDomain
+        && normalizedViewerDomain
         && _.some(PUBLIC_DOMAINS, d => primaryLogin.includes(d));
 
     if (primaryLogin) {
-        const [username, domain] = primaryLogin.split('@');
+        const [username, userDomain] = primaryLogin.split('@');
         if (CONST.REGEX.POSITIVE_INTEGER.test(username.replace('+', '')) && displayName !== username) {
             handle = username.replace('+', '');
-        } else if (isPublicEmail != null && !isPublicEmail && formattedViewerDomain === domain) {
+        } else if (isPublicEmail != null && !isPublicEmail && normalizedViewerDomain === userDomain) {
             handle = username;
         } else {
             handle = primaryLogin;

--- a/src/libs/ReportUtils.js
+++ b/src/libs/ReportUtils.js
@@ -409,10 +409,10 @@ function getPersonHandle(displayName, primaryLogin, viewerDomain) {
         && _.some(PUBLIC_DOMAINS, d => primaryLogin.includes(d));
 
     if (primaryLogin) {
-        const [username, currentDomain] = primaryLogin.split('@');
+        const [username, domain] = primaryLogin.split('@');
         if (CONST.REGEX.POSITIVE_INTEGER.test(username.replace('+', ''))) {
             handle = username.replace('+', '');
-        } else if (isPublicEmail != null && !isPublicEmail && formattedViewerDomain === currentDomain) {
+        } else if (isPublicEmail != null && !isPublicEmail && formattedViewerDomain === domain) {
             handle = username;
         } else {
             handle = primaryLogin;

--- a/src/libs/ReportUtils.js
+++ b/src/libs/ReportUtils.js
@@ -4,6 +4,7 @@ import lodashGet from 'lodash/get';
 import lodashIntersection from 'lodash/intersection';
 import Onyx from 'react-native-onyx';
 import ExpensiMark from 'expensify-common/lib/ExpensiMark';
+import {PUBLIC_DOMAINS} from 'expensify-common/lib/CONST';
 import ONYXKEYS from '../ONYXKEYS';
 import CONST from '../CONST';
 import * as Localize from './Localize';
@@ -396,6 +397,36 @@ function getRoomWelcomeMessage(report, policiesMap) {
     }
 
     return welcomeMessage;
+}
+
+function getPersonHandle(displayName, primaryLogin, viewerDomain) {
+    let handle = null;
+
+    const formattedViewerDomain = viewerDomain && viewerDomain.startsWith('+@') ? viewerDomain.slice(2) : undefined;
+
+    const isPublicEmail = primaryLogin
+        && formattedViewerDomain
+        && _.some(PUBLIC_DOMAINS, d => primaryLogin.includes(d))
+        && primaryLogin.includes(formattedViewerDomain);
+
+    if (primaryLogin) {
+        const [username, domain] = primaryLogin.split('@');
+        if (CONST.REGEX.POSITIVE_INTEGER.test(username.replace('+', ''))) {
+            handle = username.replace('+', '');
+        } else if (isPublicEmail != null && !isPublicEmail && formattedViewerDomain === domain) {
+            handle = username;
+        } else {
+            handle = primaryLogin;
+        }
+    }
+
+    if (displayName === handle) {
+        handle = null;
+    } else if (handle) {
+        handle = `@${handle}`;
+    }
+
+    return handle;
 }
 
 /**
@@ -1735,6 +1766,7 @@ export {
     getChatByParticipants,
     getAllPolicyReports,
     getIOUReportActionMessage,
+    getPersonHandle,
     getDisplayNameForParticipant,
     isIOUReport,
     chatIncludesChronos,

--- a/src/libs/ReportUtils.js
+++ b/src/libs/ReportUtils.js
@@ -399,6 +399,13 @@ function getRoomWelcomeMessage(report, policiesMap) {
     return welcomeMessage;
 }
 
+/**
+ * Function to get the handle of a person based on their display name, primary login, and viewer domain.
+ * @param {String} displayName the display name of the person
+ * @param {String} primaryLogin the primary login of the person, in the format of "username@domain"
+ * @param {String} viewerDomain the domain of the viewer
+ * @returns {String | null} the handle of the person, in the format of "@username", or null if no handle can be determined
+ */
 function getPersonHandle(displayName, primaryLogin, viewerDomain) {
     let handle = null;
 

--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -276,7 +276,7 @@ class ReportActionItem extends Component {
                                 >
                                     {!this.props.displayAsGroup
                                         ? (
-                                            <ReportActionItemSingle ownerEmail={this.props.report.ownerEmail} action={this.props.action} showHeader={!this.props.draftMessage}>
+                                            <ReportActionItemSingle currentDomain={this.props.report.ownerEmail} action={this.props.action} showHeader={!this.props.draftMessage}>
                                                 {this.renderItemContent(hovered || this.state.isContextMenuActive)}
                                             </ReportActionItemSingle>
                                         )

--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -276,7 +276,7 @@ class ReportActionItem extends Component {
                                 >
                                     {!this.props.displayAsGroup
                                         ? (
-                                            <ReportActionItemSingle action={this.props.action} showHeader={!this.props.draftMessage}>
+                                            <ReportActionItemSingle ownerEmail={this.props.report.ownerEmail} action={this.props.action} showHeader={!this.props.draftMessage}>
                                                 {this.renderItemContent(hovered || this.state.isContextMenuActive)}
                                             </ReportActionItemSingle>
                                         )

--- a/src/pages/home/report/ReportActionItemSingle.js
+++ b/src/pages/home/report/ReportActionItemSingle.js
@@ -20,6 +20,7 @@ import ControlSelection from '../../../libs/ControlSelection';
 import * as ReportUtils from '../../../libs/ReportUtils';
 import OfflineWithFeedback from '../../../components/OfflineWithFeedback';
 import CONST from '../../../CONST';
+import Text from '../../../components/Text';
 
 const propTypes = {
     /** All the data of the action */
@@ -68,6 +69,8 @@ const ReportActionItemSingle = (props) => {
         ? [{type: 'TEXT', text: Str.isSMSLogin(login) ? props.toLocalPhone(displayName) : displayName}]
         : props.action.person;
 
+    const handle = ReportUtils.getPersonHandle(personArray[0].text, actorEmail, props.ownerEmail);
+
     return (
         <View style={props.wrapperStyles}>
             <Pressable
@@ -107,6 +110,7 @@ const ReportActionItemSingle = (props) => {
                                 />
                             ))}
                         </Pressable>
+                        {!!handle && <Text style={[styles.chatItemProfileHandle, styles.mr1]}>{handle}</Text>}
                         <ReportActionItemDate created={props.action.created} />
                     </View>
                 ) : null}

--- a/src/pages/home/report/ReportActionItemSingle.js
+++ b/src/pages/home/report/ReportActionItemSingle.js
@@ -39,6 +39,9 @@ const propTypes = {
     /** Show header for action */
     showHeader: PropTypes.bool,
 
+    /** Current domain of report */
+    currentDomain: PropTypes.string,
+
     ...withLocalizePropTypes,
 };
 
@@ -46,6 +49,7 @@ const defaultProps = {
     personalDetails: {},
     wrapperStyles: [styles.chatItem],
     showHeader: true,
+    currentDomain: null,
 };
 
 const showUserDetails = (email) => {
@@ -69,7 +73,7 @@ const ReportActionItemSingle = (props) => {
         ? [{type: 'TEXT', text: Str.isSMSLogin(login) ? props.toLocalPhone(displayName) : displayName}]
         : props.action.person;
 
-    const handle = ReportUtils.getPersonHandle(personArray[0].text, actorEmail, props.ownerEmail);
+    const handle = ReportUtils.getPersonHandle(lodashGet(personArray, '[0].text', null), actorEmail, props.currentDomain);
 
     return (
         <View style={props.wrapperStyles}>
@@ -110,7 +114,7 @@ const ReportActionItemSingle = (props) => {
                                 />
                             ))}
                         </Pressable>
-                        {!!handle && <Text style={[styles.chatItemProfileHandle, styles.mr1]}>{handle}</Text>}
+                        {!!handle && <Text numberOfLines={1} ellipsizeMode="head" style={[styles.chatItemProfileHandle, styles.flexShrink1, styles.mr1]}>{handle}</Text>}
                         <ReportActionItemDate created={props.action.created} />
                     </View>
                 ) : null}

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1373,6 +1373,13 @@ const styles = {
         ...wordBreak.breakWord,
     },
 
+    chatItemProfileHandle: {
+        fontFamily: fontFamily.EXP_NEUE_BOLD,
+        color: themeColors.textSupporting,
+        fontSize: variables.fontSizeNormal,
+        lineHeight: variables.lineHeightXLarge,
+    },
+
     chatItemMessageHeaderTimestamp: {
         flexShrink: 0,
         color: themeColors.textSupporting,

--- a/tests/unit/ReportUtilsTest.js
+++ b/tests/unit/ReportUtilsTest.js
@@ -454,6 +454,16 @@ describe('ReportUtils', () => {
             expect(result).toEqual(`@test@${randomPublicDomain}`);
         });
 
+        it('returns null if displayName is the same as primaryLogin and it is phone number', () => {
+            const displayName = '+00123123123';
+            const primaryLogin = '+00123123123';
+            const viewerDomain = '+@gmail.com';
+
+            const result = ReportUtils.getPersonHandle(displayName, primaryLogin, viewerDomain);
+
+            expect(result).toBeNull();
+        });
+
         it('returns null when primaryLogin the same as the handle', () => {
             const displayName = 'testuser';
             const primaryLogin = 'testuser@different.com';

--- a/tests/unit/ReportUtilsTest.js
+++ b/tests/unit/ReportUtilsTest.js
@@ -1,5 +1,6 @@
 import Onyx from 'react-native-onyx';
 import _ from 'underscore';
+import {PUBLIC_DOMAINS} from 'expensify-common/lib/CONST';
 import CONST from '../../src/CONST';
 import ONYXKEYS from '../../src/ONYXKEYS';
 import * as ReportUtils from '../../src/libs/ReportUtils';
@@ -407,6 +408,80 @@ describe('ReportUtils', () => {
         it('shouldn\'t get the correct reportID from a deep link', () => {
             expect(ReportUtils.getReportIDFromLink('new-expensify-not-valid://r/75431276')).toBe('');
             expect(ReportUtils.getReportIDFromLink('new-expensify://settings')).toBe('');
+        });
+    });
+
+    describe('getPersonHandle', () => {
+        it("returns front of email handle if primaryLogin is on viewer's domain and is not public email", () => {
+            const displayName = 'Test User';
+            const primaryLogin = 'testUser@different.com';
+            const viewerDomain = '+@different.com';
+
+            const result = ReportUtils.getPersonHandle(displayName, primaryLogin, viewerDomain);
+
+            expect(result).toEqual('@testUser');
+        });
+
+        it("returns full email handle if primaryLogin is not on viewer's domain and is not public email", () => {
+            const displayName = 'Test User';
+            const primaryLogin = 'testUser@different.com';
+            const viewerDomain = '+@private.com';
+
+            const result = ReportUtils.getPersonHandle(displayName, primaryLogin, viewerDomain);
+
+            expect(result).toEqual('@testUser@different.com');
+        });
+
+        it('returns phone number handle if primaryLogin is phone number', () => {
+            const displayName = 'Test User';
+            const primaryLogin = '+00123123123';
+            const viewerDomain = '+@gmail.com';
+
+            const result = ReportUtils.getPersonHandle(displayName, primaryLogin, viewerDomain);
+
+            expect(result).toEqual('@00123123123');
+        });
+
+        it('returns front of email if primary login is public domain', () => {
+            // This case will never happen in real life because there is no public domain chat.
+            const randomPublicDomain = PUBLIC_DOMAINS[Math.floor(Math.random() * PUBLIC_DOMAINS.length)];
+            const displayName = 'Test User';
+            const primaryLogin = `test@${randomPublicDomain}`;
+            const viewerDomain = `+@${randomPublicDomain}`;
+
+            const result = ReportUtils.getPersonHandle(displayName, primaryLogin, viewerDomain);
+
+            expect(result).toEqual(`@test@${randomPublicDomain}`);
+        });
+
+        it('returns null when primaryLogin and displayName are both null', () => {
+            const displayName = null;
+            const primaryLogin = null;
+            const viewerDomain = '+@example.com';
+
+            const result = ReportUtils.getPersonHandle(displayName, primaryLogin, viewerDomain);
+
+            expect(result).toBeNull();
+        });
+
+        it('returns null when primaryLogin is null', () => {
+            const displayName = 'testuser';
+            const primaryLogin = null;
+            const viewerDomain = '+@example.com';
+
+            const result = ReportUtils.getPersonHandle(displayName, primaryLogin, viewerDomain);
+
+            expect(result).toBeNull();
+        });
+
+        it('returns null when primaryLogin is null', () => {
+            const displayName = 'testuser';
+            const primaryLogin = null;
+            const viewerDomain = '+@example.com';
+
+            const result = ReportUtils.getPersonHandle(displayName, primaryLogin, viewerDomain);
+
+            expect(result).toBeNull();
         });
     });
 });

--- a/tests/unit/ReportUtilsTest.js
+++ b/tests/unit/ReportUtilsTest.js
@@ -412,6 +412,8 @@ describe('ReportUtils', () => {
     });
 
     describe('getPersonHandle', () => {
+        const getRandomPublicDomain = () => PUBLIC_DOMAINS[Math.floor(Math.random() * PUBLIC_DOMAINS.length)];
+
         it("returns front of email handle if primaryLogin is on viewer's domain and is not public email", () => {
             const displayName = 'Test User';
             const primaryLogin = 'testUser@different.com';
@@ -435,16 +437,16 @@ describe('ReportUtils', () => {
         it('returns phone number handle if primaryLogin is phone number', () => {
             const displayName = 'Test User';
             const primaryLogin = '+00123123123';
-            const viewerDomain = '+@gmail.com';
+            const viewerDomain = `+@${getRandomPublicDomain()}`;
 
             const result = ReportUtils.getPersonHandle(displayName, primaryLogin, viewerDomain);
 
             expect(result).toEqual('@00123123123');
         });
 
-        it('returns front of email if primary login is public domain', () => {
+        it('returns full email handle if primary login is public domain', () => {
             // This case will never happen in real life because there is no public domain chat.
-            const randomPublicDomain = PUBLIC_DOMAINS[Math.floor(Math.random() * PUBLIC_DOMAINS.length)];
+            const randomPublicDomain = getRandomPublicDomain();
             const displayName = 'Test User';
             const primaryLogin = `test@${randomPublicDomain}`;
             const viewerDomain = `+@${randomPublicDomain}`;
@@ -457,9 +459,8 @@ describe('ReportUtils', () => {
         it('returns null if displayName is the same as primaryLogin and it is phone number', () => {
             const displayName = '+00123123123';
             const primaryLogin = '+00123123123';
-            const viewerDomain = '+@gmail.com';
 
-            const result = ReportUtils.getPersonHandle(displayName, primaryLogin, viewerDomain);
+            const result = ReportUtils.getPersonHandle(displayName, primaryLogin);
 
             expect(result).toBeNull();
         });
@@ -478,6 +479,47 @@ describe('ReportUtils', () => {
             const displayName = null;
             const primaryLogin = null;
             const viewerDomain = '+@example.com';
+
+            const result = ReportUtils.getPersonHandle(displayName, primaryLogin, viewerDomain);
+
+            expect(result).toBeNull();
+        });
+
+        it('returns full email handle when displayName is null but primary login private email domain', () => {
+            const displayName = null;
+            const primaryLogin = 'testuser@different.com';
+            const viewerDomain = '+@example.com';
+
+            const result = ReportUtils.getPersonHandle(displayName, primaryLogin, viewerDomain);
+
+            expect(result).toEqual('@testuser@different.com');
+        });
+
+        it("returns front of email when displayName is null and primaryLogin is on viewer's domain and is not public email", () => {
+            const displayName = null;
+            const primaryLogin = 'testuser@different.com';
+            const viewerDomain = '+@different.com';
+
+            const result = ReportUtils.getPersonHandle(displayName, primaryLogin, viewerDomain);
+
+            expect(result).toEqual('@testuser');
+        });
+
+        it('returns full email handle when displayName is null and primary login is public domain', () => {
+            const randomPublicDomain = getRandomPublicDomain();
+            const displayName = null;
+            const primaryLogin = `test@${randomPublicDomain}`;
+            const viewerDomain = `+@${randomPublicDomain}`;
+
+            const result = ReportUtils.getPersonHandle(displayName, primaryLogin, viewerDomain);
+
+            expect(result).toEqual(`@test@${randomPublicDomain}`);
+        });
+
+        it('returns null when all params are null', () => {
+            const displayName = null;
+            const primaryLogin = null;
+            const viewerDomain = null;
 
             const result = ReportUtils.getPersonHandle(displayName, primaryLogin, viewerDomain);
 

--- a/tests/unit/ReportUtilsTest.js
+++ b/tests/unit/ReportUtilsTest.js
@@ -454,18 +454,18 @@ describe('ReportUtils', () => {
             expect(result).toEqual(`@test@${randomPublicDomain}`);
         });
 
-        it('returns null when primaryLogin and displayName are both null', () => {
-            const displayName = null;
-            const primaryLogin = null;
-            const viewerDomain = '+@example.com';
+        it('returns null when primaryLogin the same as the handle', () => {
+            const displayName = 'testuser';
+            const primaryLogin = 'testuser@different.com';
+            const viewerDomain = '+@different.com';
 
             const result = ReportUtils.getPersonHandle(displayName, primaryLogin, viewerDomain);
 
             expect(result).toBeNull();
         });
 
-        it('returns null when primaryLogin is null', () => {
-            const displayName = 'testuser';
+        it('returns null when primaryLogin and displayName are both null', () => {
+            const displayName = null;
             const primaryLogin = null;
             const viewerDomain = '+@example.com';
 


### PR DESCRIPTION
Add "handle" next to the display name in report actions.

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues

$ https://github.com/Expensify/App/issues/15993
$ https://github.com/Expensify/App/issues/15993#issuecomment-1476377296


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Open a report with a public and private domain with some messages. Verify if the handle displays properly for cases:
 - If the handle is shown, verify if it is always prefixed with an `@` symbol
 - If their primary login is a phone number, the handle should be a full phone number as the handle (e.g. @9765473456)
 - if the handle is a phone number, it displays without the `+` prefix.
 - If their primary login is a public domain email address, the handle should be a full email address as the handle (e.g. @bob@gmail.com)
 - If their primary login is a private domain email address on a different domain than the logged-in user, the handle should be the full email address (e.g. @bob@different.com)
 - If their primary login is a private domain email address on the same domain as the logged-in user, the handle should be front of the email address (e.g. @bob)

- [x] Verify that no errors appear in the JS console

### Offline tests
No offline tests needed

### QA Steps

1. Open a report with a public and private domain with some messages. Verify if the handle displays properly for cases:
 - If the handle is shown, verify if it is always prefixed with an `@` symbol
 - If their primary login is a phone number, the handle should be a full phone number as the handle (e.g. @9765473456)
 - if the handle is a phone number, it displays without the `+` prefix.
 - If their primary login is a public domain email address, the handle should be a full email address as the handle (e.g. @bob@gmail.com)
 - If their primary login is a private domain email address on a different domain than the logged-in user, the handle should be the full email address (e.g. @bob@different.com)
 - If their primary login is a private domain email address on the same domain as the logged-in user, the handle should be front of the email address (e.g. @bob)

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<img width="865" alt="web_callstack_domain" src="https://user-images.githubusercontent.com/24796318/229809695-3f4072e3-553a-472a-a43a-11748e5757a3.png">

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<img width="537" alt="mobile chrome callstack domain" src="https://user-images.githubusercontent.com/24796318/229809420-783de8a8-caaa-4f50-b41e-f178ed3cc9ac.png">


</details>

<details>
<summary>Mobile Web - Safari</summary>

<img width="564" alt="ios safari callstack domain" src="https://user-images.githubusercontent.com/24796318/229809175-3dd2984a-37e7-4b64-8e08-f7529bf8d24e.png">


</details>

<details>
<summary>Desktop</summary>

<img width="1312" alt="desktop_phone_number_test" src="https://user-images.githubusercontent.com/24796318/229809140-0cebe825-4c89-44a4-9ca1-22d4e912b4d2.png">

</details>

<details>
<summary>iOS</summary>

<img width="564" alt="ios_callstack_domain" src="https://user-images.githubusercontent.com/24796318/229809091-f24bc783-116e-4c3d-bc80-549fb3ee2676.png">

</details>

<details>
<summary>Android</summary>

<img width="537" alt="android_callstack_domain" src="https://user-images.githubusercontent.com/24796318/229809036-6a377246-909d-4d66-8cc2-4b0115455b30.png">

</details>
