### PR TITLE
Migrate BasePicker to function component

### DIFF
--- a/src/components/Picker/BasePicker.js
+++ b/src/components/Picker/BasePicker.js
@@ -13,7 +13,7 @@ import {ScrollContext} from '../ScrollViewWithContext';
 
 const propTypes = {
     /** A forwarded ref */
-    forwardedRef: PropTypes.oneOfType([PropTypes.func, PropTypes.shape({current: PropTypes.instanceOf(React.Component)})]).isRequired,
+    forwardedRef: PropTypes.oneOfType([PropTypes.func, PropTypes.shape({current: PropTypes.instanceOf(React.Component)})]),
 
     /** BasePicker label */
     label: PropTypes.string,

--- a/src/components/Picker/BasePicker.js
+++ b/src/components/Picker/BasePicker.js
@@ -84,7 +84,7 @@ const propTypes = {
 };
 
 const defaultProps = {
-    forwardedRef: null,
+    forwardedRef: undefined,
     label: '',
     isDisabled: false,
     errorText: '',

--- a/src/components/Picker/BasePicker.js
+++ b/src/components/Picker/BasePicker.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import React, {PureComponent} from 'react';
+import React, {useContext, useEffect, useImperativeHandle, useRef, useState} from 'react';
 import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import RNPickerSelect from 'react-native-picker-select';
@@ -12,6 +12,9 @@ import themeColors from '../../styles/themes/default';
 import {ScrollContext} from '../ScrollViewWithContext';
 
 const propTypes = {
+    /** A forwarded ref */
+    forwardedRef: PropTypes.oneOfType([PropTypes.func, PropTypes.shape({current: PropTypes.instanceOf(React.Component)})]).isRequired,
+
     /** BasePicker label */
     label: PropTypes.string,
 
@@ -104,43 +107,37 @@ const defaultProps = {
     additionalPickerEvents: () => {},
 };
 
-/**
- * @property {View} root - a reference to the root View
- * @property {Object} picker - a reference to @react-native-picker/picker
- */
-class BasePicker extends PureComponent {
-    constructor(props) {
-        super(props);
-        this.state = {
-            isHighlighted: false,
-        };
+function BasePicker(props) {
+    const [isHighlighted, setIsHighlighted] = useState(false);
 
-        this.onInputChange = this.onInputChange.bind(this);
-        this.enableHighlight = this.enableHighlight.bind(this);
-        this.disableHighlight = this.disableHighlight.bind(this);
-        this.focus = this.focus.bind(this);
-        this.measureLayout = this.measureLayout.bind(this);
+    // reference to the root View
+    const root = useRef(null);
 
-        // Windows will reuse the text color of the select for each one of the options
-        // so we might need to color accordingly so it doesn't blend with the background.
-        this.placeholder = _.isEmpty(this.props.placeholder)
-            ? {}
-            : {
-                  ...this.props.placeholder,
-                  color: themeColors.pickerOptionsTextColor,
-              };
-    }
+    // reference to @react-native-picker/picker
+    const picker = useRef(null);
 
-    componentDidMount() {
-        this.setDefaultValue();
-    }
+    // Windows will reuse the text color of the select for each one of the options
+    // so we might need to color accordingly so it doesn't blend with the background.
+    const placeholder = _.isEmpty(props.placeholder)
+        ? {}
+        : {
+              ...props.placeholder,
+              color: themeColors.pickerOptionsTextColor,
+          };
 
-    componentDidUpdate(prevProps) {
-        if (prevProps.items === this.props.items) {
+    useEffect(() => {
+        if (props.value || !props.items || props.items.length !== 1 || !props.onInputChange) {
             return;
         }
-        this.setDefaultValue();
-    }
+
+        // When there is only 1 element in the selector, we do the user a favor and automatically select it for them
+        // so they don't have to spend extra time selecting the only possible value.
+        props.onInputChange(props.items[0].value, 0);
+
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [props.items]);
+
+    const context = useContext(ScrollContext);
 
     /**
      * Forms use inputID to set values. But BasePicker passes an index as the second parameter to onInputChange
@@ -148,160 +145,148 @@ class BasePicker extends PureComponent {
      * @param {String} value
      * @param {Number} index
      */
-    onInputChange(value, index) {
-        if (this.props.inputID) {
-            this.props.onInputChange(value);
+    const onInputChange = (value, index) => {
+        if (props.inputID) {
+            props.onInputChange(value);
             return;
         }
 
-        this.props.onInputChange(value, index);
-    }
+        props.onInputChange(value, index);
+    };
 
-    setDefaultValue() {
-        // When there is only 1 element in the selector, we do the user a favor and automatically select it for them
-        // so they don't have to spend extra time selecting the only possible value.
-        if (this.props.value || !this.props.items || this.props.items.length !== 1 || !this.props.onInputChange) {
-            return;
-        }
-        this.props.onInputChange(this.props.items[0].value, 0);
-    }
+    const enableHighlight = () => {
+        setIsHighlighted(true);
+    };
 
-    enableHighlight() {
-        this.setState({
-            isHighlighted: true,
-        });
-    }
+    const disableHighlight = () => {
+        setIsHighlighted(false);
+    };
 
-    disableHighlight() {
-        this.setState({
-            isHighlighted: false,
-        });
-    }
+    useImperativeHandle(props.forwardedRef, () => ({
+        /**
+         * Focuses the picker (if configured to do so)
+         *
+         * This method is used by Form
+         */
+        focus() {
+            if (!props.shouldFocusPicker) {
+                return;
+            }
 
-    /**
-     * Focuses the picker (if configured to do so)
-     *
-     * This method is used by Form
-     */
-    focus() {
-        if (!this.props.shouldFocusPicker) {
-            return;
-        }
+            // Defer the focusing to work around a bug on Mobile Safari, where focusing the `select` element in the
+            // same task when we scrolled to it left that element in a glitched state, where the dropdown list can't
+            // be opened until the element gets re-focused
+            _.defer(() => {
+                picker.current.focus();
+            });
+        },
 
-        // Defer the focusing to work around a bug on Mobile Safari, where focusing the `select` element in the same
-        // task when we scrolled to it left that element in a glitched state, where the dropdown list can't be opened
-        // until the element gets re-focused
-        _.defer(() => {
-            this.picker.focus();
-        });
-    }
+        /**
+         * Like measure(), but measures the view relative to an ancestor
+         *
+         * This method is used by Form when scrolling to the input
+         *
+         * @param {Object} relativeToNativeComponentRef - reference to an ancestor
+         * @param {function(x: number, y: number, width: number, height: number): void} onSuccess - callback called on success
+         * @param {function(): void} onFail - callback called on failure
+         */
+        measureLayout(relativeToNativeComponentRef, onSuccess, onFail) {
+            if (!root.current) {
+                return;
+            }
 
-    /**
-     * Like measure(), but measures the view relative to an ancestor
-     *
-     * This method is used by Form when scrolling to the input
-     *
-     * @param {Object} relativeToNativeComponentRef - reference to an ancestor
-     * @param {function(x: number, y: number, width: number, height: number): void} onSuccess - callback called on success
-     * @param {function(): void} onFail - callback called on failure
-     */
-    measureLayout(relativeToNativeComponentRef, onSuccess, onFail) {
-        if (!this.root) {
-            return;
-        }
+            root.current.measureLayout(relativeToNativeComponentRef, onSuccess, onFail);
+        },
+    }));
 
-        this.root.measureLayout(relativeToNativeComponentRef, onSuccess, onFail);
-    }
+    const hasError = !_.isEmpty(props.errorText);
 
-    render() {
-        const hasError = !_.isEmpty(this.props.errorText);
-
-        if (this.props.isDisabled) {
-            return (
-                <View>
-                    {Boolean(this.props.label) && (
-                        <Text
-                            style={[styles.textLabelSupporting, styles.mb1]}
-                            numberOfLines={1}
-                        >
-                            {this.props.label}
-                        </Text>
-                    )}
-                    <Text numberOfLines={1}>{this.props.value}</Text>
-                    {Boolean(this.props.hintText) && <Text style={[styles.textLabel, styles.colorMuted, styles.mt2]}>{this.props.hintText}</Text>}
-                </View>
-            );
-        }
-
+    if (props.isDisabled) {
         return (
-            <>
-                <View
-                    ref={(el) => (this.root = el)}
-                    style={[
-                        styles.pickerContainer,
-                        this.props.isDisabled && styles.inputDisabled,
-                        ...this.props.containerStyles,
-                        this.state.isHighlighted && styles.borderColorFocus,
-                        hasError && styles.borderColorDanger,
-                    ]}
-                >
-                    {this.props.label && (
-                        <Text
-                            pointerEvents="none"
-                            style={[styles.pickerLabel, styles.textLabelSupporting]}
-                        >
-                            {this.props.label}
-                        </Text>
-                    )}
-                    <RNPickerSelect
-                        onValueChange={this.onInputChange}
-                        // We add a text color to prevent white text on white background dropdown items on Windows
-                        items={_.map(this.props.items, (item) => ({...item, color: themeColors.pickerOptionsTextColor}))}
-                        style={this.props.size === 'normal' ? styles.picker(this.props.isDisabled, this.props.backgroundColor) : styles.pickerSmall(this.props.backgroundColor)}
-                        useNativeAndroidPickerStyle={false}
-                        placeholder={this.placeholder}
-                        value={this.props.value}
-                        Icon={() => this.props.icon(this.props.size)}
-                        disabled={this.props.isDisabled}
-                        fixAndroidTouchableBug
-                        onOpen={this.enableHighlight}
-                        onClose={this.disableHighlight}
-                        textInputProps={{
-                            allowFontScaling: false,
-                        }}
-                        pickerProps={{
-                            ref: (el) => (this.picker = el),
-                            onFocus: this.enableHighlight,
-                            onBlur: () => {
-                                this.disableHighlight();
-                                this.props.onBlur();
-                            },
-                            ...this.props.additionalPickerEvents(this.enableHighlight, (value, index) => {
-                                this.onInputChange(value, index);
-                                this.disableHighlight();
-                            }),
-                        }}
-                        scrollViewRef={this.context && this.context.scrollViewRef}
-                        scrollViewContentOffsetY={this.context && this.context.contentOffsetY}
-                    />
-                </View>
-                <FormHelpMessage message={this.props.errorText} />
-                {Boolean(this.props.hintText) && <Text style={[styles.textLabel, styles.colorMuted, styles.mt2]}>{this.props.hintText}</Text>}
-            </>
+            <View>
+                {Boolean(props.label) && (
+                    <Text
+                        style={[styles.textLabelSupporting, styles.mb1]}
+                        numberOfLines={1}
+                    >
+                        {props.label}
+                    </Text>
+                )}
+                <Text numberOfLines={1}>{props.value}</Text>
+                {Boolean(props.hintText) && <Text style={[styles.textLabel, styles.colorMuted, styles.mt2]}>{props.hintText}</Text>}
+            </View>
         );
     }
+
+    return (
+        <>
+            <View
+                ref={root}
+                style={[
+                    styles.pickerContainer,
+                    props.isDisabled && styles.inputDisabled,
+                    ...props.containerStyles,
+                    isHighlighted && styles.borderColorFocus,
+                    hasError && styles.borderColorDanger,
+                ]}
+            >
+                {props.label && (
+                    <Text
+                        pointerEvents="none"
+                        style={[styles.pickerLabel, styles.textLabelSupporting]}
+                    >
+                        {props.label}
+                    </Text>
+                )}
+                <RNPickerSelect
+                    onValueChange={onInputChange}
+                    // We add a text color to prevent white text on white background dropdown items on Windows
+                    items={_.map(props.items, (item) => ({...item, color: themeColors.pickerOptionsTextColor}))}
+                    style={props.size === 'normal' ? styles.picker(props.isDisabled, props.backgroundColor) : styles.pickerSmall(props.backgroundColor)}
+                    useNativeAndroidPickerStyle={false}
+                    placeholder={placeholder}
+                    value={props.value}
+                    Icon={() => props.icon(props.size)}
+                    disabled={props.isDisabled}
+                    fixAndroidTouchableBug
+                    onOpen={enableHighlight}
+                    onClose={disableHighlight}
+                    textInputProps={{
+                        allowFontScaling: false,
+                    }}
+                    pickerProps={{
+                        ref: picker,
+                        onFocus: enableHighlight,
+                        onBlur: () => {
+                            disableHighlight();
+                            props.onBlur();
+                        },
+                        ...props.additionalPickerEvents(enableHighlight, (value, index) => {
+                            onInputChange(value, index);
+                            disableHighlight();
+                        }),
+                    }}
+                    scrollViewRef={context && context.scrollViewRef}
+                    scrollViewContentOffsetY={context && context.contentOffsetY}
+                />
+            </View>
+            <FormHelpMessage message={props.errorText} />
+            {Boolean(props.hintText) && <Text style={[styles.textLabel, styles.colorMuted, styles.mt2]}>{props.hintText}</Text>}
+        </>
+    );
 }
 
 BasePicker.propTypes = propTypes;
 BasePicker.defaultProps = defaultProps;
-BasePicker.contextType = ScrollContext;
+BasePicker.displayName = 'BasePicker';
 
 export default React.forwardRef((props, ref) => (
     <BasePicker
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...props}
         // Forward the ref to BasePicker, as we implement imperative methods there
-        ref={ref}
+        forwardedRef={ref}
+        // eslint-disable-next-line react/prop-types
         key={props.inputID}
     />
 ));

--- a/src/components/Picker/BasePicker.js
+++ b/src/components/Picker/BasePicker.js
@@ -84,6 +84,7 @@ const propTypes = {
 };
 
 const defaultProps = {
+    forwardedRef: null,
     label: '',
     isDisabled: false,
     errorText: '',


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

Migrate `BasePicker` to function component

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/123`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/123#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/16189

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- Go to any page containing a picker component
  - Example: Settings > Profile > Personal details > Home address 
  - Another example: Settings > Workspaces > (a workspace with USD currency) > Reimbursements > Connect bank account > Connect manually > (Proceed to Step 2)
- [ ] Verify that selecting a value works as expected
- Fill the form so all inputs before the picker are filled correctly, but the picker is left without a selected value
- Submit the form (press "Save", "Continue", or a similar button)
- [ ] Verify that scrolling to the picker works when "Fix the errors" is pressed
- [ ] Verify that focusing the picker works when "Fix the errors" is pressed (on the Web)

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

Same as the _Tests_ steps

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://github.com/Expensify/App/assets/2590174/3d39177e-db1d-4fce-9a0f-f4560d3f9693

</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://github.com/Expensify/App/assets/2590174/98ccae9e-fe20-4306-871e-7558c4e2904a

</details>

<details>
<summary>Mobile Web - Safari</summary>

https://github.com/Expensify/App/assets/2590174/2cbccf99-a25a-478d-bb52-c7f9fca49955

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

https://github.com/Expensify/App/assets/2590174/8a9ab1cf-4d6f-407b-aefa-306c538e0a4f

</details>

<details>
<summary>Android</summary>

https://github.com/Expensify/App/assets/2590174/dac7ebef-7f8d-4329-9352-e94753d487fe

</details>
