### PR TITLE
fix OfflineWithFeedback errorRowStyles is misaligned

### DIFF
--- a/src/pages/settings/Report/ReportSettingsPage.js
+++ b/src/pages/settings/Report/ReportSettingsPage.js
@@ -119,6 +119,7 @@ class ReportSettingsPage extends Component {
                             <OfflineWithFeedback
                                 pendingAction={lodashGet(this.props.report, 'pendingFields.reportName', null)}
                                 errors={lodashGet(this.props.report, 'errorFields.reportName', null)}
+                                errorRowStyles={[styles.ph5]}
                                 onClose={() => Report.clearPolicyRoomNameErrors(this.props.report.reportID)}
                             >
                                 {shouldDisableRename ? (

--- a/src/pages/workspace/WorkspaceInitialPage.js
+++ b/src/pages/workspace/WorkspaceInitialPage.js
@@ -194,7 +194,7 @@ function WorkspaceInitialPage(props) {
                             pendingAction={policy.pendingAction}
                             onClose={() => dismissError(policy.id)}
                             errors={policy.errors}
-                            errorRowStyles={[styles.ph6, styles.pv2]}
+                            errorRowStyles={[styles.ph5, styles.pv2]}
                         >
                             <View style={[styles.flex1]}>
                                 <View style={styles.avatarSectionWrapper}>

--- a/src/pages/workspace/WorkspacesListPage.js
+++ b/src/pages/workspace/WorkspacesListPage.js
@@ -156,7 +156,7 @@ class WorkspacesListPage extends Component {
             <OfflineWithFeedback
                 key={`${keyTitle}_${index}`}
                 pendingAction={item.pendingAction}
-                errorRowStyles={styles.offlineFeedback.menuItemErrorPadding}
+                errorRowStyles={styles.ph5}
                 onClose={item.dismissError}
                 errors={item.errors}
             >

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -2837,10 +2837,6 @@ const styles = {
         errorDot: {
             marginRight: 12,
         },
-        menuItemErrorPadding: {
-            paddingLeft: 44,
-            paddingRight: 20,
-        },
     },
 
     dotIndicatorMessage: {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/21143 https://github.com/Expensify/App/issues/20420
PROPOSAL: https://github.com/Expensify/App/issues/21143#issuecomment-1599255075


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Test Steps for https://github.com/Expensify/App/issues/21143

1. Open the app.
2. Login with user A and create workspace X (remember the id of the workspace for the next step).
3. Invite user B to workspace X.
4. From Incognito Browser, Login with user B and create new public room associated with workspace X that create by user A.
5. From user A delete workspace X, you will see DeletePolicy error is trigger.
6. Verify that the margin of error is consistent with the workspace item margin.
7. Go again to the workspace using this URL: /workspace/:id, Verify that the margin of error is consistent with the workspace item margin.

Test Steps for https://github.com/Expensify/App/issues/20420

1. Sign in with any account with a workspace room.
2. Disable the internet connection in the device.
3. Click the header of the workspace room to open the room details page.
4. Click "Settings".
5. Rename the room and hit save.
6. Sign into the same account on another device or incognito window.
7. Create another workspace room on the same workspace with the same name.
8. In the main testing device - enable the internet connection.
9. Verify that the margin of error is consistent with the other items.
    
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
N/A
### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Same Tests step.
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>


https://github.com/Expensify/App/assets/41129870/43ea62e7-7292-4ad2-b4af-b3344a793928



https://github.com/Expensify/App/assets/41129870/422f6c83-defb-4857-8d56-e07f5e1a1470



![Screenshot 2023-06-27 at 7 50 05 AM](https://github.com/Expensify/App/assets/41129870/168a3303-3832-4436-8b57-1f689b1e0183)

![Screenshot 2023-06-27 at 8 09 28 AM](https://github.com/Expensify/App/assets/41129870/c651a1e9-90ad-4179-b0ea-9e99297bddc9)


![Screenshot 2023-06-27 at 7 57 42 AM](https://github.com/Expensify/App/assets/41129870/2b795263-0fc8-4844-87a4-2a0878281104)




</details>

<details>
<summary>Mobile Web - Chrome</summary>

![Screenshot 2023-06-27 at 8 15 49 AM](https://github.com/Expensify/App/assets/41129870/d174e113-5af4-4d35-a818-61c8db7be495)

![Screenshot 2023-06-27 at 8 16 48 AM](https://github.com/Expensify/App/assets/41129870/eaae6407-b81f-4a90-9e74-fefc1229e181)

![Screenshot 2023-06-27 at 8 17 15 AM](https://github.com/Expensify/App/assets/41129870/dbfde2c5-1ff8-4005-ac06-a7ecae0d5e22)


</details>

<details>
<summary>Mobile Web - Safari</summary>

![Screenshot 2023-06-27 at 8 11 28 AM](https://github.com/Expensify/App/assets/41129870/383db714-e064-4bf5-a185-e87c6641962a)

![Screenshot 2023-06-27 at 8 11 43 AM](https://github.com/Expensify/App/assets/41129870/940aedf5-98b2-4a22-b932-9e2848a94726)

![Screenshot 2023-06-27 at 8 12 37 AM](https://github.com/Expensify/App/assets/41129870/958f2996-f7d2-45d8-9f31-2bdaf722554b)

</details>

<details>
<summary>Desktop</summary>

![Screenshot 2023-06-27 at 8 41 16 AM](https://github.com/Expensify/App/assets/41129870/bfbe1ab9-ef7b-4a93-a283-0b67fb0d55e7)

![Screenshot 2023-06-27 at 8 41 22 AM](https://github.com/Expensify/App/assets/41129870/60365a0b-26f3-429a-90a8-93f95fb431d5)

![Screenshot 2023-06-27 at 8 41 36 AM](https://github.com/Expensify/App/assets/41129870/ed1ca5aa-693a-4921-be78-9d16d0321a96)


</details>

<details>
<summary>iOS</summary>

![Screenshot 2023-06-27 at 8 38 11 AM](https://github.com/Expensify/App/assets/41129870/22f0aa0d-65e5-4e04-a8e1-1dc834b5fca0)

![Screenshot 2023-06-27 at 8 38 23 AM](https://github.com/Expensify/App/assets/41129870/550be620-8ff5-4a7d-8023-94e7ce6e145b)

![Screenshot 2023-06-27 at 8 39 34 AM](https://github.com/Expensify/App/assets/41129870/a6111aeb-6297-4258-8158-82a79be06564)



</details>

<details>
<summary>Android</summary>

![Screenshot 2023-06-27 at 8 29 16 AM](https://github.com/Expensify/App/assets/41129870/9e1f5e4e-3754-4a67-baa3-4544085acd97)

![Screenshot 2023-06-27 at 8 29 28 AM](https://github.com/Expensify/App/assets/41129870/12101704-2e9d-4ec0-8cc7-6d2c0107d1f6)

![Screenshot 2023-06-27 at 8 30 05 AM](https://github.com/Expensify/App/assets/41129870/4e1b5cb1-8069-499e-a2c0-6108ccd8fd67)

</details>
