### PR TITLE
Hotfix search tooltip

### DIFF
--- a/src/components/MultipleAvatars.js
+++ b/src/components/MultipleAvatars.js
@@ -80,7 +80,7 @@ function MultipleAvatars(props) {
             <UserDetailsTooltip
                 accountID={props.icons[0].id}
                 fallbackUserDetails={{
-                    displayName: ReportUtils.getDisplayNameForParticipant(props.icons[0].name),
+                    displayName: ReportUtils.getDisplayNameForParticipant(props.icons[0].id),
                     login: lodashGet(props.icons[0], 'name', tooltipTexts[0]),
                     avatar: lodashGet(props.icons[0], 'source', ''),
                 }}

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -516,7 +516,7 @@ function createOption(accountIDs, personalDetails, report, reportActions = {}, {
 
     result.text = reportName;
     result.searchText = getSearchText(report, reportName, personalDetailList, result.isChatRoom || result.isPolicyExpenseChat, result.isThread);
-    result.icons = ReportUtils.getIcons(report, personalDetails, UserUtils.getAvatar(personalDetail.avatar, personalDetail.accountID), false, personalDetail.login);
+    result.icons = ReportUtils.getIcons(report, personalDetails, UserUtils.getAvatar(personalDetail.avatar, personalDetail.accountID), false, personalDetail.login, personalDetail.accountID);
     result.subtitle = subtitle;
 
     return result;

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -517,6 +517,7 @@ function createOption(accountIDs, personalDetails, report, reportActions = {}, {
     result.text = reportName;
     result.searchText = getSearchText(report, reportName, personalDetailList, result.isChatRoom || result.isPolicyExpenseChat, result.isThread);
     result.icons = ReportUtils.getIcons(report, personalDetails, UserUtils.getAvatar(personalDetail.avatar, personalDetail.login), false, personalDetail.login);
+    result.icons = ReportUtils.getIcons(report, personalDetails, UserUtils.getAvatar(personalDetail.avatar, personalDetail.accountID), false, personalDetail.login);
     result.subtitle = subtitle;
 
     return result;

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -516,7 +516,7 @@ function createOption(accountIDs, personalDetails, report, reportActions = {}, {
 
     result.text = reportName;
     result.searchText = getSearchText(report, reportName, personalDetailList, result.isChatRoom || result.isPolicyExpenseChat, result.isThread);
-    result.icons = ReportUtils.getIcons(report, personalDetails, UserUtils.getAvatar(personalDetail.avatar, personalDetail.accountID));
+    result.icons = ReportUtils.getIcons(report, personalDetails, UserUtils.getAvatar(personalDetail.avatar, personalDetail.login), false, personalDetail.login);
     result.subtitle = subtitle;
 
     return result;

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -516,7 +516,6 @@ function createOption(accountIDs, personalDetails, report, reportActions = {}, {
 
     result.text = reportName;
     result.searchText = getSearchText(report, reportName, personalDetailList, result.isChatRoom || result.isPolicyExpenseChat, result.isThread);
-    result.icons = ReportUtils.getIcons(report, personalDetails, UserUtils.getAvatar(personalDetail.avatar, personalDetail.login), false, personalDetail.login);
     result.icons = ReportUtils.getIcons(report, personalDetails, UserUtils.getAvatar(personalDetail.avatar, personalDetail.accountID), false, personalDetail.login);
     result.subtitle = subtitle;
 

--- a/src/libs/ReportUtils.js
+++ b/src/libs/ReportUtils.js
@@ -712,10 +712,10 @@ function getIconsForParticipants(participants, personalDetails) {
  * @param {*} [defaultIcon]
  * @param {Boolean} [isPayer]
  * @param {String} [defaultName]
- * @param {Number} [defaultID]
+ * @param {Number} [defaultAccountID]
  * @returns {Array<*>}
  */
-function getIcons(report, personalDetails, defaultIcon = null, isPayer = false, defaultName = '', defaultID = undefined) {
+function getIcons(report, personalDetails, defaultIcon = null, isPayer = false, defaultName = '', defaultAccountID = undefined) {
     const result = {
         source: '',
         type: CONST.ICON_TYPE_AVATAR,
@@ -725,7 +725,7 @@ function getIcons(report, personalDetails, defaultIcon = null, isPayer = false, 
     if (_.isEmpty(report)) {
         result.source = defaultIcon || Expensicons.FallbackAvatar;
         result.name = defaultName || '';
-        result.id = defaultID;
+        result.id = defaultAccountID;
         return [result];
     }
     if (isArchivedRoom(report)) {

--- a/src/libs/ReportUtils.js
+++ b/src/libs/ReportUtils.js
@@ -712,9 +712,10 @@ function getIconsForParticipants(participants, personalDetails) {
  * @param {*} [defaultIcon]
  * @param {Boolean} [isPayer]
  * @param {String} [defaultName]
+ * @param {Number} [defaultID]
  * @returns {Array<*>}
  */
-function getIcons(report, personalDetails, defaultIcon = null, isPayer = false, defaultName = '') {
+function getIcons(report, personalDetails, defaultIcon = null, isPayer = false, defaultName = '', defaultID = undefined) {
     const result = {
         source: '',
         type: CONST.ICON_TYPE_AVATAR,
@@ -724,6 +725,7 @@ function getIcons(report, personalDetails, defaultIcon = null, isPayer = false, 
     if (_.isEmpty(report)) {
         result.source = defaultIcon || Expensicons.FallbackAvatar;
         result.name = defaultName || '';
+        result.id = defaultID;
         return [result];
     }
     if (isArchivedRoom(report)) {

--- a/src/libs/ReportUtils.js
+++ b/src/libs/ReportUtils.js
@@ -713,7 +713,7 @@ function getIconsForParticipants(participants, personalDetails) {
  * @param {Boolean} [isPayer]
  * @returns {Array<*>}
  */
-function getIcons(report, personalDetails, defaultIcon = null, isPayer = false) {
+function getIcons(report, personalDetails, defaultIcon = null, isPayer = false, defaultName = '') {
     const result = {
         source: '',
         type: CONST.ICON_TYPE_AVATAR,
@@ -722,6 +722,7 @@ function getIcons(report, personalDetails, defaultIcon = null, isPayer = false) 
 
     if (_.isEmpty(report)) {
         result.source = defaultIcon || Expensicons.FallbackAvatar;
+        result.name = defaultName || '';
         return [result];
     }
     if (isArchivedRoom(report)) {

--- a/src/libs/ReportUtils.js
+++ b/src/libs/ReportUtils.js
@@ -711,6 +711,7 @@ function getIconsForParticipants(participants, personalDetails) {
  * @param {Object} personalDetails
  * @param {*} [defaultIcon]
  * @param {Boolean} [isPayer]
+ * @param {String} [defaultName]
  * @returns {Array<*>}
  */
 function getIcons(report, personalDetails, defaultIcon = null, isPayer = false, defaultName = '') {


### PR DESCRIPTION
### Details
Fixing the behavior of getIcon when there is no report. Tooltip implementation requires the name so the login is passed as a defaultName to show the tooltip even when the method receives no report as parameter

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/21099
PROPOSAL: https://github.com/Expensify/App/issues/21099#issuecomment-1599809305


### Tests
1. Login with a high traffic account
2. Go to search
3. Hover over the profile pictures of the user without previous chat history in the search list
4. Verify that the tooltip is displayed.

### Offline tests
- Same as tests

### QA Steps
- Same as tests

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

[Tooltip working in whole search results.webm](https://github.com/Expensify/App/assets/13544910/6ff24316-44e4-4fba-b486-cce465ecd025)

![image](https://github.com/Expensify/App/assets/13544910/cfd08729-7e7e-416f-ab10-a3acb70b3b7e)


</details>

<details>
<summary>Mobile Web - Chrome</summary>
N/A Tooltip only works in web

Search Working:

![image](https://github.com/Expensify/App/assets/13544910/4c172e09-6f6a-4bdf-81a8-c1135be601b5)


</details>

<details>
<summary>Mobile Web - Safari</summary>
N/A Tooltip only works in web

Search working:

![image](https://github.com/Expensify/App/assets/13544910/e44b4df4-7f96-4c7d-b28a-969fb906011b)

</details>

<details>
<summary>Desktop</summary>

[Desktop working 06 28.webm](https://github.com/Expensify/App/assets/13544910/7a83998d-5cab-4b00-b248-a18c5ce1e6bb)


</details>

<details>
<summary>iOS</summary>

N/A Tooltip only works in web

</details>

<details>
<summary>Android</summary>
N/A Tooltip only works in web
Search working:

![image](https://github.com/Expensify/App/assets/13544910/ff44a030-78e8-45ec-8cb4-771b998ac56c)

</details>
