### PR TITLE
Migrated Textinput/index.js to functional component

### DIFF
--- a/src/components/TextInput/index.js
+++ b/src/components/TextInput/index.js
@@ -7,7 +7,7 @@ import * as baseTextInputPropTypes from './baseTextInputPropTypes';
 import DomUtils from '../../libs/DomUtils';
 import Visibility from '../../libs/Visibility';
 
-const TextInput = (props) => {
+function TextInput(props) {
     const textInputRef = useRef(null);
     const removeVisibilityListenerRef = useRef(null);
 
@@ -29,9 +29,8 @@ const TextInput = (props) => {
         });
 
         return () => {
-            if (removeVisibilityListenerRef.current) {
-                removeVisibilityListenerRef.current();
-            }
+            if (!removeVisibilityListenerRef.current) return;
+            removeVisibilityListenerRef.current();
         };
     }, []);
 
@@ -57,14 +56,16 @@ const TextInput = (props) => {
                     return;
                 }
 
+                // eslint-disable-next-line no-param-reassign
                 props.innerRef.current = el;
             }}
             inputStyle={[styles.baseTextInput, styles.textInputDesktop, isLabeledMultiline ? styles.textInputMultiline : {}, ...props.inputStyle]}
             textInputContainerStyles={[labelAnimationStyle, ...props.textInputContainerStyles]}
         />
     );
-};
+}
 
+TextInput.displayName = 'TextInput';
 TextInput.propTypes = baseTextInputPropTypes.propTypes;
 TextInput.defaultProps = baseTextInputPropTypes.defaultProps;
 

--- a/src/components/TextInput/index.js
+++ b/src/components/TextInput/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, {useEffect, useRef} from 'react';
 import _ from 'underscore';
 import styles from '../../styles/styles';
 import * as styleConst from './styleConst';
@@ -8,70 +8,70 @@ import DomUtils from '../../libs/DomUtils';
 import Visibility from '../../libs/Visibility';
 
 const TextInput = (props) => {
-  const textInputRef = useRef(null);
-  const removeVisibilityListenerRef = useRef(null);
+    const textInputRef = useRef(null);
+    const removeVisibilityListenerRef = useRef(null);
 
-  useEffect(() => {
-    if (props.disableKeyboard) {
-      textInputRef.current.setAttribute('inputmode', 'none');
-    }
+    useEffect(() => {
+        if (props.disableKeyboard) {
+            textInputRef.current.setAttribute('inputmode', 'none');
+        }
 
-    if (props.name) {
-      textInputRef.current.setAttribute('name', props.name);
-    }
+        if (props.name) {
+            textInputRef.current.setAttribute('name', props.name);
+        }
 
-    removeVisibilityListenerRef.current = Visibility.onVisibilityChange(() => {
-      if (!Visibility.isVisible() || !textInputRef.current || DomUtils.getActiveElement() !== textInputRef.current) {
-        return;
-      }
-      textInputRef.current.blur();
-      textInputRef.current.focus();
-    });
+        removeVisibilityListenerRef.current = Visibility.onVisibilityChange(() => {
+            if (!Visibility.isVisible() || !textInputRef.current || DomUtils.getActiveElement() !== textInputRef.current) {
+                return;
+            }
+            textInputRef.current.blur();
+            textInputRef.current.focus();
+        });
 
-    return () => {
-      if (removeVisibilityListenerRef.current) {
-        removeVisibilityListenerRef.current();
-      }
+        return () => {
+            if (removeVisibilityListenerRef.current) {
+                removeVisibilityListenerRef.current();
+            }
+        };
+    }, []);
+
+    const isLabeledMultiline = Boolean(props.label.length) && props.multiline;
+    const labelAnimationStyle = {
+        '--active-label-translate-y': `${styleConst.ACTIVE_LABEL_TRANSLATE_Y}px`,
+        '--active-label-scale': `${styleConst.ACTIVE_LABEL_SCALE}`,
+        '--label-transition-duration': `${styleConst.LABEL_ANIMATION_DURATION}ms`,
     };
-  }, []);
 
-  const isLabeledMultiline = Boolean(props.label.length) && props.multiline;
-  const labelAnimationStyle = {
-    '--active-label-translate-y': `${styleConst.ACTIVE_LABEL_TRANSLATE_Y}px`,
-    '--active-label-scale': `${styleConst.ACTIVE_LABEL_SCALE}`,
-    '--label-transition-duration': `${styleConst.LABEL_ANIMATION_DURATION}ms`,
-  };
+    return (
+        <BaseTextInput
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            {...props}
+            innerRef={(el) => {
+                textInputRef.current = el;
+                if (!props.innerRef) {
+                    return;
+                }
 
-  return (
-    <BaseTextInput
-    // eslint-disable-next-line react/jsx-props-no-spreading
-      {...props}
-      innerRef={(el) => {
-        textInputRef.current = el;
-        if (!props.innerRef) {
-          return;
-      }
+                if (_.isFunction(props.innerRef)) {
+                    props.innerRef(el);
+                    return;
+                }
 
-      if (_.isFunction(props.innerRef)) {
-          props.innerRef(el);
-          return;
-      }
-
-      props.innerRef.current = el;
-      }}
-      inputStyle={[styles.baseTextInput, styles.textInputDesktop, isLabeledMultiline ? styles.textInputMultiline : {}, ...props.inputStyle]}
-      textInputContainerStyles={[labelAnimationStyle, ...props.textInputContainerStyles]}
-    />
-  );
+                props.innerRef.current = el;
+            }}
+            inputStyle={[styles.baseTextInput, styles.textInputDesktop, isLabeledMultiline ? styles.textInputMultiline : {}, ...props.inputStyle]}
+            textInputContainerStyles={[labelAnimationStyle, ...props.textInputContainerStyles]}
+        />
+    );
 };
 
 TextInput.propTypes = baseTextInputPropTypes.propTypes;
 TextInput.defaultProps = baseTextInputPropTypes.defaultProps;
 
 export default React.forwardRef((props, ref) => (
-  <TextInput
-      // eslint-disable-next-line react/jsx-props-no-spreading
-      {...props}
-      innerRef={ref}
-  />
+    <TextInput
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...props}
+        innerRef={ref}
+    />
 ));

--- a/src/components/TextInput/index.js
+++ b/src/components/TextInput/index.js
@@ -32,6 +32,7 @@ function TextInput(props) {
             if (!removeVisibilityListenerRef.current) return;
             removeVisibilityListenerRef.current();
         };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     const isLabeledMultiline = Boolean(props.label.length) && props.multiline;

--- a/src/components/TextInput/index.js
+++ b/src/components/TextInput/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import _ from 'underscore';
 import styles from '../../styles/styles';
 import * as styleConst from './styleConst';
@@ -7,72 +7,71 @@ import * as baseTextInputPropTypes from './baseTextInputPropTypes';
 import DomUtils from '../../libs/DomUtils';
 import Visibility from '../../libs/Visibility';
 
-class TextInput extends React.Component {
-    componentDidMount() {
-        if (this.props.disableKeyboard) {
-            this.textInput.setAttribute('inputmode', 'none');
-        }
+const TextInput = (props) => {
+  const textInputRef = useRef(null);
+  const removeVisibilityListenerRef = useRef(null);
 
-        if (this.props.name) {
-            this.textInput.setAttribute('name', this.props.name);
-        }
-
-        // Forcefully activate the soft keyboard when the user switches between tabs while input was focused.
-        this.removeVisibilityListener = Visibility.onVisibilityChange(() => {
-            if (!Visibility.isVisible() || !this.textInput || DomUtils.getActiveElement() !== this.textInput) {
-                return;
-            }
-            this.textInput.blur();
-            this.textInput.focus();
-        });
+  useEffect(() => {
+    if (props.disableKeyboard) {
+      textInputRef.current.setAttribute('inputmode', 'none');
     }
 
-    componentWillUnmount() {
-        if (!this.removeVisibilityListener) {
-            return;
-        }
-        this.removeVisibilityListener();
+    if (props.name) {
+      textInputRef.current.setAttribute('name', props.name);
     }
 
-    render() {
-        const isLabeledMultiline = Boolean(this.props.label.length) && this.props.multiline;
-        const labelAnimationStyle = {
-            '--active-label-translate-y': `${styleConst.ACTIVE_LABEL_TRANSLATE_Y}px`,
-            '--active-label-scale': `${styleConst.ACTIVE_LABEL_SCALE}`,
-            '--label-transition-duration': `${styleConst.LABEL_ANIMATION_DURATION}ms`,
-        };
+    removeVisibilityListenerRef.current = Visibility.onVisibilityChange(() => {
+      if (!Visibility.isVisible() || !textInputRef.current || DomUtils.getActiveElement() !== textInputRef.current) {
+        return;
+      }
+      textInputRef.current.blur();
+      textInputRef.current.focus();
+    });
 
-        return (
-            <BaseTextInput
-                // eslint-disable-next-line react/jsx-props-no-spreading
-                {...this.props}
-                innerRef={(el) => {
-                    this.textInput = el;
-                    if (!this.props.innerRef) {
-                        return;
-                    }
+    return () => {
+      if (removeVisibilityListenerRef.current) {
+        removeVisibilityListenerRef.current();
+      }
+    };
+  }, []);
 
-                    if (_.isFunction(this.props.innerRef)) {
-                        this.props.innerRef(el);
-                        return;
-                    }
+  const isLabeledMultiline = Boolean(props.label.length) && props.multiline;
+  const labelAnimationStyle = {
+    '--active-label-translate-y': `${styleConst.ACTIVE_LABEL_TRANSLATE_Y}px`,
+    '--active-label-scale': `${styleConst.ACTIVE_LABEL_SCALE}`,
+    '--label-transition-duration': `${styleConst.LABEL_ANIMATION_DURATION}ms`,
+  };
 
-                    this.props.innerRef.current = el;
-                }}
-                inputStyle={[styles.baseTextInput, styles.textInputDesktop, isLabeledMultiline ? styles.textInputMultiline : {}, ...this.props.inputStyle]}
-                textInputContainerStyles={[labelAnimationStyle, ...this.props.textInputContainerStyles]}
-            />
-        );
-    }
-}
+  return (
+    <BaseTextInput
+    // eslint-disable-next-line react/jsx-props-no-spreading
+      {...props}
+      innerRef={(el) => {
+        textInputRef.current = el;
+        if (!props.innerRef) {
+          return;
+      }
+
+      if (_.isFunction(props.innerRef)) {
+          props.innerRef(el);
+          return;
+      }
+
+      props.innerRef.current = el;
+      }}
+      inputStyle={[styles.baseTextInput, styles.textInputDesktop, isLabeledMultiline ? styles.textInputMultiline : {}, ...props.inputStyle]}
+      textInputContainerStyles={[labelAnimationStyle, ...props.textInputContainerStyles]}
+    />
+  );
+};
 
 TextInput.propTypes = baseTextInputPropTypes.propTypes;
 TextInput.defaultProps = baseTextInputPropTypes.defaultProps;
 
 export default React.forwardRef((props, ref) => (
-    <TextInput
-        // eslint-disable-next-line react/jsx-props-no-spreading
-        {...props}
-        innerRef={ref}
-    />
+  <TextInput
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...props}
+      innerRef={ref}
+  />
 ));


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/16208
PROPOSAL: https://github.com/Expensify/App/issues/16208#issuecomment-1656507533


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Open a text input (from this branch build) and another one on the production site.
2. Compare both the inputs and verify the correct styles like height, width, border, padding, margins, and colors are applied in both.
3. Click in and out of both inputs (one by one) and verify that focus and blur events work the same in both
4. Click on both inputs (one by one) and verify the input label transition is the same in both.

- [ ] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Same as "Tests" section above

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
5. Upload an image via copy paste
6. Verify a modal appears displaying a preview of that image
--->

1. Open a text input (from this branch build) and another one on the production site.
2. Compare both the inputs and verify the correct styles like height, width, border, padding, margins, and colors are applied in both.
3. Click in and out of both inputs (one by one) and verify that focus and blur events work the same in both
4. Click on both inputs (one by one) and verify the input label transition is the same in both.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

**Chrome**

https://github.com/Expensify/App/assets/68777211/b435a291-89a8-4392-8031-3a44d4a65a64



**Safari**

https://github.com/Expensify/App/assets/68777211/098407c8-7291-4495-bb3e-253e6405f956




</details>

<details>
<summary>Mobile Web - Chrome</summary>


https://github.com/Expensify/App/assets/68777211/c3ee84ad-1bb7-496b-b62c-29687cfafdfc



</details>

<details>
<summary>Mobile Web - Safari</summary>


https://github.com/Expensify/App/assets/68777211/502ace07-b728-40eb-8a3c-211e40b9313d



</details>

<details>
<summary>Desktop</summary>

https://github.com/Expensify/App/assets/68777211/aaf66993-c414-4e0b-9dd7-93ab5a1409d3




</details>

<details>
<summary>iOS</summary>


https://github.com/Expensify/App/assets/68777211/20d6a636-b67e-40b3-959b-d3fca564ad65



</details>

<details>
<summary>Android</summary>

https://github.com/Expensify/App/assets/68777211/4f20f0c8-9073-4ee4-98db-1eceb63abd9f


</details>
