### PR TITLE
Fix: 2FA "Disable Authentication" page comes up again if we navigate back to the page in Offline mode 

### DIFF
--- a/src/pages/settings/Security/TwoFactorAuth/IsEnabledPage.js
+++ b/src/pages/settings/Security/TwoFactorAuth/IsEnabledPage.js
@@ -11,6 +11,7 @@ import * as Expensicons from '../../../../components/Icon/Expensicons';
 import themeColors from '../../../../styles/themes/default';
 import styles from '../../../../styles/styles';
 import ConfirmModal from '../../../../components/ConfirmModal';
+import FullPageOfflineBlockingView from '../../../../components/BlockingViews/FullPageOfflineBlockingView';
 
 const defaultProps = {};
 
@@ -23,43 +24,45 @@ function IsEnabledPage(props) {
                 title={props.translate('twoFactorAuth.headerTitle')}
                 onBackButtonPress={() => Navigation.goBack(ROUTES.SETTINGS_SECURITY)}
             />
-            <ScrollView>
-                <Section
-                    title={props.translate('twoFactorAuth.twoFactorAuthEnabled')}
-                    icon={Illustrations.ShieldYellow}
-                    menuItems={[
-                        {
-                            title: props.translate('twoFactorAuth.disableTwoFactorAuth'),
-                            onPress: () => {
-                                setIsConfirmModalVisible(true);
+            <FullPageOfflineBlockingView>
+                <ScrollView>
+                    <Section
+                        title={props.translate('twoFactorAuth.twoFactorAuthEnabled')}
+                        icon={Illustrations.ShieldYellow}
+                        menuItems={[
+                            {
+                                title: props.translate('twoFactorAuth.disableTwoFactorAuth'),
+                                onPress: () => {
+                                    setIsConfirmModalVisible(true);
+                                },
+                                icon: Expensicons.Close,
+                                iconFill: themeColors.danger,
+                                wrapperStyle: [styles.cardMenuItem],
                             },
-                            icon: Expensicons.Close,
-                            iconFill: themeColors.danger,
-                            wrapperStyle: [styles.cardMenuItem],
-                        },
-                    ]}
-                    containerStyles={[styles.twoFactorAuthSection]}
-                >
-                    <View style={styles.mv3}>
-                        <Text style={styles.textLabel}>{props.translate('twoFactorAuth.whatIsTwoFactorAuth')}</Text>
-                    </View>
-                </Section>
-                <ConfirmModal
-                    title={props.translate('twoFactorAuth.disableTwoFactorAuth')}
-                    onConfirm={() => {
-                        setIsConfirmModalVisible(false);
-                        Navigation.navigate(ROUTES.SETTINGS_2FA_DISABLE);
-                    }}
-                    onCancel={() => setIsConfirmModalVisible(false)}
-                    onModalHide={() => setIsConfirmModalVisible(false)}
-                    isVisible={isConfirmModalVisible}
-                    prompt={props.translate('twoFactorAuth.disableTwoFactorAuthConfirmation')}
-                    confirmText={props.translate('twoFactorAuth.disable')}
-                    cancelText={props.translate('common.cancel')}
-                    shouldShowCancelButton
-                    danger
-                />
-            </ScrollView>
+                        ]}
+                        containerStyles={[styles.twoFactorAuthSection]}
+                    >
+                        <View style={styles.mv3}>
+                            <Text style={styles.textLabel}>{props.translate('twoFactorAuth.whatIsTwoFactorAuth')}</Text>
+                        </View>
+                    </Section>
+                    <ConfirmModal
+                        title={props.translate('twoFactorAuth.disableTwoFactorAuth')}
+                        onConfirm={() => {
+                            setIsConfirmModalVisible(false);
+                            Navigation.navigate(ROUTES.SETTINGS_2FA_DISABLE);
+                        }}
+                        onCancel={() => setIsConfirmModalVisible(false)}
+                        onModalHide={() => setIsConfirmModalVisible(false)}
+                        isVisible={isConfirmModalVisible}
+                        prompt={props.translate('twoFactorAuth.disableTwoFactorAuthConfirmation')}
+                        confirmText={props.translate('twoFactorAuth.disable')}
+                        cancelText={props.translate('common.cancel')}
+                        shouldShowCancelButton
+                        danger
+                    />
+                </ScrollView>
+            </FullPageOfflineBlockingView>
         </ScreenWrapper>
     );
 }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
For offline mode shows the offline blocking view for 2fa enabled screen with the help of `FullPageOfflineBlockingView`.

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/21568
PROPOSAL: https://github.com/Expensify/App/issues/21568#issuecomment-1609528537


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. For the 2fa enabled account, Goto Settings -> Security -> Two-factor authentication
2. Turn off the internet
3. Verify the Offline screen is being shown

- [X] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
1. For the 2fa enabled account, Goto Settings -> Security -> Two-factor authentication
2. Verify the Offline screen is being shown

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. For the 2fa enabled account, Goto Settings -> Security -> Two-factor authentication
2. Turn off the internet
3. Verify the Offline screen is being shown

- [X] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android / native
    - [X] Android / Chrome
    - [X] iOS / native
    - [X] iOS / Safari
    - [X] MacOS / Chrome / Safari
    - [X] MacOS / Desktop
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [X] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [X] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If a new component is created I verified that:
    - [X] A similar component doesn't exist in the codebase
    - [X] All props are defined accurately and each prop has a `/** comment above it */`
    - [X] The file is named correctly
    - [X] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [X] The only data being stored in the state is data necessary for rendering and nothing else
    - [X] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [X] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [X] All JSX used for rendering exists in the render method
    - [X] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [X] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [X] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://github.com/Expensify/App/assets/14358475/b7a3780f-a611-4fa2-8cce-ef5c0ee74dd7

</details>

<details>
<summary>Mobile Web - Chrome</summary>
![Screenshot_1688490296](https://github.com/Expensify/App/assets/14358475/00e85b80-3d34-433a-82db-76472e9cc24e)



</details>

<details>
<summary>Mobile Web - Safari</summary>

![Simulator Screen Shot - iPhone 14 - 2023-07-04 at 22 31 33](https://github.com/Expensify/App/assets/14358475/baf0f6bf-0356-4e76-bbf9-0887984b9ca7)



</details>

<details>
<summary>Desktop</summary>

<img width="1198" alt="Screenshot 2023-07-04 at 10 37 04 PM" src="https://github.com/Expensify/App/assets/14358475/71a5b933-3caf-4528-9578-161f4e1d1943">


</details>

<details>
<summary>iOS</summary>


https://github.com/Expensify/App/assets/14358475/5a6d55e5-9078-4d20-9c0b-316bb4af054a


</details>

<details>
<summary>Android</summary>


![Screenshot_1688490188](https://github.com/Expensify/App/assets/14358475/64f967cd-4db7-4266-9881-56c2a72d6238)

</details>
