### PR TITLE
Add `failureData` to `AddWorkspaceRoom` API command

### DIFF
--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -1218,6 +1218,17 @@ function addPolicyReport(policy, reportName, visibility) {
             },
         },
     ];
+    const failureData = [
+        {
+            onyxMethod: Onyx.METHOD.MERGE,
+            key: `${ONYXKEYS.COLLECTION.REPORT}${policyReport.reportID}`,
+            value: {
+                errorFields: {
+                    addWorkspaceRoom: ErrorUtils.getMicroSecondOnyxError('report.genericCreateReportFailureMessage'),
+                },
+            }
+        },
+    ];
 
     API.write(
         'AddWorkspaceRoom',
@@ -1228,7 +1239,7 @@ function addPolicyReport(policy, reportName, visibility) {
             reportID: policyReport.reportID,
             createdReportActionID: createdReportAction.reportActionID,
         },
-        {optimisticData, successData},
+        {optimisticData, successData, failureData},
     );
     Navigation.dismissModal(policyReport.reportID);
 }

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -1226,7 +1226,7 @@ function addPolicyReport(policy, reportName, visibility) {
                 errorFields: {
                     addWorkspaceRoom: ErrorUtils.getMicroSecondOnyxError('report.genericCreateReportFailureMessage'),
                 },
-            }
+            },
         },
     ];
 


### PR DESCRIPTION
### Details
At the moment, the call to `AddWorkspaceRoom` doesn't use any `failureData`, so in the rare occurrence that the backend fails but doesn't include any `onyxData` in its response, we still optimistically create a workspace and don't show any indication of an error.
This PR adds a default `failureData` so that if the backend doesn't respond with a `200` jsonCode, we'll still show an error in the room.

### Fixed Issues
$ https://github.com/Expensify/App/issues/20502

### Tests
- **On web (Chrome)**
1. Click on `+` floating action button > New Room
2. Enter the details, make sure you can create a room
3. Simulate a backend error that **does** contain a valid `onyxData`, by applying the following diff in [this block](https://github.com/Expensify/App/blob/6e8435ec6cba470dae50262439f2bacecea9222f/src/libs/HttpUtils.js#L89) of HttpUtils:
```diff
diff --git a/src/libs/HttpUtils.js b/src/libs/HttpUtils.js
index e76517e205..5608c09914 100644
--- a/src/libs/HttpUtils.js
+++ b/src/libs/HttpUtils.js
@@ -87,6 +87,48 @@ function processHTTPRequest(url, method = 'get', body = null, canCancel = true,
             return response.json();
         })
         .then((response) => {
+            if (command === 'AddWorkspaceRoom') {
+                response = {
+                    'code': 666,
+                    'jsonCode': 666,
+                    'type': 'Expensify\\Libs\\Error\\ExpError',
+                    'UUID': '8049BF3C-1161-464F-B749-92172909DF5D',
+                    'message': 'Invalid reportName',
+                    'title': '',
+                    'data': {
+                        'reportName': '#test',
+                        'onyxData': [
+                            {
+                                'onyxMethod': 'merge',
+                                'key': `report_${response.onyxData[0].value.reportID}`,
+                                'value': {
+                                    'errorFields': {
+                                        'addWorkspaceRoom': {
+                                            '1111111111111111': 'Invalid reportName',
+                                        },
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                    'htmlMessage': '',
+                    'onyxData': [
+                        {
+                            'onyxMethod': 'merge',
+                            'key': `report_${response.onyxData[0].value.reportID}`,
+                            'value': {
+                                'errorFields': {
+                                    'addWorkspaceRoom': {
+                                        '1111111111111111': 'Invalid reportName',
+                                    },
+                                },
+                            },
+                        },
+                    ],
+                    'requestID': 'abcdef',
+                };
+            }
+
             // Some retried requests will result in a "Unique Constraints Violation" error from the server, which just means the record already exists
             if (response.jsonCode === CONST.JSON_CODE.BAD_REQUEST && response.message === CONST.ERROR_TITLE.DUPLICATE_RECORD) {
                 throw new HttpsError({
```
4. Create a new room again
5. Make sure you see an error message, and the name of the workspace is grayed out in the LHN: <img width="1512" alt="Screenshot 2023-06-13 at 6 24 54 PM" src="https://github.com/Expensify/App/assets/2229301/bb01efd8-815d-4fa7-8c44-d61c416c4a25">
6. Now, simulate a backend error that does **not** contain a valid `onyxData`, by applying the following diff in [this block](https://github.com/Expensify/App/blob/6e8435ec6cba470dae50262439f2bacecea9222f/src/libs/HttpUtils.js#L89) of HttpUtils (remove the previous change):
```diff
diff --git a/src/libs/HttpUtils.js b/src/libs/HttpUtils.js
index e76517e205..3bda24bd77 100644
--- a/src/libs/HttpUtils.js
+++ b/src/libs/HttpUtils.js
@@ -87,6 +87,15 @@ function processHTTPRequest(url, method = 'get', body = null, canCancel = true,
             return response.json();
         })
         .then((response) => {
+            if (command === 'AddWorkspaceRoom') {
+                response = {
+                    'jsonCode': 500,
+                    'message': '500 Refused',
+                    'onyxData': [],
+                    'requestID': 'abcdef',
+                };
+            }
+
             // Some retried requests will result in a "Unique Constraints Violation" error from the server, which just means the record already exists
             if (response.jsonCode === CONST.JSON_CODE.BAD_REQUEST && response.message === CONST.ERROR_TITLE.DUPLICATE_RECORD) {
                 throw new HttpsError({
```
4. Create a new room again
5. Make sure you see an error message, and the name of the workspace is grayed out in the LHN: <img width="1512" alt="Screenshot 2023-06-13 at 6 27 11 PM" src="https://github.com/Expensify/App/assets/2229301/273ea7c8-e656-43a4-bc7c-0eda1b3c81cd">


- ** On other platforms**
1. Make sure you can create a new room from the FAB

- [x] Verify that no errors appear in the JS console

### Offline tests
While offline, ensure that you can create a new workspace room. After getting back online, make sure you don't see any errors.

### QA Steps
We can't really test the case where the backend returns an error without any `onyxData`, because that would require at lest partially taking down the entire site, so we'll ensure that creating a room still works in normal conditions instead.

1. Sign in to any account that has at least one workspace
2. Click on the green + Floating Action Button > New Room
3. Choose a valid name, workspace and visibility
4. Create the room
5. Make sure you don't see any errors

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

- Regular flow - when creating the room is successful

https://github.com/Expensify/App/assets/2229301/65da1ea2-7029-483a-83b6-17f5e444e749


- With a hardcoded error response:

https://github.com/Expensify/App/assets/2229301/1cd0d44e-fbce-48f4-86f8-a1bf72823f5d


</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>
