### PR TITLE
Migrate AddressPage to functional component

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -10,7 +10,6 @@ const USE_EXPENSIFY_URL = 'https://use.expensify.com';
 const PLATFORM_OS_MACOS = 'Mac OS';
 const PLATFORM_IOS = 'iOS';
 const ANDROID_PACKAGE_NAME = 'com.expensify.chat';
-const USA_COUNTRY_NAME = 'United States';
 const CURRENT_YEAR = new Date().getFullYear();
 const PULL_REQUEST_NUMBER = lodashGet(Config, 'PULL_REQUEST_NUMBER', '');
 
@@ -1299,7 +1298,6 @@ const CONST = {
     TFA_CODE_LENGTH: 6,
     CHAT_ATTACHMENT_TOKEN_KEY: 'X-Chat-Attachment-Token',
 
-    USA_COUNTRY_NAME,
     SPACE_LENGTH: 1,
     SPACE: 1,
 

--- a/src/pages/settings/Profile/PersonalDetails/AddressPage.js
+++ b/src/pages/settings/Profile/PersonalDetails/AddressPage.js
@@ -54,7 +54,7 @@ const defaultProps = {
 
 /**
  * @param {Function} translate - translate function
- * @param {Boolean} isUsaForm - selected country ISO code is US
+ * @param {Boolean} isUSAForm - selected country ISO code is US
  * @param {Object} values - form input values
  * @returns {Object} - An object containing the errors for each inputID
  */

--- a/src/pages/settings/Profile/PersonalDetails/AddressPage.js
+++ b/src/pages/settings/Profile/PersonalDetails/AddressPage.js
@@ -1,6 +1,6 @@
 import lodashGet from 'lodash/get';
 import _ from 'underscore';
-import React, {Component} from 'react';
+import React, {useState} from 'react';
 import PropTypes from 'prop-types';
 import {View} from 'react-native';
 import {CONST as COMMON_CONST} from 'expensify-common/lib/CONST';
@@ -52,175 +52,153 @@ const defaultProps = {
     },
 };
 
-class AddressPage extends Component {
-    constructor(props) {
-        super(props);
+/**
+ * @param {Function} translate - translate function
+ * @param {Boolean} isUsaForm - selected country ISO code is US
+ * @param {Object} values - form input values
+ * @returns {Object} - An object containing the errors for each inputID
+ */
+const validate = (translate, isUsaForm, values) => {
+    const errors = {};
 
-        this.validate = this.validate.bind(this);
-        this.updateAddress = this.updateAddress.bind(this);
-        this.onCountryUpdate = this.onCountryUpdate.bind(this);
+    const requiredFields = ['addressLine1', 'city', 'country', 'state'];
 
-        const currentCountry = lodashGet(this.props.privatePersonalDetails, 'address.country') || '';
-        const currentCountryISO = PersonalDetails.getCountryISO(currentCountry) || CONST.COUNTRY.US;
-        const zipSampleFormat = lodashGet(CONST.COUNTRY_ZIP_REGEX_DATA, [currentCountryISO, 'samples'], '');
-        this.state = {
-            isUsaForm: currentCountry === CONST.COUNTRY.US || currentCountry === CONST.USA_COUNTRY_NAME,
-            zipFormat: this.props.translate('common.zipCodeExampleFormat', {zipSampleFormat}),
-        };
+    // Check "State" dropdown is a valid state if selected Country is USA.
+    if (isUsaForm && !COMMON_CONST.STATES[values.state]) {
+        errors.state = translate('common.error.fieldRequired');
     }
 
-    /**
-     * @param {String} newCountry - new country selected in form
-     */
-    onCountryUpdate(newCountry) {
-        const zipSampleFormat = lodashGet(CONST.COUNTRY_ZIP_REGEX_DATA, `${newCountry}.samples`, '');
-        this.setState({
-            isUsaForm: newCountry === CONST.COUNTRY.US,
-            zipFormat: this.props.translate('common.zipCodeExampleFormat', {zipSampleFormat}),
-        });
-    }
-
-    /**
-     * Submit form to update user's first and last legal name
-     * @param {Object} values - form input values
-     */
-    updateAddress(values) {
-        PersonalDetails.updateAddress(values.addressLine1.trim(), values.addressLine2.trim(), values.city.trim(), values.state.trim(), values.zipPostCode.trim(), values.country);
-    }
-
-    /**
-     * @param {Object} values - form input values
-     * @returns {Object} - An object containing the errors for each inputID
-     */
-    validate(values) {
-        const errors = {};
-
-        const requiredFields = ['addressLine1', 'city', 'country', 'state'];
-
-        // Check "State" dropdown is a valid state if selected Country is USA.
-        if (this.state.isUsaForm && !COMMON_CONST.STATES[values.state]) {
-            errors.state = this.props.translate('common.error.fieldRequired');
+    // Add "Field required" errors if any required field is empty
+    _.each(requiredFields, (fieldKey) => {
+        if (ValidationUtils.isRequiredFulfilled(values[fieldKey])) {
+            return;
         }
+        errors[fieldKey] = translate('common.error.fieldRequired');
+    });
 
-        // Add "Field required" errors if any required field is empty
-        _.each(requiredFields, (fieldKey) => {
-            if (ValidationUtils.isRequiredFulfilled(values[fieldKey])) {
-                return;
+    // If no country is selected, default value is an empty string and there's no related regex data so we default to an empty object
+    const countryRegexDetails = lodashGet(CONST.COUNTRY_ZIP_REGEX_DATA, values.country, {});
+
+    // The postal code system might not exist for a country, so no regex either for them.
+    const countrySpecificZipRegex = lodashGet(countryRegexDetails, 'regex');
+    const zipFormat = lodashGet(countryRegexDetails, 'samples');
+
+    if (countrySpecificZipRegex) {
+        if (!countrySpecificZipRegex.test(values.zipPostCode.trim())) {
+            if (ValidationUtils.isRequiredFulfilled(values.zipPostCode.trim())) {
+                errors.zipPostCode = translate('privatePersonalDetails.error.incorrectZipFormat', {zipFormat});
+            } else {
+                errors.zipPostCode = translate('common.error.fieldRequired');
             }
-            errors[fieldKey] = this.props.translate('common.error.fieldRequired');
-        });
-
-        // If no country is selected, default value is an empty string and there's no related regex data so we default to an empty object
-        const countryRegexDetails = lodashGet(CONST.COUNTRY_ZIP_REGEX_DATA, values.country, {});
-
-        // The postal code system might not exist for a country, so no regex either for them.
-        const countrySpecificZipRegex = lodashGet(countryRegexDetails, 'regex');
-        const zipFormat = lodashGet(countryRegexDetails, 'samples');
-
-        if (countrySpecificZipRegex) {
-            if (!countrySpecificZipRegex.test(values.zipPostCode.trim())) {
-                if (ValidationUtils.isRequiredFulfilled(values.zipPostCode.trim())) {
-                    errors.zipPostCode = this.props.translate('privatePersonalDetails.error.incorrectZipFormat', {zipFormat});
-                } else {
-                    errors.zipPostCode = this.props.translate('common.error.fieldRequired');
-                }
-            }
-        } else if (!CONST.GENERIC_ZIP_CODE_REGEX.test(values.zipPostCode.trim())) {
-            errors.zipPostCode = this.props.translate('privatePersonalDetails.error.incorrectZipFormat');
         }
-
-        return errors;
+    } else if (!CONST.GENERIC_ZIP_CODE_REGEX.test(values.zipPostCode.trim())) {
+        errors.zipPostCode = translate('privatePersonalDetails.error.incorrectZipFormat');
     }
 
-    render() {
-        const address = lodashGet(this.props.privatePersonalDetails, 'address') || {};
-        const [street1, street2] = (address.street || '').split('\n');
+    return errors;
+}
 
-        return (
-            <ScreenWrapper includeSafeAreaPaddingBottom={false}>
-                <HeaderWithCloseButton
-                    title={this.props.translate('privatePersonalDetails.homeAddress')}
-                    shouldShowBackButton
-                    onBackButtonPress={() => Navigation.navigate(ROUTES.SETTINGS_PERSONAL_DETAILS)}
-                    onCloseButtonPress={() => Navigation.dismissModal(true)}
-                />
-                <Form
-                    style={[styles.flexGrow1, styles.ph5]}
-                    formID={ONYXKEYS.FORMS.HOME_ADDRESS_FORM}
-                    validate={this.validate}
-                    onSubmit={this.updateAddress}
-                    submitButtonText={this.props.translate('common.save')}
-                    enabledWhenOffline
-                >
-                    <View style={styles.mb4}>
-                        <AddressSearch
-                            inputID="addressLine1"
-                            label={this.props.translate('common.addressLine', {lineNumber: 1})}
-                            defaultValue={street1 || ''}
-                            isLimitedToUSA={false}
-                            renamedInputKeys={{
-                                street: 'addressLine1',
-                                street2: 'addressLine2',
-                                city: 'city',
-                                state: 'state',
-                                zipCode: 'zipPostCode',
-                                country: 'country',
-                            }}
-                            maxInputLength={CONST.FORM_CHARACTER_LIMIT}
-                        />
-                    </View>
-                    <View style={styles.mb4}>
-                        <TextInput
-                            inputID="addressLine2"
-                            label={this.props.translate('common.addressLine', {lineNumber: 2})}
-                            defaultValue={street2 || ''}
-                            maxLength={CONST.FORM_CHARACTER_LIMIT}
-                        />
-                    </View>
-                    <View style={styles.mb4}>
-                        <TextInput
-                            inputID="city"
-                            label={this.props.translate('common.city')}
-                            defaultValue={address.city || ''}
-                            maxLength={CONST.FORM_CHARACTER_LIMIT}
-                        />
-                    </View>
-                    <View style={styles.mb4}>
-                        {this.state.isUsaForm ? (
-                            <StatePicker
-                                inputID="state"
-                                defaultValue={address.state || ''}
-                            />
-                        ) : (
-                            <TextInput
-                                inputID="state"
-                                label={this.props.translate('common.stateOrProvince')}
-                                defaultValue={address.state || ''}
-                                maxLength={CONST.FORM_CHARACTER_LIMIT}
-                            />
-                        )}
-                    </View>
-                    <View style={styles.mb4}>
-                        <TextInput
-                            inputID="zipPostCode"
-                            label={this.props.translate('common.zipPostCode')}
-                            autoCapitalize="characters"
-                            defaultValue={address.zip || ''}
-                            maxLength={CONST.BANK_ACCOUNT.MAX_LENGTH.ZIP_CODE}
-                            hint={this.state.zipFormat}
-                        />
-                    </View>
-                    <View>
-                        <CountryPicker
-                            inputID="country"
-                            onValueChange={this.onCountryUpdate}
-                            defaultValue={PersonalDetails.getCountryISO(address.country)}
-                        />
-                    </View>
-                </Form>
-            </ScreenWrapper>
-        );
-    }
+/**
+ * Submit form to update user's first and last legal name
+ * @param {Object} values - form input values
+ */
+const updateAddress = (values) => {
+    PersonalDetails.updateAddress(values.addressLine1.trim(), values.addressLine2.trim(), values.city.trim(), values.state.trim(), values.zipPostCode.trim(), values.country);
+};
+
+const AddressPage = (props) => {
+    const [countryISO, setCountryISO] = useState(PersonalDetails.getCountryISO(lodashGet(props.privatePersonalDetails, 'address.country')) || CONST.COUNTRY.US);
+    const isUsaForm = countryISO === CONST.COUNTRY.US;
+    
+    const zipSampleFormat = lodashGet(CONST.COUNTRY_ZIP_REGEX_DATA, [countryISO, 'samples'], '');
+    const zipFormat = props.translate('common.zipCodeExampleFormat', {zipSampleFormat});
+
+    const address = lodashGet(props.privatePersonalDetails, 'address') || {};
+    const [street1, street2] = (address.street || '').split('\n');
+
+    return (
+        <ScreenWrapper includeSafeAreaPaddingBottom={false}>
+             <HeaderWithCloseButton
+                 title={props.translate('privatePersonalDetails.homeAddress')}
+                 shouldShowBackButton
+                 onBackButtonPress={() => Navigation.navigate(ROUTES.SETTINGS_PERSONAL_DETAILS)}
+                 onCloseButtonPress={() => Navigation.dismissModal(true)}
+             />
+             <Form
+                 style={[styles.flexGrow1, styles.ph5]}
+                 formID={ONYXKEYS.FORMS.HOME_ADDRESS_FORM}
+                 validate={values => validate(props.translate, isUsaForm, values)}
+                 onSubmit={updateAddress}
+                 submitButtonText={props.translate('common.save')}
+                 enabledWhenOffline
+             >
+                 <View style={styles.mb4}>
+                     <AddressSearch
+                         inputID="addressLine1"
+                         label={props.translate('common.addressLine', {lineNumber: 1})}
+                         defaultValue={street1 || ''}
+                         isLimitedToUSA={false}
+                         renamedInputKeys={{
+                             street: 'addressLine1',
+                             street2: 'addressLine2',
+                             city: 'city',
+                             state: 'state',
+                             zipCode: 'zipPostCode',
+                             country: 'country',
+                         }}
+                         maxInputLength={CONST.FORM_CHARACTER_LIMIT}
+                     />
+                 </View>
+                 <View style={styles.mb4}>
+                     <TextInput
+                         inputID="addressLine2"
+                         label={props.translate('common.addressLine', {lineNumber: 2})}
+                         defaultValue={street2 || ''}
+                         maxLength={CONST.FORM_CHARACTER_LIMIT}
+                     />
+                 </View>
+                 <View style={styles.mb4}>
+                     <TextInput
+                         inputID="city"
+                         label={props.translate('common.city')}
+                         defaultValue={address.city || ''}
+                         maxLength={CONST.FORM_CHARACTER_LIMIT}
+                     />
+                 </View>
+                 <View style={styles.mb4}>
+                     {isUsaForm ? (
+                         <StatePicker
+                             inputID="state"
+                             defaultValue={address.state || ''}
+                         />
+                     ) : (
+                         <TextInput
+                             inputID="state"
+                             label={props.translate('common.stateOrProvince')}
+                             defaultValue={address.state || ''}
+                             maxLength={CONST.FORM_CHARACTER_LIMIT}
+                         />
+                     )}
+                 </View>
+                 <View style={styles.mb4}>
+                     <TextInput
+                         inputID="zipPostCode"
+                         label={props.translate('common.zipPostCode')}
+                         autoCapitalize="characters"
+                         defaultValue={address.zip || ''}
+                         maxLength={CONST.BANK_ACCOUNT.MAX_LENGTH.ZIP_CODE}
+                         hint={zipFormat}
+                     />
+                 </View>
+                 <View>
+                     <CountryPicker
+                         inputID="country"
+                         onValueChange={setCountryISO}
+                         defaultValue={PersonalDetails.getCountryISO(address.country)}
+                     />
+                 </View>
+             </Form>
+         </ScreenWrapper>);
 }
 
 AddressPage.propTypes = propTypes;

--- a/src/pages/settings/Profile/PersonalDetails/AddressPage.js
+++ b/src/pages/settings/Profile/PersonalDetails/AddressPage.js
@@ -203,6 +203,7 @@ const AddressPage = (props) => {
 
 AddressPage.propTypes = propTypes;
 AddressPage.defaultProps = defaultProps;
+AddressPage.displayName = 'AddressPage';
 
 export default compose(
     withLocalize,

--- a/src/pages/settings/Profile/PersonalDetails/AddressPage.js
+++ b/src/pages/settings/Profile/PersonalDetails/AddressPage.js
@@ -202,7 +202,6 @@ function AddressPage(props) {
 
 AddressPage.propTypes = propTypes;
 AddressPage.defaultProps = defaultProps;
-AddressPage.displayName = 'AddressPage';
 
 export default compose(
     withLocalize,

--- a/src/pages/settings/Profile/PersonalDetails/AddressPage.js
+++ b/src/pages/settings/Profile/PersonalDetails/AddressPage.js
@@ -58,7 +58,7 @@ const defaultProps = {
  */
 function updateAddress(values) {
     PersonalDetails.updateAddress(values.addressLine1.trim(), values.addressLine2.trim(), values.city.trim(), values.state.trim(), values.zipPostCode.trim(), values.country);
-};
+}
 
 function AddressPage(props) {
     const {translate} = props;
@@ -71,6 +71,12 @@ function AddressPage(props) {
     const address = lodashGet(props.privatePersonalDetails, 'address') || {};
     const [street1, street2] = (address.street || '').split('\n');
 
+    /**
+     * @param {Function} translate - translate function
+     * @param {Boolean} isUSAForm - selected country ISO code is US
+     * @param {Object} values - form input values
+     * @returns {Object} - An object containing the errors for each inputID
+     */
     const validate = useCallback(
         (values) => {
             const errors = {};

--- a/src/pages/settings/Profile/PersonalDetails/AddressPage.js
+++ b/src/pages/settings/Profile/PersonalDetails/AddressPage.js
@@ -56,7 +56,7 @@ const defaultProps = {
  * Submit form to update user's first and last legal name
  * @param {Object} values - form input values
  */
-const updateAddress = (values) => {
+function updateAddress(values) {
     PersonalDetails.updateAddress(values.addressLine1.trim(), values.addressLine2.trim(), values.city.trim(), values.state.trim(), values.zipPostCode.trim(), values.country);
 };
 

--- a/src/pages/settings/Profile/PersonalDetails/AddressPage.js
+++ b/src/pages/settings/Profile/PersonalDetails/AddressPage.js
@@ -96,7 +96,7 @@ const validate = (translate, isUsaForm, values) => {
     }
 
     return errors;
-}
+};
 
 /**
  * Submit form to update user's first and last legal name
@@ -109,7 +109,7 @@ const updateAddress = (values) => {
 const AddressPage = (props) => {
     const [countryISO, setCountryISO] = useState(PersonalDetails.getCountryISO(lodashGet(props.privatePersonalDetails, 'address.country')) || CONST.COUNTRY.US);
     const isUsaForm = countryISO === CONST.COUNTRY.US;
-    
+
     const zipSampleFormat = lodashGet(CONST.COUNTRY_ZIP_REGEX_DATA, [countryISO, 'samples'], '');
     const zipFormat = props.translate('common.zipCodeExampleFormat', {zipSampleFormat});
 
@@ -118,88 +118,89 @@ const AddressPage = (props) => {
 
     return (
         <ScreenWrapper includeSafeAreaPaddingBottom={false}>
-             <HeaderWithCloseButton
-                 title={props.translate('privatePersonalDetails.homeAddress')}
-                 shouldShowBackButton
-                 onBackButtonPress={() => Navigation.navigate(ROUTES.SETTINGS_PERSONAL_DETAILS)}
-                 onCloseButtonPress={() => Navigation.dismissModal(true)}
-             />
-             <Form
-                 style={[styles.flexGrow1, styles.ph5]}
-                 formID={ONYXKEYS.FORMS.HOME_ADDRESS_FORM}
-                 validate={values => validate(props.translate, isUsaForm, values)}
-                 onSubmit={updateAddress}
-                 submitButtonText={props.translate('common.save')}
-                 enabledWhenOffline
-             >
-                 <View style={styles.mb4}>
-                     <AddressSearch
-                         inputID="addressLine1"
-                         label={props.translate('common.addressLine', {lineNumber: 1})}
-                         defaultValue={street1 || ''}
-                         isLimitedToUSA={false}
-                         renamedInputKeys={{
-                             street: 'addressLine1',
-                             street2: 'addressLine2',
-                             city: 'city',
-                             state: 'state',
-                             zipCode: 'zipPostCode',
-                             country: 'country',
-                         }}
-                         maxInputLength={CONST.FORM_CHARACTER_LIMIT}
-                     />
-                 </View>
-                 <View style={styles.mb4}>
-                     <TextInput
-                         inputID="addressLine2"
-                         label={props.translate('common.addressLine', {lineNumber: 2})}
-                         defaultValue={street2 || ''}
-                         maxLength={CONST.FORM_CHARACTER_LIMIT}
-                     />
-                 </View>
-                 <View style={styles.mb4}>
-                     <TextInput
-                         inputID="city"
-                         label={props.translate('common.city')}
-                         defaultValue={address.city || ''}
-                         maxLength={CONST.FORM_CHARACTER_LIMIT}
-                     />
-                 </View>
-                 <View style={styles.mb4}>
-                     {isUsaForm ? (
-                         <StatePicker
-                             inputID="state"
-                             defaultValue={address.state || ''}
-                         />
-                     ) : (
-                         <TextInput
-                             inputID="state"
-                             label={props.translate('common.stateOrProvince')}
-                             defaultValue={address.state || ''}
-                             maxLength={CONST.FORM_CHARACTER_LIMIT}
-                         />
-                     )}
-                 </View>
-                 <View style={styles.mb4}>
-                     <TextInput
-                         inputID="zipPostCode"
-                         label={props.translate('common.zipPostCode')}
-                         autoCapitalize="characters"
-                         defaultValue={address.zip || ''}
-                         maxLength={CONST.BANK_ACCOUNT.MAX_LENGTH.ZIP_CODE}
-                         hint={zipFormat}
-                     />
-                 </View>
-                 <View>
-                     <CountryPicker
-                         inputID="country"
-                         onValueChange={setCountryISO}
-                         defaultValue={PersonalDetails.getCountryISO(address.country)}
-                     />
-                 </View>
-             </Form>
-         </ScreenWrapper>);
-}
+            <HeaderWithCloseButton
+                title={props.translate('privatePersonalDetails.homeAddress')}
+                shouldShowBackButton
+                onBackButtonPress={() => Navigation.navigate(ROUTES.SETTINGS_PERSONAL_DETAILS)}
+                onCloseButtonPress={() => Navigation.dismissModal(true)}
+            />
+            <Form
+                style={[styles.flexGrow1, styles.ph5]}
+                formID={ONYXKEYS.FORMS.HOME_ADDRESS_FORM}
+                validate={(values) => validate(props.translate, isUsaForm, values)}
+                onSubmit={updateAddress}
+                submitButtonText={props.translate('common.save')}
+                enabledWhenOffline
+            >
+                <View style={styles.mb4}>
+                    <AddressSearch
+                        inputID="addressLine1"
+                        label={props.translate('common.addressLine', {lineNumber: 1})}
+                        defaultValue={street1 || ''}
+                        isLimitedToUSA={false}
+                        renamedInputKeys={{
+                            street: 'addressLine1',
+                            street2: 'addressLine2',
+                            city: 'city',
+                            state: 'state',
+                            zipCode: 'zipPostCode',
+                            country: 'country',
+                        }}
+                        maxInputLength={CONST.FORM_CHARACTER_LIMIT}
+                    />
+                </View>
+                <View style={styles.mb4}>
+                    <TextInput
+                        inputID="addressLine2"
+                        label={props.translate('common.addressLine', {lineNumber: 2})}
+                        defaultValue={street2 || ''}
+                        maxLength={CONST.FORM_CHARACTER_LIMIT}
+                    />
+                </View>
+                <View style={styles.mb4}>
+                    <TextInput
+                        inputID="city"
+                        label={props.translate('common.city')}
+                        defaultValue={address.city || ''}
+                        maxLength={CONST.FORM_CHARACTER_LIMIT}
+                    />
+                </View>
+                <View style={styles.mb4}>
+                    {isUsaForm ? (
+                        <StatePicker
+                            inputID="state"
+                            defaultValue={address.state || ''}
+                        />
+                    ) : (
+                        <TextInput
+                            inputID="state"
+                            label={props.translate('common.stateOrProvince')}
+                            defaultValue={address.state || ''}
+                            maxLength={CONST.FORM_CHARACTER_LIMIT}
+                        />
+                    )}
+                </View>
+                <View style={styles.mb4}>
+                    <TextInput
+                        inputID="zipPostCode"
+                        label={props.translate('common.zipPostCode')}
+                        autoCapitalize="characters"
+                        defaultValue={address.zip || ''}
+                        maxLength={CONST.BANK_ACCOUNT.MAX_LENGTH.ZIP_CODE}
+                        hint={zipFormat}
+                    />
+                </View>
+                <View>
+                    <CountryPicker
+                        inputID="country"
+                        onValueChange={setCountryISO}
+                        defaultValue={PersonalDetails.getCountryISO(address.country)}
+                    />
+                </View>
+            </Form>
+        </ScreenWrapper>
+    );
+};
 
 AddressPage.propTypes = propTypes;
 AddressPage.defaultProps = defaultProps;


### PR DESCRIPTION
### Details
Migration from class component to functional

### Fixed Issues
$ https://github.com/Expensify/App/issues/16293



### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Click "Avatar" to open settings
1. Click "Profile"
1. Click "Personal details"
1. Click "Home address"
1. Verify that the "Home address" form work correctly: Change data, save it, trigger validation errors by setting an invalid zip code or empty address.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>



https://github.com/Expensify/App/assets/87341702/ceea6860-80df-4232-be37-f0b8bd9781bb




</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>
