### PR TITLE
migrate native AttachmentPicker to functional component

### DIFF
--- a/src/components/AttachmentPicker/index.native.js
+++ b/src/components/AttachmentPicker/index.native.js
@@ -113,7 +113,6 @@ function AttachmentPicker({translate, type, children, isSmallScreenWidth}) {
 
     /**
      * A generic handling when we don't know the exact reason for an error
-     *
      */
     const showGeneralAlert = () => {
         Alert.alert(translate('attachmentPicker.attachmentError'), translate('attachmentPicker.errorWhileSelectingAttachment'));

--- a/src/components/AttachmentPicker/index.native.js
+++ b/src/components/AttachmentPicker/index.native.js
@@ -86,7 +86,6 @@ function getDataForUpload(fileData) {
 }
 
 function AttachmentPicker(props) {
-    // const onPicked = useRef();
     const completeAttachmentSelection = useRef();
     const onModalHide = useRef();
     const keyboardListener = useRef();

--- a/src/components/AttachmentPicker/index.native.js
+++ b/src/components/AttachmentPicker/index.native.js
@@ -350,5 +350,6 @@ function AttachmentPicker({ type, children, isSmallScreenWidth}) {
 
 AttachmentPicker.propTypes = propTypes;
 AttachmentPicker.defaultProps = defaultProps;
+AttachmentPicker.displayName = 'AttachmentPicker';
 
 export default withWindowDimensions(AttachmentPicker);

--- a/src/components/AttachmentPicker/index.native.js
+++ b/src/components/AttachmentPicker/index.native.js
@@ -40,7 +40,7 @@ const imagePickerOptions = {
  * @param {String} type
  * @returns {Object}
  */
-function getImagePickerOptions(type) {
+const getImagePickerOptions = (type) => {
     // mediaType property is one of the ImagePicker configuration to restrict types'
     const mediaType = type === CONST.ATTACHMENT_PICKER_TYPE.IMAGE ? 'photo' : 'mixed';
     return {
@@ -64,7 +64,7 @@ const documentPickerOptions = {
  * @param {Object} fileData
  * @return {Promise}
  */
-function getDataForUpload(fileData) {
+const getDataForUpload = (fileData) => {
     const fileName = fileData.fileName || fileData.name || 'chat_attachment';
     const fileResult = {
         name: FileUtils.cleanFileName(fileName),
@@ -93,7 +93,7 @@ function AttachmentPicker({translate, type, children, isSmallScreenWidth}) {
     /**
      * Inform the users when they need to grant camera access and guide them to settings
      */
-    function showPermissionsAlert() {
+    const showPermissionsAlert = () => {
         Alert.alert(
             translate('attachmentPicker.cameraPermissionRequired'),
             translate('attachmentPicker.expensifyDoesntHaveAccessToCamera'),
@@ -115,7 +115,7 @@ function AttachmentPicker({translate, type, children, isSmallScreenWidth}) {
      * A generic handling when we don't know the exact reason for an error
      *
      */
-    function showGeneralAlert() {
+    const showGeneralAlert = () => {
         Alert.alert(translate('attachmentPicker.attachmentError'), translate('attachmentPicker.errorWhileSelectingAttachment'));
     }
 
@@ -125,8 +125,7 @@ function AttachmentPicker({translate, type, children, isSmallScreenWidth}) {
      * @param {function} imagePickerFunc - RNImagePicker.launchCamera or RNImagePicker.launchImageLibrary
      * @returns {Promise<ImagePickerResponse>}
      */
-    function showImagePicker(imagePickerFunc) {
-        return new Promise((resolve, reject) => {
+    const showImagePicker = (imagePickerFunc) => new Promise((resolve, reject) => {
             imagePickerFunc(getImagePickerOptions(type), (response) => {
                 if (response.didCancel) {
                     // When the user cancelled resolve with no attachment
@@ -147,8 +146,7 @@ function AttachmentPicker({translate, type, children, isSmallScreenWidth}) {
 
                 return resolve(response.assets);
             });
-        });
-    }
+        })
 
     const [isVisible, setIsVisible] = useState(false);
     const [focusedIndex, setFocusedIndex] = useState(-1);
@@ -170,7 +168,7 @@ function AttachmentPicker({translate, type, children, isSmallScreenWidth}) {
     /**
      * An attachment error dialog when user selected malformed images
      */
-    function showImageCorruptionAlert() {
+    const showImageCorruptionAlert = () => {
         Alert.alert(translate('attachmentPicker.attachmentError'), translate('attachmentPicker.errorWhileSelectingCorruptedImage'));
     }
 
@@ -179,23 +177,21 @@ function AttachmentPicker({translate, type, children, isSmallScreenWidth}) {
      *
      * @returns {Promise<DocumentPickerResponse[]>}
      */
-    function showDocumentPicker() {
-        return RNDocumentPicker.pick(documentPickerOptions).catch((error) => {
+    const showDocumentPicker = () => RNDocumentPicker.pick(documentPickerOptions).catch((error) => {
             if (RNDocumentPicker.isCancel(error)) {
                 return;
             }
 
             showGeneralAlert(error.message);
             throw error;
-        });
-    }
+        })
 
     /**
      * Opens the attachment modal
      *
      * @param {function} onPickedHandler A callback that will be called with the selected attachment
      */
-    function open(onPickedHandler) {
+    const open = (onPickedHandler) => {
         completeAttachmentSelection.current = onPickedHandler;
         setIsVisible(true);
     }
@@ -203,7 +199,7 @@ function AttachmentPicker({translate, type, children, isSmallScreenWidth}) {
     /**
      * Closes the attachment modal
      */
-    function close() {
+    const close = () => {
         setIsVisible(false);
     }
 
@@ -214,7 +210,7 @@ function AttachmentPicker({translate, type, children, isSmallScreenWidth}) {
      * @param {Array<ImagePickerResponse|DocumentPickerResponse>} attachments
      * @returns {Promise}
      */
-    function pickAttachment(attachments = []) {
+    const pickAttachment = (attachments = []) => {
         if (attachments.length === 0) {
             return;
         }
@@ -242,7 +238,7 @@ function AttachmentPicker({translate, type, children, isSmallScreenWidth}) {
      * @param {Object} item - an item from this.menuItemData
      * @param {Function} item.pickAttachment
      */
-    function selectItem(item) {
+    const selectItem = (item) => {
         /* setTimeout delays execution to the frame after the modal closes
          * without this on iOS closing the modal closes the gallery/camera as well */
         onModalHide.current = () =>
@@ -259,7 +255,7 @@ function AttachmentPicker({translate, type, children, isSmallScreenWidth}) {
         close();
     }
 
-    function attachKeyboardListener() {
+    const attachKeyboardListener = () => {
         const shortcutConfig = CONST.KEYBOARD_SHORTCUTS.ENTER;
         keyboardListener.current = KeyboardShortcut.subscribe(
             shortcutConfig.shortcutKey,
@@ -276,7 +272,7 @@ function AttachmentPicker({translate, type, children, isSmallScreenWidth}) {
         );
     }
 
-    function removeKeyboardListener() {
+    const removeKeyboardListener = () => {
         if (!keyboardListener.current) {
             return;
         }
@@ -319,11 +315,9 @@ function AttachmentPicker({translate, type, children, isSmallScreenWidth}) {
      *
      * @returns {React.ReactNode}
      */
-    function renderChildren() {
-        return children({
+    const renderChildren = () => children({
             openPicker: ({onPicked}) => open(onPicked),
-        });
-    }
+        })
 
     return (
         <>

--- a/src/components/AttachmentPicker/index.native.js
+++ b/src/components/AttachmentPicker/index.native.js
@@ -82,6 +82,15 @@ const getDataForUpload = (fileData) => {
     });
 };
 
+
+/**
+ * This component renders a function as a child and
+ * returns a "show attachment picker" method that takes
+ * a callback. This is the ios/android implementation
+ * opening a modal with attachment options
+ * @param {propTypes} props
+ * @returns {JSX.Element}
+ */
 function AttachmentPicker({type, children}) {
     const [isVisible, setIsVisible] = useState(false);
 

--- a/src/components/AttachmentPicker/index.native.js
+++ b/src/components/AttachmentPicker/index.native.js
@@ -83,6 +83,9 @@ const getDataForUpload = (fileData) => {
 }
 
 function AttachmentPicker({ type, children}) {
+    const [isVisible, setIsVisible] = useState(false);
+    const [focusedIndex, setFocusedIndex] = useState(-1);
+
     const completeAttachmentSelection = useRef();
     const onModalHide = useRef();
     const keyboardListener = useRef();
@@ -147,8 +150,6 @@ function AttachmentPicker({ type, children}) {
             });
         })
 
-    const [isVisible, setIsVisible] = useState(false);
-    const [focusedIndex, setFocusedIndex] = useState(-1);
     const [menuItemData, setMenuItemData] = useState([
         {
             icon: Expensicons.Camera,

--- a/src/components/AttachmentPicker/index.native.js
+++ b/src/components/AttachmentPicker/index.native.js
@@ -290,7 +290,7 @@ function AttachmentPicker({ type, children, isSmallScreenWidth}) {
             {
                 icon: Expensicons.Paperclip,
                 textTranslationKey: 'attachmentPicker.chooseDocument',
-                pickAttachment: () => showDocumentPicker(),
+                pickAttachment: showDocumentPicker,
             },
         ]);
 

--- a/src/components/AttachmentPicker/index.native.js
+++ b/src/components/AttachmentPicker/index.native.js
@@ -162,8 +162,6 @@ function AttachmentPicker({ type, children, isSmallScreenWidth}) {
         },
     ]);
 
-    // const [result, setResult] = useState()
-
     /**
      * An attachment error dialog when user selected malformed images
      */

--- a/src/components/AttachmentPicker/index.native.js
+++ b/src/components/AttachmentPicker/index.native.js
@@ -12,10 +12,10 @@ import launchCamera from './launchCamera';
 import Popover from '../Popover';
 import MenuItem from '../MenuItem';
 import styles from '../../styles/styles';
-import ArrowKeyFocusManager from '../ArrowKeyFocusManager';
 import useLocalize from '../../hooks/useLocalize';
 import useWindowDimensions from '../../hooks/useWindowDimensions';
 import useKeyboardShortcut from '../../hooks/useKeyboardShortcut';
+import useArrowKeyFocusManager from '../../hooks/useArrowKeyFocusManager';
 
 const propTypes = {
     ...basePropTypes,
@@ -84,7 +84,6 @@ const getDataForUpload = (fileData) => {
 
 function AttachmentPicker({type, children}) {
     const [isVisible, setIsVisible] = useState(false);
-    const [focusedIndex, setFocusedIndex] = useState(-1);
 
     const completeAttachmentSelection = useRef();
     const onModalHide = useRef();
@@ -195,6 +194,8 @@ function AttachmentPicker({type, children}) {
 
         return data;
     }, [showDocumentPicker, showImagePicker, type]);
+
+    const [focusedIndex, setFocusedIndex] = useArrowKeyFocusManager({initialFocusedIndex: -1, maxIndex: menuItemData.length - 1, isActive: isVisible});
 
     /**
      * An attachment error dialog when user selected malformed images
@@ -311,21 +312,15 @@ function AttachmentPicker({type, children}) {
                 onModalHide={onModalHide.current}
             >
                 <View style={!isSmallScreenWidth && styles.createMenuContainer}>
-                    <ArrowKeyFocusManager
-                        focusedIndex={focusedIndex}
-                        maxIndex={menuItemData.length - 1}
-                        onFocusedIndexChanged={(index) => setFocusedIndex(index)}
-                    >
-                        {_.map(menuItemData, (item, menuIndex) => (
-                            <MenuItem
-                                key={item.textTranslationKey}
-                                icon={item.icon}
-                                title={translate(item.textTranslationKey)}
-                                onPress={() => selectItem(item)}
-                                focused={focusedIndex === menuIndex}
-                            />
-                        ))}
-                    </ArrowKeyFocusManager>
+                    {_.map(menuItemData, (item, menuIndex) => (
+                        <MenuItem
+                            key={item.textTranslationKey}
+                            icon={item.icon}
+                            title={translate(item.textTranslationKey)}
+                            onPress={() => selectItem(item)}
+                            focused={focusedIndex === menuIndex}
+                        />
+                    ))}
                 </View>
             </Popover>
             {renderChildren()}

--- a/src/components/AttachmentPicker/index.native.js
+++ b/src/components/AttachmentPicker/index.native.js
@@ -321,7 +321,7 @@ function AttachmentPicker({ type, children, isSmallScreenWidth}) {
     return (
         <>
             <Popover
-                onClose={() => close()}
+                onClose={close}
                 isVisible={isVisible}
                 anchorPosition={styles.createMenuPosition}
                 onModalHide={onModalHide.current}

--- a/src/components/AttachmentPicker/index.native.js
+++ b/src/components/AttachmentPicker/index.native.js
@@ -82,7 +82,6 @@ const getDataForUpload = (fileData) => {
     });
 };
 
-
 /**
  * This component renders a function as a child and
  * returns a "show attachment picker" method that takes

--- a/src/components/AttachmentPicker/index.native.js
+++ b/src/components/AttachmentPicker/index.native.js
@@ -296,7 +296,7 @@ function AttachmentPicker({ type, children}) {
         return () => {
             removeKeyboardListener();
         };
-        // eslint-disable-next-line react-hooks/exhaustive-deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- we only want this effect to run on initial render
     }, []);
 
     useEffect(() => {

--- a/src/components/AttachmentPicker/index.native.js
+++ b/src/components/AttachmentPicker/index.native.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import React, {useEffect, useState, useRef} from 'react';
+import React, {useEffect, useState, useRef, useCallback} from 'react';
 import {View, Alert, Linking} from 'react-native';
 import RNDocumentPicker from 'react-native-document-picker';
 import RNFetchBlob from 'react-native-blob-util';
@@ -114,9 +114,9 @@ function AttachmentPicker({ type, children, isSmallScreenWidth}) {
     /**
      * A generic handling when we don't know the exact reason for an error
      */
-    const showGeneralAlert = () => {
+    const showGeneralAlert = useCallback(() => {
         Alert.alert(translate('attachmentPicker.attachmentError'), translate('attachmentPicker.errorWhileSelectingAttachment'));
-    }
+    }, [translate])
 
     /**
      * Common image picker handling
@@ -167,9 +167,9 @@ function AttachmentPicker({ type, children, isSmallScreenWidth}) {
     /**
      * An attachment error dialog when user selected malformed images
      */
-    const showImageCorruptionAlert = () => {
+    const showImageCorruptionAlert = useCallback(() => {
         Alert.alert(translate('attachmentPicker.attachmentError'), translate('attachmentPicker.errorWhileSelectingCorruptedImage'));
-    }
+    }, [translate])
 
     /**
      * Launch the DocumentPicker. Results are in the same format as ImagePicker
@@ -209,7 +209,7 @@ function AttachmentPicker({ type, children, isSmallScreenWidth}) {
      * @param {Array<ImagePickerResponse|DocumentPickerResponse>} attachments
      * @returns {Promise}
      */
-    const pickAttachment = (attachments = []) => {
+    const pickAttachment = useCallback((attachments = []) => {
         if (attachments.length === 0) {
             return;
         }
@@ -229,7 +229,7 @@ function AttachmentPicker({ type, children, isSmallScreenWidth}) {
                 showGeneralAlert(error.message);
                 throw error;
             });
-    }
+    }, [showGeneralAlert, showImageCorruptionAlert])
 
     /**
      * Setup native attachment selection to start after this popover closes
@@ -237,7 +237,7 @@ function AttachmentPicker({ type, children, isSmallScreenWidth}) {
      * @param {Object} item - an item from this.menuItemData
      * @param {Function} item.pickAttachment
      */
-    const selectItem = (item) => {
+    const selectItem = useCallback((item) => {
         /* setTimeout delays execution to the frame after the modal closes
          * without this on iOS closing the modal closes the gallery/camera as well */
         onModalHide.current = () =>
@@ -252,9 +252,9 @@ function AttachmentPicker({ type, children, isSmallScreenWidth}) {
             );
 
         close();
-    }
+    }, [pickAttachment])
 
-    const attachKeyboardListener = () => {
+    const attachKeyboardListener = useCallback(() => {
         const shortcutConfig = CONST.KEYBOARD_SHORTCUTS.ENTER;
         keyboardListener.current = KeyboardShortcut.subscribe(
             shortcutConfig.shortcutKey,
@@ -269,7 +269,7 @@ function AttachmentPicker({ type, children, isSmallScreenWidth}) {
             shortcutConfig.modifiers,
             true,
         );
-    }
+    }, [focusedIndex, menuItemData, selectItem])
 
     const removeKeyboardListener = () => {
         if (!keyboardListener.current) {
@@ -306,8 +306,7 @@ function AttachmentPicker({ type, children, isSmallScreenWidth}) {
         } else {
             removeKeyboardListener();
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isVisible]);
+    }, [isVisible, attachKeyboardListener]);
 
     /**
      * Call the `children` renderProp with the interface defined in propTypes

--- a/src/components/AttachmentPicker/index.native.js
+++ b/src/components/AttachmentPicker/index.native.js
@@ -85,7 +85,7 @@ function getDataForUpload(fileData) {
     });
 }
 
-function AttachmentPicker(props) {
+function AttachmentPicker({translate, type, children, isSmallScreenWidth}) {
     const completeAttachmentSelection = useRef();
     const onModalHide = useRef();
     const keyboardListener = useRef();
@@ -95,15 +95,15 @@ function AttachmentPicker(props) {
      */
     function showPermissionsAlert() {
         Alert.alert(
-            props.translate('attachmentPicker.cameraPermissionRequired'),
-            props.translate('attachmentPicker.expensifyDoesntHaveAccessToCamera'),
+            translate('attachmentPicker.cameraPermissionRequired'),
+            translate('attachmentPicker.expensifyDoesntHaveAccessToCamera'),
             [
                 {
-                    text: props.translate('common.cancel'),
+                    text: translate('common.cancel'),
                     style: 'cancel',
                 },
                 {
-                    text: props.translate('common.settings'),
+                    text: translate('common.settings'),
                     onPress: () => Linking.openSettings(),
                 },
             ],
@@ -116,7 +116,7 @@ function AttachmentPicker(props) {
      *
      */
     function showGeneralAlert() {
-        Alert.alert(props.translate('attachmentPicker.attachmentError'), props.translate('attachmentPicker.errorWhileSelectingAttachment'));
+        Alert.alert(translate('attachmentPicker.attachmentError'), translate('attachmentPicker.errorWhileSelectingAttachment'));
     }
 
     /**
@@ -127,7 +127,7 @@ function AttachmentPicker(props) {
      */
     function showImagePicker(imagePickerFunc) {
         return new Promise((resolve, reject) => {
-            imagePickerFunc(getImagePickerOptions(props.type), (response) => {
+            imagePickerFunc(getImagePickerOptions(type), (response) => {
                 if (response.didCancel) {
                     // When the user cancelled resolve with no attachment
                     return resolve();
@@ -171,7 +171,7 @@ function AttachmentPicker(props) {
      * An attachment error dialog when user selected malformed images
      */
     function showImageCorruptionAlert() {
-        Alert.alert(props.translate('attachmentPicker.attachmentError'), props.translate('attachmentPicker.errorWhileSelectingCorruptedImage'));
+        Alert.alert(translate('attachmentPicker.attachmentError'), translate('attachmentPicker.errorWhileSelectingCorruptedImage'));
     }
 
     /**
@@ -286,7 +286,7 @@ function AttachmentPicker(props) {
     useEffect(() => {
         // When selecting an image on a native device, it would be redundant to have a second option for choosing a document,
         // so it is excluded in this case.
-        if (props.type === CONST.ATTACHMENT_PICKER_TYPE.IMAGE) {
+        if (type === CONST.ATTACHMENT_PICKER_TYPE.IMAGE) {
             return;
         }
 
@@ -320,7 +320,7 @@ function AttachmentPicker(props) {
      * @returns {React.ReactNode}
      */
     function renderChildren() {
-        return props.children({
+        return children({
             openPicker: ({onPicked}) => open(onPicked),
         });
     }
@@ -333,7 +333,7 @@ function AttachmentPicker(props) {
                 anchorPosition={styles.createMenuPosition}
                 onModalHide={onModalHide.current}
             >
-                <View style={props.isSmallScreenWidth ? {} : styles.createMenuContainer}>
+                <View style={isSmallScreenWidth ? {} : styles.createMenuContainer}>
                     <ArrowKeyFocusManager
                         focusedIndex={focusedIndex}
                         maxIndex={menuItemData.length - 1}
@@ -343,7 +343,7 @@ function AttachmentPicker(props) {
                             <MenuItem
                                 key={item.textTranslationKey}
                                 icon={item.icon}
-                                title={props.translate(item.textTranslationKey)}
+                                title={translate(item.textTranslationKey)}
                                 onPress={() => selectItem(item)}
                                 focused={focusedIndex === menuIndex}
                             />

--- a/src/components/AttachmentPicker/index.native.js
+++ b/src/components/AttachmentPicker/index.native.js
@@ -225,14 +225,14 @@ function AttachmentPicker({type, children}) {
     const pickAttachment = useCallback(
         (attachments = []) => {
             if (attachments.length === 0) {
-                return;
+                return Promise.resolve();
             }
 
             const fileData = _.first(attachments);
 
             if (fileData.width === -1 || fileData.height === -1) {
                 showImageCorruptionAlert();
-                return;
+                return Promise.resolve();
             }
 
             return getDataForUpload(fileData)

--- a/src/components/AttachmentPicker/index.native.js
+++ b/src/components/AttachmentPicker/index.native.js
@@ -326,7 +326,7 @@ function AttachmentPicker({translate, type, children, isSmallScreenWidth}) {
                 anchorPosition={styles.createMenuPosition}
                 onModalHide={onModalHide.current}
             >
-                <View style={isSmallScreenWidth ? {} : styles.createMenuContainer}>
+                <View style={!isSmallScreenWidth && styles.createMenuContainer}>
                     <ArrowKeyFocusManager
                         focusedIndex={focusedIndex}
                         maxIndex={menuItemData.length - 1}

--- a/src/components/AttachmentPicker/index.native.js
+++ b/src/components/AttachmentPicker/index.native.js
@@ -6,8 +6,6 @@ import RNFetchBlob from 'react-native-blob-util';
 import {launchImageLibrary} from 'react-native-image-picker';
 import {propTypes as basePropTypes, defaultProps} from './attachmentPickerPropTypes';
 import withWindowDimensions, {windowDimensionsPropTypes} from '../withWindowDimensions';
-import withLocalize, {withLocalizePropTypes} from '../withLocalize';
-import compose from '../../libs/compose';
 import CONST from '../../CONST';
 import * as FileUtils from '../../libs/fileDownload/FileUtils';
 import * as Expensicons from '../Icon/Expensicons';
@@ -17,11 +15,11 @@ import Popover from '../Popover';
 import MenuItem from '../MenuItem';
 import styles from '../../styles/styles';
 import ArrowKeyFocusManager from '../ArrowKeyFocusManager';
+import useLocalize from '../../hooks/useLocalize';
 
 const propTypes = {
     ...basePropTypes,
     ...windowDimensionsPropTypes,
-    ...withLocalizePropTypes,
 };
 
 /**
@@ -85,10 +83,12 @@ const getDataForUpload = (fileData) => {
     });
 }
 
-function AttachmentPicker({translate, type, children, isSmallScreenWidth}) {
+function AttachmentPicker({ type, children, isSmallScreenWidth}) {
     const completeAttachmentSelection = useRef();
     const onModalHide = useRef();
     const keyboardListener = useRef();
+    
+    const {translate} = useLocalize()
 
     /**
      * Inform the users when they need to grant camera access and guide them to settings
@@ -352,4 +352,4 @@ function AttachmentPicker({translate, type, children, isSmallScreenWidth}) {
 AttachmentPicker.propTypes = propTypes;
 AttachmentPicker.defaultProps = defaultProps;
 
-export default compose(withWindowDimensions, withLocalize)(AttachmentPicker);
+export default withWindowDimensions(AttachmentPicker);

--- a/src/components/AttachmentPicker/index.native.js
+++ b/src/components/AttachmentPicker/index.native.js
@@ -5,7 +5,6 @@ import RNDocumentPicker from 'react-native-document-picker';
 import RNFetchBlob from 'react-native-blob-util';
 import {launchImageLibrary} from 'react-native-image-picker';
 import {propTypes as basePropTypes, defaultProps} from './attachmentPickerPropTypes';
-import withWindowDimensions, {windowDimensionsPropTypes} from '../withWindowDimensions';
 import CONST from '../../CONST';
 import * as FileUtils from '../../libs/fileDownload/FileUtils';
 import * as Expensicons from '../Icon/Expensicons';
@@ -16,10 +15,10 @@ import MenuItem from '../MenuItem';
 import styles from '../../styles/styles';
 import ArrowKeyFocusManager from '../ArrowKeyFocusManager';
 import useLocalize from '../../hooks/useLocalize';
+import useWindowDimensions from '../../hooks/useWindowDimensions';
 
 const propTypes = {
     ...basePropTypes,
-    ...windowDimensionsPropTypes,
 };
 
 /**
@@ -83,12 +82,13 @@ const getDataForUpload = (fileData) => {
     });
 }
 
-function AttachmentPicker({ type, children, isSmallScreenWidth}) {
+function AttachmentPicker({ type, children}) {
     const completeAttachmentSelection = useRef();
     const onModalHide = useRef();
     const keyboardListener = useRef();
     
     const {translate} = useLocalize()
+    const {isSmallScreenWidth} = useWindowDimensions()
 
     /**
      * Inform the users when they need to grant camera access and guide them to settings
@@ -350,4 +350,4 @@ AttachmentPicker.propTypes = propTypes;
 AttachmentPicker.defaultProps = defaultProps;
 AttachmentPicker.displayName = 'AttachmentPicker';
 
-export default withWindowDimensions(AttachmentPicker);
+export default AttachmentPicker;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ #16116 
PROPOSAL: 


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Log into the native mobile app
2. Open any chat
3. Send an attachment in every possible way (take a photo, choose from gallery, choose document)
4. Attachments should be sent correctly with no issues

- [ ] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Same as **Tests** section above

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
5. Upload an image via copy paste
6. Verify a modal appears displaying a preview of that image
--->

Same as **Tests** section above

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->


https://github.com/Expensify/App/assets/44364829/6afe574a-6d39-4369-9c69-5f00f751ed5b


https://github.com/Expensify/App/assets/44364829/d7ac7546-cfa8-4ba0-b0da-f959511d4aef


https://github.com/Expensify/App/assets/44364829/36f1d54c-270a-4230-a532-eb96d876d308



</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->
[android1-compressed.webm](https://github.com/Expensify/App/assets/44364829/8cf46f75-aa91-4dad-9bad-1602ef3d55cc)
[android2-compressed.webm](https://github.com/Expensify/App/assets/44364829/d7afefcf-3b9e-4961-b2f4-c0373c3c1508)
[android3-compressed.webm](https://github.com/Expensify/App/assets/44364829/2af64c45-f7c0-4fc2-a1d4-621c3e391543)



</details>
