### PR TITLE
Fix: Smaller screens - Double click to close phone popup reopens the popup

### DIFF
--- a/src/components/VideoChatButtonAndMenu/BaseVideoChatButtonAndMenu.js
+++ b/src/components/VideoChatButtonAndMenu/BaseVideoChatButtonAndMenu.js
@@ -35,6 +35,7 @@ class BaseVideoChatButtonAndMenu extends Component {
         this.dimensionsEventListener = null;
 
         this.toggleVideoChatMenu = this.toggleVideoChatMenu.bind(this);
+        this.hideVideoChatMenu = this.hideVideoChatMenu.bind(this);
         this.measureVideoChatIconPosition = this.measureVideoChatIconPosition.bind(this);
         this.videoChatIconWrapper = null;
         this.menuItemData = [
@@ -83,6 +84,13 @@ class BaseVideoChatButtonAndMenu extends Component {
     }
 
     /**
+     * Hide the VideoChatMenu popover
+     */
+    hideVideoChatMenu() {
+        this.setState({isVideoChatMenuActive: false});
+    }
+
+    /**
      * This gets called onLayout to find the cooridnates of the wrapper for the video chat button.
      */
     measureVideoChatIconPosition() {
@@ -126,7 +134,7 @@ class BaseVideoChatButtonAndMenu extends Component {
                     </Tooltip>
                 </View>
                 <Popover
-                    onClose={this.toggleVideoChatMenu}
+                    onClose={this.hideVideoChatMenu}
                     isVisible={this.state.isVideoChatMenuActive}
                     anchorPosition={{
                         left: this.state.videoChatIconPosition.x - 150,

--- a/src/components/VideoChatButtonAndMenu/BaseVideoChatButtonAndMenu.js
+++ b/src/components/VideoChatButtonAndMenu/BaseVideoChatButtonAndMenu.js
@@ -34,8 +34,7 @@ class BaseVideoChatButtonAndMenu extends Component {
 
         this.dimensionsEventListener = null;
 
-        this.toggleVideoChatMenu = this.toggleVideoChatMenu.bind(this);
-        this.hideVideoChatMenu = this.hideVideoChatMenu.bind(this);
+        this.setMenuVisibility = this.setMenuVisibility.bind(this);
         this.measureVideoChatIconPosition = this.measureVideoChatIconPosition.bind(this);
         this.videoChatIconWrapper = null;
         this.menuItemData = [
@@ -43,7 +42,7 @@ class BaseVideoChatButtonAndMenu extends Component {
                 icon: ZoomIcon,
                 text: props.translate('videoChatButtonAndMenu.zoom'),
                 onPress: () => {
-                    this.toggleVideoChatMenu();
+                    this.setMenuVisibility(false);
                     Linking.openURL(CONST.NEW_ZOOM_MEETING_URL);
                 },
             },
@@ -51,7 +50,7 @@ class BaseVideoChatButtonAndMenu extends Component {
                 icon: GoogleMeetIcon,
                 text: props.translate('videoChatButtonAndMenu.googleMeet'),
                 onPress: () => {
-                    this.toggleVideoChatMenu();
+                    this.setMenuVisibility(false);
                     Linking.openURL(this.props.googleMeetURL);
                 },
             },
@@ -75,19 +74,11 @@ class BaseVideoChatButtonAndMenu extends Component {
     }
 
     /**
-     * Toggles the state variable isVideoChatMenuActive
+     * Set the state variable isVideoChatMenuActive
+     * @param {Boolean} isVideoChatMenuActive
      */
-    toggleVideoChatMenu() {
-        this.setState(prevState => ({
-            isVideoChatMenuActive: !prevState.isVideoChatMenuActive,
-        }));
-    }
-
-    /**
-     * Hide the VideoChatMenu popover
-     */
-    hideVideoChatMenu() {
-        this.setState({isVideoChatMenuActive: false});
+    setMenuVisibility(isVideoChatMenuActive) {
+        this.setState({isVideoChatMenuActive});
     }
 
     /**
@@ -122,7 +113,7 @@ class BaseVideoChatButtonAndMenu extends Component {
                                     Linking.openURL(this.props.guideCalendarLink);
                                     return;
                                 }
-                                this.toggleVideoChatMenu();
+                                this.setMenuVisibility(true);
                             }}
                             style={[styles.touchableButtonImage]}
                         >
@@ -134,7 +125,7 @@ class BaseVideoChatButtonAndMenu extends Component {
                     </Tooltip>
                 </View>
                 <Popover
-                    onClose={this.hideVideoChatMenu}
+                    onClose={() => this.setMenuVisibility(false)}
                     isVisible={this.state.isVideoChatMenuActive}
                     anchorPosition={{
                         left: this.state.videoChatIconPosition.x - 150,

--- a/src/components/VideoChatButtonAndMenu/BaseVideoChatButtonAndMenu.js
+++ b/src/components/VideoChatButtonAndMenu/BaseVideoChatButtonAndMenu.js
@@ -34,7 +34,6 @@ class BaseVideoChatButtonAndMenu extends Component {
 
         this.dimensionsEventListener = null;
 
-        this.setMenuVisibility = this.setMenuVisibility.bind(this);
         this.measureVideoChatIconPosition = this.measureVideoChatIconPosition.bind(this);
         this.videoChatIconWrapper = null;
         this.menuItemData = [


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Hide the menu popover instead of toggling as it was causing the reopens popup due to the animation time to hide the popover.

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/16582
PROPOSAL: https://github.com/Expensify/App/issues/16582#issuecomment-1498742708


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Open the VideoChatMenu by clicking on the phone icon in any chat(primarily needs to test on smaller screens)
2. Double-click on the overlay part to hide the modal
3. Verify that the modal isn't reopening 

- [X] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
1. Open the VideoChatMenu by clicking on the phone icon in any chat(primarily needs to test on smaller screens)
2. Double-click on the overlay part to hide the modal
3. Verify that the modal isn't reopening 

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
4. Upload an image via copy paste
5. Verify a modal appears displaying a preview of that image
--->
1. Open the VideoChatMenu by clicking on the phone icon in any chat(primarily needs to test on smaller screens)
2. Double-click on the overlay part to hide the modal
3. Verify that the modal isn't reopening 

- [X] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android / native
    - [X] Android / Chrome
    - [X] iOS / native
    - [X] iOS / Safari
    - [X] MacOS / Chrome / Safari
    - [X] MacOS / Desktop
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [X] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [X] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If a new component is created I verified that:
    - [X] A similar component doesn't exist in the codebase
    - [X] All props are defined accurately and each prop has a `/** comment above it */`
    - [X] The file is named correctly
    - [X] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [X] The only data being stored in the state is data necessary for rendering and nothing else
    - [X] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [X] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [X] All JSX used for rendering exists in the render method
    - [X] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [X] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [X] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://user-images.githubusercontent.com/14358475/232488938-d490bb78-5241-4f66-b3c4-14dd0895bb3e.mov


</details>

<details>
<summary>Mobile Web - Chrome</summary>

![mobile (9)](https://user-images.githubusercontent.com/14358475/232489385-8785d156-7d93-4221-a6df-00fd54e6f4b1.gif)


</details>

<details>
<summary>Mobile Web - Safari</summary>

![mobile (8)](https://user-images.githubusercontent.com/14358475/232489203-7ac2038c-4380-491a-bcd3-2b9f50254373.gif)


</details>

<details>
<summary>Desktop</summary>

https://user-images.githubusercontent.com/14358475/232493617-c8ec829c-c3b3-4197-a727-a206b3715bf5.mov

</details>

<details>
<summary>iOS</summary>

https://user-images.githubusercontent.com/14358475/232492888-e9c90ca1-d77c-4020-a9e2-7c23e1fa38a3.mp4


</details>

<details>
<summary>Android</summary>

![aand](https://user-images.githubusercontent.com/14358475/232493217-ca4abf03-eee9-4977-b220-c18962ed3e01.gif)


</details>
