### PR TITLE
Fix: Use label instead of placeholder for option selector

### DIFF
--- a/src/components/OptionsSelector/BaseOptionsSelector.js
+++ b/src/components/OptionsSelector/BaseOptionsSelector.js
@@ -279,7 +279,6 @@ class BaseOptionsSelector extends Component {
                 value={this.props.value}
                 label={this.props.textInputLabel}
                 onChangeText={this.props.onChangeText}
-                placeholder={this.props.placeholderText}
                 maxLength={this.props.maxLength}
                 keyboardType={this.props.keyboardType}
                 onBlur={(e) => {
@@ -341,7 +340,7 @@ class BaseOptionsSelector extends Component {
                                 </>
                             ) : (
                                 <>
-                                    <View style={[styles.ph5, styles.pv3]}>
+                                    <View style={[styles.ph5, styles.pb3]}>
                                         {this.props.children}
                                         {this.props.shouldShowTextInput && textInput}
                                     </View>

--- a/src/pages/NewChatPage.js
+++ b/src/pages/NewChatPage.js
@@ -257,7 +257,7 @@ class NewChatPage extends Component {
                                     shouldShowConfirmButton={this.props.isGroupChat}
                                     confirmButtonText={this.props.translate('newChatPage.createGroup')}
                                     onConfirmSelection={this.createGroup}
-                                    placeholderText={this.props.translate('optionsSelector.nameEmailOrPhoneNumber')}
+                                    textInputLabel={this.props.translate('optionsSelector.nameEmailOrPhoneNumber')}
                                     safeAreaPaddingBottomStyle={safeAreaPaddingBottomStyle}
                                 />
                             ) : (

--- a/src/pages/SearchPage.js
+++ b/src/pages/SearchPage.js
@@ -191,7 +191,7 @@ class SearchPage extends Component {
                                 hideSectionHeaders
                                 showTitleTooltip
                                 shouldShowOptions={didScreenTransitionEnd}
-                                placeholderText={this.props.translate('optionsSelector.nameEmailOrPhoneNumber')}
+                                textInputLabel={this.props.translate('optionsSelector.nameEmailOrPhoneNumber')}
                                 onLayout={this.searchRendered}
                                 safeAreaPaddingBottomStyle={safeAreaPaddingBottomStyle}
                             />

--- a/src/pages/iou/IOUCurrencySelection.js
+++ b/src/pages/iou/IOUCurrencySelection.js
@@ -124,7 +124,7 @@ class IOUCurrencySelection extends Component {
                             onSelectRow={this.confirmCurrencySelection}
                             value={this.state.searchValue}
                             onChangeText={this.changeSearchValue}
-                            placeholderText={this.props.translate('common.search')}
+                            textInputLabel={this.props.translate('common.search')}
                             headerMessage={headerMessage}
                             safeAreaPaddingBottomStyle={safeAreaPaddingBottomStyle}
                         />

--- a/src/pages/iou/steps/MoneyRequstParticipantsPage/MoneyRequestParticipantsSelector.js
+++ b/src/pages/iou/steps/MoneyRequstParticipantsPage/MoneyRequestParticipantsSelector.js
@@ -161,7 +161,7 @@ class MoneyRequestParticipantsSelector extends Component {
                 onSelectRow={this.addSingleParticipant}
                 onChangeText={this.updateOptionsWithSearchTerm}
                 headerMessage={headerMessage}
-                placeholderText={this.props.translate('optionsSelector.nameEmailOrPhoneNumber')}
+                textInputLabel={this.props.translate('optionsSelector.nameEmailOrPhoneNumber')}
                 boldStyle
                 safeAreaPaddingBottomStyle={this.props.safeAreaPaddingBottomStyle}
             />

--- a/src/pages/iou/steps/MoneyRequstParticipantsPage/MoneyRequestParticipantsSplitSelector.js
+++ b/src/pages/iou/steps/MoneyRequstParticipantsPage/MoneyRequestParticipantsSplitSelector.js
@@ -236,7 +236,7 @@ class MoneyRequestParticipantsSplitSelector extends Component {
                     shouldShowConfirmButton
                     confirmButtonText={this.props.translate('common.next')}
                     onConfirmSelection={this.finalizeParticipants}
-                    placeholderText={this.props.translate('optionsSelector.nameEmailOrPhoneNumber')}
+                    textInputLabel={this.props.translate('optionsSelector.nameEmailOrPhoneNumber')}
                     safeAreaPaddingBottomStyle={this.props.safeAreaPaddingBottomStyle}
                 />
             </View>

--- a/src/pages/settings/Profile/PronounsPage.js
+++ b/src/pages/settings/Profile/PronounsPage.js
@@ -130,7 +130,7 @@ class PronounsPage extends Component {
                             onBackButtonPress={() => Navigation.navigate(ROUTES.SETTINGS_PROFILE)}
                             onCloseButtonPress={() => Navigation.dismissModal(true)}
                         />
-                        <Text style={[styles.ph5, styles.pb3]}>
+                        <Text style={[styles.ph5, styles.mb3]}>
                             {this.props.translate('pronounsPage.isShownOnProfile')}
                         </Text>
                         <OptionsSelector

--- a/src/pages/settings/Profile/PronounsPage.js
+++ b/src/pages/settings/Profile/PronounsPage.js
@@ -130,7 +130,7 @@ class PronounsPage extends Component {
                             onBackButtonPress={() => Navigation.navigate(ROUTES.SETTINGS_PROFILE)}
                             onCloseButtonPress={() => Navigation.dismissModal(true)}
                         />
-                        <Text style={styles.ph5}>
+                        <Text style={[styles.ph5, styles.pb3]}>
                             {this.props.translate('pronounsPage.isShownOnProfile')}
                         </Text>
                         <OptionsSelector

--- a/src/pages/workspace/WorkspaceInvitePage.js
+++ b/src/pages/workspace/WorkspaceInvitePage.js
@@ -331,7 +331,7 @@ class WorkspaceInvitePage extends React.Component {
                                         hideSectionHeaders
                                         boldStyle
                                         shouldFocusOnSelectRow
-                                        placeholderText={this.props.translate('optionsSelector.nameEmailOrPhoneNumber')}
+                                        textInputLabel={this.props.translate('optionsSelector.nameEmailOrPhoneNumber')}
                                     />
                                 ) : (
                                     <FullScreenLoadingIndicator />


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR standardises the usage of placeholder across different components by removing `placeholderText` with `textInputLabel` for all the `OptionSelector` elements.

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/17873
PROPOSAL: https://github.com/Expensify/App/issues/17873#issuecomment-1519654007


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Go to any chat and open a IOU request modal
2. Enter any amount and go to the description page
3. Notice the `Whats it for` field padding.
4. Next, go to the home screen and click the search icon
Verify that the padding for the search input field is same as for the `Whats it for` field.
Repeat the same steps for Workspace Member Invite, New chat, New group chat, Request money & Split money pages.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Go to any chat and open a IOU request modal
2. Enter any amount and go to the description page
3. Notice the `Whats it for` field padding.
4. Next, go to the home screen and click the search icon
Verify that the padding for the search input field is same as for the `Whats it for` field.
Repeat the same steps for Workspace Member Invite, New chat, New group chat, Request money & Split money pages.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
    - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->
<img width="816" alt="Screenshot 2023-04-26 at 1 32 14 AM" src="https://user-images.githubusercontent.com/30054992/234401597-19cde5f5-21eb-484a-9d03-6b98fd8a7408.png">
<img width="816" alt="Screenshot 2023-04-26 at 1 32 50 AM" src="https://user-images.githubusercontent.com/30054992/234401697-48b9c2d9-6a62-411c-964f-4551028c9251.png">
<img width="816" alt="Screenshot 2023-04-26 at 1 33 00 AM" src="https://user-images.githubusercontent.com/30054992/234401735-25c97584-022a-4fba-b66e-9ff23c8a657f.png">
<img width="816" alt="Screenshot 2023-04-26 at 1 33 41 AM" src="https://user-images.githubusercontent.com/30054992/234401813-8712330f-465b-448d-9d26-27072b469d53.png">
<img width="816" alt="Screenshot 2023-04-26 at 1 34 33 AM" src="https://user-images.githubusercontent.com/30054992/234401831-18383467-038e-45f5-87e8-2016e5d539a4.png">
<img width="816" alt="Screenshot 2023-04-26 at 1 35 07 AM" src="https://user-images.githubusercontent.com/30054992/234401839-0b64d2ed-6015-4eb7-906e-dcaa461bb0bd.png">

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->
<img width="374" alt="Screenshot 2023-04-26 at 1 40 27 AM" src="https://user-images.githubusercontent.com/30054992/234401953-d2a875e9-4354-425c-8171-22093ec3cfca.png">
<img width="374" alt="Screenshot 2023-04-26 at 1 40 51 AM" src="https://user-images.githubusercontent.com/30054992/234401984-df394979-c228-40ff-9cb3-2648a4cba8b7.png">
<img width="374" alt="Screenshot 2023-04-26 at 1 41 14 AM" src="https://user-images.githubusercontent.com/30054992/234402006-59dd8017-d367-4322-aa04-83569989f8e2.png">
<img width="372" alt="Screenshot 2023-04-26 at 1 41 33 AM" src="https://user-images.githubusercontent.com/30054992/234402052-71dee665-3991-4e15-9366-d54837c5e4db.png">
<img width="375" alt="Screenshot 2023-04-26 at 1 41 54 AM" src="https://user-images.githubusercontent.com/30054992/234402085-ed85acc8-1f23-40ef-95af-08e33470eaaa.png">
<img width="376" alt="Screenshot 2023-04-26 at 1 42 18 AM" src="https://user-images.githubusercontent.com/30054992/234402111-2354041b-e7f5-45a5-82d8-0576898bff56.png">

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->
<img width="347" alt="Screenshot 2023-04-26 at 1 44 57 AM" src="https://user-images.githubusercontent.com/30054992/234402233-e5e1f664-857c-4ce0-9e29-939ce7b2f991.png">
<img width="331" alt="Screenshot 2023-04-26 at 1 45 25 AM" src="https://user-images.githubusercontent.com/30054992/234402268-c4c4173d-a493-4524-80f5-3672690dbb3d.png">
<img width="327" alt="Screenshot 2023-04-26 at 1 45 40 AM" src="https://user-images.githubusercontent.com/30054992/234402293-6e3ab17a-8734-4618-b93f-9c5d9c7f3920.png">
<img width="329" alt="Screenshot 2023-04-26 at 1 45 49 AM" src="https://user-images.githubusercontent.com/30054992/234402314-216baa3b-959a-47ce-b4d8-5a68c488931d.png">
<img width="331" alt="Screenshot 2023-04-26 at 1 46 09 AM" src="https://user-images.githubusercontent.com/30054992/234402349-881182ca-047e-48fe-8e79-d37e75d68b45.png">
<img width="342" alt="Screenshot 2023-04-26 at 1 46 24 AM" src="https://user-images.githubusercontent.com/30054992/234402377-06c1a834-e3c4-490e-bdb1-39731b7df6ad.png">

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->
<img width="1195" alt="Screenshot 2023-04-26 at 1 35 32 AM" src="https://user-images.githubusercontent.com/30054992/234402524-7e826c4a-d070-4e20-bdcb-048890bbb534.png">
<img width="1195" alt="Screenshot 2023-04-26 at 1 35 57 AM" src="https://user-images.githubusercontent.com/30054992/234402763-a8d20c77-ad57-425a-93af-e407fc48c5aa.png">
<img width="1195" alt="Screenshot 2023-04-26 at 1 36 10 AM" src="https://user-images.githubusercontent.com/30054992/234402941-2b72a33e-b849-40b3-ab56-a542150fa2a0.png">
<img width="1195" alt="Screenshot 2023-04-26 at 1 36 19 AM" src="https://user-images.githubusercontent.com/30054992/234402953-faf080d5-621b-485d-82f3-90e1100c2618.png">
<img width="1195" alt="Screenshot 2023-04-26 at 1 36 30 AM" src="https://user-images.githubusercontent.com/30054992/234402961-612b9bcf-02d4-436c-867a-f62a221bf23c.png">
<img width="1195" alt="Screenshot 2023-04-26 at 1 36 43 AM" src="https://user-images.githubusercontent.com/30054992/234402969-c8070a24-7c01-438e-bfad-555b174c3144.png">

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->
<img width="337" alt="Screenshot 2023-04-26 at 1 42 37 AM" src="https://user-images.githubusercontent.com/30054992/234403031-9025d7bb-9059-4d56-bd42-47fbf7006b37.png">
<img width="328" alt="Screenshot 2023-04-26 at 1 43 05 AM" src="https://user-images.githubusercontent.com/30054992/234403040-ad139a73-2171-4824-906a-eef7e151a5d6.png">
<img width="340" alt="Screenshot 2023-04-26 at 1 43 24 AM" src="https://user-images.githubusercontent.com/30054992/234403046-c5270c32-2316-4cc7-8a7f-b1b013f9ee68.png">
<img width="335" alt="Screenshot 2023-04-26 at 1 43 36 AM" src="https://user-images.githubusercontent.com/30054992/234403050-ce0f7e03-74f3-4755-b8a1-7c4f1183b531.png">
<img width="325" alt="Screenshot 2023-04-26 at 1 43 52 AM" src="https://user-images.githubusercontent.com/30054992/234403060-b4b22bef-bd59-4b22-bc6e-606db3dc57f7.png">
<img width="336" alt="Screenshot 2023-04-26 at 1 44 15 AM" src="https://user-images.githubusercontent.com/30054992/234403069-5101c0d3-2204-41c8-ba05-8607f18f35c9.png">

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->
<img width="372" alt="Screenshot 2023-04-26 at 1 37 33 AM" src="https://user-images.githubusercontent.com/30054992/234403140-43b0df3e-e9ed-4574-8f1a-ee3bb73ad8ea.png">
<img width="377" alt="Screenshot 2023-04-26 at 1 37 53 AM" src="https://user-images.githubusercontent.com/30054992/234403148-135695f4-d54e-4a18-bd61-c407602d477c.png">
<img width="376" alt="Screenshot 2023-04-26 at 1 38 05 AM" src="https://user-images.githubusercontent.com/30054992/234403157-97ef38b8-45f5-48e2-8b79-f37f85af1d14.png">
<img width="374" alt="Screenshot 2023-04-26 at 1 38 22 AM" src="https://user-images.githubusercontent.com/30054992/234403165-a998ad14-2b4c-4a63-acdb-9ad7e9360813.png">
<img width="375" alt="Screenshot 2023-04-26 at 1 38 52 AM" src="https://user-images.githubusercontent.com/30054992/234403171-a34f3bec-4ae8-4843-ab21-186bb0732d12.png">
<img width="374" alt="Screenshot 2023-04-26 at 1 39 18 AM" src="https://user-images.githubusercontent.com/30054992/234403175-fc3457a6-efcb-4ae4-992d-b37fd27a6ed8.png">

</details>
