### PR TITLE
Fix: Attachment Carousel not displaying images from Concierge

### DIFF
--- a/src/components/AttachmentCarousel/index.js
+++ b/src/components/AttachmentCarousel/index.js
@@ -71,21 +71,6 @@ class AttachmentCarousel extends React.Component {
     }
 
     /**
-     * Helps to navigate between next/previous attachments
-     * @param {Object} attachmentItem
-     * @returns {Object}
-     */
-    getAttachment(attachmentItem) {
-        const source = _.get(attachmentItem, 'source', '');
-        const file = _.get(attachmentItem, 'file', {name: ''});
-
-        return {
-            source,
-            file,
-        };
-    }
-
-    /**
      * Calculate items layout information to optimize scrolling performance
      * @param {*} data
      * @param {Number} index
@@ -221,7 +206,7 @@ class AttachmentCarousel extends React.Component {
 
     /**
      * Updates the page state when the user navigates between attachments
-     * @param {Array<{item: *, index: Number}>} viewableItems
+     * @param {Array<{item: {source, file}, index: Number}>} viewableItems
      */
     updatePage({viewableItems}) {
         // Since we can have only one item in view at a time, we can use the first item in the array
@@ -232,8 +217,7 @@ class AttachmentCarousel extends React.Component {
         }
 
         const page = entry.index;
-        const {source, file} = this.getAttachment(entry.item);
-        this.props.onNavigate({source: addEncryptedAuthTokenToURL(source), file});
+        this.props.onNavigate({source: addEncryptedAuthTokenToURL(entry.item.source), file: entry.item.file});
         this.setState({page, isZoomed: false});
     }
 

--- a/src/components/AttachmentCarousel/index.js
+++ b/src/components/AttachmentCarousel/index.js
@@ -189,6 +189,9 @@ class AttachmentCarousel extends React.Component {
         htmlParser.end();
 
         const page = _.findIndex(attachments, (a) => a.source === this.props.source);
+        if (page === -1) {
+            throw new Error('Attachment not found');
+        }
 
         return {
             page,

--- a/src/components/AttachmentCarousel/index.js
+++ b/src/components/AttachmentCarousel/index.js
@@ -11,7 +11,6 @@ import CarouselActions from './CarouselActions';
 import Button from '../Button';
 import * as ReportActionsUtils from '../../libs/ReportActionsUtils';
 import AttachmentView from '../AttachmentView';
-import addEncryptedAuthTokenToURL from '../../libs/addEncryptedAuthTokenToURL';
 import * as DeviceCapabilities from '../../libs/DeviceCapabilities';
 import CONST from '../../CONST';
 import ONYXKEYS from '../../ONYXKEYS';
@@ -217,7 +216,7 @@ class AttachmentCarousel extends React.Component {
         }
 
         const page = entry.index;
-        this.props.onNavigate({source: addEncryptedAuthTokenToURL(entry.item.source), file: entry.item.file});
+        this.props.onNavigate(entry.item);
         this.setState({page, isZoomed: false});
     }
 

--- a/src/components/ImageView/index.js
+++ b/src/components/ImageView/index.js
@@ -282,6 +282,7 @@ class ImageView extends PureComponent {
                 >
                     <Image
                         source={{uri: this.props.url}}
+                        isAuthTokenRequired={this.props.isAuthTokenRequired}
                         style={[styles.h100, styles.w100]}
                         resizeMode={Image.resizeMode.contain}
                         onLoadStart={this.imageLoadingStart}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

This Pull Request introduces a series of changes to improve the handling and downloading of attachments in our application. The main changes focus on the `AttachmentCarousel` and `AttachmentModal` components.

Here are the main changes:

1. Expanded compatibility of `AttachmentCarousel` with images originating from various sources, not only Expensify-related ones. This was done by updating the component's attachment parsing and state creation logic. This change fixes the issue where some attachments (for instance, Concierge ones) were not appearing in the carousel.

2. Updated error handling in the `AttachmentCarousel` component. If a user tries to open an image that cannot be mapped to available content, the application now shows an error page instead of a different image. This change enhances user experience by clearly indicating when there's a problem opening an image.

3. Refactored the `AttachmentModal` to manage the state of the `source` and `isAuthTokenRequired` attributes of the attachment, ensuring that they're in sync with the attachment displayed in the carousel. 

4. Modified the `AttachmentModal` to decide whether to append auth-related parameters to an attachment source during download, based on the `isAuthTokenRequired` flag.

5. Removed the responsibility of appending auth parameters from the `AttachmentCarousel` component. This change makes the component more reusable and focused on its core functionality.

Overall, these changes should provide a more reliable and consistent attachment downloading experience, and avoid scattering logic across components.

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/18150
PROPOSAL: https://github.com/Expensify/App/issues/18150#issuecomment-1561671991

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

#### Test 1: Verify Existing Functionality is Unaltered
Objective: To ensure that the implemented changes haven't affected the existing functionality.

1. Navigate to a chat with multiple attachments.
2. Open different types of attachments (e.g., images, documents), and verify that they are correctly displayed in the carousel.
3. Download a variety of attachments and check that the downloading functionality remains intact.

Expected Outcomes:
- Each attachment should open and display correctly when selected from the chat.
- Navigation between attachments in the carousel should be smooth, with attachments appearing in the correct order.
- All downloads should proceed as before, with no new issues introduced.

Note: This PR does not address existing known issues such as the carousel occasionally displaying the wrong image (as detailed in https://github.com/Expensify/App/issues/18150#issuecomment-1561111689).

#### Test 2: Concierge Attachments
Objective: To verify that attachments originating from Concierge are correctly identified and displayed.

1. Navigate to a chat with Concierge.
2. Request sample attachments for testing. Ask for multiple images in a single message, another message with a single image, and a third message with multiple attachments.
    <details>
      <summary>Sample message from Concierge feature an attachments</summary>

      ```html
      Lorem ipsum<br />
      <br />
      More lorem<br />
      <br />
      This lorem is only more lorem<br />
      <br />
      Lorem ipsum attachment sit<br />
      <br />
      <img src="https://s3-us-west-1.amazonaws.com/concierge-responses-expensify-com/uploads%2sample.png" 
         style="width:300px;" class="fr-fic fr-dib" alt="uploads%2sample-sample.png" /><br />
     <img src="https://s3-us-west-1.amazonaws.com/concierge-responses-expensify-com/uploads%2sample2.png" 
         style="width:300px;" class="fr-fic fr-dib" alt="uploads%2sample-sample2.png" />
      ```
    </details>

Expected Outcomes:
- All Concierge attachments should open and display correctly.
- When navigating between attachments, they should appear in the correct order in the Attachment Carousel.
- All attachments should be downloadable. Note that due to CORS, locally these might open in a new window. 

#### Test 3: Error Handling When Carousel Fails to Locate Selected Attachment Source
Objective: To verify that when the Carousel fails to initialize correctly, it handles the error in a predictable manner, displaying an error page instead of an incorrect image.

This test involves programmatically forcing incorrect data into the attachment carousel.

1. Open `ImageRenderer` and set an arbitrary string as the modal source (see https://github.com/Expensify/App/blob/2a786a71bc37004824a1012c1fd2fe4225ebf68b/src/components/HTMLEngineProvider/HTMLRenderers/ImageRenderer.js#L57).
2. Navigate to a chat and open an attachment.

Expected Outcomes:
- If the carousel is unable to present the attachment, the "Uh-oh, something went wrong!" error boundary page should be displayed.

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

The offline functionality should be unaffected by the changes introduced in this PR. 

1. Attachments that were opened recently while being online should still load when offline.
2. Attachments that haven't been opened while online, or those that were opened more than 2 hours ago, are expected to fail to load when offline.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
4. Upload an image via copy paste
5. Verify a modal appears displaying a preview of that image
--->

These steps are applicable to all platforms and both the staging and the production environments

#### Test 1: Verify Existing Functionality is Unaltered
Objective: To ensure that the implemented changes haven't affected the existing functionality.

1. Navigate to a chat with multiple attachments.
2. Open different types of attachments (e.g., images, documents), and verify that they are correctly displayed in the carousel.
3. Download a variety of attachments and check that the downloading functionality remains intact.

Expected Outcomes:
- Each attachment should open and display correctly when selected from the chat.
- Navigation between attachments in the carousel should be smooth, with attachments appearing in the correct order.
- All downloads should proceed as before, with no new issues introduced.

Note: This PR does not address existing known issues such as the carousel occasionally displaying the wrong image (as detailed in https://github.com/Expensify/App/issues/18150#issuecomment-1561111689).

#### Test 2: Concierge Attachments
Objective: To verify that attachments originating from Concierge are correctly identified and displayed.

1. Navigate to a chat with Concierge.
2. Request sample attachments for testing. Ask for multiple images in a single message, another message with a single image, and a third message with multiple attachments.

Expected Outcomes:
- All Concierge attachments should open and display correctly.
- When navigating between attachments, they should appear in the correct order in the Attachment Carousel.
- All attachments should be downloadable. Note that due to CORS, locally these might open in a new window. 

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/12156624/6a843663-5b2b-4dff-819f-1c50e5f20e1a

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->
https://github.com/Expensify/App/assets/12156624/fefd42c7-2dec-4d7f-b6a2-4057e136ebb8


</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->
https://github.com/Expensify/App/assets/12156624/42624894-a783-4a46-8c52-1ee811ba4f06

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->
https://github.com/Expensify/App/assets/12156624/fe4dde78-cb08-4445-ae68-1ca03b323652

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->
<img width="511" alt="Screenshot 2023-05-28 at 16 14 43" src="https://github.com/Expensify/App/assets/12156624/6eb6e856-6f0a-41ad-b53d-039e54efcb68">

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->
![image](https://github.com/Expensify/App/assets/12156624/58cccbb9-d523-4674-83e9-7b6fbec02a82)

</details>
