### PR TITLE
Fix - Pressing enter twice on selecting currency from search closes the send money/request money option #18265

### DIFF
--- a/src/components/OptionsSelector/BaseOptionsSelector.js
+++ b/src/components/OptionsSelector/BaseOptionsSelector.js
@@ -47,7 +47,7 @@ class BaseOptionsSelector extends Component {
         this.state = {
             allOptions,
             focusedIndex,
-            isEnterDisabled: false,
+            shouldDisableRowSelection: false,
         };
     }
 
@@ -60,13 +60,13 @@ class BaseOptionsSelector extends Component {
                 if (!focusedOption) {
                     return;
                 }
-                if (!this.state.isEnterDisabled) {
-                    this.setState({isEnterDisabled: true});
+                if (!this.state.shouldDisableRowSelection) {
+                    this.setState({shouldDisableRowSelection: true});
                     let result = this.selectRow(focusedOption);
                     if (!(result instanceof Promise)) {
                         result = Promise.resolve();
                     }
-                    setTimeout(() => result.finally(() => this.setState({isEnterDisabled: false})), 300);
+                    setTimeout(() => result.finally(() => this.setState({shouldDisableRowSelection: false})), 300);
                 }
             },
             enterConfig.descriptionKey,

--- a/src/components/OptionsSelector/BaseOptionsSelector.js
+++ b/src/components/OptionsSelector/BaseOptionsSelector.js
@@ -47,12 +47,12 @@ class BaseOptionsSelector extends Component {
         this.state = {
             allOptions,
             focusedIndex,
+            isEnterDisabled: false,
         };
     }
 
     componentDidMount() {
         const enterConfig = CONST.KEYBOARD_SHORTCUTS.ENTER;
-        let isEnterDisabled = false;
         this.unsubscribeEnter = KeyboardShortcut.subscribe(
             enterConfig.shortcutKey,
             () => {
@@ -60,14 +60,13 @@ class BaseOptionsSelector extends Component {
                 if (!focusedOption) {
                     return;
                 }
-
-                // We are handeling multiple Enter events to address the issue in https://github.com/Expensify/App/issues/18265
-                if (!isEnterDisabled) {
-                    isEnterDisabled = true;
-                    this.selectRow(focusedOption);
-                    setTimeout(() => {
-                        isEnterDisabled = false;
-                    }, 300);
+                if (!this.state.isEnterDisabled) {
+                    this.setState({isEnterDisabled: true});
+                    let result = this.selectRow(focusedOption);
+                    if (!(result instanceof Promise)) {
+                        result = Promise.resolve();
+                    }
+                    setTimeout(() => result.finally(() => this.setState({isEnterDisabled: false})), 300);
                 }
             },
             enterConfig.descriptionKey,

--- a/src/components/OptionsSelector/BaseOptionsSelector.js
+++ b/src/components/OptionsSelector/BaseOptionsSelector.js
@@ -60,13 +60,15 @@ class BaseOptionsSelector extends Component {
                 if (!focusedOption) {
                     return;
                 }
-                if (!this.state.shouldDisableRowSelection) {
+                if (this.props.canSelectMultipleOptions) {
+                    this.selectRow(focusedOption);
+                } else if (!this.state.shouldDisableRowSelection) {
                     this.setState({shouldDisableRowSelection: true});
                     let result = this.selectRow(focusedOption);
                     if (!(result instanceof Promise)) {
                         result = Promise.resolve();
                     }
-                    setTimeout(() => result.finally(() => this.setState({shouldDisableRowSelection: false})), 300);
+                    setTimeout(() => result.finally(() => this.setState({shouldDisableRowSelection: false})), 500);
                 }
             },
             enterConfig.descriptionKey,

--- a/src/components/OptionsSelector/BaseOptionsSelector.js
+++ b/src/components/OptionsSelector/BaseOptionsSelector.js
@@ -52,6 +52,7 @@ class BaseOptionsSelector extends Component {
 
     componentDidMount() {
         const enterConfig = CONST.KEYBOARD_SHORTCUTS.ENTER;
+        let isEnterDisabled = false;
         this.unsubscribeEnter = KeyboardShortcut.subscribe(
             enterConfig.shortcutKey,
             () => {
@@ -60,7 +61,14 @@ class BaseOptionsSelector extends Component {
                     return;
                 }
 
-                this.selectRow(focusedOption);
+                // We are handeling multiple Enter events to address the issue in https://github.com/Expensify/App/issues/18265
+                if (!isEnterDisabled) {
+                    isEnterDisabled = true;
+                    this.selectRow(focusedOption);
+                    setTimeout(() => {
+                        isEnterDisabled = false;
+                    }, 300);
+                }
             },
             enterConfig.descriptionKey,
             enterConfig.modifiers,


### PR DESCRIPTION
### Details
Fixes the issue with pressing Enter multiple times on selecting currency closing the entire modal by adding a logic to detect multiple fast Enter presses and handling it properly to prevent the issue behaviour.

### Fixed Issues
$ https://github.com/Expensify/App/issues/18265
PROPOSAL: https://github.com/Expensify/App/issues/18265#issuecomment-1532098032


### Tests

1. Click on the + icon to open the popoverMenu.
2. Click on Send Money or Request Money.
3. Click on the currency to open the currency selection menu.
4. Type in a currency and double press enter fast.
5. Notice that the modal doesn't close completely and you're still in the send/request money page.

- [x] Verify that no errors appear in the JS console

### Offline tests
Same steps as the Tests

### QA Steps
Same steps as the Tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://github.com/Expensify/App/assets/74202751/64ecb85e-7f65-4bdb-87c3-b07386df2fbb

</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://github.com/Expensify/App/assets/74202751/aaaac5be-51b7-424c-8e86-2d63637305e1

</details>

<details>
<summary>Mobile Web - Safari</summary>

https://github.com/Expensify/App/assets/74202751/a9ad1d42-5432-4dae-9c01-d2fcfb2e0fb1

</details>

<details>
<summary>Desktop</summary>

https://github.com/Expensify/App/assets/74202751/49f39163-a630-4fac-bade-1776080c67f6

</details>

<details>
<summary>iOS</summary>

https://github.com/Expensify/App/assets/74202751/cd0a3f4d-a204-40b7-a610-e3d3b69e6fa2

</details>

<details>
<summary>Android</summary>

https://github.com/Expensify/App/assets/74202751/8c470cfa-da0b-45a8-b06d-3888361a2bcd

</details>