### PR TITLE
Only render ReportActionItemReactions if there are reactions

### DIFF
--- a/src/components/Reactions/ReportActionItemEmojiReactions.js
+++ b/src/components/Reactions/ReportActionItemEmojiReactions.js
@@ -109,44 +109,45 @@ function ReportActionItemEmojiReactions(props) {
     return (
         totalReactionCount > 0 && (
             <View
-            ref={popoverReactionListAnchor}
-            style={[styles.flexRow, styles.flexWrap, styles.gap1, styles.mt2]}
-        >
-            {_.map(formattedReactions, (reaction) => {
-                if (reaction !== null) {
-                    return (
-                        <Tooltip
-                            renderTooltipContent={() => (
-                                <ReactionTooltipContent
-                                    emojiName={EmojiUtils.getLocalizedEmojiName(reaction.reactionEmojiName, props.preferredLocale)}
-                                    emojiCodes={reaction.emojiCodes}
-                                    accountIDs={reaction.reactionUserAccountIDs}
-                                    currentUserPersonalDetails={props.currentUserPersonalDetails}
-                                />
-                            )}
-                            renderTooltipContentKey={[..._.map(reaction.reactionUsers, (user) => user.toString()), ...reaction.emojiCodes]}
-                            key={reaction.reactionEmojiName}
-                        >
-                            <View>
-                                <EmojiReactionBubble
-                                    ref={props.forwardedRef}
-                                    count={reaction.reactionCount}
-                                    emojiCodes={reaction.emojiCodes}
-                                    onPress={reaction.onPress}
-                                    reactionUsers={reaction.reactionUsers}
-                                    hasUserReacted={reaction.hasUserReacted}
-                                    onReactionListOpen={reaction.onReactionListOpen}
-                                />
-                            </View>
-                        </Tooltip>
-                    );
-                }
-            })}
+                ref={popoverReactionListAnchor}
+                style={[styles.flexRow, styles.flexWrap, styles.gap1, styles.mt2]}
+            >
+                {_.map(formattedReactions, (reaction) => {
+                    if (reaction !== null) {
+                        return (
+                            <Tooltip
+                                renderTooltipContent={() => (
+                                    <ReactionTooltipContent
+                                        emojiName={EmojiUtils.getLocalizedEmojiName(reaction.reactionEmojiName, props.preferredLocale)}
+                                        emojiCodes={reaction.emojiCodes}
+                                        accountIDs={reaction.reactionUserAccountIDs}
+                                        currentUserPersonalDetails={props.currentUserPersonalDetails}
+                                    />
+                                )}
+                                renderTooltipContentKey={[..._.map(reaction.reactionUsers, (user) => user.toString()), ...reaction.emojiCodes]}
+                                key={reaction.reactionEmojiName}
+                            >
+                                <View>
+                                    <EmojiReactionBubble
+                                        ref={props.forwardedRef}
+                                        count={reaction.reactionCount}
+                                        emojiCodes={reaction.emojiCodes}
+                                        onPress={reaction.onPress}
+                                        reactionUsers={reaction.reactionUsers}
+                                        hasUserReacted={reaction.hasUserReacted}
+                                        onReactionListOpen={reaction.onReactionListOpen}
+                                    />
+                                </View>
+                            </Tooltip>
+                        );
+                    }
+                })}
                 <AddReactionBubble
                     onSelectEmoji={props.toggleReaction}
                     reportAction={{reportActionID: props.reportActionID}}
                 />
-        </View>)
+            </View>
+        )
     );
 }
 

--- a/src/components/Reactions/ReportActionItemEmojiReactions.js
+++ b/src/components/Reactions/ReportActionItemEmojiReactions.js
@@ -116,32 +116,32 @@ function ReportActionItemEmojiReactions(props) {
                     if (reaction === null) {
                         return;
                     }
-                        return (
-                            <Tooltip
-                                renderTooltipContent={() => (
-                                    <ReactionTooltipContent
-                                        emojiName={EmojiUtils.getLocalizedEmojiName(reaction.reactionEmojiName, props.preferredLocale)}
-                                        emojiCodes={reaction.emojiCodes}
-                                        accountIDs={reaction.reactionUserAccountIDs}
-                                        currentUserPersonalDetails={props.currentUserPersonalDetails}
-                                    />
-                                )}
-                                renderTooltipContentKey={[..._.map(reaction.reactionUsers, (user) => user.toString()), ...reaction.emojiCodes]}
-                                key={reaction.reactionEmojiName}
-                            >
-                                <View>
-                                    <EmojiReactionBubble
-                                        ref={props.forwardedRef}
-                                        count={reaction.reactionCount}
-                                        emojiCodes={reaction.emojiCodes}
-                                        onPress={reaction.onPress}
-                                        reactionUsers={reaction.reactionUsers}
-                                        hasUserReacted={reaction.hasUserReacted}
-                                        onReactionListOpen={reaction.onReactionListOpen}
-                                    />
-                                </View>
-                            </Tooltip>
-                        );
+                    return (
+                        <Tooltip
+                            renderTooltipContent={() => (
+                                <ReactionTooltipContent
+                                    emojiName={EmojiUtils.getLocalizedEmojiName(reaction.reactionEmojiName, props.preferredLocale)}
+                                    emojiCodes={reaction.emojiCodes}
+                                    accountIDs={reaction.reactionUserAccountIDs}
+                                    currentUserPersonalDetails={props.currentUserPersonalDetails}
+                                />
+                            )}
+                            renderTooltipContentKey={[..._.map(reaction.reactionUsers, (user) => user.toString()), ...reaction.emojiCodes]}
+                            key={reaction.reactionEmojiName}
+                        >
+                            <View>
+                                <EmojiReactionBubble
+                                    ref={props.forwardedRef}
+                                    count={reaction.reactionCount}
+                                    emojiCodes={reaction.emojiCodes}
+                                    onPress={reaction.onPress}
+                                    reactionUsers={reaction.reactionUsers}
+                                    hasUserReacted={reaction.hasUserReacted}
+                                    onReactionListOpen={reaction.onReactionListOpen}
+                                />
+                            </View>
+                        </Tooltip>
+                    );
                 })}
                 <AddReactionBubble
                     onSelectEmoji={props.toggleReaction}

--- a/src/components/Reactions/ReportActionItemEmojiReactions.js
+++ b/src/components/Reactions/ReportActionItemEmojiReactions.js
@@ -113,7 +113,9 @@ function ReportActionItemEmojiReactions(props) {
                 style={[styles.flexRow, styles.flexWrap, styles.gap1, styles.mt2]}
             >
                 {_.map(formattedReactions, (reaction) => {
-                    if (reaction !== null) {
+                    if (reaction === null) {
+                        return;
+                    }
                         return (
                             <Tooltip
                                 renderTooltipContent={() => (
@@ -140,7 +142,6 @@ function ReportActionItemEmojiReactions(props) {
                                 </View>
                             </Tooltip>
                         );
-                    }
                 })}
                 <AddReactionBubble
                     onSelectEmoji={props.toggleReaction}

--- a/src/components/Reactions/ReportActionItemEmojiReactions.js
+++ b/src/components/Reactions/ReportActionItemEmojiReactions.js
@@ -67,72 +67,86 @@ function ReportActionItemEmojiReactions(props) {
         return (oldestUserReactionTimestamp || emojiReaction.createdAt) + emojiName;
     });
 
+    const formattedReactions = _.map(sortedReactions, (reaction) => {
+        const reactionEmojiName = reaction.emojiName;
+        const usersWithReactions = _.pick(reaction.users, _.identity);
+        let reactionCount = 0;
+
+        // Loop through the users who have reacted and see how many skintones they reacted with so that we get the total count
+        _.forEach(usersWithReactions, (user) => {
+            reactionCount += _.size(user.skinTones);
+        });
+        if (!reactionCount) {
+            return null;
+        }
+        totalReactionCount += reactionCount;
+        const emojiAsset = EmojiUtils.findEmojiByName(reactionEmojiName);
+        const emojiCodes = EmojiUtils.getUniqueEmojiCodes(emojiAsset, reaction.users);
+        const hasUserReacted = Report.hasAccountIDEmojiReacted(props.currentUserPersonalDetails.accountID, reaction.users);
+        const reactionUsers = _.keys(usersWithReactions);
+        const reactionUserAccountIDs = _.map(reactionUsers, Number);
+
+        const onPress = () => {
+            props.toggleReaction(emojiAsset);
+        };
+
+        const onReactionListOpen = (event) => {
+            reactionListRef.current.showReactionList(event, popoverReactionListAnchor.current, reaction);
+        };
+
+        return {
+            reactionEmojiName,
+            emojiCodes,
+            reactionUserAccountIDs,
+            onPress,
+            reactionUsers,
+            reactionCount,
+            hasUserReacted,
+            onReactionListOpen,
+        };
+    });
+
     return (
-        <View
+        totalReactionCount > 0 && (
+            <View
             ref={popoverReactionListAnchor}
             style={[styles.flexRow, styles.flexWrap, styles.gap1, styles.mt2]}
         >
-            {_.map(sortedReactions, (reaction) => {
-                const reactionEmojiName = reaction.emojiName;
-                const usersWithReactions = _.pick(reaction.users, _.identity);
-                let reactionCount = 0;
-
-                // Loop through the users who have reacted and see how many skintones they reacted with so that we get the total count
-                _.forEach(usersWithReactions, (user) => {
-                    reactionCount += _.size(user.skinTones);
-                });
-                if (!reactionCount) {
-                    return null;
+            {_.map(formattedReactions, (reaction) => {
+                if (reaction !== null) {
+                    return (
+                        <Tooltip
+                            renderTooltipContent={() => (
+                                <ReactionTooltipContent
+                                    emojiName={EmojiUtils.getLocalizedEmojiName(reaction.reactionEmojiName, props.preferredLocale)}
+                                    emojiCodes={reaction.emojiCodes}
+                                    accountIDs={reaction.reactionUserAccountIDs}
+                                    currentUserPersonalDetails={props.currentUserPersonalDetails}
+                                />
+                            )}
+                            renderTooltipContentKey={[..._.map(reaction.reactionUsers, (user) => user.toString()), ...reaction.emojiCodes]}
+                            key={reaction.reactionEmojiName}
+                        >
+                            <View>
+                                <EmojiReactionBubble
+                                    ref={props.forwardedRef}
+                                    count={reaction.reactionCount}
+                                    emojiCodes={reaction.emojiCodes}
+                                    onPress={reaction.onPress}
+                                    reactionUsers={reaction.reactionUsers}
+                                    hasUserReacted={reaction.hasUserReacted}
+                                    onReactionListOpen={reaction.onReactionListOpen}
+                                />
+                            </View>
+                        </Tooltip>
+                    );
                 }
-                totalReactionCount += reactionCount;
-                const emojiAsset = EmojiUtils.findEmojiByName(reactionEmojiName);
-                const emojiCodes = EmojiUtils.getUniqueEmojiCodes(emojiAsset, reaction.users);
-                const hasUserReacted = Report.hasAccountIDEmojiReacted(props.currentUserPersonalDetails.accountID, reaction.users);
-                const reactionUsers = _.keys(usersWithReactions);
-                const reactionUserAccountIDs = _.map(reactionUsers, Number);
-
-                const onPress = () => {
-                    props.toggleReaction(emojiAsset);
-                };
-
-                const onReactionListOpen = (event) => {
-                    reactionListRef.current.showReactionList(event, popoverReactionListAnchor.current, reaction);
-                };
-
-                return (
-                    <Tooltip
-                        renderTooltipContent={() => (
-                            <ReactionTooltipContent
-                                emojiName={EmojiUtils.getLocalizedEmojiName(reactionEmojiName, props.preferredLocale)}
-                                emojiCodes={emojiCodes}
-                                accountIDs={reactionUserAccountIDs}
-                                currentUserPersonalDetails={props.currentUserPersonalDetails}
-                            />
-                        )}
-                        renderTooltipContentKey={[..._.map(reactionUsers, (user) => user.toString()), ...emojiCodes]}
-                        key={reactionEmojiName}
-                    >
-                        <View>
-                            <EmojiReactionBubble
-                                ref={props.forwardedRef}
-                                count={reactionCount}
-                                emojiCodes={emojiCodes}
-                                onPress={onPress}
-                                reactionUsers={reactionUsers}
-                                hasUserReacted={hasUserReacted}
-                                onReactionListOpen={onReactionListOpen}
-                            />
-                        </View>
-                    </Tooltip>
-                );
             })}
-            {totalReactionCount > 0 && (
                 <AddReactionBubble
                     onSelectEmoji={props.toggleReaction}
                     reportAction={{reportActionID: props.reportActionID}}
                 />
-            )}
-        </View>
+        </View>)
     );
 }
 


### PR DESCRIPTION
### Details
My [recent PR](https://github.com/Expensify/App/pull/17996) caused this regression. There was a bug where when no reactions were being shown, we were still rendering the view with a top margin and causing each message box to be too large.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/23350
PROPOSAL: n/a


### Tests
1. Add a comment to a chat
2. Make sure that the bottom and top margin are the same size
3. Add a reaction and make sure it is displayed properly
4. Right click / long press the message and make sure that you can see who has reacted
5. Remove your reaction and make sure that the message is still displayed properly (no large bottom margin)
6. Add the reaction again
7. Add the same reaction on the same message on a different account
8. Make sure that you can see all users who have reacted

- [x] Verify that no errors appear in the JS console

### Offline tests
Same as online

### QA Steps
1. Add a comment to a chat
2. Make sure that the bottom and top margin are the same size
3. Add a reaction and make sure it is displayed properly
4. Right click / long press the message and make sure that you can see who has reacted
5. Remove your reaction and make sure that the message is still displayed properly (no large bottom margin)
6. Add the reaction again
7. Add the same reaction on the same message on a different account
8. Make sure that you can see all users who have reacted

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://github.com/Expensify/App/assets/42391420/5768d42c-044d-4277-ac9b-f2246ab3191d




</details>

<details>
<summary>Mobile Web - Chrome</summary>

My environment still cannot run this.




</details>

<details>
<summary>Mobile Web - Safari</summary>

https://github.com/Expensify/App/assets/42391420/debdb696-89d6-4432-8f4f-1903255c151c




</details>

<details>
<summary>Desktop</summary>


https://github.com/Expensify/App/assets/42391420/240730da-ac21-43e5-a1d7-b86dfb377a24



</details>

<details>
<summary>iOS</summary>


https://github.com/Expensify/App/assets/42391420/6675ede8-b788-4e10-adde-febeec04a106



</details>

<details>
<summary>Android</summary>


https://github.com/Expensify/App/assets/42391420/2b31e768-3c10-494a-907b-8803a91b4d2e



</details>
