### PR TITLE
Fix: resetting the country/state picker when it is reopened

### DIFF
--- a/src/components/CountryPicker/index.js
+++ b/src/components/CountryPicker/index.js
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import lodashGet from 'lodash/get';
@@ -35,16 +35,12 @@ function CountryPicker({value, errorText, onInputChange, forwardedRef}) {
     const [isPickerVisible, setIsPickerVisible] = useState(false);
     const [searchValue, setSearchValue] = useState(lodashGet(allCountries, value, ''));
 
-    const updateSearchValue = useCallback((countries, currentValue) => {
-        setSearchValue(lodashGet(countries, currentValue, ''));
-    }, []);
-
     useEffect(() => {
-        updateSearchValue(allCountries, value);
-    }, [value, allCountries, updateSearchValue]);
+        setSearchValue(lodashGet(countries, currentValue, ''));
+    }, [value, allCountries]);
 
     const showPickerModal = () => {
-        updateSearchValue(allCountries, value);
+        setSearchValue(lodashGet(countries, currentValue, ''));
         setIsPickerVisible(true);
     };
 

--- a/src/components/CountryPicker/index.js
+++ b/src/components/CountryPicker/index.js
@@ -36,10 +36,11 @@ function CountryPicker({value, errorText, onInputChange, forwardedRef}) {
     const [searchValue, setSearchValue] = useState(lodashGet(allCountries, value, ''));
 
     useEffect(() => {
-        setSearchValue(lodashGet(allCountries, value, ''));
+        updateSearchValue();
     }, [value, allCountries]);
 
     const showPickerModal = () => {
+        updateSearchValue();
         setIsPickerVisible(true);
     };
 
@@ -51,6 +52,10 @@ function CountryPicker({value, errorText, onInputChange, forwardedRef}) {
         onInputChange(country.value);
         hidePickerModal();
     };
+
+    const updateSearchValue = () => {
+        setSearchValue(lodashGet(allCountries, value, ''));
+    }
 
     const title = allCountries[value] || '';
     const descStyle = title.length === 0 ? styles.textNormal : null;

--- a/src/components/CountryPicker/index.js
+++ b/src/components/CountryPicker/index.js
@@ -36,11 +36,11 @@ function CountryPicker({value, errorText, onInputChange, forwardedRef}) {
     const [searchValue, setSearchValue] = useState(lodashGet(allCountries, value, ''));
 
     useEffect(() => {
-        setSearchValue(lodashGet(countries, currentValue, ''));
+        setSearchValue(lodashGet(allCountries, value, ''));
     }, [value, allCountries]);
 
     const showPickerModal = () => {
-        setSearchValue(lodashGet(countries, currentValue, ''));
+        setSearchValue(lodashGet(allCountries, value, ''));
         setIsPickerVisible(true);
     };
 

--- a/src/components/CountryPicker/index.js
+++ b/src/components/CountryPicker/index.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import lodashGet from 'lodash/get';
@@ -35,12 +35,16 @@ function CountryPicker({value, errorText, onInputChange, forwardedRef}) {
     const [isPickerVisible, setIsPickerVisible] = useState(false);
     const [searchValue, setSearchValue] = useState(lodashGet(allCountries, value, ''));
 
+    const updateSearchValue = useCallback((countries, currentValue) => {
+        setSearchValue(lodashGet(countries, currentValue, ''));
+    }, []);
+
     useEffect(() => {
-        updateSearchValue();
-    }, [value, allCountries]);
+        updateSearchValue(allCountries, value);
+    }, [value, allCountries, updateSearchValue]);
 
     const showPickerModal = () => {
-        updateSearchValue();
+        updateSearchValue(allCountries, value);
         setIsPickerVisible(true);
     };
 
@@ -52,10 +56,6 @@ function CountryPicker({value, errorText, onInputChange, forwardedRef}) {
         onInputChange(country.value);
         hidePickerModal();
     };
-
-    const updateSearchValue = () => {
-        setSearchValue(lodashGet(allCountries, value, ''));
-    }
 
     const title = allCountries[value] || '';
     const descStyle = title.length === 0 ? styles.textNormal : null;

--- a/src/components/StatePicker/index.js
+++ b/src/components/StatePicker/index.js
@@ -36,11 +36,11 @@ function StatePicker({value, errorText, onInputChange, forwardedRef}) {
     const [searchValue, setSearchValue] = useState(lodashGet(allStates, `${value}.stateName`, ''));
 
     useEffect(() => {
-        setSearchValue(lodashGet(states, `${currentValue}.stateName`, ''));
+        setSearchValue(lodashGet(allStates, `${value}.stateName`, ''));
     }, [value, allStates]);
 
     const showPickerModal = () => {
-        setSearchValue(lodashGet(states, `${currentValue}.stateName`, ''));
+        setSearchValue(lodashGet(allStates, `${value}.stateName`, ''));
         setIsPickerVisible(true);
     };
 

--- a/src/components/StatePicker/index.js
+++ b/src/components/StatePicker/index.js
@@ -36,10 +36,11 @@ function StatePicker({value, errorText, onInputChange, forwardedRef}) {
     const [searchValue, setSearchValue] = useState(lodashGet(allStates, `${value}.stateName`, ''));
 
     useEffect(() => {
-        setSearchValue(lodashGet(allStates, `${value}.stateName`, ''));
+        updateSearchValue();
     }, [value, allStates]);
 
     const showPickerModal = () => {
+        updateSearchValue();
         setIsPickerVisible(true);
     };
 
@@ -51,6 +52,10 @@ function StatePicker({value, errorText, onInputChange, forwardedRef}) {
         onInputChange(state.value);
         hidePickerModal();
     };
+
+    const updateSearchValue = () => {
+        setSearchValue(lodashGet(allStates, `${value}.stateName`, ''));
+    }
 
     const title = allStates[value] ? allStates[value].stateName : '';
     const descStyle = title.length === 0 ? styles.textNormal : null;

--- a/src/components/StatePicker/index.js
+++ b/src/components/StatePicker/index.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 import {View} from 'react-native';
 import lodashGet from 'lodash/get';
 import PropTypes from 'prop-types';
@@ -35,12 +35,16 @@ function StatePicker({value, errorText, onInputChange, forwardedRef}) {
     const [isPickerVisible, setIsPickerVisible] = useState(false);
     const [searchValue, setSearchValue] = useState(lodashGet(allStates, `${value}.stateName`, ''));
 
+    const updateSearchValue = useCallback((states, currentValue) => {
+        setSearchValue(lodashGet(states, `${currentValue}.stateName`, ''));
+    }, []);
+
     useEffect(() => {
-        updateSearchValue();
-    }, [value, allStates]);
+        updateSearchValue(allStates, value);
+    }, [value, allStates, updateSearchValue]);
 
     const showPickerModal = () => {
-        updateSearchValue();
+        updateSearchValue(allStates, value);
         setIsPickerVisible(true);
     };
 
@@ -52,10 +56,6 @@ function StatePicker({value, errorText, onInputChange, forwardedRef}) {
         onInputChange(state.value);
         hidePickerModal();
     };
-
-    const updateSearchValue = () => {
-        setSearchValue(lodashGet(allStates, `${value}.stateName`, ''));
-    }
 
     const title = allStates[value] ? allStates[value].stateName : '';
     const descStyle = title.length === 0 ? styles.textNormal : null;

--- a/src/components/StatePicker/index.js
+++ b/src/components/StatePicker/index.js
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import {View} from 'react-native';
 import lodashGet from 'lodash/get';
 import PropTypes from 'prop-types';
@@ -35,16 +35,12 @@ function StatePicker({value, errorText, onInputChange, forwardedRef}) {
     const [isPickerVisible, setIsPickerVisible] = useState(false);
     const [searchValue, setSearchValue] = useState(lodashGet(allStates, `${value}.stateName`, ''));
 
-    const updateSearchValue = useCallback((states, currentValue) => {
-        setSearchValue(lodashGet(states, `${currentValue}.stateName`, ''));
-    }, []);
-
     useEffect(() => {
-        updateSearchValue(allStates, value);
-    }, [value, allStates, updateSearchValue]);
+        setSearchValue(lodashGet(states, `${currentValue}.stateName`, ''));
+    }, [value, allStates]);
 
     const showPickerModal = () => {
-        updateSearchValue(allStates, value);
+        setSearchValue(lodashGet(states, `${currentValue}.stateName`, ''));
         setIsPickerVisible(true);
     };
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
The values of the country/state pickers would remain cleared after reopening the picker

**Please note:** the state picker is broken in Storybook due to an issue with HeaderWithBackButton that I have reported [here](https://app.slack.com/client/T03SC9DTT/C049HHMV9SM/thread/C049HHMV9SM-1690924765.915249). This issue exists on [staging](https://staging.new.expensify.com/docs/index.html?path=/story/components-form--default). As [suggested](https://app.slack.com/client/T03SC9DTT/C01GTK53T8Q/thread/C01GTK53T8Q-1690918046.950089) by Jack Nam I still marked the Storybook checkbox as completed, since that issue is not caused by this PR.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/23768
PROPOSAL: https://github.com/Expensify/App/issues/23768#issuecomment-1655803335


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
#### Testing the country selector
1. Go to settings > profile > personal details > home address
2. Click on country to open the country selector
3. Pick any country
4. Reopen the country selector
5. Clear the input field and close the selector
6. Reopen the country selector
7. Verify that the country you selected is selected by default

#### Testing the state selector
1. Go to settings > profile > personal details > home address
2. Click on state to open the state selector
3. Select any state
4. Reopen the state selector
5. Clear the input field and close the selector
6. Reopen the state selector
7. Verify that the state you selected is selected by default

- [X] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Same as regular steps

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
17. Upload an image via copy paste
18. Verify a modal appears displaying a preview of that image
--->

Same as regular steps

- [X] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android / native
    - [X] Android / Chrome
    - [X] iOS / native
    - [X] iOS / Safari
    - [X] MacOS / Chrome / Safari
    - [X] MacOS / Desktop
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [X] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [X] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If a new component is created I verified that:
    - [X] A similar component doesn't exist in the codebase
    - [X] All props are defined accurately and each prop has a `/** comment above it */`
    - [X] The file is named correctly
    - [X] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [X] The only data being stored in the state is data necessary for rendering and nothing else
    - [X] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [X] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [X] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [X] All JSX used for rendering exists in the render method
    - [X] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [X] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [X] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/138504087/dedb138f-d097-4aad-b7e3-92d835ab84a1

https://github.com/Expensify/App/assets/138504087/9f0c8499-4589-464f-9870-f62e3f472c03

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/138504087/0691c436-6cd1-4ecb-9724-2aee6775f921

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/138504087/3251c58a-e47d-4fe7-82a9-0154a1050a32

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/138504087/d00d9950-2b4e-455b-8edd-bf7672186d71

https://github.com/Expensify/App/assets/138504087/4cb1ab38-aca1-4f82-81c6-cd44ca039bd8

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/138504087/1aa3d793-733d-4967-9adf-56a78fe9e9fc

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/138504087/32f2b94a-74a6-410c-889e-12418091eb1d

</details>
