### PR TITLE
fix: clicking spacebar leaves highlight focus on emoji in emoji picker

### DIFF
--- a/src/components/EmojiPicker/EmojiPickerMenuItem.js
+++ b/src/components/EmojiPicker/EmojiPickerMenuItem.js
@@ -1,8 +1,6 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import styles from '../../styles/styles';
-import * as StyleUtils from '../../styles/StyleUtils';
-import getButtonState from '../../libs/getButtonState';
 import Text from '../Text';
 import PressableWithoutFeedback from '../Pressable/PressableWithoutFeedback';
 import CONST from '../../CONST';

--- a/src/components/EmojiPicker/EmojiPickerMenuItem.js
+++ b/src/components/EmojiPicker/EmojiPickerMenuItem.js
@@ -70,8 +70,7 @@ class EmojiPickerMenuItem extends PureComponent {
                 onFocus={this.props.onFocus}
                 onBlur={this.props.onBlur}
                 ref={(ref) => (this.ref = ref)}
-                style={({pressed}) => [
-                    StyleUtils.getButtonBackgroundColorStyle(getButtonState(false, pressed)),
+                style={[
                     this.props.isHighlighted && this.props.isUsingKeyboardMovement ? styles.emojiItemKeyboardHighlighted : {},
                     this.props.isHighlighted && !this.props.isUsingKeyboardMovement ? styles.emojiItemHighlighted : {},
                     styles.emojiItem,

--- a/src/components/EmojiPicker/EmojiPickerMenuItem/index.js
+++ b/src/components/EmojiPicker/EmojiPickerMenuItem/index.js
@@ -71,7 +71,6 @@ class EmojiPickerMenuItem extends PureComponent {
                 onFocus={this.props.onFocus}
                 onBlur={this.props.onBlur}
                 ref={(ref) => (this.ref = ref)}
-                pressStyle={StyleUtils.getButtonBackgroundColorStyle(CONST.BUTTON_STATES.PRESSED)}
                 style={({pressed}) => [
                     Browser.isMobile() && StyleUtils.getButtonBackgroundColorStyle(getButtonState(false, pressed)),
                     this.props.isHighlighted && this.props.isUsingKeyboardMovement ? styles.emojiItemKeyboardHighlighted : {},

--- a/src/components/EmojiPicker/EmojiPickerMenuItem/index.js
+++ b/src/components/EmojiPicker/EmojiPickerMenuItem/index.js
@@ -1,9 +1,12 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import styles from '../../styles/styles';
-import Text from '../Text';
-import PressableWithoutFeedback from '../Pressable/PressableWithoutFeedback';
-import CONST from '../../CONST';
+import styles from '../../../styles/styles';
+import * as StyleUtils from '../../../styles/StyleUtils';
+import getButtonState from '../../../libs/getButtonState';
+import Text from '../../Text';
+import PressableWithoutFeedback from '../../Pressable/PressableWithoutFeedback';
+import CONST from '../../../CONST';
+import * as Browser from '../../../libs/Browser';
 
 const propTypes = {
     /** The unicode that is used to display the emoji */
@@ -68,7 +71,9 @@ class EmojiPickerMenuItem extends PureComponent {
                 onFocus={this.props.onFocus}
                 onBlur={this.props.onBlur}
                 ref={(ref) => (this.ref = ref)}
-                style={[
+                pressStyle={StyleUtils.getButtonBackgroundColorStyle(CONST.BUTTON_STATES.PRESSED)}
+                style={({pressed}) => [
+                    Browser.isMobile() && StyleUtils.getButtonBackgroundColorStyle(getButtonState(false, pressed)),
                     this.props.isHighlighted && this.props.isUsingKeyboardMovement ? styles.emojiItemKeyboardHighlighted : {},
                     this.props.isHighlighted && !this.props.isUsingKeyboardMovement ? styles.emojiItemHighlighted : {},
                     styles.emojiItem,

--- a/src/components/EmojiPicker/EmojiPickerMenuItem/index.native.js
+++ b/src/components/EmojiPicker/EmojiPickerMenuItem/index.native.js
@@ -1,0 +1,106 @@
+import React, {PureComponent} from 'react';
+import PropTypes from 'prop-types';
+import styles from '../../../styles/styles';
+import * as StyleUtils from '../../../styles/StyleUtils';
+import getButtonState from '../../../libs/getButtonState';
+import Text from '../../Text';
+import PressableWithoutFeedback from '../../Pressable/PressableWithoutFeedback';
+import CONST from '../../../CONST';
+
+const propTypes = {
+    /** The unicode that is used to display the emoji */
+    emoji: PropTypes.string.isRequired,
+
+    /** The function to call when an emoji is selected */
+    onPress: PropTypes.func.isRequired,
+
+    /** Handles what to do when we hover over this item with our cursor */
+    onHoverIn: PropTypes.func,
+
+    /** Handles what to do when the hover is out */
+    onHoverOut: PropTypes.func,
+
+    /** Handles what to do when the pressable is focused */
+    onFocus: PropTypes.func,
+
+    /** Handles what to do when the pressable is blurred */
+    onBlur: PropTypes.func,
+
+    /** Whether this menu item is currently highlighted or not */
+    isHighlighted: PropTypes.bool,
+
+    /** Whether this menu item is currently focused or not */
+    isFocused: PropTypes.bool,
+
+    /** Whether the emoji is highlighted by the keyboard/mouse */
+    isUsingKeyboardMovement: PropTypes.bool,
+};
+
+class EmojiPickerMenuItem extends PureComponent {
+    constructor(props) {
+        super(props);
+
+        this.ref = null;
+    }
+
+    componentDidMount() {
+        if (!this.props.isFocused) {
+            return;
+        }
+        this.ref.focus();
+    }
+
+    componentDidUpdate(prevProps) {
+        if (prevProps.isFocused === this.props.isFocused) {
+            return;
+        }
+        if (!this.props.isFocused) {
+            return;
+        }
+        this.ref.focus();
+    }
+
+    render() {
+        return (
+            <PressableWithoutFeedback
+                shouldUseAutoHitSlop={false}
+                onPress={() => this.props.onPress(this.props.emoji)}
+                onHoverIn={this.props.onHoverIn}
+                onHoverOut={this.props.onHoverOut}
+                onFocus={this.props.onFocus}
+                onBlur={this.props.onBlur}
+                ref={(ref) => (this.ref = ref)}
+                pressStyle={StyleUtils.getButtonBackgroundColorStyle(CONST.BUTTON_STATES.PRESSED)}
+                style={({pressed}) => [
+                    StyleUtils.getButtonBackgroundColorStyle(getButtonState(false, pressed)),
+                    this.props.isHighlighted && this.props.isUsingKeyboardMovement ? styles.emojiItemKeyboardHighlighted : {},
+                    this.props.isHighlighted && !this.props.isUsingKeyboardMovement ? styles.emojiItemHighlighted : {},
+                    styles.emojiItem,
+                ]}
+                accessibilityLabel={this.props.emoji}
+                accessibilityRole={CONST.ACCESSIBILITY_ROLE.BUTTON}
+            >
+                <Text style={[styles.emojiText]}>{this.props.emoji}</Text>
+            </PressableWithoutFeedback>
+        );
+    }
+}
+
+EmojiPickerMenuItem.propTypes = propTypes;
+EmojiPickerMenuItem.defaultProps = {
+    isHighlighted: false,
+    isFocused: false,
+    isUsingKeyboardMovement: false,
+    onHoverIn: () => {},
+    onHoverOut: () => {},
+    onFocus: () => {},
+    onBlur: () => {},
+};
+
+// Significantly speeds up re-renders of the EmojiPickerMenu's FlatList
+// by only re-rendering at most two EmojiPickerMenuItems that are highlighted/un-highlighted per user action.
+export default React.memo(
+    EmojiPickerMenuItem,
+    (prevProps, nextProps) =>
+        prevProps.isHighlighted === nextProps.isHighlighted && prevProps.emoji === nextProps.emoji && prevProps.isUsingKeyboardMovement === nextProps.isUsingKeyboardMovement,
+);

--- a/src/components/EmojiPicker/EmojiPickerMenuItem/index.native.js
+++ b/src/components/EmojiPicker/EmojiPickerMenuItem/index.native.js
@@ -70,7 +70,6 @@ class EmojiPickerMenuItem extends PureComponent {
                 onFocus={this.props.onFocus}
                 onBlur={this.props.onBlur}
                 ref={(ref) => (this.ref = ref)}
-                pressStyle={StyleUtils.getButtonBackgroundColorStyle(CONST.BUTTON_STATES.PRESSED)}
                 style={({pressed}) => [
                     StyleUtils.getButtonBackgroundColorStyle(getButtonState(false, pressed)),
                     this.props.isHighlighted && this.props.isUsingKeyboardMovement ? styles.emojiItemKeyboardHighlighted : {},


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This fixes issue in emoji picker, wherein clicking on spacebar leaves selected/highlight focus on emoji. Removes highlight style for web and desktop since pressing on the emoji is expected to close the popup

### Fixed Issues
$ https://github.com/Expensify/App/issues/21806
PROPOSAL: https://github.com/Expensify/App/issues/21806#issuecomment-1613401727


### Tests

1. Open expensify on chrome web/desktop
2. Go to any chat
3. Open Emoji picker from composer
4. Use tab/arrow key to navigate in emoji list
5. While focus is on any emoji, click on spacebar from keyboard
6. Verify that it shouldn't leave highlight focus on emoji and cursor should move to search input. 

- [X] Verify that no errors appear in the JS console

### Offline tests
Same as above 

### QA Steps
Same as above 
- [X] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android / native
    - [X] Android / Chrome
    - [X] iOS / native
    - [X] iOS / Safari
    - [X] MacOS / Chrome / Safari
    - [X] MacOS / Desktop
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [X] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [X] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If a new component is created I verified that:
    - [X] A similar component doesn't exist in the codebase
    - [X] All props are defined accurately and each prop has a `/** comment above it */`
    - [X] The file is named correctly
    - [X] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [X] The only data being stored in the state is data necessary for rendering and nothing else
    - [X] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [X] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [X] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [X] All JSX used for rendering exists in the render method
    - [X] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [X] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [X] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://github.com/Expensify/App/assets/130229379/c4fbdca8-e4ff-4e65-83e9-91b2848e4c24

</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://github.com/Expensify/App/assets/130229379/76cf7003-b62b-4d23-ac11-daa7dcd9ff02

</details>

<details>
<summary>Mobile Web - Safari</summary>


https://github.com/Expensify/App/assets/130229379/a8cf87dc-f6da-4b54-945e-21ee9ce7a08d


</details>

<details>
<summary>Desktop</summary>

https://github.com/Expensify/App/assets/130229379/886b95cb-162e-4cbc-b237-2419b97694a7

</details>

<details>
<summary>iOS</summary>

https://github.com/Expensify/App/assets/130229379/62e54f65-0535-4294-96c6-3cd368b13c3e

</details>

<details>
<summary>Android</summary>

https://github.com/Expensify/App/assets/130229379/2c888e15-57ff-4905-824c-774cb7b36fd9

</details>
