### PR TITLE
Fix "user is typing..." indicator - key by accountID

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -145,6 +145,7 @@ export default {
         mi: 'mile',
         km: 'kilometer',
         copied: 'Copied!',
+        someone: 'Someone',
     },
     anonymousReportFooter: {
         logoTagline: 'Join in on the discussion.',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -144,6 +144,7 @@ export default {
         mi: 'milla',
         km: 'kilómetro',
         copied: '¡Copiado!',
+        someone: 'Alguien',
     },
     anonymousReportFooter: {
         logoTagline: 'Únete a la discussion.',

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -51,7 +51,6 @@ function getDisplayName(login, personalDetail) {
 }
 
 /**
- *
  * @param {String} userAccountIDOrLogin
  * @param {String} [defaultDisplayName] display name to use if user details don't exist in Onyx or if
  *                                      found details don't include the user's displayName or login

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -52,19 +52,24 @@ function getDisplayName(login, personalDetail) {
 
 /**
  *
- * @param {Number} accountID
+ * @param {String} userAccountIDOrLogin
  * @param {String} [defaultDisplayName] display name to use if user details don't exist in Onyx or if
  *                                      found details don't include the user's displayName or login
  * @returns {String}
  */
-function getDisplayNameByAccountID(accountID, defaultDisplayName = '') {
-    const userDetails = allPersonalDetails && lodashGet(allPersonalDetails, accountID, {});
+function getDisplayNameForTypingIndicator(userAccountIDOrLogin, defaultDisplayName = '') {
+    // Try to convert to a number, which means we have an accountID
+    const accountID = Number(userAccountIDOrLogin);
 
-    if (_.isEmpty(userDetails)) {
-        return defaultDisplayName;
+    // If the user is typing on OldDot, userAccountIDOrLogin will be a string (the user's login),
+    // so Number(string) is NaN. Search for personalDetails by login to get the display name.
+    if (_.isNaN(accountID)) {
+        const detailsByLogin = _.findWhere(allPersonalDetails, {login: userAccountIDOrLogin}) || {};
+        return detailsByLogin.displayName || userAccountIDOrLogin;
     }
 
-    return userDetails.displayName || getDisplayName(userDetails.login || '', userDetails) || defaultDisplayName;
+    const detailsByAccountID = lodashGet(allPersonalDetails, accountID, {});
+    return detailsByAccountID.displayName || detailsByAccountID.login || defaultDisplayName;
 }
 
 /**
@@ -483,7 +488,7 @@ function clearAvatarErrors() {
 
 export {
     getDisplayName,
-    getDisplayNameByAccountID,
+    getDisplayNameForTypingIndicator,
     updateAvatar,
     deleteAvatar,
     openMoneyRequestModalPage,

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -51,7 +51,7 @@ function getDisplayName(login, personalDetail) {
 }
 
 /**
- * 
+ *
  * @param {Number} accountID
  * @param {String} [defaultDisplayName] display name to use if user details don't exist in Onyx or if
  *                                      found details don't include the user's displayName or login

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -20,10 +20,10 @@ Onyx.connect({
     },
 });
 
-let personalDetails;
+let allPersonalDetails;
 Onyx.connect({
     key: ONYXKEYS.PERSONAL_DETAILS_LIST,
-    callback: (val) => (personalDetails = val),
+    callback: (val) => (allPersonalDetails = val),
 });
 
 /**
@@ -37,7 +37,7 @@ function getDisplayName(login, personalDetail) {
     // If we have a number like +15857527441@expensify.sms then let's remove @expensify.sms and format it
     // so that the option looks cleaner in our UI.
     const userLogin = LocalePhoneNumber.formatPhoneNumber(login);
-    const userDetails = personalDetail || lodashGet(personalDetails, login);
+    const userDetails = personalDetail || lodashGet(allPersonalDetails, login);
 
     if (!userDetails) {
         return userLogin;
@@ -402,8 +402,8 @@ function updateAvatar(file) {
             key: ONYXKEYS.PERSONAL_DETAILS_LIST,
             value: {
                 [currentUserAccountID]: {
-                    avatar: personalDetails[currentUserAccountID].avatar,
-                    avatarThumbnail: personalDetails[currentUserAccountID].avatarThumbnail || personalDetails[currentUserAccountID].avatar,
+                    avatar: allPersonalDetails[currentUserAccountID].avatar,
+                    avatarThumbnail: allPersonalDetails[currentUserAccountID].avatarThumbnail || allPersonalDetails[currentUserAccountID].avatar,
                     pendingFields: {
                         avatar: null,
                     },
@@ -439,7 +439,7 @@ function deleteAvatar() {
             key: ONYXKEYS.PERSONAL_DETAILS_LIST,
             value: {
                 [currentUserAccountID]: {
-                    avatar: personalDetails[currentUserAccountID].avatar,
+                    avatar: allPersonalDetails[currentUserAccountID].avatar,
                 },
             },
         },

--- a/src/libs/actions/PersonalDetails.js
+++ b/src/libs/actions/PersonalDetails.js
@@ -51,6 +51,23 @@ function getDisplayName(login, personalDetail) {
 }
 
 /**
+ * 
+ * @param {Number} accountID
+ * @param {String} [defaultDisplayName] display name to use if user details don't exist in Onyx or if
+ *                                      found details don't include the user's displayName or login
+ * @returns {String}
+ */
+function getDisplayNameByAccountID(accountID, defaultDisplayName = '') {
+    const userDetails = allPersonalDetails && lodashGet(allPersonalDetails, accountID, {});
+
+    if (_.isEmpty(userDetails)) {
+        return defaultDisplayName;
+    }
+
+    return userDetails.displayName || getDisplayName(userDetails.login || '', userDetails) || defaultDisplayName;
+}
+
+/**
  * Gets the first and last name from the user's personal details.
  * If the login is the same as the displayName, then they don't exist,
  * so we return empty strings instead.
@@ -466,6 +483,7 @@ function clearAvatarErrors() {
 
 export {
     getDisplayName,
+    getDisplayNameByAccountID,
     updateAvatar,
     deleteAvatar,
     openMoneyRequestModalPage,

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -95,8 +95,6 @@ function getReportChannelName(reportID) {
 function getNormalizedTypingStatus(typingStatus) {
     let normalizedTypingStatus = typingStatus;
 
-    // TODO: figure out what to do from here
-    // probably look up login in personalDetails and convert to accountID if it exists
     if (_.first(_.keys(typingStatus)) === 'userLogin') {
         normalizedTypingStatus = {[typingStatus.userLogin]: true};
     }

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -132,7 +132,7 @@ function subscribeToReportTypingEvents(reportID) {
             return;
         }
 
-        // Use a combo of the reportID and the accountID as a key for holding our timers.
+        // Use a combo of the reportID and the accountID or login as a key for holding our timers.
         const reportUserIdentifier = `${reportID}-${accountIDOrLogin}`;
         clearTimeout(typingWatchTimers[reportUserIdentifier]);
         Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_USER_IS_TYPING}${reportID}`, normalizedTypingStatus);

--- a/src/pages/home/report/ReportTypingIndicator.js
+++ b/src/pages/home/report/ReportTypingIndicator.js
@@ -13,7 +13,7 @@ import Text from '../../../components/Text';
 import TextWithEllipsis from '../../../components/TextWithEllipsis';
 
 const propTypes = {
-    /** Key-value pairs of user logins and whether or not they are typing. Keys are logins. */
+    /** Key-value pairs of user accountIDs/logins and whether or not they are typing. Keys are accountIDs or logins. */
     userTypingStatuses: PropTypes.objectOf(PropTypes.bool),
 
     /** Information about the network */
@@ -43,7 +43,7 @@ function ReportTypingIndicator(props) {
         case 1:
             return (
                 <TextWithEllipsis
-                    leadingText={PersonalDetails.getDisplayNameByAccountID(usersTyping[0], 'Someone')}
+                    leadingText={PersonalDetails.getDisplayNameForTypingIndicator(usersTyping[0], props.translate('common.someone'))}
                     trailingText={` ${props.translate('reportTypingIndicator.isTyping')}`}
                     textStyle={[styles.chatItemComposeSecondaryRowSubText]}
                     wrapperStyle={[styles.chatItemComposeSecondaryRow, styles.flex1]}

--- a/src/pages/home/report/ReportTypingIndicator.js
+++ b/src/pages/home/report/ReportTypingIndicator.js
@@ -27,7 +27,7 @@ const defaultProps = {
 };
 
 function ReportTypingIndicator(props) {
-    const usersTyping = useMemo(() => _.filter(_.keys(props.userTypingStatuses), (accountID) => props.userTypingStatuses[accountID]), [props.userTypingStatuses]);
+    const usersTyping = useMemo(() => _.filter(_.keys(props.userTypingStatuses), (loginOrAccountID) => props.userTypingStatuses[loginOrAccountID]), [props.userTypingStatuses]);
     // If we are offline, the user typing statuses are not up-to-date so do not show them
     if (props.network.isOffline) {
         return null;

--- a/src/pages/home/report/ReportTypingIndicator.js
+++ b/src/pages/home/report/ReportTypingIndicator.js
@@ -27,7 +27,7 @@ const defaultProps = {
 };
 
 function ReportTypingIndicator(props) {
-    const usersTyping = useMemo(() => _.filter(_.keys(props.userTypingStatuses), (login) => props.userTypingStatuses[login]), [props.userTypingStatuses]);
+    const usersTyping = useMemo(() => _.filter(_.keys(props.userTypingStatuses), (accountID) => props.userTypingStatuses[accountID]), [props.userTypingStatuses]);
     // If we are offline, the user typing statuses are not up-to-date so do not show them
     if (props.network.isOffline) {
         return null;
@@ -43,7 +43,7 @@ function ReportTypingIndicator(props) {
         case 1:
             return (
                 <TextWithEllipsis
-                    leadingText={PersonalDetails.getDisplayName(usersTyping[0])}
+                    leadingText={PersonalDetails.getDisplayNameByAccountID(usersTyping[0], 'Someone')}
                     trailingText={` ${props.translate('reportTypingIndicator.isTyping')}`}
                     textStyle={[styles.chatItemComposeSecondaryRowSubText]}
                     wrapperStyle={[styles.chatItemComposeSecondaryRow, styles.flex1]}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/20956

### Tests
1. Set up User A as such:
    1. They should have a display name (set a first and / or last name)
    2. Create a public room with this user
    3. Send a few messages in this room, even though it's empty
2. Set up User B as such:
    1. Brand new user, no display name and hasn't sent a message anywhere
    2. Join User A's public room
3. Set up User C as such:
    1. Brand new user, no display name and hasn't sent a message anywhere
    2. Join User A's public room
4. Open up the room with each user in different tabs / devices (ex: 1 chrome, 1 incognito chrome, 1 in desktop)
5. Make sure you have an `*@expensify.com` account and can log in to Concierge

#### Make sure display name shows in "is typing" indicator

1. Start typing in the room with User A (you don't need to send the message)
3. Verify that while User A is typing, User B sees "<user a's display name> is typing..."

https://github.com/Expensify/App/assets/3885503/3330c9a0-a7ae-47e8-a484-5f0e472a0847

#### Make sure `"Someone"` shows in "is typing" indicator

1. Start typing in the room with User B (don't send a message)
2. Verify that while User B is typing, User C sees "Someone is typing..."

<img width="1165" alt="Screenshot 2023-06-19 at 4 35 46 PM" src="https://github.com/Expensify/App/assets/3885503/f325521d-9878-4d01-b38b-642af3c92d1a">

#### Make sure login shows in "is typing" indicator

1. As User B, send a message in the public room
2. Make sure the message shows up in the public room, on User A's device
4. Again, start typing in the room with User B
6. Verify that while User B is typing, User A sees "<user b's email> is typing..."

<img width="1165" alt="Screenshot 2023-06-19 at 4 37 35 PM" src="https://github.com/Expensify/App/assets/3885503/8af96a21-37cf-416f-9b97-34d1766044b4">

#### Make sure "Multiple users are typing" indicator still works

1. Arrange the 3 devices / windows so you can quickly send a message in 2 windows and see the results in the 3rd
2. Quickly start typing a message with both User B and User C as quickly as possible
3. Verify that while both users are typing, User A sees "Multiple users are typing..."

https://github.com/Expensify/App/assets/3885503/804650dd-558d-4798-be93-ea38021c0fff

#### Make sure Concierge live-chatting isn't broken

1. Start a conversation with User B & Concierge in NewDot - make sure you are accessing User B's chat from NewDot & the Concierge account from OldDot
2. Start typing in NewDot with User B
3. Verify in Concierge you see no "user is typing" notification (like always) & that there's no console errors, and nothing crashes
4. Start typing in Concierge (in OldDot) with the concierge account
5. Verify in NewDot, User B sees "Concierge is typing..."

- [X] Verify that no errors appear in the JS console

### Offline tests
"User is typing" indicator does not show offline, so no tests needed here

### QA Steps
Same as above - Concierge part has to be internal QA'd

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Desktop, Android, Web Chrome</summary>

Display name:
![Screenshot 2023-06-19 at 9 53 06 PM](https://github.com/Expensify/App/assets/3885503/72c2e0a7-9b00-4556-a4e9-057aa48c1606)

Login:
![Screenshot 2023-06-19 at 9 54 38 PM](https://github.com/Expensify/App/assets/3885503/dd2059b6-8a05-43e4-9fcb-f440a45a2c02)

Someone:
![Screenshot 2023-06-19 at 9 57 01 PM](https://github.com/Expensify/App/assets/3885503/47806f04-866d-4372-899e-a3c089c070eb)

Concierge:
![Screenshot 2023-06-19 at 10 00 38 PM](https://github.com/Expensify/App/assets/3885503/db2fd35a-f0a7-45ca-8ecc-abe9519f8733)


</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>
