### PR TITLE
Force emojis to use the default text color of black to fix reactions

### DIFF
--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -106,7 +106,7 @@ const webViewStyles = {
             paddingTop: 12,
             paddingBottom: 12,
             paddingRight: 8,
-            ingLeft: 8,
+            paddingLeft: 8,
             fontFamily: fontFamily.MONOSPACE,
             marginTop: 0,
             marginBottom: 0,
@@ -182,7 +182,7 @@ const styles = {
     },
 
     emojiSuggestionsEmoji: {
-        fontFamily: fontFamily.MONOSPACE,
+        fontFamily: fontFamily.EXP_NEW_KANSAS_MEDIUM, // New Kansas does not define any emojis, so we will display the emojis properly
         fontSize: variables.fontSizeMedium,
         width: 51,
         textAlign: 'center',

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1535,6 +1535,7 @@ const styles = {
         ...spacing.pv0,
         ...spacing.ph0,
         lineHeight: variables.emojiLineHeight,
+        color: themeColors.black,
     },
 
     emojiItem: {
@@ -2987,6 +2988,7 @@ const styles = {
 
     emojiReactionBubbleText: {
         textAlignVertical: 'center',
+        color: themeColors.black,
     },
 
     reactionCounterText: {
@@ -3002,6 +3004,7 @@ const styles = {
     reactionEmojiTitle: {
         fontSize: variables.iconSizeLarge,
         lineHeight: variables.iconSizeXLarge,
+        color: themeColors.black,
     },
 
     textReactionSenders: {

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -106,7 +106,7 @@ const webViewStyles = {
             paddingTop: 12,
             paddingBottom: 12,
             paddingRight: 8,
-            paddingLeft: 8,
+            ingLeft: 8,
             fontFamily: fontFamily.MONOSPACE,
             marginTop: 0,
             marginBottom: 0,
@@ -182,7 +182,7 @@ const styles = {
     },
 
     emojiSuggestionsEmoji: {
-        fontFamily: fontFamily.EMOJI_TEXT_FONT,
+        fontFamily: fontFamily.MONOSPACE,
         fontSize: variables.fontSizeMedium,
         width: 51,
         textAlign: 'center',
@@ -1529,13 +1529,12 @@ const styles = {
 
     // Emoji Picker Styles
     emojiText: {
-        fontFamily: fontFamily.EMOJI_TEXT_FONT,
+        fontFamily: fontFamily.EXP_NEW_KANSAS_MEDIUM, // New Kansas does not define any emojis, so we will display the emojis properly
         textAlign: 'center',
         fontSize: variables.emojiSize,
         ...spacing.pv0,
         ...spacing.ph0,
         lineHeight: variables.emojiLineHeight,
-        color: themeColors.black,
     },
 
     emojiItem: {
@@ -2987,8 +2986,8 @@ const styles = {
     },
 
     emojiReactionBubbleText: {
+        fontFamily: fontFamily.EXP_NEW_KANSAS_MEDIUM, // New Kansas does not define any emojis, so we will display the emojis properly
         textAlignVertical: 'center',
-        color: themeColors.black,
     },
 
     reactionCounterText: {
@@ -3002,9 +3001,9 @@ const styles = {
     },
 
     reactionEmojiTitle: {
+        fontFamily: fontFamily.EXP_NEW_KANSAS_MEDIUM, // New Kansas does not define any emojis, so we will display the emojis properly
         fontSize: variables.iconSizeLarge,
         lineHeight: variables.iconSizeXLarge,
-        color: themeColors.black,
     },
 
     textReactionSenders: {

--- a/src/styles/themes/default.js
+++ b/src/styles/themes/default.js
@@ -36,7 +36,6 @@ const darkTheme = {
     overlay: colors.greenHighlightBackground,
     inverse: colors.white,
     shadow: colors.black,
-    black: colors.black,
     componentBG: colors.greenAppBackground,
     hoverComponentBG: colors.greenHighlightBackground,
     activeComponentBG: colors.greenBorders,

--- a/src/styles/themes/default.js
+++ b/src/styles/themes/default.js
@@ -36,6 +36,7 @@ const darkTheme = {
     overlay: colors.greenHighlightBackground,
     inverse: colors.white,
     shadow: colors.black,
+    black: colors.black,
     componentBG: colors.greenAppBackground,
     hoverComponentBG: colors.greenHighlightBackground,
     activeComponentBG: colors.greenBorders,


### PR DESCRIPTION
### Details
New Kansas does not define the problematic emojis, so using them for reactions fixes the issue of emojis being recolored with the `color` property

### Fixed Issues
$ https://github.com/Expensify/App/issues/16018
PROPOSAL: N/a


### Tests
1. Send a message in chat
2. React with `black_medium_small_square`
3. Verify the emoji is black in both the reaction bubble, and the emoji selector
4. Type `:black_medium_small` in the compose box, and verify the suggestions are black

- [ ] Verify that no errors appear in the JS console

### Offline tests
Same as tests

### QA Steps
Same as tests
- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>
<img width="857" alt="image" src="https://user-images.githubusercontent.com/22447860/231898370-cffbec1a-f1e5-421f-8540-c13fe6988727.png">
<img width="928" alt="image" src="https://user-images.githubusercontent.com/22447860/231898482-b1a9dd8a-537f-4dcf-9d7c-9df7f750808c.png">
</details>

<details>
<summary>Mobile Web - Chrome</summary>

<img width="531" alt="image" src="https://user-images.githubusercontent.com/22447860/231899799-7cfeae5b-0907-406a-8018-b02a6a98e813.png">
<img width="447" alt="image" src="https://user-images.githubusercontent.com/22447860/231900563-f3c30baa-2774-492b-b947-c542ca433919.png">
<img width="512" alt="image" src="https://user-images.githubusercontent.com/22447860/231900596-00ec9bf3-53ea-4db2-90b0-d4442ff1509e.png">

</details>

<details>
<summary>Mobile Web - Safari</summary>

<img width="416" alt="image" src="https://user-images.githubusercontent.com/22447860/231900846-0abc9187-2297-461e-ba9c-d5aab32b67ab.png">
<img width="428" alt="image" src="https://user-images.githubusercontent.com/22447860/231900827-b336ed7d-5c7e-4a92-9338-949defd1debb.png">
<img width="364" alt="image" src="https://user-images.githubusercontent.com/22447860/231900875-ed3491f2-6350-487c-83a2-6f240e7c8bde.png">

</details>

<details>
<summary>Desktop</summary>

<img width="666" alt="image" src="https://user-images.githubusercontent.com/22447860/231899291-cf4e9ab3-435d-49b2-8422-4fe234a7838b.png">
<img width="704" alt="image" src="https://user-images.githubusercontent.com/22447860/231899327-c8484f9d-59e5-4bbb-9544-611c1fb24b8d.png">

</details>

<details>
<summary>iOS</summary>

<img width="424" alt="image" src="https://user-images.githubusercontent.com/22447860/231900667-d8acacba-0e8b-4df7-bcbb-eb170cb1395b.png">
<img width="427" alt="image" src="https://user-images.githubusercontent.com/22447860/231900698-c13eddb3-e2b1-4df5-b4b8-c3254d8358be.png">
<img width="391" alt="image" src="https://user-images.githubusercontent.com/22447860/231900736-2b7e7877-120d-4f26-b99f-e40fd9bb306a.png">

</details>

<details>
<summary>Android</summary>

<img width="534" alt="image" src="https://user-images.githubusercontent.com/22447860/231899401-998dd426-98b4-41a3-9b01-76fa06833a07.png">
<img width="377" alt="image" src="https://user-images.githubusercontent.com/22447860/231899439-89dea85e-799d-435c-a956-687bac5e0688.png">
<img width="524" alt="image" src="https://user-images.githubusercontent.com/22447860/231899500-e920c1f2-7861-41de-81a4-cb44da309d4d.png">

</details>