### PR TITLE
fix emoji sizing for context menu, mini context menu and reactions 

### DIFF
--- a/src/components/Reactions/AddReactionBubble.js
+++ b/src/components/Reactions/AddReactionBubble.js
@@ -13,20 +13,8 @@ import variables from '../../styles/variables';
 import withLocalize, {withLocalizePropTypes} from '../withLocalize';
 
 const propTypes = {
-    /**
-     * The default size of the reaction bubble is defined
-     * by the styles in styles.js. This scale factor can be used
-     * to make the bubble bigger or smaller.
-     */
-    sizeScale: PropTypes.number,
-
-    /**
-     * The default size of the icon is defined
-     * by the styles in styles.js. This scale factor can be used
-     * to make the icon bigger or smaller. The icon refers to the
-     * emoji.
-     */
-    iconSizeScale: PropTypes.number,
+    /** Whether it is for context menu so we can modify its style */
+    isContextMenu: PropTypes.bool,
 
     /**
      * Called when the user presses on the icon button.
@@ -49,8 +37,7 @@ const propTypes = {
 };
 
 const defaultProps = {
-    sizeScale: 1,
-    iconSizeScale: 1,
+    isContextMenu: false,
     onWillShowPicker: () => {},
     onPressOpenPicker: undefined,
 };
@@ -87,7 +74,7 @@ const AddReactionBubble = (props) => {
                     pressed,
                 }) => [
                     styles.emojiReactionBubble,
-                    StyleUtils.getEmojiReactionBubbleStyle(hovered || pressed, false, props.sizeScale),
+                    StyleUtils.getEmojiReactionBubbleStyle(hovered || pressed, false, props.isContextMenu),
                 ]}
                 onPress={onPress}
 
@@ -103,9 +90,8 @@ const AddReactionBubble = (props) => {
                             emoji reaction. We make the text invisible and put the
                             icon on top of it. */}
                         <Text style={[
-                            styles.emojiReactionText,
                             styles.opacity0,
-                            StyleUtils.getEmojiReactionTextStyle(props.sizeScale),
+                            StyleUtils.getEmojiReactionBubbleTextStyle(props.isContextMenu),
                         ]}
                         >
                             {'\u2800\u2800'}
@@ -113,8 +99,8 @@ const AddReactionBubble = (props) => {
                         <View style={styles.pAbsolute}>
                             <Icon
                                 src={Expensicons.AddReaction}
-                                width={variables.iconSizeSmall * props.iconSizeScale}
-                                height={variables.iconSizeSmall * props.iconSizeScale}
+                                width={props.isContextMenu ? variables.iconSizeNormal : variables.iconSizeSmall}
+                                height={props.isContextMenu ? variables.iconSizeNormal : variables.iconSizeSmall}
                                 fill={StyleUtils.getIconFillColor(
                                     getButtonState(hovered, pressed),
                                 )}

--- a/src/components/Reactions/EmojiReactionBubble.js
+++ b/src/components/Reactions/EmojiReactionBubble.js
@@ -37,12 +37,8 @@ const propTypes = {
      */
     reactionUsers: PropTypes.arrayOf(PropTypes.string),
 
-    /**
-     * The default size of the reaction bubble is defined
-     * by the styles in styles.js. This scale factor can be used
-     * to make the bubble bigger or smaller.
-     */
-    sizeScale: PropTypes.number,
+    /** Whether it is for context menu so we can modify its style */
+    isContextMenu: PropTypes.bool,
 
     ...withCurrentUserPersonalDetailsPropTypes,
 };
@@ -51,7 +47,7 @@ const defaultProps = {
     count: 0,
     onReactionListOpen: () => {},
     reactionUsers: [],
-    sizeScale: 1,
+    isContextMenu: false,
 
     ...withCurrentUserPersonalDetailsDefaultProps,
 };
@@ -62,7 +58,7 @@ const EmojiReactionBubble = (props) => {
         <Pressable
             style={({hovered, pressed}) => [
                 styles.emojiReactionBubble,
-                StyleUtils.getEmojiReactionBubbleStyle(hovered || pressed, hasUserReacted, props.sizeScale),
+                StyleUtils.getEmojiReactionBubbleStyle(hovered || pressed, hasUserReacted, props.isContextMenu),
             ]}
             onPress={props.onPress}
             onLongPress={props.onReactionListOpen}
@@ -71,8 +67,9 @@ const EmojiReactionBubble = (props) => {
             onMouseDown={e => e.preventDefault()}
         >
             <Text style={[
-                styles.emojiReactionText,
-                StyleUtils.getEmojiReactionTextStyle(props.sizeScale),
+                styles.emojiReactionBubbleText,
+                styles.userSelectNone,
+                StyleUtils.getEmojiReactionBubbleTextStyle(props.isContextMenu),
             ]}
             >
                 {props.emojiCodes.join('')}
@@ -80,7 +77,8 @@ const EmojiReactionBubble = (props) => {
             {props.count > 0 && (
             <Text style={[
                 styles.reactionCounterText,
-                StyleUtils.getEmojiReactionCounterTextStyle(hasUserReacted, props.sizeScale),
+                styles.userSelectNone,
+                StyleUtils.getEmojiReactionCounterTextStyle(hasUserReacted),
             ]}
             >
                 {props.count}

--- a/src/components/Reactions/MiniQuickEmojiReactions.js
+++ b/src/components/Reactions/MiniQuickEmojiReactions.js
@@ -20,8 +20,6 @@ import compose from '../../libs/compose';
 import ONYXKEYS from '../../ONYXKEYS';
 import getPreferredEmojiCode from './getPreferredEmojiCode';
 
-const ICON_SIZE_SCALE_FACTOR = 1.3;
-
 const propTypes = {
     ...baseQuickEmojiReactionsPropTypes,
 
@@ -73,8 +71,8 @@ const MiniQuickEmojiReactions = (props) => {
                     onPress={() => props.onEmojiSelected(emoji)}
                 >
                     <Text style={[
-                        styles.emojiReactionText,
-                        StyleUtils.getEmojiReactionTextStyle(ICON_SIZE_SCALE_FACTOR),
+                        styles.miniQuickEmojiReactionText,
+                        styles.userSelectNone,
                     ]}
                     >
                         {getPreferredEmojiCode(emoji, props.preferredSkinTone)}

--- a/src/components/Reactions/QuickEmojiReactions/BaseQuickEmojiReactions.js
+++ b/src/components/Reactions/QuickEmojiReactions/BaseQuickEmojiReactions.js
@@ -11,8 +11,6 @@ import ONYXKEYS from '../../../ONYXKEYS';
 import getPreferredEmojiCode from '../getPreferredEmojiCode';
 import Tooltip from '../../Tooltip';
 
-const EMOJI_BUBBLE_SCALE = 1.5;
-
 const baseQuickEmojiReactionsPropTypes = {
     /**
      * Callback to fire when an emoji is selected.
@@ -55,7 +53,7 @@ const BaseQuickEmojiReactions = props => (
             <Tooltip text={`:${emoji.name}:`} key={emoji.name} focusable={false}>
                 <EmojiReactionBubble
                     emojiCodes={[getPreferredEmojiCode(emoji, props.preferredSkinTone)]}
-                    sizeScale={EMOJI_BUBBLE_SCALE}
+                    isContextMenu
                     onPress={() => {
                         props.onEmojiSelected(emoji);
                     }}
@@ -63,8 +61,7 @@ const BaseQuickEmojiReactions = props => (
             </Tooltip>
         ))}
         <AddReactionBubble
-            iconSizeScale={1.2}
-            sizeScale={EMOJI_BUBBLE_SCALE}
+            isContextMenu
             onPressOpenPicker={props.onPressOpenPicker}
             onWillShowPicker={props.onWillShowPicker}
             onSelectEmoji={props.onEmojiSelected}

--- a/src/styles/StyleUtils.js
+++ b/src/styles/StyleUtils.js
@@ -877,12 +877,12 @@ const getColoredBackgroundStyle = isColored => ({backgroundColor: isColored ? co
 function getEmojiReactionBubbleStyle(isHovered, hasUserReacted, isContextMenu = false) {
     let backgroundColor = themeColors.border;
 
-    if (hasUserReacted) {
-        backgroundColor = themeColors.reactionActive;
-    }
-
     if (isHovered) {
         backgroundColor = themeColors.buttonHoveredBG;
+    }
+
+    if (hasUserReacted) {
+        backgroundColor = themeColors.reactionActive;
     }
 
     if (isContextMenu) {

--- a/src/styles/StyleUtils.js
+++ b/src/styles/StyleUtils.js
@@ -874,42 +874,52 @@ function getEmojiSuggestionContainerStyle(
  */
 const getColoredBackgroundStyle = isColored => ({backgroundColor: isColored ? colors.blueLink : null});
 
-function getEmojiReactionBubbleStyle(isHovered, hasUserReacted, sizeScale = 1) {
-    const sizeStyles = {
-        paddingVertical: styles.emojiReactionBubble.paddingVertical * sizeScale,
-        paddingHorizontal: styles.emojiReactionBubble.paddingHorizontal * sizeScale,
-    };
+function getEmojiReactionBubbleStyle(isHovered, hasUserReacted, isContextMenu = false) {
+    let backgroundColor = themeColors.border;
 
     if (hasUserReacted) {
-        return {backgroundColor: themeColors.reactionActive, ...sizeStyles};
+        backgroundColor = themeColors.reactionActive;
     }
+
     if (isHovered) {
-        return {backgroundColor: themeColors.buttonHoveredBG, ...sizeStyles};
+        backgroundColor = themeColors.buttonHoveredBG;
     }
 
-    return sizeStyles;
-}
-
-function getEmojiReactionTextStyle(sizeScale = 1) {
-    return {
-        fontSize: styles.emojiReactionText.fontSize * sizeScale,
-        lineHeight: styles.emojiReactionText.lineHeight * sizeScale,
-    };
-}
-
-function getEmojiReactionCounterTextStyle(hasUserReacted, sizeScale = 1) {
-    const sizeStyles = {
-        fontSize: styles.reactionCounterText.fontSize * sizeScale,
-    };
-
-    if (hasUserReacted) {
+    if (isContextMenu) {
         return {
-            ...sizeStyles,
-            color: themeColors.link,
+            paddingVertical: 3,
+            paddingHorizontal: 12,
+            backgroundColor,
         };
     }
 
-    return sizeStyles;
+    return {
+        paddingVertical: 2,
+        paddingHorizontal: 8,
+        backgroundColor,
+    };
+}
+
+function getEmojiReactionBubbleTextStyle(isContextMenu = false) {
+    if (isContextMenu) {
+        return {
+            fontSize: 17,
+            lineHeight: 28,
+        };
+    }
+
+    return {
+        fontSize: 15,
+        lineHeight: 24,
+    };
+}
+
+function getEmojiReactionCounterTextStyle(hasUserReacted) {
+    if (hasUserReacted) {
+        return {color: themeColors.textLight};
+    }
+
+    return {color: themeColors.link};
 }
 
 /**
@@ -973,7 +983,7 @@ export {
     getDefaultWorspaceAvatarColor,
     getAvatarBorderRadius,
     getEmojiReactionBubbleStyle,
-    getEmojiReactionTextStyle,
+    getEmojiReactionBubbleTextStyle,
     getEmojiReactionCounterTextStyle,
     getDirectionStyle,
 };

--- a/src/styles/StyleUtils.js
+++ b/src/styles/StyleUtils.js
@@ -916,10 +916,10 @@ function getEmojiReactionBubbleTextStyle(isContextMenu = false) {
 
 function getEmojiReactionCounterTextStyle(hasUserReacted) {
     if (hasUserReacted) {
-        return {color: themeColors.textLight};
+        return {color: themeColors.link};
     }
 
-    return {color: themeColors.link};
+    return {color: themeColors.textLight};
 }
 
 /**

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -2973,7 +2973,7 @@ const styles = {
     },
 
     miniQuickEmojiReactionText: {
-        fontSize: 13,
+        fontSize: 15,
         lineHeight: 20,
         textAlignVertical: 'center',
     },

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -2963,10 +2963,7 @@ const styles = {
     },
 
     emojiReactionBubble: {
-        paddingVertical: 2,
-        paddingHorizontal: 8,
         borderRadius: 28,
-        backgroundColor: themeColors.border,
         alignItems: 'center',
         justifyContent: 'center',
         flexDirection: 'row',
@@ -2975,20 +2972,20 @@ const styles = {
         marginRight: 4,
     },
 
-    emojiReactionText: {
-        fontSize: 12,
+    miniQuickEmojiReactionText: {
+        fontSize: 13,
         lineHeight: 20,
         textAlignVertical: 'center',
-        userSelect: 'none',
-        WebkitUserSelect: 'none',
     },
+
+    emojiReactionBubbleText: {
+        textAlignVertical: 'center',
+    },
+
     reactionCounterText: {
-        fontSize: 11,
+        fontSize: 13,
         marginLeft: 4,
         fontWeight: 'bold',
-        color: themeColors.textLight,
-        userSelect: 'none',
-        WebkitUserSelect: 'none',
     },
 
     fontColorReactionLabel: {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

Updated the size of emoji buttons at 3 locations (context menu, mini context menu and reactions)
Also removed the use of "*sizeScale" from the code.

https://github.com/Expensify/App/issues/15815#issuecomment-1472386824
https://github.com/Expensify/App/issues/15815#issuecomment-1484968670
https://github.com/Expensify/App/issues/15815#issuecomment-1490262629
https://github.com/Expensify/App/issues/15815#issuecomment-1490639510
https://github.com/Expensify/App/issues/15815#issuecomment-1491694251


### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/15815
PROPOSAL: https://github.com/Expensify/App/issues/15815#issuecomment-1472386824


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->


1. Go to any chat
2. Add a reaction to any message
3. Verify that the size of the emoji is 28px with a font size of 15px
4. Hover over the message to get the mini context menu
5. Verify that the size of the emoji is 20px with a font size of 13px
6. Right click on the message to get the context menu
7. Verify that the size of the emoji is 34px with a font size of 17px

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Go to any chat
2. Add a reaction to any message
3. Verify that the size of the emoji is 28px with a font size of 15px
4. Hover over the message to get the mini context menu
5. Verify that the size of the emoji is 20px with a font size of 13px
6. Right click on the message to get the context menu
7. Verify that the size of the emoji is 34px with a font size of 17px

- [x] Verify that no errors appear in the JS console


### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

![image](https://user-images.githubusercontent.com/71884990/230940231-facb5a6e-71a3-4c1c-82da-a03d2d5284f5.png)

![image](https://user-images.githubusercontent.com/71884990/230940597-7659b820-1c11-487d-bffc-589133e15847.png)


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://user-images.githubusercontent.com/71884990/230944690-ca3eb57d-327d-4da1-adb6-b5f452599f7a.mp4


 

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

 

https://user-images.githubusercontent.com/71884990/230944074-93579f33-69c3-42a0-98f0-e97d9db28374.mp4



<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>

 

https://user-images.githubusercontent.com/71884990/230945096-8f47c957-6301-4777-a388-83da8e3efaa2.mp4



<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

![image](https://user-images.githubusercontent.com/71884990/230941928-32ea8c6d-1f50-439c-9dcf-3e96871c4afd.png)

![image](https://user-images.githubusercontent.com/71884990/230945701-ec551705-3edc-47c1-8274-d1efaaa6b29c.png)
 
<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>

 
![image](https://user-images.githubusercontent.com/71884990/230942260-52332351-3dfe-42b3-96d9-7532e44e5db9.png)



![image](https://user-images.githubusercontent.com/71884990/230945873-4e3673c3-a521-47a1-8133-2a33de294645.png)

<!-- add screenshots or videos here -->

</details>
