### PR TITLE
fix: solve missing avatar workspace logo issue

### DIFF
--- a/src/components/Avatar.js
+++ b/src/components/Avatar.js
@@ -73,9 +73,9 @@ function Avatar(props) {
     const isWorkspace = props.type === CONST.ICON_TYPE_WORKSPACE;
     const iconSize = StyleUtils.getAvatarSize(props.size);
 
-    const imageStyle = props.imageStyles ? [StyleUtils.getAvatarStyle(props.size), ...props.imageStyles, StyleUtils.getAvatarBorderRadius(props.size, props.type)] : undefined;
+    const imageStyle = props.imageStyles && props.imageStyles.length > 0 ? [StyleUtils.getAvatarStyle(props.size), ...props.imageStyles, StyleUtils.getAvatarBorderRadius(props.size, props.type)] : [StyleUtils.getAvatarStyle(props.size), StyleUtils.getAvatarBorderRadius(props.size, props.type)];
 
-    const iconStyle = props.imageStyles ? [StyleUtils.getAvatarStyle(props.size), styles.bgTransparent, ...props.imageStyles] : undefined;
+    const iconStyle = props.imageStyles && props.imageStyles.length > 0 ? [StyleUtils.getAvatarStyle(props.size), styles.bgTransparent, ...props.imageStyles] : undefined;
 
     const iconFillColor = isWorkspace ? StyleUtils.getDefaultWorkspaceAvatarColor(props.name).fill : props.fill;
     const fallbackAvatar = isWorkspace ? ReportUtils.getDefaultWorkspaceAvatar(props.name) : props.fallbackIcon;
@@ -101,11 +101,13 @@ function Avatar(props) {
                     />
                 </View>
             ) : (
-                <Image
-                    source={{uri: props.source}}
-                    style={imageStyle}
-                    onError={() => setImageError(true)}
-                />
+                <View style={[iconStyle, ...props.iconAdditionalStyles]}>
+                    <Image
+                        source={{uri: props.source}}
+                        style={imageStyle}
+                        onError={() => setImageError(true)}
+                    />
+                </View>
             )}
         </View>
     );

--- a/src/components/Avatar.js
+++ b/src/components/Avatar.js
@@ -73,7 +73,10 @@ function Avatar(props) {
     const isWorkspace = props.type === CONST.ICON_TYPE_WORKSPACE;
     const iconSize = StyleUtils.getAvatarSize(props.size);
 
-    const imageStyle = props.imageStyles && props.imageStyles.length > 0 ? [StyleUtils.getAvatarStyle(props.size), ...props.imageStyles, StyleUtils.getAvatarBorderRadius(props.size, props.type)] : [StyleUtils.getAvatarStyle(props.size), styles.br0];
+    const imageStyle =
+        props.imageStyles && props.imageStyles.length > 0
+            ? [StyleUtils.getAvatarStyle(props.size), ...props.imageStyles, StyleUtils.getAvatarBorderRadius(props.size, props.type)]
+            : [StyleUtils.getAvatarStyle(props.size), styles.br0];
 
     const iconStyle = props.imageStyles && props.imageStyles.length > 0 ? [StyleUtils.getAvatarStyle(props.size), styles.bgTransparent, ...props.imageStyles] : undefined;
 

--- a/src/components/Avatar.js
+++ b/src/components/Avatar.js
@@ -74,11 +74,11 @@ function Avatar(props) {
     const iconSize = StyleUtils.getAvatarSize(props.size);
 
     const imageStyle =
-        props.imageStyles && props.imageStyles.length > 0
+        props.imageStyles && props.imageStyles.length
             ? [StyleUtils.getAvatarStyle(props.size), ...props.imageStyles, StyleUtils.getAvatarBorderRadius(props.size, props.type)]
             : [StyleUtils.getAvatarStyle(props.size), styles.br0];
 
-    const iconStyle = props.imageStyles && props.imageStyles.length > 0 ? [StyleUtils.getAvatarStyle(props.size), styles.bgTransparent, ...props.imageStyles] : undefined;
+    const iconStyle = props.imageStyles && props.imageStyles.length ? [StyleUtils.getAvatarStyle(props.size), styles.bgTransparent, ...props.imageStyles] : undefined;
 
     const iconFillColor = isWorkspace ? StyleUtils.getDefaultWorkspaceAvatarColor(props.name).fill : props.fill;
     const fallbackAvatar = isWorkspace ? ReportUtils.getDefaultWorkspaceAvatar(props.name) : props.fallbackIcon;

--- a/src/components/Avatar.js
+++ b/src/components/Avatar.js
@@ -73,7 +73,7 @@ function Avatar(props) {
     const isWorkspace = props.type === CONST.ICON_TYPE_WORKSPACE;
     const iconSize = StyleUtils.getAvatarSize(props.size);
 
-    const imageStyle = props.imageStyles && props.imageStyles.length > 0 ? [StyleUtils.getAvatarStyle(props.size), ...props.imageStyles, StyleUtils.getAvatarBorderRadius(props.size, props.type)] : [StyleUtils.getAvatarStyle(props.size), { borderRadius: 0 }];
+    const imageStyle = props.imageStyles && props.imageStyles.length > 0 ? [StyleUtils.getAvatarStyle(props.size), ...props.imageStyles, StyleUtils.getAvatarBorderRadius(props.size, props.type)] : [StyleUtils.getAvatarStyle(props.size), styles.br0];
 
     const iconStyle = props.imageStyles && props.imageStyles.length > 0 ? [StyleUtils.getAvatarStyle(props.size), styles.bgTransparent, ...props.imageStyles] : undefined;
 

--- a/src/components/Avatar.js
+++ b/src/components/Avatar.js
@@ -73,7 +73,7 @@ function Avatar(props) {
     const isWorkspace = props.type === CONST.ICON_TYPE_WORKSPACE;
     const iconSize = StyleUtils.getAvatarSize(props.size);
 
-    const imageStyle = props.imageStyles && props.imageStyles.length > 0 ? [StyleUtils.getAvatarStyle(props.size), ...props.imageStyles, StyleUtils.getAvatarBorderRadius(props.size, props.type)] : [StyleUtils.getAvatarStyle(props.size), StyleUtils.getAvatarBorderRadius(props.size, props.type)];
+    const imageStyle = props.imageStyles && props.imageStyles.length > 0 ? [StyleUtils.getAvatarStyle(props.size), ...props.imageStyles, StyleUtils.getAvatarBorderRadius(props.size, props.type)] : [StyleUtils.getAvatarStyle(props.size), { borderRadius: 0 }];
 
     const iconStyle = props.imageStyles && props.imageStyles.length > 0 ? [StyleUtils.getAvatarStyle(props.size), styles.bgTransparent, ...props.imageStyles] : undefined;
 
@@ -101,7 +101,7 @@ function Avatar(props) {
                     />
                 </View>
             ) : (
-                <View style={[iconStyle, ...props.iconAdditionalStyles]}>
+                <View style={[iconStyle, StyleUtils.getAvatarBorderStyle(props.size, props.type), ...props.iconAdditionalStyles]}>
                     <Image
                         source={{uri: props.source}}
                         style={imageStyle}

--- a/src/components/Avatar.js
+++ b/src/components/Avatar.js
@@ -76,7 +76,7 @@ function Avatar(props) {
     const imageStyle =
         props.imageStyles && props.imageStyles.length
             ? [StyleUtils.getAvatarStyle(props.size), ...props.imageStyles, StyleUtils.getAvatarBorderRadius(props.size, props.type)]
-            : [StyleUtils.getAvatarStyle(props.size), styles.br0];
+            : [StyleUtils.getAvatarStyle(props.size), styles.noBorderRadius];
 
     const iconStyle = props.imageStyles && props.imageStyles.length ? [StyleUtils.getAvatarStyle(props.size), styles.bgTransparent, ...props.imageStyles] : undefined;
 

--- a/src/components/SubscriptAvatar.js
+++ b/src/components/SubscriptAvatar.js
@@ -68,7 +68,6 @@ function SubscriptAvatar(props) {
             <Tooltip text={props.secondaryTooltip}>
                 <View>
                     <Avatar
-                        imageStyles={null}
                         containerStyles={[props.size === CONST.AVATAR_SIZE.SMALL ? styles.secondAvatarSubscriptCompact : styles.secondAvatarSubscript]}
                         iconAdditionalStyles={[
                             StyleUtils.getAvatarBorderWidth(props.size === CONST.AVATAR_SIZE.SMALL ? CONST.AVATAR_SIZE.SMALL_SUBSCRIPT : CONST.AVATAR_SIZE.SUBSCRIPT),

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -551,6 +551,10 @@ const styles = {
         marginVertical: 1,
     },
 
+    noBorderRadius: {
+        borderRadius: 0,
+    },
+
     noRightBorderRadius: {
         borderTopRightRadius: 0,
         borderBottomRightRadius: 0,
@@ -740,10 +744,6 @@ const styles = {
         borderWidth: 1,
         borderRadius: variables.componentBorderRadius,
         borderColor: themeColors.border,
-    },
-
-    br0: {
-        borderRadius: 0,
     },
 
     borderColorFocus: {

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -742,6 +742,10 @@ const styles = {
         borderColor: themeColors.border,
     },
 
+    br0: {
+        borderRadius: 0,
+    },
+
     borderColorFocus: {
         borderColor: themeColors.borderFocus,
     },


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues

$ https://github.com/Expensify/App/issues/19905
PROPOSAL: https://github.com/Expensify/App/issues/19905#issuecomment-1593690817

### Tests

1. Create a workspace
2. Invite a user
2.1. If you don't have a chat with the user, start one
3. Verify that the workspace logo icon appears correctly in the combined user avatar
4. Change the workspace logo to a valid image
5. Verify that the workspace logo icon appears correctly in the combined user avatar
6. The workspace icon should be consistent regardless of being a valid image or just the fallback icon, with same sizes, border and both be visibles

![image](https://github.com/Expensify/App/assets/31714350/57ee5885-40c7-4ed5-aa90-7fac68f5e950)
![image](https://github.com/Expensify/App/assets/31714350/4b74093d-1e2b-46c6-a878-bfca8b9781c1)
![image](https://github.com/Expensify/App/assets/31714350/08385378-6e1a-4d3c-90fb-ca0a5e2b2efc)

- [x] Verify that no errors appear in the JS console

### Offline tests

None. The changes do not affect offline behavior.

### QA Steps

Same as `Tests`

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->
![image](https://github.com/Expensify/App/assets/31714350/b1200a60-4dd0-4037-9cfb-59b93d36e1ca)

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->
![image](https://github.com/Expensify/App/assets/31714350/36e43040-84cc-4009-bcf7-745495bcf57a)
![image](https://github.com/Expensify/App/assets/31714350/f96ec5dc-cbd7-466e-844e-e92258d94cba)
![image](https://github.com/Expensify/App/assets/31714350/dc9bd27d-b0b5-46ef-b268-833b1faccb1b)

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->
![image](https://github.com/Expensify/App/assets/31714350/a336510c-f7f2-4803-9012-305a52632baf)
![image](https://github.com/Expensify/App/assets/31714350/a7a80f5b-f7b1-4395-b0ec-2919145e5394)

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->
![image](https://github.com/Expensify/App/assets/31714350/11bb3023-d107-4dbf-9cab-88277c17989b)
![image](https://github.com/Expensify/App/assets/31714350/9333293a-0359-41a7-9c4b-9ed2ce4a1337)

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->
![image](https://github.com/Expensify/App/assets/31714350/51fddcad-8f8d-4448-b3ba-b6e808e20c1b)
![image](https://github.com/Expensify/App/assets/31714350/aa0e2082-dabe-4c0e-900d-c91ff76f0b2d)

</details>
