### PR TITLE
Only subscribe shortcuts when modal is open

### DIFF
--- a/src/components/KeyboardShortcutsModal.js
+++ b/src/components/KeyboardShortcutsModal.js
@@ -34,8 +34,9 @@ const defaultProps = {
 
 class KeyboardShortcutsModal extends React.Component {
     componentDidMount() {
-        const openShortcutModalConfig = CONST.KEYBOARD_SHORTCUTS.SHORTCUT_MODAL;
         this.subscribedOpenModalShortcuts = [];
+
+        const openShortcutModalConfig = CONST.KEYBOARD_SHORTCUTS.SHORTCUT_MODAL;
         this.unsubscribeShortcutModal = KeyboardShortcut.subscribe(openShortcutModalConfig.shortcutKey, () => {
             ModalActions.close();
             KeyboardShortcutsActions.showKeyboardShortcutModal();
@@ -43,13 +44,13 @@ class KeyboardShortcutsModal extends React.Component {
 
         if (this.props.isShortcutsModalOpen) {
             // The modal started open, which can happen if you reload the page when the modal is open.
-            this.subscribeOpenModalKeyboardShortcuts();
+            this.subscribeOpenModalShortcuts();
         }
     }
 
     componentDidUpdate(prevProps) {
         if (!prevProps.isShortcutsModalOpen && this.props.isShortcutsModalOpen) {
-            this.subscribeOpenModalKeyboardShortcuts();
+            this.subscribeOpenModalShortcuts();
         } else if (prevProps.isShortcutsModalOpen && !this.props.isShortcutsModalOpen) {
             // Modal is closing, remove keyboard shortcuts
             this.unsubscribeOpenModalShortcuts();
@@ -66,7 +67,7 @@ class KeyboardShortcutsModal extends React.Component {
     /*
      * Subscribe shortcuts that only are used when the modal is open
      */
-    subscribeOpenModalKeyboardShortcuts() {
+    subscribeOpenModalShortcuts() {
         // Allow closing the modal with the both Enter and Escape keys
         // Both callbacks have the lowest priority (0) to ensure that they are called before any other callbacks
         // and configured so that event propagation is stopped after the callback is called (only when the modal is open)

--- a/src/components/KeyboardShortcutsModal.js
+++ b/src/components/KeyboardShortcutsModal.js
@@ -35,56 +35,24 @@ const defaultProps = {
 class KeyboardShortcutsModal extends React.Component {
     componentDidMount() {
         const openShortcutModalConfig = CONST.KEYBOARD_SHORTCUTS.SHORTCUT_MODAL;
+        this.subscribedOpenModalShortcuts = [];
         this.unsubscribeShortcutModal = KeyboardShortcut.subscribe(openShortcutModalConfig.shortcutKey, () => {
             ModalActions.close();
             KeyboardShortcutsActions.showKeyboardShortcutModal();
         }, openShortcutModalConfig.descriptionKey, openShortcutModalConfig.modifiers, true);
+
+        if (this.props.isShortcutsModalOpen) {
+            // The modal started open, which can happen if you reload the page when the modal is open.
+            this.subscribeOpenModalKeyboardShortcuts();
+        }
     }
 
     componentDidUpdate(prevProps) {
         if (!prevProps.isShortcutsModalOpen && this.props.isShortcutsModalOpen) {
-            // Modal is opening, add keyboard shortcuts
-            // Allow closing the modal with the both Enter and Escape keys
-            // Both callbacks have the lowest priority (0) to ensure that they are called before any other callbacks
-            // and configured so that event propagation is stopped after the callback is called (only when the modal is open)
-            const closeShortcutEscapeModalConfig = CONST.KEYBOARD_SHORTCUTS.ESCAPE;
-            this.unsubscribeCloseEscapeModal = KeyboardShortcut.subscribe(closeShortcutEscapeModalConfig.shortcutKey, () => {
-                ModalActions.close();
-                KeyboardShortcutsActions.hideKeyboardShortcutModal();
-            }, closeShortcutEscapeModalConfig.descriptionKey, closeShortcutEscapeModalConfig.modifiers, true, true);
-
-            const closeShortcutEnterModalConfig = CONST.KEYBOARD_SHORTCUTS.ENTER;
-            this.unsubscribeCloseEnterModal = KeyboardShortcut.subscribe(closeShortcutEnterModalConfig.shortcutKey, () => {
-                ModalActions.close();
-                KeyboardShortcutsActions.hideKeyboardShortcutModal();
-            }, closeShortcutEnterModalConfig.descriptionKey, closeShortcutEnterModalConfig.modifiers, true);
-
-            // Intercept arrow up and down keys to prevent scrolling ArrowKeyFocusManager while this modal is open
-            const arrowUpConfig = CONST.KEYBOARD_SHORTCUTS.ARROW_UP;
-            this.unsubscribeArrowUpKey = KeyboardShortcut.subscribe(arrowUpConfig.shortcutKey, () => {
-            }, arrowUpConfig.descriptionKey, arrowUpConfig.modifiers, true);
-
-            const arrowDownConfig = CONST.KEYBOARD_SHORTCUTS.ARROW_DOWN;
-            this.unsubscribeArrowDownKey = KeyboardShortcut.subscribe(arrowDownConfig.shortcutKey, () => {
-            }, arrowDownConfig.descriptionKey, arrowDownConfig.modifiers, true);
+            this.subscribeOpenModalKeyboardShortcuts();
         } else if (prevProps.isShortcutsModalOpen && !this.props.isShortcutsModalOpen) {
             // Modal is closing, remove keyboard shortcuts
-            if (this.unsubscribeCloseEscapeModal) {
-                this.unsubscribeCloseEscapeModal();
-                this.unsubscribeCloseEscapeModal = undefined;
-            }
-            if (this.unsubscribeCloseEnterModal) {
-                this.unsubscribeCloseEnterModal();
-                this.unsubscribeCloseEnterModal = undefined;
-            }
-            if (this.unsubscribeArrowUpKey) {
-                this.unsubscribeArrowUpKey();
-                this.unsubscribeArrowUpKey = undefined;
-            }
-            if (this.unsubscribeArrowDownKey) {
-                this.unsubscribeArrowDownKey();
-                this.unsubscribeArrowDownKey = undefined;
-            }
+            this.unsubscribeOpenModalShortcuts();
         }
     }
 
@@ -92,18 +60,44 @@ class KeyboardShortcutsModal extends React.Component {
         if (this.unsubscribeShortcutModal) {
             this.unsubscribeShortcutModal();
         }
-        if (this.unsubscribeCloseEscapeModal) {
-            this.unsubscribeCloseEscapeModal();
-        }
-        if (this.unsubscribeCloseEnterModal) {
-            this.unsubscribeCloseEnterModal();
-        }
-        if (this.unsubscribeArrowUpKey) {
-            this.unsubscribeArrowUpKey();
-        }
-        if (this.unsubscribeArrowDownKey) {
-            this.unsubscribeArrowDownKey();
-        }
+        this.unsubscribeOpenModalShortcuts();
+    }
+
+    /*
+     * Subscribe shortcuts that only are used when the modal is open
+     */
+    subscribeOpenModalKeyboardShortcuts() {
+        // Allow closing the modal with the both Enter and Escape keys
+        // Both callbacks have the lowest priority (0) to ensure that they are called before any other callbacks
+        // and configured so that event propagation is stopped after the callback is called (only when the modal is open)
+        const closeShortcutEscapeModalConfig = CONST.KEYBOARD_SHORTCUTS.ESCAPE;
+        this.subscribedOpenModalShortcuts.push(KeyboardShortcut.subscribe(closeShortcutEscapeModalConfig.shortcutKey, () => {
+            ModalActions.close();
+            KeyboardShortcutsActions.hideKeyboardShortcutModal();
+        }, closeShortcutEscapeModalConfig.descriptionKey, closeShortcutEscapeModalConfig.modifiers, true, true));
+
+        const closeShortcutEnterModalConfig = CONST.KEYBOARD_SHORTCUTS.ENTER;
+        this.subscribedOpenModalShortcuts.push(KeyboardShortcut.subscribe(closeShortcutEnterModalConfig.shortcutKey, () => {
+            ModalActions.close();
+            KeyboardShortcutsActions.hideKeyboardShortcutModal();
+        }, closeShortcutEnterModalConfig.descriptionKey, closeShortcutEnterModalConfig.modifiers, true));
+
+        // Intercept arrow up and down keys to prevent scrolling ArrowKeyFocusManager while this modal is open
+        const arrowUpConfig = CONST.KEYBOARD_SHORTCUTS.ARROW_UP;
+        this.subscribedOpenModalShortcuts.push(KeyboardShortcut.subscribe(arrowUpConfig.shortcutKey, () => {
+        }, arrowUpConfig.descriptionKey, arrowUpConfig.modifiers, true));
+
+        const arrowDownConfig = CONST.KEYBOARD_SHORTCUTS.ARROW_DOWN;
+        this.subscribedOpenModalShortcuts.push(KeyboardShortcut.subscribe(arrowDownConfig.shortcutKey, () => {
+        }, arrowDownConfig.descriptionKey, arrowDownConfig.modifiers, true));
+    }
+
+    /*
+     * Unsubscribe all shortcuts that were subscribed when the modal opened
+     */
+    unsubscribeOpenModalShortcuts() {
+        this.subscribedOpenModalShortcuts.forEach(unsubscribe => unsubscribe());
+        this.subscribedOpenModalShortcuts = [];
     }
 
     /**

--- a/src/components/KeyboardShortcutsModal.js
+++ b/src/components/KeyboardShortcutsModal.js
@@ -97,7 +97,7 @@ class KeyboardShortcutsModal extends React.Component {
      * Unsubscribe all shortcuts that were subscribed when the modal opened
      */
     unsubscribeOpenModalShortcuts() {
-        this.subscribedOpenModalShortcuts.forEach(unsubscribe => unsubscribe());
+        _.each(this.subscribedOpenModalShortcuts, unsubscribe);
         this.subscribedOpenModalShortcuts = [];
     }
 

--- a/src/components/KeyboardShortcutsModal.js
+++ b/src/components/KeyboardShortcutsModal.js
@@ -97,7 +97,7 @@ class KeyboardShortcutsModal extends React.Component {
      * Unsubscribe all shortcuts that were subscribed when the modal opened
      */
     unsubscribeOpenModalShortcuts() {
-        _.each(this.subscribedOpenModalShortcuts, unsubscribe);
+        _.each(this.subscribedOpenModalShortcuts, unsubscribe => unsubscribe());
         this.subscribedOpenModalShortcuts = [];
     }
 

--- a/src/components/KeyboardShortcutsModal.js
+++ b/src/components/KeyboardShortcutsModal.js
@@ -39,30 +39,53 @@ class KeyboardShortcutsModal extends React.Component {
             ModalActions.close();
             KeyboardShortcutsActions.showKeyboardShortcutModal();
         }, openShortcutModalConfig.descriptionKey, openShortcutModalConfig.modifiers, true);
+    }
 
-        // Allow closing the modal with the both Enter and Escape keys
-        // Both callbacks have the lowest priority (0) to ensure that they are called before any other callbacks
-        // and configured so that event propagation is stopped after the callback is called (only when the modal is open)
-        const closeShortcutEscapeModalConfig = CONST.KEYBOARD_SHORTCUTS.ESCAPE;
-        this.unsubscribeCloseEscapeModal = KeyboardShortcut.subscribe(closeShortcutEscapeModalConfig.shortcutKey, () => {
-            ModalActions.close();
-            KeyboardShortcutsActions.hideKeyboardShortcutModal();
-        }, closeShortcutEscapeModalConfig.descriptionKey, closeShortcutEscapeModalConfig.modifiers, true, true);
+    componentDidUpdate(prevProps) {
+        if (!prevProps.isShortcutsModalOpen && this.props.isShortcutsModalOpen) {
+            // Modal is opening, add keyboard shortcuts
+            // Allow closing the modal with the both Enter and Escape keys
+            // Both callbacks have the lowest priority (0) to ensure that they are called before any other callbacks
+            // and configured so that event propagation is stopped after the callback is called (only when the modal is open)
+            const closeShortcutEscapeModalConfig = CONST.KEYBOARD_SHORTCUTS.ESCAPE;
+            this.unsubscribeCloseEscapeModal = KeyboardShortcut.subscribe(closeShortcutEscapeModalConfig.shortcutKey, () => {
+                ModalActions.close();
+                KeyboardShortcutsActions.hideKeyboardShortcutModal();
+            }, closeShortcutEscapeModalConfig.descriptionKey, closeShortcutEscapeModalConfig.modifiers, true, true);
 
-        const closeShortcutEnterModalConfig = CONST.KEYBOARD_SHORTCUTS.ENTER;
-        this.unsubscribeCloseEnterModal = KeyboardShortcut.subscribe(closeShortcutEnterModalConfig.shortcutKey, () => {
-            ModalActions.close();
-            KeyboardShortcutsActions.hideKeyboardShortcutModal();
-        }, closeShortcutEnterModalConfig.descriptionKey, closeShortcutEnterModalConfig.modifiers, true, () => !this.props.isShortcutsModalOpen);
+            const closeShortcutEnterModalConfig = CONST.KEYBOARD_SHORTCUTS.ENTER;
+            this.unsubscribeCloseEnterModal = KeyboardShortcut.subscribe(closeShortcutEnterModalConfig.shortcutKey, () => {
+                ModalActions.close();
+                KeyboardShortcutsActions.hideKeyboardShortcutModal();
+            }, closeShortcutEnterModalConfig.descriptionKey, closeShortcutEnterModalConfig.modifiers, true);
 
-        // Intercept arrow up and down keys to prevent scrolling ArrowKeyFocusManager while this modal is open
-        const arrowUpConfig = CONST.KEYBOARD_SHORTCUTS.ARROW_UP;
-        this.unsubscribeArrowUpKey = KeyboardShortcut.subscribe(arrowUpConfig.shortcutKey, () => {
-        }, arrowUpConfig.descriptionKey, arrowUpConfig.modifiers, true, () => !this.props.isShortcutsModalOpen);
+            // Intercept arrow up and down keys to prevent scrolling ArrowKeyFocusManager while this modal is open
+            const arrowUpConfig = CONST.KEYBOARD_SHORTCUTS.ARROW_UP;
+            this.unsubscribeArrowUpKey = KeyboardShortcut.subscribe(arrowUpConfig.shortcutKey, () => {
+            }, arrowUpConfig.descriptionKey, arrowUpConfig.modifiers, true);
 
-        const arrowDownConfig = CONST.KEYBOARD_SHORTCUTS.ARROW_DOWN;
-        this.unsubscribeArrowDownKey = KeyboardShortcut.subscribe(arrowDownConfig.shortcutKey, () => {
-        }, arrowDownConfig.descriptionKey, arrowDownConfig.modifiers, true, () => !this.props.isShortcutsModalOpen);
+            const arrowDownConfig = CONST.KEYBOARD_SHORTCUTS.ARROW_DOWN;
+            this.unsubscribeArrowDownKey = KeyboardShortcut.subscribe(arrowDownConfig.shortcutKey, () => {
+            }, arrowDownConfig.descriptionKey, arrowDownConfig.modifiers, true);
+        } else if (prevProps.isShortcutsModalOpen && !this.props.isShortcutsModalOpen) {
+            // Modal is closing, remove keyboard shortcuts
+            if (this.unsubscribeCloseEscapeModal) {
+                this.unsubscribeCloseEscapeModal();
+                this.unsubscribeCloseEscapeModal = undefined;
+            }
+            if (this.unsubscribeCloseEnterModal) {
+                this.unsubscribeCloseEnterModal();
+                this.unsubscribeCloseEnterModal = undefined;
+            }
+            if (this.unsubscribeArrowUpKey) {
+                this.unsubscribeArrowUpKey();
+                this.unsubscribeArrowUpKey = undefined;
+            }
+            if (this.unsubscribeArrowDownKey) {
+                this.unsubscribeArrowDownKey();
+                this.unsubscribeArrowDownKey = undefined;
+            }
+        }
     }
 
     componentWillUnmount() {


### PR DESCRIPTION
### Details

The shortcut modal subscribe some shortcuts to block them from working while its open.
The previous implementation ended up blocking some key functions in the composer because we end up calling this `event.preventDefault()` here: https://github.com/Expensify/App/blob/2437e3787254d9b1d0e1208fe04299d6c3c2f67b/src/libs/KeyboardShortcut/bindHandlerToKeydownEvent/index.js#L46-L48

Some more details: https://github.com/Expensify/App/issues/18420#issuecomment-1535175230

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/18420
PROPOSAL: Option 1 from https://github.com/Expensify/App/issues/18420#issuecomment-1535187033

### Tests

1. Go to a chat
2. Type something
3. Press "SHIFT + ENTER"
4. Verify that a new line was added
5. Verify that you can move the cursor up and down by pressing arrow and down keys

Follow the testing steps of this other PR: https://github.com/Expensify/App/pull/18273

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps

1. Go to a chat
2. Type something
3. Press "SHIFT + ENTER"
4. Verify that a new line was added
5. Verify that you can move the cursor up and down by pressing arrow and down keys

Follow the testing steps of this other PR: https://github.com/Expensify/App/pull/18273
- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>


https://user-images.githubusercontent.com/87341702/236298833-e879041b-452b-420c-aaa2-c26d7b064000.mov



</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>


https://user-images.githubusercontent.com/87341702/236302918-778022f6-c852-4e68-8d3f-d25d214004db.mov



</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>


https://user-images.githubusercontent.com/87341702/236304668-469d4e7e-3d5e-4913-9abf-83ea37fd1a4c.mov



</details>
