### PR TITLE
Display not found page if cannot create task

### DIFF
--- a/src/pages/tasks/NewTaskPage.js
+++ b/src/pages/tasks/NewTaskPage.js
@@ -1,4 +1,4 @@
-import React, {useEffect} from 'react';
+import React, {useEffect, useMemo} from 'react';
 import {View} from 'react-native';
 import {withOnyx} from 'react-native-onyx';
 import _ from 'underscore';
@@ -18,7 +18,9 @@ import MenuItem from '../../components/MenuItem';
 import reportPropTypes from '../reportPropTypes';
 import * as TaskUtils from '../../libs/actions/Task';
 import * as OptionsListUtils from '../../libs/OptionsListUtils';
+import * as ReportUtils from '../../libs/ReportUtils';
 import FormAlertWithSubmitButton from '../../components/FormAlertWithSubmitButton';
+import FullPageNotFoundView from '../../components/BlockingViews/FullPageNotFoundView';
 
 const propTypes = {
     /** Task Creation Data */
@@ -71,6 +73,8 @@ function NewTaskPage(props) {
     const [shareDestination, setShareDestination] = React.useState({});
     const [errorMessage, setErrorMessage] = React.useState('');
     const [parentReport, setParentReport] = React.useState({});
+
+    const isAllowedToCreateTask = useMemo(() => _.isEmpty(parentReport) || ReportUtils.isAllowedToComment(parentReport), [parentReport]);
 
     useEffect(() => {
         setErrorMessage('');
@@ -138,52 +142,59 @@ function NewTaskPage(props) {
 
     return (
         <ScreenWrapper>
-            <HeaderWithBackButton
-                title={props.translate('newTaskPage.confirmTask')}
-                onCloseButtonPress={() => TaskUtils.dismissModalAndClearOutTaskInfo()}
-                shouldShowBackButton
-                onBackButtonPress={() => Navigation.goBack(ROUTES.NEW_TASK_DETAILS)}
-            />
-            <View style={[styles.containerWithSpaceBetween]}>
-                <View style={styles.mb5}>
-                    <MenuItemWithTopDescription
-                        description={props.translate('newTaskPage.title')}
-                        title={props.task.title || ''}
-                        onPress={() => Navigation.navigate(ROUTES.NEW_TASK_TITLE)}
-                        shouldShowRightIcon
-                    />
-                    <MenuItemWithTopDescription
-                        description={props.translate('newTaskPage.description')}
-                        title={props.task.description || ''}
-                        onPress={() => Navigation.navigate(ROUTES.NEW_TASK_DESCRIPTION)}
-                        shouldShowRightIcon
-                    />
-                    <MenuItem
-                        label={assignee.displayName ? props.translate('newTaskPage.assignee') : ''}
-                        title={assignee.displayName || ''}
-                        description={assignee.displayName ? assignee.subtitle : props.translate('newTaskPage.assignee')}
-                        icon={assignee.icons}
-                        onPress={() => Navigation.navigate(ROUTES.NEW_TASK_ASSIGNEE)}
-                        shouldShowRightIcon
-                    />
-                    <MenuItem
-                        label={shareDestination.displayName ? props.translate('newTaskPage.shareSomewhere') : ''}
-                        title={shareDestination.displayName || ''}
-                        description={shareDestination.displayName ? shareDestination.subtitle : props.translate('newTaskPage.shareSomewhere')}
-                        icon={shareDestination.icons}
-                        onPress={() => Navigation.navigate(ROUTES.NEW_TASK_SHARE_DESTINATION)}
-                        shouldShowRightIcon
+            <FullPageNotFoundView
+                shouldShow={!isAllowedToCreateTask}
+                onBackButtonPress={() => TaskUtils.dismissModalAndClearOutTaskInfo()}
+            >
+                <HeaderWithBackButton
+                    title={props.translate('newTaskPage.confirmTask')}
+                    onCloseButtonPress={() => TaskUtils.dismissModalAndClearOutTaskInfo()}
+                    shouldShowBackButton
+                    onBackButtonPress={() => {
+                        Navigation.goBack(ROUTES.NEW_TASK_DETAILS);
+                    }}
+                />
+                <View style={[styles.containerWithSpaceBetween]}>
+                    <View style={styles.mb5}>
+                        <MenuItemWithTopDescription
+                            description={props.translate('newTaskPage.title')}
+                            title={props.task.title || ''}
+                            onPress={() => Navigation.navigate(ROUTES.NEW_TASK_TITLE)}
+                            shouldShowRightIcon
+                        />
+                        <MenuItemWithTopDescription
+                            description={props.translate('newTaskPage.description')}
+                            title={props.task.description || ''}
+                            onPress={() => Navigation.navigate(ROUTES.NEW_TASK_DESCRIPTION)}
+                            shouldShowRightIcon
+                        />
+                        <MenuItem
+                            label={assignee.displayName ? props.translate('newTaskPage.assignee') : ''}
+                            title={assignee.displayName || ''}
+                            description={assignee.displayName ? assignee.subtitle : props.translate('newTaskPage.assignee')}
+                            icon={assignee.icons}
+                            onPress={() => Navigation.navigate(ROUTES.NEW_TASK_ASSIGNEE)}
+                            shouldShowRightIcon
+                        />
+                        <MenuItem
+                            label={shareDestination.displayName ? props.translate('newTaskPage.shareSomewhere') : ''}
+                            title={shareDestination.displayName || ''}
+                            description={shareDestination.displayName ? shareDestination.subtitle : props.translate('newTaskPage.shareSomewhere')}
+                            icon={shareDestination.icons}
+                            onPress={() => Navigation.navigate(ROUTES.NEW_TASK_SHARE_DESTINATION)}
+                            shouldShowRightIcon
+                        />
+                    </View>
+                    <FormAlertWithSubmitButton
+                        isAlertVisible={!_.isEmpty(errorMessage)}
+                        message={errorMessage}
+                        onSubmit={() => onSubmit()}
+                        enabledWhenOffline
+                        buttonText={props.translate('newTaskPage.confirmTask')}
+                        containerStyles={[styles.mh0, styles.mt5, styles.flex1, styles.ph5]}
                     />
                 </View>
-                <FormAlertWithSubmitButton
-                    isAlertVisible={!_.isEmpty(errorMessage)}
-                    message={errorMessage}
-                    onSubmit={() => onSubmit()}
-                    enabledWhenOffline
-                    buttonText={props.translate('newTaskPage.confirmTask')}
-                    containerStyles={[styles.mh0, styles.mt5, styles.flex1, styles.ph5]}
-                />
-            </View>
+            </FullPageNotFoundView>
         </ScreenWrapper>
     );
 }

--- a/src/pages/tasks/TaskShareDestinationSelectorModal.js
+++ b/src/pages/tasks/TaskShareDestinationSelectorModal.js
@@ -1,5 +1,6 @@
 /* eslint-disable es/no-optional-chaining */
-import React, {useState, useEffect} from 'react';
+import React, {useState, useEffect, useMemo} from 'react';
+import _ from 'underscore';
 import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import {withOnyx} from 'react-native-onyx';
@@ -16,6 +17,7 @@ import compose from '../../libs/compose';
 import personalDetailsPropType from '../personalDetailsPropType';
 import reportPropTypes from '../reportPropTypes';
 import * as TaskUtils from '../../libs/actions/Task';
+import * as ReportUtils from '../../libs/ReportUtils';
 import ROUTES from '../../ROUTES';
 
 const propTypes = {
@@ -46,17 +48,28 @@ function TaskShareDestinationSelectorModal(props) {
     const [filteredPersonalDetails, setFilteredPersonalDetails] = useState([]);
     const [filteredUserToInvite, setFilteredUserToInvite] = useState(null);
 
+    const reportFilters = useMemo(() => {
+        const reports = {};
+        _.keys(props.reports).forEach((reportKey) => {
+            if (!ReportUtils.isAllowedToComment(props.reports[reportKey])) {
+                return;
+            }
+            reports[reportKey] = props.reports[reportKey];
+        });
+        return reports;
+    }, [props.reports]);
+
     useEffect(() => {
-        const results = OptionsListUtils.getShareDestinationOptions(props.reports, props.personalDetails, props.betas, '', [], CONST.EXPENSIFY_EMAILS, true);
+        const results = OptionsListUtils.getShareDestinationOptions(reportFilters, props.personalDetails, props.betas, '', [], CONST.EXPENSIFY_EMAILS, true);
 
         setFilteredUserToInvite(results.userToInvite);
         setFilteredRecentReports(results.recentReports);
         setFilteredPersonalDetails(results.personalDetails);
-    }, [props]);
+    }, [props, reportFilters]);
 
     useEffect(() => {
         const {recentReports, personalDetails, userToInvite} = OptionsListUtils.getShareDestinationOptions(
-            props.reports,
+            reportFilters,
             props.personalDetails,
             props.betas,
             searchValue.trim(),
@@ -70,7 +83,7 @@ function TaskShareDestinationSelectorModal(props) {
         setFilteredUserToInvite(userToInvite);
         setFilteredRecentReports(recentReports);
         setFilteredPersonalDetails(personalDetails);
-    }, [props, searchValue]);
+    }, [props, searchValue, reportFilters]);
 
     const onChangeText = (newSearchTerm = '') => {
         setSearchValue(newSearchTerm);

--- a/src/pages/tasks/TaskShareDestinationSelectorModal.js
+++ b/src/pages/tasks/TaskShareDestinationSelectorModal.js
@@ -48,7 +48,8 @@ function TaskShareDestinationSelectorModal(props) {
     const [filteredPersonalDetails, setFilteredPersonalDetails] = useState([]);
     const [filteredUserToInvite, setFilteredUserToInvite] = useState(null);
 
-    const reportFilters = useMemo(() => {
+    // Exclude the reports that have permission as `Admins only` before get share destination options
+    const filteredReports = useMemo(() => {
         const reports = {};
         _.keys(props.reports).forEach((reportKey) => {
             if (!ReportUtils.isAllowedToComment(props.reports[reportKey])) {
@@ -60,16 +61,16 @@ function TaskShareDestinationSelectorModal(props) {
     }, [props.reports]);
 
     useEffect(() => {
-        const results = OptionsListUtils.getShareDestinationOptions(reportFilters, props.personalDetails, props.betas, '', [], CONST.EXPENSIFY_EMAILS, true);
+        const results = OptionsListUtils.getShareDestinationOptions(filteredReports, props.personalDetails, props.betas, '', [], CONST.EXPENSIFY_EMAILS, true);
 
         setFilteredUserToInvite(results.userToInvite);
         setFilteredRecentReports(results.recentReports);
         setFilteredPersonalDetails(results.personalDetails);
-    }, [props, reportFilters]);
+    }, [props, filteredReports]);
 
     useEffect(() => {
         const {recentReports, personalDetails, userToInvite} = OptionsListUtils.getShareDestinationOptions(
-            reportFilters,
+            filteredReports,
             props.personalDetails,
             props.betas,
             searchValue.trim(),
@@ -83,7 +84,7 @@ function TaskShareDestinationSelectorModal(props) {
         setFilteredUserToInvite(userToInvite);
         setFilteredRecentReports(recentReports);
         setFilteredPersonalDetails(personalDetails);
-    }, [props, searchValue, reportFilters]);
+    }, [props, searchValue, filteredReports]);
 
     const onChangeText = (newSearchTerm = '') => {
         setSearchValue(newSearchTerm);

--- a/src/pages/tasks/TaskShareDestinationSelectorModal.js
+++ b/src/pages/tasks/TaskShareDestinationSelectorModal.js
@@ -48,7 +48,7 @@ function TaskShareDestinationSelectorModal(props) {
     const [filteredPersonalDetails, setFilteredPersonalDetails] = useState([]);
     const [filteredUserToInvite, setFilteredUserToInvite] = useState(null);
 
-    // Exclude the reports that have permission as `Admins only` before get share destination options
+    // Filter out all the reports where user is not allowed to create task
     const filteredReports = useMemo(() => {
         const reports = {};
         _.keys(props.reports).forEach((reportKey) => {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
We display not found page if we create a task in room chat which has permission is "Admins only"
### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/21791
PROPOSAL: https://github.com/Expensify/App/issues/21791#issuecomment-1611294044


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Login with user A
2. On another device, login with user B
3. From user B, create a workspace and invite user A to the workspcae
4. From user A, go to announce chat of this workspace
5. Click on plus icon >  Assign task
6. Enter title, description and go to next step
7. From user B, go to announce chat of this workspace
8. Change the setting of "Who can post" to "Admins only"
9. From user A, verify that not found page appears, and after clicking on the back button, the modal is dismissed
10. Click on FAB > Assign task
11. Enter title, description and go to next step
12. Click on shareSomeWhere
13. Notice in the list option and verify that the announce report doesn't appear if the permission of it is "Admins only
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
Same as above
### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
14. Upload an image via copy paste
15. Verify a modal appears displaying a preview of that image
--->
1. Login with user A
2. On another device, login with user B
3. From user B, create a workspace and invite user A to the workspcae
4. From user A, go to announce chat of this workspace
5. Click on plus icon >  Assign task
6. Enter title, description and go to next step
7. From user B, go to announce chat of this workspace
8. Change the setting of "Who can post" to "Admins only"
9. From user A, verify that not found page appears, and after clicking on the back button, the modal is dismissed
10. Click on FAB > Assign task
11. Enter title, description and go to next step
12. Click on shareSomeWhere
13. Notice in the list option and verify that the announce report doesn't appear if the permission of it is "Admins only
- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

[Screencast from 04-07-2023 17:33:09.webm](https://github.com/Expensify/App/assets/129500732/20c4bba7-b35e-4103-a9a0-40a51c857a8a)


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>


https://github.com/Expensify/App/assets/129500732/fba86b1d-5330-4442-87e2-c96c3ec028f8


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>


https://github.com/Expensify/App/assets/129500732/e3019c7f-9766-4941-8afb-227ad28b8ac9



</details>

<details>
<summary>Desktop</summary>


https://github.com/Expensify/App/assets/129500732/1d948168-079b-4e41-8c8f-50812c7b3e8d



</details>

<details>
<summary>iOS</summary>


https://github.com/Expensify/App/assets/129500732/eed96010-f698-4e8d-a5a5-68f2673cf8a9



</details>

<details>
<summary>Android</summary>


https://github.com/Expensify/App/assets/129500732/5613ea85-49fe-4050-8d26-ca3996116e78


<!-- add screenshots or videos here -->

</details>
