### PR TITLE
fix 17664: use googleEmptyListViewHeight variable with correct value

### DIFF
--- a/src/components/AddressSearch.js
+++ b/src/components/AddressSearch.js
@@ -261,7 +261,7 @@ const AddressSearch = (props) => {
                     styles={{
                         textInputContainer: [styles.flexColumn],
                         listView: [
-                            StyleUtils.getGoolgeListViewStyle(displayListViewBorder),
+                            StyleUtils.getGoogleListViewStyle(displayListViewBorder),
                             styles.overflowAuto,
                             styles.borderLeft,
                             styles.borderRight,
@@ -279,7 +279,6 @@ const AddressSearch = (props) => {
                     onLayout={(event) => {
                         // We use the height of the element to determine if we should hide the border of the listView dropdown
                         // to prevent a lingering border when there are no address suggestions.
-                        // The height of the empty element is 14px (2px height for borders and 12px height for vertical padding)
                         setDisplayListViewBorder(event.nativeEvent.layout.height > variables.googleEmptyListViewHeight);
                     }}
                 />

--- a/src/components/AddressSearch.js
+++ b/src/components/AddressSearch.js
@@ -12,6 +12,7 @@ import * as ApiUtils from '../libs/ApiUtils';
 import * as GooglePlacesUtils from '../libs/GooglePlacesUtils';
 import CONST from '../CONST';
 import * as StyleUtils from '../styles/StyleUtils';
+import variables from '../styles/variables';
 
 // The error that's being thrown below will be ignored until we fork the
 // react-native-google-places-autocomplete repo and replace the
@@ -278,8 +279,8 @@ const AddressSearch = (props) => {
                     onLayout={(event) => {
                         // We use the height of the element to determine if we should hide the border of the listView dropdown
                         // to prevent a lingering border when there are no address suggestions.
-                        // The height of the empty element is 2px (1px height for each top and bottom borders)
-                        setDisplayListViewBorder(event.nativeEvent.layout.height > 2);
+                        // The height of the empty element is 14px (2px height for borders and 12px height for vertical padding)
+                        setDisplayListViewBorder(event.nativeEvent.layout.height > variables.googleEmptyListViewHeight);
                     }}
                 />
             </View>

--- a/src/styles/StyleUtils.js
+++ b/src/styles/StyleUtils.js
@@ -991,7 +991,7 @@ function getDirectionStyle(direction) {
  * @param {Boolean} shouldDisplayBorder
  * @returns {Object}
  */
-function getGoolgeListViewStyle(shouldDisplayBorder) {
+function getGoogleListViewStyle(shouldDisplayBorder) {
     if (shouldDisplayBorder) {
         return {
             ...styles.borderTopRounded,
@@ -1059,5 +1059,5 @@ export {
     getDirectionStyle,
     getFontSizeStyle,
     getSignInWordmarkWidthStyle,
-    getGoolgeListViewStyle,
+    getGoogleListViewStyle,
 };

--- a/src/styles/variables.js
+++ b/src/styles/variables.js
@@ -127,4 +127,5 @@ export default {
     signInLogoWidthPill: 132,
     signInLogoWidthLargeScreenPill: 162,
     modalContentMaxWidth: 360,
+    googleEmptyListViewHeight: 14,
 };

--- a/src/styles/variables.js
+++ b/src/styles/variables.js
@@ -128,7 +128,7 @@ export default {
     signInLogoWidthLargeScreenPill: 162,
     modalContentMaxWidth: 360,
 
-    // The height of the empty element is 14px (2px height for borders and 12px height for vertical padding)
+    // The height of the empty list is 14px (2px for borders and 12px for vertical padding)
     // This is calculated based on the values specified in the 'getGoogleListViewStyle' function of the 'StyleUtils' utility
     googleEmptyListViewHeight: 14,
 };

--- a/src/styles/variables.js
+++ b/src/styles/variables.js
@@ -127,5 +127,8 @@ export default {
     signInLogoWidthPill: 132,
     signInLogoWidthLargeScreenPill: 162,
     modalContentMaxWidth: 360,
+
+    // The height of the empty element is 14px (2px height for borders and 12px height for vertical padding)
+    // This is calculated based on the values specified in the 'getGoogleListViewStyle' function of the 'StyleUtils' utility
     googleEmptyListViewHeight: 14,
 };


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This is a fix for the regression caused by [PR](https://github.com/Expensify/App/pull/17403).

Even when the list view is empty, it will always have some height. We hide the list view by comparing its height against a certain value (currently: 2px). However, in the previous [PR](https://github.com/Expensify/App/pull/17403), the height value was increased by adding vertical padding, but this change wasn't reflected in the comparison value. As a solution, I added a new variable named `googleEmptyListViewHeight` with the correct value of 14 pixels. This value takes into account the 2 pixels required for borders and 12 pixels for vertical padding.

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/17664
$ https://github.com/Expensify/App/issues/17277
PROPOSAL: https://github.com/Expensify/App/issues/17664#issuecomment-1518890351


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Go to the Settings > Profile > Personal details
2. Enter some spaces on Address line 1
3. Then use a letter and remove it **OR** Enter random values till you have no results
4. Ensure that the dropdown box is not visible 

**Alternative Steps**
1. Go to Workspaces > Choose any workspace > connect bank account
2. Choose connect manually > fill details till you reach "Company Information" page or "Personal Information" page
3. Enter some spaces on the address input  > use a letter like "x" and remove it **OR** Enter random values till you have no results
4. Ensure that the dropdown box is not visible 

- [x] Verify that no errors appear in the JS console
### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Go to the Settings > Profile > Personal details
2. Enter some spaces on Address line 1
3. Then use a letter and remove it **OR** Enter random values till you have no results
4. Ensure that the dropdown box is not visible 

**Alternative Steps**
1. Go to Workspaces > Choose any workspace > connect bank account
2. Choose connect manually > fill details till you reach "Company Information" page or "Personal Information" page
3. Enter some spaces on the address input  > use a letter like "x" and remove it **OR** Enter random values till you have no results
4. Ensure that the dropdown box is not visible 

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>


https://user-images.githubusercontent.com/28243942/233811397-2f7b26c3-44b2-439d-b943-4875d1cbbeaa.mov



</details>

<details>
<summary>Mobile Web - Chrome</summary>

 

https://user-images.githubusercontent.com/28243942/233830177-a6708703-f792-476c-b070-c2b8a7a9346c.mov



</details>

<details>
<summary>Mobile Web - Safari</summary>

 

https://user-images.githubusercontent.com/28243942/233908051-3e0740e6-1164-472d-837d-58b6865894a0.mov


 

https://user-images.githubusercontent.com/28243942/233834537-f9955e00-7967-4871-9534-f2ce5f481582.mov



</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->



https://user-images.githubusercontent.com/28243942/233833079-fedce493-cc1e-43b3-b007-00e50e4d0213.mov



</details>

<details>
<summary>iOS</summary>

 
https://user-images.githubusercontent.com/28243942/233830550-10a28e6e-4e3a-4c72-b2de-5ef592ffa83c.mov



</details>

<details>
<summary>Android</summary>

 

https://user-images.githubusercontent.com/28243942/233830783-aabc5471-f23a-49dd-85f2-1b43d657183b.mov


</details>
