### PR TITLE
Fix automatic authentication with magic link.

### DIFF
--- a/src/components/ValidateCode/ValidateCodeModal.js
+++ b/src/components/ValidateCode/ValidateCodeModal.js
@@ -39,7 +39,7 @@ const defaultProps = {
 };
 
 function ValidateCodeModal(props) {
-    const signInHere = useCallback(() => Session.signInWithValidateCode(props.accountID, props.code, null, props.preferredLocale), [props.accountID, props.code, props.preferredLocale]);
+    const signInHere = useCallback(() => Session.signInWithValidateCode(props.accountID, props.code, props.preferredLocale), [props.accountID, props.code, props.preferredLocale]);
 
     return (
         <View style={styles.deeplinkWrapperContainer}>

--- a/src/libs/actions/Session/index.js
+++ b/src/libs/actions/Session/index.js
@@ -462,7 +462,7 @@ function signInWithValidateCode(accountID, code, twoFactorAuthCode, preferredLoc
         deviceInfo: getDeviceInfoForLogin(),
     };
 
-    // Pass twoFactorAuthCode to sever only if it has a valid value, otherwise php might convert it to "null" as a string.
+    // Pass twoFactorAuthCode to server only if it has a valid value, otherwise php might convert it to "null" as a string.
     if (twoFactorAuthCode) {
         params.twoFactorAuthCode = twoFactorAuthCode;
     }

--- a/src/libs/actions/Session/index.js
+++ b/src/libs/actions/Session/index.js
@@ -455,17 +455,19 @@ function signInWithValidateCode(accountID, code, twoFactorAuthCode, preferredLoc
         },
     ];
 
-    API.write(
-        'SigninUserWithLink',
-        {
-            accountID,
-            validateCode,
-            twoFactorAuthCode,
-            preferredLocale,
-            deviceInfo: getDeviceInfoForLogin(),
-        },
-        {optimisticData, successData, failureData},
-    );
+    const params = {
+        accountID,
+        validateCode,
+        twoFactorAuthCode,
+        preferredLocale,
+        deviceInfo: getDeviceInfoForLogin(),
+    };
+
+    // Pass twoFactorAuthCode to sever only if it has a valid value, otherwise php might convert it to "null" as a string.
+    if (twoFactorAuthCode) {
+        params.twoFactorAuthCode = twoFactorAuthCode;
+    }
+    API.write('SigninUserWithLink', params, {optimisticData, successData, failureData});
 }
 
 function signInWithValidateCodeAndNavigate(accountID, validateCode, twoFactorAuthCode, preferredLocale = CONST.LOCALES.DEFAULT) {

--- a/src/libs/actions/Session/index.js
+++ b/src/libs/actions/Session/index.js
@@ -393,7 +393,7 @@ function signIn(password, validateCode, twoFactorAuthCode, preferredLocale = CON
     API.write('SigninUser', params, {optimisticData, successData, failureData});
 }
 
-function signInWithValidateCode(accountID, code, twoFactorAuthCode, preferredLocale = CONST.LOCALES.DEFAULT) {
+function signInWithValidateCode(accountID, code, preferredLocale = CONST.LOCALES.DEFAULT, twoFactorAuthCode = '') {
     // If this is called from the 2fa step, get the validateCode directly from onyx
     // instead of the one passed from the component state because the state is changing when this method is called.
     const validateCode = twoFactorAuthCode ? credentials.validateCode : code;
@@ -455,22 +455,21 @@ function signInWithValidateCode(accountID, code, twoFactorAuthCode, preferredLoc
         },
     ];
 
-    const params = {
-        accountID,
-        validateCode,
-        preferredLocale,
-        deviceInfo: getDeviceInfoForLogin(),
-    };
-
-    // Pass twoFactorAuthCode to server only if it has a valid value, otherwise php might convert it to "null" as a string.
-    if (twoFactorAuthCode) {
-        params.twoFactorAuthCode = twoFactorAuthCode;
-    }
-    API.write('SigninUserWithLink', params, {optimisticData, successData, failureData});
+    API.write(
+        'SigninUserWithLink',
+        {
+            accountID,
+            validateCode,
+            twoFactorAuthCode,
+            preferredLocale,
+            deviceInfo: getDeviceInfoForLogin(),
+        },
+        {optimisticData, successData, failureData},
+    );
 }
 
-function signInWithValidateCodeAndNavigate(accountID, validateCode, twoFactorAuthCode, preferredLocale = CONST.LOCALES.DEFAULT) {
-    signInWithValidateCode(accountID, validateCode, twoFactorAuthCode, preferredLocale);
+function signInWithValidateCodeAndNavigate(accountID, validateCode, preferredLocale = CONST.LOCALES.DEFAULT, twoFactorAuthCode = '') {
+    signInWithValidateCode(accountID, validateCode, preferredLocale, twoFactorAuthCode);
     Navigation.navigate(ROUTES.HOME);
 }
 

--- a/src/libs/actions/Session/index.js
+++ b/src/libs/actions/Session/index.js
@@ -458,7 +458,6 @@ function signInWithValidateCode(accountID, code, twoFactorAuthCode, preferredLoc
     const params = {
         accountID,
         validateCode,
-        twoFactorAuthCode,
         preferredLocale,
         deviceInfo: getDeviceInfoForLogin(),
     };

--- a/src/pages/ValidateLoginPage/index.js
+++ b/src/pages/ValidateLoginPage/index.js
@@ -49,7 +49,7 @@ class ValidateLoginPage extends Component {
                 // because we don't want to block the user with the interstitial page.
                 Navigation.goBack(false);
             } else {
-                Session.signInWithValidateCodeAndNavigate(accountID, validateCode, null, this.props.preferredLocale);
+                Session.signInWithValidateCodeAndNavigate(accountID, validateCode, this.props.preferredLocale);
             }
         } else {
             User.validateLogin(accountID, validateCode);

--- a/src/pages/ValidateLoginPage/index.website.js
+++ b/src/pages/ValidateLoginPage/index.website.js
@@ -83,7 +83,7 @@ class ValidateLoginPage extends Component {
         }
 
         // The user has initiated the sign in process on the same browser, in another tab.
-        Session.signInWithValidateCode(this.getAccountID(), this.getValidateCode(), null, this.props.preferredLocale);
+        Session.signInWithValidateCode(this.getAccountID(), this.getValidateCode(), this.props.preferredLocale);
     }
 
     componentDidUpdate() {

--- a/src/pages/signin/ValidateCodeForm/BaseValidateCodeForm.js
+++ b/src/pages/signin/ValidateCodeForm/BaseValidateCodeForm.js
@@ -184,7 +184,7 @@ class BaseValidateCodeForm extends React.Component {
 
         const accountID = lodashGet(this.props, 'credentials.accountID');
         if (accountID) {
-            Session.signInWithValidateCode(accountID, this.state.validateCode, this.state.twoFactorAuthCode, this.props.preferredLocale);
+            Session.signInWithValidateCode(accountID, this.state.validateCode, this.props.preferredLocale, this.state.twoFactorAuthCode);
         } else {
             Session.signIn('', this.state.validateCode, this.state.twoFactorAuthCode, this.props.preferredLocale);
         }


### PR DESCRIPTION

### Details
Fixes the automatic authentication with magic links on accounts with 2fa enabled.

### Fixed Issues
$ https://github.com/Expensify/App/issues/19636


### Tests
Note: Automatic authentication with the magic link is disabled for the desktop App.
1. Have an account with 2fa enabled
2. Start sign-in
3. Tap on the link in the email that you automatically received
4. Verify that the magic code is automatically validated in the App and you now have to enter the 2fa code
5. Enter the 2fa code
6. Verify that you are now signed in

- [ ] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
Same as Tests

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://github.com/Expensify/App/assets/18078393/f47cce94-1d74-4575-b9e8-ef48cf5b0f0c


</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://github.com/Expensify/App/assets/18078393/ba51fec8-0d62-4896-9775-d2b5133c155c


</details>

<details>
<summary>Mobile Web - Safari</summary>

https://github.com/Expensify/App/assets/18078393/88489a90-629b-4db1-8633-03d7ca28a43f


</details>

<details>
<summary>Desktop</summary>
N/A
</details>

<details>
<summary>iOS</summary>

https://github.com/Expensify/App/assets/18078393/fb601ff8-1d70-4586-88fa-09f3dc1ab0fc


</details>

<details>
<summary>Android</summary>

https://github.com/Expensify/App/assets/18078393/31417d00-cf70-4cbf-afbf-b819c3f64b66


</details>
