### PR TITLE
Fix: update padding of “no result found” error in message input

### DIFF
--- a/src/components/EmojiPicker/CategoryShortcutBar.js
+++ b/src/components/EmojiPicker/CategoryShortcutBar.js
@@ -20,7 +20,7 @@ const propTypes = {
 };
 
 const CategoryShortcutBar = (props) => (
-    <View style={[styles.pt2, styles.ph4, styles.flexRow]}>
+    <View style={[styles.ph4, styles.flexRow]}>
         {_.map(props.headerEmojis, (headerEmoji, i) => (
             <CategoryShortcutButton
                 icon={headerEmoji.icon}

--- a/src/components/EmojiPicker/EmojiPickerMenu/index.js
+++ b/src/components/EmojiPicker/EmojiPickerMenu/index.js
@@ -483,7 +483,7 @@ class EmojiPickerMenu extends Component {
                 pointerEvents={this.state.arePointerEventsDisabled ? 'none' : 'auto'}
             >
                 {!this.props.isSmallScreenWidth && (
-                    <View style={[styles.ph4, styles.pb2, styles.pt2]}>
+                    <View style={[styles.ph4, styles.pb3, styles.pt2]}>
                         <TextInput
                             label={this.props.translate('common.search')}
                             onChangeText={this.filterEmojis}

--- a/src/pages/workspace/WorkspaceMembersPage.js
+++ b/src/pages/workspace/WorkspaceMembersPage.js
@@ -453,7 +453,7 @@ class WorkspaceMembersPage extends React.Component {
                                     onPress={this.askForConfirmationToRemove}
                                 />
                             </View>
-                            <View style={[styles.w100, styles.pv4, styles.ph5]}>
+                            <View style={[styles.w100, styles.pv3, styles.ph5]}>
                                 <TextInput
                                     value={this.state.searchValue}
                                     onChangeText={this.updateSearchValue}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
 
### Details
Padding above “no result found” error in message input “Emoji- Search bar” and Manage Member Page is not consistent. This PR fixes it

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/18909
PROPOSAL: https://github.com/Expensify/App/issues/18909#issuecomment-1550117421


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Open “Chats”
2. Click “Emoji”.
3. Search for an invalid Emoji, so that the “no result found” error appears.
4. Verify that the bottom padding of the input field is 12px
5. Go to Workspace --> Member 
6. Search for an invalid member
7. Verify that the bottom padding of the input field is 12px
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Open “Chats”
2. Click “Emoji”.
3. Search for an invalid Emoji, so that the “no result found” error appears.
4. Verify that the bottom padding of the input field is 12px
5. Go to Workspace --> Member 
6. Search for an invalid member
7. Verify that the bottom padding of the input field is 12px
- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>


<img width="865" alt="Screenshot 2023-06-01 at 10 05 47" src="https://github.com/Expensify/App/assets/129500732/b7151813-d6d4-4ad5-b025-c15a51ff12f4">

<img width="866" alt="Screenshot 2023-06-01 at 10 05 14" src="https://github.com/Expensify/App/assets/129500732/01af1760-494f-4c0e-a45e-67c0813a35e7">


</details>

<details>
<summary>Mobile Web - Chrome</summary>
<img width="307" alt="Screenshot 2023-06-01 at 10 06 49" src="https://github.com/Expensify/App/assets/129500732/f06535b0-2ed0-4591-b94d-c9121bd44b6b">

<img width="307" alt="Screenshot 2023-06-01 at 10 06 19" src="https://github.com/Expensify/App/assets/129500732/6001b123-dafb-4a6f-82fa-b5107b603075">


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>
<img width="318" alt="Screenshot 2023-06-01 at 10 07 09" src="https://github.com/Expensify/App/assets/129500732/d7b00b2a-adf3-42e5-9b2f-0fa938122040">
<img width="318" alt="Screenshot 2023-06-01 at 10 06 58" src="https://github.com/Expensify/App/assets/129500732/1d1b68f5-967c-48ae-9dc2-41296061bbb7">


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>


<img width="799" alt="Screenshot 2023-06-01 at 10 11 07" src="https://github.com/Expensify/App/assets/129500732/4b2cd08c-e3b2-4804-b23d-adf78c12d942">
<img width="805" alt="Screenshot 2023-06-01 at 10 11 33" src="https://github.com/Expensify/App/assets/129500732/32315dd9-cd0d-4ec7-90e9-9dac7a5ac136">


</details>

<details>
<summary>iOS</summary>

<img width="412" alt="Screenshot 2023-06-01 at 10 25 48" src="https://github.com/Expensify/App/assets/129500732/2adcbf1f-eae1-49b5-9ddd-19a4509420f8">
<img width="407" alt="Screenshot 2023-06-01 at 10 26 07" src="https://github.com/Expensify/App/assets/129500732/871db086-1fde-4831-9909-c3384aae83d3">


</details>

<details>
<summary>Android</summary>


<img width="357" alt="Screenshot 2023-06-01 at 10 38 51" src="https://github.com/Expensify/App/assets/129500732/a4828c68-5fbb-414f-83d4-8ee65593e9a8">
<img width="335" alt="Screenshot 2023-06-01 at 10 38 07" src="https://github.com/Expensify/App/assets/129500732/dccff94f-2f0e-486e-889e-ced63d031806">


</details>
