### PR TITLE
[No QA] Fix the padding on the subscript avatar

### DIFF
--- a/src/components/MultipleAvatars.js
+++ b/src/components/MultipleAvatars.js
@@ -55,7 +55,9 @@ const defaultProps = {
 };
 
 const MultipleAvatars = (props) => {
-    let avatarContainerStyles = props.size === CONST.AVATAR_SIZE.SMALL ? styles.emptyAvatarSmall : styles.emptyAvatar;
+    let avatarContainerStyles = props.size === CONST.AVATAR_SIZE.SMALL
+        ? [styles.emptyAvatarSmall, styles.emptyAvatarMarginSmall]
+        : [styles.emptyAvatar, styles.emptyAvatarMargin];
     const singleAvatarStyles = props.size === CONST.AVATAR_SIZE.SMALL ? styles.singleAvatarSmall : styles.singleAvatar;
     const secondAvatarStyles = [
         props.size === CONST.AVATAR_SIZE.SMALL ? styles.secondAvatarSmall : styles.secondAvatar,

--- a/src/components/OptionRow.js
+++ b/src/components/OptionRow.js
@@ -207,7 +207,6 @@ class OptionRow extends Component {
                                                     secondaryAvatar={this.props.option.icons[1]}
                                                     mainTooltip={this.props.option.ownerEmail}
                                                     secondaryTooltip={this.props.option.subtitle}
-                                                    size={CONST.AVATAR_SIZE.DEFAULT}
                                                     backgroundColor={
                                                     hovered && !this.props.optionIsFocused
                                                         ? hoveredBackgroundColor

--- a/src/components/SubscriptAvatar.js
+++ b/src/components/SubscriptAvatar.js
@@ -28,6 +28,9 @@ const propTypes = {
 
     /** Background color used for subscript avatar border */
     backgroundColor: PropTypes.string,
+
+    /** Removes margin from around the avatar, used for the chat view */
+    noMargin: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -37,36 +40,48 @@ const defaultProps = {
     backgroundColor: themeColors.componentBG,
     mainAvatar: {},
     secondaryAvatar: {},
+    noMargin: false,
 };
 
-const SubscriptAvatar = props => (
-    <View style={props.size === CONST.AVATAR_SIZE.SMALL ? styles.emptyAvatarSmall : styles.emptyAvatar}>
-        <Tooltip text={props.mainTooltip}>
-            <Avatar
-                source={props.mainAvatar.source}
-                size={props.size === CONST.AVATAR_SIZE.SMALL ? CONST.AVATAR_SIZE.SMALL : CONST.AVATAR_SIZE.DEFAULT}
-                name={props.mainAvatar.name}
-                type={props.mainAvatar.type}
-            />
-        </Tooltip>
-        <View style={[
-            props.size === CONST.AVATAR_SIZE.SMALL ? styles.secondAvatarSubscriptCompact : styles.secondAvatarSubscript,
-            StyleUtils.getBackgroundAndBorderStyle(props.backgroundColor),
-            StyleUtils.getAvatarBorderStyle(props.size, props.secondaryAvatar.type),
-        ]}
-        >
-            <Tooltip text={props.secondaryTooltip}>
+const SubscriptAvatar = (props) => {
+    const containerStyle = props.size === CONST.AVATAR_SIZE.SMALL ? styles.emptyAvatarSmall : styles.emptyAvatar;
+
+    // Default the margin style to what is normal for small or normal sized avatars
+    let marginStyle = props.size === CONST.AVATAR_SIZE.SMALL ? styles.emptyAvatarMargin : styles.emptyAvatarMarginSmall;
+
+    // Some views like the chat view require that there be no margins
+    if (props.noMargin) {
+        marginStyle = null;
+    }
+    return (
+        <View style={[containerStyle, marginStyle]}>
+            <Tooltip text={props.mainTooltip}>
                 <Avatar
-                    source={props.secondaryAvatar.source}
-                    size={props.size === CONST.AVATAR_SIZE.SMALL ? CONST.AVATAR_SIZE.SMALL_SUBSCRIPT : CONST.AVATAR_SIZE.SUBSCRIPT}
-                    fill={themeColors.iconSuccessFill}
-                    name={props.secondaryAvatar.name}
-                    type={props.secondaryAvatar.type}
+                    source={props.mainAvatar.source}
+                    size={props.size === CONST.AVATAR_SIZE.SMALL ? CONST.AVATAR_SIZE.SMALL : CONST.AVATAR_SIZE.DEFAULT}
+                    name={props.mainAvatar.name}
+                    type={props.mainAvatar.type}
                 />
             </Tooltip>
+            <View style={[
+                props.size === CONST.AVATAR_SIZE.SMALL ? styles.secondAvatarSubscriptCompact : styles.secondAvatarSubscript,
+                StyleUtils.getBackgroundAndBorderStyle(props.backgroundColor),
+                StyleUtils.getAvatarBorderStyle(props.size, props.secondaryAvatar.type),
+            ]}
+            >
+                <Tooltip text={props.secondaryTooltip}>
+                    <Avatar
+                        source={props.secondaryAvatar.source}
+                        size={props.size === CONST.AVATAR_SIZE.SMALL ? CONST.AVATAR_SIZE.SMALL_SUBSCRIPT : CONST.AVATAR_SIZE.SUBSCRIPT}
+                        fill={themeColors.iconSuccessFill}
+                        name={props.secondaryAvatar.name}
+                        type={props.secondaryAvatar.type}
+                    />
+                </Tooltip>
+            </View>
         </View>
-    </View>
-);
+    );
+};
 
 SubscriptAvatar.displayName = 'SubscriptAvatar';
 SubscriptAvatar.propTypes = propTypes;

--- a/src/components/SubscriptAvatar.js
+++ b/src/components/SubscriptAvatar.js
@@ -51,7 +51,7 @@ const SubscriptAvatar = (props) => {
 
     // Some views like the chat view require that there be no margins
     if (props.noMargin) {
-        marginStyle = null;
+        marginStyle = {};
     }
     return (
         <View style={[containerStyle, marginStyle]}>

--- a/src/pages/home/report/ReportActionItemSingle.js
+++ b/src/pages/home/report/ReportActionItemSingle.js
@@ -96,7 +96,7 @@ const ReportActionItemSingle = (props) => {
                         <SubscriptAvatar
                             mainAvatar={{source: avatarSource, type: CONST.ICON_TYPE_AVATAR}}
                             secondaryAvatar={ReportUtils.getIcons(props.report, {})[0]}
-                            mainTooltip={props.report.ownerEmail}
+                            mainTooltip={actorEmail}
                             secondaryTooltip={ReportUtils.getReportName(props.report)}
                         />
                     ) : (

--- a/src/pages/home/report/ReportActionItemSingle.js
+++ b/src/pages/home/report/ReportActionItemSingle.js
@@ -98,6 +98,7 @@ const ReportActionItemSingle = (props) => {
                             secondaryAvatar={ReportUtils.getIcons(props.report, {})[0]}
                             mainTooltip={actorEmail}
                             secondaryTooltip={ReportUtils.getReportName(props.report)}
+                            noMargin
                         />
                     ) : (
                         <Tooltip text={actorEmail}>

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1821,7 +1821,6 @@ const styles = {
     },
 
     emptyAvatarSmall: {
-        marginRight: variables.avatarChatSpacing - 4,
         height: variables.avatarSizeSmall,
         width: variables.avatarSizeSmall,
     },

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1816,7 +1816,6 @@ const styles = {
     },
 
     emptyAvatar: {
-        marginRight: variables.avatarChatSpacing,
         height: variables.avatarSizeNormal,
         width: variables.avatarSizeNormal,
     },
@@ -1825,6 +1824,14 @@ const styles = {
         marginRight: variables.avatarChatSpacing - 4,
         height: variables.avatarSizeSmall,
         width: variables.avatarSizeSmall,
+    },
+
+    emptyAvatarMargin: {
+        marginRight: variables.avatarChatSpacing,
+    },
+
+    emptyAvatarMarginSmall: {
+        marginRight: variables.avatarChatSpacing - 4,
     },
 
     modalViewContainer: {


### PR DESCRIPTION
### Fixed Issues
![image](https://user-images.githubusercontent.com/1228807/235709727-629a189e-9be8-47d6-b7d4-1c0135fa2d18.png)

Reported [here](https://expensify.slack.com/archives/C01GTK53T8Q/p1683037424779449?thread_ts=1682978128.574129&cid=C01GTK53T8Q)

### Tests
1. Update `ReportActionsList.js` to set `shouldShowSubscriptAvatar={true}`
2. Open a chat with a workspace and send a message
3. Verify the avatar padding is fixed so that all the chat messages line up on the left

![image](https://user-images.githubusercontent.com/1228807/235708896-1959f527-8869-4384-acec-db1172a1307c.png)

4. Switch between focus mode and most recent view mode
5. Verify that the padding on the avatars in the LHN is 8 (for focus) and 12 pixels (for most recent)

- [x] Verify that no errors appear in the JS console

### Offline tests
None

### QA Steps
None. This can't be QA'ed yet because there is no way to request money from a workspace at this point.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->
![2023-05-02_09-08-00](https://user-images.githubusercontent.com/1228807/235709219-8699f41a-135c-404c-8901-2d60a4be0aa9.png)


</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->
![2023-05-02_09-10-51](https://user-images.githubusercontent.com/1228807/235709252-27c5ba5a-6839-4808-8a74-28b9565c27da.png)


</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->
![2023-05-02_09-09-40](https://user-images.githubusercontent.com/1228807/235709269-9069d2db-a7d7-40bc-a48a-1ff5d4dc22a2.png)


</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

![2023-05-02_09-08-51](https://user-images.githubusercontent.com/1228807/235709297-ce5132b5-84a5-474e-9efb-bda37d7f6882.png)

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

![2023-05-02_09-10-13](https://user-images.githubusercontent.com/1228807/235709317-e26d7cad-1546-4766-9a95-ace473fd010e.png)

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->
![image](https://user-images.githubusercontent.com/1228807/235709400-58d2b6ab-bb89-4e6a-8dc7-e1e737e74814.png)


</details>
cc @luacmartins @aimane-chnaif 