### PR TITLE
Always display workspace chats in recents when creating a new request

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -825,7 +825,7 @@ const CONST = {
             EXPENSIFY: 'Expensify',
             PAYPAL_ME: 'PayPal.me',
         },
-        IOU_TYPE: {
+        MONEY_REQUEST_TYPE: {
             SEND: 'send',
             SPLIT: 'split',
             REQUEST: 'request',

--- a/src/components/IOUConfirmationList.js
+++ b/src/components/IOUConfirmationList.js
@@ -89,7 +89,7 @@ const defaultProps = {
     },
     onUpdateComment: null,
     comment: '',
-    iouType: CONST.IOU.IOU_TYPE.REQUEST,
+    iouType: CONST.IOU.MONEY_REQUEST_TYPE.REQUEST,
     canModifyParticipants: false,
     session: {
         email: null,
@@ -125,7 +125,7 @@ class IOUConfirmationList extends Component {
                     {style: 'currency', currency: this.props.iou.selectedCurrencyCode},
                 ),
             }),
-            value: this.props.hasMultipleParticipants ? CONST.IOU.IOU_TYPE.SPLIT : CONST.IOU.IOU_TYPE.REQUEST,
+            value: this.props.hasMultipleParticipants ? CONST.IOU.MONEY_REQUEST_TYPE.SPLIT : CONST.IOU.MONEY_REQUEST_TYPE.REQUEST,
         }];
     }
 
@@ -267,7 +267,7 @@ class IOUConfirmationList extends Component {
             return;
         }
 
-        if (this.props.iouType === CONST.IOU.IOU_TYPE.SEND) {
+        if (this.props.iouType === CONST.IOU.MONEY_REQUEST_TYPE.SEND) {
             if (!paymentMethod) {
                 return;
             }
@@ -281,7 +281,7 @@ class IOUConfirmationList extends Component {
 
     render() {
         const selectedParticipants = this.getSelectedParticipants();
-        const shouldShowSettlementButton = this.props.iouType === CONST.IOU.IOU_TYPE.SEND;
+        const shouldShowSettlementButton = this.props.iouType === CONST.IOU.MONEY_REQUEST_TYPE.SEND;
         const shouldDisableButton = selectedParticipants.length === 0;
         const recipient = this.state.participants[0];
         const canModifyParticipants = this.props.canModifyParticipants && this.props.hasMultipleParticipants;

--- a/src/components/ReportWelcomeText.js
+++ b/src/components/ReportWelcomeText.js
@@ -132,7 +132,7 @@ const ReportWelcomeText = (props) => {
                         ))}
                     </Text>
                 )}
-                {(moneyRequestOptions.includes(CONST.IOU.IOU_TYPE.SEND) || moneyRequestOptions.includes(CONST.IOU.IOU_TYPE.REQUEST)) && (
+                {(moneyRequestOptions.includes(CONST.IOU.MONEY_REQUEST_TYPE.SEND) || moneyRequestOptions.includes(CONST.IOU.MONEY_REQUEST_TYPE.REQUEST)) && (
                     <Text>
                         {/* Need to confirm copy for the below with marketing, and then add to translations. */}
                         {props.translate('reportActionsView.usePlusButton')}

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -496,7 +496,6 @@ function getOptions(reports, personalDetails, {
             return;
         }
 
-
         // Save the report in the map if this is a single participant so we can associate the reportID with the
         // personal detail option later. Individuals should not be associated with single participant
         // policyExpenseChats or chatRooms since those are not people.

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -451,8 +451,8 @@ function getOptions(reports, personalDetails, {
     showChatPreviewLine = false,
     sortPersonalDetailsByAlphaAsc = true,
     forcePolicyNamePreview = false,
-    excludeOwnedWorkspaceChats = true,
-    excludeManagedWorkspaceChats = true,
+    includeOwnedWorkspaceChats = false,
+    includeManagedWorkspaceChats = false,
 }) {
     let recentReportOptions = [];
     let personalDetailsOptions = [];
@@ -493,11 +493,11 @@ function getOptions(reports, personalDetails, {
         const isPolicyExpenseChat = ReportUtils.isPolicyExpenseChat(report);
         const logins = report.participants || [];
 
-        if (isPolicyExpenseChat && excludeOwnedWorkspaceChats && report.isOwnPolicyExpenseChat) {
+        if (isPolicyExpenseChat && report.isOwnPolicyExpenseChat && !includeOwnedWorkspaceChats) {
             return;
         }
 
-        if (isPolicyExpenseChat && excludeManagedWorkspaceChats && !report.isOwnPolicyExpenseChat) {
+        if (isPolicyExpenseChat && !report.isOwnPolicyExpenseChat && !includeManagedWorkspaceChats) {
             return;
         }
 
@@ -547,7 +547,7 @@ function getOptions(reports, personalDetails, {
     if (includeRecentReports) {
         for (let i = 0; i < allReportOptions.length; i++) {
             const reportOption = allReportOptions[i];
-            const isCurrentUserOwnedPolicyExpenseChatThatShouldShow = (reportOption.isPolicyExpenseChat && (reportOption.ownerEmail === currentUserLogin) && !excludeOwnedWorkspaceChats);
+            const isCurrentUserOwnedPolicyExpenseChatThatShouldShow = (reportOption.isPolicyExpenseChat && (reportOption.ownerEmail === currentUserLogin) && includeOwnedWorkspaceChats);
 
             // Stop adding options to the recentReports array when we reach the maxRecentReportsToShow value
             if (!isCurrentUserOwnedPolicyExpenseChatThatShouldShow && recentReportOptions.length > 0 && recentReportOptions.length === maxRecentReportsToShow) {
@@ -677,8 +677,8 @@ function getSearchOptions(
         showChatPreviewLine: true,
         includePersonalDetails: true,
         forcePolicyNamePreview: true,
-        excludeOwnedWorkspaceChats: false,
-        excludeManagedWorkspaceChats: false,
+        includeOwnedWorkspaceChats: true,
+        includeManagedWorkspaceChats: true,
     });
 }
 
@@ -723,11 +723,11 @@ function getIOUConfirmationOptionsFromParticipants(
  *
  * @param {Object} reports
  * @param {Object} personalDetails
- * @param {Array<String>} betas
- * @param {String} searchValue
- * @param {Array} selectedOptions
- * @param {Array} excludeLogins
- * @param {Boolean} excludeOwnedWorkspaceChats
+ * @param {Array<String>} [betas]
+ * @param {String} [searchValue]
+ * @param {Array} [selectedOptions]
+ * @param {Array} [excludeLogins]
+ * @param {Boolean} [includeOwnedWorkspaceChats]
  * @returns {Object}
  */
 function getNewChatOptions(
@@ -737,9 +737,7 @@ function getNewChatOptions(
     searchValue = '',
     selectedOptions = [],
     excludeLogins = [],
-
-    // We'll set this to false when reusing this method in MoneyRequestModal
-    excludeOwnedWorkspaceChats = true,
+    includeOwnedWorkspaceChats = false,
 ) {
     return getOptions(reports, personalDetails, {
         betas,
@@ -749,7 +747,7 @@ function getNewChatOptions(
         includePersonalDetails: true,
         maxRecentReportsToShow: 5,
         excludeLogins,
-        excludeOwnedWorkspaceChats,
+        includeOwnedWorkspaceChats,
     });
 }
 

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -452,7 +452,6 @@ function getOptions(reports, personalDetails, {
     sortPersonalDetailsByAlphaAsc = true,
     forcePolicyNamePreview = false,
     includeOwnedWorkspaceChats = false,
-    includeManagedWorkspaceChats = false,
 }) {
     let recentReportOptions = [];
     let personalDetailsOptions = [];
@@ -497,9 +496,6 @@ function getOptions(reports, personalDetails, {
             return;
         }
 
-        if (isPolicyExpenseChat && !report.isOwnPolicyExpenseChat && !includeManagedWorkspaceChats) {
-            return;
-        }
 
         // Save the report in the map if this is a single participant so we can associate the reportID with the
         // personal detail option later. Individuals should not be associated with single participant
@@ -678,7 +674,6 @@ function getSearchOptions(
         includePersonalDetails: true,
         forcePolicyNamePreview: true,
         includeOwnedWorkspaceChats: true,
-        includeManagedWorkspaceChats: true,
     });
 }
 

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -542,7 +542,11 @@ function getOptions(reports, personalDetails, {
     if (includeRecentReports) {
         for (let i = 0; i < allReportOptions.length; i++) {
             const reportOption = allReportOptions[i];
-            const isCurrentUserOwnedPolicyExpenseChatThatShouldShow = (reportOption.isPolicyExpenseChat && (reportOption.ownerEmail === currentUserLogin) && includeOwnedWorkspaceChats);
+            const isCurrentUserOwnedPolicyExpenseChatThatShouldShow = (reportOption.isPolicyExpenseChat
+                && (reportOption.ownerEmail === currentUserLogin)
+                && includeOwnedWorkspaceChats
+                && !reportOption.isArchivedRoom
+            );
 
             // Stop adding options to the recentReports array when we reach the maxRecentReportsToShow value
             if (!isCurrentUserOwnedPolicyExpenseChatThatShouldShow && recentReportOptions.length > 0 && recentReportOptions.length === maxRecentReportsToShow) {

--- a/src/libs/ReportUtils.js
+++ b/src/libs/ReportUtils.js
@@ -1642,14 +1642,14 @@ function getMoneyRequestOptions(report, reportParticipants, betas) {
     // DM chats will have the Split Bill option only when there are at least 3 people in the chat.
     // There is no Split Bill option for Workspace chats
     if (isChatRoom(report) || (hasMultipleParticipants && !isPolicyExpenseChat(report))) {
-        return [CONST.IOU.IOU_TYPE.SPLIT];
+        return [CONST.IOU.MONEY_REQUEST_TYPE.SPLIT];
     }
 
     // DM chats that only have 2 people will see the Send / Request money options.
     // Workspace chats should only see the Request money option, as "easy overages" is not available.
     return [
-        ...(canRequestMoney(report) ? [CONST.IOU.IOU_TYPE.REQUEST] : []),
-        ...(Permissions.canUseIOUSend(betas) && !isPolicyExpenseChat(report) ? [CONST.IOU.IOU_TYPE.SEND] : []),
+        ...(canRequestMoney(report) ? [CONST.IOU.MONEY_REQUEST_TYPE.REQUEST] : []),
+        ...(Permissions.canUseIOUSend(betas) && !isPolicyExpenseChat(report) ? [CONST.IOU.MONEY_REQUEST_TYPE.SEND] : []),
     ];
 }
 

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -334,17 +334,17 @@ class ReportActionCompose extends React.Component {
      */
     getMoneyRequestOptions(reportParticipants) {
         const options = {
-            [CONST.IOU.IOU_TYPE.SPLIT]: {
+            [CONST.IOU.MONEY_REQUEST_TYPE.SPLIT]: {
                 icon: Expensicons.Receipt,
                 text: this.props.translate('iou.splitBill'),
                 onSelected: () => Navigation.navigate(ROUTES.getIouSplitRoute(this.props.reportID)),
             },
-            [CONST.IOU.IOU_TYPE.REQUEST]: {
+            [CONST.IOU.MONEY_REQUEST_TYPE.REQUEST]: {
                 icon: Expensicons.MoneyCircle,
                 text: this.props.translate('iou.requestMoney'),
                 onSelected: () => Navigation.navigate(ROUTES.getIouRequestRoute(this.props.reportID)),
             },
-            [CONST.IOU.IOU_TYPE.SEND]: {
+            [CONST.IOU.MONEY_REQUEST_TYPE.SEND]: {
                 icon: Expensicons.Send,
                 text: this.props.translate('iou.sendMoney'),
                 onSelected: () => Navigation.navigate(ROUTES.getIOUSendRoute(this.props.reportID)),

--- a/src/pages/iou/IOUSendPage.js
+++ b/src/pages/iou/IOUSendPage.js
@@ -3,6 +3,6 @@ import CONST from '../../CONST';
 import MoneyRequestModal from './MoneyRequestModal';
 
 // eslint-disable-next-line react/jsx-props-no-spreading
-const IOUSendPage = props => <MoneyRequestModal {...props} iouType={CONST.IOU.IOU_TYPE.SEND} />;
+const IOUSendPage = props => <MoneyRequestModal {...props} iouType={CONST.IOU.MONEY_REQUEST_TYPE.SEND} />;
 IOUSendPage.displayName = 'IOUSendPage';
 export default IOUSendPage;

--- a/src/pages/iou/MoneyRequestModal.js
+++ b/src/pages/iou/MoneyRequestModal.js
@@ -85,7 +85,7 @@ const defaultProps = {
     report: {
         participants: [],
     },
-    iouType: CONST.IOU.IOU_TYPE.REQUEST,
+    iouType: CONST.IOU.MONEY_REQUEST_TYPE.REQUEST,
     currentUserPersonalDetails: {
         localCurrencyCode: CONST.CURRENCY.USD,
     },
@@ -194,7 +194,7 @@ const MoneyRequestModal = (props) => {
      * @returns {String}
      */
     const titleForStep = useMemo(() => {
-        const isSendingMoney = props.iouType === CONST.IOU.IOU_TYPE.SEND;
+        const isSendingMoney = props.iouType === CONST.IOU.MONEY_REQUEST_TYPE.SEND;
         if (currentStepIndex === 1 || currentStepIndex === 2) {
             const formattedAmount = props.numberFormat(
                 amount, {
@@ -382,6 +382,7 @@ const MoneyRequestModal = (props) => {
                                             onAddParticipants={selectedParticipants => setParticipants(selectedParticipants)}
                                             onStepComplete={navigateToNextStep}
                                             safeAreaPaddingBottomStyle={safeAreaPaddingBottomStyle}
+                                            iouType={props.iouType}
                                         />
                                     </AnimatedStep>
                                 )}

--- a/src/pages/iou/steps/IOUAmountPage.js
+++ b/src/pages/iou/steps/IOUAmountPage.js
@@ -269,7 +269,7 @@ class IOUAmountPage extends React.Component {
         if (this.props.hasMultipleParticipants) {
             return Navigation.navigate(ROUTES.getIouBillCurrencyRoute(this.props.reportID));
         }
-        if (this.props.iouType === CONST.IOU.IOU_TYPE.SEND) {
+        if (this.props.iouType === CONST.IOU.MONEY_REQUEST_TYPE.SEND) {
             return Navigation.navigate(ROUTES.getIouSendCurrencyRoute(this.props.reportID));
         }
         return Navigation.navigate(ROUTES.getIouRequestCurrencyRoute(this.props.reportID));

--- a/src/pages/iou/steps/IOUConfirmPage.js
+++ b/src/pages/iou/steps/IOUConfirmPage.js
@@ -50,7 +50,7 @@ const propTypes = {
 const defaultProps = {
     onUpdateComment: null,
     comment: '',
-    iouType: CONST.IOU.IOU_TYPE.REQUEST,
+    iouType: CONST.IOU.MONEY_REQUEST_TYPE.REQUEST,
     canModifyParticipants: false,
 };
 

--- a/src/pages/iou/steps/IOUParticipantsPage/IOUParticipantsPage.js
+++ b/src/pages/iou/steps/IOUParticipantsPage/IOUParticipantsPage.js
@@ -48,6 +48,9 @@ const propTypes = {
         PropTypes.arrayOf(PropTypes.object),
         PropTypes.object,
     ]),
+
+    /** The type of IOU report, i.e. bill, request, send */
+    iouType: PropTypes.string.isRequired,
 };
 
 const defaultProps = {
@@ -79,6 +82,7 @@ const IOUParticipantsPage = (props) => {
                 onStepComplete={props.onStepComplete}
                 onAddParticipants={props.onAddParticipants}
                 safeAreaPaddingBottomStyle={props.safeAreaPaddingBottomStyle}
+                iouType={props.iouType}
             />
         )
     );

--- a/src/pages/iou/steps/IOUParticipantsPage/IOUParticipantsRequest.js
+++ b/src/pages/iou/steps/IOUParticipantsPage/IOUParticipantsRequest.js
@@ -79,7 +79,11 @@ class IOUParticipantsRequest extends Component {
             searchTerm,
             [],
             CONST.EXPENSIFY_EMAILS,
-            this.props.iouType !== CONST.IOU.MONEY_REQUEST_TYPE.SEND,
+
+            // If we are using this component in the "Request money" flow then we pass the includeOwnedWorkspaceChats argument so that the current user
+            // sees the option to request money from their admin on their own Workspace Chat. These will always be shown in the "Recents" section of the selector
+            // along with any other recent chats.
+            this.props.iouType === CONST.IOU.MONEY_REQUEST_TYPE.REQUEST,
         );
     }
 

--- a/src/pages/iou/steps/IOUParticipantsPage/IOUParticipantsRequest.js
+++ b/src/pages/iou/steps/IOUParticipantsPage/IOUParticipantsRequest.js
@@ -61,6 +61,7 @@ class IOUParticipantsRequest extends Component {
             '',
             [],
             CONST.EXPENSIFY_EMAILS,
+            false,
         );
 
         this.state = {
@@ -120,6 +121,7 @@ class IOUParticipantsRequest extends Component {
             searchTerm,
             [],
             CONST.EXPENSIFY_EMAILS,
+            false,
         );
         this.setState({
             searchTerm,

--- a/src/pages/iou/steps/IOUParticipantsPage/IOUParticipantsRequest.js
+++ b/src/pages/iou/steps/IOUParticipantsPage/IOUParticipantsRequest.js
@@ -33,6 +33,9 @@ const propTypes = {
         PropTypes.object,
     ]),
 
+    /** The type of IOU report, i.e. bill, request, send */
+    iouType: PropTypes.string.isRequired,
+
     ...withLocalizePropTypes,
 };
 
@@ -54,15 +57,7 @@ class IOUParticipantsRequest extends Component {
             recentReports,
             personalDetails,
             userToInvite,
-        } = OptionsListUtils.getNewChatOptions(
-            props.reports,
-            props.personalDetails,
-            props.betas,
-            '',
-            [],
-            CONST.EXPENSIFY_EMAILS,
-            false,
-        );
+        } = this.getRequestOptions();
 
         this.state = {
             recentReports,
@@ -70,6 +65,22 @@ class IOUParticipantsRequest extends Component {
             userToInvite,
             searchTerm: '',
         };
+    }
+
+    /**
+     * @param {string} searchTerm
+     * @returns {Object}
+     */
+    getRequestOptions(searchTerm = '') {
+        return OptionsListUtils.getNewChatOptions(
+            this.props.reports,
+            this.props.personalDetails,
+            this.props.betas,
+            searchTerm,
+            [],
+            CONST.EXPENSIFY_EMAILS,
+            this.props.iouType !== CONST.IOU.MONEY_REQUEST_TYPE.SEND,
+        );
     }
 
     /**
@@ -114,15 +125,7 @@ class IOUParticipantsRequest extends Component {
             recentReports,
             personalDetails,
             userToInvite,
-        } = OptionsListUtils.getNewChatOptions(
-            this.props.reports,
-            this.props.personalDetails,
-            this.props.betas,
-            searchTerm,
-            [],
-            CONST.EXPENSIFY_EMAILS,
-            false,
-        );
+        } = this.getRequestOptions(searchTerm);
         this.setState({
             searchTerm,
             recentReports,

--- a/tests/unit/ReportUtilsTest.js
+++ b/tests/unit/ReportUtilsTest.js
@@ -354,7 +354,7 @@ describe('ReportUtils', () => {
                         chatType,
                     };
                     const moneyRequestOptions = ReportUtils.getMoneyRequestOptions(report, [currentUserEmail, participants[0]], [CONST.BETAS.IOU]);
-                    return moneyRequestOptions.length === 1 && moneyRequestOptions.includes(CONST.IOU.IOU_TYPE.SPLIT);
+                    return moneyRequestOptions.length === 1 && moneyRequestOptions.includes(CONST.IOU.MONEY_REQUEST_TYPE.SPLIT);
                 });
                 expect(onlyHaveSplitOption).toBe(true);
             });
@@ -362,7 +362,7 @@ describe('ReportUtils', () => {
             it('has multiple participants exclude self', () => {
                 const moneyRequestOptions = ReportUtils.getMoneyRequestOptions({}, [currentUserEmail, ...participants], [CONST.BETAS.IOU]);
                 expect(moneyRequestOptions.length).toBe(1);
-                expect(moneyRequestOptions.includes(CONST.IOU.IOU_TYPE.SPLIT)).toBe(true);
+                expect(moneyRequestOptions.includes(CONST.IOU.MONEY_REQUEST_TYPE.SPLIT)).toBe(true);
             });
         });
 
@@ -370,7 +370,7 @@ describe('ReportUtils', () => {
             it(' does not have iou send permission', () => {
                 const moneyRequestOptions = ReportUtils.getMoneyRequestOptions({}, [currentUserEmail, participants], [CONST.BETAS.IOU]);
                 expect(moneyRequestOptions.length).toBe(1);
-                expect(moneyRequestOptions.includes(CONST.IOU.IOU_TYPE.REQUEST)).toBe(true);
+                expect(moneyRequestOptions.includes(CONST.IOU.MONEY_REQUEST_TYPE.REQUEST)).toBe(true);
             });
 
             it('a policy expense chat', () => {
@@ -381,15 +381,15 @@ describe('ReportUtils', () => {
                 };
                 const moneyRequestOptions = ReportUtils.getMoneyRequestOptions(report, [currentUserEmail, participants], [CONST.BETAS.IOU, CONST.BETAS.IOU_SEND]);
                 expect(moneyRequestOptions.length).toBe(1);
-                expect(moneyRequestOptions.includes(CONST.IOU.IOU_TYPE.REQUEST)).toBe(true);
+                expect(moneyRequestOptions.includes(CONST.IOU.MONEY_REQUEST_TYPE.REQUEST)).toBe(true);
             });
         });
 
         it('return both iou send and request money', () => {
             const moneyRequestOptions = ReportUtils.getMoneyRequestOptions({}, [currentUserEmail, participants], [CONST.BETAS.IOU, CONST.BETAS.IOU_SEND]);
             expect(moneyRequestOptions.length).toBe(2);
-            expect(moneyRequestOptions.includes(CONST.IOU.IOU_TYPE.REQUEST)).toBe(true);
-            expect(moneyRequestOptions.includes(CONST.IOU.IOU_TYPE.SEND)).toBe(true);
+            expect(moneyRequestOptions.includes(CONST.IOU.MONEY_REQUEST_TYPE.REQUEST)).toBe(true);
+            expect(moneyRequestOptions.includes(CONST.IOU.MONEY_REQUEST_TYPE.SEND)).toBe(true);
         });
     });
 


### PR DESCRIPTION
### Details

**Doc section here:** 

https://docs.google.com/document/d/17jFcMsAotXvsMhXivoF3u7fyzeyXkKpRGXR88Ud0oWY/edit#bookmark=kix.mwuwbgdkfhxc

### Fixed Issues

$ https://github.com/Expensify/Expensify/issues/270684

### Tests
1. Login as a new user (ADMIN) who does not yet have a workspace
2. Create a workspace and invite another new user (EMPLOYEE)
3. Verify the ADMIN can see in the LHN a Workspace Chat (Chat 1) for themselves and a Workspace Chat for the EMPLOYEE
3. Run through the following flows and verify...

Search -> Both Chats appear
LHN -> Both Chats appear
Request money -> Only the user's OWN workspace chat appears (not the managed one)
New chat -> None
New group -> None
Send money -> None
Split bill -> None

1. Login next as the EMPLOYEE
2. Verify they can only see their OWN workspace chat
3. Run through the following flows and verify...

Search -> Own Chat appears
LHN -> Own Chat appears
Request money -> Own Chat appears
New chat -> None
New group -> None
Send money -> None
Split bill -> None

- [ ] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
Same as Tests

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<img width="1501" alt="2023-04-05_12-52-29" src="https://user-images.githubusercontent.com/32969087/230229650-20f34796-9f14-4883-b048-ed0277972ddf.png">

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<img width="499" alt="2023-04-05_13-13-16" src="https://user-images.githubusercontent.com/32969087/230231877-5eb14a67-d491-49d2-b050-46acc374de73.png">


</details>

<details>
<summary>Mobile Web - Safari</summary>

<img width="551" alt="2023-04-05_13-18-07" src="https://user-images.githubusercontent.com/32969087/230232524-4fda1e30-97b4-40c3-a3dd-0db070f9a081.png">

</details>

<details>
<summary>Desktop</summary>

<img width="1312" alt="2023-04-05_13-19-40" src="https://user-images.githubusercontent.com/32969087/230232697-8adb65f8-952a-48da-b981-b169d3812206.png">

</details>

<details>
<summary>iOS</summary>

<img width="551" alt="2023-04-05_12-59-44" src="https://user-images.githubusercontent.com/32969087/230231890-cf1e97dc-31e0-456b-89f9-b9452d06aea4.png">

</details>

<details>
<summary>Android</summary>

<img width="499" alt="2023-04-05_13-16-53" src="https://user-images.githubusercontent.com/32969087/230232390-6337bc4b-1ec3-4766-a192-b29fc7ddae28.png">

</details>
