### PR TITLE
Better handling of additional address fragments (e.g. Apt #) in AddressSearch

### DIFF
--- a/src/components/AddressSearch.js
+++ b/src/components/AddressSearch.js
@@ -105,6 +105,7 @@ const AddressSearch = (props) => {
         const {
             street_number: streetNumber,
             route: streetName,
+            subpremise,
             locality,
             sublocality,
             postal_town: postalTown,
@@ -114,6 +115,7 @@ const AddressSearch = (props) => {
         } = GooglePlacesUtils.getAddressComponents(addressComponents, {
             street_number: 'long_name',
             route: 'long_name',
+            subpremise: 'long_name',
             locality: 'long_name',
             sublocality: 'long_name',
             postal_town: 'long_name',
@@ -133,7 +135,10 @@ const AddressSearch = (props) => {
         // Make sure that the order of keys remains such that the country is always set above the state.
         // Refer to https://github.com/Expensify/App/issues/15633 for more information.
         const values = {
-            street: props.value ? props.value.trim() : '',
+            street: `${streetNumber} ${streetName}`.trim(),
+
+            // Autocomplete returns any additional valid address fragments (e.g. Apt #) as subpremise.
+            street2: subpremise,
 
             // When locality is not returned, many countries return the city as postalTown (e.g. 5 New Street
             // Square, London), otherwise as sublocality (e.g. 384 Court Street Brooklyn). If postalTown is
@@ -151,13 +156,10 @@ const AddressSearch = (props) => {
             values.state = longStateName;
         }
 
-        const street = `${streetNumber} ${streetName}`.trim();
-        if (street && street.length >= values.street.length) {
-            // We are only passing the street number and name if the combined length is longer than the value
-            // that was initially passed to the autocomplete component. Google Places can truncate details
-            // like Apt # and this is the best way we have to tell that the new value it's giving us is less
-            // specific than the one the user entered manually.
-            values.street = street;
+        // Not all pages define the Address Line 2 field, so in that case we append any additional address details
+        // (e.g. Apt #) to Address Line 1
+        if (subpremise && typeof props.renamedInputKeys.street2 === 'undefined') {
+            values.street += `, ${subpremise}`;
         }
 
         const isValidCountryCode = lodashGet(CONST.ALL_COUNTRIES, country);

--- a/src/pages/settings/Profile/PersonalDetails/AddressPage.js
+++ b/src/pages/settings/Profile/PersonalDetails/AddressPage.js
@@ -146,6 +146,7 @@ class AddressPage extends Component {
                             isLimitedToUSA={false}
                             renamedInputKeys={{
                                 street: 'addressLine1',
+                                street2: 'addressLine2',
                                 city: 'city',
                                 state: 'state',
                                 zipCode: 'zipPostCode',


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This adds better handling than our [initial attempt](https://github.com/Expensify/App/pull/6569) for additional address information that is not directly in Google's database, such as Apt #. Now we use the Autocomplete APIs `subpremise` parameter, which is populated when the API determines there is a valid extra address fragment, so it works for the same Apt # case as the original attempt, whilst also allowing for narrowing down searches by typing e.g. a city or a state (as in the linked issue).

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ #15784 
PROPOSAL: https://github.com/Expensify/App/issues/15784#issuecomment-1475200795


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Same as QA tests.
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Autocomplete won't work offline so no test steps necessary.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

**Narrow down searches by typing a city** (fixes the linked issue)
1. Go to Settings > Profile > Personal Details > Home address
2. Input to address line 1 following: "1 collins avenue miami"
3. Select first result
4. Verify that the Address Line 1 field only contains "1 Collins Avenue", and that "Miami Beach" is placed in the City field.

**Add additional information, e.g. Apt #, plus narrow down the search with a city** (maintains existing functionality and adds the fixed functionality)
1. Go to Settings > Profile > Personal Details > Home address
2. Input to address line 1 following: "1 collins avenue apt 123b miami"
3. Select first result
4. Verify that the Address Line 1 field only contains "1 Collins Avenue", that the appartment is added to Address Line 2 and that "Miami Beach" is placed in the City field.

**Check usage of AddressSearch without a second address line**
1. Go to Workspaces->Select a workspace->Connect bank account->Connect manually->Step 2
2. Input to address line 1 following: "1 collins avenue apt 123b miami" and select the first result
3. Verify that the Address Line 1 field contains the street address with the apt # appended to it ("1 Collins Avenue, apt 123b" and that "Miami Beach" is placed in the City field.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

**Home Address (with Address Line 2 field)**
https://user-images.githubusercontent.com/27287420/228862287-9c5cea9b-c3d8-4b4a-932f-619672d0d2b1.mp4

**Without Address Line 2**
https://user-images.githubusercontent.com/27287420/228862317-8130570e-0096-4633-820d-f37048c59c72.mp4

</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://user-images.githubusercontent.com/27287420/228862500-b78e19d1-86b2-4d04-bd09-2a87b5d6e37e.mp4

</details>

<details>
<summary>Mobile Web - Safari</summary>

https://user-images.githubusercontent.com/27287420/228862553-d610cf89-0f4e-4e12-822f-cf2a510974cd.mp4

</details>

<details>
<summary>Desktop</summary>

https://user-images.githubusercontent.com/27287420/228862584-5aabcde7-06ab-4ab6-ab15-ec778c1f2a22.mp4

</details>

<details>
<summary>iOS</summary>

https://user-images.githubusercontent.com/27287420/228862621-fb844a60-e9fd-49c2-a376-8b6334d6426b.mp4

</details>

<details>
<summary>Android</summary>

https://user-images.githubusercontent.com/27287420/228862671-70ed4d98-9c13-49d8-ae07-39c23017be02.mp4

</details>
