### PR TITLE
Fix: Date is not being displayed correctly when single digit day is entered (only fix on dob page)

### DIFF
--- a/src/components/MenuItem.js
+++ b/src/components/MenuItem.js
@@ -74,7 +74,7 @@ function MenuItem(props) {
     const descriptionVerticalMargin = props.shouldShowDescriptionOnTop ? styles.mb1 : styles.mt1;
     const titleTextStyle = StyleUtils.combineStyles(
         [
-            styles.flex1,
+            styles.flexShrink1,
             styles.popoverMenuText,
             props.icon && !_.isArray(props.icon) ? styles.ml3 : undefined,
             props.shouldShowBasicTitle ? undefined : styles.textStrong,

--- a/src/pages/settings/Profile/PersonalDetails/PersonalDetailsInitialPage.js
+++ b/src/pages/settings/Profile/PersonalDetails/PersonalDetailsInitialPage.js
@@ -109,6 +109,8 @@ function PersonalDetailsInitialPage(props) {
                         description={props.translate('common.dob')}
                         shouldShowRightIcon
                         onPress={() => Navigation.navigate(ROUTES.SETTINGS_PERSONAL_DETAILS_DATE_OF_BIRTH)}
+                        titleStyle={[
+                            styles.flex1]}
                     />
                     <MenuItemWithTopDescription
                         title={getFormattedAddress()}

--- a/src/pages/settings/Profile/PersonalDetails/PersonalDetailsInitialPage.js
+++ b/src/pages/settings/Profile/PersonalDetails/PersonalDetailsInitialPage.js
@@ -109,8 +109,7 @@ function PersonalDetailsInitialPage(props) {
                         description={props.translate('common.dob')}
                         shouldShowRightIcon
                         onPress={() => Navigation.navigate(ROUTES.SETTINGS_PERSONAL_DETAILS_DATE_OF_BIRTH)}
-                        titleStyle={[
-                            styles.flex1]}
+                        titleStyle={[styles.flex1]}
                     />
                     <MenuItemWithTopDescription
                         title={getFormattedAddress()}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
 The date is truncated when single-digit day is entered. To fix it we should use flex1 only in dob page to avoid regression

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/21404
$ https://github.com/Expensify/App/issues/21404#issuecomment-1613740753
PROPOSAL: https://github.com/Expensify/App/issues/21404#issuecomment-1608574056


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Login to ND
2. Open Settings
3. Open Profile
4. Open Personal Details
5. Click on Date of Birth
6. Choose the date 1 June, 2018 > Save Changes
7. Verify that the date is fully visible

Regression test step:
1. Send money to anyone
2. Click iou message
3. Click preview iou 
4. verify that the green tick is display close to amount
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
5. Upload an image via copy paste
6. Verify a modal appears displaying a preview of that image
--->
1. Login to ND
2. Open Settings
3. Open Profile
7. Open Personal Details
8. Click on Date of Birth
9. Choose the date 1 June, 2018 > Save Changes
10. Verify that the date is fully visible

Regression test step:
1. Send money to anyone
2. Click iou message
3. Click preview iou 
4. verify that the green tick is display close to amount
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<img width="1440" alt="Screenshot 2023-06-30 at 12 11 35" src="https://github.com/Expensify/App/assets/129500732/e63bde78-2111-4ee2-b554-a7bcb37b0cf7">
<img width="1440" alt="Screenshot 2023-06-30 at 12 11 43" src="https://github.com/Expensify/App/assets/129500732/20317c97-c401-4d64-9c37-81dbe1b650e2">


</details>

<details>
<summary>Mobile Web - Chrome</summary>

![357436788_789980812593145_7875964823029215266_n](https://github.com/Expensify/App/assets/129500732/11b53b83-ade0-462f-b9b5-d03ac98f22d7)
![357625625_1199835250694732_4788790199471455926_n](https://github.com/Expensify/App/assets/129500732/f52c5be0-7e7a-4cc1-af2d-cd5b52bc39cc)


</details>

<details>
<summary>Mobile Web - Safari</summary>

<img width="447" alt="Screenshot 2023-06-30 at 12 07 14" src="https://github.com/Expensify/App/assets/129500732/4506c159-8520-4e5c-af1c-e79f27105368">
<img width="454" alt="Screenshot 2023-06-30 at 12 07 29" src="https://github.com/Expensify/App/assets/129500732/8d69cb18-408d-4d50-9e78-19a85ff0937f">


</details>

<details>
<summary>Desktop</summary>

<img width="1204" alt="Screenshot 2023-06-30 at 12 19 13" src="https://github.com/Expensify/App/assets/129500732/ad642bc9-67f5-4f7d-8e9b-c7496723e229">
<img width="1201" alt="Screenshot 2023-06-30 at 12 19 04" src="https://github.com/Expensify/App/assets/129500732/98cced4a-61da-4bbe-89bb-624180b637b6">


</details>

<details>
<summary>iOS</summary>

<img width="446" alt="Screenshot 2023-06-30 at 12 13 41" src="https://github.com/Expensify/App/assets/129500732/3e49ae38-d3b0-44e1-8163-be883721e15b">
<img width="420" alt="Screenshot 2023-06-30 at 12 12 50" src="https://github.com/Expensify/App/assets/129500732/6e0c1b8a-3e78-4480-98cb-fd83afd38179">


</details>

<details>
<summary>Android</summary>

<img width="315" alt="Screenshot 2023-06-30 at 12 12 19" src="https://github.com/Expensify/App/assets/129500732/78bf00ea-43fa-48ce-9edc-d305808f8df7">
<img width="318" alt="Screenshot 2023-06-30 at 12 12 32" src="https://github.com/Expensify/App/assets/129500732/b0545a9f-b14a-4374-a209-3eba14a0b1ac">




<!-- add screenshots or videos here -->

</details>
