### PR TITLE
Fix crash app when opening split bill detail page by deep link

### DIFF
--- a/src/pages/home/report/withReportAndReportActionOrNotFound.js
+++ b/src/pages/home/report/withReportAndReportActionOrNotFound.js
@@ -1,0 +1,125 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import {withOnyx} from 'react-native-onyx';
+import _ from 'underscore';
+import getComponentDisplayName from '../../../libs/getComponentDisplayName';
+import NotFoundPage from '../../ErrorPage/NotFoundPage';
+import ONYXKEYS from '../../../ONYXKEYS';
+import reportPropTypes from '../../reportPropTypes';
+import reportActionPropTypes from './reportActionPropTypes';
+import FullscreenLoadingIndicator from '../../../components/FullscreenLoadingIndicator';
+import * as ReportUtils from '../../../libs/ReportUtils';
+import * as ReportActionsUtils from '../../../libs/ReportActionsUtils';
+
+export default function (WrappedComponent) {
+    const propTypes = {
+        /** The HOC takes an optional ref as a prop and passes it as a ref to the wrapped component.
+         * That way, if a ref is passed to a component wrapped in the HOC, the ref is a reference to the wrapped component, not the HOC. */
+        forwardedRef: PropTypes.func,
+
+        /** The report currently being looked at */
+        report: reportPropTypes,
+
+        /** Array of report actions for this report */
+        reportActions: PropTypes.shape(reportActionPropTypes),
+
+        /** The policies which the user has access to */
+        policies: PropTypes.objectOf(
+            PropTypes.shape({
+                /** The policy name */
+                name: PropTypes.string,
+
+                /** The type of the policy */
+                type: PropTypes.string,
+            }),
+        ),
+
+        /** Route params */
+        route: PropTypes.shape({
+            params: PropTypes.shape({
+                /** Report ID passed via route */
+                reportID: PropTypes.string,
+
+                /** ReportActionID passed via route */
+                reportActionID: PropTypes.string,
+            }),
+        }).isRequired,
+
+        /** Beta features list */
+        betas: PropTypes.arrayOf(PropTypes.string),
+
+        /** Indicated whether the report data is loading */
+        isLoadingReportData: PropTypes.bool,
+    };
+
+    const defaultProps = {
+        forwardedRef: () => {},
+        reportActions: {},
+        report: {
+            isLoadingReportActions: true,
+        },
+        policies: {},
+        betas: [],
+        isLoadingReportData: true,
+    };
+
+    // eslint-disable-next-line rulesdir/no-negated-variables
+    function WithReportAndReportActionOrNotFound(props) {
+        const isLoadingReport = props.isLoadingReportData && (_.isEmpty(props.report) || !props.report.reportID);
+        const shouldHideReport = !isLoadingReport && (_.isEmpty(props.report) || !props.report.reportID || !ReportUtils.canAccessReport(props.report, props.policies, props.betas));
+
+        let reportAction = props.reportActions[`${props.route.params.reportActionID.toString()}`];
+        // Handle threads if needed
+        if (reportAction === undefined || reportAction.reportActionID === undefined) {
+            reportAction = ReportActionsUtils.getParentReportAction(props.report);
+        }
+        const isLoadingReportAction = _.isEmpty(props.reportActions) || (props.report.isLoadingReportActions && _.isEmpty(reportAction));
+
+        if ((isLoadingReport || isLoadingReportAction) && !shouldHideReport) {
+            return <FullscreenLoadingIndicator />;
+        }
+        if (shouldHideReport || _.isEmpty(reportAction)) {
+            return <NotFoundPage />;
+        }
+        const rest = _.omit(props, ['forwardedRef']);
+        return (
+            <WrappedComponent
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                {...rest}
+                ref={props.forwardedRef}
+            />
+        );
+    }
+
+    WithReportAndReportActionOrNotFound.propTypes = propTypes;
+    WithReportAndReportActionOrNotFound.defaultProps = defaultProps;
+    WithReportAndReportActionOrNotFound.displayName = `withReportAndReportActionOrNotFound(${getComponentDisplayName(WrappedComponent)})`;
+
+    // eslint-disable-next-line rulesdir/no-negated-variables
+    const withReportAndReportActionOrNotFound = React.forwardRef((props, ref) => (
+        <WithReportAndReportActionOrNotFound
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            {...props}
+            forwardedRef={ref}
+        />
+    ));
+
+    return withOnyx({
+        report: {
+            key: ({route}) => `${ONYXKEYS.COLLECTION.REPORT}${route.params.reportID}`,
+        },
+        isLoadingReportData: {
+            key: ONYXKEYS.IS_LOADING_REPORT_DATA,
+        },
+        betas: {
+            key: ONYXKEYS.BETAS,
+        },
+        policies: {
+            key: ONYXKEYS.COLLECTION.POLICY,
+        },
+        reportActions: {
+            key: ({route}) => `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${route.params.reportID}`,
+            canEvict: false,
+        },
+    })(withReportAndReportActionOrNotFound);
+}

--- a/src/pages/home/report/withReportAndReportActionOrNotFound.js
+++ b/src/pages/home/report/withReportAndReportActionOrNotFound.js
@@ -89,8 +89,7 @@ export default function (WrappedComponent) {
                 return;
             }
             Report.openReport(props.route.params.reportID);
-            // eslint-disable-next-line react-hooks/exhaustive-deps
-        }, []);
+        }, [props.report, props.isSmallScreenWidth, props.route.params.reportID, reportAction]);
 
         // Perform all the loading checks
         const isLoadingReport = props.isLoadingReportData && (_.isEmpty(props.report) || !props.report.reportID);

--- a/src/pages/home/report/withReportAndReportActionOrNotFound.js
+++ b/src/pages/home/report/withReportAndReportActionOrNotFound.js
@@ -89,7 +89,8 @@ export default function (WrappedComponent) {
                 return;
             }
             Report.openReport(props.route.params.reportID);
-        }, [props.report, props.isSmallScreenWidth, props.route.params.reportID, reportAction]);
+            // eslint-disable-next-line react-hooks/exhaustive-deps
+        }, [props.isSmallScreenWidth, props.route.params.reportID]);
 
         // Perform all the loading checks
         const isLoadingReport = props.isLoadingReportData && (_.isEmpty(props.report) || !props.report.reportID);

--- a/src/pages/home/report/withReportAndReportActionOrNotFound.js
+++ b/src/pages/home/report/withReportAndReportActionOrNotFound.js
@@ -69,16 +69,6 @@ export default function (WrappedComponent) {
 
     // eslint-disable-next-line rulesdir/no-negated-variables
     function WithReportAndReportActionOrNotFound(props) {
-        // For small screen, we don't call openReport API when we go to a sub report page by deeplink
-        // So we need to call openReport here for small screen
-        useEffect(() => {
-            if (!props.isSmallScreenWidth || !_.isEmpty(props.report)) {
-                return;
-            }
-            Report.openReport(props.route.params.reportID);
-            // eslint-disable-next-line react-hooks/exhaustive-deps
-        }, []);
-
         const getReportAction = useCallback(() => {
             let reportAction = props.reportActions[`${props.route.params.reportActionID}`];
 
@@ -91,6 +81,16 @@ export default function (WrappedComponent) {
         }, [props.report, props.reportActions, props.route.params.reportActionID]);
 
         const reportAction = getReportAction();
+
+        // For small screen, we don't call openReport API when we go to a sub report page by deeplink
+        // So we need to call openReport here for small screen
+        useEffect(() => {
+            if (!props.isSmallScreenWidth || (!_.isEmpty(props.report) && !_.isEmpty(reportAction))) {
+                return;
+            }
+            Report.openReport(props.route.params.reportID);
+            // eslint-disable-next-line react-hooks/exhaustive-deps
+        }, []);
 
         // Perform all the loading checks
         const isLoadingReport = props.isLoadingReportData && (_.isEmpty(props.report) || !props.report.reportID);

--- a/src/pages/iou/SplitBillDetailsPage.js
+++ b/src/pages/iou/SplitBillDetailsPage.js
@@ -14,7 +14,7 @@ import withLocalize, {withLocalizePropTypes} from '../../components/withLocalize
 import compose from '../../libs/compose';
 import reportActionPropTypes from '../home/report/reportActionPropTypes';
 import reportPropTypes from '../reportPropTypes';
-import withReportOrNotFound from '../home/report/withReportOrNotFound';
+import withReportAndReportActionOrNotFound from '../home/report/withReportAndReportActionOrNotFound';
 import FullPageNotFoundView from '../../components/BlockingViews/FullPageNotFoundView';
 import CONST from '../../CONST';
 import HeaderWithBackButton from '../../components/HeaderWithBackButton';
@@ -49,18 +49,6 @@ const defaultProps = {
     personalDetails: {},
     reportActions: {},
 };
-
-/**
- * Get the reportID for the associated chatReport
- *
- * @param {Object} route
- * @param {Object} route.params
- * @param {String} route.params.reportID
- * @returns {String}
- */
-function getReportID(route) {
-    return route.params.reportID.toString();
-}
 
 function SplitBillDetailsPage(props) {
     const reportAction = props.reportActions[`${props.route.params.reportActionID.toString()}`];
@@ -108,14 +96,10 @@ SplitBillDetailsPage.displayName = 'SplitBillDetailsPage';
 
 export default compose(
     withLocalize,
-    withReportOrNotFound,
+    withReportAndReportActionOrNotFound,
     withOnyx({
         personalDetails: {
             key: ONYXKEYS.PERSONAL_DETAILS_LIST,
-        },
-        reportActions: {
-            key: ({route}) => `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${getReportID(route)}`,
-            canEvict: false,
         },
     }),
 )(SplitBillDetailsPage);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Fix crash app when opening split bill detail page by deep link
### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/23568
PROPOSAL: https://github.com/Expensify/App/issues/23568#issuecomment-1650314041


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Login with any account
2. Click on FAB > Split bill
3. Enter any amount and choose some users to create split bill
4. After the split bill is created, click on this to see split bill detail
5. Copy the URL
6. Sign out and sign in again with the URL above
7. Verify that the app doesn't crash and split bill detail appears after loading is complete
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
Need online to open the app by deep link
### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
8. Upload an image via copy paste
9. Verify a modal appears displaying a preview of that image
--->
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Login with any account
2. Click on FAB > Split bill
3. Enter any amount and choose some users to create split bill
4. After the split bill is created, click on this to see split bill detail
5. Copy the URL
6. Sign out and sign in again with the URL above
7. Verify that the app doesn't crash and split bill detail appears after loading is complete
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos

Note: For native, if we open by deep link before login app still go to LHN after login successfully. So in the video for IOS and Android, we open by deep link after login.

<details>
<summary>Web</summary>


https://github.com/Expensify/App/assets/129500732/a1f4ceb8-5e71-4620-9683-f63e6271f7cb


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>


https://github.com/Expensify/App/assets/129500732/27ee9475-60f3-4e48-b56a-e58a1047587a


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>



https://github.com/Expensify/App/assets/129500732/292d9fa6-0570-4bce-bdd8-6a092e86cfb1




<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>


https://github.com/Expensify/App/assets/129500732/c0a4c2e0-130a-482f-868d-69e8d68331f3


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>


https://github.com/Expensify/App/assets/129500732/14b3e059-fb2a-4062-b736-c70ccb308e6d


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>


https://github.com/Expensify/App/assets/129500732/e8fbeaa6-2702-4e44-87ab-f0346c521641


<!-- add screenshots or videos here -->

</details>
