### PR TITLE
feat: Add vertical padding to context popover and call popover menu

### DIFF
--- a/src/components/VideoChatButtonAndMenu/BaseVideoChatButtonAndMenu.js
+++ b/src/components/VideoChatButtonAndMenu/BaseVideoChatButtonAndMenu.js
@@ -131,15 +131,17 @@ class BaseVideoChatButtonAndMenu extends Component {
                         top: this.state.videoChatIconPosition.y + 40,
                     }}
                 >
-                    {_.map(this.menuItemData, ({icon, text, onPress}) => (
-                        <MenuItem
-                            wrapperStyle={styles.mr3}
-                            key={text}
-                            icon={icon}
-                            title={text}
-                            onPress={onPress}
-                        />
-                    ))}
+                    <View style={this.props.isSmallScreenWidth ? {} : styles.pv3}>
+                        {_.map(this.menuItemData, ({icon, text, onPress}) => (
+                            <MenuItem
+                                wrapperStyle={styles.mr3}
+                                key={text}
+                                icon={icon}
+                                title={text}
+                                onPress={onPress}
+                            />
+                        ))}
+                    </View>
                 </Popover>
             </>
         );

--- a/src/pages/home/report/ContextMenu/BaseReportActionContextMenu.js
+++ b/src/pages/home/report/ContextMenu/BaseReportActionContextMenu.js
@@ -45,7 +45,7 @@ const defaultProps = {
 class BaseReportActionContextMenu extends React.Component {
     constructor(props) {
         super(props);
-        this.wrapperStyle = getReportActionContextMenuStyles(this.props.isMini);
+        this.wrapperStyle = getReportActionContextMenuStyles(this.props.isMini, this.props.isSmallScreenWidth);
 
         this.state = {
             shouldKeepOpen: false,

--- a/src/styles/getReportActionContextMenuStyles.js
+++ b/src/styles/getReportActionContextMenuStyles.js
@@ -29,9 +29,12 @@ const bigWrapperStyle = [
  * @returns {Array}
  */
 function getReportActionContextMenuStyles(isMini, isSmallScreenWidth) {
-    // For the bottom_docked modal type, we have defined default paddings in getBaseModalStyles file, so there is no need to add vertical padding for small screen width
-    // When popover modal type, then only Need to pass vertical padding.
-    return isMini ? miniWrapperStyle : [...bigWrapperStyle, isSmallScreenWidth ? {} : styles.pv3];
+    if (isMini) {
+        return miniWrapperStyle;
+    }
+
+    // Small screens use a bottom-docked modal that already has vertical padding.
+    return [...bigWrapperStyle, isSmallScreenWidth ? {} : styles.pv3];
 }
 
 export default getReportActionContextMenuStyles;

--- a/src/styles/getReportActionContextMenuStyles.js
+++ b/src/styles/getReportActionContextMenuStyles.js
@@ -33,8 +33,12 @@ function getReportActionContextMenuStyles(isMini, isSmallScreenWidth) {
         return miniWrapperStyle;
     }
 
-    // Small screens use a bottom-docked modal that already has vertical padding.
-    return [...bigWrapperStyle, isSmallScreenWidth ? {} : styles.pv3];
+    return [
+        ...bigWrapperStyle,
+
+        // Small screens use a bottom-docked modal that already has vertical padding.
+        isSmallScreenWidth ? {} : styles.pv3,
+    ];
 }
 
 export default getReportActionContextMenuStyles;

--- a/src/styles/getReportActionContextMenuStyles.js
+++ b/src/styles/getReportActionContextMenuStyles.js
@@ -29,7 +29,9 @@ const bigWrapperStyle = [
  * @returns {Array}
  */
 function getReportActionContextMenuStyles(isMini, isSmallScreenWidth) {
-    return isMini ? miniWrapperStyle : [...bigWrapperStyle, !isSmallScreenWidth && styles.pv3];
+    // For the bottom_docked modal type, we have defined default paddings in getBaseModalStyles file, so there is no need to add vertical padding for small screen width
+    // When popover modal type, then only Need to pass vertical padding.
+    return isMini ? miniWrapperStyle : [...bigWrapperStyle, isSmallScreenWidth ? {} : styles.pv3];
 }
 
 export default getReportActionContextMenuStyles;

--- a/src/styles/getReportActionContextMenuStyles.js
+++ b/src/styles/getReportActionContextMenuStyles.js
@@ -25,10 +25,11 @@ const bigWrapperStyle = [
  * Generate the wrapper styles for the ReportActionContextMenu.
  *
  * @param {Boolean} isMini
+ * @param {Boolean} isSmallScreenWidth
  * @returns {Array}
  */
-function getReportActionContextMenuStyles(isMini) {
-    return isMini ? miniWrapperStyle : bigWrapperStyle;
+function getReportActionContextMenuStyles(isMini, isSmallScreenWidth) {
+    return isMini ? miniWrapperStyle : [...bigWrapperStyle, !isSmallScreenWidth && styles.pv3];
 }
 
 export default getReportActionContextMenuStyles;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/17791
PROPOSAL: https://github.com/Expensify/App/issues/17791#issuecomment-1518880870


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Open App
2. Go to any chat
3. Right Click / Long Press on any message to open the context menu
4. Keep pressing the TAB key to navigate through the options
5. Verify a blue frame appears on each option
6. Verify the corners of the frame are not cut
7. Close the context menu
8. Press the call button from the chat header
9. Keep pressing the TAB key to navigate through the options
10. Verify a blue frame appears on each option
11. Verify the corners of the frame are not cut


- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
Same as above Tests

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Same as above Tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://user-images.githubusercontent.com/35371050/234086774-8be0cc04-d579-48a0-865a-6fcab313e782.mov


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://user-images.githubusercontent.com/35371050/234086803-2472469c-2efd-4b3d-9285-b424f45b2f72.mp4


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

https://user-images.githubusercontent.com/35371050/234086847-620b847d-4adc-43ca-8aa3-f7a62ce50921.mov


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>

https://user-images.githubusercontent.com/35371050/234086866-75c624fb-5609-40fd-95cc-c2f8c32eea03.mov


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

https://user-images.githubusercontent.com/35371050/234086880-374e7371-0220-496b-a671-73b21b319909.mov


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>

https://user-images.githubusercontent.com/35371050/234086902-5018d0c6-4e63-4583-b3b8-f0797085631d.mov


<!-- add screenshots or videos here -->

</details>
