### PR TITLE
Corrected - Chat mp4 files with long name extend to the far edges of the screen

### DIFF
--- a/src/components/AttachmentModal.js
+++ b/src/components/AttachmentModal.js
@@ -282,6 +282,7 @@ class AttachmentModal extends PureComponent {
                             Boolean(this.state.source) &&
                             this.state.shouldLoadAttachment && (
                                 <AttachmentView
+                                    containerStyles={[styles.mh5]}
                                     source={source}
                                     isAuthTokenRequired={this.props.isAuthTokenRequired}
                                     file={this.state.file}

--- a/src/components/AttachmentView.js
+++ b/src/components/AttachmentView.js
@@ -43,6 +43,10 @@ const propTypes = {
     /** Notify parent that the UI should be modified to accommodate keyboard */
     onToggleKeyboard: PropTypes.func,
 
+    /** Extra styles to pass to View wrapper */
+    // eslint-disable-next-line react/forbid-prop-types
+    containerStyles: PropTypes.arrayOf(PropTypes.object),
+
     ...withLocalizePropTypes,
 };
 
@@ -56,6 +60,7 @@ const defaultProps = {
     onPress: undefined,
     onScaleChanged: () => {},
     onToggleKeyboard: () => {},
+    containerStyles: [],
 };
 
 const AttachmentView = (props) => {
@@ -124,7 +129,7 @@ const AttachmentView = (props) => {
     }
 
     return (
-        <View style={styles.defaultAttachmentView}>
+        <View style={[styles.defaultAttachmentView, ...props.containerStyles]}>
             <View style={styles.mr2}>
                 <Icon src={Expensicons.Paperclip} />
             </View>


### PR DESCRIPTION
@greg-schroeder @rushatgabhane PR is ready for review.

### Details
Within chat conversation if we attach mp4 having long file name, we can see that long filename will touch the left/right edges of the Attachment preview screen. So in this pr we corrected this problem i.e. we added some padding, so now long filename will not touch edge of the screen.

### Fixed Issues
$ https://github.com/Expensify/App/issues/16970
PROPOSAL: https://github.com/Expensify/App/issues/16970#issuecomment-1513860749

### Tests
1. Go to any Chat
2. Tap + button from composer
3. Tap Add Attachment
4. Select .mp4 file having long file name (here is [sample mp4](https://github.com/Expensify/App/assets/7823358/efdd452a-a28f-4d31-8111-29743cdcec82))
5. It will show **Send attachment** modal with long mp4 filename.
6. **Verify that attachment preview does not touch/extend the left/right edges of the screen**.

- [x] Verify that no errors appear in the JS console

### Offline tests
1. Go to any Chat
2. Tap + button from composer
3. Tap Add Attachment
4. Select .mp4 file having long file name (here is [sample mp4](https://github.com/Expensify/App/assets/7823358/efdd452a-a28f-4d31-8111-29743cdcec82))
5. It will show **Send attachment** modal with long mp4 filename.
6. **Verify that attachment preview does not touch/extend the left/right edges of the screen**.

### QA Steps
1. Go to any Chat
2. Tap + button from composer
3. Tap Add Attachment
4. Select .mp4 file having long file name (here is [sample mp4](https://github.com/Expensify/App/assets/7823358/efdd452a-a28f-4d31-8111-29743cdcec82))
5. It will show **Send attachment** modal with long mp4 filename.
6. **Verify that attachment preview does not touch/extend the left/right edges of the screen**.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

#### Chrome

https://github.com/Expensify/App/assets/7823358/08b1dd98-22a5-459f-a464-ff5b7268c1d5

#### Safari

https://github.com/Expensify/App/assets/7823358/70a5da64-c599-4151-82ee-8187f8c8e5a1

</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://github.com/Expensify/App/assets/7823358/7e47a946-d222-49f6-9110-b9d2bbac6bfc

</details>

<details>
<summary>Mobile Web - Safari</summary>

https://github.com/Expensify/App/assets/7823358/c296b7fd-0573-4f05-a165-f7b9d4117ccc

</details>

<details>
<summary>Desktop</summary>

https://github.com/Expensify/App/assets/7823358/69b8c1cf-0065-4f48-8302-35871a9f4ef0

</details>

<details>
<summary>iOS</summary>

https://github.com/Expensify/App/assets/7823358/4eca4888-4bd0-4579-aa1a-ef4fca22c81f

</details>

<details>
<summary>Android</summary>

https://github.com/Expensify/App/assets/7823358/bcd4e3fb-dd4a-4970-8fa6-1e8853c2645b

</details>
