### PR TITLE
fix: payment page title spacing

### DIFF
--- a/src/pages/settings/Payments/PaymentsPage/BasePaymentsPage.js
+++ b/src/pages/settings/Payments/PaymentsPage/BasePaymentsPage.js
@@ -351,28 +351,30 @@ class BasePaymentsPage extends React.Component {
                             )}
                         </View>
                         {this.props.userWallet.currentBalance > 0 && (
-                            <KYCWall
-                                onSuccessfulKYC={this.navigateToTransferBalancePage}
-                                enablePaymentsRoute={ROUTES.SETTINGS_ENABLE_PAYMENTS}
-                                addBankAccountRoute={ROUTES.SETTINGS_ADD_BANK_ACCOUNT}
-                                addDebitCardRoute={ROUTES.SETTINGS_ADD_DEBIT_CARD}
-                                popoverPlacement="bottom"
-                            >
-                                {triggerKYCFlow => (
-                                    <MenuItem
-                                        title={this.props.translate('common.transferBalance')}
-                                        icon={Expensicons.Transfer}
-                                        onPress={triggerKYCFlow}
-                                        shouldShowRightIcon
-                                        disabled={this.props.network.isOffline}
-                                    />
-                                )}
-                            </KYCWall>
+                            <View style={styles.mb3}>
+                                <KYCWall
+                                    onSuccessfulKYC={this.navigateToTransferBalancePage}
+                                    enablePaymentsRoute={ROUTES.SETTINGS_ENABLE_PAYMENTS}
+                                    addBankAccountRoute={ROUTES.SETTINGS_ADD_BANK_ACCOUNT}
+                                    addDebitCardRoute={ROUTES.SETTINGS_ADD_DEBIT_CARD}
+                                    popoverPlacement="bottom"
+                                >
+                                    {triggerKYCFlow => (
+                                        <MenuItem
+                                            title={this.props.translate('common.transferBalance')}
+                                            icon={Expensicons.Transfer}
+                                            onPress={triggerKYCFlow}
+                                            shouldShowRightIcon
+                                            disabled={this.props.network.isOffline}
+                                        />
+                                    )}
+                                </KYCWall>
+                            </View>
                         )}
                     </>
                 )}
                 <Text
-                    style={[styles.ph5, styles.mt6, styles.textLabelSupporting, styles.mb1]}
+                    style={[styles.ph5, styles.textLabelSupporting, styles.mb1]}
                 >
                     {this.props.translate('paymentsPage.paymentMethodsTitle')}
                 </Text>


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR fixes the inconsistent spacing between the header and the content of the `Payments` page when wallet is disabled.

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/17861
PROPOSAL: https://github.com/Expensify/App/issues/17861#issuecomment-1519132987


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Go to settings
2. Click on Payments
3. Make sure that your wallet is disabled (can be done either through code or having a special account without wallet permission)
4. Verify that the spacing between header and the content is consistent with other pages eg `Search, New chat`

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Go to settings
2. Click on Payments
3. Make sure that your wallet is disabled (can be done either through code or having a special account without wallet permission)
4. Verify that the spacing between header and the content is consistent with other pages eg `Search, New chat`

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
    - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->
<img width="394" alt="Screenshot 2023-05-02 at 3 08 44 AM" src="https://user-images.githubusercontent.com/30054992/235541579-89462136-4c4b-495b-9a8c-a9ff0da86425.png">
<img width="380" alt="Screenshot 2023-05-02 at 3 11 03 AM" src="https://user-images.githubusercontent.com/30054992/235541588-7465d3a2-3a3f-4c91-a2b2-fddf9399348d.png">
<img width="373" alt="Screenshot 2023-05-02 at 3 12 36 AM" src="https://user-images.githubusercontent.com/30054992/235541593-7999dd1d-4f38-4a65-b5fa-2c3c972882f0.png">

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->
<img width="378" alt="Screenshot 2023-05-02 at 3 09 23 AM" src="https://user-images.githubusercontent.com/30054992/235541719-490f1032-cdec-4ef8-b688-b0cc6d7730b4.png">
<img width="374" alt="Screenshot 2023-05-02 at 3 11 45 AM" src="https://user-images.githubusercontent.com/30054992/235541724-39210c98-dc6f-4ca1-a360-f421886a3ad2.png">
<img width="372" alt="Screenshot 2023-05-02 at 3 13 45 AM" src="https://user-images.githubusercontent.com/30054992/235541730-1a1ecdff-c2d5-4553-b683-c496470ad958.png">

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->
<img width="352" alt="Screenshot 2023-05-02 at 3 10 04 AM" src="https://user-images.githubusercontent.com/30054992/235541926-553c20de-1b94-426f-97c4-0a9be0cb2072.png">
<img width="358" alt="Screenshot 2023-05-02 at 3 28 17 AM" src="https://user-images.githubusercontent.com/30054992/235542764-5ead8511-91b5-4042-a41a-97c0786fc86a.png">
<img width="352" alt="Screenshot 2023-05-02 at 3 13 07 AM" src="https://user-images.githubusercontent.com/30054992/235541934-255e9605-f9bd-4f55-8593-d357fad625ce.png">

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->
<img width="1202" alt="Screenshot 2023-05-02 at 3 08 56 AM" src="https://user-images.githubusercontent.com/30054992/235541970-c29fe0e4-1060-4e42-9fef-927dfb0969e3.png">
<img width="1200" alt="Screenshot 2023-05-02 at 3 11 13 AM" src="https://user-images.githubusercontent.com/30054992/235541995-8f38e9a4-a5e8-4677-bdd1-ee740386898b.png">
<img width="1204" alt="Screenshot 2023-05-02 at 3 12 47 AM" src="https://user-images.githubusercontent.com/30054992/235541999-509e5a62-feb5-4578-9c71-7af8d41835fa.png">

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->
<img width="352" alt="Screenshot 2023-05-02 at 3 10 17 AM" src="https://user-images.githubusercontent.com/30054992/235542094-18979e60-f425-4ff1-9dc2-4826761b681d.png">
<img width="362" alt="Screenshot 2023-05-02 at 3 29 22 AM" src="https://user-images.githubusercontent.com/30054992/235542723-a3493c8e-9b12-48cf-a32b-b4912187b5ad.png">
<img width="351" alt="Screenshot 2023-05-02 at 3 12 57 AM" src="https://user-images.githubusercontent.com/30054992/235542099-c9fe4ebf-b6e1-4090-bc6e-00e130890932.png">

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->
<img width="376" alt="Screenshot 2023-05-02 at 3 09 45 AM" src="https://user-images.githubusercontent.com/30054992/235542204-f8d19bd9-24cf-4d84-84fe-7b497811eab4.png">
<img width="375" alt="Screenshot 2023-05-02 at 3 11 28 AM" src="https://user-images.githubusercontent.com/30054992/235542208-a7c4c20b-8ab7-49ab-90c4-0ec354be16db.png">
<img width="372" alt="Screenshot 2023-05-02 at 3 13 16 AM" src="https://user-images.githubusercontent.com/30054992/235542212-c7cb8965-6777-4f8e-a802-75efb609e121.png">

</details>
