### PR TITLE
Move checkmark icon to right of settled amount in request money report

### DIFF
--- a/src/components/MenuItem.js
+++ b/src/components/MenuItem.js
@@ -3,6 +3,7 @@ import React from 'react';
 import {View} from 'react-native';
 import Text from './Text';
 import styles from '../styles/styles';
+import themeColors from '../styles/themes/default';
 import * as StyleUtils from '../styles/StyleUtils';
 import Icon from './Icon';
 import * as Expensicons from './Icon/Expensicons';
@@ -36,6 +37,8 @@ const defaultProps = {
     wrapperStyle: [],
     style: styles.popoverMenuItem,
     titleStyle: {},
+    shouldShowTitleRightIcon: false,
+    titleRightIcon: () => {},
     descriptionTextStyle: styles.breakWord,
     success: false,
     icon: undefined,
@@ -156,14 +159,24 @@ const MenuItem = (props) => {
                                     {props.description}
                                 </Text>
                             )}
-                            {Boolean(props.title) && (
-                                <Text
-                                    style={titleTextStyle}
-                                    numberOfLines={1}
-                                >
-                                    {convertToLTR(props.title)}
-                                </Text>
-                            )}
+                            <View style={[styles.flexRow, styles.alignItemsCenter]}>
+                                {Boolean(props.title) && (
+                                    <Text
+                                        style={titleTextStyle}
+                                        numberOfLines={1}
+                                    >
+                                        {convertToLTR(props.title)}
+                                    </Text>
+                                )}
+                                {Boolean(props.shouldShowTitleRightIcon) && (
+                                    <View style={[styles.ml2]}>
+                                        <Icon
+                                            src={props.titleRightIcon}
+                                            fill={themeColors.iconSuccessFill}
+                                        />
+                                    </View>
+                                )}
+                            </View>
                             {Boolean(props.description) && !props.shouldShowDescriptionOnTop && (
                                 <Text
                                     style={descriptionTextStyle}

--- a/src/components/MenuItem.js
+++ b/src/components/MenuItem.js
@@ -69,6 +69,7 @@ const MenuItem = (props) => {
     const descriptionVerticalMargin = props.shouldShowDescriptionOnTop ? styles.mb1 : styles.mt1;
     const titleTextStyle = StyleUtils.combineStyles(
         [
+            styles.flexShrink1,
             styles.popoverMenuText,
             props.icon ? styles.ml3 : undefined,
             props.shouldShowBasicTitle ? undefined : styles.textStrong,

--- a/src/components/MenuItem.js
+++ b/src/components/MenuItem.js
@@ -37,8 +37,8 @@ const defaultProps = {
     wrapperStyle: [],
     style: styles.popoverMenuItem,
     titleStyle: {},
-    shouldShowTitleRightIcon: false,
-    titleRightIcon: () => {},
+    shouldShowTitleIcon: false,
+    titleIcon: () => {},
     descriptionTextStyle: styles.breakWord,
     success: false,
     icon: undefined,
@@ -168,10 +168,10 @@ const MenuItem = (props) => {
                                         {convertToLTR(props.title)}
                                     </Text>
                                 )}
-                                {Boolean(props.shouldShowTitleRightIcon) && (
+                                {Boolean(props.shouldShowTitleIcon) && (
                                     <View style={[styles.ml2]}>
                                         <Icon
-                                            src={props.titleRightIcon}
+                                            src={props.titleIcon}
                                             fill={themeColors.iconSuccessFill}
                                         />
                                     </View>

--- a/src/components/MoneyRequestHeader.js
+++ b/src/components/MoneyRequestHeader.js
@@ -18,7 +18,6 @@ import withWindowDimensions from './withWindowDimensions';
 import compose from '../libs/compose';
 import Navigation from '../libs/Navigation/Navigation';
 import ROUTES from '../ROUTES';
-import Icon from './Icon';
 import SettlementButton from './SettlementButton';
 import * as Policy from '../libs/actions/Policy';
 import ONYXKEYS from '../ONYXKEYS';
@@ -136,14 +135,6 @@ const MoneyRequestHeader = (props) => {
                     </View>
                     <View style={[styles.flexRow, styles.alignItemsCenter]}>
                         {!props.isSingleTransactionView && <Text style={[styles.newKansasLarge]}>{formattedAmount}</Text>}
-                        {isSettled && (
-                            <View style={styles.moneyRequestHeaderCheckmark}>
-                                <Icon
-                                    src={Expensicons.Checkmark}
-                                    fill={themeColors.iconSuccessFill}
-                                />
-                            </View>
-                        )}
                         {shouldShowSettlementButton && !props.isSmallScreenWidth && (
                             <View style={[styles.ml4]}>
                                 <SettlementButton
@@ -179,7 +170,9 @@ const MoneyRequestHeader = (props) => {
                 <>
                     <MenuItemWithTopDescription
                         title={formattedTransactionAmount}
-                        description={`${props.translate('iou.amount')} • ${props.translate('iou.cash')}`}
+                        shouldShowTitleRightIcon={isSettled}
+                        titleRightIcon={Expensicons.Checkmark}
+                        description={`${props.translate('iou.amount')} • ${props.translate('iou.cash')}${isSettled ? ` • ${props.translate('iou.settledExpensify')}` : ''}`}
                         titleStyle={styles.newKansasLarge}
                     />
                     <MenuItemWithTopDescription

--- a/src/components/MoneyRequestHeader.js
+++ b/src/components/MoneyRequestHeader.js
@@ -18,6 +18,7 @@ import withWindowDimensions from './withWindowDimensions';
 import compose from '../libs/compose';
 import Navigation from '../libs/Navigation/Navigation';
 import ROUTES from '../ROUTES';
+import Icon from './Icon';
 import SettlementButton from './SettlementButton';
 import * as Policy from '../libs/actions/Policy';
 import ONYXKEYS from '../ONYXKEYS';
@@ -135,6 +136,14 @@ const MoneyRequestHeader = (props) => {
                     </View>
                     <View style={[styles.flexRow, styles.alignItemsCenter]}>
                         {!props.isSingleTransactionView && <Text style={[styles.newKansasLarge]}>{formattedAmount}</Text>}
+                        {!props.isSingleTransactionView && isSettled && (
+                            <View style={styles.moneyRequestHeaderCheckmark}>
+                                <Icon
+                                    src={Expensicons.Checkmark}
+                                    fill={themeColors.iconSuccessFill}
+                                />
+                            </View>
+                        )}
                         {shouldShowSettlementButton && !props.isSmallScreenWidth && (
                             <View style={[styles.ml4]}>
                                 <SettlementButton

--- a/src/components/MoneyRequestHeader.js
+++ b/src/components/MoneyRequestHeader.js
@@ -179,8 +179,8 @@ const MoneyRequestHeader = (props) => {
                 <>
                     <MenuItemWithTopDescription
                         title={formattedTransactionAmount}
-                        shouldShowTitleRightIcon={isSettled}
-                        titleRightIcon={Expensicons.Checkmark}
+                        shouldShowTitleIcon={isSettled}
+                        titleIcon={Expensicons.Checkmark}
                         description={`${props.translate('iou.amount')} • ${props.translate('iou.cash')}${isSettled ? ` • ${props.translate('iou.settledExpensify')}` : ''}`}
                         titleStyle={styles.newKansasLarge}
                     />

--- a/src/components/menuItemPropTypes.js
+++ b/src/components/menuItemPropTypes.js
@@ -34,10 +34,10 @@ const propTypes = {
     title: PropTypes.string.isRequired,
 
     /** Boolean whether to display the title right icon */
-    shouldShowTitleRightIcon: PropTypes.bool,
+    shouldShowTitleIcon: PropTypes.bool,
 
     /** Icon to display at right side of title */
-    titleRightIcon: PropTypes.func,
+    titleIcon: PropTypes.func,
 
     /** Boolean whether to display the right icon */
     shouldShowRightIcon: PropTypes.bool,

--- a/src/components/menuItemPropTypes.js
+++ b/src/components/menuItemPropTypes.js
@@ -33,6 +33,12 @@ const propTypes = {
     /** Text to display for the item */
     title: PropTypes.string.isRequired,
 
+    /** Boolean whether to display the title right icon */
+    shouldShowTitleRightIcon: PropTypes.bool,
+
+    /** Icon to display at right side of title */
+    titleRightIcon: PropTypes.func,
+
     /** Boolean whether to display the right icon */
     shouldShowRightIcon: PropTypes.bool,
 


### PR DESCRIPTION
@aimane-chnaif @Julesssss PR is ready for review.

### Details
When Request money report open which is Settled, previously it was showing Green checkmark icon at right side of the "To" header. So In this pr we removed checkmark icon from right side of "To" header, and placed it at **right side of the settled amount**. We also added "Settled" word within description line as shown in screenshot.

**Note:** In this PR we did changes related settled money request report. Although, we provided screenshot for unsettled report to show that there is not any side effect.

### Fixed Issues
$ https://github.com/Expensify/App/issues/19332
PROPOSAL: https://github.com/Expensify/App/issues/19332#issuecomment-1555559374

### Tests
1. Login with any account.
2. Go on any Request money report **which is settled**.
3. Verify that it shows "Settled" word within description line i.e. "Amount • Cash • Settled"
4. Verify that Green checkmark icon shows at **right side of the settled amount**.

- [x] Verify that no errors appear in the JS console

### Offline tests
1. Login with any account.
2. Go on any Request money report **which is settled**.
3. Verify that it shows "Settled" word within description line i.e. "Amount • Cash • Settled"
4. Verify that Green checkmark icon shows at **right side of the settled amount**.

### QA Steps
1. Login with any account.
2. Go on any Request money report **which is settled**.
3. Verify that it shows "Settled" word within description line i.e. "Amount • Cash • Settled"
4. Verify that Green checkmark icon shows at **right side of the settled amount**.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

#### Chrome
| Settled | Unsettled |
|--------|--------|
| <img width="891" alt="Web-Chrome-Settled" src="https://github.com/Expensify/App/assets/7823358/4d758ea8-d912-43ca-986c-9131e28c8d85"> | <img width="882" alt="Web-Chrome-Unsettled" src="https://github.com/Expensify/App/assets/7823358/01623377-586d-4538-bf3d-f188e65eb9d8"> |

#### Safari
| Settled | Unsettled |
|--------|--------|
| <img width="894" alt="Web-Safari-Settled" src="https://github.com/Expensify/App/assets/7823358/e830b1ca-7c0c-4810-ac0e-f6758b68aaf7"> | <img width="889" alt="Web-Safari-Unsettled" src="https://github.com/Expensify/App/assets/7823358/24a0c722-862f-419e-9c0e-56b783b8da7e"> |

</details>

<details>
<summary>Mobile Web - Chrome</summary>

| Settled | Unsettled |
|--------|--------|
| <img width="549" alt="MWeb-Chrome-Settled" src="https://github.com/Expensify/App/assets/7823358/58371e39-e54c-4f28-96af-96a716044a8f"> | <img width="551" alt="MWeb-Chrome-Unsettled" src="https://github.com/Expensify/App/assets/7823358/edce7763-8651-4385-b58a-d5f3d170ce2f"> |
</details>

<details>
<summary>Mobile Web - Safari</summary>

| Settled | Unsettled |
|--------|--------|
| <img width="465" alt="MWeb-Safari-Settled" src="https://github.com/Expensify/App/assets/7823358/35d18a62-f366-461a-8378-8f3063985be6"> | <img width="469" alt="MWeb-Safari-Unsettled" src="https://github.com/Expensify/App/assets/7823358/85c3cab4-df7a-4510-96bc-ce0700da9845"> |

</details>

<details>
<summary>Desktop</summary>

| Settled | Unsettled |
|--------|--------|
| <img width="895" alt="Desktop-Settled" src="https://github.com/Expensify/App/assets/7823358/ea09c120-4732-4910-ac4f-39850078b7e6"> | <img width="889" alt="Desktop-Unsettled" src="https://github.com/Expensify/App/assets/7823358/a76de19f-387b-4be5-9e35-f75847a163b4"> |
</details>

<details>
<summary>iOS</summary>

| Settled | Unsettled |
|--------|--------|
| <img width="464" alt="iOS-Settled" src="https://github.com/Expensify/App/assets/7823358/a10bb85e-2689-4fee-9d8d-f3c6f250afa5"> | <img width="464" alt="iOS-Unsettled" src="https://github.com/Expensify/App/assets/7823358/17726536-05fa-4e36-9dca-b48e601872c2"> |

</details>

<details>
<summary>Android</summary>

| Settled | Unsettled |
|--------|--------|
| <img width="552" alt="Android-Settled" src="https://github.com/Expensify/App/assets/7823358/5710ff9e-250b-4d07-81ec-ee72ae62a96b"> | <img width="552" alt="Android-Unsettled" src="https://github.com/Expensify/App/assets/7823358/5251bf86-1f67-4a8d-8efe-52f5ce6c5cc1"> |

</details>
