### PR TITLE
Migrate DisplayNamePage.js to function

### DIFF
--- a/src/pages/settings/Profile/DisplayNamePage.js
+++ b/src/pages/settings/Profile/DisplayNamePage.js
@@ -27,18 +27,18 @@ const defaultProps = {
     ...withCurrentUserPersonalDetailsDefaultProps,
 };
 
+/**
+ * Submit form to update user's first and last name (and display name)
+ * @param {Object} values
+ * @param {String} values.firstName
+ * @param {String} values.lastName
+ */
+const updateDisplayName = (values) => {
+    PersonalDetails.updateDisplayName(values.firstName.trim(), values.lastName.trim());
+};
+
 function DisplayNamePage(props) {
     const currentUserDetails = props.currentUserPersonalDetails || {};
-
-    /**
-     * Submit form to update user's first and last name (and display name)
-     * @param {Object} values
-     * @param {String} values.firstName
-     * @param {String} values.lastName
-     */
-    const updateDisplayName = (values) => {
-        PersonalDetails.updateDisplayName(values.firstName.trim(), values.lastName.trim());
-    };
 
     /**
      * @param {Object} values

--- a/src/pages/settings/Profile/DisplayNamePage.js
+++ b/src/pages/settings/Profile/DisplayNamePage.js
@@ -1,5 +1,5 @@
 import lodashGet from 'lodash/get';
-import React, {Component} from 'react';
+import React from 'react';
 import {View} from 'react-native';
 import withCurrentUserPersonalDetails, {withCurrentUserPersonalDetailsPropTypes, withCurrentUserPersonalDetailsDefaultProps} from '../../../components/withCurrentUserPersonalDetails';
 import ScreenWrapper from '../../../components/ScreenWrapper';
@@ -38,8 +38,8 @@ function DisplayNamePage(props) {
      */
     const updateDisplayName = (values) => {
         PersonalDetails.updateDisplayName(values.firstName.trim(), values.lastName.trim());
-    }
-    
+    };
+
     /**
      * @param {Object} values
      * @param {String} values.firstName
@@ -63,7 +63,7 @@ function DisplayNamePage(props) {
         }
 
         return errors;
-    }
+    };
 
     return (
         <ScreenWrapper includeSafeAreaPaddingBottom={false}>

--- a/src/pages/settings/Profile/DisplayNamePage.js
+++ b/src/pages/settings/Profile/DisplayNamePage.js
@@ -27,13 +27,8 @@ const defaultProps = {
     ...withCurrentUserPersonalDetailsDefaultProps,
 };
 
-class DisplayNamePage extends Component {
-    constructor(props) {
-        super(props);
-
-        this.validate = this.validate.bind(this);
-        this.updateDisplayName = this.updateDisplayName.bind(this);
-    }
+function DisplayNamePage(props) {
+    const currentUserDetails = props.currentUserPersonalDetails || {};
 
     /**
      * Submit form to update user's first and last name (and display name)
@@ -41,80 +36,77 @@ class DisplayNamePage extends Component {
      * @param {String} values.firstName
      * @param {String} values.lastName
      */
-    updateDisplayName(values) {
+    const updateDisplayName = (values) => {
         PersonalDetails.updateDisplayName(values.firstName.trim(), values.lastName.trim());
     }
-
+    
     /**
      * @param {Object} values
      * @param {String} values.firstName
      * @param {String} values.lastName
      * @returns {Object} - An object containing the errors for each inputID
      */
-    validate(values) {
+    const validate = (values) => {
         const errors = {};
 
         // First we validate the first name field
         if (!ValidationUtils.isValidDisplayName(values.firstName)) {
-            ErrorUtils.addErrorMessage(errors, 'firstName', this.props.translate('personalDetails.error.hasInvalidCharacter'));
+            ErrorUtils.addErrorMessage(errors, 'firstName', props.translate('personalDetails.error.hasInvalidCharacter'));
         }
         if (ValidationUtils.doesContainReservedWord(values.firstName, CONST.DISPLAY_NAME.RESERVED_FIRST_NAMES)) {
-            ErrorUtils.addErrorMessage(errors, 'firstName', this.props.translate('personalDetails.error.containsReservedWord'));
+            ErrorUtils.addErrorMessage(errors, 'firstName', props.translate('personalDetails.error.containsReservedWord'));
         }
 
         // Then we validate the last name field
         if (!ValidationUtils.isValidDisplayName(values.lastName)) {
-            errors.lastName = this.props.translate('personalDetails.error.hasInvalidCharacter');
+            errors.lastName = props.translate('personalDetails.error.hasInvalidCharacter');
         }
 
         return errors;
     }
 
-    render() {
-        const currentUserDetails = this.props.currentUserPersonalDetails || {};
-
-        return (
-            <ScreenWrapper includeSafeAreaPaddingBottom={false}>
-                <HeaderWithBackButton
-                    title={this.props.translate('displayNamePage.headerTitle')}
-                    onBackButtonPress={() => Navigation.goBack(ROUTES.SETTINGS_PROFILE)}
-                />
-                <Form
-                    style={[styles.flexGrow1, styles.ph5]}
-                    formID={ONYXKEYS.FORMS.DISPLAY_NAME_FORM}
-                    validate={this.validate}
-                    onSubmit={this.updateDisplayName}
-                    submitButtonText={this.props.translate('common.save')}
-                    enabledWhenOffline
-                >
-                    <Text style={[styles.mb6]}>{this.props.translate('displayNamePage.isShownOnProfile')}</Text>
-                    <View style={styles.mb4}>
-                        <TextInput
-                            inputID="firstName"
-                            name="fname"
-                            label={this.props.translate('common.firstName')}
-                            defaultValue={lodashGet(currentUserDetails, 'firstName', '')}
-                            maxLength={CONST.DISPLAY_NAME.MAX_LENGTH}
-                            autoCapitalize="words"
-                        />
-                    </View>
-                    <View>
-                        <TextInput
-                            inputID="lastName"
-                            name="lname"
-                            label={this.props.translate('common.lastName')}
-                            defaultValue={lodashGet(currentUserDetails, 'lastName', '')}
-                            maxLength={CONST.DISPLAY_NAME.MAX_LENGTH}
-                            autoCapitalize="words"
-                        />
-                    </View>
-                </Form>
-            </ScreenWrapper>
-        );
-    }
+    return (
+        <ScreenWrapper includeSafeAreaPaddingBottom={false}>
+            <HeaderWithBackButton
+                title={props.translate('displayNamePage.headerTitle')}
+                onBackButtonPress={() => Navigation.goBack(ROUTES.SETTINGS_PROFILE)}
+            />
+            <Form
+                style={[styles.flexGrow1, styles.ph5]}
+                formID={ONYXKEYS.FORMS.DISPLAY_NAME_FORM}
+                validate={validate}
+                onSubmit={updateDisplayName}
+                submitButtonText={props.translate('common.save')}
+                enabledWhenOffline
+            >
+                <Text style={[styles.mb6]}>{props.translate('displayNamePage.isShownOnProfile')}</Text>
+                <View style={styles.mb4}>
+                    <TextInput
+                        inputID="firstName"
+                        name="fname"
+                        label={props.translate('common.firstName')}
+                        defaultValue={lodashGet(currentUserDetails, 'firstName', '')}
+                        maxLength={CONST.DISPLAY_NAME.MAX_LENGTH}
+                        autoCapitalize="words"
+                    />
+                </View>
+                <View>
+                    <TextInput
+                        inputID="lastName"
+                        name="lname"
+                        label={props.translate('common.lastName')}
+                        defaultValue={lodashGet(currentUserDetails, 'lastName', '')}
+                        maxLength={CONST.DISPLAY_NAME.MAX_LENGTH}
+                        autoCapitalize="words"
+                    />
+                </View>
+            </Form>
+        </ScreenWrapper>
+    );
 }
 
 DisplayNamePage.propTypes = propTypes;
 DisplayNamePage.defaultProps = defaultProps;
+DisplayNamePage.displayName = 'DisplayNamePage';
 
 export default compose(withLocalize, withCurrentUserPersonalDetails)(DisplayNamePage);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
cc @marcaaron 

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Note - There are at least two bugs with this but they are already on staging/prod so are not caused by this PR and you can ignore.
1. STAGING AND BELOW - [Display Name Form Data Doesn't Save on Web Window Resize](https://expensify.slack.com/archives/C049HHMV9SM/p1686161807163249)
2. PROD - With a name that should get an error, you only get an error once you click away from the field, the first time. After the error shows, then you get it immediately if the field has an error (I haven't made a report of this but will)

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
3. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/16292


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
4. Verify a modal appears displaying a preview of that image
--->
* Same as QA

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Go to Profile > Display Name
2. Change or add a display name
3. Use a first name of `Expensify` and ensure you get an error (you may have to click away from the field)
5. Use a first name with a semi-colon in it and ensure you get an error
6. Use a last name with a semi-colon in it and ensure you get an error
7. Fix any errors
8. Click Save
9. Ensure the name is saved
10. Reopen Display Name and ensure the new name is there.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android / native
    - [X] Android / Chrome
    - [X] iOS / native
    - [X] iOS / Safari
    - [X] MacOS / Chrome / Safari
    - [X] MacOS / Desktop
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [X] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [X] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If a new component is created I verified that:
    - [X] A similar component doesn't exist in the codebase
    - [X] All props are defined accurately and each prop has a `/** comment above it */`
    - [X] The file is named correctly
    - [X] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [X] The only data being stored in the state is data necessary for rendering and nothing else
    - [X] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [X] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [X] All JSX used for rendering exists in the render method
    - [X] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [X] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [X] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->
<img width="1069" alt="Screenshot 2023-06-07 at 11 23 29" src="https://github.com/Expensify/App/assets/5487802/466c81aa-a38e-46b8-8ce2-0c92025010ce">

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->
<img width="551" alt="Screenshot 2023-06-07 at 11 32 30" src="https://github.com/Expensify/App/assets/5487802/323836ed-5df6-4e46-be27-9548d4eeb887">

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->
<img width="564" alt="Screenshot 2023-06-07 at 11 23 46" src="https://github.com/Expensify/App/assets/5487802/5a007cf7-145e-48f7-adbe-e2550e429b48">

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->
<img width="1312" alt="Screenshot 2023-06-07 at 11 27 54" src="https://github.com/Expensify/App/assets/5487802/53bebbff-5346-4f3f-b561-2466eb9c928a">

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->
<img width="564" alt="Screenshot 2023-06-07 at 11 31 34" src="https://github.com/Expensify/App/assets/5487802/91f2f3d8-0194-473f-a275-17f3db425378">

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->
<img width="551" alt="Screenshot 2023-06-07 at 11 35 59" src="https://github.com/Expensify/App/assets/5487802/f8e213fa-c525-438c-a92a-e2347b51f3cf">

</details>
