### PR TITLE
Update functional component style in BaseSelectionListRadio

### DIFF
--- a/src/components/SelectionListRadio/BaseSelectionListRadio.js
+++ b/src/components/SelectionListRadio/BaseSelectionListRadio.js
@@ -12,11 +12,10 @@ import variables from '../../styles/variables';
 import {propTypes as selectionListRadioPropTypes, defaultProps as selectionListRadioDefaultProps} from './selectionListRadioPropTypes';
 import RadioListItem from './RadioListItem';
 import useKeyboardShortcut from '../../hooks/useKeyboardShortcut';
+import useKeyboardState from '../../hooks/useKeyboardState';
 import SafeAreaConsumer from '../SafeAreaConsumer';
-import withKeyboardState, {keyboardStatePropTypes} from '../withKeyboardState';
 
 const propTypes = {
-    ...keyboardStatePropTypes,
     ...selectionListRadioPropTypes,
 };
 
@@ -25,6 +24,8 @@ function BaseSelectionListRadio(props) {
     const textInputRef = useRef(null);
     const focusTimeoutRef = useRef(null);
     const shouldShowTextInput = Boolean(props.textInputLabel);
+
+    const {isKeyboardShown} = useKeyboardState();
 
     /**
      * Iterates through the sections and items inside each section, and builds 3 arrays along the way:
@@ -215,7 +216,7 @@ function BaseSelectionListRadio(props) {
         >
             <SafeAreaConsumer>
                 {({safeAreaPaddingBottomStyle}) => (
-                    <View style={[styles.flex1, !props.isKeyboardShown && safeAreaPaddingBottomStyle]}>
+                    <View style={[styles.flex1, !isKeyboardShown && safeAreaPaddingBottomStyle]}>
                         {shouldShowTextInput && (
                             <View style={[styles.ph5, styles.pv5]}>
                                 <TextInput
@@ -265,4 +266,4 @@ BaseSelectionListRadio.displayName = 'BaseSelectionListRadio';
 BaseSelectionListRadio.propTypes = propTypes;
 BaseSelectionListRadio.defaultProps = selectionListRadioDefaultProps;
 
-export default withKeyboardState(BaseSelectionListRadio);
+export default BaseSelectionListRadio;

--- a/src/components/SelectionListRadio/BaseSelectionListRadio.js
+++ b/src/components/SelectionListRadio/BaseSelectionListRadio.js
@@ -100,7 +100,7 @@ function BaseSelectionListRadio({
         };
     };
 
-    const flattenedSections = getFlattenedSections();
+    const {allOptions, disabledOptionsIndexes, itemLayouts} = getFlattenedSections();
 
     /**
      * Scrolls to the desired item index in the section list
@@ -109,7 +109,7 @@ function BaseSelectionListRadio({
      * @param {Boolean} animated - whether to animate the scroll
      */
     const scrollToIndex = (index, animated) => {
-        const item = flattenedSections.allOptions[index];
+        const item = allOptions[index];
 
         if (!listRef.current || !item) {
             return;
@@ -133,7 +133,7 @@ function BaseSelectionListRadio({
 
     // Calculate the initial focused index only on first render
     const initialFocusedIndex = useMemo(() => {
-        const initialIndex = _.findIndex(flattenedSections.allOptions, (option) => option.keyForList === initiallyFocusedOptionKey);
+        const initialIndex = _.findIndex(allOptions, (option) => option.keyForList === initiallyFocusedOptionKey);
         if (initialIndex <= 0) {
             return 0;
         }
@@ -142,8 +142,8 @@ function BaseSelectionListRadio({
     }, []);
     const [focusedIndex] = useArrowKeyFocusManager({
         initialFocusedIndex,
-        maxIndex: flattenedSections.allOptions.length - 1,
-        disabledIndexes: flattenedSections.disabledOptionsIndexes,
+        maxIndex: allOptions.length - 1,
+        disabledIndexes: disabledOptionsIndexes,
         onFocusedIndexChanged: (newFocusedIndex) => scrollToIndex(newFocusedIndex, true),
     });
 
@@ -164,7 +164,7 @@ function BaseSelectionListRadio({
      * @returns {Object}
      */
     const getItemLayout = (data, flatDataArrayIndex) => {
-        const targetItem = flattenedSections.itemLayouts[flatDataArrayIndex];
+        const targetItem = itemLayouts[flatDataArrayIndex];
 
         return {
             length: targetItem.length,
@@ -206,7 +206,7 @@ function BaseSelectionListRadio({
     useKeyboardShortcut(
         CONST.KEYBOARD_SHORTCUTS.ENTER,
         () => {
-            const focusedOption = flattenedSections.allOptions[focusedIndex];
+            const focusedOption = allOptions[focusedIndex];
 
             if (!focusedOption) {
                 return;
@@ -216,7 +216,7 @@ function BaseSelectionListRadio({
         },
         {
             captureOnInputs: true,
-            shouldBubble: () => !flattenedSections.allOptions[focusedIndex],
+            shouldBubble: () => !allOptions[focusedIndex],
         },
     );
 

--- a/src/components/SelectionListRadio/BaseSelectionListRadio.js
+++ b/src/components/SelectionListRadio/BaseSelectionListRadio.js
@@ -8,22 +8,34 @@ import styles from '../../styles/styles';
 import TextInput from '../TextInput';
 import CONST from '../../CONST';
 import variables from '../../styles/variables';
-import {propTypes as selectionListRadioPropTypes, defaultProps as selectionListRadioDefaultProps} from './selectionListRadioPropTypes';
+import {propTypes as selectionListRadioPropTypes} from './selectionListRadioPropTypes';
 import RadioListItem from './RadioListItem';
 import useArrowKeyFocusManager from '../../hooks/useArrowKeyFocusManager';
 import useKeyboardShortcut from '../../hooks/useKeyboardShortcut';
 import useKeyboardState from '../../hooks/useKeyboardState';
 import SafeAreaConsumer from '../SafeAreaConsumer';
 
-const propTypes = {
-    ...selectionListRadioPropTypes,
-};
+const propTypes = selectionListRadioPropTypes;
 
-function BaseSelectionListRadio(props) {
+function BaseSelectionListRadio({
+    onSelectRow,
+    sections,
+    initiallyFocusedOptionKey = '',
+    headerMessage = '',
+    keyboardType = CONST.KEYBOARD_TYPE.DEFAULT,
+    onChangeText = () => {},
+    onScroll = () => {},
+    onScrollBeginDrag = () => {},
+    shouldDelayFocus = false,
+    textInputLabel = '',
+    textInputPlaceholder = '',
+    textInputValue = '',
+    textInputMaxLength = undefined,
+}) {
     const listRef = useRef(null);
     const textInputRef = useRef(null);
     const focusTimeoutRef = useRef(null);
-    const shouldShowTextInput = Boolean(props.textInputLabel);
+    const shouldShowTextInput = Boolean(textInputLabel);
 
     const {isKeyboardShown} = useKeyboardState();
 
@@ -45,7 +57,7 @@ function BaseSelectionListRadio(props) {
         let offset = 0;
         const itemLayouts = [{length: 0, offset}];
 
-        _.each(props.sections, (section, sectionIndex) => {
+        _.each(sections, (section, sectionIndex) => {
             // We're not rendering any section header, but we need to push to the array
             // because React Native accounts for it in getItemLayout
             const sectionHeaderHeight = 0;
@@ -111,7 +123,7 @@ function BaseSelectionListRadio(props) {
         // Otherwise, it will cause an index-out-of-bounds error and crash the app.
         let adjustedSectionIndex = sectionIndex;
         for (let i = 0; i < sectionIndex; i++) {
-            if (_.isEmpty(lodashGet(props.sections, `[${i}].data`))) {
+            if (_.isEmpty(lodashGet(sections, `[${i}].data`))) {
                 adjustedSectionIndex--;
             }
         }
@@ -121,7 +133,7 @@ function BaseSelectionListRadio(props) {
 
     // Calculate the initial focused index only on first render
     const initialFocusedIndex = useMemo(() => {
-        const initialIndex = _.findIndex(flattenedSections.allOptions, (option) => option.keyForList === props.initiallyFocusedOptionKey);
+        const initialIndex = _.findIndex(flattenedSections.allOptions, (option) => option.keyForList === initiallyFocusedOptionKey);
         if (initialIndex <= 0) {
             return 0;
         }
@@ -168,15 +180,15 @@ function BaseSelectionListRadio(props) {
             <RadioListItem
                 item={item}
                 isFocused={isFocused}
-                onSelectRow={props.onSelectRow}
+                onSelectRow={onSelectRow}
             />
         );
     };
 
-    /** Focuses the text input when the component mounts. If `props.shouldDelayFocus` is true, we wait for the animation to finish */
+    /** Focuses the text input when the component mounts. If `shouldDelayFocus` is true, we wait for the animation to finish */
     useEffect(() => {
         if (shouldShowTextInput) {
-            if (props.shouldDelayFocus) {
+            if (shouldDelayFocus) {
                 focusTimeoutRef.current = setTimeout(() => textInputRef.current.focus(), CONST.ANIMATED_TRANSITION);
             } else {
                 textInputRef.current.focus();
@@ -189,7 +201,7 @@ function BaseSelectionListRadio(props) {
             }
             clearTimeout(focusTimeoutRef.current);
         };
-    }, [props.shouldDelayFocus, shouldShowTextInput]);
+    }, [shouldDelayFocus, shouldShowTextInput]);
 
     useKeyboardShortcut(
         CONST.KEYBOARD_SHORTCUTS.ENTER,
@@ -200,7 +212,7 @@ function BaseSelectionListRadio(props) {
                 return;
             }
 
-            props.onSelectRow(focusedOption);
+            onSelectRow(focusedOption);
         },
         {
             captureOnInputs: true,
@@ -216,28 +228,28 @@ function BaseSelectionListRadio(props) {
                         <View style={[styles.ph5, styles.pv5]}>
                             <TextInput
                                 ref={textInputRef}
-                                label={props.textInputLabel}
-                                value={props.textInputValue}
-                                placeholder={props.textInputPlaceholder}
-                                maxLength={props.textInputMaxLength}
-                                onChangeText={props.onChangeText}
-                                keyboardType={props.keyboardType}
+                                label={textInputLabel}
+                                value={textInputValue}
+                                placeholder={textInputPlaceholder}
+                                maxLength={textInputMaxLength}
+                                onChangeText={onChangeText}
+                                keyboardType={keyboardType}
                                 selectTextOnFocus
                             />
                         </View>
                     )}
-                    {Boolean(props.headerMessage) && (
+                    {Boolean(headerMessage) && (
                         <View style={[styles.ph5, styles.pb5]}>
-                            <Text style={[styles.textLabel, styles.colorMuted]}>{props.headerMessage}</Text>
+                            <Text style={[styles.textLabel, styles.colorMuted]}>{headerMessage}</Text>
                         </View>
                     )}
                     <SectionList
                         ref={listRef}
-                        sections={props.sections}
+                        sections={sections}
                         renderItem={renderItem}
                         getItemLayout={getItemLayout}
-                        onScroll={props.onScroll}
-                        onScrollBeginDrag={props.onScrollBeginDrag}
+                        onScroll={onScroll}
+                        onScrollBeginDrag={onScrollBeginDrag}
                         keyExtractor={(item) => item.keyForList}
                         extraData={focusedIndex}
                         indicatorStyle="white"
@@ -258,6 +270,5 @@ function BaseSelectionListRadio(props) {
 
 BaseSelectionListRadio.displayName = 'BaseSelectionListRadio';
 BaseSelectionListRadio.propTypes = propTypes;
-BaseSelectionListRadio.defaultProps = selectionListRadioDefaultProps;
 
 export default BaseSelectionListRadio;


### PR DESCRIPTION
### Details
Noticed a number of ways in which this component can be cleaned up to better follow our new functional component style.

### Fixed Issues
$ related to https://github.com/Expensify/App/issues/16110

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for the expected offline behavior in the `Offline steps` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android / native
    - [ ] Android / Chrome
    - [ ] iOS / native
    - [ ] iOS / Safari
    - [ ] MacOS / Chrome / Safari
    - [ ] MacOS / Desktop
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [ ] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [ ] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [ ] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] I verified that if a function's arguments changed that all usages have also been updated correctly
- [ ] If a new component is created I verified that:
    - [ ] A similar component doesn't exist in the codebase
    - [ ] All props are defined accurately and each prop has a `/** comment above it */`
    - [ ] The file is named correctly
    - [ ] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [ ] The only data being stored in the state is data necessary for rendering and nothing else
    - [ ] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [ ] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [ ] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [ ] All JSX used for rendering exists in the render method
    - [ ] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [ ] If any new file was added I verified that:
    - [ ] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [ ] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>
