### PR TITLE
Update Clipboard icon to Copy icon

### DIFF
--- a/assets/images/clipboard.svg
+++ b/assets/images/clipboard.svg
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 26.5.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 20 20" style="enable-background:new 0 0 20 20;" xml:space="preserve">
-<path d="M11,2h2v1c0,0.6-0.4,1-1,1H8C7.4,4,7,3.6,7,3V2h2c0-0.6,0.4-1,1-1C10.6,1,11,1.4,11,2z"/>
-<path d="M5,2H4C3.4,2,3,2.4,3,3v15c0,0.6,0.4,1,1,1h12c0.6,0,1-0.4,1-1V3c0-0.6-0.4-1-1-1h-1v1c0,1.7-1.3,3-3,3H8C6.3,6,5,4.7,5,3V2
-	z"/>
-</svg>

--- a/assets/images/copy.svg
+++ b/assets/images/copy.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 27.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 20 20" style="enable-background:new 0 0 20 20;" xml:space="preserve">
+<path d="M8,0C6.9,0,6,0.9,6,2v12c0,1.1,0.9,2,2,2h8c1.1,0,2-0.9,2-2V4.8c0-0.5-0.2-1-0.6-1.4l-2.8-2.8C14.2,0.2,13.7,0,13.2,0H8z"/>
+<path d="M2,6c0-1.1,0.9-2,2-2v12c0,1.1,0.9,2,2,2h8c0,1.1-0.9,2-2,2H4c-1.1,0-2-0.9-2-2V6z"/>
+</svg>

--- a/src/components/CommunicationsLink.js
+++ b/src/components/CommunicationsLink.js
@@ -38,7 +38,7 @@ const CommunicationsLink = props => (
                 {props.children}
             </View>
             <ContextMenuItem
-                icon={Expensicons.Clipboard}
+                icon={Expensicons.Copy}
                 text={props.translate('reportActionContextMenu.copyToClipboard')}
                 successIcon={Expensicons.Checkmark}
                 successText={props.translate('reportActionContextMenu.copied')}

--- a/src/components/CopyTextToClipboard.js
+++ b/src/components/CopyTextToClipboard.js
@@ -61,7 +61,7 @@ class CopyTextToClipboard extends React.Component {
                 <Text style={this.props.textStyles}>{this.props.text}</Text>
                 <Tooltip text={this.props.translate(`reportActionContextMenu.${this.state.showCheckmark ? 'copied' : 'copyToClipboard'}`)}>
                     <Icon
-                        src={this.state.showCheckmark ? Expensicons.Checkmark : Expensicons.Clipboard}
+                        src={this.state.showCheckmark ? Expensicons.Checkmark : Expensicons.Copy}
                         fill={this.state.showCheckmark ? themeColors.iconSuccessFill : themeColors.icon}
                         width={variables.iconSizeSmall}
                         height={variables.iconSizeSmall}

--- a/src/components/Icon/Expensicons.js
+++ b/src/components/Icon/Expensicons.js
@@ -19,13 +19,13 @@ import Cash from '../../../assets/images/cash.svg';
 import ChatBubble from '../../../assets/images/chatbubble.svg';
 import Checkmark from '../../../assets/images/checkmark.svg';
 import Chair from '../../../assets/images/chair.svg';
-import Clipboard from '../../../assets/images/clipboard.svg';
 import Close from '../../../assets/images/close.svg';
 import ClosedSign from '../../../assets/images/closed-sign.svg';
 import Collapse from '../../../assets/images/collapse.svg';
 import Concierge from '../../../assets/images/concierge.svg';
 import ConciergeAvatar from '../../../assets/images/avatars/concierge-avatar.svg';
 import Connect from '../../../assets/images/connect.svg';
+import Copy from '../../../assets/images/copy.svg';
 import CreditCard from '../../../assets/images/creditcard.svg';
 import Document from '../../../assets/images/document.svg';
 import DeletedRoomAvatar from '../../../assets/images/avatars/deleted-room.svg';
@@ -133,13 +133,13 @@ export {
     ChatBubble,
     Checkmark,
     Chair,
-    Clipboard,
     Close,
     ClosedSign,
     Collapse,
     Concierge,
     ConciergeAvatar,
     Connect,
+    Copy,
     CreditCard,
     DeletedRoomAvatar,
     Document,

--- a/src/pages/home/report/ContextMenu/ContextMenuActions.js
+++ b/src/pages/home/report/ContextMenu/ContextMenuActions.js
@@ -111,7 +111,7 @@ export default [
     },
     {
         textTranslateKey: 'reportActionContextMenu.copyURLToClipboard',
-        icon: Expensicons.Clipboard,
+        icon: Expensicons.Copy,
         successTextTranslateKey: 'reportActionContextMenu.copied',
         successIcon: Expensicons.Checkmark,
         shouldShow: type => type === CONTEXT_MENU_TYPES.LINK,
@@ -123,7 +123,7 @@ export default [
     },
     {
         textTranslateKey: 'reportActionContextMenu.copyEmailToClipboard',
-        icon: Expensicons.Clipboard,
+        icon: Expensicons.Copy,
         successTextTranslateKey: 'reportActionContextMenu.copied',
         successIcon: Expensicons.Checkmark,
         shouldShow: type => type === CONTEXT_MENU_TYPES.EMAIL,
@@ -135,7 +135,7 @@ export default [
     },
     {
         textTranslateKey: 'reportActionContextMenu.copyToClipboard',
-        icon: Expensicons.Clipboard,
+        icon: Expensicons.Copy,
         successTextTranslateKey: 'reportActionContextMenu.copied',
         successIcon: Expensicons.Checkmark,
         shouldShow: (type, reportAction) => (type === CONTEXT_MENU_TYPES.REPORT_ACTION


### PR DESCRIPTION
cc: @fukawi2 

### Details

Replaces the clipboard icon with a copy icon 

![image](https://user-images.githubusercontent.com/16747822/230246065-f311c4fb-c29c-4131-94ab-5007c478e75b.png)

### Fixed Issues

$ https://github.com/Expensify/App/issues/16682
PROPOSAL: N/A 

### Tests
1. Log into an account on newDot 
2. Send a message to someone 
3. Hover over the message and confirm the copy icon looks like so: 
![image](https://user-images.githubusercontent.com/16747822/230246482-d8b43bda-a32c-40de-ab7e-38d13675ee69.png)
    - If on iOS or Android, long press on the message to bring up the ability to copy the message

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
1. Log into an account on newDot 
2. Send a message to someone 
3. Hover over the message and confirm the copy icon looks like so: 
![image](https://user-images.githubusercontent.com/16747822/230246482-d8b43bda-a32c-40de-ab7e-38d13675ee69.png)
    - If on iOS or Android, long press on the message to bring up the ability to copy the message

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

![image](https://user-images.githubusercontent.com/16747822/230449033-deedcfa2-fdc1-43cd-b1f7-976bc9dedcb9.png)

</details>

<details>
<summary>Mobile Web - Chrome</summary>

![Screenshot_1680802192](https://user-images.githubusercontent.com/16747822/230452989-e3cf3837-8b20-45ba-adb0-df2d92c07f80.png)

</details>

<details>
<summary>Mobile Web - Safari</summary>

![Simulator Screenshot - iPhone 14 - 2023-04-06 at 10 20 49](https://user-images.githubusercontent.com/16747822/230453010-3ed631e1-caf2-49fe-98cd-86f767111b14.png)

</details>

<details>
<summary>Desktop</summary>

![image](https://user-images.githubusercontent.com/16747822/230449504-304e8e5f-bcbf-4108-ad95-86513d58996e.png)

</details>

<details>
<summary>iOS</summary>

![Simulator Screen Shot - iPhone 14 Pro - 2023-04-06 at 10 56 06](https://user-images.githubusercontent.com/16747822/230469190-2b2be5e3-cd6a-4661-ab31-d4bdb7f165f0.png)

</details>

<details>
<summary>Android</summary>

![image](https://user-images.githubusercontent.com/16747822/230472451-fd845c67-4021-4129-bca7-3b5ccf564fc4.png)

</details>
