### PR TITLE
Fix User can not validate an account in Desktop app

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -1086,6 +1086,10 @@ const CONST = {
         MENTION_REPLACER: /^@[^\n\r]*?(?=$|\s)/,
 
         MERGED_ACCOUNT_PREFIX: /^(MERGED_\d+@)/,
+
+        ROUTES: {
+            VALIDATE_LOGIN: /\/v($|(\/\/*))/,
+        }
     },
 
     PRONOUNS: {

--- a/src/CONST.js
+++ b/src/CONST.js
@@ -1089,7 +1089,7 @@ const CONST = {
 
         ROUTES: {
             VALIDATE_LOGIN: /\/v($|(\/\/*))/,
-        }
+        },
     },
 
     PRONOUNS: {

--- a/src/components/DeeplinkWrapper/DeeplinkRedirectLoadingIndicator.js
+++ b/src/components/DeeplinkWrapper/DeeplinkRedirectLoadingIndicator.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {View} from 'react-native';
+import TextLink from '../TextLink';
+import Text from '../Text';
+import Icon from '../Icon';
+import * as Illustrations from '../Icon/Illustrations';
+import * as Expensicons from '../Icon/Expensicons';
+import colors from '../../styles/colors';
+import styles from '../../styles/styles';
+import withLocalize, {withLocalizePropTypes} from '../withLocalize';
+
+const propTypes = {
+    openLinkInBrowser: PropTypes.func.isRequired,
+
+    ...withLocalizePropTypes,
+};
+
+const DeeplinkRedirectLoadingIndicator = (props) => (
+    <View style={styles.deeplinkWrapperContainer}>
+        <View style={styles.deeplinkWrapperMessage}>
+            <View style={styles.mb2}>
+                <Icon
+                    width={200}
+                    height={164}
+                    src={Illustrations.RocketBlue}
+                />
+            </View>
+            <Text style={[styles.textHeadline, styles.textXXLarge]}>{props.translate('deeplinkWrapper.launching')}</Text>
+            <View style={[styles.mt2, styles.fontSizeNormal, styles.textAlignCenter]}>
+                <Text>{props.translate('deeplinkWrapper.redirectedToDesktopApp')}</Text>
+                <Text>
+                    {props.translate('deeplinkWrapper.youCanAlso')} <TextLink onPress={props.openLinkInBrowser}>{props.translate('deeplinkWrapper.openLinkInBrowser')}</TextLink>.
+                </Text>
+            </View>
+        </View>
+        <View style={styles.deeplinkWrapperFooter}>
+            <Icon
+                width={154}
+                height={34}
+                fill={colors.green}
+                src={Expensicons.ExpensifyWordmark}
+            />
+        </View>
+    </View>
+);
+
+DeeplinkRedirectLoadingIndicator.propTypes = propTypes;
+DeeplinkRedirectLoadingIndicator.displayName = 'DeeplinkRedirectLoadingIndicator';
+
+export default withLocalize(DeeplinkRedirectLoadingIndicator);

--- a/src/components/DeeplinkWrapper/index.website.js
+++ b/src/components/DeeplinkWrapper/index.website.js
@@ -38,7 +38,7 @@ class DeeplinkWrapper extends PureComponent {
         this.state = {
             appInstallationCheckStatus:
                 this.isMacOSWeb() && CONFIG.ENVIRONMENT !== CONST.ENVIRONMENT.DEV ? CONST.DESKTOP_DEEPLINK_APP_STATE.CHECKING : CONST.DESKTOP_DEEPLINK_APP_STATE.NOT_INSTALLED,
-            isOpenLinkInBrowser: false,
+            shouldOpenLinkInBrowser: false,
         };
         this.focused = true;
         this.openLinkInBrowser = this.openLinkInBrowser.bind(this);
@@ -122,12 +122,11 @@ class DeeplinkWrapper extends PureComponent {
     }
 
     openLinkInBrowser() {
-        this.setState({isOpenLinkInBrowser: true});
+        this.setState({shouldOpenLinkInBrowser: true});
     }
 
-    deeplinkNeedRedirectLoadingIndicator() {
-        const validateLoginUrlPattern = '/v($|(//*))';
-        const routeRegex = new RegExp(validateLoginUrlPattern);
+    shouldShowDeeplinkLoadingIndicator() {
+        const routeRegex = new RegExp(CONST.REGEX.ROUTES.VALIDATE_LOGIN);
         return routeRegex.test(window.location.pathname);
     }
 
@@ -136,7 +135,7 @@ class DeeplinkWrapper extends PureComponent {
             return <FullScreenLoadingIndicator style={styles.flex1} />;
         }
 
-        if (this.state.appInstallationCheckStatus === CONST.DESKTOP_DEEPLINK_APP_STATE.INSTALLED && this.deeplinkNeedRedirectLoadingIndicator() && !this.state.isOpenLinkInBrowser) {
+        if (this.state.appInstallationCheckStatus === CONST.DESKTOP_DEEPLINK_APP_STATE.INSTALLED && this.shouldShowDeeplinkLoadingIndicator() && !this.state.shouldOpenLinkInBrowser) {
             return <DeeplinkRedirectLoadingIndicator openLinkInBrowser={this.openLinkInBrowser} />;
         }
 

--- a/src/components/DeeplinkWrapper/index.website.js
+++ b/src/components/DeeplinkWrapper/index.website.js
@@ -8,6 +8,7 @@ import CONFIG from '../../CONFIG';
 import * as Browser from '../../libs/Browser';
 import ONYXKEYS from '../../ONYXKEYS';
 import * as Authentication from '../../libs/Authentication';
+import DeeplinkRedirectLoadingIndicator from './DeeplinkRedirectLoadingIndicator';
 
 const propTypes = {
     /** Children to render. */
@@ -37,8 +38,10 @@ class DeeplinkWrapper extends PureComponent {
         this.state = {
             appInstallationCheckStatus:
                 this.isMacOSWeb() && CONFIG.ENVIRONMENT !== CONST.ENVIRONMENT.DEV ? CONST.DESKTOP_DEEPLINK_APP_STATE.CHECKING : CONST.DESKTOP_DEEPLINK_APP_STATE.NOT_INSTALLED,
+            isOpenLinkInBrowser: false,
         };
         this.focused = true;
+        this.openLinkInBrowser = this.openLinkInBrowser.bind(this);
     }
 
     componentDidMount() {
@@ -118,9 +121,23 @@ class DeeplinkWrapper extends PureComponent {
         return !Browser.isMobile() && typeof navigator === 'object' && typeof navigator.userAgent === 'string' && /Mac/i.test(navigator.userAgent) && !/Electron/i.test(navigator.userAgent);
     }
 
+    openLinkInBrowser() {
+        this.setState({isOpenLinkInBrowser: true});
+    }
+
+    deeplinkNeedRedirectLoadingIndicator() {
+        const validateLoginUrlPattern = '/v($|(//*))';
+        const routeRegex = new RegExp(validateLoginUrlPattern);
+        return routeRegex.test(window.location.pathname);
+    }
+
     render() {
         if (this.state.appInstallationCheckStatus === CONST.DESKTOP_DEEPLINK_APP_STATE.CHECKING) {
             return <FullScreenLoadingIndicator style={styles.flex1} />;
+        }
+
+        if (this.state.appInstallationCheckStatus === CONST.DESKTOP_DEEPLINK_APP_STATE.INSTALLED && this.deeplinkNeedRedirectLoadingIndicator() && !this.state.isOpenLinkInBrowser) {
+            return <DeeplinkRedirectLoadingIndicator openLinkInBrowser={this.openLinkInBrowser} />;
         }
 
         return this.props.children;

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -170,6 +170,9 @@ export default {
         launching: 'Launching Expensify',
         expired: 'Your session has expired.',
         signIn: 'Please sign in again.',
+        redirectedToDesktopApp: "We've redirected you to the desktop app.",
+        youCanAlso: 'You can also',
+        openLinkInBrowser: 'open this link in your browser',
     },
     validateCodeModal: {
         successfulSignInTitle: 'Abracadabra,\nyou are signed in!',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -169,6 +169,9 @@ export default {
         launching: 'Cargando Expensify',
         expired: 'Tu sesión ha expirado.',
         signIn: 'Por favor, inicia sesión de nuevo.',
+        redirectedToDesktopApp: 'Te hemos redirigido a la aplicación de escritorio.',
+        youCanAlso: 'También puedes',
+        openLinkInBrowser: 'abrir este enlace en tu navegador',
     },
     validateCodeModal: {
         successfulSignInTitle: 'Abracadabra,\n¡sesión iniciada!',


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/17724
PROPOSAL: https://github.com/Expensify/App/issues/17724#issuecomment-1544938013


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Access the Expensify Desktop app
2. Sign in with an email that does not exist
3. Click on Expensify's magic link from mailbox
4. Verify that the magic link opened in Web with a redirect loading page
5. Click open Desktop app in Alert
6. Verify that user can sign in normally in Desktop app
7. Sign out current user in Desktop app
8. Repeat 1->4
9. Cancel Alert
10. Click link "open this link in your browser"
11. Verify that user can see the magic link code

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
This feature can't test when offline
### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Same as Test
- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/9639873/194c6b01-11ae-48e9-8db0-bf43678ee356


</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->
N/A
</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->
N/A
</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->
N/A
</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->
N/A
</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->
N/A
</details>
