### PR TITLE
Revert "suppressHighlighting on Text components with onPress"

### DIFF
--- a/src/components/AnchorForCommentsOnly/BaseAnchorForCommentsOnly.js
+++ b/src/components/AnchorForCommentsOnly/BaseAnchorForCommentsOnly.js
@@ -88,7 +88,6 @@ function BaseAnchorForCommentsOnly({onPressIn, onPressOut, href = '', rel = '', 
                         event.preventDefault();
                         linkProps.onPress();
                     }}
-                    suppressHighlighting
                     // Add testID so it gets selected as an anchor tag by SelectionScraper
                     testID="a"
                     // eslint-disable-next-line react/jsx-props-no-spreading

--- a/src/components/Banner.js
+++ b/src/components/Banner.js
@@ -88,7 +88,6 @@ function Banner(props) {
                                 <Text
                                     style={[...props.textStyles]}
                                     onPress={props.onPress}
-                                    suppressHighlighting
                                 >
                                     {props.text}
                                 </Text>

--- a/src/components/HTMLEngineProvider/HTMLRenderers/AnchorRenderer.js
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/AnchorRenderer.js
@@ -70,7 +70,6 @@ function AnchorRenderer(props) {
             <Text
                 style={styles.link}
                 onPress={navigateToLink}
-                suppressHighlighting
             >
                 <TNodeChildrenRenderer tnode={props.tnode} />
             </Text>

--- a/src/components/ReportWelcomeText.js
+++ b/src/components/ReportWelcomeText.js
@@ -87,7 +87,6 @@ function ReportWelcomeText(props) {
                         <Text
                             style={[styles.textStrong]}
                             onPress={() => Navigation.navigate(ROUTES.getReportDetailsRoute(props.report.reportID))}
-                            suppressHighlighting
                         >
                             {ReportUtils.getReportName(props.report)}
                         </Text>
@@ -106,7 +105,6 @@ function ReportWelcomeText(props) {
                                         <Text
                                             style={[styles.textStrong]}
                                             onPress={() => Navigation.navigate(ROUTES.getProfileRoute(accountID))}
-                                            suppressHighlighting
                                         >
                                             {displayName}
                                         </Text>

--- a/src/components/TextLink.js
+++ b/src/components/TextLink.js
@@ -71,7 +71,6 @@ function TextLink(props) {
             onMouseDown={props.onMouseDown}
             onKeyDown={openLinkIfEnterKeyPressed}
             ref={props.forwardedRef}
-            suppressHighlighting
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...rest}
         >


### PR DESCRIPTION
Reverts Expensify/App#24244


Straight revert, this was not deployed yet, but tests are failing in main after it.

Thread: https://expensify.slack.com/archives/C01GTK53T8Q/p1692012729203289