### PR TITLE
Replace deprecated ::set-output

### DIFF
--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           git pull origin main
           echo "New version is $(npm run print-version --silent)"
-          echo "::set-output name=NEW_VERSION::$(npm run print-version --silent)"
+          echo "name=NEW_VERSION::$(npm run print-version --silent)" >> $GITHUB_OUTPUT
 
   cherryPick:
     needs: [validateActor, createNewVersion]
@@ -128,13 +128,13 @@ jobs:
           echo "Attempting to cherry-pick ${{ steps.getCPMergeCommit.outputs.MERGE_COMMIT_SHA }}"
           if git cherry-pick -S -x --mainline 1 ${{ steps.getCPMergeCommit.outputs.MERGE_COMMIT_SHA }}; then
             echo "🎉 No conflicts! CP was a success, PR can be automerged 🎉"
-            echo "::set-output name=SHOULD_AUTOMERGE::true"
+            echo "name=SHOULD_AUTOMERGE::true" >> $GITHUB_OUTPUT
           else
             echo "😞 PR can't be automerged, there are merge conflicts in the following files:"
             git --no-pager diff --name-only --diff-filter=U
             git add .
             GIT_MERGE_AUTOEDIT=no git cherry-pick --continue
-            echo "::set-output name=SHOULD_AUTOMERGE::false"
+            echo "name=SHOULD_AUTOMERGE::false" >> $GITHUB_OUTPUT
           fi
 
       - name: Push changes to CP branch

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Check if merged pull request was an automatic version bump PR
         id: isAutomatedPullRequest
-        run: echo "::set-output name=IS_AUTOMERGE_PR::${{ steps.getMergedPullRequest.outputs.author == 'OSBotify' }}"
+        run: echo "name=IS_AUTOMERGE_PR::${{ steps.getMergedPullRequest.outputs.author == 'OSBotify' }}" >> $GITHUB_OUTPUT
 
   deployStaging:
     runs-on: ubuntu-latest

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -74,11 +74,11 @@ jobs:
 
       - name: Check if merged pull request was an automatic version bump PR
         id: isAutomatedPullRequest
-        run: echo "::set-output name=IS_VERSION_BUMP_PR::${{ github.actor == 'OSBotify' }}"
+        run: echo "name=IS_VERSION_BUMP_PR::${{ github.actor == 'OSBotify' }}" >> $GITHUB_OUTPUT
 
       - name: Check if merged pull request has `CP Staging` label
         id: shouldCherryPick
-        run: echo "::set-output name=SHOULD_CHERRY_PICK::${{ contains(steps.getMergedPullRequest.outputs.labels, 'CP Staging') }}"
+        run: echo "name=SHOULD_CHERRY_PICK::${{ contains(steps.getMergedPullRequest.outputs.labels, 'CP Staging') }}" >> $GITHUB_OUTPUT
 
   skipDeploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Replace deprecated GitHub Workflow Action commands, as per: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

### Fixed Issues
$ https://github.com/Expensify/App/issues/11877

### Tests

This PR will test itself through GH Workflow.

### Offline tests

N/A.

### QA Steps

No QA.