### PR TITLE
Fix: update AttachmentModal translation

### DIFF
--- a/src/components/AttachmentModal.js
+++ b/src/components/AttachmentModal.js
@@ -184,25 +184,25 @@ function AttachmentModal(props) {
         (_file) => {
             const {fileExtension} = FileUtils.splitExtensionFromFileName(lodashGet(_file, 'name', ''));
             if (_.contains(CONST.API_ATTACHMENT_VALIDATIONS.UNALLOWED_EXTENSIONS, fileExtension.toLowerCase())) {
-                const invalidReason = props.translate('attachmentPicker.notAllowedExtension');
+                const invalidReason = 'attachmentPicker.notAllowedExtension';
 
                 setIsAttachmentInvalid(true);
-                setAttachmentInvalidReasonTitle(props.translate('attachmentPicker.wrongFileType'));
+                setAttachmentInvalidReasonTitle('attachmentPicker.wrongFileType');
                 setAttachmentInvalidReason(invalidReason);
                 return false;
             }
 
             if (lodashGet(_file, 'size', 0) > CONST.API_ATTACHMENT_VALIDATIONS.MAX_SIZE) {
                 setIsAttachmentInvalid(true);
-                setAttachmentInvalidReasonTitle(props.translate('attachmentPicker.attachmentTooLarge'));
-                setAttachmentInvalidReason(props.translate('attachmentPicker.sizeExceeded'));
+                setAttachmentInvalidReasonTitle('attachmentPicker.attachmentTooLarge');
+                setAttachmentInvalidReason('attachmentPicker.sizeExceeded');
                 return false;
             }
 
             if (lodashGet(_file, 'size', 0) < CONST.API_ATTACHMENT_VALIDATIONS.MIN_SIZE) {
                 setIsAttachmentInvalid(true);
-                setAttachmentInvalidReasonTitle(props.translate('attachmentPicker.attachmentTooSmall'));
-                setAttachmentInvalidReason(props.translate('attachmentPicker.sizeNotMet'));
+                setAttachmentInvalidReasonTitle('attachmentPicker.attachmentTooSmall');
+                setAttachmentInvalidReason('attachmentPicker.sizeNotMet');
                 return false;
             }
 
@@ -359,11 +359,11 @@ function AttachmentModal(props) {
             </Modal>
 
             <ConfirmModal
-                title={attachmentInvalidReasonTitle}
+                title={attachmentInvalidReasonTitle ? props.translate(attachmentInvalidReasonTitle) : ''}
                 onConfirm={closeConfirmModal}
                 onCancel={closeConfirmModal}
                 isVisible={isAttachmentInvalid}
-                prompt={attachmentInvalidReason}
+                prompt={attachmentInvalidReason ? props.translate(attachmentInvalidReason) : ''}
                 confirmText={props.translate('common.close')}
                 shouldShowCancelButton={false}
             />

--- a/src/components/AvatarWithImagePicker.js
+++ b/src/components/AvatarWithImagePicker.js
@@ -110,6 +110,7 @@ class AvatarWithImagePicker extends React.Component {
         this.state = {
             isMenuVisible: false,
             validationError: null,
+            phraseParam: {},
             isAvatarCropModalOpen: false,
             imageName: '',
             imageUri: '',
@@ -139,9 +140,10 @@ class AvatarWithImagePicker extends React.Component {
 
     /**
      * @param {String} error
+     * @param {Object} phraseParam
      */
-    setError(error) {
-        this.setState({validationError: error});
+    setError(error, phraseParam) {
+        this.setState({validationError: error, phraseParam});
     }
 
     /**
@@ -188,30 +190,29 @@ class AvatarWithImagePicker extends React.Component {
      */
     showAvatarCropModal(image) {
         if (!this.isValidExtension(image)) {
-            this.setError(this.props.translate('avatarWithImagePicker.notAllowedExtension', {allowedExtensions: CONST.AVATAR_ALLOWED_EXTENSIONS}));
+            this.setError('avatarWithImagePicker.notAllowedExtension', {allowedExtensions: CONST.AVATAR_ALLOWED_EXTENSIONS});
             return;
         }
         if (!this.isValidSize(image)) {
-            this.setError(this.props.translate('avatarWithImagePicker.sizeExceeded', {maxUploadSizeInMB: CONST.AVATAR_MAX_ATTACHMENT_SIZE / (1024 * 1024)}));
+            this.setError('avatarWithImagePicker.sizeExceeded', {maxUploadSizeInMB: CONST.AVATAR_MAX_ATTACHMENT_SIZE / (1024 * 1024)});
             return;
         }
 
         this.isValidResolution(image).then((isValidResolution) => {
             if (!isValidResolution) {
-                this.setError(
-                    this.props.translate('avatarWithImagePicker.resolutionConstraints', {
-                        minHeightInPx: CONST.AVATAR_MIN_HEIGHT_PX,
-                        minWidthInPx: CONST.AVATAR_MIN_WIDTH_PX,
-                        maxHeightInPx: CONST.AVATAR_MAX_HEIGHT_PX,
-                        maxWidthInPx: CONST.AVATAR_MAX_WIDTH_PX,
-                    }),
-                );
+                this.setError('avatarWithImagePicker.resolutionConstraints', {
+                    minHeightInPx: CONST.AVATAR_MIN_HEIGHT_PX,
+                    minWidthInPx: CONST.AVATAR_MIN_WIDTH_PX,
+                    maxHeightInPx: CONST.AVATAR_MAX_HEIGHT_PX,
+                    maxWidthInPx: CONST.AVATAR_MAX_WIDTH_PX,
+                });
                 return;
             }
 
             this.setState({
                 isAvatarCropModalOpen: true,
                 validationError: null,
+                phraseParam: {},
                 isMenuVisible: false,
                 imageUri: image.uri,
                 imageName: image.name,
@@ -249,7 +250,7 @@ class AvatarWithImagePicker extends React.Component {
                 icon: Expensicons.Trashcan,
                 text: this.props.translate('avatarWithImagePicker.removePhoto'),
                 onSelected: () => {
-                    this.setError(null);
+                    this.setError(null, {});
                     this.props.onImageRemoved();
                 },
             });
@@ -323,7 +324,7 @@ class AvatarWithImagePicker extends React.Component {
                 {this.state.validationError && (
                     <DotIndicatorMessage
                         style={[styles.mt6]}
-                        messages={{0: this.state.validationError}}
+                        messages={{0: this.props.translate(this.state.validationError, this.state.phraseParam)}}
                         type="error"
                     />
                 )}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Fix Attachment ValidationModal texts are not translated to Spanish
### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->
$ https://github.com/Expensify/App/issues/22665
PROPOSAL: https://github.com/Expensify/App/issues/22665#issuecomment-1643628510


### Tests
For AttachmentModal:
1. Login in 2 tabs.
2. From the first tab, drag a large video into composer ( > 24MB), the ValidationModal will show.
3. From second tab, change language to Spanish.
4. Now go back to the first tab. Verify that ValidationModal 's texts are translated to Spanish.

For AvatarWithImagePicker:
1. Login in 2 tabs.
2. From the first tab, go to Setting => Profile => Upload photo, choose a invalid image size. DotIndicator message will show.
3.  From second tab, change language to Spanish.
4. Now go back to the first tab. Verify that DotIndicator 's text is translated to Spanish.

- [x] Verify that no errors appear in the JS console

### Offline tests
Bug is not related to offline mode itself. No extra steps needed.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
6. Upload an image via copy paste
7. Verify a modal appears displaying a preview of that image
--->
For AttachmentModal:
1. Login in 2 tabs.
2. From the first tab, drag a large video into composer ( > 24MB), the ValidationModal will show.
3. From second tab, change language to Spanish.
4. Now go back to the first tab. Verify that ValidationModal 's texts are translated to Spanish.

For AvatarWithImagePicker:
1. Login in 2 tabs.
2. From the first tab, go to Setting => Profile => Upload photo, choose a invalid image size. DotIndicator message will show.
3.  From second tab, change language to Spanish.
4. Now go back to the first tab. Verify that DotIndicator 's text is translated to Spanish.
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

<details><summary>Web</summary>


https://github.com/Expensify/App/assets/16502320/75505d3a-1bbc-41cb-9ee7-1272b5b26633


https://github.com/Expensify/App/assets/16502320/599ea156-e649-4490-890c-103a3f11b926




</details>





<details><summary>Mobile Web - Chrome</summary>

https://github.com/Expensify/App/assets/16502320/056211f7-a92d-4b6e-8a29-a1cd397810bd

https://github.com/Expensify/App/assets/16502320/3b4b868a-5847-4c29-8791-710909b8e874


</details>







<details><summary> Mobile Web - Safari</summary>


https://github.com/Expensify/App/assets/16502320/b492ff67-3c69-443d-a284-a90e4a83c6f5


https://github.com/Expensify/App/assets/16502320/d957627c-7af9-40b5-8d70-5e947f74d33b




</details>




<details><summary>Desktop</summary>


https://github.com/Expensify/App/assets/16502320/2716a9ea-e658-406e-ad5d-fcb82c0be00b


https://github.com/Expensify/App/assets/16502320/91ce3f81-8910-45a1-8f62-a7b701bc3b3f




</details>





<details><summary>IOS</summary>

https://github.com/Expensify/App/assets/16502320/deec1855-aca9-418d-9744-4e4ce8df67eb


https://github.com/Expensify/App/assets/16502320/2227b0c6-b76b-44ab-a676-9b77b32624bd





</details>





<details><summary>Android</summary>


https://github.com/Expensify/App/assets/16502320/056211f7-a92d-4b6e-8a29-a1cd397810bd


https://github.com/Expensify/App/assets/16502320/3b4b868a-5847-4c29-8791-710909b8e874




</details>









