### PR TITLE
Chat - New font is cut if last message is from Concierge

### DIFF
--- a/src/components/InvertedFlatList/CellRendererComponent/index.android.js
+++ b/src/components/InvertedFlatList/CellRendererComponent/index.android.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import {View} from 'react-native';
+import PropTypes from 'prop-types';
+import styles from '../../../styles/styles';
+
+const propTypes = {
+    /** Position index of the list item in a list view */
+    index: PropTypes.number.isRequired,
+};
+
+function CellRendererComponent(props) {
+    return (
+        <View
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            {...props}
+            style={[styles.invert, { zIndex: -props.index }]}
+        />
+    );
+}
+
+CellRendererComponent.propTypes = propTypes;
+CellRendererComponent.displayName = 'CellRendererComponent';
+
+export default CellRendererComponent;

--- a/src/components/InvertedFlatList/CellRendererComponent/index.android.js
+++ b/src/components/InvertedFlatList/CellRendererComponent/index.android.js
@@ -13,7 +13,15 @@ function CellRendererComponent(props) {
         <View
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...props}
-            style={[styles.invert, { zIndex: -props.index }]}
+            style={[
+                styles.invert,
+                // To achieve absolute positioning and handle overflows for list items,
+                // it is necessary to assign zIndex values. In the case of inverted lists,
+                // the lower list items will have higher zIndex values compared to the upper
+                // list items. Consequently, lower list items can overflow the upper list items.
+                // See: https://github.com/Expensify/App/issues/20451
+                { zIndex: -props.index }
+            ]}
         />
     );
 }

--- a/src/components/InvertedFlatList/CellRendererComponent/index.android.js
+++ b/src/components/InvertedFlatList/CellRendererComponent/index.android.js
@@ -15,11 +15,14 @@ function CellRendererComponent(props) {
             {...props}
             style={[
                 styles.invert,
-                // To achieve absolute positioning and handle overflows for list items,
-                // it is necessary to assign zIndex values. In the case of inverted lists,
-                // the lower list items will have higher zIndex values compared to the upper
-                // list items. Consequently, lower list items can overflow the upper list items.
-                // See: https://github.com/Expensify/App/issues/20451
+
+                /**
+                 * To achieve absolute positioning and handle overflows for list items,
+                 * it is necessary to assign zIndex values. In the case of inverted lists,
+                 * the lower list items will have higher zIndex values compared to the upper
+                 * list items. Consequently, lower list items can overflow the upper list items.
+                 * See: https://github.com/Expensify/App/issues/20451
+                 */
                 { zIndex: -props.index }
             ]}
         />

--- a/src/components/InvertedFlatList/CellRendererComponent/index.android.js
+++ b/src/components/InvertedFlatList/CellRendererComponent/index.android.js
@@ -23,7 +23,7 @@ function CellRendererComponent(props) {
                  * list items. Consequently, lower list items can overflow the upper list items.
                  * See: https://github.com/Expensify/App/issues/20451
                  */
-                { zIndex: -props.index }
+                {zIndex: -props.index},
             ]}
         />
     );

--- a/src/components/InvertedFlatList/CellRendererComponent/index.ios.js
+++ b/src/components/InvertedFlatList/CellRendererComponent/index.ios.js
@@ -21,11 +21,14 @@ function CellRendererComponent(props) {
             {...props}
             style={[
                 props.style,
-                // To achieve absolute positioning and handle overflows for list items,
-                // it is necessary to assign zIndex values. In the case of inverted lists,
-                // the lower list items will have higher zIndex values compared to the upper
-                // list items. Consequently, lower list items can overflow the upper list items.
-                // See: https://github.com/Expensify/App/issues/20451
+
+                /**
+                 * To achieve absolute positioning and handle overflows for list items,
+                 * it is necessary to assign zIndex values. In the case of inverted lists,
+                 * the lower list items will have higher zIndex values compared to the upper
+                 * list items. Consequently, lower list items can overflow the upper list items.
+                 * See: https://github.com/Expensify/App/issues/20451
+                 */
                 { zIndex: -props.index }
             ]}
         />

--- a/src/components/InvertedFlatList/CellRendererComponent/index.ios.js
+++ b/src/components/InvertedFlatList/CellRendererComponent/index.ios.js
@@ -19,7 +19,15 @@ function CellRendererComponent(props) {
         <View
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...props}
-            style={[props.style, { zIndex: -props.index }]}
+            style={[
+                props.style,
+                // To achieve absolute positioning and handle overflows for list items,
+                // it is necessary to assign zIndex values. In the case of inverted lists,
+                // the lower list items will have higher zIndex values compared to the upper
+                // list items. Consequently, lower list items can overflow the upper list items.
+                // See: https://github.com/Expensify/App/issues/20451
+                { zIndex: -props.index }
+            ]}
         />
     );
 }

--- a/src/components/InvertedFlatList/CellRendererComponent/index.ios.js
+++ b/src/components/InvertedFlatList/CellRendererComponent/index.ios.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import {View} from 'react-native';
+import PropTypes from 'prop-types';
+
+const propTypes = {
+    /** Position index of the list item in a list view */
+    index: PropTypes.number.isRequired,
+
+    /** Styles that are passed to the component */
+    style: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.object]),
+};
+
+const defaultProps = {
+    style: {},
+};
+
+function CellRendererComponent(props) {
+    return (
+        <View
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            {...props}
+            style={[props.style, { zIndex: -props.index }]}
+        />
+    );
+}
+
+CellRendererComponent.propTypes = propTypes;
+CellRendererComponent.defaultProps = defaultProps;
+CellRendererComponent.displayName = 'CellRendererComponent';
+
+export default CellRendererComponent;

--- a/src/components/InvertedFlatList/CellRendererComponent/index.ios.js
+++ b/src/components/InvertedFlatList/CellRendererComponent/index.ios.js
@@ -29,7 +29,7 @@ function CellRendererComponent(props) {
                  * list items. Consequently, lower list items can overflow the upper list items.
                  * See: https://github.com/Expensify/App/issues/20451
                  */
-                { zIndex: -props.index }
+                {zIndex: -props.index},
             ]}
         />
     );

--- a/src/components/InvertedFlatList/index.android.js
+++ b/src/components/InvertedFlatList/index.android.js
@@ -1,10 +1,10 @@
 import React, {forwardRef} from 'react';
-import {View, FlatList} from 'react-native';
+import {FlatList} from 'react-native';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
 import BaseInvertedFlatList from './BaseInvertedFlatList';
-import styles from '../../styles/styles';
 import stylePropTypes from '../../styles/stylePropTypes';
+import CellRendererComponent from './CellRendererComponent';
 
 const propTypes = {
     /** Passed via forwardRef so we can access the FlatList ref */
@@ -19,16 +19,6 @@ const propTypes = {
 const defaultProps = {
     ListFooterComponentStyle: {},
 };
-
-function InvertedCell(props) {
-    return (
-        <View
-            // eslint-disable-next-line react/jsx-props-no-spreading
-            {...props}
-            style={styles.invert}
-        />
-    );
-}
 
 class InvertedFlatList extends React.Component {
     constructor(props) {
@@ -57,7 +47,9 @@ class InvertedFlatList extends React.Component {
                 style={styles.invert}
                 ListFooterComponentStyle={[styles.invert, this.props.ListFooterComponentStyle]}
                 verticalScrollbarPosition="left" // We are mirroring the X and Y axis, so we need to swap the scrollbar position
-                CellRendererComponent={InvertedCell}
+                CellRendererComponent={CellRendererComponent}
+                // Enables absolute positioning with zIndex in the list. Source: https://reactnative.dev/docs/0.71/optimizing-flatlist-configuration#removeclippedsubviews
+                removeClippedSubviews={false}
             />
         );
     }

--- a/src/components/InvertedFlatList/index.android.js
+++ b/src/components/InvertedFlatList/index.android.js
@@ -3,6 +3,7 @@ import {FlatList} from 'react-native';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
 import BaseInvertedFlatList from './BaseInvertedFlatList';
+import styles from '../../styles/styles';
 import stylePropTypes from '../../styles/stylePropTypes';
 import CellRendererComponent from './CellRendererComponent';
 

--- a/src/components/InvertedFlatList/index.android.js
+++ b/src/components/InvertedFlatList/index.android.js
@@ -48,7 +48,12 @@ class InvertedFlatList extends React.Component {
                 ListFooterComponentStyle={[styles.invert, this.props.ListFooterComponentStyle]}
                 verticalScrollbarPosition="left" // We are mirroring the X and Y axis, so we need to swap the scrollbar position
                 CellRendererComponent={CellRendererComponent}
-                // Enables absolute positioning with zIndex in the list. Source: https://reactnative.dev/docs/0.71/optimizing-flatlist-configuration#removeclippedsubviews
+
+                /**
+                 * To achieve absolute positioning and handle overflows for list items, the property must be disabled
+                 * for Android native builds.
+                 * Source: https://reactnative.dev/docs/0.71/optimizing-flatlist-configuration#removeclippedsubviews
+                 */
                 removeClippedSubviews={false}
             />
         );

--- a/src/components/InvertedFlatList/index.android.js
+++ b/src/components/InvertedFlatList/index.android.js
@@ -49,7 +49,6 @@ class InvertedFlatList extends React.Component {
                 ListFooterComponentStyle={[styles.invert, this.props.ListFooterComponentStyle]}
                 verticalScrollbarPosition="left" // We are mirroring the X and Y axis, so we need to swap the scrollbar position
                 CellRendererComponent={CellRendererComponent}
-
                 /**
                  * To achieve absolute positioning and handle overflows for list items, the property must be disabled
                  * for Android native builds.

--- a/src/components/InvertedFlatList/index.ios.js
+++ b/src/components/InvertedFlatList/index.ios.js
@@ -1,5 +1,6 @@
 import React, {forwardRef} from 'react';
 import BaseInvertedFlatList from './BaseInvertedFlatList';
+import CellRendererComponent from './CellRendererComponent';
 
 export default forwardRef((props, ref) => (
     <BaseInvertedFlatList
@@ -7,5 +8,6 @@ export default forwardRef((props, ref) => (
         {...props}
         ref={ref}
         inverted
+        CellRendererComponent={CellRendererComponent}
     />
 ));


### PR DESCRIPTION
cc @cead22 @rushatgabhane

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Problem:
When a chat message is marked as unread, the "New" separator component is not overlaying an upper message. It is problematic when the upper message has a background color(message from Concierge).

Solution:
I established a clear ordering of list items in the inverted flat list. The newer list items(in the bottom of the screen) have higher `zIndex` values and can therefore overflow older(upper) elements. I defined my own `CellRendererComponent` that assigns a proper `zIndex` value to all rendered list items.


### Fixed Issues
$ https://github.com/Expensify/App/issues/20451
PROPOSAL: https://github.com/Expensify/App/issues/20451#issuecomment-1584312046


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Changes touched only IOS and Android platforms. To test:
1. Open a chat with a message from Concierge.
2. Add a message immediately after the message from Concierge.
3. Mark the newly added message as unread.
4. Verify the "New" message is displayed properly and not cut-off by the message from Concierge.

- [x] Verify that no errors appear in the JS console

### Offline tests
The same as regular tests

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Changes touched only IOS and Android platforms. To test:
1. Open a chat with a message from Concierge.
2. Add a message immediately after the message from Concierge.
3. Mark the newly added message as unread.
4. Verify the "New" message is displayed properly and not cut-off by the message from Concierge.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
        - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

![web safari](https://github.com/Expensify/App/assets/15109844/2b77d7e1-85f7-400c-b225-5bb5e2cee571)

![web](https://github.com/Expensify/App/assets/15109844/d39be71c-28bf-4b29-a92d-c36085c95782)


</details>

<details>
<summary>Mobile Web - Chrome</summary>
<img width="394" alt="android web" src="https://github.com/Expensify/App/assets/15109844/c28730ed-e1cd-4ff5-915e-e1c7140b93cf">
</details>

<details>
<summary>Mobile Web - Safari</summary>
<img width="460" alt="ios web" src="https://github.com/Expensify/App/assets/15109844/a87bc6c5-c47e-49d3-a8c6-8bc3cbe0b9c4">
</details>

<details>
<summary>Desktop</summary>

![macos](https://github.com/Expensify/App/assets/15109844/0a2f4ec2-8a55-4795-8e4c-c3a4c91b1fd1)


</details>

<details>
<summary>iOS</summary>
<img width="440" alt="ios" src="https://github.com/Expensify/App/assets/15109844/fddca11b-8439-42f6-8769-a610c11a7355">

Video:
https://github.com/Expensify/App/assets/15109844/087c4d4c-f5db-4d1f-bbf3-de6488594830
</details>

<details>
<summary>Android</summary>
<img width="398" alt="android" src="https://github.com/Expensify/App/assets/15109844/af1a693d-cb82-4250-a5e7-cf507034e39d">

Video:
https://github.com/Expensify/App/assets/15109844/5d7177d7-91fc-45cd-af06-edc2619371ee
</details>
