### PR TITLE
[Fix] Translated error messages

### DIFF
--- a/src/components/DotIndicatorMessage.js
+++ b/src/components/DotIndicatorMessage.js
@@ -17,7 +17,7 @@ const propTypes = {
      *      timestamp: 'message',
      *  }
      */
-    messages: PropTypes.objectOf(PropTypes.string),
+    messages: PropTypes.objectOf(PropTypes.oneOfType([PropTypes.array, PropTypes.string])),
 
     // The type of message, 'error' shows a red dot, 'success' shows a green dot
     type: PropTypes.oneOf(['error', 'success']).isRequired,

--- a/src/components/FormHelpMessage.js
+++ b/src/components/FormHelpMessage.js
@@ -8,7 +8,7 @@ import Text from './Text';
 import colors from '../styles/colors';
 import styles from '../styles/styles';
 import stylePropTypes from '../styles/stylePropTypes';
-import * as Localize from "../libs/Localize";
+import * as Localize from '../libs/Localize';
 
 const propTypes = {
     /** Error or hint text. Ignored when children is not empty */
@@ -36,7 +36,7 @@ const FormHelpMessage = (props) => {
         return null;
     }
 
-    const translatedMessage = Localize.translateIfPhraseKey(props.message)
+    const translatedMessage = Localize.translateIfPhraseKey(props.message);
     return (
         <View style={[styles.flexRow, styles.alignItemsCenter, styles.mt2, styles.mb1, ...props.style]}>
             {props.isError && (

--- a/src/components/FormHelpMessage.js
+++ b/src/components/FormHelpMessage.js
@@ -12,7 +12,7 @@ import * as Localize from '../libs/Localize';
 
 const propTypes = {
     /** Error or hint text. Ignored when children is not empty */
-    message: PropTypes.oneOfType([PropTypes.string, PropTypes.array,]),
+    message: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
 
     /** Children to render next to dot indicator */
     children: PropTypes.node,

--- a/src/components/FormHelpMessage.js
+++ b/src/components/FormHelpMessage.js
@@ -8,6 +8,7 @@ import Text from './Text';
 import colors from '../styles/colors';
 import styles from '../styles/styles';
 import stylePropTypes from '../styles/stylePropTypes';
+import * as Localize from "../libs/Localize";
 
 const propTypes = {
     /** Error or hint text. Ignored when children is not empty */
@@ -35,6 +36,7 @@ const FormHelpMessage = (props) => {
         return null;
     }
 
+    const translatedMessage = Localize.translateIfPhraseKey(props.message)
     return (
         <View style={[styles.flexRow, styles.alignItemsCenter, styles.mt2, styles.mb1, ...props.style]}>
             {props.isError && (
@@ -44,7 +46,7 @@ const FormHelpMessage = (props) => {
                 />
             )}
             <View style={[styles.flex1, props.isError && styles.ml2]}>
-                {props.children || <Text style={[props.isError ? styles.formError : styles.formHelp, styles.mb0]}>{props.message}</Text>}
+                {props.children || <Text style={[props.isError ? styles.formError : styles.formHelp, styles.mb0]}>{translatedMessage}</Text>}
             </View>
         </View>
     );

--- a/src/components/FormHelpMessage.js
+++ b/src/components/FormHelpMessage.js
@@ -12,7 +12,7 @@ import * as Localize from '../libs/Localize';
 
 const propTypes = {
     /** Error or hint text. Ignored when children is not empty */
-    message: PropTypes.string,
+    message: PropTypes.oneOfType([PropTypes.string, PropTypes.array,]),
 
     /** Children to render next to dot indicator */
     children: PropTypes.node,

--- a/src/libs/Localize/index.js
+++ b/src/libs/Localize/index.js
@@ -94,14 +94,16 @@ function translateLocal(phrase, variables) {
 /**
  * Return translated string for given error.
  *
- * @param {String} phrase
+ * @param {String|Array} message
  * @returns {String}
  */
-function translateIfPhraseKey(phrase) {
+function translateIfPhraseKey(message) {
     try {
-        return translateLocal(phrase);
+        // check if error message has a variable parameter
+        const [phrase, variables] = _.isArray(message) ? message : [message];
+        return translateLocal(phrase,variables);
     } catch (error) {
-        return phrase;
+        return message;
     }
 }
 

--- a/src/libs/Localize/index.js
+++ b/src/libs/Localize/index.js
@@ -101,7 +101,7 @@ function translateIfPhraseKey(message) {
     try {
         // check if error message has a variable parameter
         const [phrase, variables] = _.isArray(message) ? message : [message];
-        return translateLocal(phrase,variables);
+        return translateLocal(phrase, variables);
     } catch (error) {
         return message;
     }

--- a/src/pages/EnablePayments/TermsStep.js
+++ b/src/pages/EnablePayments/TermsStep.js
@@ -66,7 +66,7 @@ class TermsStep extends React.Component {
     }
 
     render() {
-        const errorMessage = this.state.error ? this.props.translate('common.error.acceptTerms') : ErrorUtils.getLatestErrorMessage(this.props.walletTerms) || '';
+        const errorMessage = this.state.error ? 'common.error.acceptTerms' : ErrorUtils.getLatestErrorMessage(this.props.walletTerms) || '';
         return (
             <>
                 <HeaderWithCloseButton

--- a/src/pages/settings/PasswordPage.js
+++ b/src/pages/settings/PasswordPage.js
@@ -19,7 +19,7 @@ import TextInput from '../../components/TextInput';
 import * as Session from '../../libs/actions/Session';
 import * as ErrorUtils from '../../libs/ErrorUtils';
 import ConfirmationPage from '../../components/ConfirmationPage';
-import FormHelpMessage from "../../components/FormHelpMessage";
+import FormHelpMessage from '../../components/FormHelpMessage';
 
 const propTypes = {
     /* Onyx Props */

--- a/src/pages/settings/PasswordPage.js
+++ b/src/pages/settings/PasswordPage.js
@@ -19,6 +19,7 @@ import TextInput from '../../components/TextInput';
 import * as Session from '../../libs/actions/Session';
 import * as ErrorUtils from '../../libs/ErrorUtils';
 import ConfirmationPage from '../../components/ConfirmationPage';
+import FormHelpMessage from "../../components/FormHelpMessage";
 
 const propTypes = {
     /* Onyx Props */
@@ -201,7 +202,10 @@ class PasswordPage extends Component {
                                 {shouldShowNewPasswordPrompt && <Text style={[styles.textLabelSupporting, styles.mt1]}>{this.props.translate('passwordPage.newPasswordPrompt')}</Text>}
                             </View>
                             {_.every(this.state.errors, (error) => !error) && !_.isEmpty(this.props.account.errors) && (
-                                <Text style={styles.formError}>{ErrorUtils.getLatestErrorMessage(this.props.account)}</Text>
+                                <FormHelpMessage
+                                    isError
+                                    message={ErrorUtils.getLatestErrorMessage(this.props.account)}
+                                />
                             )}
                         </ScrollView>
                         <FixedFooter style={[styles.flexGrow0]}>

--- a/src/pages/settings/Profile/Contacts/ContactMethodDetailsPage.js
+++ b/src/pages/settings/Profile/Contacts/ContactMethodDetailsPage.js
@@ -232,7 +232,7 @@ class ContactMethodDetailsPage extends Component {
                             <DotIndicatorMessage
                                 type="success"
                                 style={[styles.mb3]}
-                                messages={{0: this.props.translate('contacts.enterMagicCode', {contactMethod: formattedContactMethod})}}
+                                messages={{0: ['contacts.enterMagicCode', {contactMethod: formattedContactMethod}]}}
                             />
                             <ValidateCodeForm
                                 contactMethod={contactMethod}

--- a/src/pages/settings/Profile/Contacts/ValidateCodeForm/BaseValidateCodeForm.js
+++ b/src/pages/settings/Profile/Contacts/ValidateCodeForm/BaseValidateCodeForm.js
@@ -146,7 +146,7 @@ function BaseValidateCodeForm(props) {
                         <DotIndicatorMessage
                             type="success"
                             style={[styles.mt6, styles.flex0]}
-                            messages={{0: props.translate('resendValidationForm.linkHasBeenResent')}}
+                            messages={{0: 'resendValidationForm.linkHasBeenResent'}}
                         />
                     )}
                 </View>

--- a/src/pages/signin/ResendValidationForm.js
+++ b/src/pages/signin/ResendValidationForm.js
@@ -81,7 +81,7 @@ const ResendValidationForm = (props) => {
                 <DotIndicatorMessage
                     style={[styles.mb5, styles.flex0]}
                     type="success"
-                    messages={{0: props.translate(props.account.message)}}
+                    messages={{0: props.account.message}}
                 />
             )}
             {!_.isEmpty(props.account.errors) && (

--- a/src/pages/tasks/NewTaskPage.js
+++ b/src/pages/tasks/NewTaskPage.js
@@ -68,7 +68,7 @@ const NewTaskPage = (props) => {
     const [assignee, setAssignee] = React.useState({});
     const [shareDestination, setShareDestination] = React.useState({});
     const [submitError, setSubmitError] = React.useState(false);
-    const [errorMessage, setErrorMessage] = React.useState(props.translate('newTaskPage.confirmError'));
+    const [errorMessage, setErrorMessage] = React.useState('newTaskPage.confirmError');
     const [parentReport, setParentReport] = React.useState({});
 
     useEffect(() => {
@@ -80,7 +80,7 @@ const NewTaskPage = (props) => {
             const assigneeDetails = lodashGet(OptionsListUtils.getPersonalDetailsForLogins([props.task.assignee], props.personalDetails), props.task.assignee);
             if (!assigneeDetails) {
                 setSubmitError(true);
-                return setErrorMessage(props.translate('newTaskPage.assigneeError'));
+                return setErrorMessage('newTaskPage.assigneeError');
             }
             const displayDetails = TaskUtils.getAssignee(assigneeDetails);
             setAssignee(displayDetails);


### PR DESCRIPTION
@luacmartins @chiragsalian 

### Details

This PR builds upon the previous changes made in PR #19324 by refactoring the micro generated error and introducing key-based error storage. However, it has come to our attention that there are some components within the application that still handle errors using the old translation-based approach, resulting in inconsistencies. This follow-up PR aims to rectify this oversight by updating those components to utilize the new error handling mechanism.

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/pull/19324#discussion_r1214562808

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/pull/19324#discussion_r1214562808
PROPOSAL: GH_LINK_ISSUE(COMMENT)


### Tests

#### Test 1 : Bank Account

- **Prerequisite :**

Update [this line](https://github.com/Expensify/App/blob/50fbe9a509dc5ee339bf22f0cf54cb45eb6ab661/src/pages/ReimbursementAccount/BankAccountManualStep.js#L57) in [/src/pages/ReimbursementAccount/BankAccountManualStep.js](https://github.com/Expensify/App/blob/50fbe9a509dc5ee339bf22f0cf54cb45eb6ab661/src/pages/ReimbursementAccount/BankAccountManualStep.js#L57) to 

```jsx
    submit(values) {
        Onyx.merge(ONYXKEYS.FORMS.REIMBURSEMENT_ACCOUNT_FORM, {
            errors: ErrorUtils.getMicroSecondOnyxError('paymentsPage.addBankAccountFailure')
        })
        return;
    }
```

- **Steps :**

1. Open the app -> Workspaces -> Select workspace -> Bank Account -> Manual bank account
2. Add routing number `021000021`
3. Add account number `231432`
4. Click continue 
5. Verify error message is displayed as `An unexpected error occurred while trying to add your bank account. Please try again.`

#### Test 2 : Account Details Login Page

- **Prerequisite :**

Add the line below to [/src/libs/actions/Session/index.js](https://github.com/Expensify/App/blob/5269e2a3fda01284dc8df6ff9d535561f0f380fe/src/libs/actions/Session/index.js#L253)

```jsx
errors: ErrorUtils.getMicroSecondOnyxError('loginForm.cannotGetAccountDetails'),
```

Update [src/libs/API.js](https://github.com/Expensify/App/blob/5269e2a3fda01284dc8df6ff9d535561f0f380fe/src/libs/API.js#L112) to include this line 

```jsx
    if (command === 'BeginSignIn'){
        return
    }
```
- **Steps :**

1. Open App and logout if necessary 
2. Enter Email and press Continue
3. Verify this message appears `Couldn't retrieve account details, please try to sign in again.`


#### Test 3 : Add Contact Method

1. Open App
2. Navigate to : Settings -> Profile -> Contact method 
3. Add new contact method and verify that magic code is sent to new email
4. Select the newly added contact method
5. Verify that this message appears : `Please enter the magic code sent to new add email`


- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
6. Upload an image via copy paste
7. Verify a modal appears displaying a preview of that image
--->

Test 3 : Add Contact Method

1. Open App
2. Navigate to : Settings -> Profile -> Contact method 
3. Add new contact method and verify that magic code is sent to new email
4. Select the newly added contact method
5. Verify that this message appears : `Please enter the magic code sent to new add email`


- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<img width="1284" alt="Screenshot 2023-06-05 at 6 34 46 AM" src="https://github.com/Expensify/App/assets/36869046/79001548-2700-45f8-b4a7-7a399fbd4688">

<img width="1322" alt="Screenshot 2023-06-05 at 7 05 29 AM" src="https://github.com/Expensify/App/assets/36869046/1ddd23a1-a17a-4735-86f5-1a3d280e2ed1">

<img width="1377" alt="Screenshot 2023-06-05 at 7 13 20 AM" src="https://github.com/Expensify/App/assets/36869046/e9e7a908-c353-46b8-b0a9-a199976cc2f3">

<img width="1209" alt="Screenshot 2023-06-05 at 9 18 16 PM" src="https://github.com/Expensify/App/assets/36869046/2c66843f-1a70-47da-a003-213285efb2f5">


</details>

<details>
<summary>Mobile Web - Chrome</summary>

<img width="436" alt="Screenshot 2023-06-05 at 6 57 54 AM" src="https://github.com/Expensify/App/assets/36869046/1ffdec9f-ef11-4669-ad2f-9468ebd29b25">

<img width="436" alt="Screenshot 2023-06-05 at 7 50 36 AM" src="https://github.com/Expensify/App/assets/36869046/b1a5666f-b5e8-45d3-a4ca-c67bab95e19b">

<img width="436" alt="Screenshot 2023-06-05 at 9 37 03 PM" src="https://github.com/Expensify/App/assets/36869046/67cdaab8-7b0c-4061-b4fc-e6dbd1cf9074">

</details>

<details>
<summary>Mobile Web - Safari</summary>

<img width="432" alt="Screenshot 2023-06-05 at 6 53 28 AM" src="https://github.com/Expensify/App/assets/36869046/9aa971ee-416d-4f9f-8468-7f02e1ab9946">

<img width="432" alt="Screenshot 2023-06-05 at 7 48 40 AM" src="https://github.com/Expensify/App/assets/36869046/6cbb3893-978e-40dd-91bd-57a74fb1fef8">

<img width="476" alt="Screenshot 2023-06-05 at 9 32 03 PM" src="https://github.com/Expensify/App/assets/36869046/414e533e-e163-40ed-b7c2-2540582c41ac">

</details>

<details>
<summary>Desktop</summary>

<img width="1179" alt="Screenshot 2023-06-05 at 6 54 25 AM" src="https://github.com/Expensify/App/assets/36869046/1cf14385-e09c-4ce1-8ab0-e7d626d1a7b6">

<img width="1150" alt="Screenshot 2023-06-05 at 7 47 33 AM" src="https://github.com/Expensify/App/assets/36869046/52aed05b-1955-456b-b766-0aa1236321f5">

<img width="1156" alt="Screenshot 2023-06-05 at 9 28 47 PM" src="https://github.com/Expensify/App/assets/36869046/0d9a7f90-ac6f-4a1d-83d2-c12af888b31c">

</details>

<details>
<summary>iOS</summary>

<img width="432" alt="Screenshot 2023-06-05 at 6 44 28 AM" src="https://github.com/Expensify/App/assets/36869046/7a06656a-5b90-4c90-9e03-eaee8cfbefd6">

<img width="432" alt="Screenshot 2023-06-05 at 7 48 06 AM" src="https://github.com/Expensify/App/assets/36869046/4db8d99d-d7b1-406a-a4aa-d8a4a55bf6a9">

<img width="432" alt="Screenshot 2023-06-05 at 9 32 42 PM" src="https://github.com/Expensify/App/assets/36869046/c7bbc76d-9ced-4323-82fb-be1647256a2a">

</details>

<details>
<summary>Android</summary>

<img width="436" alt="Screenshot 2023-06-05 at 7 00 14 AM" src="https://github.com/Expensify/App/assets/36869046/81ad42a5-efe2-4301-922a-7c47c79df938">

<img width="436" alt="Screenshot 2023-06-05 at 7 55 03 AM" src="https://github.com/Expensify/App/assets/36869046/441af6bd-466a-482b-b280-61d172420fbf">

<img width="436" alt="Screenshot 2023-06-05 at 9 39 25 PM" src="https://github.com/Expensify/App/assets/36869046/95520908-4881-4b5f-800f-941a472a689c">

</details>
