### PR TITLE
feat: use `accountID` in `ReportParticipantsPage`

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -870,6 +870,10 @@ const CONST = {
         GUIDES_DOMAIN: 'team.expensify.com',
     },
 
+    ACCOUNT_ID: {
+        CONCIERGE: '8392101',
+    },
+
     ENVIRONMENT: {
         DEV: 'development',
         STAGING: 'staging',

--- a/src/ONYXKEYS.js
+++ b/src/ONYXKEYS.js
@@ -45,6 +45,9 @@ export default {
     // Contains all the personalDetails the user has access to
     PERSONAL_DETAILS: 'personalDetails',
 
+    // Contains all the personalDetails the user has access to, keyed by accountID
+    PERSONAL_DETAILS_LIST: 'personalDetailsList',
+
     // Contains all the private personal details of the user
     PRIVATE_PERSONAL_DETAILS: 'private_personalDetails',
 

--- a/src/libs/UserUtils.js
+++ b/src/libs/UserUtils.js
@@ -66,6 +66,9 @@ function getLoginListBrickRoadIndicator(loginList) {
 
 /**
  * Hashes provided string and returns a value between [0, range)
+ *
+ * @deprecated Use hashAccountID instead.
+ *
  * @param {String} login
  * @param {Number} range
  * @returns {Number}
@@ -75,7 +78,40 @@ function hashLogin(login, range) {
 }
 
 /**
+ * Hashes provided string and returns a value between [0, range)
+ * @param {String} accountID
+ * @param {Number} range
+ * @returns {Number}
+ */
+function hashAccountID(accountID, range) {
+    return Math.abs(hashCode(accountID)) % range;
+}
+
+/**
+ * Helper method to return the default avatar associated with the given account ID
+ * @param {String} [accountID]
+ * @returns {String}
+ */
+function getDefaultAvatarWithAccountID(accountID = '') {
+    if (!accountID) {
+        return Expensicons.FallbackAvatar;
+    }
+    if (accountID === CONST.ACCOUNT_ID.CONCIERGE) {
+        return Expensicons.ConciergeAvatar;
+    }
+
+    // There are 24 possible default avatars, so we choose which one this user has based
+    // on a simple hash of their login. Note that Avatar count starts at 1.
+    const loginHashBucket = hashAccountID(accountID, CONST.DEFAULT_AVATAR_COUNT) + 1;
+
+    return defaultAvatars[`Avatar${loginHashBucket}`];
+}
+
+/**
  * Helper method to return the default avatar associated with the given login
+ *
+ * @deprecated Use getDefaultAvatarWithAccountID instead.
+ *
  * @param {String} [login]
  * @returns {String}
  */
@@ -132,6 +168,18 @@ function isDefaultAvatar(avatarURL) {
         return true;
     }
     return false;
+}
+
+/**
+ * Provided a source URL, if source is a default avatar, return the associated SVG.
+ * Otherwise, return the URL pointing to a user-uploaded avatar.
+ *
+ * @param {String} avatarURL - the avatar source from user's personalDetails
+ * @param {String} accountID - the account ID of the user
+ * @returns {String|Function}
+ */
+function getAvatarWithAccountID(avatarURL, accountID) {
+    return isDefaultAvatar(avatarURL) ? getDefaultAvatarWithAccountID(accountID) : avatarURL;
 }
 
 /**
@@ -207,9 +255,11 @@ export {
     hasLoginListInfo,
     getLoginListBrickRoadIndicator,
     getDefaultAvatar,
+    getDefaultAvatarWithAccountID,
     getDefaultAvatarURL,
     isDefaultAvatar,
     getAvatar,
+    getAvatarWithAccountID,
     getAvatarUrl,
     getSmallSizeAvatar,
     getFullSizeAvatar,

--- a/src/pages/ReportParticipantsPage.js
+++ b/src/pages/ReportParticipantsPage.js
@@ -54,28 +54,29 @@ const defaultProps = {
  * @return {Array}
  */
 const getAllParticipants = (report, personalDetails) => {
-    const {participants} = report;
+    const {participantAccountIDs} = report;
 
-    return _.chain(participants)
-        .map((login) => {
-            const userLogin = Str.removeSMSDomain(login);
-            const userPersonalDetail = lodashGet(personalDetails, login, {displayName: userLogin, avatar: ''});
+    return _.chain(participantAccountIDs)
+        .map((accountID) => {
+            const userPersonalDetail = lodashGet(personalDetails, accountID, {avatar: ''});
+            const userLogin = Str.removeSMSDomain(userPersonalDetail.login);
 
             return {
                 alternateText: userLogin,
                 displayName: userPersonalDetail.displayName,
                 icons: [
                     {
-                        source: UserUtils.getAvatar(userPersonalDetail.avatar, login),
-                        name: login,
+                        source: UserUtils.getAvatar(userPersonalDetail.avatar, userPersonalDetail.login),
+                        name: userPersonalDetail.login,
                         type: CONST.ICON_TYPE_AVATAR,
                     },
                 ],
                 keyForList: userLogin,
-                login,
+                accountID,
+                login: userPersonalDetail.login,
                 text: userPersonalDetail.displayName,
-                tooltipText: userLogin,
-                participantsList: [{login, displayName: userPersonalDetail.displayName}],
+                tooltipText: userPersonalDetail.login,
+                participantsList: [{accountID, login: userPersonalDetail.login, displayName: userPersonalDetail.displayName}],
             };
         })
         .sortBy((participant) => participant.displayName.toLowerCase())
@@ -138,7 +139,7 @@ export default compose(
     withReportOrNotFound,
     withOnyx({
         personalDetails: {
-            key: ONYXKEYS.PERSONAL_DETAILS,
+            key: ONYXKEYS.PERSONAL_DETAILS_LIST,
         },
     }),
 )(ReportParticipantsPage);

--- a/src/pages/ReportParticipantsPage.js
+++ b/src/pages/ReportParticipantsPage.js
@@ -66,7 +66,7 @@ const getAllParticipants = (report, personalDetails) => {
                 displayName: userPersonalDetail.displayName,
                 icons: [
                     {
-                        source: UserUtils.getAvatar(userPersonalDetail.avatar, userPersonalDetail.login),
+                        source: UserUtils.getAvatarWithAccountID(userPersonalDetail.avatar, accountID.toString()),
                         name: userPersonalDetail.login,
                         type: CONST.ICON_TYPE_AVATAR,
                     },


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

A part of the 'Secure Logins' issue, point 17.

- Changed `ReportParticipantsPage` to use `accountID`
- New method `UserUtils.getAvatarWithAccountID` that should replace `getAvatar` in the future. This change will result in different default avatars due to using `accountID` instead of email in the hash process - see [discussion](https://github.com/Expensify/App/issues/19007#issuecomment-1576990251).

### Fixed Issues

$ https://github.com/Expensify/App/issues/19007
https://github.com/Expensify/App/issues/19007#issuecomment-1560558505

### Tests

1. Open a chat with several users
2. Click the header of the chat
3. Go to Members
4. The avatars should be rendered in and the default ones might have changed

- [x] Verify that no errors appear in the JS console

### Offline tests

Not applicable.

### QA Steps

1. Open a chat with several users
2. Click the header of the chat
3. Go to Members
4. The avatars should be rendered in and the default ones might have changed

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://github.com/Expensify/App/assets/25725586/8166781b-2751-452f-a72a-bb05e79c1136

</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://github.com/Expensify/App/assets/25725586/6edf4fb8-f5da-45a7-910e-bf67fac99819

</details>

<details>
<summary>Mobile Web - Safari</summary>

https://github.com/Expensify/App/assets/25725586/df5dec7f-be82-4b2e-9b59-c44ccb0b24d4

</details>

<details>
<summary>Desktop</summary>

https://github.com/Expensify/App/assets/25725586/4732846f-0215-4d82-8af4-1990d1199377

</details>

<details>
<summary>iOS</summary>

https://github.com/Expensify/App/assets/25725586/8bc36c55-9927-4cb4-80ee-049993413a50

</details>

<details>
<summary>Android</summary>

https://github.com/Expensify/App/assets/25725586/7a0abcf0-fcd8-4562-a3a9-46bd1c28479e

</details>
