### PR TITLE
[WIP] Save draft display name values

### DIFF
--- a/src/components/ScreenWrapper/index.js
+++ b/src/components/ScreenWrapper/index.js
@@ -47,6 +47,7 @@ class ScreenWrapper extends React.Component {
                     return;
                 }
 
+                this.props.onEscapeKeyPressed();
                 Navigation.dismissModal();
             },
             shortcutConfig.descriptionKey,

--- a/src/components/ScreenWrapper/propTypes.js
+++ b/src/components/ScreenWrapper/propTypes.js
@@ -38,6 +38,9 @@ const propTypes = {
     /** Whether to use the maxHeight (true) or use the 100% of the height (false) */
     shouldEnableMaxHeight: PropTypes.bool,
 
+    /** A callback to execute when the escape key is pressed. */
+    onEscapeKeyPressed: PropTypes.func,
+
     ...windowDimensionsPropTypes,
 
     ...environmentPropTypes,
@@ -53,6 +56,7 @@ const defaultProps = {
     keyboardAvoidingViewBehavior: 'padding',
     shouldEnableMaxHeight: false,
     shouldEnablePickerAvoiding: true,
+    onEscapeKeyPressed: () => {},
 };
 
 export {propTypes, defaultProps};

--- a/src/libs/actions/FormActions.js
+++ b/src/libs/actions/FormActions.js
@@ -32,4 +32,11 @@ function setDraftValues(formID, draftValues) {
     Onyx.merge(`${formID}Draft`, draftValues);
 }
 
-export {setIsLoading, setErrors, setErrorFields, setDraftValues};
+/**
+ * @param {String} formID
+ */
+function clearDraftValues(formID) {
+    Onyx.set(`${formID}Draft`, null);
+}
+
+export {setIsLoading, setErrors, setErrorFields, setDraftValues, clearDraftValues};

--- a/src/pages/settings/Profile/DisplayNamePage.js
+++ b/src/pages/settings/Profile/DisplayNamePage.js
@@ -6,6 +6,7 @@ import ScreenWrapper from '../../../components/ScreenWrapper';
 import HeaderWithBackButton from '../../../components/HeaderWithBackButton';
 import withLocalize, {withLocalizePropTypes} from '../../../components/withLocalize';
 import Form from '../../../components/Form';
+import * as FormActions from '../../../libs/actions/FormActions';
 import ONYXKEYS from '../../../ONYXKEYS';
 import CONST from '../../../CONST';
 import * as ValidationUtils from '../../../libs/ValidationUtils';
@@ -74,10 +75,16 @@ class DisplayNamePage extends Component {
         const currentUserDetails = this.props.currentUserPersonalDetails || {};
 
         return (
-            <ScreenWrapper includeSafeAreaPaddingBottom={false}>
+            <ScreenWrapper
+                includeSafeAreaPaddingBottom={false}
+                onEscapeKeyPressed={() => FormActions.clearDraftValues(ONYXKEYS.FORMS.DISPLAY_NAME_FORM)}
+            >
                 <HeaderWithBackButton
                     title={this.props.translate('displayNamePage.headerTitle')}
-                    onBackButtonPress={() => Navigation.goBack(ROUTES.SETTINGS_PROFILE)}
+                    onBackButtonPress={() => {
+                        FormActions.clearDraftValues(ONYXKEYS.FORMS.DISPLAY_NAME_FORM);
+                        Navigation.goBack(ROUTES.SETTINGS_PROFILE);
+                    }}
                 />
                 <Form
                     style={[styles.flexGrow1, styles.ph5]}

--- a/src/pages/settings/Profile/DisplayNamePage.js
+++ b/src/pages/settings/Profile/DisplayNamePage.js
@@ -96,6 +96,7 @@ class DisplayNamePage extends Component {
                             defaultValue={lodashGet(currentUserDetails, 'firstName', '')}
                             maxLength={CONST.DISPLAY_NAME.MAX_LENGTH}
                             autoCapitalize="words"
+                            shouldSaveDraft
                         />
                     </View>
                     <View>
@@ -106,6 +107,7 @@ class DisplayNamePage extends Component {
                             defaultValue={lodashGet(currentUserDetails, 'lastName', '')}
                             maxLength={CONST.DISPLAY_NAME.MAX_LENGTH}
                             autoCapitalize="words"
+                            shouldSaveDraft
                         />
                     </View>
                 </Form>


### PR DESCRIPTION
### Details
Save draft values in the displayName form so that they are persisted when the component unmounts and remounts. However, clear them when the form is explicitly closed to preserve existing behavior.

### Fixed Issues
$ https://github.com/Expensify/App/issues/20404

### Tests
1. Open `Settings` -> `Profile` -> `Display Name`
1. Enter or change a display name but do not save it.
1. Resize the window so that it switches between wide (desktop) and narrow (mobile) layout.
1. Verify that the draft value you entered for the displayName is still there.
1. Close the display name form by pressing the back arrow.
1. Reopen the display name form and verify that it shows what it did the last time you opened it (draft values are gone).
1. Enter a draft value for the display name.
1. Press `ESC` to close the settings modal.
1. Reopen the displayName form. Verify that it shows what it did the last time you opened it (draft values are gone).
1. Enter a display name and hit save. Verify that your display name is updated.
1. Reopen the displayName form. Verify that the name you just saved pre-populates the form.

- [x] Verify that no errors appear in the JS console

### Offline tests
Repeat all the tests steps offline. They should all work the same offline.

### QA Steps
Same as tests + offline tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://github.com/Expensify/App/assets/47436092/7ae37f81-3ba2-4a5d-a331-aa17f3a1913e

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>

https://github.com/Expensify/App/assets/47436092/5e24e5e6-7d4b-4925-a3ab-cb9aecf22a59

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>
