### PR TITLE
Migrate BaseOptionsList.js to functional component

### DIFF
--- a/src/components/OptionsList/BaseOptionsList.js
+++ b/src/components/OptionsList/BaseOptionsList.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import React, {useRef, useEffect, forwardRef, memo} from 'react';
+import React, {useRef, useEffect, useCallback, forwardRef, memo} from 'react';
 import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import styles from '../../styles/styles';
@@ -9,6 +9,7 @@ import SectionList from '../SectionList';
 import Text from '../Text';
 import {propTypes as optionsListPropTypes, defaultProps as optionsListDefaultProps} from './optionsListPropTypes';
 import OptionsListSkeletonView from '../OptionsListSkeletonView';
+import usePrevious from '../../hooks/usePrevious';
 
 const propTypes = {
     /** Determines whether the keyboard gets dismissed in response to a drag */
@@ -56,7 +57,14 @@ function BaseOptionsList({
     innerRef,
 }) {
     const flattenedData = useRef();
+    const previousSections = usePrevious(sections);
     const didLayout = useRef(false);
+
+    /**
+     * This helper function is used to memoize the computation needed for getItemLayout. It is run whenever section data changes.
+     *
+     * @returns {Array<Object>}
+     */
     const buildFlatSectionArray = () => {
         let offset = 0;
 
@@ -92,6 +100,9 @@ function BaseOptionsList({
     };
 
     useEffect(() => {
+        if (_.isEqual(sections, previousSections)) {
+            return;
+        }
         flattenedData.current = buildFlatSectionArray();
     });
 
@@ -132,12 +143,6 @@ function BaseOptionsList({
             index: flatDataArrayIndex,
         };
     };
-
-    /**
-     * This helper function is used to memoize the computation needed for getItemLayout. It is run whenever section data changes.
-     *
-     * @returns {Array<Object>}
-     */
 
     /**
      * Returns the key used by the list

--- a/src/components/OptionsList/BaseOptionsList.js
+++ b/src/components/OptionsList/BaseOptionsList.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import React, {useRef, useEffect, useCallback, forwardRef, memo} from 'react';
+import React, {useRef, useEffect, forwardRef, memo} from 'react';
 import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import styles from '../../styles/styles';
@@ -249,7 +249,7 @@ BaseOptionsList.propTypes = propTypes;
 BaseOptionsList.defaultProps = defaultProps;
 BaseOptionsList.displayName = 'BaseOptionsList';
 
-// using memo here because the components using this components don't memoize callbacks or arrays, thus causing unnecessary rerenders of this component.
+// using memo to avoid unnecessary rerenders when parents component rerenders (thus causing this component to rerender because shallow comparison is used for some props).
 export default memo(
     forwardRef((props, ref) => (
         <BaseOptionsList

--- a/src/components/OptionsList/BaseOptionsList.js
+++ b/src/components/OptionsList/BaseOptionsList.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import React, {useRef, useEffect, forwardRef} from 'react';
+import React, {useRef, useEffect, forwardRef, memo} from 'react';
 import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import styles from '../../styles/styles';
@@ -269,10 +269,19 @@ BaseOptionsList.propTypes = propTypes;
 BaseOptionsList.defaultProps = defaultProps;
 BaseOptionsList.displayName = 'BaseOptionsList';
 
-export default forwardRef((props, ref) => (
-    <BaseOptionsList
-        // eslint-disable-next-line react/jsx-props-no-spreading
-        {...props}
-        innerRef={ref}
-    />
-));
+// using memo here because the components using this components don't memoize callbacks or arrays, thus causing unnecessary rerenders of this component.
+export default memo(
+    forwardRef((props, ref) => (
+        <BaseOptionsList
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            {...props}
+            innerRef={ref}
+        />
+    )),
+    (prevProps, nextProps) =>
+        nextProps.focusedIndex === prevProps.focusedIndex &&
+        nextProps.selectedOptions.length === prevProps.selectedOptions.length &&
+        nextProps.headerMessage === prevProps.headerMessage &&
+        nextProps.isLoading === prevProps.isLoading &&
+        _.isEqual(nextProps.sections, prevProps.sections),
+);

--- a/src/components/OptionsList/BaseOptionsList.js
+++ b/src/components/OptionsList/BaseOptionsList.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import React, {forwardRef, Component} from 'react';
+import React, {useRef, useEffect, forwardRef} from 'react';
 import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import styles from '../../styles/styles';
@@ -30,47 +30,103 @@ const defaultProps = {
     ...optionsListDefaultProps,
 };
 
-class BaseOptionsList extends Component {
-    constructor(props) {
-        super(props);
+function BaseOptionsList({
+    keyboardDismissMode,
+    onScrollBeginDrag,
+    onScroll,
+    focusedIndex,
+    selectedOptions,
+    headerMessage,
+    isLoading,
+    sections,
+    onLayout,
+    hideSectionHeaders,
+    shouldHaveOptionSeparator,
+    showTitleTooltip,
+    optionHoveredStyle,
+    contentContainerStyles,
+    showScrollIndicator,
+    listContainerStyles,
+    shouldDisableRowInnerPadding,
+    disableFocusOptions,
+    canSelectMultipleOptions,
+    onSelectRow,
+    boldStyle,
+    isDisabled,
+    innerRef,
+}) {
+    const flattenedData = useRef();
+    const didLayout = useRef(false);
+    const buildFlatSectionArray = () => {
+        let offset = 0;
 
-        this.renderItem = this.renderItem.bind(this);
-        this.renderSectionHeader = this.renderSectionHeader.bind(this);
-        this.getItemLayout = this.getItemLayout.bind(this);
-        this.buildFlatSectionArray = this.buildFlatSectionArray.bind(this);
-        this.extractKey = this.extractKey.bind(this);
-        this.onViewableItemsChanged = this.onViewableItemsChanged.bind(this);
-        this.didLayout = false;
+        // Start with just an empty list header
+        const flatArray = [{length: 0, offset}];
 
-        this.flattenedData = this.buildFlatSectionArray();
-    }
+        // Build the flat array
+        for (let sectionIndex = 0; sectionIndex < sections.length; sectionIndex++) {
+            const section = sections[sectionIndex];
 
-    shouldComponentUpdate(nextProps) {
-        return (
-            nextProps.focusedIndex !== this.props.focusedIndex ||
-            nextProps.selectedOptions.length !== this.props.selectedOptions.length ||
-            nextProps.headerMessage !== this.props.headerMessage ||
-            nextProps.isLoading !== this.props.isLoading ||
-            !_.isEqual(nextProps.sections, this.props.sections)
-        );
-    }
+            // Add the section header
+            const sectionHeaderHeight = section.title && !hideSectionHeaders ? variables.optionsListSectionHeaderHeight : 0;
+            flatArray.push({length: sectionHeaderHeight, offset});
+            offset += sectionHeaderHeight;
 
-    componentDidUpdate(prevProps) {
-        if (_.isEqual(this.props.sections, prevProps.sections)) {
+            // Add section items
+            for (let i = 0; i < section.data.length; i++) {
+                let fullOptionHeight = variables.optionRowHeight;
+                if (i > 0 && shouldHaveOptionSeparator) {
+                    fullOptionHeight += variables.borderTopWidth;
+                }
+                flatArray.push({length: fullOptionHeight, offset});
+                offset += fullOptionHeight;
+            }
+
+            // Add the section footer
+            flatArray.push({length: 0, offset});
+        }
+
+        // Then add the list footer
+        flatArray.push({length: 0, offset});
+        return flatArray;
+    };
+
+    useEffect(() => {
+        flattenedData.current = buildFlatSectionArray();
+    });
+    // constructor(props) {
+    //     super(props);
+    //     this.didLayout = false;
+
+    //     this.flattenedData = this.buildFlatSectionArray();
+    // }
+
+    // shouldComponentUpdate(nextProps) {
+    //     return (
+    //         nextProps.focusedIndex !== focusedIndex ||
+    //         nextProps.selectedOptions.length !== selectedOptions.length ||
+    //         nextProps.headerMessage !== headerMessage ||
+    //         nextProps.isLoading !== isLoading ||
+    //         !_.isEqual(nextProps.sections, sections)
+    //     );
+    // }
+
+    // componentDidUpdate(prevProps) {
+    //     if (_.isEqual(sections, prevProps.sections)) {
+    //         return;
+    //     }
+
+    //     this.flattenedData = this.buildFlatSectionArray();
+    // }
+
+    const onViewableItemsChanged = () => {
+        if (didLayout.current || !onLayout) {
             return;
         }
 
-        this.flattenedData = this.buildFlatSectionArray();
-    }
-
-    onViewableItemsChanged() {
-        if (this.didLayout || !this.props.onLayout) {
-            return;
-        }
-
-        this.didLayout = true;
-        this.props.onLayout();
-    }
+        didLayout.current = true;
+        onLayout();
+    };
 
     /**
      * This function is used to compute the layout of any given item in our list.
@@ -88,66 +144,31 @@ class BaseOptionsList extends Component {
      *
      * @returns {Object}
      */
-    getItemLayout(data, flatDataArrayIndex) {
-        if (!_.has(this.flattenedData, flatDataArrayIndex)) {
-            this.flattenedData = this.buildFlatSectionArray();
+    const getItemLayout = (data, flatDataArrayIndex) => {
+        if (!_.has(flattenedData.current, flatDataArrayIndex)) {
+            flattenedData.current = buildFlatSectionArray();
         }
 
-        const targetItem = this.flattenedData[flatDataArrayIndex];
+        const targetItem = flattenedData.current[flatDataArrayIndex];
         return {
             length: targetItem.length,
             offset: targetItem.offset,
             index: flatDataArrayIndex,
         };
-    }
+    };
 
     /**
      * This helper function is used to memoize the computation needed for getItemLayout. It is run whenever section data changes.
      *
      * @returns {Array<Object>}
      */
-    buildFlatSectionArray() {
-        let offset = 0;
-
-        // Start with just an empty list header
-        const flatArray = [{length: 0, offset}];
-
-        // Build the flat array
-        for (let sectionIndex = 0; sectionIndex < this.props.sections.length; sectionIndex++) {
-            const section = this.props.sections[sectionIndex];
-
-            // Add the section header
-            const sectionHeaderHeight = section.title && !this.props.hideSectionHeaders ? variables.optionsListSectionHeaderHeight : 0;
-            flatArray.push({length: sectionHeaderHeight, offset});
-            offset += sectionHeaderHeight;
-
-            // Add section items
-            for (let i = 0; i < section.data.length; i++) {
-                let fullOptionHeight = variables.optionRowHeight;
-                if (i > 0 && this.props.shouldHaveOptionSeparator) {
-                    fullOptionHeight += variables.borderTopWidth;
-                }
-                flatArray.push({length: fullOptionHeight, offset});
-                offset += fullOptionHeight;
-            }
-
-            // Add the section footer
-            flatArray.push({length: 0, offset});
-        }
-
-        // Then add the list footer
-        flatArray.push({length: 0, offset});
-        return flatArray;
-    }
 
     /**
      * Returns the key used by the list
      * @param {Object} option
      * @return {String}
      */
-    extractKey(option) {
-        return option.keyForList;
-    }
+    const extractKey = (option) => option.keyForList;
 
     /**
      * Function which renders a row in the list
@@ -159,24 +180,25 @@ class BaseOptionsList extends Component {
      *
      * @return {Component}
      */
-    renderItem({item, index, section}) {
-        const isDisabled = this.props.isDisabled || section.isDisabled || !!item.isDisabled;
+    const renderItem = ({item, index, section}) => {
+        const isItemDisabled = isDisabled || section.isDisabled || !!item.isDisabled;
+        console.log(`rendering base optionslist. isDisabled: ${isDisabled}`);
         return (
             <OptionRow
                 option={item}
-                showTitleTooltip={this.props.showTitleTooltip}
-                hoverStyle={this.props.optionHoveredStyle}
-                optionIsFocused={!this.props.disableFocusOptions && !isDisabled && this.props.focusedIndex === index + section.indexOffset}
-                onSelectRow={this.props.onSelectRow}
-                isSelected={Boolean(_.find(this.props.selectedOptions, (option) => option.accountID === item.accountID))}
-                showSelectedState={this.props.canSelectMultipleOptions}
-                boldStyle={this.props.boldStyle}
-                isDisabled={isDisabled}
-                shouldHaveOptionSeparator={index > 0 && this.props.shouldHaveOptionSeparator}
-                shouldDisableRowInnerPadding={this.props.shouldDisableRowInnerPadding}
+                showTitleTooltip={showTitleTooltip}
+                hoverStyle={optionHoveredStyle}
+                optionIsFocused={!disableFocusOptions && !isItemDisabled && focusedIndex === index + section.indexOffset}
+                onSelectRow={onSelectRow}
+                isSelected={Boolean(_.find(selectedOptions, (option) => option.accountID === item.accountID))}
+                showSelectedState={canSelectMultipleOptions}
+                boldStyle={boldStyle}
+                isDisabled={isItemDisabled}
+                shouldHaveOptionSeparator={index > 0 && shouldHaveOptionSeparator}
+                shouldDisableRowInnerPadding={shouldDisableRowInnerPadding}
             />
         );
-    }
+    };
 
     /**
      * Function which renders a section header component
@@ -188,8 +210,8 @@ class BaseOptionsList extends Component {
      *
      * @return {Component}
      */
-    renderSectionHeader({section: {title, shouldShow}}) {
-        if (title && shouldShow && !this.props.hideSectionHeaders) {
+    const renderSectionHeader = ({section: {title, shouldShow}}) => {
+        if (title && shouldShow && !hideSectionHeaders) {
             return (
                 // Note: The `optionsListSectionHeader` style provides an explicit height to section headers.
                 // We do this so that we can reference the height in `getItemLayout` –
@@ -202,51 +224,50 @@ class BaseOptionsList extends Component {
         }
 
         return <View />;
-    }
+    };
 
-    render() {
-        return (
-            <View style={this.props.listContainerStyles}>
-                {this.props.isLoading ? (
-                    <OptionsListSkeletonView />
-                ) : (
-                    <>
-                        {this.props.headerMessage ? (
-                            <View style={[styles.ph5, styles.pb5]}>
-                                <Text style={[styles.textLabel, styles.colorMuted]}>{this.props.headerMessage}</Text>
-                            </View>
-                        ) : null}
-                        <SectionList
-                            ref={this.props.innerRef}
-                            indicatorStyle="white"
-                            keyboardShouldPersistTaps="always"
-                            keyboardDismissMode={this.props.keyboardDismissMode}
-                            onScrollBeginDrag={this.props.onScrollBeginDrag}
-                            onScroll={this.props.onScroll}
-                            contentContainerStyle={this.props.contentContainerStyles}
-                            showsVerticalScrollIndicator={this.props.showScrollIndicator}
-                            sections={this.props.sections}
-                            keyExtractor={this.extractKey}
-                            stickySectionHeadersEnabled={false}
-                            renderItem={this.renderItem}
-                            getItemLayout={this.getItemLayout}
-                            renderSectionHeader={this.renderSectionHeader}
-                            extraData={this.props.focusedIndex}
-                            initialNumToRender={12}
-                            maxToRenderPerBatch={5}
-                            windowSize={5}
-                            viewabilityConfig={{viewAreaCoveragePercentThreshold: 95}}
-                            onViewableItemsChanged={this.onViewableItemsChanged}
-                        />
-                    </>
-                )}
-            </View>
-        );
-    }
+    return (
+        <View style={listContainerStyles}>
+            {isLoading ? (
+                <OptionsListSkeletonView />
+            ) : (
+                <>
+                    {headerMessage ? (
+                        <View style={[styles.ph5, styles.pb5]}>
+                            <Text style={[styles.textLabel, styles.colorMuted]}>{headerMessage}</Text>
+                        </View>
+                    ) : null}
+                    <SectionList
+                        ref={innerRef}
+                        indicatorStyle="white"
+                        keyboardShouldPersistTaps="always"
+                        keyboardDismissMode={keyboardDismissMode}
+                        onScrollBeginDrag={onScrollBeginDrag}
+                        onScroll={onScroll}
+                        contentContainerStyle={contentContainerStyles}
+                        showsVerticalScrollIndicator={showScrollIndicator}
+                        sections={sections}
+                        keyExtractor={extractKey}
+                        stickySectionHeadersEnabled={false}
+                        renderItem={renderItem}
+                        getItemLayout={getItemLayout}
+                        renderSectionHeader={renderSectionHeader}
+                        extraData={focusedIndex}
+                        initialNumToRender={12}
+                        maxToRenderPerBatch={5}
+                        windowSize={5}
+                        viewabilityConfig={{viewAreaCoveragePercentThreshold: 95}}
+                        onViewableItemsChanged={onViewableItemsChanged}
+                    />
+                </>
+            )}
+        </View>
+    );
 }
 
 BaseOptionsList.propTypes = propTypes;
 BaseOptionsList.defaultProps = defaultProps;
+BaseOptionsList.displayName = 'BaseOptionsList';
 
 export default forwardRef((props, ref) => (
     <BaseOptionsList

--- a/src/components/OptionsList/BaseOptionsList.js
+++ b/src/components/OptionsList/BaseOptionsList.js
@@ -94,30 +94,6 @@ function BaseOptionsList({
     useEffect(() => {
         flattenedData.current = buildFlatSectionArray();
     });
-    // constructor(props) {
-    //     super(props);
-    //     this.didLayout = false;
-
-    //     this.flattenedData = this.buildFlatSectionArray();
-    // }
-
-    // shouldComponentUpdate(nextProps) {
-    //     return (
-    //         nextProps.focusedIndex !== focusedIndex ||
-    //         nextProps.selectedOptions.length !== selectedOptions.length ||
-    //         nextProps.headerMessage !== headerMessage ||
-    //         nextProps.isLoading !== isLoading ||
-    //         !_.isEqual(nextProps.sections, sections)
-    //     );
-    // }
-
-    // componentDidUpdate(prevProps) {
-    //     if (_.isEqual(sections, prevProps.sections)) {
-    //         return;
-    //     }
-
-    //     this.flattenedData = this.buildFlatSectionArray();
-    // }
 
     const onViewableItemsChanged = () => {
         if (didLayout.current || !onLayout) {
@@ -182,7 +158,6 @@ function BaseOptionsList({
      */
     const renderItem = ({item, index, section}) => {
         const isItemDisabled = isDisabled || section.isDisabled || !!item.isDisabled;
-        console.log(`rendering base optionslist. isDisabled: ${isDisabled}`);
         return (
             <OptionRow
                 option={item}


### PR DESCRIPTION
### Details
Migration of BaseOptionsList to functional component. This component is used by OptionsSelector, which is used in many places. Because of this, we are testing more than one workflow.
### Fixed Issues

$ https://github.com/Expensify/App/issues/16182

### Tests

1. When in a room click on the header
2. Click on members
3. Check if members are correctly displayed
4. Exit the page/RHP
5. Enter the split bill workflow
6. Check if you can change the currency.
7.  Enter the amount and click next
9. Check if the list of the users you want to split with is displayed properly
10. Check if you can change the users you want to split with by clicking them
11. Exit the page/RHP
12. Try to assign task, navigate to assignee screen
13. Check if assignees are correctly displayed
14. Choose the assignee

- [x] Verify that no errors appear in the JS console

### Offline tests

1. When in a room click on the header
2. Click on members
3. Check if members are correctly displayed
4. Exit the page/RHP
5. Enter the split bill workflow
6. Check if you can change the currency.
7.  Enter the amount and click next
9. Check if the list of the users you want to split with is displayed properly
10. Check if you can change the users you want to split with by clicking them
11. Exit the page/RHP
12. Try to assign task, navigate to assignee screen
13. Check if assignees are correctly displayed
14. Choose the assignee

- [x] Verify that no errors appear in the JS console

### QA Steps

1. When in a room click on the header
2. Click on members
3. Check if members are correctly displayed
4. Exit the page/RHP
5. Enter the split bill workflow
6. Check if you can change the currency.
7.  Enter the amount and click next
9. Check if the list of the users you want to split with is displayed properly
10. Check if you can change the users you want to split with by clicking them
11. Exit the page/RHP
12. Try to assign task, navigate to assignee screen
13. Check if assignees are correctly displayed
14. Choose the assignee

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/43684335/9d559808-607e-4003-b21d-fa4c85af2172


</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/43684335/08c513e3-41e1-4625-9066-2db00b64e946


</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/43684335/46a00874-1f32-4856-b7b1-1cf1e128d3ce


</details>

<details>
<summary>Desktop</summary>


https://github.com/Expensify/App/assets/43684335/120881f8-5c0a-4a89-b2fc-820a21163cbc


</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/43684335/85bf8cf6-8ed4-4ee3-a8c7-d511b30a02c5


</details>

<details>
<summary>Android</summary>

https://github.com/Expensify/App/assets/43684335/1bee5d96-f18c-46ba-b1f8-e991a5b42d74


<!-- add screenshots or videos here -->

</details>
