### PR TITLE
Change position: absolute for position:fixed in getNavigationModalCard

### DIFF
--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -219,7 +219,6 @@ class AuthScreens extends React.Component {
             // we want pop in RHP since there are some flows that would work weird otherwise
             animationTypeForReplace: 'pop',
             cardStyle: getNavigationModalCardStyle({
-                windowHeight: this.props.windowHeight,
                 isSmallScreenWidth: this.props.isSmallScreenWidth,
             }),
         };

--- a/src/styles/getNavigationModalCardStyles/index.website.js
+++ b/src/styles/getNavigationModalCardStyles/index.website.js
@@ -3,7 +3,7 @@ import getBaseNavigationModalCardStyles from './getBaseNavigationModalCardStyles
 export default ({isSmallScreenWidth}) => ({
     ...getBaseNavigationModalCardStyles({isSmallScreenWidth}),
 
-    // This height is passed from JavaScript, instead of using CSS expressions like "100%" or "100vh", to work around
+    // position: fixed is set instead of position absolute to workaround Safari known issues of updating heights in DOM.
     // Safari issues:
     // https://github.com/Expensify/App/issues/12005
     // https://github.com/Expensify/App/issues/17824

--- a/src/styles/getNavigationModalCardStyles/index.website.js
+++ b/src/styles/getNavigationModalCardStyles/index.website.js
@@ -1,6 +1,6 @@
 import getBaseNavigationModalCardStyles from './getBaseNavigationModalCardStyles';
 
-export default ({windowHeight, isSmallScreenWidth}) => ({
+export default ({isSmallScreenWidth}) => ({
     ...getBaseNavigationModalCardStyles({isSmallScreenWidth}),
 
     // This height is passed from JavaScript, instead of using CSS expressions like "100%" or "100vh", to work around
@@ -8,7 +8,5 @@ export default ({windowHeight, isSmallScreenWidth}) => ({
     // https://github.com/Expensify/App/issues/12005
     // https://github.com/Expensify/App/issues/17824
     // https://github.com/Expensify/App/issues/20709
-
-    height: `${windowHeight}px`,
-    minHeight: `${windowHeight}px`,
+    position: 'fixed',
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
We need to add `position: fixed`intead of `position: absolute` these makes that safari updates the height value correctly.
Also this implementation allow to delete `height` and `minHeight` on  [getNavigationModalCardStyles/index.website.js](https://github.com/Expensify/App/blob/c08d5887b18914d95e64e925bfed290fecfffc94/src/styles/getNavigationModalCardStyles/index.website.js#L12:L13)

        export default ({isSmallScreenWidth}) => ({
        ...getBaseNavigationModalCardStyles({isSmallScreenWidth}),

              position: "fixed",
        });
### Fixed Issues
$ https://github.com/Expensify/App/issues/20709
$ https://github.com/Expensify/App/issues/23481
PROPOSAL:  https://github.com/Expensify/App/issues/23481#issuecomment-1669687735



### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
5. Verify a modal appears displaying a preview of that image
--->
#### First Scenario
1. Download the New Expensify app for the Smart Banner to appear.
2. Open in safari iOS the and navigate to newDot home. 
3. Open settings clicking on profiles avatar
4. Scroll down 
5. Sign out option should be visible and easily clickable.
6. Go to Security
7. Go to Two factor authentication
8. Copy de codes
9. Open the iOS keyboard by focusing the input
10. the next button should be in the button.

#### Second Scenario

1. Download the New Expensify app for the Smart Banner to appear.
2. Open in safari iOS the and navigate to newDot home. 
3. Open settings clicking on profiles avatar
4. Click on Workspaces
5. New workspace button should be fully visible and easily clickable




- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
4. Verify a modal appears displaying a preview of that image
--->
#### First Scenario
1. Download the New Expensify app for the Smart Banner to appear.
2. Open in safari iOS the and navigate to newDot home. 
3. Open settings clicking on profiles avatar
4. Scroll down 
5. Sign out option should be visible and easily clickable.
6. Go to Security
7. Go to Two factor authentication
8. Copy de codes
9. Open the iOS keyboard by focusing the input
10. the next button should be in the button.

#### Second Scenario

1. Download the New Expensify app for the Smart Banner to appear.
2. Open in safari iOS the and navigate to newDot home. 
3. Open settings clicking on profiles avatar
4. Click on Workspaces
5. New workspace button should be fully visible and easily clickable

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [ x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
This just happens in Mobile Web - Safari 
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/16781411/e000c280-303c-42da-9b42-c25c17abd832

</details>
<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->


https://github.com/Expensify/App/assets/16781411/d76cf354-2387-4fbd-b75b-f550d0297cd7


</details>
<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->
https://github.com/Expensify/App/assets/16781411/e130cf00-62f5-46b5-a870-e0a0f9f68d8f


</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/16781411/05c2b4a3-a746-41cb-90dd-89a9f2ea64d5


</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->


https://github.com/Expensify/App/assets/16781411/2befc487-976d-448f-8a54-c5058b7f5c48


</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->


https://github.com/Expensify/App/assets/16781411/aba5623d-ea4d-4f85-b927-d6916d1575f7


</details>


