### PR TITLE
Move the cancel and save changes to inside the compose box

### DIFF
--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -266,7 +266,9 @@ class ReportActionItem extends Component {
                     {content}
                 </ReportActionItemDraft>
             );
-        } if (!this.props.displayAsGroup) {
+        }
+
+        if (!this.props.displayAsGroup) {
             return (
                 <ReportActionItemSingle
                     action={this.props.action}
@@ -279,6 +281,7 @@ class ReportActionItem extends Component {
                 </ReportActionItemSingle>
             );
         }
+
         return (
             <ReportActionItemGrouped wrapperStyles={[styles.chatItem, isWhisper ? styles.pt1 : {}]}>
                 {content}

--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -50,6 +50,7 @@ import * as Expensicons from '../../../components/Icon/Expensicons';
 import Text from '../../../components/Text';
 import DisplayNames from '../../../components/DisplayNames';
 import personalDetailsPropType from '../../personalDetailsPropType';
+import ReportActionItemDraft from './ReportActionItemDraft';
 
 const propTypes = {
     /** Report for this action */
@@ -239,12 +240,43 @@ class ReportActionItem extends Component {
             <>
                 {children}
                 {hasReactions && (
-                    <ReportActionItemReactions
-                        reactions={reactions}
-                        toggleReaction={this.toggleReaction}
-                    />
+                    <View style={this.props.draftMessage ? styles.chatItemReactionsDraftRight : null}>
+                        <ReportActionItemReactions
+                            reactions={reactions}
+                            toggleReaction={this.toggleReaction}
+                        />
+                    </View>
                 )}
             </>
+        );
+    }
+
+    renderReportActionItem(hovered, isWhisper) {
+        const content = this.renderItemContent(hovered || this.state.isContextMenuActive);
+
+        if (this.props.draftMessage) {
+            return (
+                <ReportActionItemDraft>
+                    {content}
+                </ReportActionItemDraft>
+            );
+        } if (!this.props.displayAsGroup) {
+            return (
+                <ReportActionItemSingle
+                    action={this.props.action}
+                    showHeader={!this.props.draftMessage}
+                    wrapperStyles={[styles.chatItem, isWhisper ? styles.pt1 : {}]}
+                    shouldShowSubscriptAvatar={this.props.shouldShowSubscriptAvatar}
+                    report={this.props.report}
+                >
+                    {content}
+                </ReportActionItemSingle>
+            );
+        }
+        return (
+            <ReportActionItemGrouped wrapperStyles={[styles.chatItem, isWhisper ? styles.pt1 : {}]}>
+                {content}
+            </ReportActionItemGrouped>
         );
     }
 
@@ -335,23 +367,7 @@ class ReportActionItem extends Component {
                                             />
                                         </View>
                                     )}
-                                    {!this.props.displayAsGroup
-                                        ? (
-                                            <ReportActionItemSingle
-                                                action={this.props.action}
-                                                showHeader={!this.props.draftMessage}
-                                                wrapperStyles={[styles.chatItem, isWhisper ? styles.pt1 : {}]}
-                                                shouldShowSubscriptAvatar={this.props.shouldShowSubscriptAvatar}
-                                                report={this.props.report}
-                                            >
-                                                {this.renderItemContent(hovered || this.state.isContextMenuActive)}
-                                            </ReportActionItemSingle>
-                                        )
-                                        : (
-                                            <ReportActionItemGrouped wrapperStyles={[styles.chatItem, isWhisper ? styles.pt1 : {}]}>
-                                                {this.renderItemContent(hovered || this.state.isContextMenuActive)}
-                                            </ReportActionItemGrouped>
-                                        )}
+                                    {this.renderReportActionItem(hovered, isWhisper)}
                                 </OfflineWithFeedback>
                             </View>
                         </View>

--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -240,7 +240,7 @@ class ReportActionItem extends Component {
             <>
                 {children}
                 {hasReactions && (
-                    <View style={this.props.draftMessage ? styles.chatItemReactionsDraftRight : null}>
+                    <View style={this.props.draftMessage ? styles.chatItemReactionsDraftRight : {}}>
                         <ReportActionItemReactions
                             reactions={reactions}
                             toggleReaction={this.toggleReaction}

--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -251,6 +251,12 @@ class ReportActionItem extends Component {
         );
     }
 
+    /**
+     * Get ReportActionItem with a proper wrapper
+     * @param {Boolean} hovered whether the ReportActionItem is hovered
+     * @param {Boolean} isWhisper whether the ReportActionItem is a whisper
+     * @returns {Object} report action item
+     */
     renderReportActionItem(hovered, isWhisper) {
         const content = this.renderItemContent(hovered || this.state.isContextMenuActive);
 

--- a/src/pages/home/report/ReportActionItemDraft.js
+++ b/src/pages/home/report/ReportActionItemDraft.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import {View} from 'react-native';
+import PropTypes from 'prop-types';
+import styles from '../../../styles/styles';
+
+const propTypes = {
+    /** Children view component for this action item */
+    children: PropTypes.node.isRequired,
+};
+
+const ReportActionItemDraft = props => (
+    <View style={[styles.chatItemDraft]}>
+        <View style={styles.flex1}>
+            {props.children}
+        </View>
+    </View>
+);
+
+ReportActionItemDraft.propTypes = propTypes;
+ReportActionItemDraft.displayName = 'ReportActionItemDraft';
+export default ReportActionItemDraft;

--- a/src/pages/home/report/ReportActionItemMessageEdit.js
+++ b/src/pages/home/report/ReportActionItemMessageEdit.js
@@ -304,8 +304,6 @@ class ReportActionItemMessageEdit extends React.Component {
                             value={this.state.draft}
                             maxLines={16} // This is the same that slack has
                             style={[styles.textInputCompose, styles.flex1, styles.bgTransparent]}
-
-                            // textAlignVertical="top"
                             onFocus={() => {
                                 this.setState({isFocused: true});
                                 ReportScrollManager.scrollToIndex({animated: true, index: this.props.index}, true);

--- a/src/pages/home/report/ReportActionItemMessageEdit.js
+++ b/src/pages/home/report/ReportActionItemMessageEdit.js
@@ -262,102 +262,103 @@ class ReportActionItemMessageEdit extends React.Component {
     render() {
         const hasExceededMaxCommentLength = this.state.hasExceededMaxCommentLength;
         return (
-            <View style={[styles.chatItemMessage, styles.flexRow]}>
-                <View
-                    style={[styles.justifyContentEnd]}
-                >
-                    <Tooltip text={this.props.translate('common.cancel')}>
-                        <Pressable
-                            style={({hovered, pressed}) => ([styles.chatItemSubmitButton, StyleUtils.getButtonBackgroundColorStyle(getButtonState(hovered, pressed))])}
-                            nativeID={this.cancelButtonID}
-                            onPress={this.deleteDraft}
-                            hitSlop={{
-                                top: 3, right: 3, bottom: 3, left: 3,
-                            }}
-                            disabled={hasExceededMaxCommentLength}
-                        >
-                            {({hovered, pressed}) => (
-                                <Icon src={Expensicons.Close} fill={StyleUtils.getIconFillColor(getButtonState(hovered, pressed))} />
-                            )}
-                        </Pressable>
-                    </Tooltip>
-                </View>
-                <View
-                    style={[
-                        this.state.isFocused ? styles.chatItemComposeBoxFocusedColor : styles.chatItemComposeBoxColor,
-                        styles.flexRow,
-                        styles.flex1,
-                        styles.chatItemComposeBox,
-                        hasExceededMaxCommentLength && styles.borderColorDanger,
-                    ]}
-                >
-                    <View style={styles.textInputComposeSpacing}>
-                        <Composer
-                            multiline
-                            ref={(el) => {
-                                this.textInput = el;
-                                this.props.forwardedRef(el);
-                            }}
-                            nativeID={this.messageEditInput}
-                            onChangeText={this.updateDraft} // Debounced saveDraftComment
-                            onKeyPress={this.triggerSaveOrCancel}
-                            value={this.state.draft}
-                            maxLines={16} // This is the same that slack has
-                            style={[styles.textInputCompose, styles.flex1, styles.bgTransparent]}
-                            onFocus={() => {
-                                this.setState({isFocused: true});
-                                ReportScrollManager.scrollToIndex({animated: true, index: this.props.index}, true);
-                                toggleReportActionComposeView(false, this.props.isSmallScreenWidth);
-                            }}
-                            onBlur={(event) => {
-                                this.setState({isFocused: false});
-                                const relatedTargetId = lodashGet(event, 'nativeEvent.relatedTarget.id');
-
-                                // Return to prevent re-render when save/cancel button is pressed which cancels the onPress event by re-rendering
-                                if (_.contains([this.saveButtonID, this.cancelButtonID, this.emojiButtonID], relatedTargetId)) {
-                                    return;
-                                }
-
-                                if (this.messageEditInput === relatedTargetId) {
-                                    return;
-                                }
-                                openReportActionComposeViewWhenClosingMessageEdit(this.props.isSmallScreenWidth);
-                            }}
-                            selection={this.state.selection}
-                            onSelectionChange={this.onSelectionChange}
-                        />
-                    </View>
-                    <View style={styles.editChatItemEmojiWrapper}>
-                        <EmojiPickerButton
-                            isDisabled={this.props.shouldDisableEmojiPicker}
-                            onModalHide={() => InteractionManager.runAfterInteractions(() => this.textInput.focus())}
-                            onEmojiSelected={this.addEmojiToTextBox}
-                            nativeID={this.emojiButtonID}
-                        />
-                    </View>
-
-                    <View style={styles.alignSelfEnd}>
-                        <Tooltip text={this.props.translate('common.saveChanges')}>
-                            <TouchableOpacity
-                                style={[styles.chatItemSubmitButton,
-                                    (this.state.isCommentEmpty || hasExceededMaxCommentLength) ? undefined : styles.buttonSuccess,
-                                ]}
-
-                                onPress={this.publishDraft}
+            <>
+                <View style={[styles.chatItemMessage, styles.flexRow]}>
+                    <View
+                        style={[styles.justifyContentEnd]}
+                    >
+                        <Tooltip text={this.props.translate('common.cancel')}>
+                            <Pressable
+                                style={({hovered, pressed}) => ([styles.chatItemSubmitButton, StyleUtils.getButtonBackgroundColorStyle(getButtonState(hovered, pressed))])}
+                                nativeID={this.cancelButtonID}
+                                onPress={this.deleteDraft}
                                 hitSlop={{
                                     top: 3, right: 3, bottom: 3, left: 3,
                                 }}
-                                nativeID={this.saveButtonID}
-                                disabled={hasExceededMaxCommentLength}
                             >
-                                <Icon src={Expensicons.Checkmark} fill={(this.state.isCommentEmpty || hasExceededMaxCommentLength) ? themeColors.icon : themeColors.textLight} />
-                            </TouchableOpacity>
+                                {({hovered, pressed}) => (
+                                    <Icon src={Expensicons.Close} fill={StyleUtils.getIconFillColor(getButtonState(hovered, pressed))} />
+                                )}
+                            </Pressable>
                         </Tooltip>
                     </View>
-                </View>
+                    <View
+                        style={[
+                            this.state.isFocused ? styles.chatItemComposeBoxFocusedColor : styles.chatItemComposeBoxColor,
+                            styles.flexRow,
+                            styles.flex1,
+                            styles.chatItemComposeBox,
+                            hasExceededMaxCommentLength && styles.borderColorDanger,
+                        ]}
+                    >
+                        <View style={styles.textInputComposeSpacing}>
+                            <Composer
+                                multiline
+                                ref={(el) => {
+                                    this.textInput = el;
+                                    this.props.forwardedRef(el);
+                                }}
+                                nativeID={this.messageEditInput}
+                                onChangeText={this.updateDraft} // Debounced saveDraftComment
+                                onKeyPress={this.triggerSaveOrCancel}
+                                value={this.state.draft}
+                                maxLines={16} // This is the same that slack has
+                                style={[styles.textInputCompose, styles.flex1, styles.bgTransparent]}
+                                onFocus={() => {
+                                    this.setState({isFocused: true});
+                                    ReportScrollManager.scrollToIndex({animated: true, index: this.props.index}, true);
+                                    toggleReportActionComposeView(false, this.props.isSmallScreenWidth);
+                                }}
+                                onBlur={(event) => {
+                                    this.setState({isFocused: false});
+                                    const relatedTargetId = lodashGet(event, 'nativeEvent.relatedTarget.id');
 
+                                    // Return to prevent re-render when save/cancel button is pressed which cancels the onPress event by re-rendering
+                                    if (_.contains([this.saveButtonID, this.cancelButtonID, this.emojiButtonID], relatedTargetId)) {
+                                        return;
+                                    }
+
+                                    if (this.messageEditInput === relatedTargetId) {
+                                        return;
+                                    }
+                                    openReportActionComposeViewWhenClosingMessageEdit(this.props.isSmallScreenWidth);
+                                }}
+                                selection={this.state.selection}
+                                onSelectionChange={this.onSelectionChange}
+                            />
+                        </View>
+                        <View style={styles.editChatItemEmojiWrapper}>
+                            <EmojiPickerButton
+                                isDisabled={this.props.shouldDisableEmojiPicker}
+                                onModalHide={() => InteractionManager.runAfterInteractions(() => this.textInput.focus())}
+                                onEmojiSelected={this.addEmojiToTextBox}
+                                nativeID={this.emojiButtonID}
+                            />
+                        </View>
+
+                        <View style={styles.alignSelfEnd}>
+                            <Tooltip text={this.props.translate('common.saveChanges')}>
+                                <TouchableOpacity
+                                    style={[styles.chatItemSubmitButton,
+                                        hasExceededMaxCommentLength ? {} : styles.buttonSuccess,
+                                    ]}
+
+                                    onPress={this.publishDraft}
+                                    hitSlop={{
+                                        top: 3, right: 3, bottom: 3, left: 3,
+                                    }}
+                                    nativeID={this.saveButtonID}
+                                    disabled={hasExceededMaxCommentLength}
+                                >
+                                    <Icon src={Expensicons.Checkmark} fill={hasExceededMaxCommentLength ? themeColors.icon : themeColors.textLight} />
+                                </TouchableOpacity>
+                            </Tooltip>
+                        </View>
+                    </View>
+
+                </View>
                 <ExceededCommentLength comment={this.state.draft} onExceededMaxCommentLength={this.setExceededMaxCommentLength} />
-            </View>
+            </>
         );
     }
 }

--- a/src/pages/home/report/ReportActionItemMessageEdit.js
+++ b/src/pages/home/report/ReportActionItemMessageEdit.js
@@ -284,47 +284,51 @@ class ReportActionItemMessageEdit extends React.Component {
                 </View>
                 <View
                     style={[
+                        this.state.isFocused ? styles.chatItemComposeBoxFocusedColor : styles.chatItemComposeBoxColor,
+                        styles.flexRow,
                         styles.flex1,
                         styles.chatItemComposeBox,
-                        styles.flexRow,
-                        this.state.isFocused ? styles.chatItemComposeBoxFocusedColor : styles.chatItemComposeBoxColor,
                         hasExceededMaxCommentLength && styles.borderColorDanger,
                     ]}
                 >
-                    <Composer
-                        multiline
-                        ref={(el) => {
-                            this.textInput = el;
-                            this.props.forwardedRef(el);
-                        }}
-                        nativeID={this.messageEditInput}
-                        onChangeText={this.updateDraft} // Debounced saveDraftComment
-                        onKeyPress={this.triggerSaveOrCancel}
-                        value={this.state.draft}
-                        maxLines={16} // This is the same that slack has
-                        style={[styles.textInputCompose, styles.flex1, styles.editInputComposeSpacing]}
-                        onFocus={() => {
-                            this.setState({isFocused: true});
-                            ReportScrollManager.scrollToIndex({animated: true, index: this.props.index}, true);
-                            toggleReportActionComposeView(false, this.props.isSmallScreenWidth);
-                        }}
-                        onBlur={(event) => {
-                            this.setState({isFocused: false});
-                            const relatedTargetId = lodashGet(event, 'nativeEvent.relatedTarget.id');
+                    <View style={styles.textInputComposeSpacing}>
+                        <Composer
+                            multiline
+                            ref={(el) => {
+                                this.textInput = el;
+                                this.props.forwardedRef(el);
+                            }}
+                            nativeID={this.messageEditInput}
+                            onChangeText={this.updateDraft} // Debounced saveDraftComment
+                            onKeyPress={this.triggerSaveOrCancel}
+                            value={this.state.draft}
+                            maxLines={16} // This is the same that slack has
+                            style={[styles.textInputCompose, styles.flex1, styles.bgTransparent]}
 
-                            // Return to prevent re-render when save/cancel button is pressed which cancels the onPress event by re-rendering
-                            if (_.contains([this.saveButtonID, this.cancelButtonID, this.emojiButtonID], relatedTargetId)) {
-                                return;
-                            }
+                            // textAlignVertical="top"
+                            onFocus={() => {
+                                this.setState({isFocused: true});
+                                ReportScrollManager.scrollToIndex({animated: true, index: this.props.index}, true);
+                                toggleReportActionComposeView(false, this.props.isSmallScreenWidth);
+                            }}
+                            onBlur={(event) => {
+                                this.setState({isFocused: false});
+                                const relatedTargetId = lodashGet(event, 'nativeEvent.relatedTarget.id');
 
-                            if (this.messageEditInput === relatedTargetId) {
-                                return;
-                            }
-                            openReportActionComposeViewWhenClosingMessageEdit(this.props.isSmallScreenWidth);
-                        }}
-                        selection={this.state.selection}
-                        onSelectionChange={this.onSelectionChange}
-                    />
+                                // Return to prevent re-render when save/cancel button is pressed which cancels the onPress event by re-rendering
+                                if (_.contains([this.saveButtonID, this.cancelButtonID, this.emojiButtonID], relatedTargetId)) {
+                                    return;
+                                }
+
+                                if (this.messageEditInput === relatedTargetId) {
+                                    return;
+                                }
+                                openReportActionComposeViewWhenClosingMessageEdit(this.props.isSmallScreenWidth);
+                            }}
+                            selection={this.state.selection}
+                            onSelectionChange={this.onSelectionChange}
+                        />
+                    </View>
                     <View style={styles.editChatItemEmojiWrapper}>
                         <EmojiPickerButton
                             isDisabled={this.props.shouldDisableEmojiPicker}

--- a/src/pages/home/report/ReportActionItemMessageEdit.js
+++ b/src/pages/home/report/ReportActionItemMessageEdit.js
@@ -1,25 +1,32 @@
 /* eslint-disable rulesdir/onyx-props-must-have-default */
 import lodashGet from 'lodash/get';
 import React from 'react';
-import {InteractionManager, Keyboard, View} from 'react-native';
+import {
+    InteractionManager, Keyboard, Pressable, TouchableOpacity, View,
+} from 'react-native';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
 import ExpensiMark from 'expensify-common/lib/ExpensiMark';
 import Str from 'expensify-common/lib/str';
 import reportActionPropTypes from './reportActionPropTypes';
 import styles from '../../../styles/styles';
+import themeColors from '../../../styles/themes/default';
+import * as StyleUtils from '../../../styles/StyleUtils';
 import Composer from '../../../components/Composer';
 import * as Report from '../../../libs/actions/Report';
 import * as ReportScrollManager from '../../../libs/ReportScrollManager';
 import toggleReportActionComposeView from '../../../libs/toggleReportActionComposeView';
 import openReportActionComposeViewWhenClosingMessageEdit from '../../../libs/openReportActionComposeViewWhenClosingMessageEdit';
-import Button from '../../../components/Button';
 import ReportActionComposeFocusManager from '../../../libs/ReportActionComposeFocusManager';
 import compose from '../../../libs/compose';
 import EmojiPickerButton from '../../../components/EmojiPicker/EmojiPickerButton';
+import Icon from '../../../components/Icon';
+import * as Expensicons from '../../../components/Icon/Expensicons';
+import Tooltip from '../../../components/Tooltip';
 import * as ReportActionContextMenu from './ContextMenu/ReportActionContextMenu';
 import * as ReportUtils from '../../../libs/ReportUtils';
 import * as EmojiUtils from '../../../libs/EmojiUtils';
+import getButtonState from '../../../libs/getButtonState';
 import reportPropTypes from '../../reportPropTypes';
 import ExceededCommentLength from '../../../components/ExceededCommentLength';
 import CONST from '../../../CONST';
@@ -255,9 +262,29 @@ class ReportActionItemMessageEdit extends React.Component {
     render() {
         const hasExceededMaxCommentLength = this.state.hasExceededMaxCommentLength;
         return (
-            <View style={styles.chatItemMessage}>
+            <View style={[styles.chatItemMessage, styles.flexRow]}>
+                <View
+                    style={[styles.justifyContentEnd]}
+                >
+                    <Tooltip text={this.props.translate('common.cancel')}>
+                        <Pressable
+                            style={({hovered, pressed}) => ([styles.chatItemSubmitButton, StyleUtils.getButtonBackgroundColorStyle(getButtonState(hovered, pressed))])}
+                            nativeID={this.cancelButtonID}
+                            onPress={this.deleteDraft}
+                            hitSlop={{
+                                top: 3, right: 3, bottom: 3, left: 3,
+                            }}
+                            disabled={hasExceededMaxCommentLength}
+                        >
+                            {({hovered, pressed}) => (
+                                <Icon src={Expensicons.Close} fill={StyleUtils.getIconFillColor(getButtonState(hovered, pressed))} />
+                            )}
+                        </Pressable>
+                    </Tooltip>
+                </View>
                 <View
                     style={[
+                        styles.flex1,
                         styles.chatItemComposeBox,
                         styles.flexRow,
                         this.state.isFocused ? styles.chatItemComposeBoxFocusedColor : styles.chatItemComposeBoxColor,
@@ -275,7 +302,7 @@ class ReportActionItemMessageEdit extends React.Component {
                         onKeyPress={this.triggerSaveOrCancel}
                         value={this.state.draft}
                         maxLines={16} // This is the same that slack has
-                        style={[styles.textInputCompose, styles.flex4, styles.editInputComposeSpacing]}
+                        style={[styles.textInputCompose, styles.flex1, styles.editInputComposeSpacing]}
                         onFocus={() => {
                             this.setState({isFocused: true});
                             ReportScrollManager.scrollToIndex({animated: true, index: this.props.index}, true);
@@ -307,26 +334,27 @@ class ReportActionItemMessageEdit extends React.Component {
                         />
                     </View>
 
+                    <View style={styles.alignSelfEnd}>
+                        <Tooltip text={this.props.translate('common.saveChanges')}>
+                            <TouchableOpacity
+                                style={[styles.chatItemSubmitButton,
+                                    (this.state.isCommentEmpty || hasExceededMaxCommentLength) ? undefined : styles.buttonSuccess,
+                                ]}
+
+                                onPress={this.publishDraft}
+                                hitSlop={{
+                                    top: 3, right: 3, bottom: 3, left: 3,
+                                }}
+                                nativeID={this.saveButtonID}
+                                disabled={hasExceededMaxCommentLength}
+                            >
+                                <Icon src={Expensicons.Checkmark} fill={(this.state.isCommentEmpty || hasExceededMaxCommentLength) ? themeColors.icon : themeColors.textLight} />
+                            </TouchableOpacity>
+                        </Tooltip>
+                    </View>
                 </View>
-                <View style={[styles.flexRow, styles.mt1]}>
-                    <Button
-                        small
-                        style={[styles.mr2]}
-                        nativeID={this.cancelButtonID}
-                        onPress={this.deleteDraft}
-                        text={this.props.translate('common.cancel')}
-                    />
-                    <Button
-                        small
-                        success
-                        isDisabled={hasExceededMaxCommentLength}
-                        nativeID={this.saveButtonID}
-                        style={[styles.mr2]}
-                        onPress={this.publishDraft}
-                        text={this.props.translate('common.saveChanges')}
-                    />
-                    <ExceededCommentLength comment={this.state.draft} onExceededMaxCommentLength={this.setExceededMaxCommentLength} />
-                </View>
+
+                <ExceededCommentLength comment={this.state.draft} onExceededMaxCommentLength={this.setExceededMaxCommentLength} />
             </View>
         );
     }

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1491,6 +1491,19 @@ const styles = {
         flex: 1,
     },
 
+    chatItemDraft: {
+        display: 'flex',
+        flexDirection: 'row',
+        paddingTop: 8,
+        paddingBottom: 8,
+        paddingLeft: 20,
+        paddingRight: 20,
+    },
+
+    chatItemReactionsDraftRight: {
+        marginLeft: 52,
+    },
+
     // Be extremely careful when editing the compose styles, as it is easy to introduce regressions.
     // Make sure you run the following tests against any changes: #12669
     textInputCompose: addOutlineWidth({
@@ -1523,7 +1536,7 @@ const styles = {
 
     editInputComposeSpacing: {
         backgroundColor: themeColors.transparent,
-        marginVertical: 6,
+        marginVertical: 8,
     },
 
     // composer padding should not be modified unless thoroughly tested against the cases in this PR: #12669


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

This PR moves the save button inside the edit composer box similar to how we have the send button in the composer. The cancel button now replaces the user avatar following the design we discussed [here](https://expensify.slack.com/archives/C049HHMV9SM/p1681308579645129?thread_ts=1677476774.053969&cid=C049HHMV9SM).



<details>
<summary>The proposed design</summary>

![image](https://user-images.githubusercontent.com/7809008/232905308-ec74749c-4548-47a2-9edb-7d17b77c2825.png)


</details>



### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/15598
PROPOSAL: GH_LINK_ISSUE(COMMENT)


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->


1. Click on edit comment
2. The edit box should contain a checkmark save button on the right and emoji button next to it following the styles of the report composer input
3. The cancel button should be on the left
4. The buttons are centered if the input is a single line and stays on the bottom when it's multiline 

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Click on edit comment
2. The edit box should contain a checkmark save button on the right and emoji button next to it following the styles of the report composer input
3. The cancel button should be on the left
4. The buttons are centered if the input is a single line and stays on the bottom when it's multiline 

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->


https://user-images.githubusercontent.com/7809008/233006108-113855ec-f870-4be3-afed-3abd98e4a11a.mov


https://user-images.githubusercontent.com/7809008/233006428-7c91737b-43b8-450d-ad62-822a3cc71e63.mov



</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->


https://user-images.githubusercontent.com/7809008/233011614-da93696a-9222-49c4-a581-0765913478c3.mp4



</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/7809008/233012011-b546e1ca-6e6a-4ce7-a87b-ceb736210fbe.MP4


</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->


https://user-images.githubusercontent.com/7809008/233115342-b3551a18-f4ac-401c-888c-b1936c4127bf.mov



</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->


https://user-images.githubusercontent.com/7809008/233114678-d7d12bbd-c860-4f71-abda-ad4727b47352.mov



</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->


https://user-images.githubusercontent.com/7809008/233111886-dbf595d6-bedc-4dfc-a28d-0acc4a7aa504.mp4



</details>
