### PR TITLE
Use IOU/Expense reportID for IOU actions

### DIFF
--- a/src/components/ReportActionItem/MoneyRequestAction.js
+++ b/src/components/ReportActionItem/MoneyRequestAction.js
@@ -2,6 +2,7 @@ import _ from 'underscore';
 import React from 'react';
 import PropTypes from 'prop-types';
 import {withOnyx} from 'react-native-onyx';
+import lodashGet from 'lodash/get';
 import ONYXKEYS from '../../ONYXKEYS';
 import CONST from '../../CONST';
 import {withNetwork} from '../OnyxProvider';
@@ -63,15 +64,13 @@ const defaultProps = {
     chatReport: {
         participants: [],
     },
-    iouReport: {
-        participants: [],
-    },
+    iouReport: {},
     reportActions: {},
     isHovered: false,
 };
 
 const MoneyRequestAction = (props) => {
-    const hasMultipleParticipants = props.iouReport.participants.length > 1;
+    const hasMultipleParticipants = lodashGet(props.chatReport, 'participants.length', 0) > 1;
     const onIOUPreviewPressed = () => {
         if (hasMultipleParticipants) {
             Navigation.navigate(ROUTES.getReportParticipantsRoute(props.chatReportID));

--- a/src/components/ReportActionItem/MoneyRequestAction.js
+++ b/src/components/ReportActionItem/MoneyRequestAction.js
@@ -63,13 +63,15 @@ const defaultProps = {
     chatReport: {
         participants: [],
     },
-    iouReport: {},
+    iouReport: {
+        participants: [],
+    },
     reportActions: {},
     isHovered: false,
 };
 
 const MoneyRequestAction = (props) => {
-    const hasMultipleParticipants = props.chatReport.participants.length > 1;
+    const hasMultipleParticipants = props.iouReport.participants.length > 1;
     const onIOUPreviewPressed = () => {
         if (hasMultipleParticipants) {
             Navigation.navigate(ROUTES.getReportParticipantsRoute(props.chatReportID));

--- a/src/pages/iou/IOUDetailsModal.js
+++ b/src/pages/iou/IOUDetailsModal.js
@@ -93,9 +93,7 @@ const propTypes = {
 const defaultProps = {
     iou: {},
     reportActions: {},
-    iouReport: {
-        participants: [],
-    },
+    iouReport: {},
     session: {
         email: null,
     },
@@ -188,7 +186,7 @@ class IOUDetailsModal extends Component {
                                     <IOUPreview
                                         chatReportID={this.props.route.params.chatReportID}
                                         iouReportID={this.props.route.params.iouReportID}
-                                        isBillSplit={this.props.iouReport.participants.length > 1}
+                                        isBillSplit={lodashGet(this.props.chatReport, 'participants.length', 0) > 1}
                                         isIOUAction={false}
                                         pendingAction={pendingAction}
                                     />

--- a/src/pages/iou/IOUDetailsModal.js
+++ b/src/pages/iou/IOUDetailsModal.js
@@ -93,7 +93,9 @@ const propTypes = {
 const defaultProps = {
     iou: {},
     reportActions: {},
-    iouReport: undefined,
+    iouReport: {
+        participants: [],
+    },
     session: {
         email: null,
     },
@@ -186,7 +188,7 @@ class IOUDetailsModal extends Component {
                                     <IOUPreview
                                         chatReportID={this.props.route.params.chatReportID}
                                         iouReportID={this.props.route.params.iouReportID}
-                                        isBillSplit={this.props.chatReport.participants.length > 1}
+                                        isBillSplit={this.props.iouReport.participants.length > 1}
                                         isIOUAction={false}
                                         pendingAction={pendingAction}
                                     />

--- a/tests/actions/IOUTest.js
+++ b/tests/actions/IOUTest.js
@@ -32,7 +32,6 @@ describe('actions/IOU', () => {
         it('creates new chat if needed', () => {
             const amount = 10000;
             const comment = 'Giv money plz';
-            let chatReportID;
             let iouReportID;
             let createdAction;
             let iouAction;
@@ -55,7 +54,6 @@ describe('actions/IOU', () => {
                                     expect(_.size(chatReports)).toBe(1);
                                     expect(_.size(iouReports)).toBe(1);
                                     const chatReport = chatReports[0];
-                                    chatReportID = chatReport.reportID;
                                     const iouReport = iouReports[0];
                                     iouReportID = iouReport.reportID;
 
@@ -73,15 +71,15 @@ describe('actions/IOU', () => {
                     () =>
                         new Promise((resolve) => {
                             const connectionID = Onyx.connect({
-                                key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${chatReportID}`,
+                                key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${iouReportID}`,
                                 waitForCollectionCallback: true,
-                                callback: (reportActionsForChatReport) => {
+                                callback: (reportActionsForIOUReport) => {
                                     Onyx.disconnect(connectionID);
 
-                                    // The chat report should have a CREATED action and IOU action
-                                    expect(_.size(reportActionsForChatReport)).toBe(2);
-                                    const createdActions = _.filter(reportActionsForChatReport, (reportAction) => reportAction.actionName === CONST.REPORT.ACTIONS.TYPE.CREATED);
-                                    const iouActions = _.filter(reportActionsForChatReport, (reportAction) => reportAction.actionName === CONST.REPORT.ACTIONS.TYPE.IOU);
+                                    // The IOU report should have a CREATED action and IOU action
+                                    expect(_.size(reportActionsForIOUReport)).toBe(2);
+                                    const createdActions = _.filter(reportActionsForIOUReport, (reportAction) => reportAction.actionName === CONST.REPORT.ACTIONS.TYPE.CREATED);
+                                    const iouActions = _.filter(reportActionsForIOUReport, (reportAction) => reportAction.actionName === CONST.REPORT.ACTIONS.TYPE.IOU);
                                     expect(_.size(createdActions)).toBe(1);
                                     expect(_.size(iouActions)).toBe(1);
                                     createdAction = createdActions[0];
@@ -152,12 +150,12 @@ describe('actions/IOU', () => {
                     () =>
                         new Promise((resolve) => {
                             const connectionID = Onyx.connect({
-                                key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${chatReportID}`,
+                                key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${iouReportID}`,
                                 waitForCollectionCallback: true,
-                                callback: (reportActionsForChatReport) => {
+                                callback: (reportActionsForIOUReport) => {
                                     Onyx.disconnect(connectionID);
-                                    expect(_.size(reportActionsForChatReport)).toBe(2);
-                                    _.each(reportActionsForChatReport, (reportAction) => expect(reportAction.pendingAction).toBeFalsy());
+                                    expect(_.size(reportActionsForIOUReport)).toBe(2);
+                                    _.each(reportActionsForIOUReport, (reportAction) => expect(reportAction.pendingAction).toBeFalsy());
                                     resolve();
                                 },
                             });
@@ -236,12 +234,12 @@ describe('actions/IOU', () => {
                     () =>
                         new Promise((resolve) => {
                             const connectionID = Onyx.connect({
-                                key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${chatReport.reportID}`,
+                                key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${iouReportID}`,
                                 waitForCollectionCallback: true,
                                 callback: (allReportActions) => {
                                     Onyx.disconnect(connectionID);
 
-                                    // The chat report should have a CREATED and an IOU action
+                                    // The IOU report should have an IOU action
                                     expect(_.size(allReportActions)).toBe(2);
                                     iouAction = _.find(allReportActions, (reportAction) => reportAction.actionName === CONST.REPORT.ACTIONS.TYPE.IOU);
 
@@ -309,12 +307,12 @@ describe('actions/IOU', () => {
                     () =>
                         new Promise((resolve) => {
                             const connectionID = Onyx.connect({
-                                key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${chatReport.reportID}`,
+                                key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${iouReportID}`,
                                 waitForCollectionCallback: true,
-                                callback: (reportActionsForChatReport) => {
+                                callback: (reportActionsForIOUReport) => {
                                     Onyx.disconnect(connectionID);
-                                    expect(_.size(reportActionsForChatReport)).toBe(2);
-                                    _.each(reportActionsForChatReport, (reportAction) => expect(reportAction.pendingAction).toBeFalsy());
+                                    expect(_.size(reportActionsForIOUReport)).toBe(1);
+                                    _.each(reportActionsForIOUReport, (reportAction) => expect(reportAction.pendingAction).toBeFalsy());
                                     resolve();
                                 },
                             });
@@ -427,14 +425,14 @@ describe('actions/IOU', () => {
                     () =>
                         new Promise((resolve) => {
                             const connectionID = Onyx.connect({
-                                key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${chatReportID}`,
+                                key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${iouReportID}`,
                                 waitForCollectionCallback: true,
-                                callback: (reportActionsForChatReport) => {
+                                callback: (reportActionsForIOUReport) => {
                                     Onyx.disconnect(connectionID);
 
-                                    expect(_.size(reportActionsForChatReport)).toBe(3);
+                                    expect(_.size(reportActionsForIOUReport)).toBe(3);
                                     newIOUAction = _.find(
-                                        reportActionsForChatReport,
+                                        reportActionsForIOUReport,
                                         (reportAction) => reportAction.reportActionID !== createdAction.reportActionID && reportAction.reportActionID !== iouAction.reportActionID,
                                     );
 
@@ -491,12 +489,12 @@ describe('actions/IOU', () => {
                     () =>
                         new Promise((resolve) => {
                             const connectionID = Onyx.connect({
-                                key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${chatReport.reportID}`,
+                                key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${iouReportID}`,
                                 waitForCollectionCallback: true,
-                                callback: (reportActionsForChatReport) => {
+                                callback: (reportActionsForIOUReport) => {
                                     Onyx.disconnect(connectionID);
-                                    expect(_.size(reportActionsForChatReport)).toBe(3);
-                                    _.each(reportActionsForChatReport, (reportAction) => expect(reportAction.pendingAction).toBeFalsy());
+                                    expect(_.size(reportActionsForIOUReport)).toBe(3);
+                                    _.each(reportActionsForIOUReport, (reportAction) => expect(reportAction.pendingAction).toBeFalsy());
                                     resolve();
                                 },
                             });
@@ -563,15 +561,15 @@ describe('actions/IOU', () => {
                         () =>
                             new Promise((resolve) => {
                                 const connectionID = Onyx.connect({
-                                    key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${chatReportID}`,
+                                    key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${iouReportID}`,
                                     waitForCollectionCallback: true,
-                                    callback: (reportActionsForChatReport) => {
+                                    callback: (reportActionsForIOUReport) => {
                                         Onyx.disconnect(connectionID);
 
                                         // The chat report should have a CREATED action and IOU action
-                                        expect(_.size(reportActionsForChatReport)).toBe(2);
-                                        const createdActions = _.filter(reportActionsForChatReport, (reportAction) => reportAction.actionName === CONST.REPORT.ACTIONS.TYPE.CREATED);
-                                        const iouActions = _.filter(reportActionsForChatReport, (reportAction) => reportAction.actionName === CONST.REPORT.ACTIONS.TYPE.IOU);
+                                        expect(_.size(reportActionsForIOUReport)).toBe(2);
+                                        const createdActions = _.filter(reportActionsForIOUReport, (reportAction) => reportAction.actionName === CONST.REPORT.ACTIONS.TYPE.CREATED);
+                                        const iouActions = _.filter(reportActionsForIOUReport, (reportAction) => reportAction.actionName === CONST.REPORT.ACTIONS.TYPE.IOU);
                                         expect(_.size(createdActions)).toBe(1);
                                         expect(_.size(iouActions)).toBe(1);
                                         createdAction = createdActions[0];
@@ -637,12 +635,12 @@ describe('actions/IOU', () => {
                         () =>
                             new Promise((resolve) => {
                                 const connectionID = Onyx.connect({
-                                    key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${chatReportID}`,
+                                    key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${iouReportID}`,
                                     waitForCollectionCallback: true,
-                                    callback: (reportActionsForChatReport) => {
+                                    callback: (reportActionsForIOUReport) => {
                                         Onyx.disconnect(connectionID);
-                                        expect(_.size(reportActionsForChatReport)).toBe(2);
-                                        iouAction = _.find(reportActionsForChatReport, (reportAction) => reportAction.actionName === CONST.REPORT.ACTIONS.TYPE.IOU);
+                                        expect(_.size(reportActionsForIOUReport)).toBe(2);
+                                        iouAction = _.find(reportActionsForIOUReport, (reportAction) => reportAction.actionName === CONST.REPORT.ACTIONS.TYPE.IOU);
                                         expect(iouAction.pendingAction).toBe(CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD);
                                         resolve();
                                     },
@@ -1193,9 +1191,9 @@ describe('actions/IOU', () => {
                                 callback: (allReportActions) => {
                                     Onyx.disconnect(connectionID);
 
-                                    const reportActionsForChatReport = allReportActions[`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${chatReport.reportID}`];
+                                    const reportActionsForIOUReport = allReportActions[`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${iouReport.reportID}`];
 
-                                    createIOUAction = _.find(reportActionsForChatReport, (ra) => ra.actionName === CONST.REPORT.ACTIONS.TYPE.IOU);
+                                    createIOUAction = _.find(reportActionsForIOUReport, (ra) => ra.actionName === CONST.REPORT.ACTIONS.TYPE.IOU);
                                     expect(createIOUAction).toBeTruthy();
                                     expect(createIOUAction.originalMessage.IOUReportID).toBe(iouReport.reportID);
 
@@ -1263,11 +1261,11 @@ describe('actions/IOU', () => {
                                 callback: (allReportActions) => {
                                     Onyx.disconnect(connectionID);
 
-                                    const reportActionsForChatReport = allReportActions[`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${chatReport.reportID}`];
-                                    expect(_.size(reportActionsForChatReport)).toBe(3);
+                                    const reportActionsForIOUReport = allReportActions[`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${iouReport.reportID}`];
+                                    expect(_.size(reportActionsForIOUReport)).toBe(3);
 
                                     payIOUAction = _.find(
-                                        reportActionsForChatReport,
+                                        reportActionsForIOUReport,
                                         (ra) => ra.actionName === CONST.REPORT.ACTIONS.TYPE.IOU && ra.originalMessage.type === CONST.IOU.REPORT_ACTION_TYPE.PAY,
                                     );
                                     expect(payIOUAction).toBeTruthy();
@@ -1314,11 +1312,11 @@ describe('actions/IOU', () => {
                                 callback: (allReportActions) => {
                                     Onyx.disconnect(connectionID);
 
-                                    const reportActionsForChatReport = allReportActions[`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${chatReport.reportID}`];
-                                    expect(_.size(reportActionsForChatReport)).toBe(3);
+                                    const reportActionsForIOUReport = allReportActions[`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${iouReport.reportID}`];
+                                    expect(_.size(reportActionsForIOUReport)).toBe(3);
 
                                     payIOUAction = _.find(
-                                        reportActionsForChatReport,
+                                        reportActionsForIOUReport,
                                         (ra) => ra.actionName === CONST.REPORT.ACTIONS.TYPE.IOU && ra.originalMessage.type === CONST.IOU.REPORT_ACTION_TYPE.PAY,
                                     );
                                     expect(payIOUAction).toBeTruthy();

--- a/tests/actions/IOUTest.js
+++ b/tests/actions/IOUTest.js
@@ -311,7 +311,7 @@ describe('actions/IOU', () => {
                                 waitForCollectionCallback: true,
                                 callback: (reportActionsForIOUReport) => {
                                     Onyx.disconnect(connectionID);
-                                    expect(_.size(reportActionsForIOUReport)).toBe(1);
+                                    expect(_.size(reportActionsForIOUReport)).toBe(2);
                                     _.each(reportActionsForIOUReport, (reportAction) => expect(reportAction.pendingAction).toBeFalsy());
                                     resolve();
                                 },


### PR DESCRIPTION
Add the IOU reportAction to the IOU/Expense report instead of the parent chatReport.

We are gonna start creating IOU reportActions directly in the IOU/Expense report and as part of the switch, we are temporarily skipping test so that Auth integration tests pass. The plan to make the switch is:

1. Merge https://github.com/Expensify/Web-Expensify/pull/37375 and CP to prod
2. Web-E Integrations tests in this https://github.com/Expensify/Auth/pull/7863 should pass
3. Merge the https://github.com/Expensify/Auth/pull/7863
4. Deploy the Auth PR
5. Merge https://github.com/Expensify/Web-Expensify/pull/37337 that re-enables tests using the correct reportID
6. CP the https://github.com/Expensify/Web-Expensify/pull/37337 PR to prod
7. Merge https://github.com/Expensify/App/pull/18856, CPing it to staging to minimize the amount of time IOUs are broken
8. Run the bulkCQ from https://github.com/Expensify/Expensify/issues/282420 to change the reportID of all previous IOU actions

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/281893

### Web Tests
Will be tested with the [App PR](https://github.com/Expensify/App/pull/18604)

### Mobile Tests
N/A

### Automated Auth Tests
Updated tests

### Query Timings/Plans
N/A
