### PR TITLE
add padding bottom to base modal

### DIFF
--- a/src/components/Modal/BaseModal.js
+++ b/src/components/Modal/BaseModal.js
@@ -144,7 +144,7 @@ class BaseModal extends PureComponent {
 
                         const modalPaddingStyles = StyleUtils.getModalPaddingStyles({
                             safeAreaPaddingTop,
-                            safeAreaPaddingBottom,
+                            safeAreaPaddingBottom: insets.bottom === 0 ? 12 : safeAreaPaddingBottom,
                             safeAreaPaddingLeft,
                             safeAreaPaddingRight,
                             shouldAddBottomSafeAreaMargin,

--- a/src/components/Modal/BaseModal.js
+++ b/src/components/Modal/BaseModal.js
@@ -144,7 +144,7 @@ class BaseModal extends PureComponent {
 
                         const modalPaddingStyles = StyleUtils.getModalPaddingStyles({
                             safeAreaPaddingTop,
-                            safeAreaPaddingBottom: insets.bottom === 0 ? 12 : safeAreaPaddingBottom,
+                            safeAreaPaddingBottom,
                             safeAreaPaddingLeft,
                             safeAreaPaddingRight,
                             shouldAddBottomSafeAreaMargin,
@@ -155,6 +155,7 @@ class BaseModal extends PureComponent {
                             modalContainerStyleMarginBottom: modalContainerStyle.marginBottom,
                             modalContainerStylePaddingTop: modalContainerStyle.paddingTop,
                             modalContainerStylePaddingBottom: modalContainerStyle.paddingBottom,
+                            insets,
                         });
 
                         return (

--- a/src/styles/StyleUtils.js
+++ b/src/styles/StyleUtils.js
@@ -420,7 +420,14 @@ function getModalPaddingStyles({
     modalContainerStyleMarginBottom,
     modalContainerStylePaddingTop,
     modalContainerStylePaddingBottom,
+    insets,
 }) {
+    // set fallback value for safeAreaPaddingBottom to keep padding bottom consistent with padding top.
+    // // More info: issue #17376
+    if (insets.bottom === 0) {
+        // eslint-disable-next-line no-param-reassign
+        safeAreaPaddingBottom = modalContainerStylePaddingTop;
+    }
     return {
         marginTop: (modalContainerStyleMarginTop || 0) + (shouldAddTopSafeAreaMargin ? safeAreaPaddingTop : 0),
         marginBottom: (modalContainerStyleMarginBottom || 0) + (shouldAddBottomSafeAreaMargin ? safeAreaPaddingBottom : 0),

--- a/src/styles/StyleUtils.js
+++ b/src/styles/StyleUtils.js
@@ -422,20 +422,17 @@ function getModalPaddingStyles({
     modalContainerStylePaddingBottom,
     insets,
 }) {
-    // set fallback value for safeAreaPaddingBottom to keep padding bottom consistent with padding top.
+    // use fallback value for safeAreaPaddingBottom to keep padding bottom consistent with padding top.
     // More info: issue #17376
-    if (insets.bottom === 0) {
-        // eslint-disable-next-line no-param-reassign
-        safeAreaPaddingBottom = modalContainerStylePaddingTop;
-    }
+    const safeAreaPaddingBottomWithFallback = insets.bottom === 0 ? modalContainerStylePaddingTop : safeAreaPaddingBottom;
     return {
         marginTop: (modalContainerStyleMarginTop || 0) + (shouldAddTopSafeAreaMargin ? safeAreaPaddingTop : 0),
-        marginBottom: (modalContainerStyleMarginBottom || 0) + (shouldAddBottomSafeAreaMargin ? safeAreaPaddingBottom : 0),
+        marginBottom: (modalContainerStyleMarginBottom || 0) + (shouldAddBottomSafeAreaMargin ? safeAreaPaddingBottomWithFallback : 0),
         paddingTop: shouldAddTopSafeAreaPadding
             ? (modalContainerStylePaddingTop || 0) + safeAreaPaddingTop
             : modalContainerStylePaddingTop || 0,
         paddingBottom: shouldAddBottomSafeAreaPadding
-            ? (modalContainerStylePaddingBottom || 0) + safeAreaPaddingBottom
+            ? (modalContainerStylePaddingBottom || 0) + safeAreaPaddingBottomWithFallback
             : modalContainerStylePaddingBottom || 0,
         paddingLeft: safeAreaPaddingLeft || 0,
         paddingRight: safeAreaPaddingRight || 0,

--- a/src/styles/StyleUtils.js
+++ b/src/styles/StyleUtils.js
@@ -423,7 +423,7 @@ function getModalPaddingStyles({
     insets,
 }) {
     // set fallback value for safeAreaPaddingBottom to keep padding bottom consistent with padding top.
-    // // More info: issue #17376
+    // More info: issue #17376
     if (insets.bottom === 0) {
         // eslint-disable-next-line no-param-reassign
         safeAreaPaddingBottom = modalContainerStylePaddingTop;

--- a/src/styles/StyleUtils.js
+++ b/src/styles/StyleUtils.js
@@ -424,7 +424,7 @@ function getModalPaddingStyles({
 }) {
     // use fallback value for safeAreaPaddingBottom to keep padding bottom consistent with padding top.
     // More info: issue #17376
-    const safeAreaPaddingBottomWithFallback = insets.bottom === 0 ? modalContainerStylePaddingTop : safeAreaPaddingBottom;
+    const safeAreaPaddingBottomWithFallback = insets.bottom === 0 ? (modalContainerStylePaddingTop || 0) : safeAreaPaddingBottom;
     return {
         marginTop: (modalContainerStyleMarginTop || 0) + (shouldAddTopSafeAreaMargin ? safeAreaPaddingTop : 0),
         marginBottom: (modalContainerStyleMarginBottom || 0) + (shouldAddBottomSafeAreaMargin ? safeAreaPaddingBottomWithFallback : 0),


### PR DESCRIPTION

### Details
Feature request : add some bottom padding to all the bottom docked modals on mobile to be consistent with padding top.

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ #17376 
PROPOSAL: [#17376(comment)](https://github.com/Expensify/App/issues/17376#issuecomment-1507220551)


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
#### android and iphone with and without bottom notch (home bar).
1. open app and login with any account.
2. open any chat and send link in message.
3. long press on the link in the message you last sent, and ensure that "copy link bottom-docked dialog" padding bottom is consistent with padding top.
4. long press on any message, and ensure that "message options bottom-docked dialog" padding bottom is consistent with padding top.
5. long press on any message to show message options then click delete option, and ensure that "delete confirmation bottom-docked dialog" padding bottom is consistent with padding top.
- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
same tests steps

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>


![web](https://user-images.githubusercontent.com/41129870/232450161-4e279107-889b-4b4e-aeb7-81b17142da90.png)

![web1](https://user-images.githubusercontent.com/41129870/232450197-76b798da-7512-476e-aa99-ce0d503c8556.png)
![web del](https://user-images.githubusercontent.com/41129870/232450245-f0ea6e40-f47b-4a14-bb25-2b99ff5f46cd.png)


</details>

<details>
<summary>Mobile Web - Chrome</summary>

![web-android1](https://user-images.githubusercontent.com/41129870/232448430-7c503995-37e2-4ddc-8b11-011221669818.png)
![Screenshot 2023-04-16 at 1 13 02 PM](https://user-images.githubusercontent.com/41129870/232448487-8ec97975-63fb-458c-8d91-5c4b8f1abef6.png)
![Screenshot 2023-04-16 at 1 12 21 PM](https://user-images.githubusercontent.com/41129870/232448502-5fb75883-98bd-4936-9606-7851f83164dc.png)


</details>

<details>
<summary>Mobile Web - Safari</summary>

![Screenshot 2023-04-16 at 1 17 06 PM](https://user-images.githubusercontent.com/41129870/232448756-ef84bd9f-8fbd-444d-81ce-7060f63ae6d1.png)
![Screenshot 2023-04-16 at 1 17 25 PM](https://user-images.githubusercontent.com/41129870/232448766-fe8c1cb1-2ea9-455d-81f1-1bce699f284c.png)
![Screenshot 2023-04-16 at 1 17 47 PM](https://user-images.githubusercontent.com/41129870/232448783-f6df8cd1-941d-4680-bc11-ad61dd76049b.png)


</details>

<details>
<summary>Desktop</summary>

![Screenshot 2023-04-17 at 10 19 49 AM](https://user-images.githubusercontent.com/41129870/232448829-b63231eb-a479-4d6a-90a2-19f3affa7aa0.png)
![Screenshot 2023-04-17 at 10 20 20 AM](https://user-images.githubusercontent.com/41129870/232448856-c829e1f4-10c8-4654-a5ab-a16a6de2a6f0.png)
![Screenshot 2023-04-17 at 10 20 39 AM](https://user-images.githubusercontent.com/41129870/232448871-2eec0690-5bd0-41ca-acce-c00b24bb1253.png)


</details>

<details>
<summary>iOS</summary>

![Screenshot 2023-04-16 at 12 45 20 PM](https://user-images.githubusercontent.com/41129870/232450724-56531c15-9cc4-4690-a1f0-4116ff0ade36.png)
![Screenshot 2023-04-16 at 12 45 31 PM](https://user-images.githubusercontent.com/41129870/232450764-56ca08c0-9514-4f56-a681-15bd095db783.png)

![Screenshot 2023-04-16 at 12 58 17 PM](https://user-images.githubusercontent.com/41129870/232450799-303956a8-3837-468a-956d-a9f21e4e06e0.png)
![Screenshot 2023-04-16 at 12 44 21 PM](https://user-images.githubusercontent.com/41129870/232450856-d7c75dd2-dd66-45b0-8051-4677310b954a.png)
![Screenshot 2023-04-16 at 12 44 10 PM](https://user-images.githubusercontent.com/41129870/232450883-cd7c100b-fb12-475a-a8bb-58538ba6237d.png)

![Screenshot 2023-04-16 at 1 00 50 PM](https://user-images.githubusercontent.com/41129870/232450910-88f907d3-6586-48e5-937d-bb4c369e1d54.png)

</details>

<details>
<summary>Android</summary>

![Screenshot 2023-04-16 at 12 53 58 PM](https://user-images.githubusercontent.com/41129870/232450990-d94cf4db-8a7d-4e4e-8f4a-b204612a9277.png)

![Screenshot 2023-04-16 at 12 54 10 PM](https://user-images.githubusercontent.com/41129870/232451006-84afd50d-2402-426e-bed7-0cb28f40e2f3.png)
![Screenshot 2023-04-16 at 12 56 25 PM](https://user-images.githubusercontent.com/41129870/232451034-8130cb40-46d5-4b03-a5a1-49eb34081ec8.png)


</details>
