### PR TITLE
Re-adding paywithwallet functionality for manual requests

### DIFF
--- a/src/libs/actions/IOU.js
+++ b/src/libs/actions/IOU.js
@@ -1172,6 +1172,19 @@ function payMoneyRequest(paymentType, chatReport, iouReport) {
     }
 }
 
+/**
+ * @param {Object} chatReport
+ * @param {Object} iouReport
+ * @param {Object} recipient
+ */
+function payMoneyRequestWithWallet(chatReport, iouReport, recipient) {
+    const {params, optimisticData, successData, failureData} = getPayMoneyRequestParams(chatReport, iouReport, recipient, CONST.IOU.PAYMENT_TYPE.EXPENSIFY);
+
+    API.write('PayMoneyRequestWithWallet', params, {optimisticData, successData, failureData});
+
+    Navigation.navigate(ROUTES.getReportRoute(chatReport.reportID));
+}
+
 export {
     deleteMoneyRequest,
     splitBill,
@@ -1180,6 +1193,7 @@ export {
     sendMoneyElsewhere,
     sendMoneyViaPaypal,
     payMoneyRequest,
+    payMoneyRequestWithWallet,
     setIOUSelectedCurrency,
     setMoneyRequestDescription,
     sendMoneyWithWallet,

--- a/src/libs/actions/IOU.js
+++ b/src/libs/actions/IOU.js
@@ -1165,24 +1165,15 @@ function payMoneyRequest(paymentType, chatReport, iouReport) {
     };
     const {params, optimisticData, successData, failureData} = getPayMoneyRequestParams(chatReport, iouReport, recipient, paymentType);
 
-    API.write('PayMoneyRequest', params, {optimisticData, successData, failureData});
+    // For now we need to call the PayMoneyRequestWithWallet API since PayMoneyRequest was not updated to work with
+    // Expensify Wallets.
+    const apiCommand = paymentType === CONST.IOU.PAYMENT_TYPE.EXPENSIFY ? 'PayMoneyRequestWithWallet' : 'PayMoneyRequest';
+
+    API.write(apiCommand, params, {optimisticData, successData, failureData});
     Navigation.navigate(ROUTES.getReportRoute(chatReport.reportID));
     if (paymentType === CONST.IOU.PAYMENT_TYPE.PAYPAL_ME) {
         asyncOpenURL(Promise.resolve(), buildPayPalPaymentUrl(iouReport.total, recipient.payPalMeAddress, iouReport.currency));
     }
-}
-
-/**
- * @param {Object} chatReport
- * @param {Object} iouReport
- * @param {Object} recipient
- */
-function payMoneyRequestWithWallet(chatReport, iouReport, recipient) {
-    const {params, optimisticData, successData, failureData} = getPayMoneyRequestParams(chatReport, iouReport, recipient, CONST.IOU.PAYMENT_TYPE.EXPENSIFY);
-
-    API.write('PayMoneyRequestWithWallet', params, {optimisticData, successData, failureData});
-
-    Navigation.navigate(ROUTES.getReportRoute(chatReport.reportID));
 }
 
 export {
@@ -1193,7 +1184,6 @@ export {
     sendMoneyElsewhere,
     sendMoneyViaPaypal,
     payMoneyRequest,
-    payMoneyRequestWithWallet,
     setIOUSelectedCurrency,
     setMoneyRequestDescription,
     sendMoneyWithWallet,

--- a/src/pages/iou/IOUDetailsModal.js
+++ b/src/pages/iou/IOUDetailsModal.js
@@ -133,16 +133,6 @@ class IOUDetailsModal extends Component {
         return reportActionWithPendingAction ? reportActionWithPendingAction.pendingAction : undefined;
     }
 
-    onPressSettlementButton(paymentMethodType) {
-        // Payment via Expensify Wallet is handled differently for now so make sure we call the right API
-        if (paymentMethodType === CONST.IOU.PAYMENT_TYPE.EXPENSIFY) {
-            IOU.payMoneyRequestWithWallet(this.props.chatReport, this.props.iouReport, recipient);
-            return;
-        }
-
-        IOU.payMoneyRequest(paymentMethodType, this.props.chatReport, this.props.iouReport)
-    }
-
     render() {
         const sessionEmail = lodashGet(this.props.session, 'email', null);
         const pendingAction = this.findPendingAction();
@@ -185,7 +175,7 @@ class IOUDetailsModal extends Component {
                                 {hasOutstandingIOU && this.props.iouReport.managerEmail === sessionEmail && (
                                     <FixedFooter>
                                         <SettlementButton
-                                            onPress={this.onPressSettlementButton}
+                                            onPress={(paymentMethodType) => IOU.payMoneyRequest(paymentMethodType, this.props.chatReport, this.props.iouReport)}
                                             shouldShowPaypal={Boolean(lodashGet(this.props, 'iouReport.submitterPayPalMeAddress'))}
                                             currency={lodashGet(this.props, 'iouReport.currency')}
                                             enablePaymentsRoute={ROUTES.IOU_DETAILS_ENABLE_PAYMENTS}

--- a/src/pages/iou/IOUDetailsModal.js
+++ b/src/pages/iou/IOUDetailsModal.js
@@ -133,6 +133,16 @@ class IOUDetailsModal extends Component {
         return reportActionWithPendingAction ? reportActionWithPendingAction.pendingAction : undefined;
     }
 
+    onPressSettlementButton(paymentMethodType) {
+        // Payment via Expensify Wallet is handled differently for now so make sure we call the right API
+        if (paymentMethodType === CONST.IOU.PAYMENT_TYPE.EXPENSIFY) {
+            IOU.payMoneyRequestWithWallet(this.props.chatReport, this.props.iouReport, recipient);
+            return;
+        }
+
+        IOU.payMoneyRequest(paymentMethodType, this.props.chatReport, this.props.iouReport)
+    }
+
     render() {
         const sessionEmail = lodashGet(this.props.session, 'email', null);
         const pendingAction = this.findPendingAction();
@@ -175,7 +185,7 @@ class IOUDetailsModal extends Component {
                                 {hasOutstandingIOU && this.props.iouReport.managerEmail === sessionEmail && (
                                     <FixedFooter>
                                         <SettlementButton
-                                            onPress={(paymentMethodType) => IOU.payMoneyRequest(paymentMethodType, this.props.chatReport, this.props.iouReport)}
+                                            onPress={this.onPressSettlementButton}
                                             shouldShowPaypal={Boolean(lodashGet(this.props, 'iouReport.submitterPayPalMeAddress'))}
                                             currency={lodashGet(this.props, 'iouReport.currency')}
                                             enablePaymentsRoute={ROUTES.IOU_DETAILS_ENABLE_PAYMENTS}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/Expensify/issues/285824
PROPOSAL: GH_LINK_ISSUE(COMMENT)


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

You'll need to get some things set up first, for internal engineers you'll want to use the cliscripts and probably 2 different accounts to test.

1. Testing with IOU with Withdrawal account only
    accountA - create a verified withdrawal bank account
    ```
    Expensidev/Web-Expensify (bondy-fix-latestReleases) $ ../script/clitools.sh generator:bankaccount
    Account email? [dbondy@expensify.com] dbondy@expensifail.com
    Let's authenticate you
    success
    Deposit or Withdrawal?
      [0] Deposit
      [1] Withdrawal
     > 1
    Validated?
      [0] Yes
      [1] No
     > 0
    Upgraded?
      [0] Yes
      [1] No
     > 0
    Use Stripe Test Acct Information?
      [0] Yes
      [1] No
     > 0
    ```
    
    And make sure the wallet is upgraded to Gold
    ```
    Expensidev/Web-Expensify (bondy-fix-latestReleases) $ ../script/clitools.sh validator:wallet
    Account email? [dbondy@expensify.com] dbondy@expensifail.com
    Let's authenticate you
    success
    Success! Wallet account set to GOLD
    ```
    
    Then send a money request from another account (accountB) to accountA, in accountA click the `Pay with Expensify` button and ensure your logs show that we called `PayMoneyRequestWithWallet` not `PayMoneyRequest`
    ```
    2023-05-24T17:38:59.846456+00:00 expensidev2004 php-fpm: aDdtNU /api.php dbondy@expensifail.com !ecash1.3.17-1! ?api? [info] Processing 'PayMoneyRequestWithWallet' for 'expensify.com' from '73.14.190.93'  ~~ command: 'PayMoneyRequestWithWallet' iouReportID: '476197244592615' chatReportID: '2794916923029281' reportActionID: '6502895055215705994' paymentMethodType: 'Expensify' appversion: '1.3.17-1' pusherSocketID: '467599.1951998' authToken: '<REDACTED>' referer: 'ecash' platform: 'web' api_setCookie: 'false' email: 'dbondy@expensifail.com' partnerName: 'expensify.com' browserGUID: '646e4bb3ce7fc' HTTP_CF_BOT_SCORE: '' HTTP_CF_JA3_HASH: ''
    ```
    
    Confirmed no errors showed and that the IOU was paid
    <img width="1512" alt="image" src="https://github.com/Expensify/App/assets/4073354/8a961a17-5ff7-4b50-8728-edf71442d42e"> 
    
    And verified in the db that rows were properly inserted into the DB
    ```
    sqlite> select * from reimbursements where reportid=476197244592615;
                entryID = 2
                created = 2023-05-24 17:38:59
     debitBankAccountID = 1030901
    creditBankAccountID = 1030790
                 amount = -700
               reportID = 476197244592615
            debitPosted =
           creditPosted =
                   type = 9
                  state = 4
                details = {"walletToWalletEntryID":3}
            debitFundID =
           creditFundID =
    
                entryID = 3
                created = 2023-05-24 17:38:59
     debitBankAccountID = 1030790
    creditBankAccountID = 1030865
                 amount = -700
               reportID = 476197244592615
            debitPosted =
           creditPosted =
                   type = 9
                  state = 0
                details = {"pending":"true"}
            debitFundID =
           creditFundID =
    sqlite> select a.email from bankaccounts ba join accounts a on ba.accountid = a.accountid where ba.bankaccountid =1030790;
    email = dbondy@expensifail.com
    sqlite> select a.email from bankaccounts ba join accounts a on ba.accountid = a.accountid where ba.bankaccountid = 1030865;
    email = zoey@dog.com
    ```

2. Testing IOU with deposit only bank account and card on line
    Set up accountA so that it only has a deposit-only bank account and a gold wallet
    ```
    Expensidev/Web-Expensify (bondy-fix-latestReleases) $ ../script/clitools.sh validator:wallet
    Account email? [dbondy@expensify.com] zoey@dog.com
    Let's authenticate you
    success
    ```
    
    ```
    Expensidev/Web-Expensify (bondy-fix-latestReleases) $ ../script/clitools.sh generator:billingcard
    Account email? [dbondy@expensify.com] zoey@dog.com
    Let's authenticate you
    success
    Should charges succeed?
      [0] Yes
      [1] No
     > 0
    Should we make this a P2P debit card?
      [0] Yes
      [1] No
     > 0
    Should this card be taxable?
      [0] Yes
      [1] No
     > 0

    Success
    ```
    
    Send an IOU from accountB to accountA <img width="1512" alt="image" src="https://github.com/Expensify/App/assets/4073354/64274c1f-a2bf-439d-9a3e-8680379ae739">

    As accountA, pay via expensify <img width="1512" alt="image" src="https://github.com/Expensify/App/assets/4073354/ec1116e7-1ce6-41cf-b0bc-57afcb423d6b">
    
    Ensure logs show we hit `PayManualRequestWithWallet`
    ```
    2023-05-24T20:48:50.082683+00:00 expensidev2004 php-fpm: aqMQ5y /api.php zoey@dog.com !ecash1.3.17-1! ?api? [info] Processing 'PayMoneyRequestWithWallet' for 'expensify.com' from '73.14.190.93'  ~~ command: 'PayMoneyRequestWithWallet' iouReportID: '2991313505446224' chatReportID: '5596022678305035' reportActionID: '5476717101922320582' paymentMethodType: 'Expensify' appversion: '1.3.17-1' pusherSocketID: '467982.1882253' authToken: '<REDACTED>' referer: 'ecash' platform: 'web' api_setCookie: 'false' email: 'zoey@dog.com' partnerName: 'expensify.com' browserGUID: '646e783214211' HTTP_CF_BOT_SCORE: '' HTTP_CF_JA3_HASH: ''
    ```
    
    ... :sad-panda: I couldn't actually get this to work b/c of an error trying to talk to the bancorp sandbox URL ...

3.  Testing Expense Report Manual Request goes through PayManualRequest

    created a request from a workspace member to the workspace <img width="1512" alt="image" src="https://github.com/Expensify/App/assets/4073354/091985ac-7df3-472d-bc83-9243ea9e09fa">
    
    Make sure you have a bank account set up, you might likely have to create it manually in new dot and then CQ to set it to a validated state:
    ```sql
    UPDATE bankaccounts SET state=1, addressState='true' WHERE bankaccountid=1030904;
    ```
    
    As the workspace admin go in and click Pay with Expensify <img width="1512" alt="image" src="https://github.com/Expensify/App/assets/4073354/8f0c0199-396c-4c58-a2c7-9b0e8a44278b">
    
    Verified we made the correct API request
    ```
    2023-05-24T22:37:45.411411+00:00 expensidev2004 php-fpm: zS5iPC /api.php zoey@dog.com !ecash1.3.17-1! ?api? [info] Processing 'PayMoneyRequest' for 'expensify.com' from '73.14.190.93'  ~~ command: 'PayMoneyRequest' iouReportID: '8661658847583965' chatReportID: '211217264253708' reportActionID: '3085159208262961606' paymentMethodType: 'ACH' appversion: '1.3.17-1' pusherSocketID: '467839.1944297' authToken: '<REDACTED>' referer: 'ecash' platform: 'web' api_setCookie: 'false' email: 'zoey@dog.com' partnerName: 'expensify.com' browserGUID: '646e91b964566' HTTP_CF_BOT_SCORE: '' HTTP_CF_JA3_HASH: ''
    ```
    
    We don't actually add the reimbursement though https://github.com/Expensify/Auth/blob/74b89a906c3734cd4991296bee2395efe3434d00/auth/lib/ACHReimbursement.cpp#L1778-L1781 so I can't confirm the data in my DB but can at least verify that log line was hit:
    ```
    2023-05-24T22:37:45.471868+00:00 expensidev2004 bedrock: zS5iPC zoey@dog.com (ACHReimbursement.cpp:1779) queue [socket284] [hmmm] Cannot reimburse from Plaid test bank account
    ```
    
### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

None specifically since this requires you be connected to the internet to actually settle an IOU. 

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
4. Upload an image via copy paste
5. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

I am not sure if we have testing set up for Policy Expense Chat to get reimbursements from a workspace or not.

If we do then we should test that flow AND the IOU/P2P flow.

We can also have David test this since he currently has an IOU that needs to be paid if we CP this staging. 

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos

N/A really see tests I guess.

<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>
