### PR TITLE
Fix unable to unlink secondary login in Desktop App

### DIFF
--- a/src/components/ValidateCode/ValidateCodeModal.js
+++ b/src/components/ValidateCode/ValidateCodeModal.js
@@ -1,4 +1,4 @@
-import React, {useCallback} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import {compose} from 'underscore';
 import {withOnyx} from 'react-native-onyx';

--- a/src/components/ValidateCode/ValidateCodeModal.js
+++ b/src/components/ValidateCode/ValidateCodeModal.js
@@ -14,14 +14,16 @@ import * as Illustrations from '../Icon/Illustrations';
 import variables from '../../styles/variables';
 import TextLink from '../TextLink';
 import ONYXKEYS from '../../ONYXKEYS';
-import * as Session from '../../libs/actions/Session';
 
 const propTypes = {
     /** Code to display. */
     code: PropTypes.string.isRequired,
 
     /** The ID of the account to which the code belongs. */
-    accountID: PropTypes.string.isRequired,
+    justValidateHereText: PropTypes.string,
+
+    /** Function to call when user click on just validate here text */
+    justValidateHereCallback: PropTypes.func,
 
     /** Session of currently logged in user */
     session: PropTypes.shape({
@@ -33,14 +35,14 @@ const propTypes = {
 };
 
 const defaultProps = {
+    justValidateHereText: '',
+    justValidateHereCallback: () => {},
     session: {
         authToken: null,
     },
 };
 
 function ValidateCodeModal(props) {
-    const signInHere = useCallback(() => Session.signInWithValidateCode(props.accountID, props.code, props.preferredLocale), [props.accountID, props.code, props.preferredLocale]);
-
     return (
         <View style={styles.deeplinkWrapperContainer}>
             <View style={styles.deeplinkWrapperMessage}>
@@ -57,10 +59,10 @@ function ValidateCodeModal(props) {
                         {props.translate('validateCodeModal.description')}
                         {!lodashGet(props, 'session.authToken', null) && (
                             <>
-                                {props.translate('validateCodeModal.or')} <TextLink onPress={signInHere}>{props.translate('validateCodeModal.signInHere')}</TextLink>
+                                {props.translate('validateCodeModal.or')} <TextLink onPress={props.justValidateHereCallback}>{props.justValidateHereText}</TextLink>
                             </>
                         )}
-                        {props.shouldShowSignInHere ? '!' : '.'}
+                        {'.'}
                     </Text>
                 </View>
                 <View style={styles.mt6}>

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -193,6 +193,7 @@ export default {
         description: 'Please enter the code using the device\nwhere it was originally requested',
         or: ', or',
         signInHere: 'just sign in here',
+        unlinkHere: 'just unlink here',
         expiredCodeTitle: 'Magic code expired',
         expiredCodeDescription: 'Go back to the original device and request a new code.',
         requestNewCode: 'You can also',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -192,6 +192,7 @@ export default {
         or: ', ¡o',
         description: 'Por favor, introduce el código utilizando el dispositivo\nen el que se solicitó originalmente',
         signInHere: 'simplemente inicia sesión aquí',
+        unlinkHere: 'TBU',
         expiredCodeTitle: 'Código mágico caducado',
         expiredCodeDescription: 'Vuelve al dispositivo original y solicita un código nuevo.',
         requestNewCode: '¡También puedes',

--- a/src/libs/actions/Session/index.js
+++ b/src/libs/actions/Session/index.js
@@ -10,7 +10,6 @@ import Log from '../../Log';
 import PushNotification from '../../Notification/PushNotification';
 import Timing from '../Timing';
 import CONST from '../../../CONST';
-import * as Localize from '../../Localize';
 import Timers from '../../Timers';
 import * as Pusher from '../../Pusher/pusher';
 import * as Authentication from '../../Authentication';

--- a/src/libs/actions/Session/index.js
+++ b/src/libs/actions/Session/index.js
@@ -767,7 +767,7 @@ function unlinkLogin(accountID, validateCode) {
             key: ONYXKEYS.ACCOUNT,
             value: {
                 isLoading: false,
-                message: Localize.translateLocal('unlinkLoginForm.succesfullyUnlinkedLogin'),
+                message: 'unlinkLoginForm.succesfullyUnlinkedLogin',
             },
         },
         {

--- a/src/pages/UnlinkLoginPage/index.js
+++ b/src/pages/UnlinkLoginPage/index.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import lodashGet from 'lodash/get';
-import {propTypes as validateLinkPropTypes, defaultProps as validateLinkDefaultProps} from './ValidateLoginPage/validateLinkPropTypes';
-import FullScreenLoadingIndicator from '../components/FullscreenLoadingIndicator';
-import Navigation from '../libs/Navigation/Navigation';
-import * as Session from '../libs/actions/Session';
-import ROUTES from '../ROUTES';
+import {propTypes as validateLinkPropTypes, defaultProps as validateLinkDefaultProps} from '../ValidateLoginPage/validateLinkPropTypes';
+import FullScreenLoadingIndicator from '../../components/FullscreenLoadingIndicator';
+import Navigation from '../../libs/Navigation/Navigation';
+import * as Session from '../../libs/actions/Session';
+import ROUTES from '../../ROUTES';
 
 const propTypes = {
     /** The accountID and validateCode are passed via the URL */

--- a/src/pages/UnlinkLoginPage/index.website.js
+++ b/src/pages/UnlinkLoginPage/index.website.js
@@ -1,0 +1,78 @@
+import React, {useEffect, useState, useCallback} from 'react';
+import PropTypes from 'prop-types';
+import lodashGet from 'lodash/get';
+import {withOnyx} from 'react-native-onyx';
+import {propTypes as validateLinkPropTypes, defaultProps as validateLinkDefaultProps} from '../ValidateLoginPage/validateLinkPropTypes';
+import FullScreenLoadingIndicator from '../../components/FullscreenLoadingIndicator';
+import ValidateCodeModal from '../../components/ValidateCode/ValidateCodeModal';
+import Navigation from '../../libs/Navigation/Navigation';
+import * as Session from '../../libs/actions/Session';
+import ROUTES from '../../ROUTES';
+import ONYXKEYS from '../../ONYXKEYS';
+import compose from '../../libs/compose';
+import withLocalize, {withLocalizePropTypes} from '../../components/withLocalize';
+
+const propTypes = {
+    /** The accountID and validateCode are passed via the URL */
+    route: validateLinkPropTypes,
+
+    /** The credentials of the person logging in */
+    credentials: PropTypes.shape({
+        /** The email the user logged in with */
+        login: PropTypes.string,
+    }),
+
+    ...withLocalizePropTypes,
+};
+
+const defaultProps = {
+    route: validateLinkDefaultProps,
+    credentials: {},
+};
+
+function UnlinkLoginPage(props) {
+    const [isMagicCodePage, setIsMagicCodePage] = useState(false);
+    const accountID = lodashGet(props.route.params, 'accountID', '');
+    const validateCode = lodashGet(props.route.params, 'validateCode', '');
+
+    const unLinkCallback = useCallback(() => {
+        Session.unlinkLogin(accountID, validateCode);
+        Navigation.navigate(ROUTES.HOME);
+    }, [accountID, validateCode]);
+
+    useEffect(() => {
+        const login = lodashGet(props, 'credentials.login', null);
+
+        // A fresh session (i.e: user opens link incognito or requests sign in in desktop but open link in web browser) will not have credentials.login
+        // Same as sign in with magic link page, we would like to show the Magic code screen in order to give a chance for user to unlink here or in original device.  
+        if (!login) {
+            setIsMagicCodePage(true);
+            return;
+        }
+
+        // The user would like to unlink via magic link on the same browser, in another tab.
+        unLinkCallback();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    return isMagicCodePage ? (
+        <ValidateCodeModal
+            code={validateCode}
+            justValidateHereText={props.translate('validateCodeModal.unlinkHere')}
+            justValidateHereCallback={unLinkCallback}
+        />
+    ) : (
+        <FullScreenLoadingIndicator />
+    );
+}
+
+UnlinkLoginPage.propTypes = propTypes;
+UnlinkLoginPage.defaultProps = defaultProps;
+UnlinkLoginPage.displayName = 'UnlinkLoginPage';
+
+export default compose(
+    withLocalize,
+    withOnyx({
+        credentials: {key: ONYXKEYS.CREDENTIALS},
+    }),
+)(UnlinkLoginPage);

--- a/src/pages/UnlinkLoginPage/index.website.js
+++ b/src/pages/UnlinkLoginPage/index.website.js
@@ -43,8 +43,8 @@ function UnlinkLoginPage(props) {
     useEffect(() => {
         const login = lodashGet(props, 'credentials.login', null);
 
-        // A fresh session (i.e: user opens link incognito or requests sign in in desktop but open link in web browser) will not have credentials.login
-        // Same as sign in with magic link page, we would like to show the Magic code screen in order to give a chance for user to unlink here or in original device.  
+        // A fresh session (i.e: user opens link in incognito browser or requests unlink in desktop but open link in web browser) will not have credentials.login
+        // Same as sign in with magic link page, we would like to show the Magic code screen in order to give a chance for user to unlink here or in original device.
         if (!login) {
             setIsMagicCodePage(true);
             return;

--- a/src/pages/ValidateLoginPage/index.website.js
+++ b/src/pages/ValidateLoginPage/index.website.js
@@ -59,6 +59,11 @@ const defaultProps = {
 };
 
 class ValidateLoginPage extends Component {
+    constructor(props) {
+        super(props);
+        this.signInWithValidateCode = this.signInWithValidateCode.bind(this);
+    }
+
     componentDidMount() {
         const login = lodashGet(this.props, 'credentials.login', null);
 
@@ -83,7 +88,7 @@ class ValidateLoginPage extends Component {
         }
 
         // The user has initiated the sign in process on the same browser, in another tab.
-        Session.signInWithValidateCode(this.getAccountID(), this.getValidateCode(), this.props.preferredLocale);
+        this.signInWithValidateCode();
     }
 
     componentDidUpdate() {
@@ -116,6 +121,10 @@ class ValidateLoginPage extends Component {
         return lodashGet(this.props.route.params, 'validateCode', '');
     }
 
+    signInWithValidateCode() {
+        Session.signInWithValidateCode(this.getAccountID(), this.getValidateCode(), this.props.preferredLocale);
+    }
+
     render() {
         const is2FARequired = lodashGet(this.props, 'account.requiresTwoFactorAuth', false);
         const isSignedIn = Boolean(lodashGet(this.props, 'session.authToken', null));
@@ -127,8 +136,9 @@ class ValidateLoginPage extends Component {
                 {currentAuthState === CONST.AUTO_AUTH_STATE.JUST_SIGNED_IN && isSignedIn && <JustSignedInModal is2FARequired={false} />}
                 {currentAuthState === CONST.AUTO_AUTH_STATE.NOT_STARTED && !isSignedIn && (
                     <ValidateCodeModal
-                        accountID={this.getAccountID()}
                         code={this.getValidateCode()}
+                        justValidateHereText={this.props.translate('validateCodeModal.signInHere')}
+                        justValidateHereCallback={this.signInWithValidateCode()}
                     />
                 )}
                 {currentAuthState === CONST.AUTO_AUTH_STATE.SIGNING_IN && <FullScreenLoadingIndicator />}

--- a/src/pages/ValidateLoginPage/index.website.js
+++ b/src/pages/ValidateLoginPage/index.website.js
@@ -138,7 +138,7 @@ class ValidateLoginPage extends Component {
                     <ValidateCodeModal
                         code={this.getValidateCode()}
                         justValidateHereText={this.props.translate('validateCodeModal.signInHere')}
-                        justValidateHereCallback={this.signInWithValidateCode()}
+                        justValidateHereCallback={this.signInWithValidateCode}
                     />
                 )}
                 {currentAuthState === CONST.AUTO_AUTH_STATE.SIGNING_IN && <FullScreenLoadingIndicator />}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/19681
PROPOSAL: https://github.com/Expensify/App/issues/19681#issuecomment-1565023149


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

**On Web/mWeb**
1. Add a secondary login account, and leave it unverified
2. Sign out and sign in to the secondary login account above
3. Click on Unlink button
4. Open email account, click on 'the validation link here' to unlink the account
5. Verify that the page shows "Secondary login successfull unlinked" message

**On Desktop**
Ensure you logged out Expensify account in Web browser
1. Add a secondary login account, and leave it unverified
2. Sign out and sign in to the secondary login account above
3. Click on Unlink button
4. Open email account, click on 'the validation link here' to unlink the account
5. Verify that the link opened in Web browser and it shows Magic codes page
6. Open deeplink in Desktop
7. Verify that the Desktop shows "Secondary login successfull unlinked" message

**On Native app**
Ensure you logged out Expensify account in Web browser
1. Add a secondary login account, and leave it unverified
2. Sign out and sign in to the secondary login account above
3. Click on Unlink button
4. Open email account, click on 'the validation link here' to unlink the account
5. Verify that the link opened in Web browser and it shows Magic codes page
6. Click "just unlink here" text link
7. Verify that the Web browser shows "Secondary login successfull unlinked" message

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
Can not test when offline
### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Same as Tests
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/9639873/b4602609-b446-4f0b-bd31-e3c74b65c54a


</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/9639873/73ba0ff5-e638-4f6b-a2df-04757560bb85


</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/9639873/c7691fee-3ae9-4c7d-a606-05765ce49206


</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->


https://github.com/Expensify/App/assets/9639873/47487508-bd83-4f5e-af39-c98d761eb8ea



</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/9639873/40c677a6-2f02-48ff-a1bb-6e42d33af6d9


</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/9639873/46a82fed-ec18-45cf-aa38-f3cf04501ef5


</details>
