### PR TITLE
Aggregate expense reports in OptionsListUtils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -135,7 +135,7 @@
         "css-loader": "^6.7.2",
         "diff-so-fancy": "^1.3.0",
         "dotenv": "^16.0.3",
-        "electron": "^22.3.5",
+        "electron": "22.3.5",
         "electron-builder": "23.5.0",
         "electron-notarize": "^1.2.1",
         "eslint": "^7.6.0",

--- a/src/CONST.js
+++ b/src/CONST.js
@@ -403,6 +403,7 @@ const CONST = {
         },
         TYPE: {
             CHAT: 'chat',
+            EXPENSE: 'expense',
             IOU: 'iou',
         },
         CHAT_TYPE: {

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -68,10 +68,9 @@ Onyx.connect({
             return;
         }
 
-        if (!ReportUtils.isIOUReport(report)) {
-            return;
+        if (ReportUtils.isIOUReport(report)) {
+            iouReports[key] = report;
         }
-        iouReports[key] = report;
     },
 });
 

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -54,14 +54,24 @@ Onyx.connect({
     },
 });
 
+const expenseReports = {};
 const iouReports = {};
 Onyx.connect({
     key: ONYXKEYS.COLLECTION.REPORT,
-    callback: (iouReport, key) => {
-        if (!iouReport || !key || !iouReport.ownerEmail || !ReportUtils.isIOUReport(iouReport)) {
+    callback: (report, key) => {
+        if (!report || !key || !report.ownerEmail) {
             return;
         }
-        iouReports[key] = iouReport;
+
+        if (ReportUtils.isExpenseReport(report)) {
+            expenseReports[key] = report;
+            return;
+        }
+
+        if (!ReportUtils.isIOUReport(report)) {
+            return;
+        }
+        iouReports[key] = report;
     },
 });
 

--- a/src/libs/ReportUtils.js
+++ b/src/libs/ReportUtils.js
@@ -990,8 +990,8 @@ function buildOptimisticIOUReport(ownerEmail, userEmail, total, chatReportID, cu
         });
 
     return {
-        // If we're sending money, hasOutstandingIOU should be false
         type: CONST.REPORT.TYPE.IOU,
+        // If we're sending money, hasOutstandingIOU should be false
         hasOutstandingIOU: !isSendingMoney,
         cachedTotal: formattedTotal,
         chatReportID,

--- a/src/libs/ReportUtils.js
+++ b/src/libs/ReportUtils.js
@@ -990,9 +990,9 @@ function buildOptimisticIOUReport(ownerEmail, userEmail, total, chatReportID, cu
         });
 
     return {
-        type: CONST.REPORT.TYPE.IOU,
         // If we're sending money, hasOutstandingIOU should be false
         hasOutstandingIOU: !isSendingMoney,
+        type: CONST.REPORT.TYPE.IOU,
         cachedTotal: formattedTotal,
         chatReportID,
         currency,

--- a/src/libs/ReportUtils.js
+++ b/src/libs/ReportUtils.js
@@ -99,12 +99,23 @@ function getReportParticipantsTitle(logins) {
 }
 
 /**
- * Attempts to find a report in onyx with the provided list of participants
+ * Checks if a report is an Expense report.
+ *
+ * @param {Object} report
+ * @returns {Boolean}
+ */
+function isExpenseReport(report) {
+    return lodashGet(report, 'type') === CONST.REPORT.TYPE.EXPENSE;
+}
+
+/**
+ * Checks if a report is an IOU report.
+ *
  * @param {Object} report
  * @returns {Boolean}
  */
 function isIOUReport(report) {
-    return report && _.has(report, 'total');
+    return lodashGet(report, 'type') === CONST.REPORT.TYPE.IOU;
 }
 
 /**
@@ -1736,6 +1747,7 @@ export {
     getAllPolicyReports,
     getIOUReportActionMessage,
     getDisplayNameForParticipant,
+    isExpenseReport,
     isIOUReport,
     chatIncludesChronos,
     getAvatar,

--- a/src/libs/ReportUtils.js
+++ b/src/libs/ReportUtils.js
@@ -991,6 +991,7 @@ function buildOptimisticIOUReport(ownerEmail, userEmail, total, chatReportID, cu
 
     return {
         // If we're sending money, hasOutstandingIOU should be false
+        type: CONST.REPORT.TYPE.IOU,
         hasOutstandingIOU: !isSendingMoney,
         cachedTotal: formattedTotal,
         chatReportID,
@@ -1157,6 +1158,7 @@ function buildOptimisticChatReport(
 ) {
     const currentTime = DateUtils.getDBTime();
     return {
+        type: CONST.REPORT.TYPE.CHAT,
         chatType,
         hasOutstandingIOU: false,
         isOwnPolicyExpenseChat,

--- a/tests/unit/SidebarOrderTest.js
+++ b/tests/unit/SidebarOrderTest.js
@@ -330,6 +330,7 @@ describe('Sidebar', () => {
             };
             const iouReport = {
                 ...LHNTestUtils.getFakeReport(['email7@test.com', 'email8@test.com']),
+                type: CONST.REPORT.TYPE.IOU,
                 ownerEmail: 'email2@test.com',
                 hasOutstandingIOU: true,
                 total: 10000,
@@ -635,6 +636,7 @@ describe('Sidebar', () => {
             };
             const iouReport1 = {
                 ...LHNTestUtils.getFakeReport(['email7@test.com', 'email8@test.com']),
+                type: CONST.REPORT.TYPE.IOU,
                 ownerEmail: 'email2@test.com',
                 hasOutstandingIOU: true,
                 total: 10000,
@@ -643,6 +645,7 @@ describe('Sidebar', () => {
             };
             const iouReport2 = {
                 ...LHNTestUtils.getFakeReport(['email9@test.com', 'email10@test.com']),
+                type: CONST.REPORT.TYPE.IOU,
                 ownerEmail: 'email2@test.com',
                 hasOutstandingIOU: true,
                 total: 10000,
@@ -651,6 +654,7 @@ describe('Sidebar', () => {
             };
             const iouReport3 = {
                 ...LHNTestUtils.getFakeReport(['email11@test.com', 'email12@test.com']),
+                type: CONST.REPORT.TYPE.IOU,
                 ownerEmail: 'email2@test.com',
                 hasOutstandingIOU: true,
                 total: 10000,

--- a/tests/utils/LHNTestUtils.js
+++ b/tests/utils/LHNTestUtils.js
@@ -75,6 +75,7 @@ let lastFakeReportID = 0;
 function getFakeReport(participants = ['email1@test.com', 'email2@test.com'], millisecondsInThePast = 0, isUnread = false) {
     const lastVisibleActionCreated = DateUtils.getDBTime(Date.now() - millisecondsInThePast);
     return {
+        type: CONST.REPORT.TYPE.CHAT,
         reportID: `${++lastFakeReportID}`,
         reportName: 'Report',
         lastVisibleActionCreated,
@@ -98,6 +99,7 @@ function getFakeReport(participants = ['email1@test.com', 'email2@test.com'], mi
 function getAdvancedFakeReport(isArchived, isUserCreatedPolicyRoom, hasAddWorkspaceError, isUnread, isPinned, hasDraft) {
     return {
         ...getFakeReport(['email1@test.com', 'email2@test.com'], 0, isUnread),
+        type: CONST.REPORT.TYPE.CHAT,
         chatType: isUserCreatedPolicyRoom ? CONST.REPORT.CHAT_TYPE.POLICY_ROOM : CONST.REPORT.CHAT_TYPE.POLICY_ADMINS,
         statusNum: isArchived ? CONST.REPORT.STATUS.CLOSED : 0,
         stateNum: isArchived ? CONST.REPORT.STATE_NUM.SUBMITTED : 0,


### PR DESCRIPTION
### Details
Aggregates Expense reports in OptionsListUtils. This is kind of an unusual PR in that it doesn't really make any real changes yet, is just some prep work for Manual Requests and aggregates a variable that's not yet used.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/270490

### Tests
Nothing really to test here – just implementing what it says in the doc and I assume will be a pre-requisite for future PRs.

- [x] Verify that no errors appear in the JS console

### Offline tests
None.

### QA Steps
None.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
There's nothing to screenshot here as this new aggregation of Expense Reports is as-yet unused, I'm just implementing what it says in the design doc.

<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>
