### PR TITLE
Add delete confirmation modal to money request header

### DIFF
--- a/src/components/MoneyRequestHeader.js
+++ b/src/components/MoneyRequestHeader.js
@@ -55,7 +55,7 @@ const defaultProps = {
 
 function MoneyRequestHeader(props) {
     const {translate} = useLocalize();
-    const {isDeleteModalVisible, setIsDeleteModalVisible} = useState(false);
+    const [isDeleteModalVisible, setIsDeleteModalVisible] = useState(false);
     const moneyRequestReport = props.parentReport;
     const isSettled = ReportUtils.isSettled(moneyRequestReport.reportID);
     const policy = props.policies[`${ONYXKEYS.COLLECTION.POLICY}${props.report.policyID}`];
@@ -99,7 +99,7 @@ function MoneyRequestHeader(props) {
                 isVisible={isDeleteModalVisible}
                 onConfirm={deleteTransaction}
                 onCancel={() => setIsDeleteModalVisible(false)}
-                prompt={translate('reportActionContextMenu.deleteConfirmation', {action: this.state.reportAction})}
+                prompt={translate('iou.deleteConfirmation')}
                 confirmText={translate('common.delete')}
                 cancelText={translate('common.cancel')}
                 danger

--- a/src/components/MoneyRequestHeader.js
+++ b/src/components/MoneyRequestHeader.js
@@ -18,6 +18,7 @@ import * as Policy from '../libs/actions/Policy';
 import ONYXKEYS from '../ONYXKEYS';
 import * as IOU from '../libs/actions/IOU';
 import * as ReportActionsUtils from '../libs/ReportActionsUtils';
+import ConfirmModal from './ConfirmModal';
 
 const propTypes = {
     /** The report currently being looked at */
@@ -67,27 +68,44 @@ function MoneyRequestHeader(props) {
     }, [parentReportAction]);
 
     return (
-        <View style={[styles.pl0]}>
-            <HeaderWithBackButton
-                shouldShowAvatarWithDisplay
-                shouldShowPinButton={false}
-                shouldShowThreeDotsButton={!isPayer && !isSettled}
-                threeDotsMenuItems={[
-                    {
-                        icon: Expensicons.Trashcan,
-                        text: props.translate('reportActionContextMenu.deleteAction', {action: parentReportAction}),
-                        onSelected: deleteTransaction,
-                    },
-                ]}
-                threeDotsAnchorPosition={styles.threeDotsPopoverOffsetNoCloseButton(props.windowWidth)}
-                report={report}
-                policies={props.policies}
-                personalDetails={props.personalDetails}
-                shouldShowBackButton={props.isSmallScreenWidth}
-                onBackButtonPress={() => Navigation.goBack(ROUTES.HOME, false, true)}
-                shouldShowBorderBottom
+        <>
+            <View style={[styles.pl0]}>
+                <HeaderWithBackButton
+                    shouldShowAvatarWithDisplay
+                    shouldShowPinButton={false}
+                    shouldShowThreeDotsButton={!isPayer && !isSettled}
+                    threeDotsMenuItems={[
+                        {
+                            icon: Expensicons.Trashcan,
+                            text: props.translate('reportActionContextMenu.deleteAction', {action: parentReportAction}),
+                            onSelected: deleteTransaction,
+                        },
+                    ]}
+                    threeDotsAnchorPosition={styles.threeDotsPopoverOffsetNoCloseButton(props.windowWidth)}
+                    report={report}
+                    policies={props.policies}
+                    personalDetails={props.personalDetails}
+                    shouldShowBackButton={props.isSmallScreenWidth}
+                    onBackButtonPress={() => Navigation.goBack(ROUTES.HOME, false, true)}
+                    shouldShowBorderBottom
+                />
+            </View>
+            <ConfirmModal
+                title={this.props.translate('reportActionContextMenu.deleteAction', {action: this.state.reportAction})}
+                isVisible={this.state.isDeleteCommentConfirmModalVisible}
+                shouldSetModalVisibility={this.state.shouldSetModalVisibilityForDeleteConfirmation}
+                onConfirm={this.confirmDeleteAndHideModal}
+                onCancel={this.hideDeleteModal}
+                onModalHide={() => {
+                    this.setState({reportID: '0', reportAction: {}});
+                    this.callbackWhenDeleteModalHide();
+                }}
+                prompt={this.props.translate('reportActionContextMenu.deleteConfirmation', {action: this.state.reportAction})}
+                confirmText={this.props.translate('common.delete')}
+                cancelText={this.props.translate('common.cancel')}
+                danger
             />
-        </View>
+        </>
     );
 }
 

--- a/src/components/MoneyRequestHeader.js
+++ b/src/components/MoneyRequestHeader.js
@@ -1,4 +1,4 @@
-import React, {useCallback} from 'react';
+import React, {useState, useCallback} from 'react';
 import {withOnyx} from 'react-native-onyx';
 import {View} from 'react-native';
 import PropTypes from 'prop-types';
@@ -19,6 +19,7 @@ import ONYXKEYS from '../ONYXKEYS';
 import * as IOU from '../libs/actions/IOU';
 import * as ReportActionsUtils from '../libs/ReportActionsUtils';
 import ConfirmModal from './ConfirmModal';
+import useLocalize from '../hooks/useLocalize';
 
 const propTypes = {
     /** The report currently being looked at */
@@ -53,6 +54,8 @@ const defaultProps = {
 };
 
 function MoneyRequestHeader(props) {
+    const {translate} = useLocalize();
+    const {isDeleteModalVisible, setIsDeleteModalVisible} = useState(false);
     const moneyRequestReport = props.parentReport;
     const isSettled = ReportUtils.isSettled(moneyRequestReport.reportID);
     const policy = props.policies[`${ONYXKEYS.COLLECTION.POLICY}${props.report.policyID}`];
@@ -65,7 +68,8 @@ function MoneyRequestHeader(props) {
 
     const deleteTransaction = useCallback(() => {
         IOU.deleteMoneyRequest(parentReportAction.originalMessage.IOUTransactionID, parentReportAction, true);
-    }, [parentReportAction]);
+        setIsDeleteModalVisible(false);
+    }, [parentReportAction, setIsDeleteModalVisible]);
 
     return (
         <>
@@ -78,7 +82,7 @@ function MoneyRequestHeader(props) {
                         {
                             icon: Expensicons.Trashcan,
                             text: props.translate('reportActionContextMenu.deleteAction', {action: parentReportAction}),
-                            onSelected: deleteTransaction,
+                            onSelected: () => setIsDeleteModalVisible(true),
                         },
                     ]}
                     threeDotsAnchorPosition={styles.threeDotsPopoverOffsetNoCloseButton(props.windowWidth)}
@@ -91,18 +95,13 @@ function MoneyRequestHeader(props) {
                 />
             </View>
             <ConfirmModal
-                title={this.props.translate('reportActionContextMenu.deleteAction', {action: this.state.reportAction})}
-                isVisible={this.state.isDeleteCommentConfirmModalVisible}
-                shouldSetModalVisibility={this.state.shouldSetModalVisibilityForDeleteConfirmation}
-                onConfirm={this.confirmDeleteAndHideModal}
-                onCancel={this.hideDeleteModal}
-                onModalHide={() => {
-                    this.setState({reportID: '0', reportAction: {}});
-                    this.callbackWhenDeleteModalHide();
-                }}
-                prompt={this.props.translate('reportActionContextMenu.deleteConfirmation', {action: this.state.reportAction})}
-                confirmText={this.props.translate('common.delete')}
-                cancelText={this.props.translate('common.cancel')}
+                title={translate('iou.deleteRequest')}
+                isVisible={isDeleteModalVisible}
+                onConfirm={deleteTransaction}
+                onCancel={() => setIsDeleteModalVisible(false)}
+                prompt={translate('reportActionContextMenu.deleteConfirmation', {action: this.state.reportAction})}
+                confirmText={translate('common.delete')}
+                cancelText={translate('common.cancel')}
                 danger
             />
         </>

--- a/src/components/MoneyRequestHeader.js
+++ b/src/components/MoneyRequestHeader.js
@@ -5,12 +5,11 @@ import PropTypes from 'prop-types';
 import lodashGet from 'lodash/get';
 import HeaderWithBackButton from './HeaderWithBackButton';
 import iouReportPropTypes from '../pages/iouReportPropTypes';
-import withLocalize, {withLocalizePropTypes} from './withLocalize';
 import * as ReportUtils from '../libs/ReportUtils';
 import * as Expensicons from './Icon/Expensicons';
 import participantPropTypes from './participantPropTypes';
 import styles from '../styles/styles';
-import withWindowDimensions from './withWindowDimensions';
+import withWindowDimensions, {windowDimensionsPropTypes} from './withWindowDimensions';
 import compose from '../libs/compose';
 import Navigation from '../libs/Navigation/Navigation';
 import ROUTES from '../ROUTES';
@@ -43,7 +42,7 @@ const propTypes = {
         email: PropTypes.string,
     }),
 
-    ...withLocalizePropTypes,
+    ...windowDimensionsPropTypes,
 };
 
 const defaultProps = {
@@ -81,7 +80,7 @@ function MoneyRequestHeader(props) {
                     threeDotsMenuItems={[
                         {
                             icon: Expensicons.Trashcan,
-                            text: props.translate('reportActionContextMenu.deleteAction', {action: parentReportAction}),
+                            text: translate('reportActionContextMenu.deleteAction', {action: parentReportAction}),
                             onSelected: () => setIsDeleteModalVisible(true),
                         },
                     ]}
@@ -114,7 +113,6 @@ MoneyRequestHeader.defaultProps = defaultProps;
 
 export default compose(
     withWindowDimensions,
-    withLocalize,
     withOnyx({
         session: {
             key: ONYXKEYS.SESSION,

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -354,6 +354,7 @@ export default {
         pay: 'Pay',
         viewDetails: 'View details',
         pending: 'Pending',
+        deleteRequest: 'Delete request',
         settledExpensify: 'Paid',
         settledElsewhere: 'Paid elsewhere',
         settledPaypalMe: 'Paid using Paypal.me',

--- a/src/languages/en.js
+++ b/src/languages/en.js
@@ -355,6 +355,7 @@ export default {
         viewDetails: 'View details',
         pending: 'Pending',
         deleteRequest: 'Delete request',
+        deleteConfirmation: 'Are you sure that you want to delete this request?',
         settledExpensify: 'Paid',
         settledElsewhere: 'Paid elsewhere',
         settledPaypalMe: 'Paid using Paypal.me',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -353,6 +353,7 @@ export default {
         pay: 'Pagar',
         viewDetails: 'Ver detalles',
         pending: 'Pendiente',
+        deleteRequest: 'Eliminar pedido',
         settledExpensify: 'Pagado',
         settledElsewhere: 'Pagado de otra forma',
         settledPaypalMe: 'Pagado con PayPal.me',

--- a/src/languages/es.js
+++ b/src/languages/es.js
@@ -354,6 +354,7 @@ export default {
         viewDetails: 'Ver detalles',
         pending: 'Pendiente',
         deleteRequest: 'Eliminar pedido',
+        deleteConfirmation: '¿Estás seguro de que quieres eliminar este pedido?',
         settledExpensify: 'Pagado',
         settledElsewhere: 'Pagado de otra forma',
         settledPaypalMe: 'Pagado con PayPal.me',


### PR DESCRIPTION
### Details
Adds a confirmation modal before deleting a transaction from the thread header.

### Fixed Issues
$ https://github.com/Expensify/App/issues/23858

### Tests
1. Request money from another user
2. Tap the report preview (this will navigate you to the iou report)
3. Hover the IOU preview and tap the thrash can icon
4. Verify that a modal confirming if you want to delete the request shows up
5. Tap `Cancel` and verify that the modal closes
6. Repeat step 1-4 but this time tap `Delete`
7. Verify that the request is deleted
8. Request money again
9. Tap the report preview (this will navigate you to the iou report)
10. Tap the IOU preview (this will navigate you to the transaction thread report)
11. Tap the three dot menu at the top right of the page and then `Delete request`
12. Verify that the same confirmation modal shows up
13. Tap `Cancel` and verify that the modal closes
14. Tap the three dot menu at the top right of the page and then `Delete request` again
15. Tap `Delete request` and verify that the request is delete and the modal closes

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
Same as test stesp

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://github.com/Expensify/App/assets/22219519/70f3951a-c3e7-4909-ba3c-8728d04751a3

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://github.com/Expensify/App/assets/22219519/57a40fdb-d51a-45f7-8686-320921243ff1


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

https://github.com/Expensify/App/assets/22219519/94744ae6-c6ef-48ba-9773-dcaecbb17924


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>

https://github.com/Expensify/App/assets/22219519/f975488b-5bcd-4ca5-ad7c-a35a6267a01f


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

https://github.com/Expensify/App/assets/22219519/854116aa-8fb5-4580-98e6-d509108f50ed


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>

https://github.com/Expensify/App/assets/22219519/8c8a1b6c-8df3-48ec-bec6-e9704ee4a03a


<!-- add screenshots or videos here -->

</details>
