### PR TITLE
fix: prevent browser form validation

### DIFF
--- a/src/components/FormSubmit/index.js
+++ b/src/components/FormSubmit/index.js
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import lodashGet from 'lodash/get';
 import {View} from 'react-native';
 import * as formSubmitPropTypes from './formSubmitPropTypes';
 import CONST from '../../CONST';
 import isEnterWhileComposition from '../../libs/KeyboardShortcut/isEnterWhileComposition';
+import * as ComponentUtils from '../../libs/ComponentUtils';
 
 function FormSubmit({innerRef, children, onSubmit, style}) {
     /**
@@ -36,11 +37,21 @@ function FormSubmit({innerRef, children, onSubmit, style}) {
         }
     };
 
+    const preventDefaultFormBehavior = (e) => e.preventDefault();
+
+    useEffect(() => {
+        // Prevent the browser from applying its own validation, which affects the email input
+        innerRef.current.setAttribute('novalidate', '');
+
+        innerRef.current.addEventListener('submit', preventDefaultFormBehavior);
+    }, []);
+
     return (
         // React-native-web prevents event bubbling on TextInput for key presses
         // https://github.com/necolas/react-native-web/blob/fa47f80d34ee6cde2536b2a2241e326f84b633c4/packages/react-native-web/src/exports/TextInput/index.js#L272
         // Thus use capture phase.
         <View
+            accessibilityRole={ComponentUtils.ACCESSIBILITY_ROLE_FORM}
             ref={innerRef}
             onKeyDownCapture={submitForm}
             style={style}

--- a/src/components/FormSubmit/index.js
+++ b/src/components/FormSubmit/index.js
@@ -52,6 +52,7 @@ function FormSubmit({innerRef, children, onSubmit, style}) {
             
             innerRef.current.removeEventListener('submit', preventDefaultFormBehavior);
         };
+    }, [innerRef]);
 
     return (
         // React-native-web prevents event bubbling on TextInput for key presses

--- a/src/components/FormSubmit/index.js
+++ b/src/components/FormSubmit/index.js
@@ -44,7 +44,14 @@ function FormSubmit({innerRef, children, onSubmit, style}) {
         innerRef.current.setAttribute('novalidate', '');
 
         innerRef.current.addEventListener('submit', preventDefaultFormBehavior);
-    }, []);
+
+        return () => {
+            if (!innerRef.current) {
+                return;
+            }
+            
+            innerRef.current.removeEventListener('submit', preventDefaultFormBehavior);
+        };
 
     return (
         // React-native-web prevents event bubbling on TextInput for key presses

--- a/src/components/FormSubmit/index.js
+++ b/src/components/FormSubmit/index.js
@@ -40,17 +40,19 @@ function FormSubmit({innerRef, children, onSubmit, style}) {
     const preventDefaultFormBehavior = (e) => e.preventDefault();
 
     useEffect(() => {
-        // Prevent the browser from applying its own validation, which affects the email input
-        innerRef.current.setAttribute('novalidate', '');
+        const form = innerRef.current;
 
-        innerRef.current.addEventListener('submit', preventDefaultFormBehavior);
+        // Prevent the browser from applying its own validation, which affects the email input
+        form.setAttribute('novalidate', '');
+
+        form.addEventListener('submit', preventDefaultFormBehavior);
 
         return () => {
-            if (!innerRef.current) {
+            if (!form) {
                 return;
             }
-            
-            innerRef.current.removeEventListener('submit', preventDefaultFormBehavior);
+
+            form.removeEventListener('submit', preventDefaultFormBehavior);
         };
     }, [innerRef]);
 

--- a/src/components/SignInPageForm/index.js
+++ b/src/components/SignInPageForm/index.js
@@ -13,6 +13,9 @@ class Form extends React.Component {
             return;
         }
 
+        // Prevent the browser from applying its own validation, which affects the email input
+        this.form.setAttribute('novalidate', '');
+
         // Password Managers need these attributes to be able to identify the form elements properly.
         this.form.setAttribute('method', 'post');
         this.form.setAttribute('action', '/');


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Entering a phone number on the sign in and contact method page leads to a validation error triggered by the browser, due to it being seen as an invalid email. This PR prevents this unwanted browser validation.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/23633
PROPOSAL: https://github.com/Expensify/App/issues/23633#issuecomment-1651678673


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Go to the Sign in page
2. Enter a phone number
3. Hover the cursor on the input
4. Verify that no validation error appears as a tooltip
5. Sign in successfully
6. Go to Settings
7. Go to Profile
8. Go to Contact method
9. Click New contact method
10. Enter a phone number
11. Hover the cursor on the input
12. Verify that no validation error appears as a tooltip

- [X] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
1. Go to the Sign in page
2. Enter a phone number
3. Hover the cursor on the input
4. Verify that no validation error appears as a tooltip
5. Sign in successfully (internet connectivity is required for this)
6. Go to Settings
7. Go to Profile
8. Go to Contact method
9. Click New contact method
10. Enter a phone number
11. Hover the cursor on the input
12. Verify that no validation error appears as a tooltip

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
11. Upload an image via copy paste
12. Verify a modal appears displaying a preview of that image
--->
1. Go to the Sign in page
2. Enter a phone number
3. Hover the cursor on the input
4. Verify that no validation error appears as a tooltip
5. Sign in successfully
6. Go to Settings
7. Go to Profile
8. Go to Contact method
9. Click New contact method
10. Enter a phone number
11. Hover the cursor on the input
12. Verify that no validation error appears as a tooltip

- [X] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android / native
    - [X] Android / Chrome
    - [X] iOS / native
    - [X] iOS / Safari
    - [X] MacOS / Chrome / Safari
    - [X] MacOS / Desktop
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [X] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [X] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If a new component is created I verified that:
    - [X] A similar component doesn't exist in the codebase
    - [X] All props are defined accurately and each prop has a `/** comment above it */`
    - [X] The file is named correctly
    - [X] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [X] The only data being stored in the state is data necessary for rendering and nothing else
    - [X] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [X] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [X] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [X] All JSX used for rendering exists in the render method
    - [X] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [X] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [X] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/137707942/b7e9dbaf-bcbc-4340-af64-ddd6b1a26747



</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/137707942/a8c08653-80f9-4ac2-a38e-1f71c9e872be



</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/137707942/253e52e6-9870-4e79-a883-d20f24e2cc33



</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/137707942/4dc197f4-78ed-400a-92ef-9d81fadbec85



</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/137707942/f3744624-fa75-41d2-985a-a0f8af0c2896



</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/137707942/baf77241-053d-40b8-bc36-fd378898348d



</details>
