### PR TITLE
fix: 20848 enable 2fa button in verify page

### DIFF
--- a/src/pages/settings/Security/TwoFactorAuth/TwoFactorAuthForm/BaseTwoFactorAuthForm.js
+++ b/src/pages/settings/Security/TwoFactorAuth/TwoFactorAuthForm/BaseTwoFactorAuthForm.js
@@ -1,4 +1,4 @@
-import React, {useCallback, useState} from 'react';
+import React, {useCallback, useState, forwardRef, useImperativeHandle} from 'react';
 import PropTypes from 'prop-types';
 import {withOnyx} from 'react-native-onyx';
 import MagicCodeInput from '../../../../../components/MagicCodeInput';
@@ -31,6 +31,7 @@ const defaultProps = {
 function BaseTwoFactorAuthForm(props) {
     const [formError, setFormError] = useState({});
     const [twoFactorAuthCode, setTwoFactorAuthCode] = useState('');
+    const inputRef = React.useRef(null);
 
     /**
      * Handle text input and clear formError upon text change
@@ -53,6 +54,7 @@ function BaseTwoFactorAuthForm(props) {
      * Check that all the form fields are valid, then trigger the submit callback
      */
     const validateAndSubmitForm = useCallback(() => {
+        inputRef.current.blur();
         if (!twoFactorAuthCode.trim()) {
             setFormError({twoFactorAuthCode: 'twoFactorAuthForm.error.pleaseFillTwoFactorAuth'});
             return;
@@ -67,6 +69,12 @@ function BaseTwoFactorAuthForm(props) {
         Session.validateTwoFactorAuth(twoFactorAuthCode);
     }, [twoFactorAuthCode]);
 
+    useImperativeHandle(props.innerRef, () => ({
+        validateAndSubmitForm() {
+            validateAndSubmitForm();
+        },
+    }));
+
     return (
         <MagicCodeInput
             autoComplete={props.autoComplete}
@@ -78,6 +86,7 @@ function BaseTwoFactorAuthForm(props) {
             onChangeText={onTextInput}
             onFulfill={validateAndSubmitForm}
             errorText={formError.twoFactorAuthCode ? props.translate(formError.twoFactorAuthCode) : ErrorUtils.getLatestErrorMessage(props.account)}
+            ref={inputRef}
         />
     );
 }
@@ -90,4 +99,12 @@ export default compose(
     withOnyx({
         account: {key: ONYXKEYS.ACCOUNT},
     }),
-)(BaseTwoFactorAuthForm);
+)(
+    forwardRef((props, ref) => (
+        <BaseTwoFactorAuthForm
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            {...props}
+            innerRef={ref}
+        />
+    )),
+);

--- a/src/pages/settings/Security/TwoFactorAuth/TwoFactorAuthForm/BaseTwoFactorAuthForm.js
+++ b/src/pages/settings/Security/TwoFactorAuth/TwoFactorAuthForm/BaseTwoFactorAuthForm.js
@@ -54,7 +54,9 @@ function BaseTwoFactorAuthForm(props) {
      * Check that all the form fields are valid, then trigger the submit callback
      */
     const validateAndSubmitForm = useCallback(() => {
-        inputRef.current.blur();
+        if (inputRef.current) {
+            inputRef.current.blur();
+        }
         if (!twoFactorAuthCode.trim()) {
             setFormError({twoFactorAuthCode: 'twoFactorAuthForm.error.pleaseFillTwoFactorAuth'});
             return;

--- a/src/pages/settings/Security/TwoFactorAuth/TwoFactorAuthForm/index.android.js
+++ b/src/pages/settings/Security/TwoFactorAuth/TwoFactorAuthForm/index.android.js
@@ -1,10 +1,29 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import BaseTwoFactorAuthForm from './BaseTwoFactorAuthForm';
 
-function TwoFactorAuthForm() {
-    return <BaseTwoFactorAuthForm autoComplete="sms-otp" />;
+const propTypes = {
+    /**
+     * A ref to forward to the Pressable
+     */
+    innerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+};
+
+const defaultProps = {
+    innerRef: () => {},
+};
+
+function TwoFactorAuthForm(props) {
+    return (
+        <BaseTwoFactorAuthForm
+            ref={props.innerRef}
+            autoComplete="sms-otp"
+        />
+    );
 }
 
+TwoFactorAuthForm.propTypes = propTypes;
+TwoFactorAuthForm.defaultProps = defaultProps;
 TwoFactorAuthForm.displayName = 'TwoFactorAuthForm';
 
 export default TwoFactorAuthForm;

--- a/src/pages/settings/Security/TwoFactorAuth/TwoFactorAuthForm/index.js
+++ b/src/pages/settings/Security/TwoFactorAuth/TwoFactorAuthForm/index.js
@@ -1,10 +1,29 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import BaseTwoFactorAuthForm from './BaseTwoFactorAuthForm';
 
-function TwoFactorAuthForm() {
-    return <BaseTwoFactorAuthForm autoComplete="one-time-code" />;
+const propTypes = {
+    /**
+     * A ref to forward to the Pressable
+     */
+    innerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+};
+
+const defaultProps = {
+    innerRef: () => {},
+};
+
+function TwoFactorAuthForm(props) {
+    return (
+        <BaseTwoFactorAuthForm
+            ref={props.innerRef}
+            autoComplete="one-time-code"
+        />
+    );
 }
 
+TwoFactorAuthForm.propTypes = propTypes;
+TwoFactorAuthForm.defaultProps = defaultProps;
 TwoFactorAuthForm.displayName = 'TwoFactorAuthForm';
 
 export default TwoFactorAuthForm;

--- a/src/pages/settings/Security/TwoFactorAuth/VerifyPage.js
+++ b/src/pages/settings/Security/TwoFactorAuth/VerifyPage.js
@@ -55,6 +55,8 @@ const defaultProps = {
 };
 
 function VerifyPage(props) {
+    const formRef = React.useRef(null);
+
     useEffect(() => {
         Session.clearAccountMessages();
     }, []);
@@ -139,15 +141,17 @@ function VerifyPage(props) {
                         <Text style={styles.mt11}>{props.translate('twoFactorAuth.enterCode')}</Text>
                     </View>
                     <View style={[styles.mt3, styles.mh5]}>
-                        <TwoFactorAuthForm />
+                        <TwoFactorAuthForm innerRef={formRef} />
                     </View>
                 </ScrollView>
                 <FixedFooter style={[styles.mtAuto, styles.pt2]}>
                     <Button
                         success
                         text={props.translate('common.next')}
-                        isDisabled
                         isLoading={props.account.isLoading}
+                        onPress={() => {
+                            formRef.current.validateAndSubmitForm();
+                        }}
                     />
                 </FixedFooter>
             </FullPageOfflineBlockingView>

--- a/src/pages/settings/Security/TwoFactorAuth/VerifyPage.js
+++ b/src/pages/settings/Security/TwoFactorAuth/VerifyPage.js
@@ -150,6 +150,9 @@ function VerifyPage(props) {
                         text={props.translate('common.next')}
                         isLoading={props.account.isLoading}
                         onPress={() => {
+                            if (!formRef.current) {
+                                return;
+                            }
                             formRef.current.validateAndSubmitForm();
                         }}
                     />


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/20848
PROPOSAL: https://github.com/Expensify/App/issues/20848#issuecomment-1603700861


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Go to settings -> security -> 2FA
2. Copy/ download codes and continue
3. Meanwhile download the authenticator application. Now, Scan the QR.
4. Now type the generated code.
5. Notice that the "loading sign along with the next button" is displayed as disabled before moving to the next page. ( even when the correct code is typed)
6. However, if similar steps are followed (i.e after typing magic code ) on the signing page, "the loading bar on sign-in button" is shown enabled.
7. Verify that the next button is clickable

- [ ] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

same as above

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Go to settings -> security -> 2FA
2. Copy/ download codes and continue
3. Meanwhile download the authenticator application. Now, Scan the QR.
4. Now type the generated code.
5. Notice that the "loading sign along with the next button" is displayed as disabled before moving to the next page. ( even when the correct code is typed)
6. However, if similar steps are followed (i.e after typing magic code ) on the signing page, "the loading bar on sign-in button" is shown enabled.
7. Verify that the next button is clickable

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is correct English and approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/113963320/52af022f-b3b7-4a46-a6d3-6b2c487a4131


</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/113963320/c4a5c404-13e6-4a78-9fd0-3c4a6f27375d


</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/113963320/902ba7ef-8314-4e12-8ea6-2c2ced44a63b

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/113963320/f87085a8-7f0b-4f50-a277-77265a34eb3d

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/113963320/ba5bcb32-d639-46c5-8193-a39bc0ba8c74

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

[Screencast from 04-07-2023 15:29:13.webm](https://github.com/Expensify/App/assets/113963320/86af4ca5-78f3-4652-a7c3-407cc1e94144)

</details>
