### PR TITLE
[Fix] Missing Email in Workspace invite page

### DIFF
--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -181,7 +181,6 @@ function getPersonalDetailsForAccountIDs(accountIDs, personalDetails) {
         let personalDetail = personalDetails[accountID];
         if (!personalDetail) {
             personalDetail = {
-                accountID: cleanAccountID,
                 avatar: UserUtils.getDefaultAvatar(cleanAccountID),
             };
         }
@@ -190,6 +189,7 @@ function getPersonalDetailsForAccountIDs(accountIDs, personalDetails) {
             personalDetail.avatar = CONST.CONCIERGE_ICON_URL;
         }
 
+        personalDetail.accountID = cleanAccountID;
         personalDetailsForAccountIDs[cleanAccountID] = personalDetail;
     });
     return personalDetailsForAccountIDs;

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -475,7 +475,7 @@ function createOption(accountIDs, personalDetails, report, reportActions = {}, {
     } else {
         reportName = ReportUtils.getDisplayNameForParticipant(accountIDs[0]);
         result.keyForList = String(accountIDs[0]);
-        result.alternateText = '';
+        result.alternateText = LocalePhoneNumber.formatPhoneNumber(lodashGet(personalDetails, `${accountIDs[0]}.login`, ''));
     }
 
     result.isIOUReportOwner = ReportUtils.isIOUOwnedByCurrentUser(result, iouReports);

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -475,7 +475,7 @@ function createOption(accountIDs, personalDetails, report, reportActions = {}, {
     } else {
         reportName = ReportUtils.getDisplayNameForParticipant(accountIDs[0]);
         result.keyForList = String(accountIDs[0]);
-        result.alternateText = LocalePhoneNumber.formatPhoneNumber(lodashGet(personalDetails, `${accountIDs[0]}.login`, ''));
+        result.alternateText = LocalePhoneNumber.formatPhoneNumber(lodashGet(personalDetails, [accountIDs[0], 'login'], ''));
     }
 
     result.isIOUReportOwner = ReportUtils.isIOUOwnedByCurrentUser(result, iouReports);

--- a/src/pages/home/sidebar/SidebarLinks.js
+++ b/src/pages/home/sidebar/SidebarLinks.js
@@ -274,7 +274,7 @@ const personalDetailsSelector = (personalDetails) =>
             // It's OK to do param-reassignment in _.reduce() because we absolutely know the starting state of finalPersonalDetails
             // eslint-disable-next-line no-param-reassign
             finalPersonalDetails[accountID] = {
-                accountID,
+                accountID: Number(accountID),
                 login: personalData.login,
                 displayName: personalData.displayName,
                 firstName: personalData.firstName,


### PR DESCRIPTION
cc @Beamanator @vit

### Details

Within the create option we return empty string for the `alternateText` , Before the Refactor it was set to login, we should keep the same behaviour by returning the `login`
https://github.com/Expensify/App/blob/d39643006874bf5ffec923291afa6b43884a4aec/src/libs/OptionsListUtils.js#L478

### Fixed Issues

$ https://github.com/Expensify/App/issues/20803
PROPOSAL: GH_LINK_ISSUE(COMMENT)


### Tests

1. Go to Settings -> Workspaces -> Select Workspace -> Members
2. Click on invite
3. Verify email address is included in the option list

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Go to Settings -> Workspaces -> Select Workspace -> Members
2. Click on invite
3. Verify email address is included in the option list

### QA Steps

1. Go to Settings -> Workspaces -> Select Workspace -> Members
2. Click on invite
3. Verify email address is included in the option list

- [x] Verify that no errors appear in the JS console

### PR Author Checklist


- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<img width="1312" alt="Screenshot 2023-06-15 at 2 07 10 PM" src="https://github.com/Expensify/App/assets/36869046/8346dcf8-5ea1-4d1f-a54a-443be007e7d5">

</details>

<details>
<summary>Mobile Web - Chrome</summary>
<img width="436" alt="Screenshot 2023-06-15 at 2 22 29 PM" src="https://github.com/Expensify/App/assets/36869046/9d25de20-6c79-4720-aa0c-97bb35a6b800">

</details>

<details>
<summary>Mobile Web - Safari</summary>

<img width="468" alt="Screenshot 2023-06-15 at 2 10 34 PM" src="https://github.com/Expensify/App/assets/36869046/33c84ee3-94a1-4daa-9bb4-5ce19bbe5ef6">

</details>

<details>
<summary>Desktop</summary>

<img width="1312" alt="Screenshot 2023-06-15 at 2 11 01 PM" src="https://github.com/Expensify/App/assets/36869046/8f187360-f608-476c-9e4a-4aada1e6edb6">

</details>

<details>
<summary>iOS</summary>
<img width="512" alt="Screenshot 2023-06-15 at 2 16 04 PM" src="https://github.com/Expensify/App/assets/36869046/0717c8b1-14d4-4f31-a71a-b4dad063a82f">

</details>

<details>
<summary>Android</summary>

<img width="436" alt="Screenshot 2023-06-15 at 2 20 21 PM" src="https://github.com/Expensify/App/assets/36869046/d4268876-6d30-45df-89d1-c949975e121e">

</details>
