### PR TITLE
Migrate ReportFooter.js to function component

### DIFF
--- a/src/pages/home/report/ReportFooter.js
+++ b/src/pages/home/report/ReportFooter.js
@@ -58,8 +58,7 @@ const defaultProps = {
 };
 
 function ReportFooter(props) {
-    const getChatFooterStyles = () => ({...styles.chatFooter, minHeight: !props.isOffline ? CONST.CHAT_FOOTER_MIN_HEIGHT : 0});
-
+    const chatFooterStyles = {...styles.chatFooter, minHeight: !props.isOffline ? CONST.CHAT_FOOTER_MIN_HEIGHT : 0};
     const isArchivedRoom = ReportUtils.isArchivedRoom(props.report);
     const isAllowedToComment = ReportUtils.isAllowedToComment(props.report);
     const hideComposer = isArchivedRoom || !_.isEmpty(props.errors) || !isAllowedToComment;
@@ -75,7 +74,7 @@ function ReportFooter(props) {
                 </View>
             )}
             {!hideComposer && (props.shouldShowComposeInput || !props.isSmallScreenWidth) && (
-                <View style={[getChatFooterStyles, props.isComposerFullSize && styles.chatFooterFullCompose]}>
+                <View style={[chatFooterStyles, props.isComposerFullSize && styles.chatFooterFullCompose]}>
                     <SwipeableView onSwipeDown={Keyboard.dismiss}>
                         {Session.isAnonymousUser() ? (
                             <AnonymousReportFooter report={props.report} />

--- a/src/pages/home/report/ReportFooter.js
+++ b/src/pages/home/report/ReportFooter.js
@@ -1,4 +1,4 @@
-import React, {useMemo} from 'react';
+import React from 'react';
 import _ from 'underscore';
 import PropTypes from 'prop-types';
 import {withOnyx} from 'react-native-onyx';

--- a/src/pages/home/report/ReportFooter.js
+++ b/src/pages/home/report/ReportFooter.js
@@ -58,20 +58,11 @@ const defaultProps = {
 };
 
 function ReportFooter(props) {
-    /**
-     * @returns {Object}
-     */
-    const getChatFooterStyles = useMemo(
-        () => ({
-            ...styles.chatFooter,
-            minHeight: !props.isOffline ? CONST.CHAT_FOOTER_MIN_HEIGHT : 0,
-        }),
-        [props.isOffline],
-    );
+    const getChatFooterStyles = () => ({...styles.chatFooter, minHeight: !props.isOffline ? CONST.CHAT_FOOTER_MIN_HEIGHT : 0});
 
-    const isArchivedRoom = useMemo(() => ReportUtils.isArchivedRoom(props.report), [props.report]);
-    const isAllowedToComment = useMemo(() => ReportUtils.isAllowedToComment(props.report), [props.report]);
-    const hideComposer = useMemo(() => isArchivedRoom || !_.isEmpty(props.errors) || !isAllowedToComment, [isArchivedRoom, props.errors, isAllowedToComment]);
+    const isArchivedRoom = ReportUtils.isArchivedRoom(props.report);
+    const isAllowedToComment = ReportUtils.isAllowedToComment(props.report);
+    const hideComposer = isArchivedRoom || !_.isEmpty(props.errors) || !isAllowedToComment;
 
     return (
         <>

--- a/src/pages/home/report/ReportFooter.js
+++ b/src/pages/home/report/ReportFooter.js
@@ -1,4 +1,4 @@
-import React, {useMemo, useCallback} from 'react';
+import React, {useMemo} from 'react';
 import _ from 'underscore';
 import PropTypes from 'prop-types';
 import {withOnyx} from 'react-native-onyx';
@@ -57,44 +57,46 @@ const defaultProps = {
     shouldDisableCompose: false,
 };
 
-const ReportFooter = ({report, reportActions, isOffline, onSubmitComment, errors, pendingAction, shouldShowComposeInput, shouldDisableCompose, isSmallScreenWidth, isComposerFullSize}) => {
+function ReportFooter(props) {
     /**
      * @returns {Object}
      */
-    const getChatFooterStyles = useCallback(
+    const getChatFooterStyles = useMemo(
         () => ({
             ...styles.chatFooter,
-            minHeight: !isOffline ? CONST.CHAT_FOOTER_MIN_HEIGHT : 0,
+            minHeight: !props.isOffline ? CONST.CHAT_FOOTER_MIN_HEIGHT : 0,
         }),
-        [isOffline],
+        [props.isOffline],
     );
 
-    const isArchivedRoom = useMemo(() => ReportUtils.isArchivedRoom(report), [report]);
-    const isAllowedToComment = useMemo(() => ReportUtils.isAllowedToComment(report), [report]);
-    const hideComposer = useMemo(() => isArchivedRoom || !_.isEmpty(errors) || !isAllowedToComment, [isArchivedRoom, errors, isAllowedToComment]);
+    const isArchivedRoom = useMemo(() => ReportUtils.isArchivedRoom(props.report), [props.report]);
+    const isAllowedToComment = useMemo(() => ReportUtils.isAllowedToComment(props.report), [props.report]);
+    const hideComposer = useMemo(() => isArchivedRoom || !_.isEmpty(props.errors) || !isAllowedToComment, [isArchivedRoom, props.errors, isAllowedToComment]);
 
     return (
         <>
             {(isArchivedRoom || hideComposer) && (
-                <View style={[styles.chatFooter, isSmallScreenWidth ? styles.mb5 : null]}>
-                    {isArchivedRoom && <ArchivedReportFooter report={report} />}
-                    {!isSmallScreenWidth && <View style={styles.offlineIndicatorRow}>{hideComposer && <OfflineIndicator containerStyles={[styles.chatItemComposeSecondaryRow]} />}</View>}
+                <View style={[styles.chatFooter, props.isSmallScreenWidth ? styles.mb5 : null]}>
+                    {isArchivedRoom && <ArchivedReportFooter report={props.report} />}
+                    {!props.isSmallScreenWidth && (
+                        <View style={styles.offlineIndicatorRow}>{hideComposer && <OfflineIndicator containerStyles={[styles.chatItemComposeSecondaryRow]} />}</View>
+                    )}
                 </View>
             )}
-            {!hideComposer && (shouldShowComposeInput || !isSmallScreenWidth) && (
-                <View style={[getChatFooterStyles(), isComposerFullSize && styles.chatFooterFullCompose]}>
+            {!hideComposer && (props.shouldShowComposeInput || !props.isSmallScreenWidth) && (
+                <View style={[getChatFooterStyles, props.isComposerFullSize && styles.chatFooterFullCompose]}>
                     <SwipeableView onSwipeDown={Keyboard.dismiss}>
                         {Session.isAnonymousUser() ? (
-                            <AnonymousReportFooter report={report} />
+                            <AnonymousReportFooter report={props.report} />
                         ) : (
                             <ReportActionCompose
-                                onSubmit={onSubmitComment}
-                                reportID={report.reportID.toString()}
-                                reportActions={reportActions}
-                                report={report}
-                                pendingAction={pendingAction}
-                                isComposerFullSize={isComposerFullSize}
-                                disabled={shouldDisableCompose}
+                                onSubmit={props.onSubmitComment}
+                                reportID={props.report.reportID.toString()}
+                                reportActions={props.reportActions}
+                                report={props.report}
+                                pendingAction={props.pendingAction}
+                                isComposerFullSize={props.isComposerFullSize}
+                                disabled={props.shouldDisableCompose}
                             />
                         )}
                     </SwipeableView>
@@ -102,7 +104,7 @@ const ReportFooter = ({report, reportActions, isOffline, onSubmitComment, errors
             )}
         </>
     );
-};
+}
 
 ReportFooter.displayName = 'ReportFooter';
 ReportFooter.propTypes = propTypes;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/16268
PROPOSAL: https://github.com/Expensify/App/issues/16268#issuecomment-1574301505


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Migrate ReportFooter.js to function component
1. log in to ND
2. Go to any chat conversation
3. Verify that footer looks correct

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
Same as above
### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Migrate ReportFooter.js to function component
1. log in to ND
2. Go to any chat conversation
3. Verify that footer looks correct

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>
<img width="1266" alt="web" src="https://github.com/Expensify/App/assets/47522946/332e1f48-608e-42f6-82af-aed79a7e9c3c">

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>
<img width="297" alt="mobile-chrome" src="https://github.com/Expensify/App/assets/47522946/ab987f97-f06a-464e-ab5f-af561554691c">

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>
<img src=https://github.com/Expensify/App/assets/47522946/0cd75829-8b39-41c8-89de-9527eece658b  width=50%>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>
<img width="1195" alt="desktop" src="https://github.com/Expensify/App/assets/47522946/c2607d18-2ddb-4589-a0fe-7b4d7fdf87b6">

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>
<img width="585" alt="ios" src="https://github.com/Expensify/App/assets/47522946/650419d1-bfd5-4782-88c7-7c5e3a38116e">

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>
<img width="576" alt="android" src="https://github.com/Expensify/App/assets/47522946/70c0cc7d-8e1e-4de8-a4ab-51e59a72ee38">

<!-- add screenshots or videos here -->

</details>
