### PR TITLE
fix offline indicator not show in mobile

### DIFF
--- a/src/components/AvatarCropModal/AvatarCropModal.js
+++ b/src/components/AvatarCropModal/AvatarCropModal.js
@@ -22,6 +22,7 @@ import HeaderGap from '../HeaderGap';
 import * as StyleUtils from '../../styles/StyleUtils';
 import Tooltip from '../Tooltip';
 import PressableWithoutFeedback from '../Pressable/PressableWithoutFeedback';
+import ScreenWrapper from '../ScreenWrapper';
 
 const propTypes = {
     /** Link to image for cropping */
@@ -361,79 +362,85 @@ function AvatarCropModal(props) {
             type={CONST.MODAL.MODAL_TYPE.RIGHT_DOCKED}
             onModalHide={resetState}
         >
-            {props.isSmallScreenWidth && <HeaderGap />}
-            <HeaderWithBackButton
-                title={props.translate('avatarCropModal.title')}
-                onBackButtonPress={props.onClose}
-            />
-            <Text style={[styles.mh5]}>{props.translate('avatarCropModal.description')}</Text>
-            <GestureHandlerRootView
-                onLayout={initializeImageContainer}
-                style={[styles.alignSelfStretch, styles.m5, styles.flex1, styles.alignItemsCenter]}
+            <ScreenWrapper
+                style={[styles.pb0]}
+                includePaddingTop={false}
+                includeSafeAreaPaddingBottom={false}
             >
-                {/* To avoid layout shift we should hide this component until the image container & image is initialized */}
-                {!isImageInitialized || !isImageContainerInitialized ? (
-                    <ActivityIndicator
-                        color={themeColors.spinner}
-                        style={[styles.flex1]}
-                        size="large"
-                    />
-                ) : (
-                    <>
-                        <ImageCropView
-                            imageUri={props.imageUri}
-                            containerSize={imageContainerSize}
-                            panGestureEventHandler={panGestureEventHandler}
-                            originalImageHeight={originalImageHeight}
-                            originalImageWidth={originalImageWidth}
-                            scale={scale}
-                            translateY={translateY}
-                            translateX={translateX}
-                            rotation={rotation}
-                            maskImage={props.maskImage}
+                {props.isSmallScreenWidth && <HeaderGap />}
+                <HeaderWithBackButton
+                    title={props.translate('avatarCropModal.title')}
+                    onBackButtonPress={props.onClose}
+                />
+                <Text style={[styles.mh5]}>{props.translate('avatarCropModal.description')}</Text>
+                <GestureHandlerRootView
+                    onLayout={initializeImageContainer}
+                    style={[styles.alignSelfStretch, styles.m5, styles.flex1, styles.alignItemsCenter]}
+                >
+                    {/* To avoid layout shift we should hide this component until the image container & image is initialized */}
+                    {!isImageInitialized || !isImageContainerInitialized ? (
+                        <ActivityIndicator
+                            color={themeColors.spinner}
+                            style={[styles.flex1]}
+                            size="large"
                         />
-                        <View style={[styles.mt5, styles.justifyContentBetween, styles.alignItemsCenter, styles.flexRow, StyleUtils.getWidthStyle(imageContainerSize)]}>
-                            <Icon
-                                src={Expensicons.Zoom}
-                                fill={themeColors.icons}
+                    ) : (
+                        <>
+                            <ImageCropView
+                                imageUri={props.imageUri}
+                                containerSize={imageContainerSize}
+                                panGestureEventHandler={panGestureEventHandler}
+                                originalImageHeight={originalImageHeight}
+                                originalImageWidth={originalImageWidth}
+                                scale={scale}
+                                translateY={translateY}
+                                translateX={translateX}
+                                rotation={rotation}
+                                maskImage={props.maskImage}
                             />
-                            <PressableWithoutFeedback
-                                style={[styles.mh5, styles.flex1]}
-                                onLayout={initializeSliderContainer}
-                                onPressIn={(e) => runOnUI(sliderOnPress)(e.nativeEvent.locationX)}
-                                accessibilityLabel="slider"
-                                accessibilityRole={CONST.ACCESSIBILITY_ROLE.ADJUSTABLE}
-                            >
-                                <Slider
-                                    sliderValue={translateSlider}
-                                    onGesture={panSliderGestureEventHandler}
+                            <View style={[styles.mt5, styles.justifyContentBetween, styles.alignItemsCenter, styles.flexRow, StyleUtils.getWidthStyle(imageContainerSize)]}>
+                                <Icon
+                                    src={Expensicons.Zoom}
+                                    fill={themeColors.icons}
                                 />
-                            </PressableWithoutFeedback>
-                            <Tooltip
-                                text={props.translate('common.rotate')}
-                                shiftVertical={-2}
-                            >
-                                <View>
-                                    <Button
-                                        medium
-                                        icon={Expensicons.Rotate}
-                                        iconFill={themeColors.inverse}
-                                        iconStyles={[styles.mr0]}
-                                        onPress={rotateImage}
+                                <PressableWithoutFeedback
+                                    style={[styles.mh5, styles.flex1]}
+                                    onLayout={initializeSliderContainer}
+                                    onPressIn={(e) => runOnUI(sliderOnPress)(e.nativeEvent.locationX)}
+                                    accessibilityLabel="slider"
+                                    accessibilityRole={CONST.ACCESSIBILITY_ROLE.ADJUSTABLE}
+                                >
+                                    <Slider
+                                        sliderValue={translateSlider}
+                                        onGesture={panSliderGestureEventHandler}
                                     />
-                                </View>
-                            </Tooltip>
-                        </View>
-                    </>
-                )}
-            </GestureHandlerRootView>
-            <Button
-                success
-                style={[styles.m5]}
-                onPress={cropAndSaveImage}
-                pressOnEnter
-                text={props.translate('common.save')}
-            />
+                                </PressableWithoutFeedback>
+                                <Tooltip
+                                    text={props.translate('common.rotate')}
+                                    shiftVertical={-2}
+                                >
+                                    <View>
+                                        <Button
+                                            medium
+                                            icon={Expensicons.Rotate}
+                                            iconFill={themeColors.inverse}
+                                            iconStyles={[styles.mr0]}
+                                            onPress={rotateImage}
+                                        />
+                                    </View>
+                                </Tooltip>
+                            </View>
+                        </>
+                    )}
+                </GestureHandlerRootView>
+                <Button
+                    success
+                    style={[styles.m5]}
+                    onPress={cropAndSaveImage}
+                    pressOnEnter
+                    text={props.translate('common.save')}
+                />
+            </ScreenWrapper>
         </Modal>
     );
 }

--- a/src/components/CountryPicker/CountrySelectorModal.js
+++ b/src/components/CountryPicker/CountrySelectorModal.js
@@ -6,6 +6,8 @@ import useLocalize from '../../hooks/useLocalize';
 import HeaderWithBackButton from '../HeaderWithBackButton';
 import SelectionListRadio from '../SelectionListRadio';
 import Modal from '../Modal';
+import ScreenWrapper from '../ScreenWrapper';
+import styles from '../../styles/styles';
 import searchCountryOptions from '../../libs/searchCountryOptions';
 
 const propTypes = {
@@ -61,23 +63,29 @@ function CountrySelectorModal({currentCountry, isVisible, onClose, onCountrySele
             hideModalContentWhileAnimating
             useNativeDriver
         >
-            <HeaderWithBackButton
-                title={translate('common.country')}
-                onBackButtonPress={onClose}
-            />
-            <SelectionListRadio
-                headerMessage={headerMessage}
-                textInputLabel={translate('common.country')}
-                textInputPlaceholder={translate('countrySelectorModal.placeholderText')}
-                textInputValue={searchValue}
-                sections={[{data: searchResults, indexOffset: 0}]}
-                onSelectRow={onCountrySelected}
-                onChangeText={setSearchValue}
-                shouldFocusOnSelectRow
-                shouldHaveOptionSeparator
-                shouldDelayFocus
-                initiallyFocusedOptionKey={currentCountry}
-            />
+            <ScreenWrapper
+                style={[styles.pb0]}
+                includePaddingTop={false}
+                includeSafeAreaPaddingBottom={false}
+            >
+                <HeaderWithBackButton
+                    title={translate('common.country')}
+                    onBackButtonPress={onClose}
+                />
+                <SelectionListRadio
+                    headerMessage={headerMessage}
+                    textInputLabel={translate('common.country')}
+                    textInputPlaceholder={translate('countrySelectorModal.placeholderText')}
+                    textInputValue={searchValue}
+                    sections={[{data: searchResults, indexOffset: 0}]}
+                    onSelectRow={onCountrySelected}
+                    onChangeText={setSearchValue}
+                    shouldFocusOnSelectRow
+                    shouldHaveOptionSeparator
+                    shouldDelayFocus
+                    initiallyFocusedOptionKey={currentCountry}
+                />
+            </ScreenWrapper>
         </Modal>
     );
 }

--- a/src/components/NewDatePicker/CalendarPicker/YearPickerModal.js
+++ b/src/components/NewDatePicker/CalendarPicker/YearPickerModal.js
@@ -7,6 +7,8 @@ import SelectionListRadio from '../../SelectionListRadio';
 import Modal from '../../Modal';
 import {radioListItemPropTypes} from '../../SelectionListRadio/selectionListRadioPropTypes';
 import useLocalize from '../../../hooks/useLocalize';
+import ScreenWrapper from '../../ScreenWrapper';
+import styles from '../../../styles/styles';
 
 const propTypes = {
     /** Whether the modal is visible */
@@ -58,22 +60,28 @@ function YearPickerModal(props) {
             hideModalContentWhileAnimating
             useNativeDriver
         >
-            <HeaderWithBackButton
-                title={translate('yearPickerPage.year')}
-                onBackButtonPress={props.onClose}
-            />
-            <SelectionListRadio
-                shouldDelayFocus
-                textInputLabel={translate('yearPickerPage.selectYear')}
-                textInputValue={searchText}
-                textInputMaxLength={4}
-                onChangeText={(text) => setSearchText(text.replace(CONST.REGEX.NON_NUMERIC, '').trim())}
-                keyboardType={CONST.KEYBOARD_TYPE.NUMBER_PAD}
-                headerMessage={headerMessage}
-                sections={sections}
-                onSelectRow={(option) => props.onYearChange(option.value)}
-                initiallyFocusedOptionKey={props.currentYear.toString()}
-            />
+            <ScreenWrapper
+                style={[styles.pb0]}
+                includePaddingTop={false}
+                includeSafeAreaPaddingBottom={false}
+            >
+                <HeaderWithBackButton
+                    title={translate('yearPickerPage.year')}
+                    onBackButtonPress={props.onClose}
+                />
+                <SelectionListRadio
+                    shouldDelayFocus
+                    textInputLabel={translate('yearPickerPage.selectYear')}
+                    textInputValue={searchText}
+                    textInputMaxLength={4}
+                    onChangeText={(text) => setSearchText(text.replace(CONST.REGEX.NON_NUMERIC, '').trim())}
+                    keyboardType={CONST.KEYBOARD_TYPE.NUMBER_PAD}
+                    headerMessage={headerMessage}
+                    sections={sections}
+                    onSelectRow={(option) => props.onYearChange(option.value)}
+                    initiallyFocusedOptionKey={props.currentYear.toString()}
+                />
+            </ScreenWrapper>
         </Modal>
     );
 }

--- a/src/components/ScreenWrapper/index.js
+++ b/src/components/ScreenWrapper/index.js
@@ -111,7 +111,7 @@ class ScreenWrapper extends React.Component {
                             {...(this.props.environment === CONST.ENVIRONMENT.DEV ? this.panResponder.panHandlers : {})}
                         >
                             <View
-                                style={[...this.props.style, styles.flex1, paddingStyle]}
+                                style={[styles.flex1, paddingStyle, ...this.props.style]}
                                 // eslint-disable-next-line react/jsx-props-no-spreading
                                 {...this.keyboardDissmissPanResponder.panHandlers}
                             >

--- a/src/components/StatePicker/StateSelectorModal.js
+++ b/src/components/StatePicker/StateSelectorModal.js
@@ -6,6 +6,8 @@ import Modal from '../Modal';
 import HeaderWithBackButton from '../HeaderWithBackButton';
 import SelectionListRadio from '../SelectionListRadio';
 import useLocalize from '../../hooks/useLocalize';
+import ScreenWrapper from '../ScreenWrapper';
+import styles from '../../styles/styles';
 import searchCountryOptions from '../../libs/searchCountryOptions';
 
 const propTypes = {
@@ -65,24 +67,30 @@ function StateSelectorModal({currentState, isVisible, onClose, onStateSelected, 
             hideModalContentWhileAnimating
             useNativeDriver
         >
-            <HeaderWithBackButton
-                title={label || translate('common.state')}
-                shouldShowBackButton
-                onBackButtonPress={onClose}
-            />
-            <SelectionListRadio
-                headerMessage={headerMessage}
-                textInputLabel={label || translate('common.state')}
-                textInputPlaceholder={translate('stateSelectorModal.placeholderText')}
-                textInputValue={searchValue}
-                sections={[{data: searchResults, indexOffset: 0}]}
-                onSelectRow={onStateSelected}
-                onChangeText={setSearchValue}
-                shouldFocusOnSelectRow
-                shouldHaveOptionSeparator
-                shouldDelayFocus
-                initiallyFocusedOptionKey={currentState}
-            />
+            <ScreenWrapper
+                style={[styles.pb0]}
+                includePaddingTop={false}
+                includeSafeAreaPaddingBottom={false}
+            >
+                <HeaderWithBackButton
+                    title={label || translate('common.state')}
+                    shouldShowBackButton
+                    onBackButtonPress={onClose}
+                />
+                <SelectionListRadio
+                    headerMessage={headerMessage}
+                    textInputLabel={label || translate('common.state')}
+                    textInputPlaceholder={translate('stateSelectorModal.placeholderText')}
+                    textInputValue={searchValue}
+                    sections={[{data: searchResults, indexOffset: 0}]}
+                    onSelectRow={onStateSelected}
+                    onChangeText={setSearchValue}
+                    shouldFocusOnSelectRow
+                    shouldHaveOptionSeparator
+                    shouldDelayFocus
+                    initiallyFocusedOptionKey={currentState}
+                />
+            </ScreenWrapper>
         </Modal>
     );
 }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Fix offline indicator not show in mobile
### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/23165
PROPOSAL: https://github.com/Expensify/App/issues/23165#issuecomment-1659490197


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Login with any account
2. Turn off the internet connection (or enable force offline in Preferences). 
3. Go to Profile => Click user photo => upload photo => choose any photo.
4. Verify there's OfflineIndicator at bottom.
5. Go to Profile => Personal Details => Date of Birth => Click on the year => YearPickModal will show up.
6. Verify there's OfflineIndicator at bottom.
7.  Go to Profile => Personal Details => Home Address => Click on the Country filed => CountrySelectorModal will show up.
8. Verify there's OfflineIndicator at bottom.
9. Go to Profile => Personal Details => Home Address => Click on the State filed => StateSelectorModal will show up.
10. Verify there's OfflineIndicator at bottom.
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Login with any account
2. Turn off the internet connection (or enable force offline in Preferences). 
3. Go to Profile => Click user photo => upload photo => choose any photo.
4. Verify there's OfflineIndicator at bottom.
5. Go to Profile => Personal Details => Date of Birth => Click on the year => YearPickModal will show up.
6. Verify there's OfflineIndicator at bottom.
7.  Go to Profile => Personal Details => Home Address => Click on the Country filed => CountrySelectorModal will show up.
8. Verify there's OfflineIndicator at bottom.
9. Go to Profile => Personal Details => Home Address => Click on the State filed => StateSelectorModal will show up.
10. Verify there's OfflineIndicator at bottom.
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->
https://github.com/Expensify/App/assets/16502320/932aa6b6-be1f-48f2-9f82-38780cc01f34

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->
https://github.com/Expensify/App/assets/16502320/d2565dc9-dae5-4f75-9200-f7bb6a934935

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->
https://github.com/Expensify/App/assets/16502320/82262d30-0cfe-4bd8-abc7-fa138bbc82d1

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->
https://github.com/Expensify/App/assets/16502320/932aa6b6-be1f-48f2-9f82-38780cc01f34

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

![Simulator Screen Shot - iPhone 14 - 2023-08-06 at 17 28 41](https://github.com/Expensify/App/assets/16502320/aa89ea41-6d8d-4987-9066-25ccc0f0cabb)
![Simulator Screen Shot - iPhone 14 - 2023-08-06 at 17 28 59](https://github.com/Expensify/App/assets/16502320/381dc49d-393e-40c4-ba15-0d09895b5885)


<img width="373" alt="Screen Shot 2023-08-04 at 22 41 53" src="https://github.com/Expensify/App/assets/16502320/64bd5ae0-736b-4992-939e-537d97d161d2">


</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->
https://github.com/Expensify/App/assets/16502320/d2565dc9-dae5-4f75-9200-f7bb6a934935

</details>