### PR TITLE
fix: clicking title of url preview don't open site

### DIFF
--- a/src/pages/home/report/LinkPreviewer.js
+++ b/src/pages/home/report/LinkPreviewer.js
@@ -6,6 +6,7 @@ import {uniqBy} from 'lodash';
 import useWindowDimensions from '../../../hooks/useWindowDimensions';
 import Text from '../../../components/Text';
 import TextLink from '../../../components/TextLink';
+import * as StyleUtils from '../../../styles/StyleUtils';
 import styles from '../../../styles/styles';
 import variables from '../../../styles/variables';
 import colors from '../../../styles/colors';
@@ -106,7 +107,7 @@ function LinkPreviewer(props) {
                         {!_.isEmpty(title) && (
                             <TextLink
                                 fontSize={variables.fontSizeNormal}
-                                style={[styles.pv2, {color: colors.blueLinkPreview}]}
+                                style={[styles.pv2, StyleUtils.getTextColorStyle(colors.blueLinkPreview)]}
                                 href={url}
                             >
                                 {title}

--- a/src/pages/home/report/LinkPreviewer.js
+++ b/src/pages/home/report/LinkPreviewer.js
@@ -5,6 +5,7 @@ import _ from 'underscore';
 import {uniqBy} from 'lodash';
 import useWindowDimensions from '../../../hooks/useWindowDimensions';
 import Text from '../../../components/Text';
+import TextLink from '../../../components/TextLink';
 import styles from '../../../styles/styles';
 import variables from '../../../styles/variables';
 import colors from '../../../styles/colors';
@@ -103,13 +104,14 @@ function LinkPreviewer(props) {
                             )}
                         </View>
                         {!_.isEmpty(title) && (
-                            <Text
+                            <TextLink
                                 fontSize={variables.fontSizeNormal}
                                 style={styles.pv2}
                                 color={colors.blueLinkPreview}
+                                href={url}
                             >
                                 {title}
-                            </Text>
+                            </TextLink>
                         )}
                         {!_.isEmpty(description) && <Text fontSize={variables.fontSizeNormal}>{description}</Text>}
                         {!_.isEmpty(image) && IMAGE_TYPES.includes(image.type) && (

--- a/src/pages/home/report/LinkPreviewer.js
+++ b/src/pages/home/report/LinkPreviewer.js
@@ -106,8 +106,7 @@ function LinkPreviewer(props) {
                         {!_.isEmpty(title) && (
                             <TextLink
                                 fontSize={variables.fontSizeNormal}
-                                style={styles.pv2}
-                                color={colors.blueLinkPreview}
+                                style={[styles.pv2, {color: colors.blueLinkPreview}]}
                                 href={url}
                             >
                                 {title}

--- a/src/styles/StyleUtils.js
+++ b/src/styles/StyleUtils.js
@@ -356,6 +356,18 @@ function getBackgroundColorStyle(backgroundColor) {
 }
 
 /**
+ * Returns a style for text color
+ *
+ * @param {String} linkPreviewColor
+ * @returns {Object}
+ */
+function getTextColorStyle(textColor) {
+    return {
+        color: textColor,
+    };
+}
+
+/**
  * Returns a style with the specified borderColor
  *
  * @param {String} borderColor
@@ -1230,6 +1242,7 @@ export {
     getAutoGrowHeightInputStyle,
     getBackgroundAndBorderStyle,
     getBackgroundColorStyle,
+    getTextColorStyle,
     getBorderColorStyle,
     getBackgroundColorWithOpacityStyle,
     getBadgeColorStyle,

--- a/src/styles/StyleUtils.js
+++ b/src/styles/StyleUtils.js
@@ -358,12 +358,12 @@ function getBackgroundColorStyle(backgroundColor) {
 /**
  * Returns a style for text color
  *
- * @param {String} linkPreviewColor
+ * @param {String} color
  * @returns {Object}
  */
-function getTextColorStyle(textColor) {
+function getTextColorStyle(color) {
     return {
-        color: textColor,
+        color,
     };
 }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/21190
PROPOSAL: https://github.com/Expensify/App/issues/21190#issuecomment-1600676518

### Tests
1. Go to a chat and add a comment `google.com`
2. Wait for the URL preview to load
3. Click the blue title of URL preview and verify that it opens google.com

- [x] Verify that no errors appear in the JS console

### Offline tests


### QA Steps
Same as test

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->


https://github.com/Expensify/App/assets/117511920/e4dc2d8f-71fd-476f-ac53-e22b1b4e009a



</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->
[mobile-chrome.webm](https://github.com/Expensify/App/assets/117511920/c0bb97d6-c15c-4b56-8c76-740ae1b8897c)




</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->


https://github.com/Expensify/App/assets/117511920/4a96bc25-5040-4cef-9efd-4155c8448bac




</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/117511920/0cb87e78-39ec-405e-bfbf-022714256498





</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/117511920/2ab203ed-c0a6-4b54-8043-a6ff626758c8





</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

[android.webm](https://github.com/Expensify/App/assets/117511920/df33739e-5076-4905-b7ac-5b404e5e0e83)



</details>
