### PR TITLE
Reintroduce error message in "Connect Bank Account" flow when wrong bank account number is entered

### DIFF
--- a/src/pages/ReimbursementAccount/BankAccountManualStep.js
+++ b/src/pages/ReimbursementAccount/BankAccountManualStep.js
@@ -59,7 +59,7 @@ class BankAccountManualStep extends React.Component {
             lodashGet(this.props.reimbursementAccount, 'achData.bankAccountID') || 0,
             values.accountNumber,
             values.routingNumber,
-            this.props.getDefaultStateForField('plaidMask'),
+            lodashGet(this.props, ['reimbursementAccountDraft', 'plaidMask']),
         );
     }
 
@@ -97,6 +97,7 @@ class BankAccountManualStep extends React.Component {
                         shouldDelayFocus={shouldDelayFocus}
                         inputID="routingNumber"
                         label={this.props.translate('bankAccount.routingNumber')}
+                        /* maybe update this? */
                         defaultValue={this.props.getDefaultStateForField('routingNumber', '')}
                         keyboardType={CONST.KEYBOARD_TYPE.NUMBER_PAD}
                         disabled={shouldDisableInputs}
@@ -107,6 +108,7 @@ class BankAccountManualStep extends React.Component {
                         inputID="accountNumber"
                         containerStyles={[styles.mt4]}
                         label={this.props.translate('bankAccount.accountNumber')}
+                        /* maybe update this? */
                         defaultValue={this.props.getDefaultStateForField('accountNumber', '')}
                         keyboardType={CONST.KEYBOARD_TYPE.NUMBER_PAD}
                         disabled={shouldDisableInputs}
@@ -129,6 +131,7 @@ class BankAccountManualStep extends React.Component {
                                 </TextLink>
                             </Text>
                         )}
+                        /* maybe update this? */
                         defaultValue={this.props.getDefaultStateForField('acceptTerms', false)}
                         shouldSaveDraft
                     />

--- a/src/pages/ReimbursementAccount/BankAccountManualStep.js
+++ b/src/pages/ReimbursementAccount/BankAccountManualStep.js
@@ -97,7 +97,6 @@ class BankAccountManualStep extends React.Component {
                         shouldDelayFocus={shouldDelayFocus}
                         inputID="routingNumber"
                         label={this.props.translate('bankAccount.routingNumber')}
-                        /* maybe update this? */
                         defaultValue={this.props.getDefaultStateForField('routingNumber', '')}
                         keyboardType={CONST.KEYBOARD_TYPE.NUMBER_PAD}
                         disabled={shouldDisableInputs}
@@ -108,7 +107,6 @@ class BankAccountManualStep extends React.Component {
                         inputID="accountNumber"
                         containerStyles={[styles.mt4]}
                         label={this.props.translate('bankAccount.accountNumber')}
-                        /* maybe update this? */
                         defaultValue={this.props.getDefaultStateForField('accountNumber', '')}
                         keyboardType={CONST.KEYBOARD_TYPE.NUMBER_PAD}
                         disabled={shouldDisableInputs}
@@ -131,7 +129,6 @@ class BankAccountManualStep extends React.Component {
                                 </TextLink>
                             </Text>
                         )}
-                        /* maybe update this? */
                         defaultValue={this.props.getDefaultStateForField('acceptTerms', false)}
                         shouldSaveDraft
                     />

--- a/src/pages/ReimbursementAccount/ReimbursementAccountPage.js
+++ b/src/pages/ReimbursementAccount/ReimbursementAccountPage.js
@@ -182,8 +182,7 @@ class ReimbursementAccountPage extends React.Component {
      * @returns {*}
      */
     getDefaultStateForField(fieldName, defaultValue = '') {
-        return lodashGet(this.props, ['reimbursementAccountDraft', fieldName])
-        || lodashGet(this.props, ['reimbursementAccount', 'achData', fieldName], defaultValue);
+        return lodashGet(this.props, ['reimbursementAccount', 'achData', fieldName], defaultValue);
     }
 
     /**

--- a/src/pages/ReimbursementAccount/ReimbursementAccountPage.js
+++ b/src/pages/ReimbursementAccount/ReimbursementAccountPage.js
@@ -182,7 +182,8 @@ class ReimbursementAccountPage extends React.Component {
      * @returns {*}
      */
     getDefaultStateForField(fieldName, defaultValue = '') {
-        return lodashGet(this.props.reimbursementAccount, ['achData', fieldName], defaultValue);
+        return lodashGet(this.props, ['reimbursementAccountDraft', fieldName])
+        || lodashGet(this.props, ['reimbursementAccount', 'achData', fieldName], defaultValue);
     }
 
     /**

--- a/src/pages/ReimbursementAccount/ReimbursementAccountPage.js
+++ b/src/pages/ReimbursementAccount/ReimbursementAccountPage.js
@@ -182,7 +182,7 @@ class ReimbursementAccountPage extends React.Component {
      * @returns {*}
      */
     getDefaultStateForField(fieldName, defaultValue = '') {
-        return lodashGet(this.props, ['reimbursementAccount', 'achData', fieldName], defaultValue);
+        return lodashGet(this.props.reimbursementAccount, ['achData', fieldName], defaultValue);
     }
 
     /**


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/16669

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

#### Main case this PR fixes

1. Log into an account without a Workspace VBA set up (create a new workspace if needed)
1. Go to Workspace settings > Connect bank account
1. Select the `Connect online with Plaid` method to add a bank account
1. On the bank account list select "Chase"
1. Enter the credentials "user_good / pass_good"
1. If a verification is prompted - select `Mobile` and enter "credentials_good" as the verification mode
1. Select the "Plaid Checking" and "Plaid Saving" accounts
1. Complete the flow (Check the 2 boxes under "additional information you want to share" > tap on Continue; check the T&C and click "Connect account information"; Tap on the last confirmation on the Plaid modal)
1. Once redirected back to NewDot, select the bank account ending in `1111`. You'll be redirected to the enter back account details manually (this is a special case for the Chase bank account selection)
1. Enter routing number 011401533
1. Enter an incorrect bank account number (e.g 1111222233334444)
1. **Verify** there's an error for entering the wrong bank account number

#### Regression test (Manual bank account setup with 2 devices)
_Since https://github.com/Expensify/App/issues/16669 is a regression from https://github.com/Expensify/App/pull/15772, let's verify we don't break the case https://github.com/Expensify/App/pull/15772 intended to fix_

1. Log into an account without a Workspace VBA set up (create a new workspace if needed)
1. Go to Workspace settings > Connect bank account
1. Select the `Connect manually` method to add a bank account
1. Type in incorrect routing and account numbers
1. In a second device, log in to the same account and navigate again to Workspace settings > Connect bank account
1. Enter routing and account numbers that satisfy the requirements (ex `041215032` and `123456`), then continue on and complete Step 2 in the flow
1. Refresh the page in first device and verify that the Routing number and Account number are now updated to match that from your other device, and the inputs are disabled

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://user-images.githubusercontent.com/7277067/233494633-8e06b0b3-2bd6-4d2b-8848-02385d751c71.mov

Regression test:
![regression-test](https://user-images.githubusercontent.com/7277067/233664319-866a7b94-388a-4b2f-b799-2904aa6ed3e6.png)

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>

![mweb-chrome](https://user-images.githubusercontent.com/7277067/233663687-55e435b4-5b9a-48ef-9975-b5d21b4abc08.png)

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

![mweb-safari](https://user-images.githubusercontent.com/7277067/233663729-b8fdfe08-0835-4b57-ac6f-84d377070386.png)

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>

![desktop](https://user-images.githubusercontent.com/7277067/233663809-c48d8ebf-9ae4-459c-9fe5-90878389c14b.png)

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

![ios](https://user-images.githubusercontent.com/7277067/233663852-45e43e39-4af6-4c1b-b69e-336b814bd07a.png)

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>

![android](https://user-images.githubusercontent.com/7277067/233663912-ddeb5e58-6c41-44cb-a9ca-5b8cd5e5abaf.png)

<!-- add screenshots or videos here -->

</details>
