### PR TITLE
[NoQA] Revert "Show the Copilot details if a delegate is set in a report action"

### DIFF
--- a/src/components/UserDetailsTooltip/index.js
+++ b/src/components/UserDetailsTooltip/index.js
@@ -9,49 +9,33 @@ import Tooltip from '../Tooltip';
 import {propTypes, defaultProps} from './userDetailsTooltipPropTypes';
 import styles from '../../styles/styles';
 import ONYXKEYS from '../../ONYXKEYS';
-import withLocalize from '../withLocalize';
-import compose from '../../libs/compose';
 import * as UserUtils from '../../libs/UserUtils';
 
 function UserDetailsTooltip(props) {
     const userDetails = lodashGet(props.personalDetailsList, props.accountID, props.fallbackUserDetails);
-    let userDisplayName = userDetails.displayName ? userDetails.displayName.trim() : '';
-    let userLogin = (userDetails.login || '').trim() && !_.isEqual(userDetails.login, userDetails.displayName) ? Str.removeSMSDomain(userDetails.login) : '';
-    let userAvatar = userDetails.avatar;
-    let userAccountID = props.accountID;
-
-    // We replace the actor's email, name, and avatar with the Copilot manually for now. This will be improved upon when
-    // the Copilot feature is implemented.
-    if (props.delegateAccountID) {
-        const delegateUserDetails = lodashGet(props.personalDetailsList, props.delegateAccountID, {});
-        const delegateUserDisplayName = delegateUserDetails.displayName ? delegateUserDetails.displayName.trim() : '';
-        userDisplayName = `${delegateUserDisplayName} (${props.translate('reportAction.asCopilot')} ${userDisplayName})`;
-        userLogin = delegateUserDetails.login;
-        userAvatar = delegateUserDetails.avatar;
-        userAccountID = props.delegateAccountID;
-    }
-
     const renderTooltipContent = useCallback(
         () => (
             <View style={[styles.alignItemsCenter, styles.ph2, styles.pv2]}>
                 <View style={styles.emptyAvatar}>
                     <Avatar
                         containerStyles={[styles.actionAvatar]}
-                        source={UserUtils.getAvatar(userAvatar, userAccountID)}
+                        source={UserUtils.getAvatar(userDetails.avatar, userDetails.accountID)}
                     />
                 </View>
 
-                <Text style={[styles.mt2, styles.textMicroBold, styles.textReactionSenders, styles.textAlignCenter]}>{userDisplayName}</Text>
+                <Text style={[styles.mt2, styles.textMicroBold, styles.textReactionSenders, styles.textAlignCenter]}>
+                    {String(userDetails.displayName).trim() ? userDetails.displayName : ''}
+                </Text>
 
                 <Text style={[styles.textMicro, styles.fontColorReactionLabel]}>
-                    {(userLogin || '').trim() && !_.isEqual(userLogin, userDisplayName) ? Str.removeSMSDomain(userLogin) : ''}
+                    {String(userDetails.login || '').trim() && !_.isEqual(userDetails.login, userDetails.displayName) ? Str.removeSMSDomain(userDetails.login) : ''}
                 </Text>
             </View>
         ),
-        [userAvatar, userDisplayName, userLogin, userAccountID],
+        [userDetails.avatar, userDetails.displayName, userDetails.login, userDetails.accountID],
     );
 
-    if (!userDisplayName && !userLogin) {
+    if (!userDetails.displayName && !userDetails.login) {
         return props.children;
     }
 
@@ -62,11 +46,8 @@ UserDetailsTooltip.propTypes = propTypes;
 UserDetailsTooltip.defaultProps = defaultProps;
 UserDetailsTooltip.displayName = 'UserDetailsTooltip';
 
-export default compose(
-    withLocalize,
-    withOnyx({
-        personalDetailsList: {
-            key: ONYXKEYS.PERSONAL_DETAILS_LIST,
-        },
-    }),
-)(UserDetailsTooltip);
+export default withOnyx({
+    personalDetailsList: {
+        key: ONYXKEYS.PERSONAL_DETAILS_LIST,
+    },
+})(UserDetailsTooltip);

--- a/src/components/UserDetailsTooltip/userDetailsTooltipPropTypes.js
+++ b/src/components/UserDetailsTooltip/userDetailsTooltipPropTypes.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import personalDetailsPropType from '../../pages/personalDetailsPropType';
-import {withLocalizePropTypes} from '../withLocalize';
 
 const propTypes = {
     /** User's Account ID */
@@ -18,19 +17,12 @@ const propTypes = {
     children: PropTypes.node.isRequired,
     /** List of personalDetails (keyed by accountID)  */
     personalDetailsList: PropTypes.objectOf(personalDetailsPropType),
-
-    /** The accountID of the copilot who took this action on behalf of the user */
-    delegateAccountID: PropTypes.number,
-
-    /** Localization props */
-    ...withLocalizePropTypes,
 };
 
 const defaultProps = {
     accountID: '',
     fallbackUserDetails: {displayName: '', login: '', avatar: ''},
     personalDetailsList: {},
-    delegateAccountID: 0,
 };
 
 export {propTypes, defaultProps};

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -299,9 +299,6 @@ export default {
         sayHello: 'Say hello!',
         usePlusButton: '\n\nYou can also use the + button below to send or request money!',
     },
-    reportAction: {
-        asCopilot: 'as copilot for',
-    },
     mentionSuggestions: {
         hereAlternateText: 'Notify everyone online in this room',
     },

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -298,9 +298,6 @@ export default {
         sayHello: '¡Saluda!',
         usePlusButton: '\n\n¡También puedes usar el botón + de abajo para enviar o pedir dinero!',
     },
-    reportAction: {
-        asCopilot: 'como copiloto de',
-    },
     mentionSuggestions: {
         hereAlternateText: 'Notificar a todos los que estén en linea de esta sala',
     },

--- a/src/pages/home/report/ReportActionItemFragment.js
+++ b/src/pages/home/report/ReportActionItemFragment.js
@@ -57,9 +57,6 @@ const propTypes = {
     // Additional styles to add after local styles
     style: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.object]),
 
-    /** The accountID of the copilot who took this action on behalf of the user */
-    delegateAccountID: PropTypes.number,
-
     ...windowDimensionsPropTypes,
 
     /** localization props */
@@ -78,7 +75,6 @@ const defaultProps = {
     isSingleLine: false,
     source: '',
     style: [],
-    delegateAccountID: 0,
 };
 
 function ReportActionItemFragment(props) {
@@ -149,10 +145,7 @@ function ReportActionItemFragment(props) {
         }
         case 'TEXT':
             return (
-                <UserDetailsTooltip
-                    accountID={props.accountID}
-                    delegateAccountID={props.delegateAccountID}
-                >
+                <UserDetailsTooltip accountID={props.accountID}>
                     <Text
                         numberOfLines={props.isSingleLine ? 1 : undefined}
                         style={[styles.chatItemMessageHeaderSender, props.isSingleLine ? styles.pre : styles.preWrap]}

--- a/src/pages/home/report/ReportActionItemSingle.js
+++ b/src/pages/home/report/ReportActionItemSingle.js
@@ -69,19 +69,8 @@ const showUserDetails = (accountID) => {
 function ReportActionItemSingle(props) {
     const actorEmail = lodashGet(props.action, 'actorEmail', '').replace(CONST.REGEX.MERGED_ACCOUNT_PREFIX, '');
     const actorAccountID = props.action.actorAccountID;
-    let {avatar, displayName} = props.personalDetailsList[actorAccountID] || {};
-    const {pendingFields} = props.personalDetailsList[actorAccountID] || {};
-
-    // We replace the actor's email, name, and avatar with the Copilot manually for now. This will be improved upon when
-    // the Copilot feature is implemented.
-    if (props.action.delegateAccountID) {
-        const delegateDetails = props.personalDetailsList[props.action.delegateAccountID];
-        const delegateDisplayName = delegateDetails.displayName;
-        displayName = `${delegateDisplayName} (${props.translate('reportAction.asCopilot')} ${displayName})`;
-        avatar = delegateDetails.avatar;
-    }
-
-    const avatarSource = UserUtils.getAvatar(avatar, props.action.delegateAccountID ? props.action.delegateAccountID : actorAccountID);
+    const {avatar, displayName, pendingFields} = props.personalDetailsList[actorAccountID] || {};
+    const avatarSource = UserUtils.getAvatar(avatar, actorAccountID);
 
     // Since the display name for a report action message is delivered with the report history as an array of fragments
     // we'll need to take the displayName from personal details and have it be in the same format for now. Eventually,
@@ -101,7 +90,7 @@ function ReportActionItemSingle(props) {
                 style={[styles.alignSelfStart, styles.mr3]}
                 onPressIn={ControlSelection.block}
                 onPressOut={ControlSelection.unblock}
-                onPress={() => showUserDetails(props.action.delegateAccountID ? props.action.delegateAccountID : actorAccountID)}
+                onPress={() => showUserDetails(actorAccountID)}
                 accessibilityLabel={actorEmail}
                 accessibilityRole="button"
             >
@@ -115,10 +104,7 @@ function ReportActionItemSingle(props) {
                             noMargin
                         />
                     ) : (
-                        <UserDetailsTooltip
-                            accountID={actorAccountID}
-                            delegateAccountID={props.action.delegateAccountID}
-                        >
+                        <UserDetailsTooltip accountID={actorAccountID}>
                             <View>
                                 <Avatar
                                     containerStyles={[styles.actionAvatar]}
@@ -136,7 +122,7 @@ function ReportActionItemSingle(props) {
                             style={[styles.flexShrink1, styles.mr1]}
                             onPressIn={ControlSelection.block}
                             onPressOut={ControlSelection.unblock}
-                            onPress={() => showUserDetails(props.action.delegateAccountID ? props.action.delegateAccountID : actorAccountID)}
+                            onPress={() => showUserDetails(actorAccountID)}
                             accessibilityLabel={actorEmail}
                             accessibilityRole="button"
                         >
@@ -147,7 +133,6 @@ function ReportActionItemSingle(props) {
                                     fragment={fragment}
                                     isAttachment={props.action.isAttachment}
                                     isLoading={props.action.isLoading}
-                                    delegateAccountID={props.action.delegateAccountID}
                                     isSingleLine
                                 />
                             ))}


### PR DESCRIPTION
cc @allroundexperts 

Accidentally merged this by mistake so will revert and recreate the old PR here: https://github.com/Expensify/App/pull/20738#issuecomment-1601337171

Reverts Expensify/App#20738

### QA Steps

No QA

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>
