### PR TITLE
fix: remove the selection prop from the task description input fields

### DIFF
--- a/src/libs/actions/Task.js
+++ b/src/libs/actions/Task.js
@@ -672,6 +672,25 @@ function isTaskAssigneeOrTaskOwner(taskReport, sessionAccountID) {
     return sessionAccountID === getTaskOwnerAccountID(taskReport) || sessionAccountID === getTaskAssigneeAccountID(taskReport);
 }
 
+/**
+ * Focus the task description text input and place the cursor at the end of the value (if there is a value in the input).
+ *
+ * @param {Object} input the input element
+ */
+function focusAndUpdateTaskDescriptionInputRange(input) {
+    if (!input) {
+        return;
+    }
+
+    input.focus();
+    if (input.value && input.setSelectionRange) {
+        const length = input.value.length;
+        input.setSelectionRange(length, length);
+        // eslint-disable-next-line no-param-reassign
+        input.scrollTop = input.scrollHeight;
+    }
+}
+
 export {
     createTaskAndNavigate,
     editTaskAndNavigate,
@@ -693,4 +712,5 @@ export {
     dismissModalAndClearOutTaskInfo,
     getTaskAssigneeAccountID,
     isTaskAssigneeOrTaskOwner,
+    focusAndUpdateTaskDescriptionInputRange,
 };

--- a/src/libs/actions/Task.js
+++ b/src/libs/actions/Task.js
@@ -672,25 +672,6 @@ function isTaskAssigneeOrTaskOwner(taskReport, sessionAccountID) {
     return sessionAccountID === getTaskOwnerAccountID(taskReport) || sessionAccountID === getTaskAssigneeAccountID(taskReport);
 }
 
-/**
- * Focus the task description text input and place the cursor at the end of the value (if there is a value in the input).
- *
- * @param {Object} input the input element
- */
-function focusAndUpdateTaskDescriptionInputRange(input) {
-    if (!input) {
-        return;
-    }
-
-    input.focus();
-    if (input.value && input.setSelectionRange) {
-        const length = input.value.length;
-        input.setSelectionRange(length, length);
-        // eslint-disable-next-line no-param-reassign
-        input.scrollTop = input.scrollHeight;
-    }
-}
-
 export {
     createTaskAndNavigate,
     editTaskAndNavigate,
@@ -712,5 +693,4 @@ export {
     dismissModalAndClearOutTaskInfo,
     getTaskAssigneeAccountID,
     isTaskAssigneeOrTaskOwner,
-    focusAndUpdateTaskDescriptionInputRange,
 };

--- a/src/libs/focusAndUpdateMultilineInputRange.js
+++ b/src/libs/focusAndUpdateMultilineInputRange.js
@@ -1,0 +1,24 @@
+/**
+ * Focus a multiline text input and place the cursor at the end of the value (if there is a value in the input).
+ *
+ * When a multiline input contains a text value that goes beyond the scroll height, the cursor will be placed
+ * at the end of the text value, and automatically scroll the input field to this position after the field gains
+ * focus. This provides a better user experience in cases where the text in the field has to be edited. The auto-
+ * scroll behaviour works on all platforms except iOS native.
+ * See https://github.com/Expensify/App/issues/20836 for more details.
+ *
+ * @param {Object} input the input element
+ */
+export default function focusAndUpdateMultilineInputRange(input) {
+    if (!input) {
+        return;
+    }
+
+    input.focus();
+    if (input.value && input.setSelectionRange) {
+        const length = input.value.length;
+        input.setSelectionRange(length, length);
+        // eslint-disable-next-line no-param-reassign
+        input.scrollTop = input.scrollHeight;
+    }
+}

--- a/src/pages/tasks/NewTaskDescriptionPage.js
+++ b/src/pages/tasks/NewTaskDescriptionPage.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useRef} from 'react';
 import {View} from 'react-native';
 import {withOnyx} from 'react-native-onyx';
 import PropTypes from 'prop-types';
@@ -38,17 +38,6 @@ const defaultProps = {
 function NewTaskDescriptionPage(props) {
     const inputRef = useRef(null);
 
-    // The selection will be used to place the cursor at the end if there is prior text in the text input area
-    const [selection, setSelection] = useState({start: 0, end: 0});
-
-    // eslint-disable-next-line rulesdir/prefer-early-return
-    useEffect(() => {
-        if (props.task.description) {
-            const length = props.task.description.length;
-            setSelection({start: length, end: length});
-        }
-    }, [props.task.description]);
-
     // On submit, we want to call the assignTask function and wait to validate
     // the response
     const onSubmit = (values) => {
@@ -63,13 +52,7 @@ function NewTaskDescriptionPage(props) {
     return (
         <ScreenWrapper
             includeSafeAreaPaddingBottom={false}
-            onEntryTransitionEnd={() => {
-                if (!inputRef.current) {
-                    return;
-                }
-
-                inputRef.current.focus();
-            }}
+            onEntryTransitionEnd={() => TaskUtils.focusAndUpdateTaskDescriptionInputRange(inputRef.current)}
         >
             <HeaderWithBackButton
                 title={props.translate('newTaskPage.description')}
@@ -92,10 +75,6 @@ function NewTaskDescriptionPage(props) {
                         autoGrowHeight
                         containerStyles={[styles.autoGrowHeightMultilineInput]}
                         textAlignVertical="top"
-                        selection={selection}
-                        onSelectionChange={(e) => {
-                            setSelection(e.nativeEvent.selection);
-                        }}
                     />
                 </View>
             </Form>

--- a/src/pages/tasks/NewTaskDescriptionPage.js
+++ b/src/pages/tasks/NewTaskDescriptionPage.js
@@ -14,6 +14,7 @@ import TextInput from '../../components/TextInput';
 import Permissions from '../../libs/Permissions';
 import ROUTES from '../../ROUTES';
 import * as TaskUtils from '../../libs/actions/Task';
+import focusAndUpdateMultilineInputRange from '../../libs/focusAndUpdateMultilineInputRange';
 
 const propTypes = {
     /** Beta features list */
@@ -52,7 +53,7 @@ function NewTaskDescriptionPage(props) {
     return (
         <ScreenWrapper
             includeSafeAreaPaddingBottom={false}
-            onEntryTransitionEnd={() => TaskUtils.focusAndUpdateTaskDescriptionInputRange(inputRef.current)}
+            onEntryTransitionEnd={() => focusAndUpdateMultilineInputRange(inputRef.current)}
         >
             <HeaderWithBackButton
                 title={props.translate('newTaskPage.description')}

--- a/src/pages/tasks/TaskDescriptionPage.js
+++ b/src/pages/tasks/TaskDescriptionPage.js
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useRef, useState} from 'react';
+import React, {useCallback, useRef} from 'react';
 import PropTypes from 'prop-types';
 import {View} from 'react-native';
 import {withOnyx} from 'react-native-onyx';
@@ -48,21 +48,10 @@ function TaskDescriptionPage(props) {
 
     const inputRef = useRef(null);
 
-    // Same as NewtaskDescriptionPage, use the selection to place the cursor correctly if there is prior text
-    const [selection, setSelection] = useState({start: 0, end: 0});
-
-    // eslint-disable-next-line rulesdir/prefer-early-return
-    useEffect(() => {
-        if (props.task.report && props.task.report.description) {
-            const length = props.task.report.description.length;
-            setSelection({start: length, end: length});
-        }
-    }, [props.task.report]);
-
     return (
         <ScreenWrapper
             includeSafeAreaPaddingBottom={false}
-            onEntryTransitionEnd={() => inputRef.current && inputRef.current.focus()}
+            onEntryTransitionEnd={() => TaskUtils.focusAndUpdateTaskDescriptionInputRange(inputRef.current)}
         >
             <HeaderWithBackButton title={props.translate('newTaskPage.task')} />
             <Form
@@ -83,10 +72,6 @@ function TaskDescriptionPage(props) {
                         autoGrowHeight
                         containerStyles={[styles.autoGrowHeightMultilineInput]}
                         textAlignVertical="top"
-                        selection={selection}
-                        onSelectionChange={(e) => {
-                            setSelection(e.nativeEvent.selection);
-                        }}
                     />
                 </View>
             </Form>

--- a/src/pages/tasks/TaskDescriptionPage.js
+++ b/src/pages/tasks/TaskDescriptionPage.js
@@ -12,6 +12,7 @@ import styles from '../../styles/styles';
 import compose from '../../libs/compose';
 import reportPropTypes from '../reportPropTypes';
 import * as TaskUtils from '../../libs/actions/Task';
+import focusAndUpdateMultilineInputRange from '../../libs/focusAndUpdateMultilineInputRange';
 
 const propTypes = {
     /** Current user session */
@@ -51,7 +52,7 @@ function TaskDescriptionPage(props) {
     return (
         <ScreenWrapper
             includeSafeAreaPaddingBottom={false}
-            onEntryTransitionEnd={() => TaskUtils.focusAndUpdateTaskDescriptionInputRange(inputRef.current)}
+            onEntryTransitionEnd={() => focusAndUpdateMultilineInputRange(inputRef.current)}
         >
             <HeaderWithBackButton title={props.translate('newTaskPage.task')} />
             <Form


### PR DESCRIPTION
### Details
This avoids using the selection prop on the task description text input which is causing issues on iOS native, when trying to edit a task.

### Fixed Issues
$ https://github.com/Expensify/App/issues/20836
PROPOSAL: https://github.com/Expensify/App/issues/20836#issuecomment-1593572133


### Tests
1. Assign a new task and provide a title and a description
2. After saving the new task, tap on the task description to edit the description
3. Verify that the cursor does not jump around when typing in the description field

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://github.com/Expensify/App/assets/4160319/d5a83c5e-b2d3-4fb6-91f9-ac721c261672

</details>

<details>
<summary>Mobile Web - Chrome</summary>

[20836-android-chrome.webm](https://github.com/Expensify/App/assets/4160319/eccd736a-35b5-4b4d-9a42-eb744a022c1e)

</details>

<details>
<summary>Mobile Web - Safari</summary>

https://github.com/Expensify/App/assets/4160319/f3b00d52-5095-41ed-8ed6-550e7506759a

</details>

<details>
<summary>Desktop</summary>

https://github.com/Expensify/App/assets/4160319/866ab570-1783-4213-9036-22dfbe75bce9

</details>

<details>
<summary>iOS</summary>


https://github.com/Expensify/App/assets/4160319/16be1c9d-cfea-43d7-ada6-4f4ba4deb1c7

</details>

<details>
<summary>Android</summary>

[20836-android-native.webm](https://github.com/Expensify/App/assets/4160319/f7c3c1cd-350b-441f-bc69-76e8dc6d9c75)

</details>
