### PR TITLE
Allow Hoverable to accept single element array of children and improve tooltip overlapping check

### DIFF
--- a/src/components/Hoverable/index.js
+++ b/src/components/Hoverable/index.js
@@ -71,10 +71,8 @@ class Hoverable extends Component {
         let child = this.props.children;
         if (_.isFunction(this.props.children)) {
             child = this.props.children(this.state.isHovered);
-        } else {
-            if (_.isArray(this.props.children) && this.props.children.length === 1) {
-                child = this.props.children[0];
-            }
+        } else if (_.isArray(this.props.children) && this.props.children.length === 1) {
+            child = this.props.children[0];
         }
 
         return React.cloneElement(React.Children.only(child), {

--- a/src/components/Hoverable/index.js
+++ b/src/components/Hoverable/index.js
@@ -68,10 +68,13 @@ class Hoverable extends Component {
     }
 
     render() {
-        const child = _.isFunction(this.props.children) ? this.props.children(this.state.isHovered) : this.props.children;
-
-        if (!React.isValidElement(child)) {
-            throw Error('Children is not a valid element.');
+        let child = this.props.children;
+        if (_.isFunction(this.props.children)) {
+            child = this.props.children(this.state.isHovered);
+        } else {
+            if (_.isArray(this.props.children) && this.props.children.length === 1) {
+                child = this.props.children[0];
+            }
         }
 
         return React.cloneElement(React.Children.only(child), {

--- a/src/components/Hoverable/index.js
+++ b/src/components/Hoverable/index.js
@@ -69,10 +69,12 @@ class Hoverable extends Component {
 
     render() {
         let child = this.props.children;
-        if (_.isFunction(this.props.children)) {
-            child = this.props.children(this.state.isHovered);
-        } else if (_.isArray(this.props.children) && this.props.children.length === 1) {
+        if (_.isArray(this.props.children) && this.props.children.length === 1) {
             child = this.props.children[0];
+        }
+
+        if (_.isFunction(child)) {
+            child = child(this.state.isHovered);
         }
 
         return React.cloneElement(React.Children.only(child), {

--- a/src/components/MultipleAvatars.js
+++ b/src/components/MultipleAvatars.js
@@ -115,7 +115,6 @@ const MultipleAvatars = (props) => {
                         <Tooltip
                             key={`stackedAvatars-${index}`}
                             text={tooltipTexts[index]}
-                            absolute
                         >
                             <View
                                 style={[
@@ -145,7 +144,6 @@ const MultipleAvatars = (props) => {
                         <Tooltip
                             // We only want to cap tooltips to only the first 10 users or so since some reports have hundreds of users, causing performance to degrade.
                             text={tooltipTexts.slice(3, 10).join(', ')}
-                            absolute
                         >
                             <View
                                 style={[

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -116,10 +116,6 @@ class Tooltip extends PureComponent {
             return this.props.children;
         }
 
-        if (!React.isValidElement(this.props.children)) {
-            throw Error('Children is not a valid element.');
-        }
-
         return (
             <>
                 {this.state.isRendered && (
@@ -149,7 +145,7 @@ class Tooltip extends PureComponent {
                         onHoverIn={this.showTooltip}
                         onHoverOut={this.hideTooltip}
                     >
-                        {React.Children.only(this.props.children)}
+                        {this.props.children}
                     </Hoverable>
                 </BoundsObserver>
             </>

--- a/src/styles/getTooltipStyles.js
+++ b/src/styles/getTooltipStyles.js
@@ -67,7 +67,7 @@ function isOverlappingAtTop(xOffset, yOffset, tooltip, tooltipTargetWidth, toolt
     }
 
     // Use the vertical position of the target to prevent wrong element returned by elementFromPoint
-    // in case the target has a border radius or is a text.
+    // in case the target has a border radius or is a multiline text.
     const targetCenterX = xOffset + tooltipTargetWidth / 2;
     const targetCenterY = yOffset + tooltipTargetHeight / 2;
     const elementAtTargetCenterX = document.elementFromPoint(targetCenterX, yOffset);

--- a/src/styles/getTooltipStyles.js
+++ b/src/styles/getTooltipStyles.js
@@ -50,8 +50,17 @@ function computeHorizontalShift(windowWidth, xOffset, componentWidth, tooltipWid
 }
 
 /**
- * Determines if there is an overlapping element at the top of a given coordinate.
- *
+ * Determines if there is an overlapping element at the top of both given coordinates.
+ *                    (targetCenterX, y)
+ *                            |
+ *                            v
+ *                        _ _ _ _ _
+ *                       |         |
+ *                       |         |
+ * (x, targetCenterY) -> |         |
+ *                       |         |
+ *                       |_ _ _ _ _|
+ * 
  * @param {Number} xOffset - The distance between the left edge of the window
  *                           and the left edge of the wrapped component.
  * @param {Number} yOffset - The distance between the top edge of the window
@@ -66,8 +75,8 @@ function isOverlappingAtTop(xOffset, yOffset, tooltip, tooltipTargetWidth, toolt
         return false;
     }
 
-    // Use the vertical position of the target to prevent wrong element returned by elementFromPoint
-    // in case the target has a border radius or is a multiline text.
+    // Use the x and y center position of the target to prevent wrong element
+    // returned by elementFromPoint in case the target has a border radius or is a multiline text.
     const targetCenterX = xOffset + tooltipTargetWidth / 2;
     const targetCenterY = yOffset + tooltipTargetHeight / 2;
     const elementAtTargetCenterX = document.elementFromPoint(targetCenterX, yOffset);

--- a/src/styles/getTooltipStyles.js
+++ b/src/styles/getTooltipStyles.js
@@ -60,7 +60,7 @@ function computeHorizontalShift(windowWidth, xOffset, componentWidth, tooltipWid
  * (x, targetCenterY) -> |         |
  *                       |         |
  *                       |_ _ _ _ _|
- * 
+ *
  * @param {Number} xOffset - The distance between the left edge of the window
  *                           and the left edge of the wrapped component.
  * @param {Number} yOffset - The distance between the top edge of the window

--- a/src/styles/getTooltipStyles.js
+++ b/src/styles/getTooltipStyles.js
@@ -75,7 +75,7 @@ function isOverlappingAtTop(xOffset, yOffset, tooltip, tooltipTargetWidth, toolt
     const tooltipRef = (tooltip && tooltip.current) || tooltip;
 
     // Ensure it's not the already rendered element of this very tooltip, so the tooltip doesn't try to "avoid" itself
-    if (!elementAtTargetCenterX || !elementAtTargetCenterY || (tooltipRef && tooltipRef.contains(elementAtTargetCenterX)) || tooltipRef.contains(elementAtTargetCenterY)) {
+    if (!elementAtTargetCenterX || !elementAtTargetCenterY || (tooltipRef && (tooltipRef.contains(elementAtTargetCenterX) || tooltipRef.contains(elementAtTargetCenterY)))) {
         return false;
     }
 

--- a/src/styles/getTooltipStyles.js
+++ b/src/styles/getTooltipStyles.js
@@ -57,29 +57,38 @@ function computeHorizontalShift(windowWidth, xOffset, componentWidth, tooltipWid
  * @param {Number} yOffset - The distance between the top edge of the window
  *                           and the top edge of the wrapped component.
  * @param {Element} [tooltip] - The reference to the tooltip's root element
+ * @param {Number} tooltipTargetWidth - The width of the tooltip's target
  * @param {Number} tooltipTargetHeight - The height of the tooltip's target
  * @returns {Boolean}
  */
-function isOverlappingAtTop(xOffset, yOffset, tooltip, tooltipTargetHeight) {
+function isOverlappingAtTop(xOffset, yOffset, tooltip, tooltipTargetWidth, tooltipTargetHeight) {
     if (typeof document.elementFromPoint !== 'function') {
         return false;
     }
 
-    // Use the vertical center of the target to prevent wrong element returned by elementFromPoint in case the target has a border radius.
-    const centerY = yOffset + tooltipTargetHeight / 2;
-    const element = document.elementFromPoint(xOffset, centerY);
+    // Use the vertical position of the target to prevent wrong element returned by elementFromPoint
+    // in case the target has a border radius or is a text.
+    const targetCenterX = xOffset + tooltipTargetWidth / 2;
+    const targetCenterY = yOffset + tooltipTargetHeight / 2;
+    const elementAtTargetCenterX = document.elementFromPoint(targetCenterX, yOffset);
+    const elementAtTargetCenterY = document.elementFromPoint(xOffset, targetCenterY);
     const tooltipRef = (tooltip && tooltip.current) || tooltip;
 
     // Ensure it's not the already rendered element of this very tooltip, so the tooltip doesn't try to "avoid" itself
-    if (!element || (tooltipRef && tooltipRef.contains(element))) {
+    if (!elementAtTargetCenterX || !elementAtTargetCenterY || (tooltipRef && tooltipRef.contains(elementAtTargetCenterX)) || tooltipRef.contains(elementAtTargetCenterY)) {
         return false;
     }
 
-    const rect = element.getBoundingClientRect();
+    const rectAtTargetCenterX = elementAtTargetCenterX.getBoundingClientRect();
+    const rectAtTargetCenterY = elementAtTargetCenterY.getBoundingClientRect();
 
     // Ensure it's not overlapping with another element by checking if the yOffset is greater than the top of the element
     // and less than the bottom of the element
-    return yOffset > rect.top && yOffset < rect.bottom;
+    const isOverlappingAtTargetCenterX = yOffset > rectAtTargetCenterX.top && yOffset < rectAtTargetCenterX.bottom;
+    const isOverlappingAtTargetCenterY = yOffset > rectAtTargetCenterY.top && yOffset < rectAtTargetCenterY.bottom;
+
+    // Return true only if both elementAtTargetCenterX and elementAtTargetCenterY overlap with another element
+    return isOverlappingAtTargetCenterX && isOverlappingAtTargetCenterY;
 }
 
 /**
@@ -144,7 +153,7 @@ export default function getTooltipStyles(
         // If either a tooltip will try to render within GUTTER_WIDTH logical pixels of the top of the screen,
         // Or the wrapped component is overlapping at top-left with another element
         // we'll display it beneath its wrapped component rather than above it as usual.
-        shouldShowBelow = yOffset - tooltipHeight < GUTTER_WIDTH || isOverlappingAtTop(xOffset, yOffset, tooltip, tooltipTargetHeight);
+        shouldShowBelow = yOffset - tooltipHeight < GUTTER_WIDTH || isOverlappingAtTop(xOffset, yOffset, tooltip, tooltipTargetWidth, tooltipTargetHeight);
 
         // When the tooltip size is ready, we can start animating the scale.
         scale = currentSize;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This is a fix to a regression of https://github.com/Expensify/App/issues/19830 and https://github.com/Expensify/App/issues/15796#issuecomment-1565291043

https://github.com/Expensify/App/issues/19830: Crash when delete a workspace while offline
https://github.com/Expensify/App/issues/15796#issuecomment-1565291043: Tooltip shows below multiline link message

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/19830
$ https://github.com/Expensify/App/issues/15796
PROPOSAL: GH_LINK_ISSUE(COMMENT)


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Same as QA Steps
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
Same as QA Steps
### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

**Tooltip shows below multiline link message (Web/Desktop)**
1. Send a multiline link message, for example:
```
[a
b](google.com)
```
2. Hover over the link
3. Verify a tooltip shows and it is shown above the link

**Crash when delete a workspace while offline**
Precondition: have a workspace
1. Turn off internet connection
2. Delete any workspace
3. Verify the app does not crash

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

Tooltip shows below multiline link message

https://github.com/Expensify/App/assets/50919443/81cc9dec-6c1d-4a47-b48e-9071e63a0eee


Crash when delete a workspace while offline

https://github.com/Expensify/App/assets/50919443/6885ae24-d8af-43ce-a023-661e2d0ee35d


</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/50919443/d700b757-ba32-4930-98e1-bd31856de19d


</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/50919443/c3d89cf2-120b-42ea-aa27-2abecac6ef01


</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/50919443/deba0d53-bf63-4146-8fd3-62bbae88c7c1


https://github.com/Expensify/App/assets/50919443/7da5927a-2bf5-40b6-b66d-ae97d42d4aae


</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/50919443/3aae9823-d7f7-4d41-bd5b-e0cc37e1347f


</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/50919443/edbee372-297d-4683-bd61-2bee1e94a463


</details>
