### PR TITLE
fix: CodesPage buttons overlapping

### DIFF
--- a/src/pages/settings/Security/TwoFactorAuth/CodesPage.js
+++ b/src/pages/settings/Security/TwoFactorAuth/CodesPage.js
@@ -25,6 +25,7 @@ import Clipboard from '../../../../libs/Clipboard';
 import themeColors from '../../../../styles/themes/default';
 import localFileDownload from '../../../../libs/localFileDownload';
 import * as TwoFactorAuthActions from '../../../../libs/actions/TwoFactorAuthActions';
+import * as StyleUtils from '../../../../styles/StyleUtils';
 
 const propTypes = {
     ...withLocalizePropTypes,
@@ -95,7 +96,7 @@ function CodesPage(props) {
                                                 </Text>
                                             ))}
                                     </View>
-                                    <View style={styles.twoFactorAuthCodesButtonsContainer(props.isExtraSmallScreenWidth)}>
+                                    <View style={[styles.twoFactorAuthCodesButtonsContainer, StyleUtils.getExtraSmallWrappingStyle(props.isExtraSmallScreenWidth)]}>
                                         <PressableWithDelayToggle
                                             text={props.translate('twoFactorAuth.copyCodes')}
                                             icon={Expensicons.Copy}

--- a/src/pages/settings/Security/TwoFactorAuth/CodesPage.js
+++ b/src/pages/settings/Security/TwoFactorAuth/CodesPage.js
@@ -96,7 +96,7 @@ function CodesPage(props) {
                                                 </Text>
                                             ))}
                                     </View>
-                                    <View style={[styles.twoFactorAuthCodesButtonsContainer, StyleUtils.getExtraSmallWrappingStyle(props.isExtraSmallScreenWidth)]}>
+                                    <View style={[styles.twoFactorAuthCodesButtonsContainer, StyleUtils.getWrappingStyle(props.isExtraSmallScreenWidth)]}>
                                         <PressableWithDelayToggle
                                             text={props.translate('twoFactorAuth.copyCodes')}
                                             icon={Expensicons.Copy}

--- a/src/pages/settings/Security/TwoFactorAuth/CodesPage.js
+++ b/src/pages/settings/Security/TwoFactorAuth/CodesPage.js
@@ -67,7 +67,7 @@ function CodesPage(props) {
                 onBackButtonPress={() => Navigation.goBack(ROUTES.SETTINGS_SECURITY)}
             />
             <FullPageOfflineBlockingView>
-                <ScrollView contentContainerStyle={styles.flex1}>
+                <ScrollView>
                     <Section
                         title={props.translate('twoFactorAuth.keepCodesSafe')}
                         icon={Illustrations.ShieldYellow}
@@ -95,7 +95,7 @@ function CodesPage(props) {
                                                 </Text>
                                             ))}
                                     </View>
-                                    <View style={styles.twoFactorAuthCodesButtonsContainer}>
+                                    <View style={styles.twoFactorAuthCodesButtonsContainer(props.isExtraSmallScreenWidth)}>
                                         <PressableWithDelayToggle
                                             text={props.translate('twoFactorAuth.copyCodes')}
                                             icon={Expensicons.Copy}
@@ -123,15 +123,15 @@ function CodesPage(props) {
                             )}
                         </View>
                     </Section>
-                    <FixedFooter style={[styles.twoFactorAuthFooter]}>
-                        <Button
-                            success
-                            text={props.translate('common.next')}
-                            onPress={() => Navigation.navigate(ROUTES.SETTINGS_2FA_VERIFY)}
-                            isDisabled={isNextButtonDisabled}
-                        />
-                    </FixedFooter>
                 </ScrollView>
+                <FixedFooter style={[styles.mtAuto, styles.pt2]}>
+                    <Button
+                        success
+                        text={props.translate('common.next')}
+                        onPress={() => Navigation.navigate(ROUTES.SETTINGS_2FA_VERIFY)}
+                        isDisabled={isNextButtonDisabled}
+                    />
+                </FixedFooter>
             </FullPageOfflineBlockingView>
         </ScreenWrapper>
     );

--- a/src/pages/settings/Security/TwoFactorAuth/VerifyPage.js
+++ b/src/pages/settings/Security/TwoFactorAuth/VerifyPage.js
@@ -138,7 +138,7 @@ function VerifyPage(props) {
                         <TwoFactorAuthForm />
                     </View>
                 </ScrollView>
-                <FixedFooter style={[styles.twoFactorAuthFooter]}>
+                <FixedFooter style={[styles.mtAuto, styles.pt2]}>
                     <Button
                         success
                         text={props.translate('common.next')}

--- a/src/styles/StyleUtils.js
+++ b/src/styles/StyleUtils.js
@@ -1184,6 +1184,11 @@ function getOuterModalStyle(windowHeight, viewportOffsetTop) {
     return Browser.isMobile() ? {maxHeight: windowHeight, marginTop: viewportOffsetTop} : {};
 }
 
+/**
+ * Returns style object for flexWrap depending on the screen size
+ * @param {Boolean} isExtraSmallScreenWidth
+ * @return {Object}
+ */
 function getWrappingStyle(isExtraSmallScreenWidth) {
     return {
         flexWrap: isExtraSmallScreenWidth ? 'wrap' : 'nowrap',

--- a/src/styles/StyleUtils.js
+++ b/src/styles/StyleUtils.js
@@ -1184,7 +1184,7 @@ function getOuterModalStyle(windowHeight, viewportOffsetTop) {
     return Browser.isMobile() ? {maxHeight: windowHeight, marginTop: viewportOffsetTop} : {};
 }
 
-function getExtraSmallWrappingStyle(isExtraSmallScreenWidth) {
+function getWrappingStyle(isExtraSmallScreenWidth) {
     return {
         flexWrap: isExtraSmallScreenWidth ? 'wrap' : 'nowrap',
     };
@@ -1256,5 +1256,5 @@ export {
     getMentionTextColor,
     getHeightOfMagicCodeInput,
     getOuterModalStyle,
-    getExtraSmallWrappingStyle,
+    getWrappingStyle,
 };

--- a/src/styles/StyleUtils.js
+++ b/src/styles/StyleUtils.js
@@ -1184,6 +1184,12 @@ function getOuterModalStyle(windowHeight, viewportOffsetTop) {
     return Browser.isMobile() ? {maxHeight: windowHeight, marginTop: viewportOffsetTop} : {};
 }
 
+function getExtraSmallWrappingStyle(isExtraSmallScreenWidth) {
+    return {
+        flexWrap: isExtraSmallScreenWidth ? 'wrap' : 'nowrap',
+    };
+}
+
 export {
     getAvatarSize,
     getAvatarStyle,
@@ -1250,4 +1256,5 @@ export {
     getMentionTextColor,
     getHeightOfMagicCodeInput,
     getOuterModalStyle,
+    getExtraSmallWrappingStyle,
 };

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -2218,7 +2218,8 @@ const styles = {
     },
 
     twoFactorAuthCodesButtonsContainer: (isExtraSmallScreenWidth) => ({
-        flexDirection: isExtraSmallScreenWidth ? 'column' : 'row',
+        flexDirection: 'row',
+        flexWrap: isExtraSmallScreenWidth ? 'wrap' : 'nowrap',
         justifyContent: 'center',
         gap: 12,
         marginTop: 20,
@@ -2226,10 +2227,6 @@ const styles = {
 
     twoFactorAuthCodesButton: {
         minWidth: 100,
-    },
-
-    twoFactorAuthFooter: {
-        marginTop: 'auto',
     },
 
     anonymousRoomFooter: {

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -2217,13 +2217,12 @@ const styles = {
         textAlign: 'center',
     },
 
-    twoFactorAuthCodesButtonsContainer: (isExtraSmallScreenWidth) => ({
+    twoFactorAuthCodesButtonsContainer: {
         flexDirection: 'row',
-        flexWrap: isExtraSmallScreenWidth ? 'wrap' : 'nowrap',
         justifyContent: 'center',
         gap: 12,
         marginTop: 20,
-    }),
+    },
 
     twoFactorAuthCodesButton: {
         minWidth: 100,

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -2217,12 +2217,12 @@ const styles = {
         textAlign: 'center',
     },
 
-    twoFactorAuthCodesButtonsContainer: {
-        flexDirection: 'row',
+    twoFactorAuthCodesButtonsContainer: (isExtraSmallScreenWidth) => ({
+        flexDirection: isExtraSmallScreenWidth ? 'column' : 'row',
         justifyContent: 'center',
         gap: 12,
         marginTop: 20,
-    },
+    }),
 
     twoFactorAuthCodesButton: {
         minWidth: 100,

--- a/src/styles/utilities/spacing.js
+++ b/src/styles/utilities/spacing.js
@@ -189,6 +189,10 @@ export default {
         marginTop: 44,
     },
 
+    mtAuto: {
+        marginTop: 'auto',
+    },
+
     mb0: {
         marginBottom: 0,
     },


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/20138
PROPOSAL: https://github.com/Expensify/App/issues/20138#issuecomment-1584802256


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console
- [ ] Change language to Spanish
- [ ] Enter two-factor auth (Seguridad -> Autenticacion de dos factores)
- [ ] Verify that the "Copiar codigos" and "Descargar" buttons are not overlapping with the "Siguiente" button on small screens, like iPhone 7 or 8

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console
- [ ] Change language to Spanish
- [ ] Enter two-factor auth (Seguridad -> Autenticacion de dos factores)
- [ ] Verify that the "Copiar codigos" and "Descargar" buttons are not overlapping with the "Siguiente" button on small screens, like iPhone 7 or 8

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android / native
    - [X] Android / Chrome
    - [X] iOS / native
    - [X] iOS / Safari
    - [X] MacOS / Chrome / Safari
    - [X] MacOS / Desktop
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [X] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [X] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If a new component is created I verified that:
    - [X] A similar component doesn't exist in the codebase
    - [X] All props are defined accurately and each prop has a `/** comment above it */`
    - [X] The file is named correctly
    - [X] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [X] The only data being stored in the state is data necessary for rendering and nothing else
    - [X] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [X] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [X] All JSX used for rendering exists in the render method
    - [X] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [X] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [X] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web - Chrome</summary>
<img src="https://github.com/Expensify/App/assets/26878038/6edc6398-089f-46c9-8a94-3a259f0ce78f" />
</details>

<details>
<summary>Web - Safari</summary>
<img src="https://github.com/Expensify/App/assets/26878038/fea0e2b7-4559-4369-8809-783e039b6b5e" />
</details>

<details>
<summary>Mobile Web - Chrome</summary>
<video src="https://github.com/Expensify/App/assets/26878038/c6a8250a-bfc6-460a-889a-024f3a2d00c1" />
</details>

<details>
<summary>Mobile Web - Safari</summary>
<video src="https://github.com/Expensify/App/assets/26878038/c8e14e20-3f0d-4854-a029-d671f9a53b3e" />
</details>

<details>
<summary>Desktop</summary>
<img width="1193" alt="desktop" src="https://github.com/Expensify/App/assets/26878038/0681dee8-5d78-4766-815a-14cc5da5fd30">
</details>

<details>
<summary>iOS - iPhone 7</summary>
<video src="https://github.com/Expensify/App/assets/26878038/07cc25d4-ddbc-499d-a8af-ac8acd4788ae" />
</details>

<details>
<summary>iOS - iPhone 8</summary>
<video src="https://github.com/Expensify/App/assets/26878038/deb2fe84-e41b-4fe4-82a6-2e5604499291" />
</details>

<details>
<summary>iOS - iPhone 14</summary>
<video src="https://github.com/Expensify/App/assets/26878038/619c2ed7-ae0a-4bb2-91be-987640c364e8" />
</details>

<details>
<summary>Android - Pixel 5</summary>
<video src="https://github.com/Expensify/App/assets/26878038/95737325-066c-41bc-99ea-c0ebdb18b0c5" />
</details>

<details>
<summary>Android - Galaxy Fold</summary>
<video src="https://github.com/Expensify/App/assets/26878038/224df10d-d49c-47bc-be19-9c048af24e33" />
</details>
