### PR TITLE
Fix bugs surrounding report name when deleting first thread comment

### DIFF
--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -965,10 +965,13 @@ function deleteReportComment(reportID, reportAction) {
 
     // If the reportID doesn't equal the originalReportID then this is the first comment on a thread report and we need to trigger
     // some sort of update to let the LHN know that the parentReportAction is now deleted.
-    if (reportID !== originalReportID) {
+    if (ReportUtils.isThreadFirstChat(reportAction, reportID)) {
         optimisticData.push({
             onyxMethod: Onyx.METHOD.MERGE,
             key: `${ONYXKEYS.COLLECTION.REPORT}${reportID}`,
+
+            // This may appear to be unused, but we don't use this field for anything other than to trigger an
+            // update to the LHN that the report action we are deleting is the first message of a thread.
             value: {isParentReportActionDeleted: true},
         });
     }

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -963,16 +963,13 @@ function deleteReportComment(reportID, reportAction) {
         optimisticData.push(optimisticParentReportData);
     }
 
-    // If the reportID doesn't equal the originalReportID then this is the first comment on a thread report and we need to trigger
-    // some sort of update to let the LHN know that the parentReportAction is now deleted.
+    // Check to see if the report action we are deleting is the first comment on a thread report. In this case, we need to trigger
+    // an update to let the LHN know that the parentReportAction is now deleted.
     if (ReportUtils.isThreadFirstChat(reportAction, reportID)) {
         optimisticData.push({
             onyxMethod: Onyx.METHOD.MERGE,
             key: `${ONYXKEYS.COLLECTION.REPORT}${reportID}`,
-
-            // This may appear to be unused, but we don't use this field for anything other than to trigger an
-            // update to the LHN that the report action we are deleting is the first message of a thread.
-            value: {isParentReportActionDeleted: true},
+            value: {updateReportInLHN: true},
         });
     }
 

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -897,7 +897,7 @@ function deleteReportComment(reportID, reportAction) {
         lastMessageText: '',
         lastVisibleActionCreated: '',
     };
-    if (reportAction.reportActionID && reportAction.childVisibleActionCount > 0) {
+    if (reportAction.reportActionID && reportAction.childVisibleActionCount === 0) {
         optimisticReport = {
             lastMessageTranslationKey: '',
             lastMessageText: '',
@@ -961,6 +961,16 @@ function deleteReportComment(reportID, reportAction) {
     const optimisticParentReportData = ReportUtils.getOptimisticDataForParentReportAction(reportID, optimisticReport.lastVisibleActionCreated, CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE);
     if (!_.isEmpty(optimisticParentReportData)) {
         optimisticData.push(optimisticParentReportData);
+    }
+
+    // If the reportID doesn't equal the originalReportID then this is the first comment on a thread report and we need to trigger
+    // some sort of update to let the LHN know that the parentReportAction is now deleted.
+    if (reportID !== originalReportID) {
+        optimisticData.push({
+            onyxMethod: Onyx.METHOD.MERGE,
+            key: `${ONYXKEYS.COLLECTION.REPORT}${reportID}`,
+            value: {isParentReportActionDeleted: true},
+        });
     }
 
     const parameters = {

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -897,7 +897,7 @@ function deleteReportComment(reportID, reportAction) {
         lastMessageText: '',
         lastVisibleActionCreated: '',
     };
-    if (reportAction.reportActionID && reportAction.childVisibleActionCount === 0) {
+    if (reportAction.childVisibleActionCount === 0) {
         optimisticReport = {
             lastMessageTranslationKey: '',
             lastMessageText: '',


### PR DESCRIPTION
### Details
There are two issues being fixed here:

1. We are incorrectly flagging the "parent report" of a thread as having a "last message" that is a "deleted parent action" (of a thread report). We are looking to see if the report action (which is the parent action) has any visible child actions (which seems to be the logical **opposite** of what we really want).
2. Once we fix that issue - the "thread report" itself in the LHN does not update because we are not changing anything about it and there are no other data changes that would trigger an Onyx update (and for it to rerender with the updated titled generated [here](https://github.com/Expensify/App/blob/c3fd1ea89fecb01477261565cb0acdfef325e797/src/libs/ReportUtils.js#L1142-L1162)).

Ideally, we would subscribe to the `parentReportAction` for the thread report [here](https://github.com/Expensify/App/blob/c3fd1ea89fecb01477261565cb0acdfef325e797/src/components/LHNOptionsList/OptionRowLHNData.js#L144-L158). I couldn't find an easy way to do this as we must check to see if the report is a thread and then subscribe to just the first report action (not possible with Onyx selectors AFAICT).

### Fixed Issues
$ https://github.com/Expensify/App/issues/23401

### Tests
1. Create a chat report between two users
2. Leave several comments on the chat report
4. On any message that is not the last message create a thread
5. Leave another message on the thread report
6. Delete the parent message (top/first) of the thread report
7. Verify in the LHN that:

- The subtitle of the initial chat has the correct "last message" 
- The title of the thread chat says `[Deleted message]` and it's subtitle reflects the correct "last message" for the thread.

- [ ] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
Same as tests

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

![2023-07-24_12-46-34](https://github.com/Expensify/App/assets/32969087/f19be843-67e0-4637-b769-0c1cfc7843ec)

</details>

<details>
<summary>Mobile Web - Chrome</summary>

![2023-07-24_13-07-08](https://github.com/Expensify/App/assets/32969087/a82d09f3-b2ce-4d5c-9b37-f8494c1cd05c)


</details>

<details>
<summary>Mobile Web - Safari</summary>

Full disclosure iOS sim issues prevented me from testing

</details>

<details>
<summary>Desktop</summary>

![2023-07-24_13-23-53](https://github.com/Expensify/App/assets/32969087/89094323-82f3-406d-806e-a2224c872998)

</details>

<details>
<summary>iOS</summary>

Full disclosure iOS sim issues prevented me from testing

</details>

<details>
<summary>Android</summary>

![2023-07-24_13-03-46](https://github.com/Expensify/App/assets/32969087/f020b32c-34a7-4c5f-8de7-a576abd858c7)

</details>
