### PR TITLE
Fix screen shaking when editing between 2 tabs

### DIFF
--- a/src/pages/home/report/ReportActionItemMessageEdit.js
+++ b/src/pages/home/report/ReportActionItemMessageEdit.js
@@ -5,7 +5,6 @@ import {InteractionManager, Keyboard, View} from 'react-native';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
 import ExpensiMark from 'expensify-common/lib/ExpensiMark';
-import {withOnyx} from 'react-native-onyx';
 import reportActionPropTypes from './reportActionPropTypes';
 import styles from '../../../styles/styles';
 import Composer from '../../../components/Composer';
@@ -26,7 +25,6 @@ import CONST from '../../../CONST';
 import withWindowDimensions, {windowDimensionsPropTypes} from '../../../components/withWindowDimensions';
 import withLocalize, {withLocalizePropTypes} from '../../../components/withLocalize';
 import withKeyboardState, {keyboardStatePropTypes} from '../../../components/withKeyboardState';
-import ONYXKEYS from '../../../ONYXKEYS';
 import * as ComposerUtils from '../../../libs/ComposerUtils';
 
 const propTypes = {
@@ -35,9 +33,6 @@ const propTypes = {
 
     /** Draft message */
     draftMessage: PropTypes.string.isRequired,
-
-    /** Number of lines for the draft message */
-    numberOfLines: PropTypes.number,
 
     /** ReportID that holds the comment we're editing */
     reportID: PropTypes.string.isRequired,
@@ -67,7 +62,6 @@ const defaultProps = {
     forwardedRef: () => {},
     report: {},
     shouldDisableEmojiPicker: false,
-    numberOfLines: undefined,
     preferredSkinTone: CONST.EMOJI_DEFAULT_SKIN_TONE,
 };
 
@@ -82,7 +76,6 @@ class ReportActionItemMessageEdit extends React.Component {
         this.onSelectionChange = this.onSelectionChange.bind(this);
         this.addEmojiToTextBox = this.addEmojiToTextBox.bind(this);
         this.setExceededMaxCommentLength = this.setExceededMaxCommentLength.bind(this);
-        this.updateNumberOfLines = this.updateNumberOfLines.bind(this);
         this.saveButtonID = 'saveButton';
         this.cancelButtonID = 'cancelButton';
         this.emojiButtonID = 'emojiButton';
@@ -158,14 +151,6 @@ class ReportActionItemMessageEdit extends React.Component {
         } else {
             this.debouncedSaveDraft(this.props.action.message[0].html);
         }
-    }
-
-    /**
-     * Update the number of lines for a draft in Onyx
-     * @param {Number} numberOfLines
-     */
-    updateNumberOfLines(numberOfLines) {
-        Report.saveReportActionDraftNumberOfLines(this.props.reportID, this.props.action.reportActionID, numberOfLines);
     }
 
     /**
@@ -303,8 +288,6 @@ class ReportActionItemMessageEdit extends React.Component {
                         }}
                         selection={this.state.selection}
                         onSelectionChange={this.onSelectionChange}
-                        numberOfLines={this.props.numberOfLines}
-                        onNumberOfLinesChange={this.updateNumberOfLines}
                     />
                     <View style={styles.editChatItemEmojiWrapper}>
                         <EmojiPickerButton
@@ -346,12 +329,6 @@ export default compose(
     withLocalize,
     withWindowDimensions,
     withKeyboardState,
-    withOnyx({
-        numberOfLines: {
-            key: ({reportID, action}) => `${ONYXKEYS.COLLECTION.REPORT_DRAFT_COMMENT_NUMBER_OF_LINES}${reportID}_${action.reportActionID}`,
-            initWithStoredValues: false,
-        },
-    }),
 )(React.forwardRef((props, ref) => (
     /* eslint-disable-next-line react/jsx-props-no-spreading */
     <ReportActionItemMessageEdit {...props} forwardedRef={ref} />


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Fix: Screen is shaking when scrolling while user edit a comment between 2 tabs.
### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/16931
PROPOSAL: https://github.com/Expensify/App/issues/16931#issuecomment-1512816652


### Tests
1. Go to new report.
2. Chat 3,4 messages.
3. Send a very long message, just to make sure content of edit message is scrollable, like this:
```
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
```
4. Edit the message, delete all the content but don't save, now open that report in another tab.
5. Scroll inside your edit message then scroll outside.
6. Verify that screen isn't shaking.

- [x] Verify that no errors appear in the JS console

### Offline tests
Bug is related to offline mode itself. No extra steps needed.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
5. Upload an image via copy paste
7. Verify a modal appears displaying a preview of that image
--->
1. Go to new report.
2. Chat 3,4 messages.
3. Send a very long message, just to make sure content of edit message is scrollable, like this:
```
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
[https://staging.new.expensify.com/r/6006786908332036](https://staging.new.expensify.com/r/6006786908332036)
```
4. Edit the message, delete all the content but don't save, now open that report in another tab.
5. Scroll inside your edit message then scroll outside.
6. Verify that screen isn't shaking.
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
<!-- Insert screenshots of your changes on the web platform-->

https://user-images.githubusercontent.com/16502320/234051616-91d17ff8-198c-4e20-8c18-3e7a283e41a7.mov


#### Mobile Web - Chrome
<!-- Insert screenshots of your changes on the web platform (from chrome mobile browser)-->
https://user-images.githubusercontent.com/16502320/234060223-7e0c265e-03ef-4f52-97f7-f03da8254ae2.mov


#### Mobile Web - Safari
<!-- Insert screenshots of your changes on the web platform (from safari mobile browser)-->

https://user-images.githubusercontent.com/16502320/234159259-60ad60fe-183a-40d4-8203-1b1fcd7339bd.mov


#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

https://user-images.githubusercontent.com/16502320/234054056-01c29a17-8555-4f43-9d5c-fa0c5f8edf30.mov


#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

https://user-images.githubusercontent.com/16502320/234059409-4d289891-06a6-4950-8521-0ada7d84f5d0.mov


#### Android
<!-- Insert screenshots of your changes on the Android platform-->

https://user-images.githubusercontent.com/16502320/234060383-82c025fb-5570-40e8-9d64-86c05fdafc20.mov

