### PR TITLE
refactor: migrate withEnvironment to function component

### DIFF
--- a/src/components/EnvironmentBadge.js
+++ b/src/components/EnvironmentBadge.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import CONST from '../CONST';
-import withEnvironment, {environmentPropTypes} from './withEnvironment';
 import Badge from './Badge';
 import styles from '../styles/styles';
 import * as Environment from '../libs/Environment/Environment';
 import pkg from '../../package.json';
+import useEnvironment from '../hooks/useEnvironment';
 
 const ENVIRONMENT_SHORT_FORM = {
     [CONST.ENVIRONMENT.DEV]: 'DEV',
@@ -13,26 +13,27 @@ const ENVIRONMENT_SHORT_FORM = {
     [CONST.ENVIRONMENT.ADHOC]: 'ADHOC',
 };
 
-function EnvironmentBadge(props) {
+function EnvironmentBadge() {
+    const {environment} = useEnvironment();
+
     // If we are on production, don't show any badge
-    if (props.environment === CONST.ENVIRONMENT.PRODUCTION) {
+    if (environment === CONST.ENVIRONMENT.PRODUCTION) {
         return null;
     }
 
-    const text = Environment.isInternalTestBuild() ? `v${pkg.version} PR:${CONST.PULL_REQUEST_NUMBER}` : ENVIRONMENT_SHORT_FORM[props.environment];
+    const text = Environment.isInternalTestBuild() ? `v${pkg.version} PR:${CONST.PULL_REQUEST_NUMBER}` : ENVIRONMENT_SHORT_FORM[environment];
 
     return (
         <Badge
-            success={props.environment === CONST.ENVIRONMENT.STAGING || props.environment === CONST.ENVIRONMENT.ADHOC}
-            error={props.environment !== CONST.ENVIRONMENT.STAGING && props.environment !== CONST.ENVIRONMENT.ADHOC}
+            success={environment === CONST.ENVIRONMENT.STAGING || environment === CONST.ENVIRONMENT.ADHOC}
+            error={environment !== CONST.ENVIRONMENT.STAGING && environment !== CONST.ENVIRONMENT.ADHOC}
             text={text}
             badgeStyles={[styles.alignSelfEnd, styles.headerEnvBadge]}
             textStyles={[styles.headerEnvBadgeText]}
-            environment={props.environment}
+            environment={environment}
         />
     );
 }
 
 EnvironmentBadge.displayName = 'EnvironmentBadge';
-EnvironmentBadge.propTypes = environmentPropTypes;
-export default withEnvironment(EnvironmentBadge);
+export default EnvironmentBadge;

--- a/src/components/ExpensifyCashLogo.js
+++ b/src/components/ExpensifyCashLogo.js
@@ -24,6 +24,7 @@ const logoComponents = {
 
 function ExpensifyCashLogo(props) {
     const {environment} = useEnvironment();
+    
     // PascalCase is required for React components, so capitalize the const here
     const LogoComponent = logoComponents[environment];
     return (

--- a/src/components/ExpensifyCashLogo.js
+++ b/src/components/ExpensifyCashLogo.js
@@ -24,7 +24,7 @@ const logoComponents = {
 
 function ExpensifyCashLogo(props) {
     const {environment} = useEnvironment();
-    
+
     // PascalCase is required for React components, so capitalize the const here
     const LogoComponent = logoComponents[environment];
     return (

--- a/src/components/ExpensifyCashLogo.js
+++ b/src/components/ExpensifyCashLogo.js
@@ -5,7 +5,7 @@ import DevLogo from '../../assets/images/new-expensify-dev.svg';
 import StagingLogo from '../../assets/images/new-expensify-stg.svg';
 import AdhocLogo from '../../assets/images/new-expensify-adhoc.svg';
 import CONST from '../CONST';
-import withEnvironment, {environmentPropTypes} from './withEnvironment';
+import useEnvironment from '../hooks/useEnvironment';
 
 const propTypes = {
     /** Width of logo */
@@ -13,8 +13,6 @@ const propTypes = {
 
     /** Height of logo */
     height: PropTypes.number.isRequired,
-
-    ...environmentPropTypes,
 };
 
 const logoComponents = {
@@ -25,8 +23,9 @@ const logoComponents = {
 };
 
 function ExpensifyCashLogo(props) {
+    const {environment} = useEnvironment();
     // PascalCase is required for React components, so capitalize the const here
-    const LogoComponent = logoComponents[props.environment];
+    const LogoComponent = logoComponents[environment];
     return (
         <LogoComponent
             width={props.width}
@@ -37,4 +36,4 @@ function ExpensifyCashLogo(props) {
 
 ExpensifyCashLogo.displayName = 'ExpensifyCashLogo';
 ExpensifyCashLogo.propTypes = propTypes;
-export default withEnvironment(ExpensifyCashLogo);
+export default ExpensifyCashLogo;

--- a/src/components/ExpensifyWordmark.js
+++ b/src/components/ExpensifyWordmark.js
@@ -34,7 +34,7 @@ const logoComponents = {
 function ExpensifyWordmark(props) {
     const {environment} = useEnvironment();
     // PascalCase is required for React components, so capitalize the const here
-    
+
     const LogoComponent = logoComponents[environment] || AdHocLogo;
     return (
         <>

--- a/src/components/ExpensifyWordmark.js
+++ b/src/components/ExpensifyWordmark.js
@@ -34,6 +34,7 @@ const logoComponents = {
 function ExpensifyWordmark(props) {
     const {environment} = useEnvironment();
     // PascalCase is required for React components, so capitalize the const here
+    
     const LogoComponent = logoComponents[environment] || AdHocLogo;
     return (
         <>

--- a/src/components/ExpensifyWordmark.js
+++ b/src/components/ExpensifyWordmark.js
@@ -7,19 +7,17 @@ import DevLogo from '../../assets/images/expensify-logo--dev.svg';
 import StagingLogo from '../../assets/images/expensify-logo--staging.svg';
 import AdHocLogo from '../../assets/images/expensify-logo--adhoc.svg';
 import CONST from '../CONST';
-import withEnvironment, {environmentPropTypes} from './withEnvironment';
 import withWindowDimensions, {windowDimensionsPropTypes} from './withWindowDimensions';
-import compose from '../libs/compose';
 import themeColors from '../styles/themes/default';
 import styles from '../styles/styles';
 import * as StyleUtils from '../styles/StyleUtils';
 import variables from '../styles/variables';
+import useEnvironment from '../hooks/useEnvironment';
 
 const propTypes = {
     /** Additional styles to add to the component */
     style: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.object]),
 
-    ...environmentPropTypes,
     ...windowDimensionsPropTypes,
 };
 
@@ -34,15 +32,16 @@ const logoComponents = {
 };
 
 function ExpensifyWordmark(props) {
+    const {environment} = useEnvironment();
     // PascalCase is required for React components, so capitalize the const here
-    const LogoComponent = logoComponents[props.environment] || AdHocLogo;
+    const LogoComponent = logoComponents[environment] || AdHocLogo;
     return (
         <>
             <View
                 style={[
-                    StyleUtils.getSignInWordmarkWidthStyle(props.environment, props.isSmallScreenWidth),
+                    StyleUtils.getSignInWordmarkWidthStyle(environment, props.isSmallScreenWidth),
                     StyleUtils.getHeight(props.isSmallScreenWidth ? variables.signInLogoHeightSmallScreen : variables.signInLogoHeight),
-                    props.isSmallScreenWidth && (props.environment === CONST.ENVIRONMENT.DEV || props.environment === CONST.ENVIRONMENT.STAGING) ? styles.ml3 : {},
+                    props.isSmallScreenWidth && (environment === CONST.ENVIRONMENT.DEV || environment === CONST.ENVIRONMENT.STAGING) ? styles.ml3 : {},
                     ...(_.isArray(props.style) ? props.style : [props.style]),
                 ]}
             >
@@ -55,4 +54,4 @@ function ExpensifyWordmark(props) {
 ExpensifyWordmark.displayName = 'ExpensifyWordmark';
 ExpensifyWordmark.defaultProps = defaultProps;
 ExpensifyWordmark.propTypes = propTypes;
-export default compose(withEnvironment, withWindowDimensions)(ExpensifyWordmark);
+export default withWindowDimensions(ExpensifyWordmark);

--- a/src/components/withEnvironment.js
+++ b/src/components/withEnvironment.js
@@ -1,8 +1,7 @@
-import React, {Component} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import * as Environment from '../libs/Environment/Environment';
-import CONST from '../CONST';
 import getComponentDisplayName from '../libs/getComponentDisplayName';
+import useEnvironemnt from '../hooks/useEnvironment';
 
 const environmentPropTypes = {
     /** The string value representing the current environment */
@@ -13,36 +12,18 @@ const environmentPropTypes = {
 };
 
 export default function (WrappedComponent) {
-    class WithEnvironment extends Component {
-        constructor(props) {
-            super(props);
+    function WithEnvironment(props) {
+        const {environment, environmentURL} = useEnvironemnt();
 
-            this.state = {
-                environment: CONST.ENVIRONMENT.PRODUCTION,
-                environmentURL: CONST.NEW_EXPENSIFY_URL,
-            };
-        }
-
-        componentDidMount() {
-            Environment.getEnvironment().then((environment) => {
-                this.setState({environment});
-            });
-            Environment.getEnvironmentURL().then((environmentURL) => {
-                this.setState({environmentURL});
-            });
-        }
-
-        render() {
-            return (
-                <WrappedComponent
-                    // eslint-disable-next-line react/jsx-props-no-spreading
-                    {...this.props}
-                    ref={this.props.forwardedRef}
-                    environment={this.state.environment}
-                    environmentURL={this.state.environmentURL}
-                />
-            );
-        }
+        return (
+            <WrappedComponent
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                {...props}
+                ref={props.forwardedRef}
+                environment={environment}
+                environmentURL={environmentURL}
+            />
+        );
     }
 
     WithEnvironment.displayName = `withEnvironment(${getComponentDisplayName(WrappedComponent)})`;

--- a/src/components/withEnvironment.js
+++ b/src/components/withEnvironment.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import getComponentDisplayName from '../libs/getComponentDisplayName';
-import useEnvironemnt from '../hooks/useEnvironment';
+import useEnvironment from '../hooks/useEnvironment';
 
 const environmentPropTypes = {
     /** The string value representing the current environment */
@@ -13,7 +13,7 @@ const environmentPropTypes = {
 
 export default function (WrappedComponent) {
     function WithEnvironment(props) {
-        const {environment, environmentURL} = useEnvironemnt();
+        const {environment, environmentURL} = useEnvironment();
 
         return (
             <WrappedComponent

--- a/src/hooks/useEnvironment.js
+++ b/src/hooks/useEnvironment.js
@@ -1,0 +1,22 @@
+import {useEffect, useState} from 'react';
+import * as Environment from '../libs/Environment/Environment';
+import CONST from '../CONST';
+
+export default function useEnvironment() {
+    const [environment, setEnvironment] = useState(CONST.ENVIRONMENT.PRODUCTION);
+    const [environmentURL, setEnvironmentURL] = useState(CONST.NEW_EXPENSIFY_URL);
+
+    useEffect(() => {
+        Environment.getEnvironment().then((env) => {
+            setEnvironment(env);
+        });
+        Environment.getEnvironmentURL().then((envUrl) => {
+            setEnvironmentURL(envUrl);
+        });
+    }, []);
+
+    return {
+        environment,
+        environmentURL,
+    };
+}

--- a/src/pages/settings/Preferences/PreferencesPage.js
+++ b/src/pages/settings/Preferences/PreferencesPage.js
@@ -16,9 +16,9 @@ import ScreenWrapper from '../../../components/ScreenWrapper';
 import Switch from '../../../components/Switch';
 import withLocalize, {withLocalizePropTypes} from '../../../components/withLocalize';
 import compose from '../../../libs/compose';
-import withEnvironment, {environmentPropTypes} from '../../../components/withEnvironment';
 import TestToolMenu from '../../../components/TestToolMenu';
 import MenuItemWithTopDescription from '../../../components/MenuItemWithTopDescription';
+import useEnvironment from '../../../hooks/useEnvironment';
 
 const propTypes = {
     /** The chat priority mode */
@@ -34,7 +34,6 @@ const propTypes = {
     preferredLocale: PropTypes.string.isRequired,
 
     ...withLocalizePropTypes,
-    ...environmentPropTypes,
 };
 
 const defaultProps = {
@@ -43,11 +42,12 @@ const defaultProps = {
 };
 
 function PreferencesPage(props) {
+    const {environment} = useEnvironment();
     const priorityModes = props.translate('priorityModePage.priorityModes');
     const languages = props.translate('languagePage.languages');
 
     // Enable additional test features in the staging or dev environments
-    const shouldShowTestToolMenu = _.contains([CONST.ENVIRONMENT.STAGING, CONST.ENVIRONMENT.ADHOC, CONST.ENVIRONMENT.DEV], props.environment);
+    const shouldShowTestToolMenu = _.contains([CONST.ENVIRONMENT.STAGING, CONST.ENVIRONMENT.ADHOC, CONST.ENVIRONMENT.DEV], environment);
 
     return (
         <ScreenWrapper includeSafeAreaPaddingBottom={false}>
@@ -103,7 +103,6 @@ PreferencesPage.defaultProps = defaultProps;
 PreferencesPage.displayName = 'PreferencesPage';
 
 export default compose(
-    withEnvironment,
     withLocalize,
     withOnyx({
         priorityMode: {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Migrate withEnvironment.js to function component

1. Adds new useEnvironment hook
2. Updated the current withEnvironment HOC to use the new useEnvironment hook and make it a functional component
3. Updated below functional components that use withEnvironment HOC to use the useEnvironment hook
    - EnvironmentBadge
    - ExpensifyCashLogo
    - ExpensifyWordmark
    - PreferencesPage

### Fixed Issues
$ https://github.com/Expensify/App/issues/16220
PROPOSAL: https://github.com/Expensify/App/issues/16220#issuecomment-1634154954


### Tests
1. On login page, verify expensify logo has environment badge i.e. DEV, STG
2. Post login successfully, verify LHS sidebar top expensify logo has environment label i.e. DEV, STG
3. Go to Setting -> Preferences, verify that it shows test tool menu option for Dev and Staging environment.

- [X] Verify that no errors appear in the JS console

### Offline tests

### QA Steps
Same as above

- [X] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android / native
    - [X] Android / Chrome
    - [X] iOS / native
    - [X] iOS / Safari
    - [X] MacOS / Chrome / Safari
    - [X] MacOS / Desktop
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [X] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [X] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If a new component is created I verified that:
    - [X] A similar component doesn't exist in the codebase
    - [X] All props are defined accurately and each prop has a `/** comment above it */`
    - [X] The file is named correctly
    - [X] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [X] The only data being stored in the state is data necessary for rendering and nothing else
    - [X] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [X] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [X] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [X] All JSX used for rendering exists in the render method
    - [X] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [X] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [X] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<img width="1726" alt="Screenshot 2023-07-14 at 11 07 30 AM" src="https://github.com/Expensify/App/assets/49274347/201f36d8-2d85-42b0-84a1-6ac3249748b8">
<img width="1726" alt="Screenshot 2023-07-14 at 11 08 29 AM" src="https://github.com/Expensify/App/assets/49274347/e89da797-efd6-4563-accd-33dd572dc846">
<img width="1727" alt="Screenshot 2023-07-14 at 11 08 58 AM" src="https://github.com/Expensify/App/assets/49274347/515250d1-ca64-4fb0-9ab4-1be1404b4bf5">

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<img width="486" alt="Screenshot 2023-07-14 at 11 29 43 AM" src="https://github.com/Expensify/App/assets/49274347/324a10cd-80dc-49a2-90e8-453255f8adfc">
<img width="484" alt="Screenshot 2023-07-14 at 11 31 02 AM" src="https://github.com/Expensify/App/assets/49274347/b6a83799-5121-4e81-8d2d-8a7df7e5dc9e">
<img width="484" alt="Screenshot 2023-07-14 at 11 31 27 AM" src="https://github.com/Expensify/App/assets/49274347/352add8e-69d8-49a3-9289-e7e6e7fcb197">

</details>

<details>
<summary>Mobile Web - Safari</summary>

<img width="442" alt="Screenshot 2023-07-14 at 11 40 34 AM" src="https://github.com/Expensify/App/assets/49274347/3aa7d857-955c-4452-b459-7ba1761333e9">
<img width="457" alt="Screenshot 2023-07-14 at 11 41 12 AM" src="https://github.com/Expensify/App/assets/49274347/6dabfdf6-137a-41f9-9efd-8cd32dd54d00">
<img width="453" alt="Screenshot 2023-07-14 at 11 41 35 AM" src="https://github.com/Expensify/App/assets/49274347/58ccb022-d2aa-4b68-a68f-47f322e4a7e3">

</details>

<details>
<summary>Desktop</summary>

<img width="1205" alt="Screenshot 2023-07-14 at 11 11 44 AM" src="https://github.com/Expensify/App/assets/49274347/6d4bc690-4280-4fba-8a1c-a7fcfbfb52f9">
<img width="1213" alt="Screenshot 2023-07-14 at 11 12 32 AM" src="https://github.com/Expensify/App/assets/49274347/d8347adc-00fa-4745-a2d8-5d420b406b1b">
<img width="1206" alt="Screenshot 2023-07-14 at 11 13 10 AM" src="https://github.com/Expensify/App/assets/49274347/d4e6db70-4d7c-44ee-bc02-0d26a8492aaf">

</details>

<details>
<summary>iOS</summary>

<img width="447" alt="Screenshot 2023-07-14 at 11 38 12 AM" src="https://github.com/Expensify/App/assets/49274347/f690b80f-0671-4c62-ba0c-ef017f27001f">
<img width="452" alt="Screenshot 2023-07-14 at 11 38 55 AM" src="https://github.com/Expensify/App/assets/49274347/06c7e554-93ba-4cda-9a2b-8b608aa074b1">
<img width="447" alt="Screenshot 2023-07-14 at 11 39 11 AM" src="https://github.com/Expensify/App/assets/49274347/189ccfc0-a43d-4085-8076-e388c2a2db3c">

</details>

<details>
<summary>Android</summary>

<img width="494" alt="Screenshot 2023-07-14 at 11 22 24 AM" src="https://github.com/Expensify/App/assets/49274347/d6a3f37b-f2df-4268-a48b-335138b38e40">
<img width="493" alt="Screenshot 2023-07-14 at 11 23 20 AM" src="https://github.com/Expensify/App/assets/49274347/df8bd859-a137-4265-947a-da76687077e6">
<img width="491" alt="Screenshot 2023-07-14 at 11 23 48 AM" src="https://github.com/Expensify/App/assets/49274347/c0d3e65f-12b5-4480-810b-1a57ec87227f">

</details>
