### PR TITLE
refactor: forward ref to datepicker instance

### DIFF
--- a/src/components/NewDatePicker/index.js
+++ b/src/components/NewDatePicker/index.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import {View, Animated} from 'react-native';
 import moment from 'moment';
-import _ from 'underscore';
 import TextInput from '../TextInput';
 import CalendarPicker from '../CalendarPicker';
 import CONST from '../../CONST';

--- a/src/components/NewDatePicker/index.js
+++ b/src/components/NewDatePicker/index.js
@@ -128,13 +128,7 @@ class NewDatePicker extends React.Component {
                 <View style={[this.props.isSmallScreenWidth ? styles.flex2 : {}]}>
                     <TextInput
                         forceActiveLabel
-                        ref={(el) => {
-                            this.textInputRef = el;
-                            if (!_.isFunction(this.props.innerRef)) {
-                                return;
-                            }
-                            this.props.innerRef(el);
-                        }}
+                        ref={el => this.textInputRef = el}
                         icon={Expensicons.Calendar}
                         onPress={this.showPicker}
                         label={this.props.label}
@@ -177,7 +171,4 @@ class NewDatePicker extends React.Component {
 NewDatePicker.propTypes = propTypes;
 NewDatePicker.defaultProps = datePickerDefaultProps;
 
-export default withLocalize(React.forwardRef((props, ref) => (
-    /* eslint-disable-next-line react/jsx-props-no-spreading */
-    <NewDatePicker {...props} innerRef={ref} />
-)));
+export default withLocalize(NewDatePicker);

--- a/src/components/NewDatePicker/index.js
+++ b/src/components/NewDatePicker/index.js
@@ -45,6 +45,10 @@ class NewDatePicker extends React.Component {
     }
 
     componentDidMount() {
+        if (this.props.autoFocus) {
+            this.showPicker();
+        }
+
         const shortcutConfig = CONST.KEYBOARD_SHORTCUTS.ESCAPE;
         this.unsubscribeEscapeKey = KeyboardShortcut.subscribe(shortcutConfig.shortcutKey, () => {
             if (!this.state.isPickerVisible) {

--- a/src/components/NewDatePicker/index.js
+++ b/src/components/NewDatePicker/index.js
@@ -47,6 +47,7 @@ class NewDatePicker extends React.Component {
     componentDidMount() {
         if (this.props.autoFocus) {
             this.showPicker();
+            this.textInputRef.focus();
         }
 
         const shortcutConfig = CONST.KEYBOARD_SHORTCUTS.ESCAPE;

--- a/src/pages/settings/Profile/PersonalDetails/DateOfBirthPage.js
+++ b/src/pages/settings/Profile/PersonalDetails/DateOfBirthPage.js
@@ -58,7 +58,7 @@ class DateOfBirthPage extends Component {
                 return;
             }
             this.datePicker.showPicker();
-        }, 1);
+        }, 100);
     }
 
     componentWillUnmount() {

--- a/src/pages/settings/Profile/PersonalDetails/DateOfBirthPage.js
+++ b/src/pages/settings/Profile/PersonalDetails/DateOfBirthPage.js
@@ -51,13 +51,6 @@ class DateOfBirthPage extends Component {
 
     componentDidMount() {
         this.props.navigation.addListener('focus', this.getYearFromRouteParams);
-
-        setTimeout(() => {
-            if (!this.datePicker) {
-                return;
-            }
-            this.datePicker.showPicker();
-        }, 100);
     }
 
     componentWillUnmount() {
@@ -137,6 +130,7 @@ class DateOfBirthPage extends Component {
                     enabledWhenOffline
                 >
                     <NewDatePicker
+                        autoFocus
                         ref={ref => this.datePicker = ref}
                         inputID="dob"
                         label={this.props.translate('common.date')}

--- a/src/pages/settings/Profile/PersonalDetails/DateOfBirthPage.js
+++ b/src/pages/settings/Profile/PersonalDetails/DateOfBirthPage.js
@@ -52,6 +52,13 @@ class DateOfBirthPage extends Component {
 
     componentDidMount() {
         this.props.navigation.addListener('focus', this.getYearFromRouteParams);
+
+        setTimeout(() => {
+            if (!this.datePicker) {
+                return;
+            }
+            this.datePicker.showPicker();
+        }, 1);
     }
 
     componentWillUnmount() {
@@ -67,10 +74,7 @@ class DateOfBirthPage extends Component {
         if (params && params.year) {
             this.setState({selectedYear: params.year});
             if (this.datePicker) {
-                this.datePicker.focus();
-                if (_.isFunction(this.datePicker.click)) {
-                    this.datePicker.click();
-                }
+                this.datePicker.showPicker();
             }
         }
     }

--- a/src/pages/settings/Profile/PersonalDetails/DateOfBirthPage.js
+++ b/src/pages/settings/Profile/PersonalDetails/DateOfBirthPage.js
@@ -2,7 +2,6 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {withOnyx} from 'react-native-onyx';
 import moment from 'moment';
-import _ from 'underscore';
 import ScreenWrapper from '../../../../components/ScreenWrapper';
 import HeaderWithCloseButton from '../../../../components/HeaderWithCloseButton';
 import withLocalize, {withLocalizePropTypes} from '../../../../components/withLocalize';


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues

$ https://github.com/Expensify/App/issues/16551
$ https://github.com/Expensify/App/issues/16551#issuecomment-1490344206


### Tests
1. Go to settings -> Profile -> Personal Details
2. Click Date of birth
3. It should open the date of birth page with opened new calendar picker

- [x] Verify that no errors appear in the JS console

### Offline tests
No offline tests needed

### QA Steps
1. Go to settings -> Profile -> Personal Details
2. Click Date of birth
3. It should open the date of birth page with opened new calendar picker

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>


https://user-images.githubusercontent.com/24796318/229082360-c21d045c-5632-4367-9ac0-0007061865e2.mov



</details>

<details>
<summary>Mobile Web - Chrome</summary>


https://user-images.githubusercontent.com/24796318/229082345-f0920cb9-a6a0-44be-9628-f96b6d7712b9.mov



</details>

<details>
<summary>Mobile Web - Safari</summary>


https://user-images.githubusercontent.com/24796318/229082316-569d5bd9-f7d9-4eab-91a4-d0fdc160f2f0.mov



</details>

<details>
<summary>Desktop</summary>


https://user-images.githubusercontent.com/24796318/229082267-eb7a158a-8c0e-427e-bcee-9c26ef9c867a.mov



</details>

<details>
<summary>iOS</summary>


https://user-images.githubusercontent.com/24796318/229082211-c7286a28-8798-4396-a0f4-76a7fa52d670.mov



</details>

<details>
<summary>Android</summary>


https://user-images.githubusercontent.com/24796318/229082240-2404329c-0c53-47b7-8089-8f89ab03aa46.mov



</details>
