### PR TITLE
Updated country and state searches to fix extra spaces + support searching with/without non alphabet chars in country name

### DIFF
--- a/src/CONST.js
+++ b/src/CONST.js
@@ -1165,6 +1165,7 @@ const CONST = {
         CARD_EXPIRATION_DATE: /^(0[1-9]|1[0-2])([^0-9])?([0-9]{4}|([0-9]{2}))$/,
         PAYPAL_ME_USERNAME: /^[a-zA-Z0-9]{1,20}$/,
         ROOM_NAME: /^#[a-z0-9à-ÿ-]{1,80}$/,
+        COUNTRY_NAME_WITH_ONLY_ALPHABETS: /[-'().&\s]/g,
 
         // eslint-disable-next-line max-len, no-misleading-character-class
         EMOJIS: /[\p{Extended_Pictographic}\u200d\u{1f1e6}-\u{1f1ff}\u{1f3fb}-\u{1f3ff}\u{e0020}-\u{e007f}\u20E3\uFE0F]|[#*0-9]\uFE0F?\u20E3/gu,

--- a/src/CONST.js
+++ b/src/CONST.js
@@ -1152,6 +1152,7 @@ const CONST = {
         SPECIAL_CHARS_WITHOUT_NEWLINE: /((?!\n)[()-\s\t])/g,
         DIGITS_AND_PLUS: /^\+?[0-9]*$/,
         ALPHABETIC_AND_LATIN_CHARS: /^[a-zA-ZÀ-ÿ ]*$/,
+        NON_ALPHABETIC_AND_NON_LATIN_CHARS: /[^a-zA-ZÀ-ÿ]/g,
         POSITIVE_INTEGER: /^\d+$/,
         PO_BOX: /\b[P|p]?(OST|ost)?\.?\s*[O|o|0]?(ffice|FFICE)?\.?\s*[B|b][O|o|0]?[X|x]?\.?\s+[#]?(\d+)\b/,
         ANY_VALUE: /^.+$/,
@@ -1165,7 +1166,6 @@ const CONST = {
         CARD_EXPIRATION_DATE: /^(0[1-9]|1[0-2])([^0-9])?([0-9]{4}|([0-9]{2}))$/,
         PAYPAL_ME_USERNAME: /^[a-zA-Z0-9]{1,20}$/,
         ROOM_NAME: /^#[a-z0-9à-ÿ-]{1,80}$/,
-        COUNTRY_NAME_WITH_ONLY_ALPHABETS: /[-'().&\s]/g,
 
         // eslint-disable-next-line max-len, no-misleading-character-class
         EMOJIS: /[\p{Extended_Pictographic}\u200d\u{1f1e6}-\u{1f1ff}\u{1f3fb}-\u{1f3ff}\u{e0020}-\u{e007f}\u20E3\uFE0F]|[#*0-9]\uFE0F?\u20E3/gu,

--- a/src/components/CountryPicker/CountrySelectorModal.js
+++ b/src/components/CountryPicker/CountrySelectorModal.js
@@ -6,7 +6,7 @@ import useLocalize from '../../hooks/useLocalize';
 import HeaderWithBackButton from '../HeaderWithBackButton';
 import SelectionListRadio from '../SelectionListRadio';
 import Modal from '../Modal';
-import searchOptions from '../../libs/CountrySelectorUtils';
+import searchOptions from '../../libs/searchCountryOptions';
 
 const propTypes = {
     /** Whether the modal is visible */

--- a/src/components/CountryPicker/CountrySelectorModal.js
+++ b/src/components/CountryPicker/CountrySelectorModal.js
@@ -34,15 +34,15 @@ const defaultProps = {
 };
 
 function searchOptions(searchValue, data) {
-    const searchValueWithOnlyAlphabets = searchValue.toLowerCase().replaceAll(CONST.REGEX.NON_ALPHABETIC_AND_NON_LATIN_CHARS, '');
-    if (searchValueWithOnlyAlphabets.length === 0) {
+    const trimmedSearchValue = searchValue.toLowerCase().replaceAll(CONST.REGEX.NON_ALPHABETIC_AND_NON_LATIN_CHARS, '');
+    if (trimmedSearchValue.length === 0) {
         return [];
     }
 
-    const filteredData = _.filter(data, (country) => country.searchValue.includes(searchValueWithOnlyAlphabets));
+    const filteredData = _.filter(data, (country) => country.searchValue.includes(trimmedSearchValue));
 
     // sort by country code
-    return _.sortBy(filteredData, (country) => (country.value.toLowerCase() === searchValueWithOnlyAlphabets ? -1 : 1));
+    return _.sortBy(filteredData, (country) => (country.value.toLowerCase() === trimmedSearchValue ? -1 : 1));
 }
 
 function CountrySelectorModal({currentCountry, isVisible, onClose, onCountrySelected, setSearchValue, searchValue}) {

--- a/src/components/CountryPicker/CountrySelectorModal.js
+++ b/src/components/CountryPicker/CountrySelectorModal.js
@@ -33,13 +33,16 @@ const defaultProps = {
     onCountrySelected: () => {},
 };
 
-function filterOptions(searchValue, data) {
-    const searchValueWithOnlyAlphabets = searchValue.toLowerCase().replaceAll(CONST.REGEX.COUNTRY_NAME_WITH_ONLY_ALPHABETS, '');
+function searchOptions(searchValue, data) {
+    const searchValueWithOnlyAlphabets = searchValue.toLowerCase().replaceAll(CONST.REGEX.NON_ALPHABETIC_AND_NON_LATIN_CHARS, '');
     if (searchValueWithOnlyAlphabets.length === 0) {
         return [];
     }
 
-    return _.filter(data, (country) => country.searchValue.includes(searchValueWithOnlyAlphabets) || country.value.toLowerCase().includes(searchValueWithOnlyAlphabets));
+    const filteredData = _.filter(data, (country) => country.searchValue.includes(searchValueWithOnlyAlphabets));
+
+    // sort by country code
+    return _.sortBy(filteredData, (country) => (country.value.toLowerCase() === searchValueWithOnlyAlphabets ? -1 : 1));
 }
 
 function CountrySelectorModal({currentCountry, isVisible, onClose, onCountrySelected, setSearchValue, searchValue}) {
@@ -52,13 +55,13 @@ function CountrySelectorModal({currentCountry, isVisible, onClose, onCountrySele
                 keyForList: countryISO,
                 text: countryName,
                 isSelected: currentCountry === countryISO,
-                searchValue: countryName.toLowerCase().replaceAll(CONST.REGEX.COUNTRY_NAME_WITH_ONLY_ALPHABETS, ''),
+                searchValue: `${countryISO}${countryName}`.toLowerCase().replaceAll(CONST.REGEX.NON_ALPHABETIC_AND_NON_LATIN_CHARS, ''),
             })),
         [translate, currentCountry],
     );
 
-    const filteredData = filterOptions(searchValue, countries);
-    const headerMessage = searchValue.trim() && !filteredData.length ? translate('common.noResultsFound') : '';
+    const searchResults = searchOptions(searchValue, countries);
+    const headerMessage = searchValue.trim() && !searchResults.length ? translate('common.noResultsFound') : '';
 
     return (
         <Modal
@@ -78,7 +81,7 @@ function CountrySelectorModal({currentCountry, isVisible, onClose, onCountrySele
                 textInputLabel={translate('common.country')}
                 textInputPlaceholder={translate('countrySelectorModal.placeholderText')}
                 textInputValue={searchValue}
-                sections={[{data: filteredData, indexOffset: 0}]}
+                sections={[{data: searchResults, indexOffset: 0}]}
                 onSelectRow={onCountrySelected}
                 onChangeText={setSearchValue}
                 shouldFocusOnSelectRow

--- a/src/components/CountryPicker/CountrySelectorModal.js
+++ b/src/components/CountryPicker/CountrySelectorModal.js
@@ -34,12 +34,12 @@ const defaultProps = {
 };
 
 function filterOptions(searchValue, data) {
-    const trimmedSearchValue = searchValue.trim();
-    if (trimmedSearchValue.length === 0) {
+    const searchValueWithOnlyAlphabets = searchValue.toLowerCase().replaceAll(CONST.REGEX.COUNTRY_NAME_WITH_ONLY_ALPHABETS, '');
+    if (searchValueWithOnlyAlphabets.length === 0) {
         return [];
     }
 
-    return _.filter(data, (country) => country.text.toLowerCase().includes(searchValue.toLowerCase()));
+    return _.filter(data, (country) => country.searchValue.includes(searchValueWithOnlyAlphabets));
 }
 
 function CountrySelectorModal({currentCountry, isVisible, onClose, onCountrySelected, setSearchValue, searchValue}) {
@@ -52,6 +52,7 @@ function CountrySelectorModal({currentCountry, isVisible, onClose, onCountrySele
                 keyForList: countryISO,
                 text: countryName,
                 isSelected: currentCountry === countryISO,
+                searchValue: countryName.toLowerCase().replaceAll(CONST.REGEX.COUNTRY_NAME_WITH_ONLY_ALPHABETS, ''),
             })),
         [translate, currentCountry],
     );

--- a/src/components/CountryPicker/CountrySelectorModal.js
+++ b/src/components/CountryPicker/CountrySelectorModal.js
@@ -6,6 +6,7 @@ import useLocalize from '../../hooks/useLocalize';
 import HeaderWithBackButton from '../HeaderWithBackButton';
 import SelectionListRadio from '../SelectionListRadio';
 import Modal from '../Modal';
+import searchOptions from '../../libs/CountrySelectorUtils';
 
 const propTypes = {
     /** Whether the modal is visible */
@@ -32,18 +33,6 @@ const defaultProps = {
     onClose: () => {},
     onCountrySelected: () => {},
 };
-
-function searchOptions(searchValue, data) {
-    const trimmedSearchValue = searchValue.toLowerCase().replaceAll(CONST.REGEX.NON_ALPHABETIC_AND_NON_LATIN_CHARS, '');
-    if (trimmedSearchValue.length === 0) {
-        return [];
-    }
-
-    const filteredData = _.filter(data, (country) => country.searchValue.includes(trimmedSearchValue));
-
-    // sort by country code
-    return _.sortBy(filteredData, (country) => (country.value.toLowerCase() === trimmedSearchValue ? -1 : 1));
-}
 
 function CountrySelectorModal({currentCountry, isVisible, onClose, onCountrySelected, setSearchValue, searchValue}) {
     const {translate} = useLocalize();

--- a/src/components/CountryPicker/CountrySelectorModal.js
+++ b/src/components/CountryPicker/CountrySelectorModal.js
@@ -39,7 +39,7 @@ function filterOptions(searchValue, data) {
         return [];
     }
 
-    return _.filter(data, (country) => country.searchValue.includes(searchValueWithOnlyAlphabets));
+    return _.filter(data, (country) => country.searchValue.includes(searchValueWithOnlyAlphabets) || country.value.toLowerCase().includes(searchValueWithOnlyAlphabets));
 }
 
 function CountrySelectorModal({currentCountry, isVisible, onClose, onCountrySelected, setSearchValue, searchValue}) {

--- a/src/components/CountryPicker/CountrySelectorModal.js
+++ b/src/components/CountryPicker/CountrySelectorModal.js
@@ -6,7 +6,7 @@ import useLocalize from '../../hooks/useLocalize';
 import HeaderWithBackButton from '../HeaderWithBackButton';
 import SelectionListRadio from '../SelectionListRadio';
 import Modal from '../Modal';
-import searchOptions from '../../libs/searchCountryOptions';
+import searchCountryOptions from '../../libs/searchCountryOptions';
 
 const propTypes = {
     /** Whether the modal is visible */
@@ -49,7 +49,7 @@ function CountrySelectorModal({currentCountry, isVisible, onClose, onCountrySele
         [translate, currentCountry],
     );
 
-    const searchResults = searchOptions(searchValue, countries);
+    const searchResults = searchCountryOptions(searchValue, countries);
     const headerMessage = searchValue.trim() && !searchResults.length ? translate('common.noResultsFound') : '';
 
     return (

--- a/src/components/StatePicker/StateSelectorModal.js
+++ b/src/components/StatePicker/StateSelectorModal.js
@@ -37,13 +37,16 @@ const defaultProps = {
     label: undefined,
 };
 
-function filterOptions(searchValue, data) {
-    const searchValueWithOnlyAlphabets = searchValue.toLowerCase().replaceAll(' ', '');
+function searchOptions(searchValue, data) {
+    const searchValueWithOnlyAlphabets = searchValue.toLowerCase().replaceAll(CONST.REGEX.NON_ALPHABETIC_AND_NON_LATIN_CHARS, '');
     if (searchValueWithOnlyAlphabets.length === 0) {
         return [];
     }
 
-    return _.filter(data, (countryState) => countryState.searchValue.includes(searchValueWithOnlyAlphabets) || countryState.value.toLowerCase().includes(searchValueWithOnlyAlphabets));
+    const filteredData = _.filter(data, (countryState) => countryState.searchValue.includes(searchValueWithOnlyAlphabets));
+
+    // sort by state code
+    return _.sortBy(filteredData, (countryState) => (countryState.value.toLowerCase() === searchValueWithOnlyAlphabets ? -1 : 1));
 }
 
 function StateSelectorModal({currentState, isVisible, onClose, onStateSelected, searchValue, setSearchValue, label}) {
@@ -56,13 +59,13 @@ function StateSelectorModal({currentState, isVisible, onClose, onStateSelected, 
                 keyForList: state.stateISO,
                 text: state.stateName,
                 isSelected: currentState === state.stateISO,
-                searchValue: state.stateName.toLowerCase().replaceAll(' ', ''),
+                searchValue: `${state.stateISO}${state.stateName}`.toLowerCase().replaceAll(CONST.REGEX.NON_ALPHABETIC_AND_NON_LATIN_CHARS, ''),
             })),
         [translate, currentState],
     );
 
-    const filteredData = filterOptions(searchValue, countryStates);
-    const headerMessage = searchValue.trim() && !filteredData.length ? translate('common.noResultsFound') : '';
+    const searchResults = searchOptions(searchValue, countryStates);
+    const headerMessage = searchValue.trim() && !searchResults.length ? translate('common.noResultsFound') : '';
 
     return (
         <Modal
@@ -83,7 +86,7 @@ function StateSelectorModal({currentState, isVisible, onClose, onStateSelected, 
                 textInputLabel={label || translate('common.state')}
                 textInputPlaceholder={translate('stateSelectorModal.placeholderText')}
                 textInputValue={searchValue}
-                sections={[{data: filteredData, indexOffset: 0}]}
+                sections={[{data: searchResults, indexOffset: 0}]}
                 onSelectRow={onStateSelected}
                 onChangeText={setSearchValue}
                 shouldFocusOnSelectRow

--- a/src/components/StatePicker/StateSelectorModal.js
+++ b/src/components/StatePicker/StateSelectorModal.js
@@ -6,7 +6,7 @@ import Modal from '../Modal';
 import HeaderWithBackButton from '../HeaderWithBackButton';
 import SelectionListRadio from '../SelectionListRadio';
 import useLocalize from '../../hooks/useLocalize';
-import searchOptions from '../../libs/CountrySelectorUtils';
+import searchOptions from '../../libs/searchCountryOptions';
 
 const propTypes = {
     /** Whether the modal is visible */

--- a/src/components/StatePicker/StateSelectorModal.js
+++ b/src/components/StatePicker/StateSelectorModal.js
@@ -43,7 +43,7 @@ function filterOptions(searchValue, data) {
         return [];
     }
 
-    return _.filter(data, (country) => country.searchValue.includes(searchValueWithOnlyAlphabets));
+    return _.filter(data, (countryState) => countryState.searchValue.includes(searchValueWithOnlyAlphabets) || countryState.value.toLowerCase().includes(searchValueWithOnlyAlphabets));
 }
 
 function StateSelectorModal({currentState, isVisible, onClose, onStateSelected, searchValue, setSearchValue, label}) {

--- a/src/components/StatePicker/StateSelectorModal.js
+++ b/src/components/StatePicker/StateSelectorModal.js
@@ -6,7 +6,7 @@ import Modal from '../Modal';
 import HeaderWithBackButton from '../HeaderWithBackButton';
 import SelectionListRadio from '../SelectionListRadio';
 import useLocalize from '../../hooks/useLocalize';
-import searchOptions from '../../libs/searchCountryOptions';
+import searchCountryOptions from '../../libs/searchCountryOptions';
 
 const propTypes = {
     /** Whether the modal is visible */
@@ -53,7 +53,7 @@ function StateSelectorModal({currentState, isVisible, onClose, onStateSelected, 
         [translate, currentState],
     );
 
-    const searchResults = searchOptions(searchValue, countryStates);
+    const searchResults = searchCountryOptions(searchValue, countryStates);
     const headerMessage = searchValue.trim() && !searchResults.length ? translate('common.noResultsFound') : '';
 
     return (

--- a/src/components/StatePicker/StateSelectorModal.js
+++ b/src/components/StatePicker/StateSelectorModal.js
@@ -38,12 +38,12 @@ const defaultProps = {
 };
 
 function filterOptions(searchValue, data) {
-    const trimmedSearchValue = searchValue.trim();
-    if (trimmedSearchValue.length === 0) {
+    const searchValueWithOnlyAlphabets = searchValue.toLowerCase().replaceAll(' ', '');
+    if (searchValueWithOnlyAlphabets.length === 0) {
         return [];
     }
 
-    return _.filter(data, (country) => country.text.toLowerCase().includes(searchValue.toLowerCase()));
+    return _.filter(data, (country) => country.searchValue.includes(searchValueWithOnlyAlphabets));
 }
 
 function StateSelectorModal({currentState, isVisible, onClose, onStateSelected, searchValue, setSearchValue, label}) {
@@ -56,6 +56,7 @@ function StateSelectorModal({currentState, isVisible, onClose, onStateSelected, 
                 keyForList: state.stateISO,
                 text: state.stateName,
                 isSelected: currentState === state.stateISO,
+                searchValue: state.stateName.toLowerCase().replaceAll(' ', ''),
             })),
         [translate, currentState],
     );

--- a/src/components/StatePicker/StateSelectorModal.js
+++ b/src/components/StatePicker/StateSelectorModal.js
@@ -38,15 +38,15 @@ const defaultProps = {
 };
 
 function searchOptions(searchValue, data) {
-    const searchValueWithOnlyAlphabets = searchValue.toLowerCase().replaceAll(CONST.REGEX.NON_ALPHABETIC_AND_NON_LATIN_CHARS, '');
-    if (searchValueWithOnlyAlphabets.length === 0) {
+    const trimmedSearchValue = searchValue.toLowerCase().replaceAll(CONST.REGEX.NON_ALPHABETIC_AND_NON_LATIN_CHARS, '');
+    if (trimmedSearchValue.length === 0) {
         return [];
     }
 
-    const filteredData = _.filter(data, (countryState) => countryState.searchValue.includes(searchValueWithOnlyAlphabets));
+    const filteredData = _.filter(data, (countryState) => countryState.searchValue.includes(trimmedSearchValue));
 
     // sort by state code
-    return _.sortBy(filteredData, (countryState) => (countryState.value.toLowerCase() === searchValueWithOnlyAlphabets ? -1 : 1));
+    return _.sortBy(filteredData, (countryState) => (countryState.value.toLowerCase() === trimmedSearchValue ? -1 : 1));
 }
 
 function StateSelectorModal({currentState, isVisible, onClose, onStateSelected, searchValue, setSearchValue, label}) {

--- a/src/components/StatePicker/StateSelectorModal.js
+++ b/src/components/StatePicker/StateSelectorModal.js
@@ -6,6 +6,7 @@ import Modal from '../Modal';
 import HeaderWithBackButton from '../HeaderWithBackButton';
 import SelectionListRadio from '../SelectionListRadio';
 import useLocalize from '../../hooks/useLocalize';
+import searchOptions from '../../libs/CountrySelectorUtils';
 
 const propTypes = {
     /** Whether the modal is visible */
@@ -36,18 +37,6 @@ const defaultProps = {
     onStateSelected: () => {},
     label: undefined,
 };
-
-function searchOptions(searchValue, data) {
-    const trimmedSearchValue = searchValue.toLowerCase().replaceAll(CONST.REGEX.NON_ALPHABETIC_AND_NON_LATIN_CHARS, '');
-    if (trimmedSearchValue.length === 0) {
-        return [];
-    }
-
-    const filteredData = _.filter(data, (countryState) => countryState.searchValue.includes(trimmedSearchValue));
-
-    // sort by state code
-    return _.sortBy(filteredData, (countryState) => (countryState.value.toLowerCase() === trimmedSearchValue ? -1 : 1));
-}
 
 function StateSelectorModal({currentState, isVisible, onClose, onStateSelected, searchValue, setSearchValue, label}) {
     const {translate} = useLocalize();

--- a/src/libs/CountrySelectorUtils/index.js
+++ b/src/libs/CountrySelectorUtils/index.js
@@ -1,10 +1,11 @@
+import _ from 'underscore';
 import CONST from '../../CONST';
 
 /**
  * Searches the countriesData and returns sorted results based on country code
  * @param {String} searchValue
- * @param {Object} countriesData
- * @returns
+ * @param {Object[]} countriesData - An array of country data objects
+ * @returns {Object[]} An array of sorted country data based on country code
  */
 function searchOptions(searchValue, countriesData) {
     const trimmedSearchValue = searchValue.toLowerCase().replaceAll(CONST.REGEX.NON_ALPHABETIC_AND_NON_LATIN_CHARS, '');

--- a/src/libs/CountrySelectorUtils/index.js
+++ b/src/libs/CountrySelectorUtils/index.js
@@ -1,0 +1,21 @@
+import CONST from '../../CONST';
+
+/**
+ * Searches the countriesData and returns sorted results based on country code
+ * @param {String} searchValue
+ * @param {Object} countriesData
+ * @returns
+ */
+function searchOptions(searchValue, countriesData) {
+    const trimmedSearchValue = searchValue.toLowerCase().replaceAll(CONST.REGEX.NON_ALPHABETIC_AND_NON_LATIN_CHARS, '');
+    if (trimmedSearchValue.length === 0) {
+        return [];
+    }
+
+    const filteredData = _.filter(countriesData, (country) => country.searchValue.includes(trimmedSearchValue));
+
+    // sort by country code
+    return _.sortBy(filteredData, (country) => (country.value.toLowerCase() === trimmedSearchValue ? -1 : 1));
+}
+
+export default searchOptions;

--- a/src/libs/searchCountryOptions.js
+++ b/src/libs/searchCountryOptions.js
@@ -1,13 +1,13 @@
 import _ from 'underscore';
-import CONST from '../../CONST';
+import CONST from '../CONST';
 
 /**
- * Searches the countriesData and returns sorted results based on country code
+ * Searches the countries/states data and returns sorted results based on the search query
  * @param {String} searchValue
  * @param {Object[]} countriesData - An array of country data objects
- * @returns {Object[]} An array of sorted country data based on country code
+ * @returns {Object[]} An array of countries/states sorted based on the search query
  */
-function searchOptions(searchValue, countriesData) {
+function searchCountryOptions(searchValue, countriesData) {
     const trimmedSearchValue = searchValue.toLowerCase().replaceAll(CONST.REGEX.NON_ALPHABETIC_AND_NON_LATIN_CHARS, '');
     if (trimmedSearchValue.length === 0) {
         return [];
@@ -19,4 +19,4 @@ function searchOptions(searchValue, countriesData) {
     return _.sortBy(filteredData, (country) => (country.value.toLowerCase() === trimmedSearchValue ? -1 : 1));
 }
 
-export default searchOptions;
+export default searchCountryOptions;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/expensify/App/issues/23727
PROPOSAL: https://github.com/expensify/App/issues/23727#issuecomment-1653419529


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Go to settings > profile > personal details > home address 
2. Go to the country selector
3. Try out different searches with/without 1 or more than 1 spaces in the start, middle or end of the search term -- Verify that it works
4. Try out different searches with a search term with/without brackets ex: `Myanmar (Burma), Cocos (Keeling) Islands` -- Verify that it works
5. Try out different searches with a search term with/without dots ex: `St. Lucia, U.S Virgin Islands` -- Verify that it works
6. Try out different searches with a search term with/without dashes ex: `Congo - Kinshasa, Congo - Brazzaville, Timor-Leste` -- Verify that it works
7. Try out different searches with a search term with/without ampersand ex: `St. Kitts & Nevis, St. Vincent & Grenadines` -- Verify that it works
8. Try out different searches with a search term with/without single quote ex: `Côte d'Ivoire` -- Verify that it works
8. Try out different searches with country code ex: `AF -> Afganistan, US -> United States, DZ -> Argeliz` -- Verify that it works
9. Now go back and go to state selector
10. Try out different searches with/without 1 or more than 1 spaces in the start, middle or end of the search term -- Verify that it works
11. Try out different searches with state code ex: `NY -> New York, DC -> District Of Columbia` -- Verify that it works

- [ ] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Same as "Tests" section above

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
5. Upload an image via copy paste
7. Verify a modal appears displaying a preview of that image
--->

Same as "Tests" section above

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

**Chrome:**

https://github.com/Expensify/App/assets/68777211/d31bf6ba-c84b-4791-81ad-3de6798b4447

https://github.com/Expensify/App/assets/68777211/d04b012d-d0aa-4a1b-a819-a737339b6b01



**Safari:**

https://github.com/Expensify/App/assets/68777211/3f708ed8-4531-4643-98c5-6fda6dd0cfe4

https://github.com/Expensify/App/assets/68777211/f9517685-19f3-43d8-86ff-68ca900b82a6



</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://github.com/Expensify/App/assets/68777211/5678f05a-3136-4110-a175-f6418378a24e


https://github.com/Expensify/App/assets/68777211/92af882f-dbe7-4cc5-80cf-7c4716ad1e23




</details>

<details>
<summary>Mobile Web - Safari</summary>

https://github.com/Expensify/App/assets/68777211/f4c76090-e906-4dc1-8a81-13eb3118b133


https://github.com/Expensify/App/assets/68777211/65e12414-4339-4145-b09f-d6d9cf3aefdd



</details>

<details>
<summary>Desktop</summary>

https://github.com/Expensify/App/assets/68777211/12f738c0-44c4-40e2-801b-13fdb3068614

https://github.com/Expensify/App/assets/68777211/07c7398d-24da-498f-8a79-239a97e033ff


</details>

<details>
<summary>iOS</summary>


https://github.com/Expensify/App/assets/68777211/f24042f4-8cc2-43c1-bff0-a46b9bccb482

https://github.com/Expensify/App/assets/68777211/339efae2-99b9-4fb0-be10-a4c0b338757b




</details>

<details>
<summary>Android</summary>

https://github.com/Expensify/App/assets/68777211/594297d4-b821-4b32-afda-ed5afde9062f


https://github.com/Expensify/App/assets/68777211/f98cec88-2829-44c0-a29b-6ad49acc33e5




</details>
