### PR TITLE
Fix inconsistent color on Onfido's back icon desktop

### DIFF
--- a/src/components/Onfido/BaseOnfidoWeb.js
+++ b/src/components/Onfido/BaseOnfidoWeb.js
@@ -57,6 +57,8 @@ class Onfido extends React.Component {
                 colorBackgroundSelector: themeColors.appBG,
                 colorBackgroundDocTypeButton: themeColors.success,
                 colorBackgroundDocTypeButtonHover: themeColors.successHover,
+                colorBackgroundButtonIconHover: themeColors.transparent,
+                colorBackgroundButtonIconActive: themeColors.transparent,
             },
             steps: [
                 {

--- a/src/components/Onfido/index.css
+++ b/src/components/Onfido/index.css
@@ -16,6 +16,12 @@
     box-shadow: none !important;
 }
 
+.onfido-sdk-ui-NavigationBar-iconBack {
+    /* Onfido's back icon with our theme colors. */
+    --back-icon-svg: url("data:image/svg+xml,%3Csvg width='32' height='32' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Ccircle fill='none' cx='16' cy='16' r='16'/%3E%3Cpath d='M16.668 11.811L11.738 16l4.93 4.189a1.014 1.014 0 0 1 0 1.5 1.191 1.191 0 0 1-1.604 0l-5.736-4.873A1.01 1.01 0 0 1 9.003 16a1.01 1.01 0 0 1 .325-.816l5.736-4.873a1.191 1.191 0 0 1 1.604 0 1.014 1.014 0 0 1 0 1.5z' fill='%238B9C8F' fill-rule='nonzero'/%3E%3Crect fill='%238B9C8F' fill-rule='nonzero' x='9' y='15' width='16' height='2' rx='1'/%3E%3C/g%3E%3C/svg%3E");
+    background-image: var(--back-icon-svg) !important;
+}
+
 @media only screen and (max-width: 600px) {
     .onfido-sdk-ui-Modal-inner {
         /* This keeps the bottom of the Onfido window from being cut off on mobile web because the height was being


### PR DESCRIPTION
### Details
<!-- Explanation of the change or anything fishy that is going on -->
Web - Inconsistent color on "<- Back" button under Bank Connection (3 rd step: Personal Information)

### Fixed Issues

$ https://github.com/Expensify/App/issues/21971
PROPOSAL: https://github.com/Expensify/App/issues/21971#issuecomment-1615162561


### Tests
1. Open website and settings.
2. Go to Workspace > Bank Connection (3 rd step: Personal Information)

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
N/A
### QA Steps
Same as tests
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.
--->

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>
<img width="380" alt="Screen Shot 2023-07-11 at 4 52 19 PM" src="https://github.com/Expensify/App/assets/13113013/9f038a5d-608a-489d-95d6-9111944a1dda">

<img width="381" alt="Screen Shot 2023-07-11 at 4 52 25 PM" src="https://github.com/Expensify/App/assets/13113013/808b74dd-7365-4554-bf33-80008f8a9761">



</details>

<details>
<summary>Mobile Web - Safari</summary>

<img width="378" alt="Screen Shot 2023-07-11 at 4 57 44 PM" src="https://github.com/Expensify/App/assets/13113013/71c1bc23-f517-40f7-98d9-fcf6b816b63b">



</details>

<details>
<summary>Mobile Web - Chrome</summary>

<img width="619" alt="Screen Shot 2023-07-11 at 5 56 28 PM" src="https://github.com/Expensify/App/assets/13113013/e156523e-48a2-432c-95c6-fa5e817d66af">



</details>

<details>
<summary>Desktop</summary>
<img width="379" alt="Screen Shot 2023-07-11 at 4 55 35 PM" src="https://github.com/Expensify/App/assets/13113013/989a9dad-28ee-4f15-aa27-eff89a54eda4">

<img width="382" alt="Screen Shot 2023-07-11 at 4 55 39 PM" src="https://github.com/Expensify/App/assets/13113013/0b67a08c-f59c-477b-96f7-494d2a5b9f73">



</details>

<details>
<summary>iOS</summary>

<img width="382" alt="Screen Shot 2023-07-11 at 5 05 08 PM" src="https://github.com/Expensify/App/assets/13113013/ca4c5bc3-0e64-4d3a-b3c0-7e3343c9f5eb">



</details>

<details>

<summary>Android</summary>

<img width="623" alt="Screen Shot 2023-07-11 at 6 02 57 PM" src="https://github.com/Expensify/App/assets/13113013/0b20d2ce-b516-4b8d-8ae8-9b9cece34ede">



</details>
