### PR TITLE
Fix: hide draft icon when composer hides

### DIFF
--- a/src/components/LHNOptionsList/OptionRowLHN.js
+++ b/src/components/LHNOptionsList/OptionRowLHN.js
@@ -45,9 +45,6 @@ const propTypes = {
     /** The item that should be rendered */
     // eslint-disable-next-line react/forbid-prop-types
     optionItem: PropTypes.object,
-
-    /** Whether user is allowed to comment so that we can hide the draft icon if user is not allowed to comment */
-    isAllowedToComment: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -57,7 +54,6 @@ const defaultProps = {
     style: null,
     optionItem: null,
     isFocused: false,
-    isAllowedToComment: false,
 };
 
 function OptionRowLHN(props) {
@@ -235,7 +231,7 @@ function OptionRowLHN(props) {
                                     fill={themeColors.success}
                                 />
                             )}
-                            {optionItem.hasDraftComment && props.isAllowedToComment && (
+                            {optionItem.hasDraftComment && optionItem.isAllowedToComment && (
                                 <View
                                     style={styles.ml2}
                                     accessibilityLabel={translate('sidebarScreen.draftedMessage')}

--- a/src/components/LHNOptionsList/OptionRowLHN.js
+++ b/src/components/LHNOptionsList/OptionRowLHN.js
@@ -45,6 +45,9 @@ const propTypes = {
     /** The item that should be rendered */
     // eslint-disable-next-line react/forbid-prop-types
     optionItem: PropTypes.object,
+
+    /** Whether user is allowed to comment so that we can hide the draft icon if user is not allowed to comment */
+    isAllowedToComment: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -54,6 +57,7 @@ const defaultProps = {
     style: null,
     optionItem: null,
     isFocused: false,
+    isAllowedToComment: false,
 };
 
 function OptionRowLHN(props) {
@@ -231,7 +235,7 @@ function OptionRowLHN(props) {
                                     fill={themeColors.success}
                                 />
                             )}
-                            {optionItem.hasDraftComment && (
+                            {optionItem.hasDraftComment && props.isAllowedToComment && (
                                 <View
                                     style={styles.ml2}
                                     accessibilityLabel={translate('sidebarScreen.draftedMessage')}

--- a/src/components/LHNOptionsList/OptionRowLHNData.js
+++ b/src/components/LHNOptionsList/OptionRowLHNData.js
@@ -12,6 +12,7 @@ import withCurrentReportID, {withCurrentReportIDPropTypes, withCurrentReportIDDe
 import OptionRowLHN, {propTypes as basePropTypes, defaultProps as baseDefaultProps} from './OptionRowLHN';
 import * as Report from '../../libs/actions/Report';
 import * as UserUtils from '../../libs/UserUtils';
+import * as ReportUtils from '../../libs/ReportUtils';
 import participantPropTypes from '../participantPropTypes';
 import CONST from '../../CONST';
 
@@ -80,6 +81,12 @@ function OptionRowLHNData({shouldDisableFocusOptions, currentReportID, fullRepor
         return item;
     }, [fullReport, personalDetails, preferredLocale, policy]);
 
+    const isAllowedToComment = useMemo(() => {
+        const {addWorkspaceRoomOrChatErrors} = ReportUtils.getReportOfflinePendingActionAndErrors(fullReport);
+        // if composer is hidden then user is not allowed to comment therefore draft icon should be hidden
+        return !ReportUtils.shouldHideComposer(fullReport, addWorkspaceRoomOrChatErrors);
+    }, [fullReport]);
+
     useEffect(() => {
         if (!optionItem || optionItem.hasDraftComment || !comment || comment.length <= 0 || isFocused) {
             return;
@@ -94,6 +101,7 @@ function OptionRowLHNData({shouldDisableFocusOptions, currentReportID, fullRepor
             {...propsToForward}
             isFocused={isFocused}
             optionItem={optionItem}
+            isAllowedToComment={isAllowedToComment}
         />
     );
 }

--- a/src/components/LHNOptionsList/OptionRowLHNData.js
+++ b/src/components/LHNOptionsList/OptionRowLHNData.js
@@ -12,7 +12,6 @@ import withCurrentReportID, {withCurrentReportIDPropTypes, withCurrentReportIDDe
 import OptionRowLHN, {propTypes as basePropTypes, defaultProps as baseDefaultProps} from './OptionRowLHN';
 import * as Report from '../../libs/actions/Report';
 import * as UserUtils from '../../libs/UserUtils';
-import * as ReportUtils from '../../libs/ReportUtils';
 import participantPropTypes from '../participantPropTypes';
 import CONST from '../../CONST';
 
@@ -81,12 +80,6 @@ function OptionRowLHNData({shouldDisableFocusOptions, currentReportID, fullRepor
         return item;
     }, [fullReport, personalDetails, preferredLocale, policy]);
 
-    const isAllowedToComment = useMemo(() => {
-        const {addWorkspaceRoomOrChatErrors} = ReportUtils.getReportOfflinePendingActionAndErrors(fullReport);
-        // if composer is hidden then user is not allowed to comment therefore draft icon should be hidden
-        return !ReportUtils.shouldHideComposer(fullReport, addWorkspaceRoomOrChatErrors);
-    }, [fullReport]);
-
     useEffect(() => {
         if (!optionItem || optionItem.hasDraftComment || !comment || comment.length <= 0 || isFocused) {
             return;
@@ -101,7 +94,6 @@ function OptionRowLHNData({shouldDisableFocusOptions, currentReportID, fullRepor
             {...propsToForward}
             isFocused={isFocused}
             optionItem={optionItem}
-            isAllowedToComment={isAllowedToComment}
         />
     );
 }

--- a/src/libs/SidebarUtils.js
+++ b/src/libs/SidebarUtils.js
@@ -227,7 +227,7 @@ function getOptionData(report, personalDetails, preferredLocale, policy) {
         isExpenseRequest: false,
         isWaitingOnBankAccount: false,
         isLastMessageDeletedParentAction: false,
-        isAllowedToComment: false,
+        isAllowedToComment: true,
     };
 
     const participantPersonalDetailList = _.values(OptionsListUtils.getPersonalDetailsForAccountIDs(report.participantAccountIDs, personalDetails));
@@ -264,7 +264,7 @@ function getOptionData(report, personalDetails, preferredLocale, policy) {
     result.notificationPreference = report.notificationPreference || null;
 
     const {addWorkspaceRoomOrChatErrors} = ReportUtils.getReportOfflinePendingActionAndErrors(report);
-    // if composer is hidden then user is not allowed to comment, this is used to hide draft icon
+    // If the composer is hidden then the user is not allowed to comment, same can be used to hide the draft icon.
     result.isAllowedToComment = !ReportUtils.shouldHideComposer(report, addWorkspaceRoomOrChatErrors);
 
     const hasMultipleParticipants = participantPersonalDetailList.length > 1 || result.isChatRoom || result.isPolicyExpenseChat;

--- a/src/libs/SidebarUtils.js
+++ b/src/libs/SidebarUtils.js
@@ -227,6 +227,7 @@ function getOptionData(report, personalDetails, preferredLocale, policy) {
         isExpenseRequest: false,
         isWaitingOnBankAccount: false,
         isLastMessageDeletedParentAction: false,
+        isAllowedToComment: false,
     };
 
     const participantPersonalDetailList = _.values(OptionsListUtils.getPersonalDetailsForAccountIDs(report.participantAccountIDs, personalDetails));
@@ -261,6 +262,11 @@ function getOptionData(report, personalDetails, preferredLocale, policy) {
     result.parentReportID = report.parentReportID || null;
     result.isWaitingOnBankAccount = report.isWaitingOnBankAccount;
     result.notificationPreference = report.notificationPreference || null;
+
+    const {addWorkspaceRoomOrChatErrors} = ReportUtils.getReportOfflinePendingActionAndErrors(report);
+    // if composer is hidden then user is not allowed to comment, this is used to hide draft icon
+    result.isAllowedToComment = !ReportUtils.shouldHideComposer(report, addWorkspaceRoomOrChatErrors);
+
     const hasMultipleParticipants = participantPersonalDetailList.length > 1 || result.isChatRoom || result.isPolicyExpenseChat;
     const subtitle = ReportUtils.getChatRoomSubtitle(report);
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Hide the draft (pencil) icon in LHN when the composer hides (user is not allowed to comment).

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
5. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/21835
PROPOSAL: https://github.com/Expensify/App/issues/21835#issuecomment-1612090423


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
6. Verify a modal appears displaying a preview of that image
--->

1. Open app and log in using an account which is an admin of a room with permissions set to all members. You can do this on your phone (a different device) for testing quickly rather than switching tabs on the same device.
2. On second tab/device, log in using an account which is a member of the room above.
3. On the second tab/device, navigate to the room chat and type a message. Verify that the pencil icon is visible.
4. Now on the first tab/device, open the room settings and change permission to admins only.
5. On the second tab/device, verify that the composer and the pencil icon are not visible any more.
6. Now on the first device, change permissions back to all members.
7. Go back to second tab/device, verify that the composer and draft icon reappear and you can see your draft message.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

NA

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
9. Upload an image via copy paste
10. Verify a modal appears displaying a preview of that image
--->

Same as above.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>


https://github.com/Expensify/App/assets/31413407/04d769e5-d04e-4e5e-9b04-a80f2b459eb5


https://github.com/Expensify/App/assets/31413407/907db874-41d6-4478-a368-c05fbca5a3c0



</details>

<details>
<summary>Mobile Web - Chrome</summary>


https://github.com/Expensify/App/assets/31413407/68fefc41-278d-4016-97a4-78bd90d3ad62



</details>

<details>
<summary>Mobile Web - Safari</summary>


https://github.com/Expensify/App/assets/31413407/72406fff-3d12-4d33-ac72-4918325ffc1f



</details>

<details>
<summary>Desktop</summary>


https://github.com/Expensify/App/assets/31413407/7ebddedc-ba63-44d4-810c-657bb48e0569



</details>

<details>
<summary>iOS</summary>


https://github.com/Expensify/App/assets/31413407/65115edf-b3e3-4ebf-bc04-983e7cc3e5be



</details>

<details>
<summary>Android</summary>


https://github.com/Expensify/App/assets/31413407/400182d0-a3c5-496d-b484-adebd1785272



</details>
