### PR TITLE
Migrate FloatingMessageCounter to function component

### DIFF
--- a/src/pages/home/report/FloatingMessageCounter/index.js
+++ b/src/pages/home/report/FloatingMessageCounter/index.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useMemo} from 'react';
+import React, {useEffect, useMemo, useCallback} from 'react';
 import {Animated, View} from 'react-native';
 import PropTypes from 'prop-types';
 import styles from '../../../../styles/styles';
@@ -30,29 +30,29 @@ function FloatingMessageCounter(props) {
     const {translate} = useLocalize();
     const translateY = useMemo(() => new Animated.Value(MARKER_INACTIVE_TRANSLATE_Y), []);
 
+    const show = useCallback(() => {
+        Animated.spring(translateY, {
+            toValue: MARKER_ACTIVE_TRANSLATE_Y,
+            duration: 80,
+            useNativeDriver: true,
+        }).start();
+    }, [translateY]);
+
+    const hide = useCallback(() => {
+        Animated.spring(translateY, {
+            toValue: MARKER_INACTIVE_TRANSLATE_Y,
+            duration: 80,
+            useNativeDriver: true,
+        }).start();
+    }, [translateY]);
+
     useEffect(() => {
-        const show = () => {
-            Animated.spring(translateY, {
-                toValue: MARKER_ACTIVE_TRANSLATE_Y,
-                duration: 80,
-                useNativeDriver: true,
-            }).start();
-        };
-
-        const hide = () => {
-            Animated.spring(translateY, {
-                toValue: MARKER_INACTIVE_TRANSLATE_Y,
-                duration: 80,
-                useNativeDriver: true,
-            }).start();
-        };
-
         if (props.isActive) {
             show();
         } else {
             hide();
         }
-    }, [props.isActive, translateY]);
+    }, [props.isActive, show, hide]);
 
     return (
         <FloatingMessageCounterContainer

--- a/src/pages/home/report/FloatingMessageCounter/index.js
+++ b/src/pages/home/report/FloatingMessageCounter/index.js
@@ -1,4 +1,4 @@
-import React, {PureComponent} from 'react';
+import React, {useEffect, useMemo} from 'react';
 import {Animated, View} from 'react-native';
 import PropTypes from 'prop-types';
 import styles from '../../../../styles/styles';
@@ -7,7 +7,7 @@ import Text from '../../../../components/Text';
 import Icon from '../../../../components/Icon';
 import * as Expensicons from '../../../../components/Icon/Expensicons';
 import themeColors from '../../../../styles/themes/default';
-import withLocalize, {withLocalizePropTypes} from '../../../../components/withLocalize';
+import useLocalize from '../../../../hooks/useLocalize';
 import FloatingMessageCounterContainer from './FloatingMessageCounterContainer';
 
 const propTypes = {
@@ -16,8 +16,6 @@ const propTypes = {
 
     /** Callback to be called when user clicks the New Messages indicator */
     onClick: PropTypes.func,
-
-    ...withLocalizePropTypes,
 };
 
 const defaultProps = {
@@ -28,73 +26,67 @@ const defaultProps = {
 const MARKER_INACTIVE_TRANSLATE_Y = -40;
 const MARKER_ACTIVE_TRANSLATE_Y = 10;
 
-class FloatingMessageCounter extends PureComponent {
-    constructor(props) {
-        super(props);
-        this.translateY = new Animated.Value(MARKER_INACTIVE_TRANSLATE_Y);
-        this.show = this.show.bind(this);
-        this.hide = this.hide.bind(this);
-    }
+function FloatingMessageCounter(props) {
+    const {translate} = useLocalize();
+    const translateY = useMemo(() => new Animated.Value(MARKER_INACTIVE_TRANSLATE_Y), []);
 
-    componentDidUpdate() {
-        if (this.props.isActive) {
-            this.show();
+    useEffect(() => {
+        const show = () => {
+            Animated.spring(translateY, {
+                toValue: MARKER_ACTIVE_TRANSLATE_Y,
+                duration: 80,
+                useNativeDriver: true,
+            }).start();
+        };
+
+        const hide = () => {
+            Animated.spring(translateY, {
+                toValue: MARKER_INACTIVE_TRANSLATE_Y,
+                duration: 80,
+                useNativeDriver: true,
+            }).start();
+        };
+
+        if (props.isActive) {
+            show();
         } else {
-            this.hide();
+            hide();
         }
-    }
+    }, [props.isActive, translateY]);
 
-    show() {
-        Animated.spring(this.translateY, {
-            toValue: MARKER_ACTIVE_TRANSLATE_Y,
-            duration: 80,
-            useNativeDriver: true,
-        }).start();
-    }
-
-    hide() {
-        Animated.spring(this.translateY, {
-            toValue: MARKER_INACTIVE_TRANSLATE_Y,
-            duration: 80,
-            useNativeDriver: true,
-        }).start();
-    }
-
-    render() {
-        return (
-            <FloatingMessageCounterContainer
-                accessibilityHint={this.props.translate('accessibilityHints.scrollToNewestMessages')}
-                containerStyles={[styles.floatingMessageCounterTransformation(this.translateY)]}
-            >
-                <View style={styles.floatingMessageCounter}>
-                    <View style={[styles.flexRow, styles.justifyContentBetween, styles.alignItemsCenter]}>
-                        <Button
-                            success
-                            small
-                            onPress={this.props.onClick}
-                        >
-                            <View style={[styles.flexRow, styles.alignItemsCenter]}>
-                                <Icon
-                                    small
-                                    src={Expensicons.DownArrow}
-                                    fill={themeColors.textLight}
-                                />
-                                <Text
-                                    selectable={false}
-                                    style={[styles.ml2, styles.buttonSmallText, styles.textWhite]}
-                                >
-                                    {this.props.translate('newMessages')}
-                                </Text>
-                            </View>
-                        </Button>
-                    </View>
+    return (
+        <FloatingMessageCounterContainer
+            accessibilityHint={translate('accessibilityHints.scrollToNewestMessages')}
+            containerStyles={[styles.floatingMessageCounterTransformation(translateY)]}
+        >
+            <View style={styles.floatingMessageCounter}>
+                <View style={[styles.flexRow, styles.justifyContentBetween, styles.alignItemsCenter]}>
+                    <Button
+                        success
+                        small
+                        onPress={props.onClick}
+                    >
+                        <View style={[styles.flexRow, styles.alignItemsCenter]}>
+                            <Icon
+                                small
+                                src={Expensicons.DownArrow}
+                                fill={themeColors.textLight}
+                            />
+                            <Text
+                                selectable={false}
+                                style={[styles.ml2, styles.buttonSmallText, styles.textWhite]}
+                            >
+                                {translate('newMessages')}
+                            </Text>
+                        </View>
+                    </Button>
                 </View>
-            </FloatingMessageCounterContainer>
-        );
-    }
+            </View>
+        </FloatingMessageCounterContainer>
+    );
 }
 
 FloatingMessageCounter.propTypes = propTypes;
 FloatingMessageCounter.defaultProps = defaultProps;
-
-export default withLocalize(FloatingMessageCounter);
+FloatingMessageCounter.displayName = 'FloatingMessageCounter';
+export default React.memo(FloatingMessageCounter);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Migrate FloatingMessageCounter to function component


### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/16261
PROPOSAL: https://github.com/Expensify/App/issues/16261#issuecomment-1633365601

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

make sure there are plenty of past messages that gives you the ability to scroll up at least 5 messages

1. have two accounts  `a` and `b` open that are in the same group
2. have `a` looking at a different group and the `b` in the room they share
3. have `b` send a message
4. have `a` return to the group chat with `b` (for `a` there will be a new message)
5. have `a` scroll up to the past messages( there should be a green button that comes down with the text New messages)
6. scroll down to make sure the button moves up and disappears 
7. scroll back up and click the green button and make sure it takes you down to the new messages
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Works only when online 

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

make sure there are plenty of past messages that gives you the ability to scroll up at least 5 messages

1. have two accounts  `a` and `b` open that are in the same group
2. have `a` looking at a different group and the `b` in the room they share
3. have `b` send a message
4. have `a` return to the group chat with `b` (for `a` there will be a new message)
5. have `a` scroll up to the past messages( there should be a green button that comes down with the text New messages)
6. scroll down to make sure the button moves up and disappears 
7. scroll back up and click the green button and make sure it takes you down to the new messages


- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/47678409/d72b059a-565c-49b4-ba2f-9966c3f28499


</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/47678409/0cbcc009-d002-4d81-9b3d-bb2babd4ffe4

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->
<img width="551" alt="Screenshot 2023-07-25 at 1 35 47 PM" src="https://github.com/Expensify/App/assets/1371996/e2c8f32e-59f5-457c-b64c-0f697531cf85">

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->
<img width="1312" alt="Screenshot 2023-07-25 at 1 29 59 PM" src="https://github.com/Expensify/App/assets/1371996/c97d4994-78ba-459b-9f16-476a5f914b14">

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->
<img width="551" alt="Screenshot 2023-07-25 at 1 34 20 PM" src="https://github.com/Expensify/App/assets/1371996/27caf5d0-12aa-4695-87ce-1a88f850259b">

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->
<img width="499" alt="Screenshot 2023-07-25 at 1 38 24 PM" src="https://github.com/Expensify/App/assets/1371996/52455411-78b0-437f-9456-1c6f2864d82a">

</details>
