### PR TITLE
fix: header message for already invited member of workspace

### DIFF
--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -921,6 +921,7 @@ export default {
     messages: {
         errorMessageInvalidPhone: `Please enter a valid phone number without brackets or dashes. If you're outside the US please include your country code (e.g. ${CONST.EXAMPLE_PHONE_NUMBER}).`,
         errorMessageInvalidEmail: 'Invalid email',
+        userIsAlreadyMemberOfWorkspace: ({login, workspace}) => `${login} is already a member of ${workspace}`,
     },
     onfidoStep: {
         acceptTerms: 'By continuing with the request to activate your Expensify wallet, you confirm that you have read, understand and accept ',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -928,6 +928,7 @@ export default {
     messages: {
         errorMessageInvalidPhone: `Por favor, introduce un número de teléfono válido sin paréntesis o guiones. Si reside fuera de Estados Unidos, por favor incluye el prefijo internacional (p. ej. ${CONST.EXAMPLE_PHONE_NUMBER}).`,
         errorMessageInvalidEmail: 'Email inválido',
+        userIsAlreadyMemberOfWorkspace: ({login, workspace}) => `${login} ya es miembro de ${workspace}`,
     },
     onfidoStep: {
         acceptTerms: 'Al continuar con la solicitud para activar su billetera Expensify, confirma que ha leído, comprende y acepta ',

--- a/src/pages/workspace/WorkspaceInvitePage.js
+++ b/src/pages/workspace/WorkspaceInvitePage.js
@@ -97,7 +97,7 @@ function WorkspaceInvitePage(props) {
         setPersonalDetails(inviteOptions.personalDetails);
         setSelectedOptions(newSelectedOptions);
         // eslint-disable-next-line react-hooks/exhaustive-deps -- we don't want to recalculate when selectedOptions change
-    }, [props.personalDetails, props.policyMembers, props.betas, searchTerm]);
+    }, [props.personalDetails, props.policyMembers, props.betas, searchTerm, excludedUsers]);
 
     const getSections = () => {
         const sections = [];

--- a/src/pages/workspace/WorkspaceInvitePage.js
+++ b/src/pages/workspace/WorkspaceInvitePage.js
@@ -80,13 +80,10 @@ function WorkspaceInvitePage(props) {
 
     useOnNetworkReconnect(openWorkspaceInvitePage);
 
+    const excludedUsers = useMemo(() => PolicyUtils.getIneligibleInvitees(props.policyMembers, props.personalDetails), [props.policyMembers, props.personalDetails]);
+
     useEffect(() => {
-        const inviteOptions = OptionsListUtils.getMemberInviteOptions(
-            props.personalDetails,
-            props.betas,
-            searchTerm,
-            PolicyUtils.getIneligibleInvitees(props.policyMembers, props.personalDetails),
-        );
+        const inviteOptions = OptionsListUtils.getMemberInviteOptions(props.personalDetails, props.betas, searchTerm, excludedUsers);
 
         // Update selectedOptions with the latest personalDetails and policyMembers information
         const detailsMap = {};
@@ -188,7 +185,6 @@ function WorkspaceInvitePage(props) {
     );
 
     const headerMessage = useMemo(() => {
-        const excludedUsers = PolicyUtils.getIneligibleInvitees(props.policyMembers, props.personalDetails);
         const searchValue = searchTerm.trim();
         if (!userToInvite && CONST.EXPENSIFY_EMAILS.includes(searchValue)) {
             return translate('messages.errorMessageInvalidEmail');
@@ -197,7 +193,7 @@ function WorkspaceInvitePage(props) {
             return translate('messages.userIsAlreadyMemberOfWorkspace', {login: searchValue, workspace: policyName});
         }
         return OptionsListUtils.getHeaderMessage(personalDetails.length !== 0, Boolean(userToInvite), searchValue);
-    }, [props.policyMembers, props.personalDetails, translate, searchTerm, policyName, userToInvite, personalDetails]);
+    }, [excludedUsers, translate, searchTerm, policyName, userToInvite, personalDetails]);
 
     return (
         <ScreenWrapper shouldEnableMaxHeight>

--- a/src/pages/workspace/WorkspaceInvitePage.js
+++ b/src/pages/workspace/WorkspaceInvitePage.js
@@ -197,7 +197,7 @@ function WorkspaceInvitePage(props) {
             return translate('messages.userIsAlreadyMemberOfWorkspace', {login: searchValue, workspace: policyName});
         }
         return OptionsListUtils.getHeaderMessage(personalDetails.length !== 0, Boolean(userToInvite), searchValue);
-    }
+    };
 
     return (
         <ScreenWrapper shouldEnableMaxHeight>

--- a/src/pages/workspace/WorkspaceInvitePage.js
+++ b/src/pages/workspace/WorkspaceInvitePage.js
@@ -182,11 +182,22 @@ function WorkspaceInvitePage(props) {
         Navigation.navigate(ROUTES.getWorkspaceInviteMessageRoute(props.route.params.policyID));
     };
 
-    const headerMessage = OptionsListUtils.getHeaderMessage(personalDetails.length !== 0, Boolean(userToInvite), searchTerm);
     const [policyName, shouldShowAlertPrompt] = useMemo(
         () => [lodashGet(props.policy, 'name'), _.size(lodashGet(props.policy, 'errors', {})) > 0 || lodashGet(props.policy, 'alertMessage', '').length > 0],
         [props.policy],
     );
+
+    const getHeaderMessage = () => {
+        const excludedUsers = PolicyUtils.getIneligibleInvitees(props.policyMembers, props.personalDetails);
+        const searchValue = searchTerm.trim();
+        if (!userToInvite && CONST.EXPENSIFY_EMAILS.includes(searchValue)) {
+            return translate('messages.errorMessageInvalidEmail');
+        }
+        if (!userToInvite && excludedUsers.includes(searchValue)) {
+            return translate('messages.userIsAlreadyMemberOfWorkspace', {login: searchValue, workspace: policyName});
+        }
+        return OptionsListUtils.getHeaderMessage(personalDetails.length !== 0, Boolean(userToInvite), searchValue);
+    }
 
     return (
         <ScreenWrapper shouldEnableMaxHeight>
@@ -220,7 +231,7 @@ function WorkspaceInvitePage(props) {
                                 onSelectRow={toggleOption}
                                 onChangeText={setSearchTerm}
                                 onConfirmSelection={inviteUser}
-                                headerMessage={headerMessage}
+                                headerMessage={getHeaderMessage()}
                                 hideSectionHeaders
                                 boldStyle
                                 shouldDelayFocus

--- a/src/pages/workspace/WorkspaceInvitePage.js
+++ b/src/pages/workspace/WorkspaceInvitePage.js
@@ -187,7 +187,7 @@ function WorkspaceInvitePage(props) {
         [props.policy],
     );
 
-    const getHeaderMessage = () => {
+    const headerMessage = useMemo(() => {
         const excludedUsers = PolicyUtils.getIneligibleInvitees(props.policyMembers, props.personalDetails);
         const searchValue = searchTerm.trim();
         if (!userToInvite && CONST.EXPENSIFY_EMAILS.includes(searchValue)) {
@@ -197,7 +197,7 @@ function WorkspaceInvitePage(props) {
             return translate('messages.userIsAlreadyMemberOfWorkspace', {login: searchValue, workspace: policyName});
         }
         return OptionsListUtils.getHeaderMessage(personalDetails.length !== 0, Boolean(userToInvite), searchValue);
-    };
+    }, [props.policyMembers, props.personalDetails, translate, searchTerm, policyName, userToInvite, personalDetails]);
 
     return (
         <ScreenWrapper shouldEnableMaxHeight>
@@ -231,7 +231,7 @@ function WorkspaceInvitePage(props) {
                                 onSelectRow={toggleOption}
                                 onChangeText={setSearchTerm}
                                 onConfirmSelection={inviteUser}
-                                headerMessage={getHeaderMessage()}
+                                headerMessage={headerMessage}
                                 hideSectionHeaders
                                 boldStyle
                                 shouldDelayFocus


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/21193
PROPOSAL: https://github.com/Expensify/App/issues/21193#issuecomment-1617945832


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Go to Settings => Workspaces => Select a Workspace => Members => Click Invite member button
2. Search an invited member of the workspace
3. Verify that header message is shown in format `${login} is already a member of ${workspace}`
4. Search an Expensify service account, like `concierge@expensify.com`
5. Verify that header message `Invalid email is shown`
6. Go to Settings => Preferences => Language => Select Spanish
7. Repeat step 1 to 6 and verify corresponding header messages in Spanish

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
8. Upload an image via copy paste
9. Verify a modal appears displaying a preview of that image
--->
Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->



- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->
<img width="1440" alt="web-1" src="https://github.com/Expensify/App/assets/117511920/7c523e34-9a8c-4645-aa19-27baf92c0d8e">
<img width="1440" alt="web-2" src="https://github.com/Expensify/App/assets/117511920/bc6f9013-5fd5-4b6d-b373-b1cfa2d2dcff">
<img width="1440" alt="web-3" src="https://github.com/Expensify/App/assets/117511920/6493210d-ce17-4ec0-bc76-cfd74dfcc94f">
<img width="1440" alt="web-4" src="https://github.com/Expensify/App/assets/117511920/7ff4723f-78d9-41d8-97ea-8ef2f3c456e0">



</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->
![mobile-chrome-1](https://github.com/Expensify/App/assets/117511920/2b38c1af-acae-4dcf-8f68-316be6af656f)
![mobile-chrome-2](https://github.com/Expensify/App/assets/117511920/df7235e4-3a48-4ae1-94bf-dbe2e1e9f7b4)
![mobile-chrome-3](https://github.com/Expensify/App/assets/117511920/a924ad29-d008-4386-a4ee-d98eb38e701f)
![mobile-chrome-4](https://github.com/Expensify/App/assets/117511920/8ba93fdb-228f-4b78-aea2-fcc01b211d15)





</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

![mobile-safari-1](https://github.com/Expensify/App/assets/117511920/2d2c6234-1216-492f-9627-81419ba74681)
![mobile-safari-2](https://github.com/Expensify/App/assets/117511920/229de7b9-e367-414e-8669-c8e8d8715862)
![mobile-safari-3](https://github.com/Expensify/App/assets/117511920/be0aae52-27b0-482c-b73d-5612d5355143)
![mobile-safari-4](https://github.com/Expensify/App/assets/117511920/a985fab8-db4c-4e92-8aa9-5fd8d8342951)



</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->


<img width="1205" alt="desktop-1" src="https://github.com/Expensify/App/assets/117511920/31d0ac01-210c-4e82-a8ee-b573cf7fbf01">
<img width="1207" alt="desktop-2" src="https://github.com/Expensify/App/assets/117511920/5493d026-c1f0-4f77-8e5c-92472d92b6d6">
<img width="1204" alt="desktop-3" src="https://github.com/Expensify/App/assets/117511920/d32ed13d-54a2-4e23-a55b-e1d96e4a1765">
<img width="1207" alt="desktop-4" src="https://github.com/Expensify/App/assets/117511920/15481b5f-0bac-4228-9a16-c15b3c1a2595">




</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

![ios-1](https://github.com/Expensify/App/assets/117511920/8ae2a5b0-8716-4fe6-af1b-923137325656)
![ios-2](https://github.com/Expensify/App/assets/117511920/59c69230-5cf1-4054-9756-47b3fe826264)
![ios-3](https://github.com/Expensify/App/assets/117511920/5ebb50dc-f160-4390-859b-8c5846d0b0d5)
![ios-4](https://github.com/Expensify/App/assets/117511920/e5f5afd5-cf3f-4a42-bd17-e963f9e9eff7)




</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->
![andorid-1](https://github.com/Expensify/App/assets/117511920/313bcf37-837c-44ec-8c0f-359e531e2eb8)
![android-2](https://github.com/Expensify/App/assets/117511920/20cfdc28-572d-446b-a45e-9a2734df711c)
![android-3](https://github.com/Expensify/App/assets/117511920/6ca94933-f108-44e3-8162-8a240305ed9a)
![android-4](https://github.com/Expensify/App/assets/117511920/c3ace59a-77ab-49aa-81bf-790671401e74)





</details>
