### PR TITLE
fix stale focusedIndex when maxIndex changed in ArrowKeyFocusManager

### DIFF
--- a/src/components/ArrowKeyFocusManager.js
+++ b/src/components/ArrowKeyFocusManager.js
@@ -33,55 +33,16 @@ class ArrowKeyFocusManager extends Component {
         const arrowUpConfig = CONST.KEYBOARD_SHORTCUTS.ARROW_UP;
         const arrowDownConfig = CONST.KEYBOARD_SHORTCUTS.ARROW_DOWN;
 
-        this.unsubscribeArrowUpKey = KeyboardShortcut.subscribe(
-            arrowUpConfig.shortcutKey,
-            () => {
-                if (this.props.maxIndex < 0) {
-                    return;
-                }
+        this.onArrowUpKey = this.onArrowUpKey.bind(this);
+        this.onArrowDownKey = this.onArrowDownKey.bind(this);
 
-                const currentFocusedIndex = this.props.focusedIndex > 0 ? this.props.focusedIndex - 1 : this.props.maxIndex;
-                let newFocusedIndex = currentFocusedIndex;
-
-                while (this.props.disabledIndexes.includes(newFocusedIndex)) {
-                    newFocusedIndex = newFocusedIndex > 0 ? newFocusedIndex - 1 : this.props.maxIndex;
-                    if (newFocusedIndex === currentFocusedIndex) {
-                        // all indexes are disabled
-                        return; // no-op
-                    }
-                }
-
-                this.props.onFocusedIndexChanged(newFocusedIndex);
-            },
-            arrowUpConfig.descriptionKey,
-            arrowUpConfig.modifiers,
-            true,
-            false,
-            0,
-            true,
-            [this.props.shouldExcludeTextAreaNodes && 'TEXTAREA'],
-        );
+        this.unsubscribeArrowUpKey = KeyboardShortcut.subscribe(arrowUpConfig.shortcutKey, this.onArrowUpKey, arrowUpConfig.descriptionKey, arrowUpConfig.modifiers, true, false, 0, true, [
+            this.props.shouldExcludeTextAreaNodes && 'TEXTAREA',
+        ]);
 
         this.unsubscribeArrowDownKey = KeyboardShortcut.subscribe(
             arrowDownConfig.shortcutKey,
-            () => {
-                if (this.props.maxIndex < 0) {
-                    return;
-                }
-
-                const currentFocusedIndex = this.props.focusedIndex < this.props.maxIndex ? this.props.focusedIndex + 1 : 0;
-                let newFocusedIndex = currentFocusedIndex;
-
-                while (this.props.disabledIndexes.includes(newFocusedIndex)) {
-                    newFocusedIndex = newFocusedIndex < this.props.maxIndex ? newFocusedIndex + 1 : 0;
-                    if (newFocusedIndex === currentFocusedIndex) {
-                        // all indexes are disabled
-                        return; // no-op
-                    }
-                }
-
-                this.props.onFocusedIndexChanged(newFocusedIndex);
-            },
+            this.onArrowDownKey,
             arrowDownConfig.descriptionKey,
             arrowDownConfig.modifiers,
             true,
@@ -92,6 +53,15 @@ class ArrowKeyFocusManager extends Component {
         );
     }
 
+    componentDidUpdate(prevProps) {
+        if (prevProps.maxIndex === this.props.maxIndex) {
+            return;
+        }
+        if (this.props.focusedIndex > this.props.maxIndex) {
+            this.onArrowDownKey();
+        }
+    }
+
     componentWillUnmount() {
         if (this.unsubscribeArrowUpKey) {
             this.unsubscribeArrowUpKey();
@@ -100,6 +70,44 @@ class ArrowKeyFocusManager extends Component {
         if (this.unsubscribeArrowDownKey) {
             this.unsubscribeArrowDownKey();
         }
+    }
+
+    onArrowUpKey() {
+        if (this.props.maxIndex < 0) {
+            return;
+        }
+
+        const currentFocusedIndex = this.props.focusedIndex > 0 ? this.props.focusedIndex - 1 : this.props.maxIndex;
+        let newFocusedIndex = currentFocusedIndex;
+
+        while (this.props.disabledIndexes.includes(newFocusedIndex)) {
+            newFocusedIndex = newFocusedIndex > 0 ? newFocusedIndex - 1 : this.props.maxIndex;
+            if (newFocusedIndex === currentFocusedIndex) {
+                // all indexes are disabled
+                return; // no-op
+            }
+        }
+
+        this.props.onFocusedIndexChanged(newFocusedIndex);
+    }
+
+    onArrowDownKey() {
+        if (this.props.maxIndex < 0) {
+            return;
+        }
+
+        const currentFocusedIndex = this.props.focusedIndex < this.props.maxIndex ? this.props.focusedIndex + 1 : 0;
+        let newFocusedIndex = currentFocusedIndex;
+
+        while (this.props.disabledIndexes.includes(newFocusedIndex)) {
+            newFocusedIndex = newFocusedIndex < this.props.maxIndex ? newFocusedIndex + 1 : 0;
+            if (newFocusedIndex === currentFocusedIndex) {
+                // all indexes are disabled
+                return; // no-op
+            }
+        }
+
+        this.props.onFocusedIndexChanged(newFocusedIndex);
     }
 
     render() {

--- a/src/pages/home/report/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose.js
@@ -152,8 +152,8 @@ const defaultProps = {
 const getMaxArrowIndex = (numRows, isAutoSuggestionPickerLarge) => {
     // EmojiRowCount is number of emoji suggestions. For small screen we can fit 3 items and for large we show up to 5 items
     const emojiRowCount = isAutoSuggestionPickerLarge
-        ? Math.max(numRows, CONST.AUTO_COMPLETE_SUGGESTER.MAX_AMOUNT_OF_ITEMS)
-        : Math.max(numRows, CONST.AUTO_COMPLETE_SUGGESTER.MIN_AMOUNT_OF_ITEMS);
+        ? Math.min(numRows, CONST.AUTO_COMPLETE_SUGGESTER.MAX_AMOUNT_OF_ITEMS)
+        : Math.min(numRows, CONST.AUTO_COMPLETE_SUGGESTER.MIN_AMOUNT_OF_ITEMS);
 
     // -1 because we start at 0
     return emojiRowCount - 1;


### PR DESCRIPTION
### Details
fixed 2 issues:
- wrong `maxIndex` when suggestions list changes
- remove stale `focusedIndex` when maxIndex decreased by resetting it to smallest not-disabled index (technically simulate arrow down key press to start from 0 index thanks to [this condition](https://github.com/Expensify/App/blob/5743b159f7ae44fb792f87d860b161c6b5c7bbf1/src/components/ArrowKeyFocusManager.js#L72))

### Fixed Issues
$ https://github.com/Expensify/App/issues/18744
PROPOSAL: N/A


### Tests
1. Login any account and go to any chat room
2. Type in composer - `@` to show suggestions
3. Press Arrow Down key 2 times to focus 3rd item
4. Type more until number of suggestions becomes less than 3
5. Verify that focus changes to first item
6. Repeat pressing arrow up/down keys and verify that focus is not lost
7. Press Enter key and verify that selected item is picked up

- [ ] Verify that no errors appear in the JS console

### Offline tests
Same as Tests

### QA Steps
Same as Tests

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>


https://github.com/Expensify/App/assets/97473779/1e67eafd-dd3d-4469-8246-21cfcef267f7



</details>

<details>
<summary>Mobile Web - Chrome</summary>


https://github.com/Expensify/App/assets/97473779/01a62b5e-0b0a-4a3f-a918-15f2c0bd1a4f



</details>

<details>
<summary>Mobile Web - Safari</summary>


https://github.com/Expensify/App/assets/97473779/a7c7b9f0-9063-4f3c-9fb0-1d4d50d59bb9



</details>

<details>
<summary>Desktop</summary>


https://github.com/Expensify/App/assets/97473779/69b31785-1e8e-4c3c-9a61-6a81f5e3acac



</details>

<details>
<summary>iOS</summary>


https://github.com/Expensify/App/assets/97473779/2b9e841f-e3c2-45cb-95ce-158f6a4f3a08



</details>

<details>
<summary>Android</summary>


https://github.com/Expensify/App/assets/97473779/309a6c12-2560-4fb1-bb7e-9e328ffd6f22



</details>
