### PR TITLE
Refactor `LogInWithShortLivedAuthTokenPage` to a functional component

### DIFF
--- a/src/pages/LogInWithShortLivedAuthTokenPage.js
+++ b/src/pages/LogInWithShortLivedAuthTokenPage.js
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import React, {useEffect} from 'react';
 import lodashGet from 'lodash/get';
 import PropTypes from 'prop-types';
 import {withOnyx} from 'react-native-onyx';
@@ -43,57 +43,57 @@ const defaultProps = {
     isTokenValid: true,
 };
 
-class LogInWithShortLivedAuthTokenPage extends Component {
-    componentDidMount() {
-        const email = lodashGet(this.props, 'route.params.email', '');
+const LogInWithShortLivedAuthTokenPage = (props) => {
+
+    useEffect(() => {
+        const email = lodashGet(props, 'route.params.email', '');
 
         // We have to check for both shortLivedAuthToken and shortLivedToken, as the old mobile app uses shortLivedToken, and is not being actively updated.
-        const shortLivedAuthToken = lodashGet(this.props, 'route.params.shortLivedAuthToken', '') || lodashGet(this.props, 'route.params.shortLivedToken', '');
+        const shortLivedAuthToken = lodashGet(props, 'route.params.shortLivedAuthToken', '') || lodashGet(props, 'route.params.shortLivedToken', '');
         if (shortLivedAuthToken) {
             Session.signInWithShortLivedAuthToken(email, shortLivedAuthToken);
             return;
         }
-        const exitTo = lodashGet(this.props, 'route.params.exitTo', '');
+        const exitTo = lodashGet(props, 'route.params.exitTo', '');
         if (exitTo) {
             Navigation.isNavigationReady().then(() => {
                 Navigation.navigate(exitTo);
             });
         }
+    }, []);
+
+    if (props.isTokenValid) {
+        return <FullScreenLoadingIndicator />;
     }
 
-    render() {
-        if (this.props.isTokenValid) {
-            return <FullScreenLoadingIndicator />;
-        }
-        return (
-            <View style={styles.deeplinkWrapperContainer}>
-                <View style={styles.deeplinkWrapperMessage}>
-                    <View style={styles.mb2}>
-                        <Icon
-                            width={200}
-                            height={164}
-                            src={Illustrations.RocketBlue}
-                        />
-                    </View>
-                    <Text style={[styles.textHeadline, styles.textXXLarge]}>{this.props.translate('deeplinkWrapper.launching')}</Text>
-                    <View style={styles.mt2}>
-                        <Text style={[styles.fontSizeNormal, styles.textAlignCenter]}>
-                            {this.props.translate('deeplinkWrapper.expired')} <TextLink onPress={() => Navigation.navigate()}>{this.props.translate('deeplinkWrapper.signIn')}</TextLink>
-                        </Text>
-                    </View>
-                </View>
-                <View style={styles.deeplinkWrapperFooter}>
+    return (
+        <View style={styles.deeplinkWrapperContainer}>
+            <View style={styles.deeplinkWrapperMessage}>
+                <View style={styles.mb2}>
                     <Icon
-                        width={154}
-                        height={34}
-                        fill={colors.green}
-                        src={Expensicons.ExpensifyWordmark}
+                        width={200}
+                        height={164}
+                        src={Illustrations.RocketBlue}
                     />
                 </View>
+                <Text style={[styles.textHeadline, styles.textXXLarge]}>{props.translate('deeplinkWrapper.launching')}</Text>
+                <View style={styles.mt2}>
+                    <Text style={[styles.fontSizeNormal, styles.textAlignCenter]}>
+                        {props.translate('deeplinkWrapper.expired')} <TextLink onPress={() => Navigation.navigate()}>{props.translate('deeplinkWrapper.signIn')}</TextLink>
+                    </Text>
+                </View>
             </View>
-        );
-    }
-}
+            <View style={styles.deeplinkWrapperFooter}>
+                <Icon
+                    width={154}
+                    height={34}
+                    fill={colors.green}
+                    src={Expensicons.ExpensifyWordmark}
+                />
+            </View>
+        </View>
+    );
+};
 
 LogInWithShortLivedAuthTokenPage.propTypes = propTypes;
 LogInWithShortLivedAuthTokenPage.defaultProps = defaultProps;

--- a/src/pages/LogInWithShortLivedAuthTokenPage.js
+++ b/src/pages/LogInWithShortLivedAuthTokenPage.js
@@ -18,14 +18,14 @@ import TextLink from '../components/TextLink';
 import ONYXKEYS from '../ONYXKEYS';
 
 const propTypes = {
-    /** The parameters needed to authenticate with a short lived token are in the URL */
+    /** The parameters needed to authenticate with a short-lived token are in the URL */
     route: PropTypes.shape({
         /** Each parameter passed via the URL */
         params: PropTypes.shape({
-            /** Short lived authToken to sign in a user */
+            /** Short-lived authToken to sign in a user */
             shortLivedAuthToken: PropTypes.string,
 
-            /** Short lived authToken to sign in as a user, if they are coming from the old mobile app */
+            /** Short-lived authToken to sign in as a user, if they are coming from the old mobile app */
             shortLivedToken: PropTypes.string,
 
             /** The email of the transitioning user */
@@ -35,7 +35,7 @@ const propTypes = {
 
     ...withLocalizePropTypes,
 
-    /** Whether the short lived auth token is valid */
+    /** Whether the short-lived auth token is valid */
     isTokenValid: PropTypes.bool,
 };
 
@@ -44,7 +44,6 @@ const defaultProps = {
 };
 
 const LogInWithShortLivedAuthTokenPage = (props) => {
-
     useEffect(() => {
         const email = lodashGet(props, 'route.params.email', '');
 
@@ -60,7 +59,9 @@ const LogInWithShortLivedAuthTokenPage = (props) => {
                 Navigation.navigate(exitTo);
             });
         }
-    }, []);
+        // The only dependencies of the effect are based on props.route
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [props.route]);
 
     if (props.isTokenValid) {
         return <FullScreenLoadingIndicator />;
@@ -97,6 +98,7 @@ const LogInWithShortLivedAuthTokenPage = (props) => {
 
 LogInWithShortLivedAuthTokenPage.propTypes = propTypes;
 LogInWithShortLivedAuthTokenPage.defaultProps = defaultProps;
+LogInWithShortLivedAuthTokenPage.displayName = 'LogInWithShortLivedAuthTokenPage';
 
 export default compose(
     withLocalize,


### PR DESCRIPTION
### Details
Refactor `LogInWithShortLivedAuthTokenPage` into a function component.

### Fixed Issues
$ https://github.com/Expensify/App/issues/16237

## Tests

#### 1. Desktop Web

- Valid authentication flow:
1. Sign out of NewDot
2. Sign in to any account in OldDot
3. Click on the blue Concierge icon in the bottom right corner of the page
4. Make sure a new tab opens to NewDot, and you get automatically signed in

----

- Expired/invalid authToken flow:
1. Sign out of NewDot
2. Go to http://localhost:8080/transition?accountID=111111111&email=test%40expensifail.com&shortLivedAuthToken=abc&encryptedAuthToken=abc&shouldForceLogin=true
3. Make sure you see the "Your session has expired. [Please sign in again]." page

#### 2. mWeb Android

1. Sign out of NewDot
2. Sign in to any account in OldDot
3. Click on "Set up my company for free"
4. After being redirected to `localhost:8080/transition?...`, manually update the URL to `10.0.2.2:8080/transition?...`
5. Make sure you get automatically signed in to NewDot, on the "Create a new workspace" page


- [x] Verify that no errors appear in the JS console

### Offline tests
N/A, must be online to sign in

### QA Steps


- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://github.com/Expensify/App/assets/2229301/2d4d073b-dec7-49cb-a2d9-f42c1ed03018

</details>


<details>
<summary>Mobile Web - Chrome</summary>

https://github.com/Expensify/App/assets/2229301/3ac3ea3d-16b4-4b24-80d2-4f6aa728110f


</details>

<details>
<summary>Mobile Web - Safari</summary>

N/A, flow not supported for mWeb Safari

</details>

<details>
<summary>Desktop</summary>

N/A, transition not supported

</details>

<details>
<summary>iOS</summary>

N/A, transition not supported

</details>

<details>
<summary>Android</summary>

N/A, transition not supported

</details>
