### PR TITLE
Allow guides (and anyone) to opt into memory only keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "react-native-key-command": "^1.0.1",
         "react-native-localize": "^2.2.6",
         "react-native-modal": "^13.0.0",
-        "react-native-onyx": "1.0.43",
+        "react-native-onyx": "1.0.50",
         "react-native-pdf": "^6.6.2",
         "react-native-performance": "^4.0.0",
         "react-native-permissions": "^3.0.1",
@@ -36787,9 +36787,9 @@
       }
     },
     "node_modules/react-native-onyx": {
-      "version": "1.0.43",
-      "resolved": "https://registry.npmjs.org/react-native-onyx/-/react-native-onyx-1.0.43.tgz",
-      "integrity": "sha512-NwS1SxZJWhk/7FUAAE9HrnupQR1yrSAheuhggdeA3+oFLn9X6UJM7n7w9DodFqCQbUIUy9biKtYk29sChfk9hQ==",
+      "version": "1.0.50",
+      "resolved": "https://registry.npmjs.org/react-native-onyx/-/react-native-onyx-1.0.50.tgz",
+      "integrity": "sha512-tBqJRUBb2M/giIgqf2V0kw1jMr2iAW64CpgtWJbETv1ihOitP6+YAJpqoPIB0SGSFByfgTYY4k/KSVZBgcynMg==",
       "dependencies": {
         "ascii-table": "0.0.9",
         "fast-equals": "^4.0.3",
@@ -36801,7 +36801,6 @@
         "npm": "8.11.0"
       },
       "peerDependencies": {
-        "expensify-common": ">=1",
         "localforage": "^1.10.0",
         "localforage-removeitems": "^1.4.0",
         "react": ">=18.1.0",
@@ -68550,9 +68549,9 @@
       }
     },
     "react-native-onyx": {
-      "version": "1.0.43",
-      "resolved": "https://registry.npmjs.org/react-native-onyx/-/react-native-onyx-1.0.43.tgz",
-      "integrity": "sha512-NwS1SxZJWhk/7FUAAE9HrnupQR1yrSAheuhggdeA3+oFLn9X6UJM7n7w9DodFqCQbUIUy9biKtYk29sChfk9hQ==",
+      "version": "1.0.50",
+      "resolved": "https://registry.npmjs.org/react-native-onyx/-/react-native-onyx-1.0.50.tgz",
+      "integrity": "sha512-tBqJRUBb2M/giIgqf2V0kw1jMr2iAW64CpgtWJbETv1ihOitP6+YAJpqoPIB0SGSFByfgTYY4k/KSVZBgcynMg==",
       "requires": {
         "ascii-table": "0.0.9",
         "fast-equals": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "react-native-key-command": "^1.0.1",
     "react-native-localize": "^2.2.6",
     "react-native-modal": "^13.0.0",
-    "react-native-onyx": "1.0.43",
+    "react-native-onyx": "1.0.50",
     "react-native-pdf": "^6.6.2",
     "react-native-performance": "^4.0.0",
     "react-native-permissions": "^3.0.1",

--- a/src/ONYXKEYS.js
+++ b/src/ONYXKEYS.js
@@ -230,4 +230,7 @@ export default {
 
     // Report ID of the last report the user viewed as anonymous user
     LAST_OPENED_PUBLIC_ROOM_ID: 'lastOpenedPublicRoomID',
+
+    // Experimental memory only Onyx mode flag
+    IS_USING_MEMORY_ONLY_KEYS: 'isUsingMemoryOnlyKeys',
 };

--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -317,6 +317,6 @@ export default compose(
         },
         isUsingMemoryOnlyKeys: {
             key: ONYXKEYS.IS_USING_MEMORY_ONLY_KEYS,
-        }
+        },
     }),
 )(AuthScreens);

--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -91,10 +91,14 @@ const propTypes = {
     /** The report ID of the last opened public room as anonymous user */
     lastOpenedPublicRoomID: PropTypes.string,
 
+    /** Opt-in experimental mode that prevents certain Onyx keys from persisting to disk */
+    isUsingMemoryOnlyKeys: PropTypes.bool,
+
     ...windowDimensionsPropTypes,
 };
 
 const defaultProps = {
+    isUsingMemoryOnlyKeys: false,
     session: {
         email: null,
     },

--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -122,7 +122,9 @@ class AuthScreens extends React.Component {
 
         // If we are on this screen then we are "logged in", but the user might not have "just logged in". They could be reopening the app
         // or returning from background. If so, we'll assume they have some app data already and we can call reconnectApp() instead of openApp().
-        if (SessionUtils.didUserLogInDuringSession()) {
+        // Note: There is an experimental Onyx mode that will allow the user to avoid persisting some data entirely - if we have this mode enabled then
+        // always call OpenApp when the app starts since these users will not be able to rehydrate data they didn't save (outside of memory).
+        if (Onyx.hasMemoryOnlyKeys() || SessionUtils.didUserLogInDuringSession()) {
             App.openApp();
         } else {
             App.reconnectApp();

--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -126,6 +126,9 @@ class AuthScreens extends React.Component {
 
         // If we are on this screen then we are "logged in", but the user might not have "just logged in". They could be reopening the app
         // or returning from background. If so, we'll assume they have some app data already and we can call reconnectApp() instead of openApp().
+        // Note: If a Guide has enabled the memory only key mode then we do want to run OpenApp as their app will not be rehydrated with
+        // the correct state on refresh. They are explicitly opting out of storing data they would need (i.e. reports_) to take advantage of
+        // the optimizations performed during ReconnectApp.
         if (this.props.isUsingMemoryOnlyKeys || SessionUtils.didUserLogInDuringSession()) {
             App.openApp();
         } else {

--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -122,9 +122,7 @@ class AuthScreens extends React.Component {
 
         // If we are on this screen then we are "logged in", but the user might not have "just logged in". They could be reopening the app
         // or returning from background. If so, we'll assume they have some app data already and we can call reconnectApp() instead of openApp().
-        // Note: There is an experimental Onyx mode that will allow the user to avoid persisting some data entirely - if we have this mode enabled then
-        // always call OpenApp when the app starts since these users will not be able to rehydrate data they didn't save (outside of memory).
-        if (Onyx.hasMemoryOnlyKeys() || SessionUtils.didUserLogInDuringSession()) {
+        if (this.props.isUsingMemoryOnlyKeys || SessionUtils.didUserLogInDuringSession()) {
             App.openApp();
         } else {
             App.reconnectApp();
@@ -310,5 +308,8 @@ export default compose(
         lastOpenedPublicRoomID: {
             key: ONYXKEYS.LAST_OPENED_PUBLIC_ROOM_ID,
         },
+        isUsingMemoryOnlyKeys: {
+            key: ONYXKEYS.IS_USING_MEMORY_ONLY_KEYS,
+        }
     }),
 )(AuthScreens);

--- a/src/setup/index.js
+++ b/src/setup/index.js
@@ -43,11 +43,21 @@ export default function () {
     });
 
     // When enabled we will skip persisting to disk any server-side downloaded objects (e.g. workspaces, chats, etc) that can hog up a user's resources.
-    window.enableMemoryOnlyKeys = () => Onyx.setMemoryOnlyKeys([
-        ONYXKEYS.COLLECTION.REPORT,
-        ONYXKEYS.COLLECTION.POLICY,
-        ONYXKEYS.PERSONAL_DETAILS_LIST,
-    ]);
+    window.enableMemoryOnlyKeys = () => {
+        // eslint-disable-next-line rulesdir/prefer-actions-set-data
+        Onyx.set(ONYXKEYS.IS_USING_MEMORY_ONLY_KEYS, true);
+        Onyx.setMemoryOnlyKeys([
+            ONYXKEYS.COLLECTION.REPORT,
+            ONYXKEYS.COLLECTION.POLICY,
+            ONYXKEYS.PERSONAL_DETAILS_LIST,
+        ]);
+    };
+
+    window.disableMemoryOnlyKeys = () => {
+        // eslint-disable-next-line rulesdir/prefer-actions-set-data
+        Onyx.set(ONYXKEYS.IS_USING_MEMORY_ONLY_KEYS, false);
+        Onyx.setMemoryOnlyKeys([]);
+    }
 
     Device.setDeviceID();
 

--- a/src/setup/index.js
+++ b/src/setup/index.js
@@ -46,18 +46,14 @@ export default function () {
     window.enableMemoryOnlyKeys = () => {
         // eslint-disable-next-line rulesdir/prefer-actions-set-data
         Onyx.set(ONYXKEYS.IS_USING_MEMORY_ONLY_KEYS, true);
-        Onyx.setMemoryOnlyKeys([
-            ONYXKEYS.COLLECTION.REPORT,
-            ONYXKEYS.COLLECTION.POLICY,
-            ONYXKEYS.PERSONAL_DETAILS_LIST,
-        ]);
+        Onyx.setMemoryOnlyKeys([ONYXKEYS.COLLECTION.REPORT, ONYXKEYS.COLLECTION.POLICY, ONYXKEYS.PERSONAL_DETAILS_LIST]);
     };
 
     window.disableMemoryOnlyKeys = () => {
         // eslint-disable-next-line rulesdir/prefer-actions-set-data
         Onyx.set(ONYXKEYS.IS_USING_MEMORY_ONLY_KEYS, false);
         Onyx.setMemoryOnlyKeys([]);
-    }
+    };
 
     Device.setDeviceID();
 

--- a/src/setup/index.js
+++ b/src/setup/index.js
@@ -42,6 +42,13 @@ export default function () {
         },
     });
 
+    // When enabled we will skip persisting to disk any server-side downloaded objects (e.g. workspaces, chats, etc) that can hog up a user's resources.
+    window.enableMemoryOnlyKeys = () => Onyx.setMemoryOnlyKeys([
+        ONYXKEYS.COLLECTION.REPORT,
+        ONYXKEYS.COLLECTION.POLICY,
+        ONYXKEYS.PERSONAL_DETAILS_LIST,
+    ]);
+
     Device.setDeviceID();
 
     // Force app layout to work left to right because our design does not currently support devices using this mode


### PR DESCRIPTION
### Details

Related to -> https://github.com/Expensify/react-native-onyx/pull/270

### Fixed Issues (Not entirely - more of a bandaid)

https://github.com/Expensify/App/issues/21766

### Tests

1. Pull down https://github.com/Expensify/react-native-onyx/pull/270
2. `cd` into the `react-native-onyx` directory (note - not the one in `App/node_modules` but wherever it is cloned)
3. Run `npm run build`
4. Copy the `dist` folder to `App/node_modules/react-native-onyx` and replace the existing `dist` folder
5. Run `npm run web` for `App`
6. On sign in page enable the experimental mode by running `window.enableMemoryOnlyKeys()` in the JS console.
7. Sign in
8. Verify the app works more or less normally
9. Refresh the page
10. Verify the app data eventually loads again (we should be calling `OpenApp` and not `ReconnectApp`)

**Other notes:** This mode is "opt-in" so it's not end of the world if some things seem off with it enabled. Though, let's verify everything is working exactly the same as before when it's not enabled.
 
- [ ] Verify that no errors appear in the JS console

### Offline tests
❌ 

### QA Steps

Internal QA. We will test this with a Guide on staging.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<img width="803" alt="2023-07-11_17-21-36" src="https://github.com/Expensify/App/assets/32969087/ebbf16bf-c58a-4269-b0f8-243f38786810">

</details>

<details>
<summary>Mobile Web - Chrome</summary>

Not relevant for mWeb

</details>

<details>
<summary>Mobile Web - Safari</summary>

Not relevant for mWeb

</details>

<details>
<summary>Desktop</summary>

<img width="935" alt="2023-07-11_17-26-56" src="https://github.com/Expensify/App/assets/32969087/222c91f8-e1b5-4e91-824e-ecd19becf31d">

</details>

<details>
<summary>iOS</summary>

N/A to native

</details>

<details>
<summary>Android</summary>

N/A to native
</details>
