### PR TITLE
Fix MulitpleAvatars alignment

### DIFF
--- a/src/components/MultipleAvatars.js
+++ b/src/components/MultipleAvatars.js
@@ -151,18 +151,9 @@ function MultipleAvatars(props) {
     const overlapSize = oneAvatarSize.width / 3;
 
     if (props.shouldStackHorizontally) {
-        let width;
-
         // Height of one avatar + border space
         const height = oneAvatarSize.height + 2 * oneAvatarBorderWidth;
-        if (props.icons.length > 4) {
-            const length = avatarRows.length > 1 ? Math.max(avatarRows[0].length, avatarRows[1].length) : avatarRows[0].length;
-            width = oneAvatarSize.width + overlapSize * 2 * (length - 1) + oneAvatarBorderWidth * (length * 2);
-        } else {
-            // one avatar width + overlaping avatar sizes + border space
-            width = oneAvatarSize.width + overlapSize * 2 * (props.icons.length - 1) + oneAvatarBorderWidth * (props.icons.length * 2);
-        }
-        avatarContainerStyles = StyleUtils.combineStyles([styles.alignItemsCenter, styles.flexRow, StyleUtils.getHeight(height), StyleUtils.getWidthStyle(width)]);
+        avatarContainerStyles = StyleUtils.combineStyles([styles.alignItemsCenter, styles.flexRow, StyleUtils.getHeight(height)]);
     }
 
     return (

--- a/src/styles/StyleUtils.js
+++ b/src/styles/StyleUtils.js
@@ -904,7 +904,7 @@ function getHorizontalStackedAvatarBorderStyle({isHovered, isPressed, isInReport
  */
 function getHorizontalStackedAvatarStyle(index, overlapSize, borderWidth, borderRadius) {
     return {
-        left: -(overlapSize * index),
+        marginLeft: index > 0 ? -overlapSize : 0,
         borderRadius,
         borderWidth,
         zIndex: index + 2,
@@ -921,7 +921,7 @@ function getHorizontalStackedOverlayAvatarStyle(oneAvatarSize, oneAvatarBorderWi
     return {
         borderWidth: oneAvatarBorderWidth,
         borderRadius: oneAvatarSize.width,
-        left: -(oneAvatarSize.width * 2 + oneAvatarBorderWidth * 2),
+        marginLeft: -(oneAvatarSize.width + oneAvatarBorderWidth * 2),
         zIndex: 6,
         borderStyle: 'solid',
     };


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Replace `left` with `margin-left` for positioning `MultipleAvatars`, which removes the need for calculating the `width`, removing the issues caused by the wrong calculation of the `width`.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/22632
PROPOSAL: https://github.com/Expensify/App/issues/22632#issuecomment-1631418875


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

#### Case 1:  Workspace icons are aligned to the left #22632

1. Open settings.
2. Create 5 or more Workspaces if needed.
3. Check the avatars in the Workspaces menu item.
4. Verify if the avatars are properly aligned.

#### Case 2: Avatars group on final screen moves to the left if admin invites more 8 users #22685

1. Go to the existing or create a new workspace.
2. Go to Workspace > Members.
3. Click / Tap 'Invite'.
4. Select more than 8 users.
5. Click 'Next'.
6. Verify if the avatars are properly center aligned.

#### Case 3: Split bill icons are aligned to the left #22993

1. Split bill with 8 users.
2. Check the icons on the split bill report.
3. Verify if the avatars are properly aligned.  

#### Case 4:  Multiple avatars in group

1. Create a group of five or more.
2. Verify if the avatars are properly aligned.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
8. Upload an image via copy paste
9. Verify a modal appears displaying a preview of that image
--->

#### Case 1:  Workspace icons are aligned to the left #22632

1. Open settings.
2. Create 5 or more Workspaces if needed.
3. Check the avatars in the Workspaces menu item.
4. Verify if the avatars are properly aligned.

#### Case 2: Avatars group on final screen moves to the left if admin invites more 8 users #22685

1. Go to the existing or create a new workspace.
2. Go to Workspace > Members.
3. Click / Tap 'Invite'.
4. Select more than 8 users.
5. Click 'Next'.
6. Verify if the avatars are properly center aligned.

#### Case 3: Split bill icons are aligned to the left #22993

1. Split bill with 8 users.
2. Check the icons on the split bill report.
3. Verify if the avatars are properly aligned.  

#### Case 4:  Multiple avatars in group

1. Create a group of five or more.
2. Verify if the avatars are properly aligned.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

**Case 1**
<img width="1424" alt="Screenshot 2023-07-25 at 11 17 43 PM" src="https://github.com/Expensify/App/assets/120749263/3342afdc-77b2-40ca-b396-9b2942092364">

**Case 2**
<img width="1424" alt="Screenshot 2023-07-26 at 3 43 50 PM" src="https://github.com/Expensify/App/assets/120749263/c352d355-9c56-4c83-b577-3d8304c3ed5c">

**Case 3 & 4**
<img width="1424" alt="Screenshot 2023-07-26 at 3 37 55 PM" src="https://github.com/Expensify/App/assets/120749263/55202eaf-2882-4436-8241-daa951097e8e">

</details>

<details>
<summary>Mobile Web - Chrome</summary>

**Case 1**
![Screenshot_1690306356](https://github.com/Expensify/App/assets/120749263/ab526cba-02fe-4861-84e3-7e1dc14e4942)

**Case 2**
![Screenshot_1690371982](https://github.com/Expensify/App/assets/120749263/f4de2212-c29b-4fe3-8fd1-d9526f995068)

**Case 3 & 4**
![Screenshot_1690371925](https://github.com/Expensify/App/assets/120749263/08624e70-e11f-4f9c-a103-03a25dc190c4)

</details>

<details>
<summary>Mobile Web - Safari</summary>

**Case 1**
![Simulator Screenshot - iPhone 14 - 2023-07-25 at 23 13 08](https://github.com/Expensify/App/assets/120749263/3571d666-2ab1-495b-ab07-54c1a0d4e3ab)

**Case 2**
![Simulator Screenshot - iPhone 14 - 2023-07-26 at 17 08 33](https://github.com/Expensify/App/assets/120749263/16c666dd-a784-4bda-a748-75716bdcc0fc)

**Case 3 & 4**
![Simulator Screenshot - iPhone 14 - 2023-07-26 at 17 07 30](https://github.com/Expensify/App/assets/120749263/3e282695-64f6-44d0-b745-e60136c084a4)

</details>

<details>
<summary>Desktop</summary>

**Case 1**
<img width="1312" alt="Screenshot 2023-07-25 at 11 23 48 PM" src="https://github.com/Expensify/App/assets/120749263/362f360f-66b5-4c1b-aa5d-f968ac2de676">

**Case 2**
<img width="1312" alt="Screenshot 2023-07-26 at 4 42 56 PM" src="https://github.com/Expensify/App/assets/120749263/0cff6221-eef0-4c19-aa07-4b27c916a718">

**Case 3 & 4**
<img width="1312" alt="Screenshot 2023-07-26 at 4 40 44 PM" src="https://github.com/Expensify/App/assets/120749263/0ca918c9-6341-4cee-886e-88aaf40176bd">

</details>

<details>
<summary>iOS</summary>

**Case 1**
![Simulator Screenshot - iPhone 14 - 2023-07-25 at 23 07 40](https://github.com/Expensify/App/assets/120749263/07d6aca6-944d-419a-aa1f-1e2528bfcddd)

**Case 2**
![Simulator Screenshot - iPhone 14 - 2023-07-26 at 17 05 13](https://github.com/Expensify/App/assets/120749263/536e2471-ec2b-4a89-83cd-bfb08661fe7b)

**Case 3 & 4**
![Simulator Screenshot - iPhone 14 - 2023-07-26 at 16 45 47](https://github.com/Expensify/App/assets/120749263/773e8029-4f36-454d-8fc2-53650d29e353)

</details>

<details>
<summary>Android</summary>

**Case 1**
![Screenshot_1690306030](https://github.com/Expensify/App/assets/120749263/961a93d1-8ba2-43b3-980d-b8a27ca2292e)

**Case 2**
![Screenshot_1690372556](https://github.com/Expensify/App/assets/120749263/806d17c2-03f8-4630-bea5-c69927e7de7a)


**Case 3 & 4**
![Screenshot_1690372485](https://github.com/Expensify/App/assets/120749263/afe204dd-7c97-431c-b319-cae82072912b)


</details>