### PR TITLE
migration from class to functional component

### DIFF
--- a/src/components/GrowlNotification/index.js
+++ b/src/components/GrowlNotification/index.js
@@ -104,7 +104,7 @@ function GrowlNotification(_, ref) {
                 <GrowlNotificationContainer translateY={translateY}>
                     <PressableWithoutFeedback
                         accessibilityLabel={bodyText}
-                        onPress={fling}
+                        onPress={() => fling()}
                     >
                         <View style={styles.growlNotificationBox}>
                             <Icon

--- a/src/components/GrowlNotification/index.js
+++ b/src/components/GrowlNotification/index.js
@@ -1,4 +1,4 @@
-import React, {forwardRef, useCallback, useEffect, useImperativeHandle, useState} from 'react';
+import React, {forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState} from 'react';
 import {Directions, FlingGestureHandler, State} from 'react-native-gesture-handler';
 import {View, Animated} from 'react-native';
 import colors from '../../styles/colors';
@@ -29,9 +29,9 @@ const types = {
 const INACTIVE_POSITION_Y = -255;
 
 const PressableWithoutFeedback = Pressables.PressableWithoutFeedback;
-const translateY = new Animated.Value(INACTIVE_POSITION_Y);
 
 function GrowlNotification(_, ref) {
+    const translateY = useRef(new Animated.Value(INACTIVE_POSITION_Y)).current;
     const [bodyText, setBodyText] = useState('');
     const [type, setType] = useState('success');
     const [duration, setDuration] = useState();
@@ -54,13 +54,16 @@ function GrowlNotification(_, ref) {
      *
      * @param {Number} val
      */
-    const fling = useCallback((val = INACTIVE_POSITION_Y) => {
-        Animated.spring(translateY, {
-            toValue: val,
-            duration: 80,
-            useNativeDriver: true,
-        }).start();
-    }, []);
+    const fling = useCallback(
+        (val = INACTIVE_POSITION_Y) => {
+            Animated.spring(translateY, {
+                toValue: val,
+                duration: 80,
+                useNativeDriver: true,
+            }).start();
+        },
+        [translateY],
+    );
 
     useImperativeHandle(
         ref,

--- a/src/components/GrowlNotification/index.js
+++ b/src/components/GrowlNotification/index.js
@@ -81,7 +81,7 @@ function GrowlNotification(_, ref) {
 
         fling(0);
         setTimeout(() => {
-            fling(INACTIVE_POSITION_Y);
+            fling();
             setDuration(undefined);
         }, duration);
     }, [duration, fling]);
@@ -94,14 +94,14 @@ function GrowlNotification(_, ref) {
                     return;
                 }
 
-                fling(INACTIVE_POSITION_Y);
+                fling();
             }}
         >
             <View style={styles.growlNotificationWrapper}>
                 <GrowlNotificationContainer translateY={translateY}>
                     <PressableWithoutFeedback
                         accessibilityLabel={bodyText}
-                        onPress={() => fling(INACTIVE_POSITION_Y)}
+                        onPress={() => fling()}
                     >
                         <View style={styles.growlNotificationBox}>
                             <Icon

--- a/src/components/GrowlNotification/index.js
+++ b/src/components/GrowlNotification/index.js
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useState} from 'react';
+import React, {forwardRef, useCallback, useEffect, useImperativeHandle, useState} from 'react';
 import {Directions, FlingGestureHandler, State} from 'react-native-gesture-handler';
 import {View, Animated} from 'react-native';
 import colors from '../../styles/colors';
@@ -31,7 +31,7 @@ const INACTIVE_POSITION_Y = -255;
 const PressableWithoutFeedback = Pressables.PressableWithoutFeedback;
 const translateY = new Animated.Value(INACTIVE_POSITION_Y);
 
-function GrowlNotification() {
+function GrowlNotification(_, ref) {
     const [bodyText, setBodyText] = useState('');
     const [type, setType] = useState('success');
     const [duration, setDuration] = useState();
@@ -43,7 +43,6 @@ function GrowlNotification() {
      * @param {String} type
      * @param {Number} duration
      */
-    // eslint-disable-next-line no-unused-vars
     const show = useCallback((text, growlType, growlDuration) => {
         setBodyText(text);
         setType(growlType);
@@ -62,6 +61,14 @@ function GrowlNotification() {
             useNativeDriver: true,
         }).start();
     }, []);
+
+    useImperativeHandle(
+        ref,
+        () => ({
+            show,
+        }),
+        [show],
+    );
 
     useEffect(() => {
         Growl.setIsReady();
@@ -112,4 +119,4 @@ function GrowlNotification() {
 
 GrowlNotification.displayName = 'GrowlNotification';
 
-export default GrowlNotification;
+export default forwardRef(GrowlNotification);

--- a/src/components/GrowlNotification/index.js
+++ b/src/components/GrowlNotification/index.js
@@ -104,7 +104,7 @@ function GrowlNotification(_, ref) {
                 <GrowlNotificationContainer translateY={translateY}>
                     <PressableWithoutFeedback
                         accessibilityLabel={bodyText}
-                        onPress={() => fling()}
+                        onPress={fling}
                     >
                         <View style={styles.growlNotificationBox}>
                             <Icon

--- a/src/components/GrowlNotification/index.js
+++ b/src/components/GrowlNotification/index.js
@@ -1,6 +1,6 @@
-import React, {Component} from 'react';
-import {View, Animated} from 'react-native';
+import React, {useCallback, useEffect, useState} from 'react';
 import {Directions, FlingGestureHandler, State} from 'react-native-gesture-handler';
+import {View, Animated} from 'react-native';
 import colors from '../../styles/colors';
 import Text from '../Text';
 import Icon from '../Icon';
@@ -29,24 +29,12 @@ const types = {
 const INACTIVE_POSITION_Y = -255;
 
 const PressableWithoutFeedback = Pressables.PressableWithoutFeedback;
+const translateY = new Animated.Value(INACTIVE_POSITION_Y);
 
-class GrowlNotification extends Component {
-    constructor(props) {
-        super(props);
-
-        this.state = {
-            bodyText: '',
-            type: 'success',
-            translateY: new Animated.Value(INACTIVE_POSITION_Y),
-        };
-
-        this.show = this.show.bind(this);
-        this.fling = this.fling.bind(this);
-    }
-
-    componentDidMount() {
-        Growl.setIsReady();
-    }
+function GrowlNotification() {
+    const [bodyText, setBodyText] = useState('');
+    const [type, setType] = useState('success');
+    const [duration, setDuration] = useState();
 
     /**
      * Show the growl notification
@@ -55,65 +43,73 @@ class GrowlNotification extends Component {
      * @param {String} type
      * @param {Number} duration
      */
-    show(bodyText, type, duration) {
-        this.setState(
-            {
-                bodyText,
-                type,
-            },
-            () => {
-                this.fling(0);
-                setTimeout(() => {
-                    this.fling(INACTIVE_POSITION_Y);
-                }, duration);
-            },
-        );
-    }
+    // eslint-disable-next-line no-unused-vars
+    const show = useCallback((text, growlType, growlDuration) => {
+        setBodyText(text);
+        setType(growlType);
+        setDuration(growlDuration);
+    }, []);
 
     /**
      * Animate growl notification
      *
      * @param {Number} val
      */
-    fling(val = INACTIVE_POSITION_Y) {
-        Animated.spring(this.state.translateY, {
+    const fling = useCallback((val = INACTIVE_POSITION_Y) => {
+        Animated.spring(translateY, {
             toValue: val,
             duration: 80,
             useNativeDriver: true,
         }).start();
-    }
+    }, []);
 
-    render() {
-        return (
-            <FlingGestureHandler
-                direction={Directions.UP}
-                onHandlerStateChange={({nativeEvent}) => {
-                    if (nativeEvent.state !== State.ACTIVE) {
-                        return;
-                    }
+    useEffect(() => {
+        Growl.setIsReady();
+    }, []);
 
-                    this.fling(INACTIVE_POSITION_Y);
-                }}
-            >
-                <View style={styles.growlNotificationWrapper}>
-                    <GrowlNotificationContainer translateY={this.state.translateY}>
-                        <PressableWithoutFeedback
-                            accessibilityLabel={this.state.bodyText}
-                            onPress={() => this.fling(INACTIVE_POSITION_Y)}
-                        >
-                            <View style={styles.growlNotificationBox}>
-                                <Icon
-                                    src={types[this.state.type].icon}
-                                    fill={types[this.state.type].iconColor}
-                                />
-                                <Text style={styles.growlNotificationText}>{this.state.bodyText}</Text>
-                            </View>
-                        </PressableWithoutFeedback>
-                    </GrowlNotificationContainer>
-                </View>
-            </FlingGestureHandler>
-        );
-    }
+    useEffect(() => {
+        if (!duration) {
+            return;
+        }
+
+        fling(0);
+        setTimeout(() => {
+            fling(INACTIVE_POSITION_Y);
+            setDuration(undefined);
+        }, duration);
+    }, [duration, fling]);
+
+    return (
+        <FlingGestureHandler
+            direction={Directions.UP}
+            onHandlerStateChange={({nativeEvent}) => {
+                if (nativeEvent.state !== State.ACTIVE) {
+                    return;
+                }
+
+                fling(INACTIVE_POSITION_Y);
+            }}
+        >
+            <View style={styles.growlNotificationWrapper}>
+                <GrowlNotificationContainer translateY={translateY}>
+                    <PressableWithoutFeedback
+                        accessibilityLabel={bodyText}
+                        onPress={() => fling(INACTIVE_POSITION_Y)}
+                    >
+                        <View style={styles.growlNotificationBox}>
+                            <Icon
+                                src={types[type].icon}
+                                fill={types[type].iconColor}
+                            />
+                            <Text style={styles.growlNotificationText}>{bodyText}</Text>
+                        </View>
+                    </PressableWithoutFeedback>
+                </GrowlNotificationContainer>
+            </View>
+        </FlingGestureHandler>
+    );
 }
+
+GrowlNotification.displayName = 'GrowlNotification';
 
 export default GrowlNotification;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

Simple migration of the class component into the functional component with some minor improvement like moving `translateY` variable outside the component because it does not change anywhere.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/16154
PROPOSAL: 


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Log in to the App
2. Go to Settings -> Payments
3. Click "Add payment method" button
4. Choose PayPal.me
5. Provide PayPal username (might be just "test" or smth)
6. Click "Add PayPal account" button
7. Observe, if the toast message appears and then, after few seconds, disappears

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Same as above

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
8. Upload an image via copy paste
9. Verify a modal appears displaying a preview of that image
--->

Same as above

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://github.com/Expensify/App/assets/7771498/64bf5de1-9c2c-43ed-9b31-24965d98e066

</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://github.com/Expensify/App/assets/7771498/51810e21-a5ec-42d3-9796-9330e6476fe5

</details>

<details>
<summary>Mobile Web - Safari</summary>

https://github.com/Expensify/App/assets/7771498/b3dfd01b-8f94-4d1c-9b45-f50fb1638a44

</details>

<details>
<summary>Desktop</summary>

https://github.com/Expensify/App/assets/7771498/8ddac5d0-beec-4781-bd94-acde1e24d012

</details>

<details>
<summary>iOS</summary>

https://github.com/Expensify/App/assets/7771498/c0b55969-c460-4783-8944-9836ea9206c8

</details>

<details>
<summary>Android</summary>

https://github.com/Expensify/App/assets/7771498/ca4efba1-9fe8-400c-a1f1-068784743ad0

</details>
