### PR TITLE
Add tooltip to Next and Prev button in Attachment Carousel

### DIFF
--- a/src/components/AttachmentCarousel/index.js
+++ b/src/components/AttachmentCarousel/index.js
@@ -16,6 +16,9 @@ import CONST from '../../CONST';
 import ONYXKEYS from '../../ONYXKEYS';
 import reportActionPropTypes from '../../pages/home/report/reportActionPropTypes';
 import tryResolveUrlFromApiRoot from '../../libs/tryResolveUrlFromApiRoot';
+import Tooltip from '../Tooltip';
+import withLocalize, {withLocalizePropTypes} from '../withLocalize';
+import compose from '../../libs/compose';
 
 const propTypes = {
     /** source is used to determine the starting index in the array of attachments */
@@ -26,6 +29,8 @@ const propTypes = {
 
     /** Object of report actions for this report */
     reportActions: PropTypes.objectOf(PropTypes.shape(reportActionPropTypes)),
+
+    ...withLocalizePropTypes,
 };
 
 const defaultProps = {
@@ -163,26 +168,32 @@ class AttachmentCarousel extends React.Component {
                 {(isPageSet && this.state.shouldShowArrow) && (
                     <>
                         {!this.state.isBackDisabled && (
-                            <Button
-                                medium
-                                style={[styles.leftAttachmentArrow]}
-                                innerStyles={[styles.arrowIcon]}
-                                icon={Expensicons.BackArrow}
-                                iconFill={themeColors.text}
-                                iconStyles={[styles.mr0]}
-                                onPress={() => this.cycleThroughAttachments(-1)}
-                            />
+                            <View style={styles.leftAttachmentArrow}>
+                                <Tooltip text={this.props.translate('common.previous')}>
+                                    <Button
+                                        medium
+                                        innerStyles={[styles.arrowIcon]}
+                                        icon={Expensicons.BackArrow}
+                                        iconFill={themeColors.text}
+                                        iconStyles={[styles.mr0]}
+                                        onPress={() => this.cycleThroughAttachments(-1)}
+                                    />
+                                </Tooltip>
+                            </View>
                         )}
                         {!this.state.isForwardDisabled && (
-                            <Button
-                                medium
-                                style={[styles.rightAttachmentArrow]}
-                                innerStyles={[styles.arrowIcon]}
-                                icon={Expensicons.ArrowRight}
-                                iconFill={themeColors.text}
-                                iconStyles={[styles.mr0]}
-                                onPress={() => this.cycleThroughAttachments(1)}
-                            />
+                            <View style={styles.rightAttachmentArrow}>
+                                <Tooltip text={this.props.translate('common.next')}>
+                                    <Button
+                                        medium
+                                        innerStyles={[styles.arrowIcon]}
+                                        icon={Expensicons.ArrowRight}
+                                        iconFill={themeColors.text}
+                                        iconStyles={[styles.mr0]}
+                                        onPress={() => this.cycleThroughAttachments(1)}
+                                    />
+                                </Tooltip>
+                            </View>
                         )}
                     </>
                 )}
@@ -208,9 +219,12 @@ class AttachmentCarousel extends React.Component {
 AttachmentCarousel.propTypes = propTypes;
 AttachmentCarousel.defaultProps = defaultProps;
 
-export default withOnyx({
-    reportActions: {
-        key: ({reportID}) => `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`,
-        canEvict: false,
-    },
-})(AttachmentCarousel);
+export default compose(
+    withOnyx({
+        reportActions: {
+            key: ({reportID}) => `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`,
+            canEvict: false,
+        },
+    }),
+    withLocalize,
+)(AttachmentCarousel);

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -14,6 +14,7 @@ export default {
         new: 'New',
         search: 'Search',
         next: 'Next',
+        previous: 'Previous',
         goBack: 'Go back',
         add: 'Add',
         resend: 'Resend',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -13,7 +13,7 @@ export default {
         new: 'Nuevo',
         search: 'Buscar',
         next: 'Siguiente',
-        previous: 'Previo',
+        previous: 'Anterior',
         goBack: 'Volver',
         add: 'Agregar',
         resend: 'Reenviar',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -13,6 +13,7 @@ export default {
         new: 'Nuevo',
         search: 'Buscar',
         next: 'Siguiente',
+        previous: 'Previo',
         goBack: 'Volver',
         add: 'Agregar',
         resend: 'Reenviar',


### PR DESCRIPTION
@Santhosh-Sellavel  @NikkiWines PR is ready for review.

### Details
Within Web and Desktop tooltip is not shown in previous or next arrow button while viewing images/or files in attachment  carousel. So in this PR we added tooltip to Next and Prev arrow button in English and Spanish. 

**Note:** _Tooltip is applicable for Web and Desktop only. I added other platform video to show that there is not any side effect on other platform with this changes._

### Fixed Issues
$ https://github.com/Expensify/App/issues/16721
PROPOSAL: https://github.com/Expensify/App/issues/16721#issuecomment-1490141526

### Tests
1. Open App in **Web or Desktop** 
2. Go to any chat (Make sure at least 2 /3 images are there as attachments sent/received)
3. Click to open any attached image/file.
4. Hover to Previous/Next Button and Verify that it shows tooltip.
5. For English tooltip will be "Previous" and "Next"
6. For Spanish tooltip will be "Anterior" and "Siguiente"

- [x] Verify that no errors appear in the JS console

### Offline tests
1. Open App in **Web or Desktop** 
2. Go to any chat (Make sure at least 2 /3 images are there as attachments sent/received)
3. Click to open any attached image/file.
4. Hover to Previous/Next Button and Verify that it shows tooltip.
5. For English tooltip will be "Previous" and "Next"
6. For Spanish tooltip will be "Anterior" and "Siguiente"

### QA Steps
1. Open App in **Web or Desktop** 
2. Go to any chat (Make sure at least 2 /3 images are there as attachments sent/received)
3. Click to open any attached image/file.
4. Hover to Previous/Next Button and Verify that it shows tooltip.
5. For English tooltip will be "Previous" and "Next"
6. For Spanish tooltip will be "Anterior" and "Siguiente"

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

#### Chrome EN  

https://user-images.githubusercontent.com/7823358/229619920-066f7e52-189f-46ed-ad2c-8a80432c6982.mp4

#### Chrome ES

https://user-images.githubusercontent.com/7823358/229670503-2674f4aa-e2e2-4b75-b404-8c23868f9f31.mov

#### Safari EN  

https://user-images.githubusercontent.com/7823358/229619990-fb332298-0a1b-4ca9-985c-a28acbdff138.mp4

#### Safari ES 

https://user-images.githubusercontent.com/7823358/229670579-f8d0394e-1d88-4d1e-9d2b-722a5974bbca.mov

</details>

<details>
<summary>Mobile Web - Chrome</summary>

#### EN

https://user-images.githubusercontent.com/7823358/229620400-750d5140-f0a5-4910-abda-d4cb01202988.mov

#### ES 

https://user-images.githubusercontent.com/7823358/229620418-a294f4b8-1318-48d5-ba38-221ff89d2b00.mov

</details>

<details>
<summary>Mobile Web - Safari</summary>

#### EN

https://user-images.githubusercontent.com/7823358/229620492-4adc2751-5e01-425e-8749-e9676c9068a8.mov

#### ES

https://user-images.githubusercontent.com/7823358/229620516-459cbb1d-c10a-4556-ac4a-c0064a748810.mov

</details>

<details>
<summary>Desktop</summary>

#### EN

https://user-images.githubusercontent.com/7823358/229620804-02c7ad4e-3e02-434e-801c-32dd82b75cd2.mp4

#### ES 

https://user-images.githubusercontent.com/7823358/229670787-5f61fc8c-eba5-4019-a164-f958ea9530bc.mp4

</details>

<details>
<summary>iOS</summary>

#### EN

https://user-images.githubusercontent.com/7823358/229620910-3d8a9517-2d71-47b3-bee8-c599d84d3090.mov

#### ES

https://user-images.githubusercontent.com/7823358/229620939-6c092578-4ca1-4e08-8794-dc46e0981524.mov

</details>

<details>
<summary>Android</summary>

#### EN

https://user-images.githubusercontent.com/7823358/229621056-1d8d8446-5016-4b6b-8d66-698326cf0472.mov

#### ES

https://user-images.githubusercontent.com/7823358/229621084-4c55d4da-4d8a-4c00-b4c2-10b10deca6e6.mov

</details>
