### PR TITLE
Revert "Bump Reanimated to 3.4.0"

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -672,12 +672,11 @@ PODS:
     - React-Core
   - RNReactNativeHapticFeedback (1.14.0):
     - React-Core
-  - RNReanimated (3.4.0):
+  - RNReanimated (3.1.0):
     - DoubleConversion
     - FBLazyVector
     - FBReactNativeSpec
     - glog
-    - hermes-engine
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -687,7 +686,6 @@ PODS:
     - React-Core/RCTWebSocket
     - React-CoreModules
     - React-cxxreact
-    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-jsinspector
@@ -1132,7 +1130,7 @@ SPEC CHECKSUMS:
   RNLocalize: d4b8af4e442d4bcca54e68fc687a2129b4d71a81
   RNPermissions: dcdb7b99796bbeda6975a6e79ad519c41b251b1c
   RNReactNativeHapticFeedback: 1e3efeca9628ff9876ee7cdd9edec1b336913f8c
-  RNReanimated: 532818a3578a0832d95ea9d0a6a9dc0e73bbce29
+  RNReanimated: b1220a0e5168745283ff5d53bfc7d2144b2cee1b
   RNScreens: 0df01424e9e0ed7827200d6ed1087ddd06c493f9
   RNSVG: 53c661b76829783cdaf9b7a57258f3d3b4c28315
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,7 @@
         "react-native-plaid-link-sdk": "^10.0.0",
         "react-native-qrcode-svg": "^6.2.0",
         "react-native-quick-sqlite": "^8.0.0-beta.2",
-        "react-native-reanimated": "3.4.0",
+        "react-native-reanimated": "3.1.0",
         "react-native-render-html": "6.3.1",
         "react-native-safe-area-context": "4.4.1",
         "react-native-screens": "3.17.0",
@@ -36901,9 +36901,9 @@
       }
     },
     "node_modules/react-native-reanimated": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.4.0.tgz",
-      "integrity": "sha512-B5cZJseoIkYlZTRBRN0xuU1NBxUza/6GSHhiEBQfbOufWVlUMMcWUecIRVglW49l8d2wXbfCdQlNyVoFqmHkaQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.1.0.tgz",
+      "integrity": "sha512-8YJR7yHnrqK6yKWzkGLVEawi1WZqJ9bGIehKEnE8zG58yLrSwUZe1T220XTbftpkA3r37Sy0kJJ/HOOiaIU+HQ==",
       "dependencies": {
         "@babel/plugin-transform-object-assign": "^7.16.7",
         "@babel/preset-typescript": "^7.16.7",
@@ -68601,9 +68601,9 @@
       "requires": {}
     },
     "react-native-reanimated": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.4.0.tgz",
-      "integrity": "sha512-B5cZJseoIkYlZTRBRN0xuU1NBxUza/6GSHhiEBQfbOufWVlUMMcWUecIRVglW49l8d2wXbfCdQlNyVoFqmHkaQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.1.0.tgz",
+      "integrity": "sha512-8YJR7yHnrqK6yKWzkGLVEawi1WZqJ9bGIehKEnE8zG58yLrSwUZe1T220XTbftpkA3r37Sy0kJJ/HOOiaIU+HQ==",
       "requires": {
         "@babel/plugin-transform-object-assign": "^7.16.7",
         "@babel/preset-typescript": "^7.16.7",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "react-native-plaid-link-sdk": "^10.0.0",
     "react-native-qrcode-svg": "^6.2.0",
     "react-native-quick-sqlite": "^8.0.0-beta.2",
-    "react-native-reanimated": "3.4.0",
+    "react-native-reanimated": "3.1.0",
     "react-native-render-html": "6.3.1",
     "react-native-safe-area-context": "4.4.1",
     "react-native-screens": "3.17.0",

--- a/patches/react-native-reanimated+3.1.0.patch
+++ b/patches/react-native-reanimated+3.1.0.patch
@@ -1,0 +1,177 @@
+diff --git a/node_modules/react-native-reanimated/ios/REANodesManager.mm b/node_modules/react-native-reanimated/ios/REANodesManager.mm
+index 26bb253..4108293 100644
+--- a/node_modules/react-native-reanimated/ios/REANodesManager.mm
++++ b/node_modules/react-native-reanimated/ios/REANodesManager.mm
+@@ -85,19 +85,77 @@ - (void)runSyncUIUpdatesWithObserver:(id<RCTUIManagerObserver>)observer
+ 
+ @end
+ 
+-@interface REANodesManager () <RCTUIManagerObserver>
++#ifndef RCT_NEW_ARCH_ENABLED
+ 
++@interface REASyncUpdateObserver : NSObject <RCTUIManagerObserver>
+ @end
+ 
++@implementation REASyncUpdateObserver {
++  volatile void (^_mounting)(void);
++  volatile BOOL _waitTimedOut;
++  dispatch_semaphore_t _semaphore;
++}
++
++- (instancetype)init
++{
++  self = [super init];
++  if (self) {
++    _mounting = nil;
++    _waitTimedOut = NO;
++    _semaphore = dispatch_semaphore_create(0);
++  }
++  return self;
++}
++
++- (void)dealloc
++{
++  RCTAssert(_mounting == nil, @"Mouting block was set but never executed. This may lead to UI inconsistencies");
++}
++
++- (void)unblockUIThread
++{
++  RCTAssertUIManagerQueue();
++  dispatch_semaphore_signal(_semaphore);
++}
++
++- (void)waitAndMountWithTimeout:(NSTimeInterval)timeout
++{
++  RCTAssertMainQueue();
++  long result = dispatch_semaphore_wait(_semaphore, dispatch_time(DISPATCH_TIME_NOW, timeout * NSEC_PER_SEC));
++  if (result != 0) {
++    @synchronized(self) {
++      _waitTimedOut = YES;
++    }
++  }
++  if (_mounting) {
++    _mounting();
++    _mounting = nil;
++  }
++}
++
++- (BOOL)uiManager:(RCTUIManager *)manager performMountingWithBlock:(RCTUIManagerMountingBlock)block
++{
++  RCTAssertUIManagerQueue();
++  @synchronized(self) {
++    if (_waitTimedOut) {
++      return NO;
++    } else {
++      _mounting = block;
++      return YES;
++    }
++  }
++}
++
++@end
++
++#endif
++
+ @implementation REANodesManager {
+   CADisplayLink *_displayLink;
+   BOOL _wantRunUpdates;
+   NSMutableArray<REAOnAnimationCallback> *_onAnimationCallbacks;
+   BOOL _tryRunBatchUpdatesSynchronously;
+   REAEventHandler _eventHandler;
+-  volatile void (^_mounting)(void);
+-  NSObject *_syncLayoutUpdatesWaitLock;
+-  volatile BOOL _syncLayoutUpdatesWaitTimedOut;
+   NSMutableDictionary<NSNumber *, ComponentUpdate *> *_componentUpdateBuffer;
+   NSMutableDictionary<NSNumber *, UIView *> *_viewRegistry;
+ #ifdef RCT_NEW_ARCH_ENABLED
+@@ -125,7 +183,6 @@ - (nonnull instancetype)initWithModule:(REAModule *)reanimatedModule
+     _operationsInBatch = [NSMutableDictionary new];
+     _componentUpdateBuffer = [NSMutableDictionary new];
+     _viewRegistry = [_uiManager valueForKey:@"_viewRegistry"];
+-    _syncLayoutUpdatesWaitLock = [NSObject new];
+   }
+ 
+   _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(onAnimationFrame:)];
+@@ -241,19 +298,6 @@ - (void)onAnimationFrame:(CADisplayLink *)displayLink
+   }
+ }
+ 
+-- (BOOL)uiManager:(RCTUIManager *)manager performMountingWithBlock:(RCTUIManagerMountingBlock)block
+-{
+-  RCTAssert(_mounting == nil, @"Mouting block is expected to not be set");
+-  @synchronized(_syncLayoutUpdatesWaitLock) {
+-    if (_syncLayoutUpdatesWaitTimedOut) {
+-      return NO;
+-    } else {
+-      _mounting = block;
+-      return YES;
+-    }
+-  }
+-}
+-
+ - (void)performOperations
+ {
+ #ifdef RCT_NEW_ARCH_ENABLED
+@@ -268,8 +312,7 @@ - (void)performOperations
+     _tryRunBatchUpdatesSynchronously = NO;
+ 
+     __weak __typeof__(self) weakSelf = self;
+-    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+-    _syncLayoutUpdatesWaitTimedOut = NO;
++    REASyncUpdateObserver *syncUpdateObserver = [REASyncUpdateObserver new];
+     RCTExecuteOnUIManagerQueue(^{
+       __typeof__(self) strongSelf = weakSelf;
+       if (strongSelf == nil) {
+@@ -278,7 +321,7 @@ - (void)performOperations
+       BOOL canUpdateSynchronously = trySynchronously && ![strongSelf.uiManager hasEnqueuedUICommands];
+ 
+       if (!canUpdateSynchronously) {
+-        dispatch_semaphore_signal(semaphore);
++        [syncUpdateObserver unblockUIThread];
+       }
+ 
+       for (int i = 0; i < copiedOperationsQueue.count; i++) {
+@@ -286,8 +329,8 @@ - (void)performOperations
+       }
+ 
+       if (canUpdateSynchronously) {
+-        [strongSelf.uiManager runSyncUIUpdatesWithObserver:strongSelf];
+-        dispatch_semaphore_signal(semaphore);
++        [strongSelf.uiManager runSyncUIUpdatesWithObserver:syncUpdateObserver];
++        [syncUpdateObserver unblockUIThread];
+       }
+       // In case canUpdateSynchronously=true we still have to send uiManagerWillPerformMounting event
+       // to observers because some components (e.g. TextInput) update their UIViews only on that event.
+@@ -298,17 +341,7 @@ - (void)performOperations
+       // from CADisplayLink but it is easier to hardcode it for the time being.
+       // The reason why we use frame duration here is that if takes longer than one frame to complete layout tasks
+       // there is no point of synchronizing layout with the UI interaction as we get that one frame delay anyways.
+-      long result = dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, 16 * NSEC_PER_MSEC));
+-      if (result != 0) {
+-        @synchronized(_syncLayoutUpdatesWaitLock) {
+-          _syncLayoutUpdatesWaitTimedOut = YES;
+-        }
+-      }
+-    }
+-
+-    if (_mounting) {
+-      _mounting();
+-      _mounting = nil;
++      [syncUpdateObserver waitAndMountWithTimeout:0.016];
+     }
+   }
+   _wantRunUpdates = NO;
+diff --git a/node_modules/react-native-reanimated/mock.js b/node_modules/react-native-reanimated/mock.js
+index 68b20d2..b088001 100644
+--- a/node_modules/react-native-reanimated/mock.js
++++ b/node_modules/react-native-reanimated/mock.js
+@@ -41,6 +41,9 @@ const Reanimated = {
+   createAnimatedComponent: (Component) => Component,
+   addWhitelistedUIProps: NOOP,
+   addWhitelistedNativeProps: NOOP,
++
++  // used by react-navigation fork
++  isConfigured: () => true,
+ };
+ 
+ module.exports = {


### PR DESCRIPTION
Reverts Expensify/App#23550


### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.