### PR TITLE
fix: disable hover in draft mode

### DIFF
--- a/src/components/Hoverable/hoverablePropTypes.js
+++ b/src/components/Hoverable/hoverablePropTypes.js
@@ -4,6 +4,9 @@ const propTypes = {
     /** Whether to disable additional wrapper around the children. It will only work for single native(View|Text) child.  */
     absolute: PropTypes.bool,
 
+    /** Whether to disable the hover action */
+    disabled: PropTypes.bool,
+
     /** Children to wrap with Hoverable. */
     children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
 
@@ -20,6 +23,7 @@ const propTypes = {
 
 const defaultProps = {
     absolute: false,
+    disabled: false,
     containerStyles: [],
     onHoverIn: () => {},
     onHoverOut: () => {},

--- a/src/components/Hoverable/index.js
+++ b/src/components/Hoverable/index.js
@@ -44,6 +44,11 @@ class Hoverable extends Component {
      * @param {Boolean} isHovered - Whether or not this component is hovered.
      */
     setIsHovered(isHovered) {
+        if (this.props.disabled) {
+            this.disableHover();
+            return;
+        }
+
         if (isHovered !== this.state.isHovered && !(isHovered && this.hoverDisabled)) {
             this.setState({isHovered}, isHovered ? this.props.onHoverIn : this.props.onHoverOut);
         }

--- a/src/components/Hoverable/index.js
+++ b/src/components/Hoverable/index.js
@@ -38,9 +38,8 @@ class Hoverable extends Component {
             return;
         }
 
-        this.setState({isHovered: false});
-
         if (this.props.disabled) {
+            this.setState({isHovered: false});
             this.disableHover();
         } else {
             this.enableHover();

--- a/src/components/Hoverable/index.js
+++ b/src/components/Hoverable/index.js
@@ -44,11 +44,6 @@ class Hoverable extends Component {
      * @param {Boolean} isHovered - Whether or not this component is hovered.
      */
     setIsHovered(isHovered) {
-        if (this.props.disabled) {
-            this.disableHover();
-            return;
-        }
-
         if (isHovered !== this.state.isHovered && !(isHovered && this.hoverDisabled)) {
             this.setState({isHovered}, isHovered ? this.props.onHoverIn : this.props.onHoverOut);
         }
@@ -60,6 +55,8 @@ class Hoverable extends Component {
     }
 
     render() {
+        const isHovered = this.state.isHovered && !this.props.disabled;
+
         if (this.props.absolute && React.isValidElement(this.props.children)) {
             return React.cloneElement(React.Children.only(this.props.children), {
                 ref: (el) => {
@@ -111,7 +108,7 @@ class Hoverable extends Component {
             >
                 {
                     // If this.props.children is a function, call it to provide the hover state to the children.
-                    _.isFunction(this.props.children) ? this.props.children(this.state.isHovered) : this.props.children
+                    _.isFunction(this.props.children) ? this.props.children(isHovered) : this.props.children
                 }
             </View>
         );

--- a/src/components/Hoverable/index.js
+++ b/src/components/Hoverable/index.js
@@ -33,21 +33,23 @@ class Hoverable extends Component {
         document.addEventListener('touchmove', this.enableHover);
     }
 
+    componentDidUpdate(prevProps) {
+        if (prevProps.disabled === this.props.disabled) {
+            return;
+        }
+
+        this.setState({isHovered: false});
+
+        if (this.props.disabled) {
+            this.disableHover();
+        } else {
+            this.enableHover();
+        }
+    }
+
     componentWillUnmount() {
         document.removeEventListener('touchstart', this.disableHover);
         document.removeEventListener('touchmove', this.enableHover);
-    }
-
-    componentDidUpdate(prevProps) {
-        if (prevProps.disabled !== this.props.disabled) {
-            this.setState({isHovered: false});
-
-            if (this.props.disabled) {
-                this.disableHover();
-            } else {
-                this.enableHover();
-            }
-        }
     }
 
     /**

--- a/src/components/Hoverable/index.js
+++ b/src/components/Hoverable/index.js
@@ -38,11 +38,8 @@ class Hoverable extends Component {
             return;
         }
 
-        if (this.props.disabled) {
+        if (this.props.disabled && this.state.isHovered) {
             this.setState({isHovered: false});
-            this.disableHover();
-        } else {
-            this.enableHover();
         }
     }
 

--- a/src/components/Hoverable/index.js
+++ b/src/components/Hoverable/index.js
@@ -38,12 +38,28 @@ class Hoverable extends Component {
         document.removeEventListener('touchmove', this.enableHover);
     }
 
+    componentDidUpdate(prevProps) {
+        if (prevProps.disabled !== this.props.disabled) {
+            this.setState({isHovered: false});
+
+            if (this.props.disabled) {
+                this.disableHover();
+            } else {
+                this.enableHover();
+            }
+        }
+    }
+
     /**
      * Sets the hover state of this component to true and execute the onHoverIn callback.
      *
      * @param {Boolean} isHovered - Whether or not this component is hovered.
      */
     setIsHovered(isHovered) {
+        if (this.props.disabled) {
+            return;
+        }
+
         if (isHovered !== this.state.isHovered && !(isHovered && this.hoverDisabled)) {
             this.setState({isHovered}, isHovered ? this.props.onHoverIn : this.props.onHoverOut);
         }
@@ -55,8 +71,6 @@ class Hoverable extends Component {
     }
 
     render() {
-        const isHovered = this.state.isHovered && !this.props.disabled;
-
         if (this.props.absolute && React.isValidElement(this.props.children)) {
             return React.cloneElement(React.Children.only(this.props.children), {
                 ref: (el) => {
@@ -108,7 +122,7 @@ class Hoverable extends Component {
             >
                 {
                     // If this.props.children is a function, call it to provide the hover state to the children.
-                    _.isFunction(this.props.children) ? this.props.children(isHovered) : this.props.children
+                    _.isFunction(this.props.children) ? this.props.children(this.state.isHovered) : this.props.children
                 }
             </View>
         );

--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -363,7 +363,7 @@ function ReportActionItem(props) {
             preventDefaultContextMenu={!props.draftMessage && !hasErrors}
             withoutFocusOnSecondaryInteraction
         >
-            <Hoverable>
+            <Hoverable disabled={!!props.draftMessage}>
                 {(hovered) => (
                     <View accessibilityLabel={props.translate('accessibilityHints.chatMessage')}>
                         {props.shouldDisplayNewMarker && <UnreadActionIndicator reportActionID={props.action.reportActionID} />}

--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -363,7 +363,7 @@ function ReportActionItem(props) {
             preventDefaultContextMenu={!props.draftMessage && !hasErrors}
             withoutFocusOnSecondaryInteraction
         >
-            <Hoverable disabled={!!props.draftMessage}>
+            <Hoverable disabled={Boolean(props.draftMessage)}>
                 {(hovered) => (
                     <View accessibilityLabel={props.translate('accessibilityHints.chatMessage')}>
                         {props.shouldDisplayNewMarker && <UnreadActionIndicator reportActionID={props.action.reportActionID} />}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/16923
PROPOSAL: https://github.com/Expensify/App/issues/16923#issuecomment-1543676311


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Open any chat
2. Send any message(e.g. test 1), send another message(e.g. test 2)
3. Hover over the first sent message (in this example, test 1)
4. Now press `arrow up` key so that the last message will show edit composer(in this case, test 2)
5. Now press enter or esc

- [ ] Verify that the action menu is displayed on one message(last focused), not on two messages at the same time.

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

1. Open any chat
2. Send any message(e.g. test 1), send another message(e.g. test 2)
3. Hover over the first sent message (in this example, test 1)
4. Now press `arrow up` key so that the last message will show edit composer(in this case, test 2)
5. Now press enter or esc

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
7. Upload an image via copy paste
8. Verify a modal appears displaying a preview of that image
--->

1. Open any chat
2. Send any message(e.g. test 1), send another message(e.g. test 2)
3. Hover over the first sent message (in this example, test 1)
4. Now press `arrow up` key so that the last message will show edit composer(in this case, test 2)
5. Now press enter or esc

- [ ] Verify that the action menu is displayed on one message(last focused), not on two messages at the same time.

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/126839717/c9e0d2a0-0d0f-47ca-b12a-ec938405ed3a


</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/126839717/a9afe58b-7f94-44d6-921a-d7dd2b363a68


</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/126839717/19056b7b-bb29-4a90-ac65-171502127734


</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/126839717/2375499d-6dea-4d3b-8f33-3ef6c7e63437


</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/126839717/5b7a1cdd-97a7-4bfd-97c7-b0381de4729b


</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/126839717/f6241f9c-1efb-4316-89c3-b64b093b30e1


</details>
