### PR TITLE
Don't hide picker on esc key press or tap outside

### DIFF
--- a/src/components/NewDatePicker/datePickerPropTypes.js
+++ b/src/components/NewDatePicker/datePickerPropTypes.js
@@ -29,9 +29,6 @@ const propTypes = {
 
     /** Default year to be set in the calendar picker */
     selectedYear: PropTypes.string,
-
-    /** A function called when picked is closed */
-    onHidePicker: PropTypes.func,
 };
 
 const defaultProps = {
@@ -39,7 +36,6 @@ const defaultProps = {
     minDate: moment().year(CONST.CALENDAR_PICKER.MIN_YEAR).toDate(),
     maxDate: moment().year(CONST.CALENDAR_PICKER.MAX_YEAR).toDate(),
     value: undefined,
-    onHidePicker: () => {},
 };
 
 export {propTypes, defaultProps};

--- a/src/components/NewDatePicker/index.js
+++ b/src/components/NewDatePicker/index.js
@@ -110,10 +110,7 @@ class NewDatePicker extends React.Component {
 
     render() {
         return (
-            <View
-                ref={ref => this.wrapperRef = ref}
-                style={styles.datePickerRoot}
-            >
+            <View style={styles.datePickerRoot}>
                 <View style={[this.props.isSmallScreenWidth ? styles.flex2 : {}]}>
                     <TextInput
                         forceActiveLabel

--- a/src/components/NewDatePicker/index.js
+++ b/src/components/NewDatePicker/index.js
@@ -7,7 +7,6 @@ import CONST from '../../CONST';
 import styles from '../../styles/styles';
 import * as Expensicons from '../Icon/Expensicons';
 import {propTypes as datePickerPropTypes, defaultProps as defaultDatePickerProps} from './datePickerPropTypes';
-import KeyboardShortcut from '../../libs/KeyboardShortcut';
 import withLocalize, {withLocalizePropTypes} from '../withLocalize';
 
 const propTypes = {
@@ -45,19 +44,11 @@ class NewDatePicker extends React.Component {
     }
 
     componentDidMount() {
-        if (this.props.autoFocus) {
-            this.showPicker();
-            this.textInputRef.focus();
+        if (!this.props.autoFocus) {
+            return;
         }
-
-        const shortcutConfig = CONST.KEYBOARD_SHORTCUTS.ESCAPE;
-        this.unsubscribeEscapeKey = KeyboardShortcut.subscribe(shortcutConfig.shortcutKey, () => {
-            if (!this.state.isPickerVisible) {
-                return;
-            }
-            this.hidePicker();
-            this.textInputRef.blur();
-        }, shortcutConfig.descriptionKey, shortcutConfig.modifiers, true, () => !this.state.isPickerVisible);
+        this.showPicker();
+        this.textInputRef.focus();
     }
 
     componentWillUnmount() {
@@ -121,12 +112,6 @@ class NewDatePicker extends React.Component {
         return (
             <View
                 ref={ref => this.wrapperRef = ref}
-                onBlur={(event) => {
-                    if (this.wrapperRef && event.relatedTarget && this.wrapperRef.contains(event.relatedTarget)) {
-                        return;
-                    }
-                    this.hidePicker();
-                }}
                 style={styles.datePickerRoot}
             >
                 <View style={[this.props.isSmallScreenWidth ? styles.flex2 : {}]}>

--- a/src/components/NewDatePicker/index.js
+++ b/src/components/NewDatePicker/index.js
@@ -30,7 +30,6 @@ class NewDatePicker extends React.Component {
 
         this.setDate = this.setDate.bind(this);
         this.showPicker = this.showPicker.bind(this);
-        this.hidePicker = this.hidePicker.bind(this);
         this.setCurrentSelectedMonth = this.setCurrentSelectedMonth.bind(this);
 
         this.opacity = new Animated.Value(0);
@@ -74,7 +73,6 @@ class NewDatePicker extends React.Component {
     setDate(selectedDate) {
         this.setState({selectedDate}, () => {
             this.props.onInputChange(moment(selectedDate).format(CONST.DATE.MOMENT_FORMAT_STRING));
-            this.hidePicker();
             this.textInputRef.blur();
         });
     }
@@ -89,22 +87,6 @@ class NewDatePicker extends React.Component {
                 duration: 100,
                 useNativeDriver: true,
             }).start();
-        });
-    }
-
-    /**
-     * Function to animate and hide the picker.
-     */
-    hidePicker() {
-        Animated.timing(this.opacity, {
-            toValue: 0,
-            duration: 100,
-            useNativeDriver: true,
-        }).start((animationResult) => {
-            if (!animationResult.finished) {
-                return;
-            }
-            this.setState({isPickerVisible: false}, this.props.onHidePicker);
         });
     }
 

--- a/src/components/NewDatePicker/index.js
+++ b/src/components/NewDatePicker/index.js
@@ -47,14 +47,6 @@ class NewDatePicker extends React.Component {
             return;
         }
         this.showPicker();
-        this.textInputRef.focus();
-    }
-
-    componentWillUnmount() {
-        if (!this.unsubscribeEscapeKey) {
-            return;
-        }
-        this.unsubscribeEscapeKey();
     }
 
     /**
@@ -73,7 +65,6 @@ class NewDatePicker extends React.Component {
     setDate(selectedDate) {
         this.setState({selectedDate}, () => {
             this.props.onInputChange(moment(selectedDate).format(CONST.DATE.MOMENT_FORMAT_STRING));
-            this.textInputRef.blur();
         });
     }
 
@@ -96,7 +87,6 @@ class NewDatePicker extends React.Component {
                 <View style={[this.props.isSmallScreenWidth ? styles.flex2 : {}]}>
                     <TextInput
                         forceActiveLabel
-                        ref={el => this.textInputRef = el}
                         icon={Expensicons.Calendar}
                         onPress={this.showPicker}
                         label={this.props.label}
@@ -113,10 +103,6 @@ class NewDatePicker extends React.Component {
                 {
                     this.state.isPickerVisible && (
                     <Animated.View
-                        onMouseDown={(e) => {
-                            // To prevent focus stealing
-                            e.preventDefault();
-                        }}
                         style={[styles.datePickerPopover, styles.border, {opacity: this.opacity}]}
                     >
                         <CalendarPicker

--- a/src/pages/settings/Profile/PersonalDetails/DateOfBirthPage.js
+++ b/src/pages/settings/Profile/PersonalDetails/DateOfBirthPage.js
@@ -39,7 +39,6 @@ class DateOfBirthPage extends Component {
 
         this.validate = this.validate.bind(this);
         this.updateDateOfBirth = this.updateDateOfBirth.bind(this);
-        this.clearSelectedYear = this.clearSelectedYear.bind(this);
         this.getYearFromRouteParams = this.getYearFromRouteParams.bind(this);
         this.minDate = moment().subtract(CONST.DATE_BIRTH.MAX_AGE, 'Y').toDate();
         this.maxDate = moment().subtract(CONST.DATE_BIRTH.MIN_AGE, 'Y').toDate();
@@ -65,9 +64,6 @@ class DateOfBirthPage extends Component {
         const {params} = this.props.route;
         if (params && params.year) {
             this.setState({selectedYear: params.year});
-            if (this.datePicker) {
-                this.datePicker.showPicker();
-            }
         }
     }
 
@@ -80,13 +76,6 @@ class DateOfBirthPage extends Component {
         PersonalDetails.updateDateOfBirth(
             values.dob,
         );
-    }
-
-    /**
-     * A function to clear selected year
-     */
-    clearSelectedYear() {
-        this.setState({selectedYear: ''});
     }
 
     /**
@@ -131,14 +120,12 @@ class DateOfBirthPage extends Component {
                 >
                     <NewDatePicker
                         autoFocus
-                        ref={ref => this.datePicker = ref}
                         inputID="dob"
                         label={this.props.translate('common.date')}
                         defaultValue={privateDetails.dob || ''}
                         minDate={this.minDate}
                         maxDate={this.maxDate}
                         selectedYear={this.state.selectedYear}
-                        onHidePicker={this.clearSelectedYear}
                     />
                 </Form>
             </ScreenWrapper>


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

As per [this slack convo](https://expensify.slack.com/archives/C01GTK53T8Q/p1680648190769399?thread_ts=1673894240.895279&cid=C01GTK53T8Q), we decided to not to hide the calendar when the click event happens outside or the ESC key is pressed. With this PR, the calendar doesn't hide itself anymore on web (on mobile native platforms, the calendar already doesn't hide when tapped outside.).

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/16422


### Tests / QA Steps
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Login to NewDot
2. Settings (click or tap the profile avatar) > Profile > Personal details > Date of birth
3. Check the date picker (calendar) opens up
4. Click or tap outside the date picker. Make sure that the calendar does NOT close
5. Select a date on the date picker. Make sure that the calendar does NOT close
6. On a device with a keyboard (laptop chrome or safari), do the same thing though step 1 - step 3
7. Press the Escape key. Make sure that the calendar does NOT close
8. Verify that no errors appear in the JS console throughout the process

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://user-images.githubusercontent.com/98560306/229936357-f9301852-9136-47c3-920f-4ef6ef44c4db.mov

https://user-images.githubusercontent.com/98560306/229936363-82c509e9-d8e3-45a4-af20-d3e17d7326b6.mov

</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://user-images.githubusercontent.com/98560306/229936389-4721cc39-3888-45e2-bf80-8d6d4e5e6c17.mov

</details>

<details>
<summary>Mobile Web - Safari</summary>

https://user-images.githubusercontent.com/98560306/229936417-1d164898-2996-4b97-8d3a-74ae9f621833.mov

</details>

<details>
<summary>Desktop</summary>

https://user-images.githubusercontent.com/98560306/229936810-4215058c-df44-465d-afea-bf393ca73ec4.mov

</details>

<details>
<summary>iOS</summary>

https://user-images.githubusercontent.com/98560306/229936468-e179e992-2b8b-4b4a-9d46-eb996dcc8903.mov

</details>

<details>
<summary>Android</summary>

https://user-images.githubusercontent.com/98560306/229936563-94f06ca1-f87b-4ecd-bd54-a88395caf54d.mov

</details>
