### PR TITLE
[navigation-refactor] fix: currency and date picker selection

### DIFF
--- a/src/components/CalendarPicker/index.js
+++ b/src/components/CalendarPicker/index.js
@@ -58,19 +58,21 @@ class CalendarPicker extends React.PureComponent {
         throw new Error('Minimum date cannot be greater than the maximum date.');
     }
 
-    componentDidUpdate(prevProps) {
-        // Check if selectedYear has changed
-        if (this.props.selectedYear === prevProps.selectedYear && this.props.selectedYear === this.state.selectedYear) {
-            return;
+    componentDidUpdate(prevProps, prevState) {
+        // if the selectedYear prop or state has changed, update the currentDateView state with the new year value
+        if (this.props.selectedYear === prevProps.selectedYear && prevState.selectedYear === this.state.selectedYear) {
+            return;   
         }
 
-        // If the selectedYear prop has changed, update the currentDateView state with the new year value
+        // If we changed the prop for selectedYear, update the state to match it, otherwise use the state value
+        const newSelectedYear = this.props.selectedYear !== prevProps.selectedYear ? this.props.selectedYear : this.state.selectedYear;
+
         this.setState(
             (prev) => {
-                const newMomentDate = moment(prev.currentDateView).set('year', this.props.selectedYear);
+                const newMomentDate = moment(prev.currentDateView).set('year', newSelectedYear);
 
                 return {
-                    selectedYear: this.props.selectedYear,
+                    selectedYear: newSelectedYear,
                     currentDateView: this.clampDate(newMomentDate.toDate()),
                 };
             },

--- a/src/components/CalendarPicker/index.js
+++ b/src/components/CalendarPicker/index.js
@@ -61,7 +61,7 @@ class CalendarPicker extends React.PureComponent {
     componentDidUpdate(prevProps, prevState) {
         // if the selectedYear prop or state has changed, update the currentDateView state with the new year value
         if (this.props.selectedYear === prevProps.selectedYear && prevState.selectedYear === this.state.selectedYear) {
-            return;   
+            return;
         }
 
         // If we changed the prop for selectedYear, update the state to match it, otherwise use the state value

--- a/src/components/CalendarPicker/index.js
+++ b/src/components/CalendarPicker/index.js
@@ -60,7 +60,7 @@ class CalendarPicker extends React.PureComponent {
 
     componentDidUpdate(prevProps) {
         // Check if selectedYear has changed
-        if (this.props.selectedYear === prevProps.selectedYear) {
+        if (this.props.selectedYear === prevProps.selectedYear && this.props.selectedYear === this.state.selectedYear) {
             return;
         }
 

--- a/src/libs/Navigation/Navigation.js
+++ b/src/libs/Navigation/Navigation.js
@@ -158,15 +158,10 @@ function getActiveRoute() {
         return '';
     }
 
-    const routeState = navigationRef.current.getState();
-    const currentRoute = routeState.routes[routeState.index];
+    const routeFromState = getPathFromState(navigationRef.getRootState(), linkingConfig.config);
 
-    if (currentRoute.state) {
-        return getPathFromState(routeState, linkingConfig.config);
-    }
-
-    if (currentRoute.params && currentRoute.params.path) {
-        return currentRoute.params.path;
+    if (routeFromState) {
+        return routeFromState;
     }
 
     return '';

--- a/src/libs/ReportUtils.js
+++ b/src/libs/ReportUtils.js
@@ -1048,7 +1048,7 @@ function getReportName(report) {
  * @returns {Object}
  */
 function getReport(reportID) {
-    return allReports[`${ONYXKEYS.COLLECTION.REPORT}${reportID}`];
+    return lodashGet(allReports, `${ONYXKEYS.COLLECTION.REPORT}${reportID}`, {});
 }
 
 /**

--- a/src/pages/YearPickerPage.js
+++ b/src/pages/YearPickerPage.js
@@ -1,4 +1,5 @@
 import _ from 'underscore';
+import lodashGet from 'lodash/get';
 import React from 'react';
 import {withCurrentUserPersonalDetailsPropTypes, withCurrentUserPersonalDetailsDefaultProps} from '../components/withCurrentUserPersonalDetails';
 import ScreenWrapper from '../components/ScreenWrapper';
@@ -64,7 +65,15 @@ class YearPickerPage extends React.Component {
      */
     updateSelectedYear(selectedYear) {
         // We have to navigate using concatenation here as it is not possible to pass a function as a route param
-        Navigation.goBack(`${ROUTES.SETTINGS_PERSONAL_DETAILS_DATE_OF_BIRTH}?year=${selectedYear}`, true);
+        const routes = lodashGet(this.props.navigation.getState(), 'routes', []);
+        const dateOfBirthRoute = _.find(routes, (route) => route.name === 'Settings_PersonalDetails_DateOfBirth');
+
+        if (dateOfBirthRoute) {
+            Navigation.setParams({year: selectedYear.toString()}, lodashGet(dateOfBirthRoute, 'key', ''));
+            Navigation.goBack();
+        } else {
+            Navigation.goBack(`${ROUTES.SETTINGS_PERSONAL_DETAILS_DATE_OF_BIRTH}?year=${selectedYear}`);
+        }
     }
 
     /**

--- a/src/pages/tasks/TaskDescriptionPage.js
+++ b/src/pages/tasks/TaskDescriptionPage.js
@@ -9,11 +9,9 @@ import Form from '../../components/Form';
 import ONYXKEYS from '../../ONYXKEYS';
 import TextInput from '../../components/TextInput';
 import styles from '../../styles/styles';
-import Navigation from '../../libs/Navigation/Navigation';
 import compose from '../../libs/compose';
 import reportPropTypes from '../reportPropTypes';
 import * as TaskUtils from '../../libs/actions/Task';
-import ROUTES from '../../ROUTES';
 
 const propTypes = {
     /** Current user session */
@@ -55,12 +53,7 @@ function TaskDescriptionPage(props) {
             includeSafeAreaPaddingBottom={false}
             onEntryTransitionEnd={() => inputRef.current && inputRef.current.focus()}
         >
-            <HeaderWithBackButton
-                title={props.translate('newTaskPage.task')}
-                shouldShowBackButton
-                onBackButtonPress={() => Navigation.goBack(ROUTES.NEW_TASK)}
-                onCloseButtonPress={() => TaskUtils.dismissModalAndClearOutTaskInfo()}
-            />
+            <HeaderWithBackButton title={props.translate('newTaskPage.task')} />
             <Form
                 style={[styles.flexGrow1, styles.ph5]}
                 formID={ONYXKEYS.FORMS.EDIT_TASK_FORM}

--- a/src/pages/tasks/TaskTitlePage.js
+++ b/src/pages/tasks/TaskTitlePage.js
@@ -10,11 +10,9 @@ import Form from '../../components/Form';
 import ONYXKEYS from '../../ONYXKEYS';
 import TextInput from '../../components/TextInput';
 import styles from '../../styles/styles';
-import Navigation from '../../libs/Navigation/Navigation';
 import reportPropTypes from '../reportPropTypes';
 import compose from '../../libs/compose';
 import * as TaskUtils from '../../libs/actions/Task';
-import ROUTES from '../../ROUTES';
 
 const propTypes = {
     /** Task Report Info */
@@ -73,12 +71,7 @@ function TaskTitlePage(props) {
             includeSafeAreaPaddingBottom={false}
             onEntryTransitionEnd={() => inputRef.current && inputRef.current.focus()}
         >
-            <HeaderWithBackButton
-                title={props.translate('newTaskPage.task')}
-                shouldShowBackButton
-                onBackButtonPress={() => Navigation.goBack(ROUTES.NEW_TASK)}
-                onCloseButtonPress={() => TaskUtils.dismissModalAndClearOutTaskInfo()}
-            />
+            <HeaderWithBackButton title={props.translate('newTaskPage.task')} />
             <Form
                 style={[styles.flexGrow1, styles.ph5]}
                 formID={ONYXKEYS.FORMS.EDIT_TASK_FORM}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

When we are selection currency or year in the date picker the value is lost after selection

Simplify `getActiveRoute` and make it always work.

Aslo safely access the report


### Fixed Issues
https://expensify.slack.com/archives/C049HHMV9SM/p1686118076977069
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).



Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/20357
$ https://github.com/Expensify/App/issues/20358
$ https://github.com/Expensify/App/issues/20361


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Click on Fab icon
1. Send/request money
1. Click on the currency icon
1. Choose a different currency
2. Verify the currency was correctly selected

____

1. Sign in with an account without a date of birth
1. Go to Settings > Profile > Personal Details
1. Go to Date of birth
1. Click on Year picker
1. Select any year
1. Click on any date on the calendar
2. Verify the data is correctly selected without any error

____


1. Go to staging dot on web chrome
2. Create a new workspace and create a room with public mode
3. Click on room header and click on share code and copy the URL
4. Now open a new window and first make sure that on that window, you're are logged out of all the staging and new Expensify accounts
5. Paste the link on a new tab and notice that the screen freezes on that point. I remember, it used to show the chat room and used to ask users to sign in previously. But now, it is stuck at the same point. Since it's a public room, it should have shown the chat room or anything.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
4. Upload an image via copy paste
5. Verify a modal appears displaying a preview of that image
--->

Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos

Datepicker videos

iOS


https://github.com/Expensify/App/assets/36083550/a417584d-1519-4171-b7e4-9ce7bf6403d2



Web

https://github.com/Expensify/App/assets/36083550/d0154fbc-2e4d-4656-8b02-f5192f34e7a3





<details>
<summary>Web</summary>

https://github.com/Expensify/App/assets/67908363/7c62d010-fcb8-4eac-bc7a-023b11867662

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>
