### PR TITLE
Migrate emoji skin tone list

### DIFF
--- a/src/components/EmojiPicker/EmojiSkinToneList.js
+++ b/src/components/EmojiPicker/EmojiSkinToneList.js
@@ -58,7 +58,7 @@ function EmojiSkinToneList(props) {
                         <EmojiPickerMenuItem
                             onPress={() => updateSelectedSkinTone(skinToneEmoji)}
                             onHoverIn={() => setHighlightedIndex(skinToneEmoji.skinTone)}
-                            onHoverOut={() => setHighlightedIndex(currentSkinTone.skinTone)}
+                            onHoverOut={() => setHighlightedIndex(null)}
                             key={skinToneEmoji.code}
                             emoji={skinToneEmoji.code}
                             isHighlighted={skinToneEmoji.skinTone === highlightedIndex || skinToneEmoji.skinTone === currentSkinTone.skinTone}

--- a/src/components/EmojiPicker/EmojiSkinToneList.js
+++ b/src/components/EmojiPicker/EmojiSkinToneList.js
@@ -21,7 +21,7 @@ const propTypes = {
 };
 
 function EmojiSkinToneList(props) {
-    const [highlightedIndex, setHighlightedIndex] = useState(-1);
+    const [highlightedIndex, setHighlightedIndex] = useState(null);
     const [isSkinToneListVisible, setIsSkinToneListVisible] = useState(false);
 
     const toggleIsSkinToneListVisible = useCallback(() => {

--- a/src/components/EmojiPicker/EmojiSkinToneList.js
+++ b/src/components/EmojiPicker/EmojiSkinToneList.js
@@ -71,5 +71,6 @@ function EmojiSkinToneList(props) {
 }
 
 EmojiSkinToneList.propTypes = propTypes;
+EmojiSkinToneList.displayName = 'EmojiSkinToneList';
 
 export default withLocalize(EmojiSkinToneList);

--- a/src/components/EmojiPicker/EmojiSkinToneList.js
+++ b/src/components/EmojiPicker/EmojiSkinToneList.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import React, {Component} from 'react';
+import React, {useState, useCallback} from 'react';
 import {View, Pressable} from 'react-native';
 import PropTypes from 'prop-types';
 import styles from '../../styles/styles';
@@ -20,75 +20,54 @@ const propTypes = {
     ...withLocalizePropTypes,
 };
 
-class EmojiSkinToneList extends Component {
-    constructor(props) {
-        super(props);
+function EmojiSkinToneList(props) {
+    const [highlightedIndex, setHighlightedIndex] = useState(-1);
+    const [isSkinToneListVisible, setIsSkinToneListVisible] = useState(false);
 
-        this.updateSelectedSkinTone = this.updateSelectedSkinTone.bind(this);
-
-        this.state = {
-            highlightedIndex: -1,
-            isSkinToneListVisible: false,
-        };
-    }
-
-    componentDidMount() {
-        // Get the selected skinToneEmoji based on the index
-        const selectedEmoji = getSkinToneEmojiFromIndex(this.props.preferredSkinTone);
-        this.setState({highlightedIndex: selectedEmoji.skinTone});
-    }
-
-    componentDidUpdate(prevProps) {
-        // Update the highlighted skin tone only if the selected one changes
-        if (prevProps.preferredSkinTone === this.props.preferredSkinTone) {
-            return;
-        }
-
-        const selectedEmoji = getSkinToneEmojiFromIndex(this.props.preferredSkinTone);
-        this.setState({highlightedIndex: selectedEmoji.skinTone});
-    }
+    const toggleIsSkinToneListVisible = useCallback(() => {
+        setIsSkinToneListVisible((prev) => !prev);
+    }, []);
 
     /**
      * Pass the skinTone to props and hide the picker
      * @param {object} skinToneEmoji
      */
-    updateSelectedSkinTone(skinToneEmoji) {
-        this.setState((prev) => ({isSkinToneListVisible: !prev.isSkinToneListVisible, highlightedIndex: skinToneEmoji.skinTone}));
-        this.props.updatePreferredSkinTone(skinToneEmoji.skinTone);
+    function updateSelectedSkinTone(skinToneEmoji) {
+        toggleIsSkinToneListVisible();
+        setHighlightedIndex(skinToneEmoji.skinTone);
+        props.updatePreferredSkinTone(skinToneEmoji.skinTone);
     }
 
-    render() {
-        const selectedEmoji = getSkinToneEmojiFromIndex(this.props.preferredSkinTone);
-        return (
-            <View style={[styles.flexRow, styles.p3, styles.ph4, styles.emojiPickerContainer]}>
-                {!this.state.isSkinToneListVisible && (
-                    <Pressable
-                        onPress={() => this.setState((prev) => ({isSkinToneListVisible: !prev.isSkinToneListVisible}))}
-                        style={[styles.flex1, styles.flexRow, styles.alignSelfCenter, styles.justifyContentStart, styles.alignItemsCenter]}
-                    >
-                        <View style={[styles.emojiItem, styles.justifyContentCenter]}>
-                            <Text style={[styles.emojiText, styles.ph2, styles.textNoWrap]}>{selectedEmoji.code}</Text>
-                        </View>
-                        <Text style={[styles.emojiSkinToneTitle]}>{this.props.translate('emojiPicker.skinTonePickerLabel')}</Text>
-                    </Pressable>
-                )}
-                {this.state.isSkinToneListVisible && (
-                    <View style={[styles.flexRow, styles.flex1]}>
-                        {_.map(Emojis.skinTones, (skinToneEmoji) => (
-                            <EmojiPickerMenuItem
-                                onPress={() => this.updateSelectedSkinTone(skinToneEmoji)}
-                                onHoverIn={() => this.setState({highlightedIndex: skinToneEmoji.skinTone})}
-                                onHoverOut={() => this.setState({highlightedIndex: selectedEmoji.skinTone})}
-                                key={skinToneEmoji.code}
-                                emoji={skinToneEmoji.code}
-                                isHighlighted={skinToneEmoji.skinTone === this.state.highlightedIndex || skinToneEmoji.skinTone === selectedEmoji.skinTone}
-                            />
-                        ))}
+    const currentSkinTone = getSkinToneEmojiFromIndex(props.preferredSkinTone);
+    return (
+        <View style={[styles.flexRow, styles.p3, styles.ph4, styles.emojiPickerContainer]}>
+            {!isSkinToneListVisible && (
+                <Pressable
+                    onPress={toggleIsSkinToneListVisible}
+                    style={[styles.flex1, styles.flexRow, styles.alignSelfCenter, styles.justifyContentStart, styles.alignItemsCenter]}
+                >
+                    <View style={[styles.emojiItem, styles.justifyContentCenter]}>
+                        <Text style={[styles.emojiText, styles.ph2, styles.textNoWrap]}>{currentSkinTone.code}</Text>
                     </View>
-                )}
-            </View>
-        );
-    }
+                    <Text style={[styles.emojiSkinToneTitle]}>{props.translate('emojiPicker.skinTonePickerLabel')}</Text>
+                </Pressable>
+            )}
+            {isSkinToneListVisible && (
+                <View style={[styles.flexRow, styles.flex1]}>
+                    {_.map(Emojis.skinTones, (skinToneEmoji) => (
+                        <EmojiPickerMenuItem
+                            onPress={() => updateSelectedSkinTone(skinToneEmoji)}
+                            onHoverIn={() => setHighlightedIndex(skinToneEmoji.skinTone)}
+                            onHoverOut={() => setHighlightedIndex(currentSkinTone.skinTone)}
+                            key={skinToneEmoji.code}
+                            emoji={skinToneEmoji.code}
+                            isHighlighted={skinToneEmoji.skinTone === highlightedIndex || skinToneEmoji.skinTone === currentSkinTone.skinTone}
+                        />
+                    ))}
+                </View>
+            )}
+        </View>
+    );
 }
 
 EmojiSkinToneList.propTypes = propTypes;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/16147


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Click the Emoji button
2. Change the skin tone
3. Observe that the skin tone inside the emoji picker got updated
4. Select one of the emojis
5. Verify that the composer has emoji with correct skin tone
6. Repeat steps 2-5 for different skin tone
7. Send the message and verify that it the emojis have correct skin tones

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
8. Upload an image via copy paste
9. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/3111202/9b4eaf57-d421-43cf-b20e-c64f33cae902


</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/3111202/21016315-80e8-4b79-8605-0727f816cd21


</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/3111202/9f0e9d01-c37d-423d-8f8d-18e65b837da9


</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/3111202/a7d3442d-f462-493c-b724-89998534d897



</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/3111202/da0d28a4-94d4-44b4-813e-fa3c2674c56e


</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/3111202/6acce743-daff-4a82-a6c2-fff61ef51794


</details>
