### PR TITLE
Hide transaction detail and dismiss the edit modal when the request is deleted

### DIFF
--- a/src/components/ReportActionItem/MoneyRequestView.js
+++ b/src/components/ReportActionItem/MoneyRequestView.js
@@ -84,7 +84,7 @@ function MoneyRequestView({report, parentReport, shouldShowHorizontalRule, polic
     }
 
     // A temporary solution to hide the transaction detail
-    // This will be removed after we probably add the transaction as a prop
+    // This will be removed after we properly add the transaction as a prop
     if (ReportActionsUtils.isDeletedAction(parentReportAction)) {
         return null;
     }

--- a/src/components/ReportActionItem/MoneyRequestView.js
+++ b/src/components/ReportActionItem/MoneyRequestView.js
@@ -83,6 +83,12 @@ function MoneyRequestView({report, parentReport, shouldShowHorizontalRule, polic
         description += ` • ${translate('iou.pending')}`;
     }
 
+    // A temporary solution to hide the transaction detail
+    // This will be removed after we probably add the transaction as a prop
+    if (ReportActionsUtils.isDeletedAction(parentReportAction)) {
+        return null;
+    }
+
     return (
         <View>
             <View style={[StyleUtils.getReportWelcomeContainerStyle(isSmallScreenWidth), StyleUtils.getMinimumHeight(CONST.EMPTY_STATE_BACKGROUND.MONEY_REPORT.MIN_HEIGHT)]}>

--- a/src/libs/TransactionUtils.js
+++ b/src/libs/TransactionUtils.js
@@ -140,7 +140,7 @@ function getCurrency(transaction) {
     if (currency) {
         return currency;
     }
-    return lodashGet(transaction, 'currency', '');
+    return lodashGet(transaction, 'currency', CONST.CURRENCY.USD);
 }
 
 /**
@@ -150,11 +150,11 @@ function getCurrency(transaction) {
  * @returns {String}
  */
 function getCreated(transaction) {
-    const created = lodashGet(transaction, 'modifiedCreated', '');
+    const created = lodashGet(transaction, 'modifiedCreated', '') || lodashGet(transaction, 'created', '');
     if (created) {
         return format(new Date(created), CONST.DATE.FNS_FORMAT_STRING);
     }
-    return format(new Date(lodashGet(transaction, 'created', '')), CONST.DATE.FNS_FORMAT_STRING);
+    return format(new Date(), CONST.DATE.FNS_FORMAT_STRING);
 }
 
 export {buildOptimisticTransaction, getUpdatedTransaction, getTransaction, getDescription, getAmount, getCurrency, getCreated};

--- a/src/libs/TransactionUtils.js
+++ b/src/libs/TransactionUtils.js
@@ -154,7 +154,7 @@ function getCreated(transaction) {
     if (created) {
         return format(new Date(created), CONST.DATE.FNS_FORMAT_STRING);
     }
-    return format(new Date(), CONST.DATE.FNS_FORMAT_STRING);
+    return '';
 }
 
 export {buildOptimisticTransaction, getUpdatedTransaction, getTransaction, getDescription, getAmount, getCurrency, getCreated};

--- a/src/pages/EditRequestPage.js
+++ b/src/pages/EditRequestPage.js
@@ -2,7 +2,6 @@ import React, {useEffect} from 'react';
 import PropTypes from 'prop-types';
 import lodashGet from 'lodash/get';
 import {withOnyx} from 'react-native-onyx';
-import {format} from 'date-fns';
 import compose from '../libs/compose';
 import CONST from '../CONST';
 import Navigation from '../libs/Navigation/Navigation';
@@ -51,8 +50,7 @@ function EditRequestPage({report, route, parentReport}) {
     const transactionCurrency = TransactionUtils.getCurrency(transaction);
 
     // Take only the YYYY-MM-DD value
-    const transactionCreatedDate = new Date(TransactionUtils.getCreated(transaction));
-    const transactionCreated = format(transactionCreatedDate, CONST.DATE.FNS_FORMAT_STRING);
+    const transactionCreated = TransactionUtils.getCreated(transaction);
     const fieldToEdit = lodashGet(route, ['params', 'field'], '');
 
     const isDeleted = ReportActionsUtils.isDeletedAction(parentReportAction);

--- a/src/pages/EditRequestPage.js
+++ b/src/pages/EditRequestPage.js
@@ -141,7 +141,7 @@ export default compose(
     }),
     withOnyx({
         parentReport: {
-            key: ({report}) => `${ONYXKEYS.COLLECTION.REPORT}${report.parentReportID}`,
+            key: ({report}) => `${ONYXKEYS.COLLECTION.REPORT}${report ? report.parentReportID : '0'}`,
         },
     }),
 )(EditRequestPage);

--- a/src/pages/EditRequestPage.js
+++ b/src/pages/EditRequestPage.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import lodashGet from 'lodash/get';
 import {withOnyx} from 'react-native-onyx';
 import {format} from 'date-fns';
+import compose from '../libs/compose';
 import CONST from '../CONST';
 import Navigation from '../libs/Navigation/Navigation';
 import ONYXKEYS from '../ONYXKEYS';
@@ -31,14 +32,17 @@ const propTypes = {
 
     /** The report object for the thread report */
     report: reportPropTypes,
+
+    /** The parent report object for the thread report */
+    parentReport: reportPropTypes,
 };
 
 const defaultProps = {
     report: {},
+    parentReport: {},
 };
 
-function EditRequestPage({report, route}) {
-    const parentReport = ReportUtils.getParentReport(report);
+function EditRequestPage({report, route, parentReport}) {
     const parentReportAction = ReportActionsUtils.getParentReportAction(report);
     const transactionID = lodashGet(parentReportAction, 'originalMessage.IOUTransactionID', '');
     const transaction = TransactionUtils.getTransaction(transactionID);
@@ -129,8 +133,15 @@ function EditRequestPage({report, route}) {
 EditRequestPage.displayName = 'EditRequestPage';
 EditRequestPage.propTypes = propTypes;
 EditRequestPage.defaultProps = defaultProps;
-export default withOnyx({
-    report: {
-        key: ({route}) => `${ONYXKEYS.COLLECTION.REPORT}${route.params.threadReportID}`,
-    },
-})(EditRequestPage);
+export default compose(
+    withOnyx({
+        report: {
+            key: ({route}) => `${ONYXKEYS.COLLECTION.REPORT}${route.params.threadReportID}`,
+        },
+    }),
+    withOnyx({
+        parentReport: {
+            key: ({report}) => `${ONYXKEYS.COLLECTION.REPORT}${report.parentReportID}`,
+        },
+    }),
+)(EditRequestPage);

--- a/src/pages/EditRequestPage.js
+++ b/src/pages/EditRequestPage.js
@@ -43,7 +43,7 @@ function EditRequestPage({report, route}) {
     const transactionID = lodashGet(parentReportAction, 'originalMessage.IOUTransactionID', '');
     const transaction = TransactionUtils.getTransaction(transactionID);
     const transactionDescription = TransactionUtils.getDescription(transaction);
-    const transactionAmount = TransactionUtils.getAmount(transaction, ReportUtils.isExpenseReport(ReportUtils.getParentReport(report)));
+    const transactionAmount = TransactionUtils.getAmount(transaction, ReportUtils.isExpenseReport(parentReport));
     const transactionCurrency = TransactionUtils.getCurrency(transaction);
 
     // Take only the YYYY-MM-DD value

--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -463,7 +463,7 @@ function ReportActionItem(props) {
 
     if (props.action.actionName === CONST.REPORT.ACTIONS.TYPE.CREATED) {
         const parentReportAction = ReportActionsUtils.getParentReportAction(props.report);
-        if (ReportActionsUtils.isTransactionThread(parentReportAction) && !ReportActionsUtils.isDeletedAction(parentReportAction)) {
+        if (ReportActionsUtils.isTransactionThread(parentReportAction)) {
             return (
                 <OfflineWithFeedback pendingAction={props.action.pendingAction}>
                     <MoneyRequestView
@@ -472,9 +472,6 @@ function ReportActionItem(props) {
                     />
                 </OfflineWithFeedback>
             );
-        }
-        if (ReportActionsUtils.isTransactionThread(parentReportAction) && ReportActionsUtils.isDeletedAction(parentReportAction)) {
-            return null;
         }
         if (ReportUtils.isTaskReport(props.report)) {
             return (

--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -463,7 +463,7 @@ function ReportActionItem(props) {
 
     if (props.action.actionName === CONST.REPORT.ACTIONS.TYPE.CREATED) {
         const parentReportAction = ReportActionsUtils.getParentReportAction(props.report);
-        if (ReportActionsUtils.isTransactionThread(parentReportAction)) {
+        if (ReportActionsUtils.isTransactionThread(parentReportAction) && !ReportActionsUtils.isDeletedParentAction(parentReportAction)) {
             return (
                 <OfflineWithFeedback pendingAction={props.action.pendingAction}>
                     <MoneyRequestView
@@ -472,6 +472,9 @@ function ReportActionItem(props) {
                     />
                 </OfflineWithFeedback>
             );
+        }
+        if (ReportActionsUtils.isTransactionThread(parentReportAction) && ReportActionsUtils.isDeletedParentAction(parentReportAction)) {
+            return null;
         }
         if (ReportUtils.isTaskReport(props.report)) {
             return (

--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -463,7 +463,7 @@ function ReportActionItem(props) {
 
     if (props.action.actionName === CONST.REPORT.ACTIONS.TYPE.CREATED) {
         const parentReportAction = ReportActionsUtils.getParentReportAction(props.report);
-        if (ReportActionsUtils.isTransactionThread(parentReportAction) && !ReportActionsUtils.isDeletedParentAction(parentReportAction)) {
+        if (ReportActionsUtils.isTransactionThread(parentReportAction) && !ReportActionsUtils.isDeletedAction(parentReportAction)) {
             return (
                 <OfflineWithFeedback pendingAction={props.action.pendingAction}>
                     <MoneyRequestView
@@ -473,7 +473,7 @@ function ReportActionItem(props) {
                 </OfflineWithFeedback>
             );
         }
-        if (ReportActionsUtils.isTransactionThread(parentReportAction) && ReportActionsUtils.isDeletedParentAction(parentReportAction)) {
+        if (ReportActionsUtils.isTransactionThread(parentReportAction) && ReportActionsUtils.isDeletedAction(parentReportAction)) {
             return null;
         }
         if (ReportUtils.isTaskReport(props.report)) {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
We will hide transaction detail and dismiss the edit modal when the request money is deleted
### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/24578
PROPOSAL: https://github.com/Expensify/App/issues/24578#issuecomment-1679004264


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
- Hide transaction detail
1. Login with any account
2. Create a request money
3. Go to the thread of transaction detail
4. Send a message
5. Click on three dot in header
6. Click on the delete request and confirm the modal to delete the request money
7. Verify after deleting request money, transaction detail is hidden
- The edit request page should be dismissed when the request is paid or deleted
1. From user A, create a request money with user B
2. Go to the thread of transaction detail
3. Send a message
4. Click on the amonut to go to edit page
5. From user B, paid the request money
6. From user A, verify that the edit page is dismissed
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
7. Upload an image via copy paste
8. Verify a modal appears displaying a preview of that image
--->
- Hide transaction detail
1. Login with any account
2. Create a request money
3. Go to the thread of transaction detail
4. Send a message
5. Click on three dot in header
6. Click on the delete request and confirm the modal to delete the request money
7. Verify after deleting request money, transaction detail is hidden
- The edit request page should be dismissed when the request is paid or deleted
1. From user A, create a request money with user B
2. Go to the thread of transaction detail
3. Send a message
4. Click on the amonut to go to edit page
5. From user B, paid the request money
6. From user A, verify that the edit page is dismissed
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

- Hide transaction detail

[Screencast from 16-08-2023 00:04:05.webm](https://github.com/Expensify/App/assets/129500732/c81e96bc-73d9-4360-99b3-05022e9af2d0)


- The edit request page should be dismissed when the request is paid or deleted

[Screencast from 15-08-2023 23:25:12.webm](https://github.com/Expensify/App/assets/129500732/7f8d1606-1398-4235-9ba7-b0b8e7346cb2)


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>

- Hide transaction detail


https://github.com/Expensify/App/assets/129500732/72cbe529-e297-43d0-a863-508673360465



- The edit request page should be dismissed when the request is paid or deleted


https://github.com/Expensify/App/assets/129500732/9823abfd-eae0-44ff-a0c6-e985ed439f55



<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

- Hide transaction detail


https://github.com/Expensify/App/assets/129500732/e5b0077b-46ce-4dab-aa95-36343352be69



- The edit request page should be dismissed when the request is paid or deleted


https://github.com/Expensify/App/assets/129500732/4f6a821a-1427-47f6-ab69-1d62bbda4341


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>

- Hide transaction detail


https://github.com/Expensify/App/assets/129500732/e3bb5e37-cfc8-4f49-ba3c-e27b0f2c675e


- The edit request page should be dismissed when the request is paid or deleted


https://github.com/Expensify/App/assets/129500732/0a653f8d-664c-4d59-b485-cb5b87ff9ce9



<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

- Hide transaction detail


https://github.com/Expensify/App/assets/129500732/4a79664b-252a-4249-b3ef-e762fdedbb7a



- The edit request page should be dismissed when the request is paid or deleted


https://github.com/Expensify/App/assets/129500732/e718a4c5-a4e7-42d1-ade2-a61e5cada864



<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>

- Hide transaction detail

[24578-1.webm](https://github.com/Expensify/App/assets/129500732/a02fe462-26ed-4b30-b48c-591a37519448)


- The edit request page should be dismissed when the request is paid or deleted

[24578-2.webm](https://github.com/Expensify/App/assets/129500732/5c175317-a77d-446e-932c-548ea66dd7a0)


<!-- add screenshots or videos here -->

</details>
