### PR TITLE
Fix: Settings page: remove code preventing rendering before currentUserPersonalDetails is ready

### DIFF
--- a/src/components/CurrentUserPersonalDetailsSkeletonView/index.js
+++ b/src/components/CurrentUserPersonalDetailsSkeletonView/index.js
@@ -21,9 +21,9 @@ const defaultProps = {
 function CurrentUserPersonalDetailsSkeletonView(props) {
     const avatarPlaceholderSize = StyleUtils.getAvatarSize(CONST.AVATAR_SIZE.LARGE);
     const avatarPlaceholderRadius = avatarPlaceholderSize / 2;
-    const headlineMarginTop = 16;
+    const spaceBetweenAvatarAndHeadline = styles.mb3.marginBottom + styles.mt1.marginTop + (variables.lineHeightXXLarge - variables.fontSizeXLarge) / 2;
     const headlineSize = variables.fontSizeXLarge;
-    const labelMarginTop = 4;
+    const spaceBetweenHeadlineAndLabel = styles.mt1.marginTop + (variables.lineHeightXXLarge - variables.fontSizeXLarge) / 2;
     const labelSize = variables.fontSizeLabel;
     return (
         <View style={styles.avatarSectionWrapperSkeleton}>
@@ -31,7 +31,7 @@ function CurrentUserPersonalDetailsSkeletonView(props) {
                 animate={props.shouldAnimate}
                 backgroundColor={themeColors.highlightBG}
                 foregroundColor={themeColors.border}
-                height={avatarPlaceholderSize + headlineMarginTop + headlineSize + labelMarginTop + labelSize}
+                height={avatarPlaceholderSize + spaceBetweenAvatarAndHeadline + headlineSize + spaceBetweenHeadlineAndLabel + labelSize}
             >
                 <Circle
                     cx="50%"
@@ -40,13 +40,13 @@ function CurrentUserPersonalDetailsSkeletonView(props) {
                 />
                 <Rect
                     x="20%"
-                    y={avatarPlaceholderSize + headlineMarginTop}
+                    y={avatarPlaceholderSize + spaceBetweenAvatarAndHeadline}
                     width="60%"
                     height={headlineSize}
                 />
                 <Rect
                     x="15%"
-                    y={avatarPlaceholderSize + headlineMarginTop + headlineSize + labelMarginTop}
+                    y={avatarPlaceholderSize + spaceBetweenAvatarAndHeadline + headlineSize + spaceBetweenHeadlineAndLabel}
                     width="70%"
                     height={labelSize}
                 />

--- a/src/components/CurrentUserPersonalDetailsSkeletonView/index.js
+++ b/src/components/CurrentUserPersonalDetailsSkeletonView/index.js
@@ -26,31 +26,34 @@ function CurrentUserPersonalDetailsSkeletonView(props) {
     const headlineSize = variables.fontSizeXLarge;
     const labelMarginTop = 4;
     const labelSize = variables.fontSizeLabel;
-    return (<View style={styles.avatarSectionWrapper}>
-        <SkeletonViewContentLoader
-            animate={props.shouldAnimate}
-            backgroundColor={themeColors.highlightBG}
-            foregroundColor={themeColors.border}
-        >
-            <Circle
-                cx="50%"
-                cy={avatarPlaceholderRadius}
-                r={avatarPlaceholderRadius}
-            />
-            <Rect
-                x="20%"
-                y={avatarPlaceholderSize + headlineMarginTop}
-                width="60%"
-                height={headlineSize}
-            />
-            <Rect
-                x="15%"
-                y={avatarPlaceholderSize + headlineMarginTop + headlineSize + labelMarginTop}
-                width="70%"
-                height={labelSize}
-            />
-        </SkeletonViewContentLoader>
-    </View>)
+    return (
+        <View style={styles.avatarSectionWrapperSkeleton}>
+                <SkeletonViewContentLoader
+                    animate={props.shouldAnimate}
+                    backgroundColor={themeColors.highlightBG}
+                    foregroundColor={themeColors.border}
+                    height={avatarPlaceholderSize + headlineMarginTop + headlineSize + labelMarginTop + labelSize}
+                >
+                    <Circle
+                        cx="50%"
+                        cy={avatarPlaceholderRadius}
+                        r={avatarPlaceholderRadius}
+                    />
+                    <Rect
+                        x="20%"
+                        y={avatarPlaceholderSize + headlineMarginTop}
+                        width="60%"
+                        height={headlineSize}
+                    />
+                    <Rect
+                        x="15%"
+                        y={avatarPlaceholderSize + headlineMarginTop + headlineSize + labelMarginTop}
+                        width="70%"
+                        height={labelSize}
+                    />
+                </SkeletonViewContentLoader>
+        </View>
+    );
 }
 
 CurrentUserPersonalDetailsSkeletonView.displayName = 'CurrentUserPersonalDetailsSkeletonView';

--- a/src/components/CurrentUserPersonalDetailsSkeletonView/index.js
+++ b/src/components/CurrentUserPersonalDetailsSkeletonView/index.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import PropTypes from "prop-types";
+import SkeletonViewContentLoader from 'react-content-loader/native';
+import {Circle, Rect} from "react-native-svg";
+import {View} from "react-native";
+import * as StyleUtils from "../../styles/StyleUtils";
+import CONST from '../../CONST';
+import themeColors from "../../styles/themes/default";
+import variables from "../../styles/variables";
+import styles from "../../styles/styles";
+
+
+const propTypes = {
+    /** Whether to animate the skeleton view */
+    shouldAnimate: PropTypes.bool,
+};
+
+const defaultProps = {
+    shouldAnimate: true,
+};
+
+function CurrentUserPersonalDetailsSkeletonView(props) {
+    const avatarPlaceholderSize = StyleUtils.getAvatarSize(CONST.AVATAR_SIZE.LARGE);
+    const avatarPlaceholderRadius = avatarPlaceholderSize / 2;
+    const headlineMarginTop = 16;
+    const headlineSize = variables.fontSizeXLarge;
+    const labelMarginTop = 4;
+    const labelSize = variables.fontSizeLabel;
+    return (<View style={styles.avatarSectionWrapper}>
+        <SkeletonViewContentLoader
+            animate={props.shouldAnimate}
+            backgroundColor={themeColors.highlightBG}
+            foregroundColor={themeColors.border}
+        >
+            <Circle
+                cx="50%"
+                cy={avatarPlaceholderRadius}
+                r={avatarPlaceholderRadius}
+            />
+            <Rect
+                x="20%"
+                y={avatarPlaceholderSize + headlineMarginTop}
+                width="60%"
+                height={headlineSize}
+            />
+            <Rect
+                x="15%"
+                y={avatarPlaceholderSize + headlineMarginTop + headlineSize + labelMarginTop}
+                width="70%"
+                height={labelSize}
+            />
+        </SkeletonViewContentLoader>
+    </View>)
+}
+
+CurrentUserPersonalDetailsSkeletonView.displayName = 'CurrentUserPersonalDetailsSkeletonView';
+CurrentUserPersonalDetailsSkeletonView.propTypes = propTypes;
+CurrentUserPersonalDetailsSkeletonView.defaultProps = defaultProps;
+export default CurrentUserPersonalDetailsSkeletonView

--- a/src/components/CurrentUserPersonalDetailsSkeletonView/index.js
+++ b/src/components/CurrentUserPersonalDetailsSkeletonView/index.js
@@ -1,14 +1,13 @@
 import React from 'react';
-import PropTypes from "prop-types";
+import PropTypes from 'prop-types';
 import SkeletonViewContentLoader from 'react-content-loader/native';
-import {Circle, Rect} from "react-native-svg";
-import {View} from "react-native";
-import * as StyleUtils from "../../styles/StyleUtils";
+import {Circle, Rect} from 'react-native-svg';
+import {View} from 'react-native';
+import * as StyleUtils from '../../styles/StyleUtils';
 import CONST from '../../CONST';
-import themeColors from "../../styles/themes/default";
-import variables from "../../styles/variables";
-import styles from "../../styles/styles";
-
+import themeColors from '../../styles/themes/default';
+import variables from '../../styles/variables';
+import styles from '../../styles/styles';
 
 const propTypes = {
     /** Whether to animate the skeleton view */
@@ -28,30 +27,30 @@ function CurrentUserPersonalDetailsSkeletonView(props) {
     const labelSize = variables.fontSizeLabel;
     return (
         <View style={styles.avatarSectionWrapperSkeleton}>
-                <SkeletonViewContentLoader
-                    animate={props.shouldAnimate}
-                    backgroundColor={themeColors.highlightBG}
-                    foregroundColor={themeColors.border}
-                    height={avatarPlaceholderSize + headlineMarginTop + headlineSize + labelMarginTop + labelSize}
-                >
-                    <Circle
-                        cx="50%"
-                        cy={avatarPlaceholderRadius}
-                        r={avatarPlaceholderRadius}
-                    />
-                    <Rect
-                        x="20%"
-                        y={avatarPlaceholderSize + headlineMarginTop}
-                        width="60%"
-                        height={headlineSize}
-                    />
-                    <Rect
-                        x="15%"
-                        y={avatarPlaceholderSize + headlineMarginTop + headlineSize + labelMarginTop}
-                        width="70%"
-                        height={labelSize}
-                    />
-                </SkeletonViewContentLoader>
+            <SkeletonViewContentLoader
+                animate={props.shouldAnimate}
+                backgroundColor={themeColors.highlightBG}
+                foregroundColor={themeColors.border}
+                height={avatarPlaceholderSize + headlineMarginTop + headlineSize + labelMarginTop + labelSize}
+            >
+                <Circle
+                    cx="50%"
+                    cy={avatarPlaceholderRadius}
+                    r={avatarPlaceholderRadius}
+                />
+                <Rect
+                    x="20%"
+                    y={avatarPlaceholderSize + headlineMarginTop}
+                    width="60%"
+                    height={headlineSize}
+                />
+                <Rect
+                    x="15%"
+                    y={avatarPlaceholderSize + headlineMarginTop + headlineSize + labelMarginTop}
+                    width="70%"
+                    height={labelSize}
+                />
+            </SkeletonViewContentLoader>
         </View>
     );
 }
@@ -59,4 +58,4 @@ function CurrentUserPersonalDetailsSkeletonView(props) {
 CurrentUserPersonalDetailsSkeletonView.displayName = 'CurrentUserPersonalDetailsSkeletonView';
 CurrentUserPersonalDetailsSkeletonView.propTypes = propTypes;
 CurrentUserPersonalDetailsSkeletonView.defaultProps = defaultProps;
-export default CurrentUserPersonalDetailsSkeletonView
+export default CurrentUserPersonalDetailsSkeletonView;

--- a/src/pages/settings/InitialSettingsPage.js
+++ b/src/pages/settings/InitialSettingsPage.js
@@ -1,6 +1,6 @@
 import lodashGet from 'lodash/get';
 import React from 'react';
-import {View, ScrollView} from 'react-native';
+import {ScrollView, View} from 'react-native';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
 import {withOnyx} from 'react-native-onyx';
@@ -21,7 +21,10 @@ import withLocalize, {withLocalizePropTypes} from '../../components/withLocalize
 import compose from '../../libs/compose';
 import CONST from '../../CONST';
 import Permissions from '../../libs/Permissions';
-import withCurrentUserPersonalDetails, {withCurrentUserPersonalDetailsPropTypes, withCurrentUserPersonalDetailsDefaultProps} from '../../components/withCurrentUserPersonalDetails';
+import withCurrentUserPersonalDetails, {
+    withCurrentUserPersonalDetailsDefaultProps,
+    withCurrentUserPersonalDetailsPropTypes
+} from '../../components/withCurrentUserPersonalDetails';
 import * as PaymentMethods from '../../libs/actions/PaymentMethods';
 import bankAccountPropTypes from '../../components/bankAccountPropTypes';
 import cardPropTypes from '../../components/cardPropTypes';
@@ -303,13 +306,6 @@ class InitialSettingsPage extends React.Component {
     }
 
     render() {
-        // On the very first sign in or after clearing storage these
-        // details will not be present on the first render so we'll just
-        // return nothing for now.
-        if (_.isEmpty(this.props.currentUserPersonalDetails)) {
-            return null;
-        }
-
         return (
             <ScreenWrapper includeSafeAreaPaddingBottom={false}>
                 {({safeAreaPaddingBottomStyle}) => (
@@ -320,7 +316,8 @@ class InitialSettingsPage extends React.Component {
                             style={[styles.settingsPageBackground]}
                         >
                             <View style={styles.w100}>
-                                <View style={styles.avatarSectionWrapper}>
+                                {!_.isEmpty(this.props.currentUserPersonalDetails) && !_.isUndefined(this.props.currentUserPersonalDetails.displayName)
+                                && <View style={styles.avatarSectionWrapper}>
                                     <Tooltip text={this.props.translate('common.profile')}>
                                         <PressableWithoutFeedback
                                             style={[styles.mb3]}
@@ -328,7 +325,8 @@ class InitialSettingsPage extends React.Component {
                                             accessibilityLabel={this.props.translate('common.profile')}
                                             accessibilityRole={CONST.ACCESSIBILITY_ROLE.BUTTON}
                                         >
-                                            <OfflineWithFeedback pendingAction={lodashGet(this.props.currentUserPersonalDetails, 'pendingFields.avatar', null)}>
+                                            <OfflineWithFeedback
+                                                pendingAction={lodashGet(this.props.currentUserPersonalDetails, 'pendingFields.avatar', null)}>
                                                 <Avatar
                                                     imageStyles={[styles.avatarLarge]}
                                                     source={UserUtils.getAvatar(this.props.currentUserPersonalDetails.avatar, this.props.session.accountID)}
@@ -362,7 +360,7 @@ class InitialSettingsPage extends React.Component {
                                             {this.props.formatPhoneNumber(this.props.session.email)}
                                         </Text>
                                     )}
-                                </View>
+                                </View>}
                                 {_.map(this.getDefaultMenuItems(), (item, index) => this.getMenuItem(item, index))}
 
                                 <ConfirmModal

--- a/src/pages/settings/InitialSettingsPage.js
+++ b/src/pages/settings/InitialSettingsPage.js
@@ -4,7 +4,7 @@ import {ScrollView, View} from 'react-native';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
 import {withOnyx} from 'react-native-onyx';
-import CurrentUserPersonalDetailsSkeletonView from "../../components/CurrentUserPersonalDetailsSkeletonView";
+import CurrentUserPersonalDetailsSkeletonView from '../../components/CurrentUserPersonalDetailsSkeletonView';
 import {withNetwork} from '../../components/OnyxProvider';
 import styles from '../../styles/styles';
 import Text from '../../components/Text';
@@ -22,10 +22,7 @@ import withLocalize, {withLocalizePropTypes} from '../../components/withLocalize
 import compose from '../../libs/compose';
 import CONST from '../../CONST';
 import Permissions from '../../libs/Permissions';
-import withCurrentUserPersonalDetails, {
-    withCurrentUserPersonalDetailsDefaultProps,
-    withCurrentUserPersonalDetailsPropTypes
-} from '../../components/withCurrentUserPersonalDetails';
+import withCurrentUserPersonalDetails, {withCurrentUserPersonalDetailsDefaultProps, withCurrentUserPersonalDetailsPropTypes} from '../../components/withCurrentUserPersonalDetails';
 import * as PaymentMethods from '../../libs/actions/PaymentMethods';
 import bankAccountPropTypes from '../../components/bankAccountPropTypes';
 import cardPropTypes from '../../components/cardPropTypes';
@@ -317,9 +314,10 @@ class InitialSettingsPage extends React.Component {
                             style={[styles.settingsPageBackground]}
                         >
                             <View style={styles.w100}>
-                                {(_.isEmpty(this.props.currentUserPersonalDetails) || _.isUndefined(this.props.currentUserPersonalDetails.displayName))
-                                    ? <CurrentUserPersonalDetailsSkeletonView/>
-                                    : <View style={styles.avatarSectionWrapper}>
+                                {_.isEmpty(this.props.currentUserPersonalDetails) || _.isUndefined(this.props.currentUserPersonalDetails.displayName) ? (
+                                    <CurrentUserPersonalDetailsSkeletonView />
+                                ) : (
+                                    <View style={styles.avatarSectionWrapper}>
                                         <Tooltip text={this.props.translate('common.profile')}>
                                             <PressableWithoutFeedback
                                                 style={[styles.mb3]}
@@ -327,8 +325,7 @@ class InitialSettingsPage extends React.Component {
                                                 accessibilityLabel={this.props.translate('common.profile')}
                                                 accessibilityRole={CONST.ACCESSIBILITY_ROLE.BUTTON}
                                             >
-                                                <OfflineWithFeedback
-                                                    pendingAction={lodashGet(this.props.currentUserPersonalDetails, 'pendingFields.avatar', null)}>
+                                                <OfflineWithFeedback pendingAction={lodashGet(this.props.currentUserPersonalDetails, 'pendingFields.avatar', null)}>
                                                     <Avatar
                                                         imageStyles={[styles.avatarLarge]}
                                                         source={UserUtils.getAvatar(this.props.currentUserPersonalDetails.avatar, this.props.session.accountID)}
@@ -362,7 +359,8 @@ class InitialSettingsPage extends React.Component {
                                                 {this.props.formatPhoneNumber(this.props.session.email)}
                                             </Text>
                                         )}
-                                    </View>}
+                                    </View>
+                                )}
                                 {_.map(this.getDefaultMenuItems(), (item, index) => this.getMenuItem(item, index))}
 
                                 <ConfirmModal

--- a/src/pages/settings/InitialSettingsPage.js
+++ b/src/pages/settings/InitialSettingsPage.js
@@ -4,6 +4,7 @@ import {ScrollView, View} from 'react-native';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
 import {withOnyx} from 'react-native-onyx';
+import CurrentUserPersonalDetailsSkeletonView from "../../components/CurrentUserPersonalDetailsSkeletonView";
 import {withNetwork} from '../../components/OnyxProvider';
 import styles from '../../styles/styles';
 import Text from '../../components/Text';
@@ -316,51 +317,52 @@ class InitialSettingsPage extends React.Component {
                             style={[styles.settingsPageBackground]}
                         >
                             <View style={styles.w100}>
-                                {!_.isEmpty(this.props.currentUserPersonalDetails) && !_.isUndefined(this.props.currentUserPersonalDetails.displayName)
-                                && <View style={styles.avatarSectionWrapper}>
-                                    <Tooltip text={this.props.translate('common.profile')}>
+                                {(_.isEmpty(this.props.currentUserPersonalDetails) || _.isUndefined(this.props.currentUserPersonalDetails.displayName))
+                                    ? <CurrentUserPersonalDetailsSkeletonView/>
+                                    : <View style={styles.avatarSectionWrapper}>
+                                        <Tooltip text={this.props.translate('common.profile')}>
+                                            <PressableWithoutFeedback
+                                                style={[styles.mb3]}
+                                                onPress={this.openProfileSettings}
+                                                accessibilityLabel={this.props.translate('common.profile')}
+                                                accessibilityRole={CONST.ACCESSIBILITY_ROLE.BUTTON}
+                                            >
+                                                <OfflineWithFeedback
+                                                    pendingAction={lodashGet(this.props.currentUserPersonalDetails, 'pendingFields.avatar', null)}>
+                                                    <Avatar
+                                                        imageStyles={[styles.avatarLarge]}
+                                                        source={UserUtils.getAvatar(this.props.currentUserPersonalDetails.avatar, this.props.session.accountID)}
+                                                        size={CONST.AVATAR_SIZE.LARGE}
+                                                    />
+                                                </OfflineWithFeedback>
+                                            </PressableWithoutFeedback>
+                                        </Tooltip>
                                         <PressableWithoutFeedback
-                                            style={[styles.mb3]}
+                                            style={[styles.mt1, styles.mw100]}
                                             onPress={this.openProfileSettings}
                                             accessibilityLabel={this.props.translate('common.profile')}
-                                            accessibilityRole={CONST.ACCESSIBILITY_ROLE.BUTTON}
+                                            accessibilityRole={CONST.ACCESSIBILITY_ROLE.LINK}
                                         >
-                                            <OfflineWithFeedback
-                                                pendingAction={lodashGet(this.props.currentUserPersonalDetails, 'pendingFields.avatar', null)}>
-                                                <Avatar
-                                                    imageStyles={[styles.avatarLarge]}
-                                                    source={UserUtils.getAvatar(this.props.currentUserPersonalDetails.avatar, this.props.session.accountID)}
-                                                    size={CONST.AVATAR_SIZE.LARGE}
-                                                />
-                                            </OfflineWithFeedback>
+                                            <Tooltip text={this.props.translate('common.profile')}>
+                                                <Text
+                                                    style={[styles.textHeadline, styles.pre]}
+                                                    numberOfLines={1}
+                                                >
+                                                    {this.props.currentUserPersonalDetails.displayName
+                                                        ? this.props.currentUserPersonalDetails.displayName
+                                                        : this.props.formatPhoneNumber(this.props.session.email)}
+                                                </Text>
+                                            </Tooltip>
                                         </PressableWithoutFeedback>
-                                    </Tooltip>
-                                    <PressableWithoutFeedback
-                                        style={[styles.mt1, styles.mw100]}
-                                        onPress={this.openProfileSettings}
-                                        accessibilityLabel={this.props.translate('common.profile')}
-                                        accessibilityRole={CONST.ACCESSIBILITY_ROLE.LINK}
-                                    >
-                                        <Tooltip text={this.props.translate('common.profile')}>
+                                        {Boolean(this.props.currentUserPersonalDetails.displayName) && (
                                             <Text
-                                                style={[styles.textHeadline, styles.pre]}
+                                                style={[styles.textLabelSupporting, styles.mt1]}
                                                 numberOfLines={1}
                                             >
-                                                {this.props.currentUserPersonalDetails.displayName
-                                                    ? this.props.currentUserPersonalDetails.displayName
-                                                    : this.props.formatPhoneNumber(this.props.session.email)}
+                                                {this.props.formatPhoneNumber(this.props.session.email)}
                                             </Text>
-                                        </Tooltip>
-                                    </PressableWithoutFeedback>
-                                    {Boolean(this.props.currentUserPersonalDetails.displayName) && (
-                                        <Text
-                                            style={[styles.textLabelSupporting, styles.mt1]}
-                                            numberOfLines={1}
-                                        >
-                                            {this.props.formatPhoneNumber(this.props.session.email)}
-                                        </Text>
-                                    )}
-                                </View>}
+                                        )}
+                                    </View>}
                                 {_.map(this.getDefaultMenuItems(), (item, index) => this.getMenuItem(item, index))}
 
                                 <ConfirmModal

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -2356,6 +2356,12 @@ const styles = {
         paddingBottom: 20,
     },
 
+    avatarSectionWrapperSkeleton: {
+        width: '100%',
+        paddingHorizontal: 20,
+        paddingBottom: 20,
+    },
+
     selectCircle: {
         width: variables.componentSizeSmall,
         height: variables.componentSizeSmall,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
I removed the code that previously prevented the Settings screen from rendering before currentUserPersonalDetails was ready.

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/18569
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ [#18569](https://github.com/Expensify/App/issues/18569)
PROPOSAL: [#18569(COMMENT)](https://github.com/Expensify/App/issues/18569#issuecomment-1568141167)

### Tests
1. Log out
2. Optionally slow down internet connection
3. Open settings with link (http://localhost:8080/settings)
4. Log in to your account

- [x] Verify that no errors appear in the JS console

### Offline tests
Same as above

### QA Steps
1. Log out
2. Optionally slow down internet connection
3. Open settings with link (https://staging.new.expensify.com/settings)
4. Log in to your account

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://github.com/Expensify/App/assets/91068263/2e6430e3-24a1-40fd-83fb-2e14d1cbb138


</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://github.com/Expensify/App/assets/91068263/167cd3b9-3659-4437-8abf-0d5b0e262af8


</details>

<details>
<summary>Mobile Web - Safari</summary>

https://github.com/Expensify/App/assets/91068263/2a078b92-faa3-4fde-90af-dcae27a80dfc


</details>

<details>
<summary>Desktop</summary>

https://github.com/Expensify/App/assets/91068263/39f26df1-9a0c-44cf-8075-ccc5adbdf439


</details>

<details>
<summary>iOS</summary>

https://github.com/Expensify/App/assets/91068263/8c4f30d9-7d11-47e4-a5a8-ff6bd82b6917


</details>

<details>
<summary>Android</summary>

https://github.com/Expensify/App/assets/91068263/ff179b76-cc39-4390-97df-178e42afd2c8


</details>
