### PR TITLE
fix: unable to paste copied value into amount field when at least one number is present

### DIFF
--- a/src/pages/iou/steps/MoneyRequestAmountPage.js
+++ b/src/pages/iou/steps/MoneyRequestAmountPage.js
@@ -127,6 +127,8 @@ class MoneyRequestAmountPage extends React.Component {
      * @returns {Object}
      */
     getNewState(prevState, newAmount) {
+        // Remove spaces from the newAmount value because Safari on iOS adds spaces when pasting a copied value
+        // More info: https://github.com/Expensify/App/issues/16974
         const newAmountWithoutSpaces = this.stripSpacesFromAmount(newAmount);
         if (!this.validateAmount(newAmountWithoutSpaces)) {
             // Use a shallow copy of selection to trigger setSelection

--- a/src/pages/iou/steps/MoneyRequestAmountPage.js
+++ b/src/pages/iou/steps/MoneyRequestAmountPage.js
@@ -59,6 +59,7 @@ class MoneyRequestAmountPage extends React.Component {
         this.updateLongPressHandlerState = this.updateLongPressHandlerState.bind(this);
         this.updateAmount = this.updateAmount.bind(this);
         this.stripCommaFromAmount = this.stripCommaFromAmount.bind(this);
+        this.stripSpacesFromAmount = this.stripSpacesFromAmount.bind(this);
         this.focusTextInput = this.focusTextInput.bind(this);
         this.navigateToCurrencySelectionPage = this.navigateToCurrencySelectionPage.bind(this);
         this.amountViewID = 'amountView';
@@ -126,13 +127,14 @@ class MoneyRequestAmountPage extends React.Component {
      * @returns {Object}
      */
     getNewState(prevState, newAmount) {
-        if (!this.validateAmount(newAmount)) {
+        const newAmountWithoutSpaces = this.stripSpacesFromAmount(newAmount);
+        if (!this.validateAmount(newAmountWithoutSpaces)) {
             // Use a shallow copy of selection to trigger setSelection
             // More info: https://github.com/Expensify/App/issues/16385
             return {amount: prevState.amount, selection: {...prevState.selection}};
         }
-        const selection = this.getNewSelection(prevState.selection, prevState.amount.length, newAmount.length);
-        return {amount: this.stripCommaFromAmount(newAmount), selection};
+        const selection = this.getNewSelection(prevState.selection, prevState.amount.length, newAmountWithoutSpaces.length);
+        return {amount: this.stripCommaFromAmount(newAmountWithoutSpaces), selection};
     }
 
     /**
@@ -192,6 +194,16 @@ class MoneyRequestAmountPage extends React.Component {
      */
     stripCommaFromAmount(amount) {
         return amount.replace(/,/g, '');
+    }
+
+    /**
+     * Strip spaces from the amount
+     *
+     * @param {String} amount
+     * @returns {String}
+     */
+    stripSpacesFromAmount(amount) {
+        return amount.replace(/\s+/g, '');
     }
 
     /**


### PR DESCRIPTION
### Details
Implement a `stripSpacesFromAmount` method to remove spaces from the amount value which iOS Safari includes when pasting copied values.

### Fixed Issues
$ https://github.com/Expensify/App/issues/16974
PROPOSAL: https://github.com/Expensify/App/issues/16974#issuecomment-1507960454


### Tests
1. Open the URL on iOS Safari and login.
2. Tap on the green FAB "+" icon.
3. Tap "Send money" or "Request money".
4. Type any number into the "amount" field (e.g. 42).
5. Copy the number.
6. Enter one number into the "amount" field (e.g. 4).
7. Long press on the space in front of or behind the number in the field (make sure the number is not selected).
8. Paste using the system clipboard menu (if displayed) or use the "Paste" keyboard shortcut (Cmd+V).

- [x] Verify that no errors appear in the JS console

### Offline tests
Same as tests.

### QA Steps
Same as tests.
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://user-images.githubusercontent.com/4160319/232634186-31258594-c3bf-4e7f-8a9b-e0dac3467f4f.mov

</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://user-images.githubusercontent.com/4160319/232634248-fb24d696-5a88-42e9-8c19-ac903654b2de.webm

</details>

<details>
<summary>Mobile Web - Safari</summary>

https://user-images.githubusercontent.com/4160319/232634275-e29bbab1-5900-4d29-b030-524d16a3f86b.mov

</details>

<details>
<summary>Desktop</summary>

https://user-images.githubusercontent.com/4160319/232634299-2c1fb5f6-c922-49ba-98da-ae8469b8d943.mov

</details>

<details>
<summary>iOS</summary>

https://user-images.githubusercontent.com/4160319/232634321-d370915a-c0b4-44c0-9e20-b833cbbe2f77.mov

</details>

<details>
<summary>Android</summary>

https://user-images.githubusercontent.com/4160319/232634340-7def7aad-70f2-4002-917f-0dedeac77f47.webm

</details>

