### PR TITLE
Migrate Image/index.js to function component

### DIFF
--- a/src/components/Image/index.js
+++ b/src/components/Image/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useCallback, useEffect} from 'react';
 import {Image as RNImage} from 'react-native';
 import {withOnyx} from 'react-native-onyx';
 import lodashGet from 'lodash/get';
@@ -7,67 +7,63 @@ import ONYXKEYS from '../../ONYXKEYS';
 import {defaultProps, imagePropTypes} from './imagePropTypes';
 import RESIZE_MODES from './resizeModes';
 
-class Image extends React.Component {
-    componentDidMount() {
-        this.configureOnLoad();
-    }
 
-    componentDidUpdate(prevProps) {
-        if (prevProps.source === this.props.source) {
-            return;
-        }
-        this.configureOnLoad();
-    }
-
+function Image (props) {
     /**
      * Check if the image source is a URL - if so the `encryptedAuthToken` is appended
      * to the source.
      * @returns {Object} - the configured image source
      */
-    getImageSource() {
-        const source = this.props.source;
+    const getImageSource = useCallback(() => {
+        const source = props.source;
         let imageSource = source;
-        if (this.props.isAuthTokenRequired) {
+        if (props.isAuthTokenRequired) {
             // There is currently a `react-native-web` bug preventing the authToken being passed
             // in the headers of the image request so the authToken is added as a query param.
             // On native the authToken IS passed in the image request headers
-            const authToken = lodashGet(this.props, 'session.encryptedAuthToken', null);
+            const authToken = lodashGet(props, 'session.encryptedAuthToken', null);
             imageSource = {uri: `${source.uri}?encryptedAuthToken=${encodeURIComponent(authToken)}`};
         }
 
         return imageSource;
-    }
+    }, [props])
 
     /**
      * The natural image dimensions are retrieved using the updated source
      * and as a result the `onLoad` event needs to be manually invoked to return these dimensions
      */
-    configureOnLoad() {
+    const configureOnLoad = useCallback(
+        () => {
         // If an onLoad callback was specified then manually call it and pass
         // the natural image dimensions to match the native API
-        if (this.props.onLoad == null) {
+        if (props.onLoad == null) {
             return;
         }
 
-        const imageSource = this.getImageSource();
+        const imageSource = getImageSource();
         RNImage.getSize(imageSource.uri, (width, height) => {
-            this.props.onLoad({nativeEvent: {width, height}});
+            props.onLoad({nativeEvent: {width, height}});
         });
-    }
+    },
+        [getImageSource, props],
+    );
 
-    render() {
-        // Omit the props which the underlying RNImage won't use
-        const forwardedProps = _.omit(this.props, ['source', 'onLoad', 'session', 'isAuthTokenRequired']);
-        const source = this.getImageSource();
 
-        return (
-            <RNImage
-                // eslint-disable-next-line react/jsx-props-no-spreading
-                {...forwardedProps}
-                source={source}
-            />
-        );
-    }
+    useEffect(() => {
+        configureOnLoad()
+    }, [configureOnLoad, props])
+
+    // Omit the props which the underlying RNImage won't use
+    const forwardedProps = _.omit(props, ['source', 'onLoad', 'session', 'isAuthTokenRequired']);
+    const source = getImageSource();
+
+    return (
+        <RNImage
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            {...forwardedProps}
+            source={source}
+        />
+    );
 }
 
 Image.propTypes = imagePropTypes;

--- a/src/components/Image/index.js
+++ b/src/components/Image/index.js
@@ -12,16 +12,14 @@ function Image(props) {
     /**
      * Check if the image source is a URL - if so the `encryptedAuthToken` is appended
      * to the source.
-     * @returns {Object} - the configured image source
      */
     const source = useMemo(() => {
         if (isAuthTokenRequired) {
-            const innerSource = propsSource;
             // There is currently a `react-native-web` bug preventing the authToken being passed
             // in the headers of the image request so the authToken is added as a query param.
             // On native the authToken IS passed in the image request headers
             const authToken = lodashGet(session, 'encryptedAuthToken', null);
-            return {uri: `${innerSource.uri}?encryptedAuthToken=${encodeURIComponent(authToken)}`};
+            return {uri: `${propsSource.uri}?encryptedAuthToken=${encodeURIComponent(authToken)}`};
         }
         return propsSource;
     }, [propsSource, isAuthTokenRequired, session]);

--- a/src/components/Image/index.js
+++ b/src/components/Image/index.js
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect} from 'react';
+import React, {useEffect, useMemo} from 'react';
 import {Image as RNImage} from 'react-native';
 import {withOnyx} from 'react-native-onyx';
 import lodashGet from 'lodash/get';
@@ -8,49 +8,41 @@ import {defaultProps, imagePropTypes} from './imagePropTypes';
 import RESIZE_MODES from './resizeModes';
 
 function Image(props) {
+    const {source: propsSource, isAuthTokenRequired, onLoad, session} = props;
     /**
      * Check if the image source is a URL - if so the `encryptedAuthToken` is appended
      * to the source.
      * @returns {Object} - the configured image source
      */
-    const getImageSource = useCallback(() => {
-        const source = props.source;
-        let imageSource = source;
-        if (props.isAuthTokenRequired) {
+    const source = useMemo(() => {
+        if (isAuthTokenRequired) {
+            const innerSource = propsSource;
             // There is currently a `react-native-web` bug preventing the authToken being passed
             // in the headers of the image request so the authToken is added as a query param.
             // On native the authToken IS passed in the image request headers
-            const authToken = lodashGet(props, 'session.encryptedAuthToken', null);
-            imageSource = {uri: `${source.uri}?encryptedAuthToken=${encodeURIComponent(authToken)}`};
+            const authToken = lodashGet(session, 'encryptedAuthToken', null);
+            return {uri: `${innerSource.uri}?encryptedAuthToken=${encodeURIComponent(authToken)}`};
         }
-
-        return imageSource;
-    }, [props]);
+        return propsSource;
+    }, [propsSource, isAuthTokenRequired, session]);
 
     /**
      * The natural image dimensions are retrieved using the updated source
      * and as a result the `onLoad` event needs to be manually invoked to return these dimensions
      */
-    const configureOnLoad = useCallback(() => {
+    useEffect(() => {
         // If an onLoad callback was specified then manually call it and pass
         // the natural image dimensions to match the native API
-        if (props.onLoad == null) {
+        if (onLoad == null) {
             return;
         }
-
-        const imageSource = getImageSource();
-        RNImage.getSize(imageSource.uri, (width, height) => {
-            props.onLoad({nativeEvent: {width, height}});
+        RNImage.getSize(source.uri, (width, height) => {
+            onLoad({nativeEvent: {width, height}});
         });
-    }, [getImageSource, props]);
-
-    useEffect(() => {
-        configureOnLoad();
-    }, [configureOnLoad, props]);
+    }, [onLoad, source]);
 
     // Omit the props which the underlying RNImage won't use
     const forwardedProps = _.omit(props, ['source', 'onLoad', 'session', 'isAuthTokenRequired']);
-    const source = getImageSource();
 
     return (
         <RNImage
@@ -61,13 +53,20 @@ function Image(props) {
     );
 }
 
+function imagePropsAreEqual(prevProps, nextProps) {
+    return prevProps.source === nextProps.source;
+}
+
 Image.propTypes = imagePropTypes;
 Image.defaultProps = defaultProps;
 
-const ImageWithOnyx = withOnyx({
-    session: {
-        key: ONYXKEYS.SESSION,
-    },
-})(Image);
+const ImageWithOnyx = React.memo(
+    withOnyx({
+        session: {
+            key: ONYXKEYS.SESSION,
+        },
+    })(Image),
+    imagePropsAreEqual,
+);
 ImageWithOnyx.resizeMode = RESIZE_MODES;
 export default ImageWithOnyx;

--- a/src/components/Image/index.js
+++ b/src/components/Image/index.js
@@ -7,8 +7,7 @@ import ONYXKEYS from '../../ONYXKEYS';
 import {defaultProps, imagePropTypes} from './imagePropTypes';
 import RESIZE_MODES from './resizeModes';
 
-
-function Image (props) {
+function Image(props) {
     /**
      * Check if the image source is a URL - if so the `encryptedAuthToken` is appended
      * to the source.
@@ -26,14 +25,13 @@ function Image (props) {
         }
 
         return imageSource;
-    }, [props])
+    }, [props]);
 
     /**
      * The natural image dimensions are retrieved using the updated source
      * and as a result the `onLoad` event needs to be manually invoked to return these dimensions
      */
-    const configureOnLoad = useCallback(
-        () => {
+    const configureOnLoad = useCallback(() => {
         // If an onLoad callback was specified then manually call it and pass
         // the natural image dimensions to match the native API
         if (props.onLoad == null) {
@@ -44,14 +42,11 @@ function Image (props) {
         RNImage.getSize(imageSource.uri, (width, height) => {
             props.onLoad({nativeEvent: {width, height}});
         });
-    },
-        [getImageSource, props],
-    );
-
+    }, [getImageSource, props]);
 
     useEffect(() => {
-        configureOnLoad()
-    }, [configureOnLoad, props])
+        configureOnLoad();
+    }, [configureOnLoad, props]);
 
     // Omit the props which the underlying RNImage won't use
     const forwardedProps = _.omit(props, ['source', 'onLoad', 'session', 'isAuthTokenRequired']);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This pull request migrates Image/main.js from class component to functional component using hooks and retaining workflow of the previous version as much as possible. The componentDidUpdate and componentDidMount has been migrated by use of useEffect hook.

### Fixed Issues
$ https://github.com/Expensify/App/issues/16164
PROPOSAL: 


### Tests
1. Open chat window
2. Send an image
3. Check if sent image renders correctly

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
1. Open chat window
2. Send an image
3. Check if sent image renders correctly

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<img width="1554" alt="Screenshot 2023-08-04 at 15 49 07" src="https://github.com/Expensify/App/assets/91068263/4779f767-cc71-4fb4-a546-c773dc5dd4bf">


</details>

<details>
<summary>Mobile Web - Chrome</summary>

![Screenshot_1691160399](https://github.com/Expensify/App/assets/91068263/b6fb2c95-a5b6-4dbf-857b-612c60828270)


</details>

<details>
<summary>Mobile Web - Safari</summary>

![Simulator Screenshot - iPhone 14 Pro - 2023-08-04 at 17 18 13](https://github.com/Expensify/App/assets/91068263/cd54132d-847a-4413-86d4-be6990578e77)

</details>

<details>
<summary>Desktop</summary>

<img width="1193" alt="Screenshot 2023-08-04 at 16 22 33" src="https://github.com/Expensify/App/assets/91068263/3b6dc41b-d8c8-4c3d-9e1b-aaee9189ad21">

</details>

<details>
<summary>iOS</summary>

![Simulator Screenshot - iPhone 14 Pro - 2023-08-04 at 17 17 21](https://github.com/Expensify/App/assets/91068263/7caa9fd1-60a6-4fa5-8ad5-dd1dcbde1e22)

</details>

<details>
<summary>Android</summary>

![Screenshot_1691160055](https://github.com/Expensify/App/assets/91068263/cf406f08-6368-4a35-8d6b-5251fc525eed)

</details>
