### PR TITLE
Fix Back Button Navigation in Help Doc.

### DIFF
--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -48,7 +48,7 @@ function isInRange(num, min, max) {
 function navigateBack() {
     const currentHost = window.location.host;
     const referrer = document.referrer;
-    
+
     // Check if the referrer is the same as the current host
     if (referrer.includes(currentHost) && window.history.length > 1) {
         window.history.back(); // Use browser history to go back

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -44,18 +44,20 @@ function clamp(num, min, max) {
 function isInRange(num, min, max) {
     return num >= min && num <= max;
 }
-
+/**
+ * Checks if the user has navigated within the docs using internal links and uses browser history to navigate back.
+ * If a page is directly accessed (e.g., via deep link, bookmark, or opened in a new tab),the user will be navigated
+ * back to the relevant hub page of that article.
+ */
 function navigateBack() {
     const currentHost = window.location.host;
     const referrer = document.referrer;
 
-    // Check if the referrer is the same as the current host
     if (referrer.includes(currentHost) && window.history.length > 1) {
-        window.history.back(); // Use browser history to go back
-        return; // Exit the function
+        window.history.back();
+        return;
     }
 
-    // If the referrer is not the same as the current host, use the following logic
     const hubs = JSON.parse(document.getElementById('hubs-data').value);
     const hubToNavigate = hubs.find((hub) => window.location.pathname.includes(hub)); // eslint-disable-line rulesdir/prefer-underscore-method
     if (hubToNavigate) {

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -46,6 +46,16 @@ function isInRange(num, min, max) {
 }
 
 function navigateBack() {
+    const currentHost = window.location.host;
+    const referrer = document.referrer;
+    
+    // Check if the referrer is the same as the current host
+    if (referrer.includes(currentHost) && window.history.length > 1) {
+        window.history.back(); // Use browser history to go back
+        return; // Exit the function
+    }
+
+    // If the referrer is not the same as the current host, use the following logic
     const hubs = JSON.parse(document.getElementById('hubs-data').value);
     const hubToNavigate = hubs.find((hub) => window.location.pathname.includes(hub)); // eslint-disable-line rulesdir/prefer-underscore-method
     if (hubToNavigate) {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/123`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/123#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ [#22014 ](https://github.com/Expensify/App/issues/22014)
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/22014
PROPOSAL: https://github.com/Expensify/App/issues/22014#issuecomment-1634835919


### Tests

#### Note: 
This task should be tested on the local dev environment because the Help tab in the Settings sidebar has hardcoded link to https://help.expensify.com. (See [here](https://github.com/Expensify/App/blob/main/src/pages/settings/InitialSettingsPage.js#L238))

Pre-condition: If testing on local dev environment please go to the following files and omit the hard coded hostname(https://help.expensify.com) such that the links become relative to the current host.

Files:
- https://github.com/Expensify/App/blob/main/docs/articles/playbooks/Expensify-Playbook-for-Small-to-Medium-Sized-Businesses.md?plain=1#L8
- https://github.com/Expensify/App/blob/main/docs/articles/playbooks/Expensify-Playbook-for-US-Based-Bootstrapped-Startups.md?plain=1#L7-L8

For Dev Environment:
1. In root run `npm run createDocsRoutes`
2. `cd docs &&  bundle exec jekyll serve`

Test Case 1:
1. Click Playbooks
2. Select Expensify playbook for small to medium sized business
3. Click the link US-based VS-backed Startups
4. Click the back button
5. Verify that user is navigated back to the previous page instead of the hubs page.

Test Case 2:
1. Click Playbooks
2. Select Expensify playbook for small to medium sized business
3. Click the link US-based VS-backed Startups and open it in a new tab
4. Click the back button
5. Verify that user is navigated back to the relevant hubs page.
6. Same behaviour should happen in case of deep link and bookmarked link.


<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->


- [ ] Verify that no errors appear in the JS console

### Offline tests
Same as above
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps

This cannot be tested on staging because the Help Docs are only available on production. To test the changes once on production, follow the following steps:

Test Case 1:
1. Go to settings > help > Playbooks
2. Select Expensify playbook for small to medium sized business
3. Click the link US-based VS-backed Startups
5. Verify that user is navigated back to the previous page instead of the hubs page.

Test Case 2:
1. Go to settings > help > Playbooks
2. Select Expensify playbook for small to medium sized business
3. Click the link US-based VS-backed Startups and open it in a new tab
4. Click the back button
5. Verify that user is navigated back to the relevant hubs page.
7. Same behaviour should happen in case of deep link and bookmarked link.

<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://github.com/Expensify/App/assets/36226639/1653cce2-5efa-431d-8dc9-9c6f95ae14a8


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>


https://github.com/Expensify/App/assets/36226639/93a14490-35c6-4c71-8e16-7bb7cee9fbaf



<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>


https://github.com/Expensify/App/assets/36226639/5d7f24b1-d395-4888-be6c-405fe7a244e6



<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>

Not Applicable as help docs are only web based
<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>
Not Applicable as help docs are only web based
<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>
Not Applicable as help docs are only web based
<!-- add screenshots or videos here -->

</details>
