### PR TITLE
LegalNamePage function component refactor

### DIFF
--- a/src/pages/settings/Profile/PersonalDetails/LegalNamePage.js
+++ b/src/pages/settings/Profile/PersonalDetails/LegalNamePage.js
@@ -1,8 +1,9 @@
 import _ from 'underscore';
-import React, {Component} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import {View} from 'react-native';
 import {withOnyx} from 'react-native-onyx';
+import lodashGet from 'lodash/get';
 import ScreenWrapper from '../../../../components/ScreenWrapper';
 import HeaderWithCloseButton from '../../../../components/HeaderWithCloseButton';
 import withLocalize, {withLocalizePropTypes} from '../../../../components/withLocalize';
@@ -36,92 +37,72 @@ const defaultProps = {
     },
 };
 
-class LegalNamePage extends Component {
-    constructor(props) {
-        super(props);
+function LegalNamePage(props) {
+    const legalFirstName = lodashGet(props.privatePersonalDetails, 'legalFirstName', '');
+    const legalLastName = lodashGet(props.privatePersonalDetails, 'legalLastName', '');
 
-        this.validate = this.validate.bind(this);
-        this.updateLegalName = this.updateLegalName.bind(this);
-    }
-
-    /**
-     * Submit form to update user's legal first and last name
-     * @param {Object} values
-     * @param {String} values.legalFirstName
-     * @param {String} values.legalLastName
-     */
-    updateLegalName(values) {
+    const updateLegalName = (values) => {
         PersonalDetails.updateLegalName(
             values.legalFirstName.trim(),
             values.legalLastName.trim(),
         );
-    }
+    };
 
-    /**
-     * @param {Object} values
-     * @param {String} values.legalFirstName
-     * @param {String} values.legalLastName
-     * @returns {Object} - An object containing the errors for each inputID
-     */
-    validate(values) {
+    const validate = (values) => {
         const errors = {};
 
         if (!ValidationUtils.isValidLegalName(values.legalFirstName)) {
-            errors.legalFirstName = this.props.translate('privatePersonalDetails.error.hasInvalidCharacter');
+            errors.legalFirstName = props.translate('privatePersonalDetails.error.hasInvalidCharacter');
         } else if (_.isEmpty(values.legalFirstName)) {
-            errors.legalFirstName = this.props.translate('common.error.fieldRequired');
+            errors.legalFirstName = props.translate('common.error.fieldRequired');
         }
 
         if (!ValidationUtils.isValidLegalName(values.legalLastName)) {
-            errors.legalLastName = this.props.translate('privatePersonalDetails.error.hasInvalidCharacter');
+            errors.legalLastName = props.translate('privatePersonalDetails.error.hasInvalidCharacter');
         } else if (_.isEmpty(values.legalLastName)) {
-            errors.legalLastName = this.props.translate('common.error.fieldRequired');
+            errors.legalLastName = props.translate('common.error.fieldRequired');
         }
 
         return errors;
-    }
+    };
 
-    render() {
-        const privateDetails = this.props.privatePersonalDetails || {};
-
-        return (
-            <ScreenWrapper includeSafeAreaPaddingBottom={false}>
-                <HeaderWithCloseButton
-                    title={this.props.translate('privatePersonalDetails.legalName')}
-                    shouldShowBackButton
-                    onBackButtonPress={() => Navigation.navigate(ROUTES.SETTINGS_PERSONAL_DETAILS)}
-                    onCloseButtonPress={() => Navigation.dismissModal(true)}
-                />
-                <Form
-                    style={[styles.flexGrow1, styles.ph5]}
-                    formID={ONYXKEYS.FORMS.LEGAL_NAME_FORM}
-                    validate={this.validate}
-                    onSubmit={this.updateLegalName}
-                    submitButtonText={this.props.translate('common.save')}
-                    enabledWhenOffline
-                >
-                    <View style={[styles.mb4]}>
-                        <TextInput
-                            inputID="legalFirstName"
-                            name="lfname"
-                            label={this.props.translate('privatePersonalDetails.legalFirstName')}
-                            defaultValue={privateDetails.legalFirstName || ''}
-                            maxLength={CONST.DISPLAY_NAME.MAX_LENGTH}
-                        />
-                    </View>
-                    <View>
-                        <TextInput
-                            inputID="legalLastName"
-                            name="llname"
-                            label={this.props.translate('privatePersonalDetails.legalLastName')}
-                            defaultValue={privateDetails.legalLastName || ''}
-                            maxLength={CONST.DISPLAY_NAME.MAX_LENGTH}
-                        />
-                    </View>
-                </Form>
-            </ScreenWrapper>
-        );
-    }
+    return (
+        <ScreenWrapper includeSafeAreaPaddingBottom={false}>
+            <HeaderWithCloseButton
+                title={props.translate('privatePersonalDetails.legalName')}
+                shouldShowBackButton
+                onBackButtonPress={() => Navigation.navigate(ROUTES.SETTINGS_PERSONAL_DETAILS)}
+                onCloseButtonPress={() => Navigation.dismissModal(true)}
+            />
+            <Form
+                style={[styles.flexGrow1, styles.ph5]}
+                formID={ONYXKEYS.FORMS.LEGAL_NAME_FORM}
+                validate={validate}
+                onSubmit={updateLegalName}
+                submitButtonText={props.translate('common.save')}
+                enabledWhenOffline
+            >
+                <View style={[styles.mb4]}>
+                    <TextInput
+                        inputID="legalFirstName"
+                        name="lfname"
+                        label={props.translate('privatePersonalDetails.legalFirstName')}
+                        defaultValue={legalFirstName}
+                        maxLength={CONST.DISPLAY_NAME.MAX_LENGTH}
+                    />
+                </View>
+                <View>
+                    <TextInput
+                        inputID="legalLastName"
+                        name="llname"
+                        label={props.translate('privatePersonalDetails.legalLastName')}
+                        defaultValue={legalLastName}
+                        maxLength={CONST.DISPLAY_NAME.MAX_LENGTH}
+                    />
+                </View>
+            </Form>
+        </ScreenWrapper>
+    );
 }
 
 LegalNamePage.propTypes = propTypes;

--- a/src/pages/settings/Profile/PersonalDetails/LegalNamePage.js
+++ b/src/pages/settings/Profile/PersonalDetails/LegalNamePage.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import React from 'react';
+import React, {useCallback} from 'react';
 import PropTypes from 'prop-types';
 import {View} from 'react-native';
 import {withOnyx} from 'react-native-onyx';
@@ -37,34 +37,35 @@ const defaultProps = {
     },
 };
 
+const updateLegalName = (values) => {
+    PersonalDetails.updateLegalName(
+        values.legalFirstName.trim(),
+        values.legalLastName.trim(),
+    );
+};
+
 function LegalNamePage(props) {
     const legalFirstName = lodashGet(props.privatePersonalDetails, 'legalFirstName', '');
     const legalLastName = lodashGet(props.privatePersonalDetails, 'legalLastName', '');
+    const translate = props.translate;
 
-    const updateLegalName = (values) => {
-        PersonalDetails.updateLegalName(
-            values.legalFirstName.trim(),
-            values.legalLastName.trim(),
-        );
-    };
-
-    const validate = (values) => {
+    const validate = useCallback((values) => {
         const errors = {};
 
         if (!ValidationUtils.isValidLegalName(values.legalFirstName)) {
-            errors.legalFirstName = props.translate('privatePersonalDetails.error.hasInvalidCharacter');
+            errors.legalFirstName = translate('privatePersonalDetails.error.hasInvalidCharacter');
         } else if (_.isEmpty(values.legalFirstName)) {
-            errors.legalFirstName = props.translate('common.error.fieldRequired');
+            errors.legalFirstName = translate('common.error.fieldRequired');
         }
 
         if (!ValidationUtils.isValidLegalName(values.legalLastName)) {
-            errors.legalLastName = props.translate('privatePersonalDetails.error.hasInvalidCharacter');
+            errors.legalLastName = translate('privatePersonalDetails.error.hasInvalidCharacter');
         } else if (_.isEmpty(values.legalLastName)) {
-            errors.legalLastName = props.translate('common.error.fieldRequired');
+            errors.legalLastName = translate('common.error.fieldRequired');
         }
 
         return errors;
-    };
+    }, [translate]);
 
     return (
         <ScreenWrapper includeSafeAreaPaddingBottom={false}>


### PR DESCRIPTION
### Details
Rewrites LegalNamePage as function component

### Fixed Issues
$ https://github.com/Expensify/App/issues/16295

### Tests

1. Create a new account
2. Log in
3. Settings > Profile > Personal details > Legal name
4. Enter a first and last name
5. Select save
6. Verify the new name displays on the personal details page
7. Open the legal name page again
8. Add `_` to the first and last name
9. Verify there's an error for using only letters and numbers

### Offline tests
None

### QA Steps

Same as Tests

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->
![Screenshot 2023-04-17 at 5 30 52 PM](https://user-images.githubusercontent.com/6833644/232621773-74d6e629-73b4-475b-b5ea-b4634c003843.png)

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->
![Screenshot_20230417-215013](https://user-images.githubusercontent.com/6833644/232621915-32da7ff6-240e-4474-891f-14328aa34373.png)

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->
![IMG_3FC40DEDD1C0-1](https://user-images.githubusercontent.com/6833644/232621798-46553720-3680-49dc-be1f-df6efe556e04.jpeg)

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->
![Screenshot 2023-04-17 at 5 32 36 PM](https://user-images.githubusercontent.com/6833644/232621852-a5fb91e0-22c5-4f5a-a8de-18ca374a6252.png)

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->
![IMG_0E0D39DB587F-1](https://user-images.githubusercontent.com/6833644/232621839-08505fbe-be1c-4403-b815-1bf2d6220ea7.jpeg)

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->
![Screenshot_20230417-215830](https://user-images.githubusercontent.com/6833644/232621898-0e57445b-c305-461c-8ae7-0ee71eaa75b6.png)

</details>
