### PR TITLE
Remove this so it doesn't crash after building it

### DIFF
--- a/src/libs/ReportUtils.js
+++ b/src/libs/ReportUtils.js
@@ -1703,6 +1703,15 @@ function canLeaveRoom(report, isPolicyMember) {
     return true;
 }
 
+
+/**
+ * @param {string[]} participants
+ * @returns {Boolean}
+ */
+function isCurrentUserTheOnlyParticipant(participants) {
+    return participants && participants.length === 1 && participants[0] === sessionEmail;
+}
+
 /**
  * Returns display names for those that can see the whisper.
  * However, it returns "you" if the current user is the only one who can see it besides the person that sent it.
@@ -1711,7 +1720,7 @@ function canLeaveRoom(report, isPolicyMember) {
  * @returns {string}
  */
 function getWhisperDisplayNames(participants) {
-    const isWhisperOnlyVisibleToCurrentUSer = this.isCurrentUserTheOnlyParticipant(participants);
+    const isWhisperOnlyVisibleToCurrentUSer = isCurrentUserTheOnlyParticipant(participants);
 
     // When the current user is the only participant, the display name needs to be "you" because that's the only person reading it
     if (isWhisperOnlyVisibleToCurrentUSer) {
@@ -1719,14 +1728,6 @@ function getWhisperDisplayNames(participants) {
     }
 
     return _.map(participants, login => getDisplayNameForParticipant(login, !isWhisperOnlyVisibleToCurrentUSer)).join(', ');
-}
-
-/**
- * @param {string[]} participants
- * @returns {Boolean}
- */
-function isCurrentUserTheOnlyParticipant(participants) {
-    return participants && participants.length === 1 && participants[0] === sessionEmail;
 }
 
 export {

--- a/src/libs/ReportUtils.js
+++ b/src/libs/ReportUtils.js
@@ -1703,7 +1703,6 @@ function canLeaveRoom(report, isPolicyMember) {
     return true;
 }
 
-
 /**
  * @param {string[]} participants
  * @returns {Boolean}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
On dev this refers to the module (ReportUtils), but when it's built, minified version, it's not the case so it crashes.

### Fixed Issues
$ https://github.com/Expensify/App/issues/17786

### Tests

1. Run CQ to add a welcome message to an announce room:
```
INSERT INTO reportNameValuePairs (reportID, name, value) VALUES (<reportID>, 'welcomeMessage', JSON('{"html":"Welcome to my public room!"}'));
```
3. Send yourself via DM the link to the public room and click on it.
4. As soon as you join the room, you should get the custom welcome message added via CQ.
5. Message should be coming from the policy owner.
6. Run CQ to make welcome message come from Concierge:
```
INSERT INTO reportNameValuePairs (reportID, name, value) VALUES (<reportID>, 'isWelcomeMessageFromConcierge', "true");
```
8. Repeat steps 2-3 with a different account. However, this time the message should be coming from Concierge
9. Make sure you can’t see the welcome message sent to the user from step 1-4 while being logged into another second account.

- [x] Verify that no errors appear in the JS console

### Offline tests
Can't join a chat room offline.

### QA

1. Send yourself via DM the link to this public room and click on it: https://new.expensify.com/r/2660055103772983
4. As soon as you join the room, you should get the custom welcome message like this:
5. Message should be coming from Concierge.
6. Leave a couple of messages.
7. Log in as another user and join the announce room as well.
8. As soon as you join the room, you should get the custom welcome message as well.
9. However, you shouldn't see the welcome message sent to the first user and only the latest one sent to you.
10. Log out and log in as our previous user, you can still the welcome message that was sent originally to you but not the second message sent to the user that just joined.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

![image](https://user-images.githubusercontent.com/6474442/233181679-7c8dd3af-8375-46e5-80d4-c8a43d0b3eb8.png)

</details>

<details>
<summary>Mobile Web - Chrome</summary>

![image](https://user-images.githubusercontent.com/6474442/233191280-68092164-8e49-409d-9a61-14a79e6f1423.png)

</details>

<details>
<summary>Mobile Web - Safari</summary>

![image](https://user-images.githubusercontent.com/6474442/233184209-1c4a652b-1094-4c66-ae69-b0e35e928303.png)

</details>

<details>
<summary>Desktop</summary>

![image](https://user-images.githubusercontent.com/6474442/233182128-d7d693b2-e361-45db-9db9-5bc9db486568.png)

</details>

<details>
<summary>iOS</summary>

![image](https://user-images.githubusercontent.com/6474442/233185522-5020bd29-57ed-4aa9-98f0-56568c0637bc.png)

</details>

<details>
<summary>Android</summary>

![image](https://user-images.githubusercontent.com/6474442/233204012-cd9217c5-4439-441f-beda-286c4f86d54c.png)

</details>
