### PR TITLE
Sort state list alphabetically

### DIFF
--- a/src/components/StatePicker.js
+++ b/src/components/StatePicker.js
@@ -39,10 +39,10 @@ const defaultProps = {
 };
 
 const StatePicker = forwardRef((props, ref) => {
-    const STATES = _.map(props.translate('allStates'), ({stateISO, stateName}) => ({
-        value: stateISO,
-        label: stateName,
-    }));
+    const STATES = _.chain(props.translate('allStates'))
+        .sortBy(({stateName}) => stateName.toLowerCase())
+        .map(({stateISO, stateName}) => ({value: stateISO, label: stateName}))
+        .value();
 
     return (
         <Picker

--- a/src/components/StatePicker.js
+++ b/src/components/StatePicker.js
@@ -40,8 +40,8 @@ const defaultProps = {
 
 const StatePicker = forwardRef((props, ref) => {
     const STATES = _.chain(props.translate('allStates'))
-        .sortBy(({stateName}) => stateName.toLowerCase())
-        .map(({stateISO, stateName}) => ({value: stateISO, label: stateName}))
+        .sortBy(state => state.stateName.toLowerCase())
+        .map(state => ({value: state.stateISO, label: state.stateName}))
         .value();
 
     return (


### PR DESCRIPTION
@bondydaa @0xmiroslav PR is ready for review.

### Details
State list is not sorted correctly in Spanish. So in this pr corrected that problem. So now state list shows alphabetically sorted in Spanish and English also.

### Fixed Issues
$ https://github.com/Expensify/App/issues/17080
PROPOSAL: https://github.com/Expensify/App/issues/17080#issuecomment-1501644362


### Tests
1. Go to Settings > Workspace > Connect bank account
2. Check State dropdown at step 2 and 3
3. Verify that **State list is sorted alphabetically** in **English** and **Spanish** both.

- [x] Verify that no errors appear in the JS console

### Offline tests
1. Go to Settings > Workspace > Connect bank account
2. Check State dropdown at step 2 and 3
3. Verify that **State list is sorted alphabetically** in **English** and **Spanish** both.

### QA Steps
1. Go to Settings > Workspace > Connect bank account
2. Check State dropdown at step 2 and 3
3. Verify that **State list is sorted alphabetically** in **English** and **Spanish** both.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

#### Chrome En

https://user-images.githubusercontent.com/7823358/230948111-4b55cf52-6f83-41e0-9b30-231f74018c26.mp4

#### Chrome Es

https://user-images.githubusercontent.com/7823358/230948166-ec2b08a9-02c9-4cd6-9906-67acef49bfcb.mp4

#### Safari En

https://user-images.githubusercontent.com/7823358/230948210-2701527e-7f21-4d1e-b12e-b80cddfe3a63.mp4

#### Safari Es

https://user-images.githubusercontent.com/7823358/230948239-5ee12edb-c95c-4b91-a303-8d16dd5a1e06.mp4

</details>

<details>
<summary>Mobile Web - Chrome</summary>

#### En

https://user-images.githubusercontent.com/7823358/230948334-ad9c860f-38cd-4e88-b1a2-6f4959f8c4aa.mp4

#### Es

https://user-images.githubusercontent.com/7823358/230948374-6c792752-c8f5-46ac-b461-c26d5ee7d495.mp4

</details>

<details>
<summary>Mobile Web - Safari</summary>

#### En

https://user-images.githubusercontent.com/7823358/230948452-a3a94dbd-0884-4492-a70d-a89a9689b068.mp4

#### Es

https://user-images.githubusercontent.com/7823358/230948755-b0a96775-64e3-41ce-8c2d-adfd272dc784.mp4

</details>

<details>
<summary>Desktop</summary>

#### En

https://user-images.githubusercontent.com/7823358/230948880-1f4bf627-cc1c-483b-9da3-8adb9e723bbd.mov

#### Es

https://user-images.githubusercontent.com/7823358/230948951-4d16f523-27cd-4081-b05f-0e226d34482f.mov

</details>

<details>
<summary>iOS</summary>

#### En

https://user-images.githubusercontent.com/7823358/230949074-4112d4d7-72c2-47c0-9e08-b231eaf65229.mp4

#### Es

https://user-images.githubusercontent.com/7823358/230949117-58132671-ed48-43ce-a4ab-d6fa50c1a4ae.mp4

</details>

<details>
<summary>Android</summary>

#### En

https://user-images.githubusercontent.com/7823358/230949189-6d049ade-6aaa-4013-b8e6-12822a7c4d3c.mp4

#### Es

https://user-images.githubusercontent.com/7823358/230949229-e2810b65-402c-4b3c-b0d4-496f3437ca9b.mp4

</details>
