### PR TITLE
Fix link preview size

### DIFF
--- a/src/pages/home/report/LinkPreviewer.js
+++ b/src/pages/home/report/LinkPreviewer.js
@@ -12,8 +12,9 @@ import variables from '../../../styles/variables';
 import colors from '../../../styles/colors';
 
 const IMAGE_TYPES = ['jpg', 'jpeg', 'png'];
-const MAX_IMAGE_SIZE = 350;
-const SMALL_SCREEN_MAX_IMAGE_SIZE = 180;
+const LARGE_SCREEN_MAX_IMAGE_SIZE = 240; // used for both width and height on large screens
+const SMALL_SCREEN_MAX_IMAGE_HEIGHT = 180;
+const SMALL_SCREEN_MAX_IMAGE_WIDTH = 340;
 
 const propTypes = {
     /** Data about links provided in message. */
@@ -67,12 +68,15 @@ const defaultProps = {
 };
 
 function LinkPreviewer(props) {
-    const {windowHeight} = useWindowDimensions();
-    const [maxImageSize, setMaxImageSize] = useState(MAX_IMAGE_SIZE);
+    const {isSmallScreenWidth} = useWindowDimensions();
+    const [maxImageSize, setMaxImageSize] = useState({height: LARGE_SCREEN_MAX_IMAGE_SIZE, width: LARGE_SCREEN_MAX_IMAGE_SIZE});
 
     useEffect(() => {
-        setMaxImageSize(windowHeight / 2 < MAX_IMAGE_SIZE ? SMALL_SCREEN_MAX_IMAGE_SIZE : MAX_IMAGE_SIZE);
-    }, [windowHeight]);
+        setMaxImageSize({
+            height: isSmallScreenWidth ? SMALL_SCREEN_MAX_IMAGE_HEIGHT : LARGE_SCREEN_MAX_IMAGE_SIZE,
+            width: isSmallScreenWidth ? SMALL_SCREEN_MAX_IMAGE_WIDTH : LARGE_SCREEN_MAX_IMAGE_SIZE,
+        });
+    }, [isSmallScreenWidth]);
 
     return _.map(
         _.take(uniqBy(props.linkMetadata, 'url'), props.maxAmountOfPreviews >= 0 ? Math.min(props.maxAmountOfPreviews, props.linkMetadata.length) : props.linkMetadata.length),
@@ -120,10 +124,10 @@ function LinkPreviewer(props) {
                                     styles.linkPreviewImage,
                                     {
                                         aspectRatio: image.width / image.height,
-                                        maxHeight: Math.min(image.height, maxImageSize),
+                                        maxHeight: Math.min(image.height, maxImageSize.height),
 
                                         // Calculate maximum width when image is too tall, so it doesn't move away from left
-                                        maxWidth: Math.min((Math.min(image.height, maxImageSize) / image.height) * image.width, maxImageSize),
+                                        maxWidth: Math.min((Math.min(image.height, maxImageSize.height) / image.height) * image.width, maxImageSize.width),
                                     },
                                 ]}
                                 resizeMode="contain"

--- a/src/pages/home/report/LinkPreviewer.js
+++ b/src/pages/home/report/LinkPreviewer.js
@@ -1,9 +1,8 @@
-import React, {useState, useEffect} from 'react';
+import React from 'react';
 import {View, Image} from 'react-native';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
 import {uniqBy} from 'lodash';
-import useWindowDimensions from '../../../hooks/useWindowDimensions';
 import Text from '../../../components/Text';
 import TextLink from '../../../components/TextLink';
 import * as StyleUtils from '../../../styles/StyleUtils';
@@ -12,9 +11,8 @@ import variables from '../../../styles/variables';
 import colors from '../../../styles/colors';
 
 const IMAGE_TYPES = ['jpg', 'jpeg', 'png'];
-const LARGE_SCREEN_MAX_IMAGE_SIZE = 240; // used for both width and height on large screens
-const SMALL_SCREEN_MAX_IMAGE_HEIGHT = 180;
-const SMALL_SCREEN_MAX_IMAGE_WIDTH = 340;
+const MAX_IMAGE_HEIGHT = 180;
+const MAX_IMAGE_WIDTH = 340;
 
 const propTypes = {
     /** Data about links provided in message. */
@@ -68,16 +66,6 @@ const defaultProps = {
 };
 
 function LinkPreviewer(props) {
-    const {isSmallScreenWidth} = useWindowDimensions();
-    const [maxImageSize, setMaxImageSize] = useState({height: LARGE_SCREEN_MAX_IMAGE_SIZE, width: LARGE_SCREEN_MAX_IMAGE_SIZE});
-
-    useEffect(() => {
-        setMaxImageSize({
-            height: isSmallScreenWidth ? SMALL_SCREEN_MAX_IMAGE_HEIGHT : LARGE_SCREEN_MAX_IMAGE_SIZE,
-            width: isSmallScreenWidth ? SMALL_SCREEN_MAX_IMAGE_WIDTH : LARGE_SCREEN_MAX_IMAGE_SIZE,
-        });
-    }, [isSmallScreenWidth]);
-
     return _.map(
         _.take(uniqBy(props.linkMetadata, 'url'), props.maxAmountOfPreviews >= 0 ? Math.min(props.maxAmountOfPreviews, props.linkMetadata.length) : props.linkMetadata.length),
         (linkData) => {
@@ -124,10 +112,10 @@ function LinkPreviewer(props) {
                                     styles.linkPreviewImage,
                                     {
                                         aspectRatio: image.width / image.height,
-                                        maxHeight: Math.min(image.height, maxImageSize.height),
+                                        maxHeight: Math.min(image.height, MAX_IMAGE_HEIGHT),
 
                                         // Calculate maximum width when image is too tall, so it doesn't move away from left
-                                        maxWidth: Math.min((Math.min(image.height, maxImageSize.height) / image.height) * image.width, maxImageSize.width),
+                                        maxWidth: Math.min((Math.min(image.height, MAX_IMAGE_HEIGHT) / image.height) * image.width, MAX_IMAGE_WIDTH),
                                     },
                                 ]}
                                 resizeMode="contain"


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Size of link previews was very big, this PR reduces it for both mobiles and desktops.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/23179
PROPOSAL: https://github.com/Expensify/App/issues/23179#issuecomment-1642264461


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
You can use the following links to compare the size of link previews - `facebook.com`, `youtube.com`, `cnn.com`.
1. Send one or more of the links above in a chat.
2. Open the same chat on testing environment (staging for QA) and on prod (new.expensify.com).
3. Compare the size of link previews in testing and prod environment, size of preview should be lesser now. 
4. Here is the exact change in size -
**Before** -
Large screen (web/desktop app) - max width = 350px, max height = 350px
Small screen (apps/browsers) - max width = 180px, max height = 180px but this was only being applied on browser (chrome/safari) and not on apps because of wrong logic in code
**After** - 
On all screens sizes (mobile/desktop), preview size is same - max-width = 340px, max-height = 180px
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Same as above.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
6. Upload an image via copy paste
7. Verify a modal appears displaying a preview of that image
--->

Same as above. 

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

**Before followed by after**

<img width="400" alt="WEB_BEFORE1" src="https://github.com/Expensify/App/assets/31413407/e408076c-8b6b-4c03-82f1-a65e93c74502">
<img width="400" alt="image" src="https://github.com/Expensify/App/assets/31413407/9e9a0a4d-ca88-4b0c-8f32-fb1fa65ba28b">
<img width="400" alt="WEB_BEFORE2" src="https://github.com/Expensify/App/assets/31413407/55e7aee8-763f-4d42-8f31-41592baab1b4">
<img width="400" alt="image" src="https://github.com/Expensify/App/assets/31413407/2b4d535b-98cd-4938-a266-d88a83ccbe16">
</details>

<details>
<summary>Mobile Web - Chrome</summary>

**Before followed by after** - Here, mobile styles were being applied before as well, CNN preview was smaller because, max width was smaller (180px) and image also maintains the aspect ratio. Now, we have increased max width to 340px on all screens, so height is also allowed to be more (still less than max height 180px though).

<img width="400" alt="CHROME_BEFORE1" src="https://github.com/Expensify/App/assets/31413407/062fcea6-2b8a-4f3d-b743-825adafb00f3">
<img width="400" alt="CHROME_AFTER1" src="https://github.com/Expensify/App/assets/31413407/314ca5a3-a02e-4138-9a00-85953149ffea">
<img width="400" alt="CHROME_BEFORE2" src="https://github.com/Expensify/App/assets/31413407/58a193db-830e-41bf-a2ba-64c63d4a8e94">
<img width="400" alt="CHROME_AFTER2" src="https://github.com/Expensify/App/assets/31413407/9305d5fa-e2e5-4a44-b10a-fa6cc1278df1">


</details>

<details>
<summary>Mobile Web - Safari</summary>

**Before followed by after** - Here, mobile styles were being applied before as well

<img width="400" alt="SAFARI_BEFORE1" src="https://github.com/Expensify/App/assets/31413407/f9120f48-035c-4b4a-9ece-415ef10bd16d">
<img width="400" alt="SAFARI_AFTER1" src="https://github.com/Expensify/App/assets/31413407/1dd9ed78-690d-4faf-8eb7-ae61e0f20019">
<img width="400" alt="SAFARI_BEFORE2" src="https://github.com/Expensify/App/assets/31413407/29924d78-9bc9-4b30-ad31-2dfd16b82c18">
<img width="400" alt="SAFARI_AFTER2" src="https://github.com/Expensify/App/assets/31413407/c4430a09-6489-4fb9-900b-ddbc6a6e5b1b">



</details>

<details>
<summary>Desktop</summary>

**Before followed by after** -

<img width="400" alt="DESKTOP_BEFORE" src="https://github.com/Expensify/App/assets/31413407/8c6f85b1-df12-4dd8-adfe-ecc2f5153f2f">
<img width="400" alt="image" src="https://github.com/Expensify/App/assets/31413407/9d2eff03-1bce-4d00-a677-8fe55ba0b37a">
</details>

<details>
<summary>iOS</summary>

**Before followed by after** - Image also maintains the aspect ratio which also affects the width, height. See the formula.

<img width="400" alt="IOS_BEFORE1" src="https://github.com/Expensify/App/assets/31413407/8e5d18ad-d402-40b7-bc5a-ff4c74850d57">
<img width="400" alt="IOS_AFTER1" src="https://github.com/Expensify/App/assets/31413407/d306f984-76c5-4aa0-9321-8a74e320e434">
<img width="400" alt="IOS_BEFORE2" src="https://github.com/Expensify/App/assets/31413407/616961d0-bf1a-41f9-b797-698eb5716dc4">
<img width="400" alt="IOS_AFTER2" src="https://github.com/Expensify/App/assets/31413407/8095c8bc-856b-4b41-8f54-94e9450c4caa">


</details>

<details>
<summary>Android</summary>

**Before followed by after** -

<img width="400" alt="ANDROID_BEFORE1" src="https://github.com/Expensify/App/assets/31413407/65c13c7e-24a4-47e5-a1b6-bb14df0fda5f">
<img width="400" alt="ANDROID_AFTER1" src="https://github.com/Expensify/App/assets/31413407/0423b95c-593a-412c-b842-8e119fd66351">
<img width="400" alt="ANDROID_BEFORE2" src="https://github.com/Expensify/App/assets/31413407/0f6be700-28f9-4385-8127-cae8f548a30d">
<img width="400" alt="ANDROID_AFTER2" src="https://github.com/Expensify/App/assets/31413407/40db4d0d-442f-4858-aed2-3d9c03507aa6">

</details>
