### PR TITLE
Create DesignDocIssue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/DesignDocIssue
+++ b/.github/ISSUE_TEMPLATE/DesignDocIssue
@@ -1,0 +1,12 @@
+---
+name: Design Doc Project Issue Template
+about: A template to follow when creating a new issue related to a design doc project
+---
+
+# Part of the <Project Name> project
+Main issue: <Issue Link>
+Doc: <Doc Link>
+Project: <Project Link>
+
+# <Feature Description>
+<!-- Describe the section of the doc that this issue is covering -->

--- a/.github/ISSUE_TEMPLATE/DesignDocIssue
+++ b/.github/ISSUE_TEMPLATE/DesignDocIssue
@@ -9,7 +9,7 @@ Doc section: <Doc Link>
 Project: <Project Link>
 
 # <Feature Description>
-<!-- Describe the section of the doc that this issue is covering -->
+<!-- Describe the section of the doc that this issue is covering, along with any relevant screenshots -->
 
 # Manual Test Steps
 

--- a/.github/ISSUE_TEMPLATE/DesignDocIssue
+++ b/.github/ISSUE_TEMPLATE/DesignDocIssue
@@ -5,7 +5,7 @@ about: A template to follow when creating a new issue related to a design doc pr
 
 # Part of the <Project Name> project
 Main issue: <Issue Link>
-Doc: <Doc Link>
+Doc section: <Doc Link>
 Project: <Project Link>
 
 # <Feature Description>

--- a/.github/ISSUE_TEMPLATE/DesignDocIssue
+++ b/.github/ISSUE_TEMPLATE/DesignDocIssue
@@ -10,3 +10,7 @@ Project: <Project Link>
 
 # <Feature Description>
 <!-- Describe the section of the doc that this issue is covering -->
+
+# Manual Test Steps
+
+#Automated Tests


### PR DESCRIPTION
Add a new template for issues related to design doc projects


### Details
Right now when we create new issues for design doc projects, we don't have a template to use. The standard issue template contains _way_ too much unnecessary information, so most employees use the blank issue template. This will allow us to standardize what our design doc issues look like. 
