### PR TITLE
[No QA] Allow mapbox token to stop listening to all listeners and add a network listener

### DIFF
--- a/src/libs/actions/MapboxToken.js
+++ b/src/libs/actions/MapboxToken.js
@@ -73,7 +73,7 @@ const init = () => {
             // The API sets a token in Onyx with a 30 minute expiration.
             if (_.isEmpty(token)) {
                 console.debug('[MapboxToken] Token does not exist so fetching one');
-                API.read('GetMapboxAccessToken');
+                API.write('GetMapboxAccessToken');
                 return;
             }
 
@@ -102,6 +102,20 @@ const init = () => {
         }
         console.debug('[MapboxToken] Token is expired after app became active');
         clearToken();
+    });
+
+    let network;
+    Onyx.connect({
+        key: ONYXKEYS.NETWORK,
+        callback: (val) => {
+            // When the network reconnects, check if the token has expired. If it has, then clearing the token will
+            // trigger the fetch of a new one
+            if (network && network.isOffline && val && !val.isOffline) {
+                console.debug('[MapboxToken] Token is expired after network came online');
+                clearToken();
+            }
+            network = val;
+        },
     });
 };
 

--- a/src/libs/actions/MapboxToken.js
+++ b/src/libs/actions/MapboxToken.js
@@ -118,7 +118,7 @@ const init = () => {
             callback: (val) => {
                 // When the network reconnects, check if the token has expired. If it has, then clearing the token will
                 // trigger the fetch of a new one
-                if (network && network.isOffline && val && !val.isOffline && !isCurrentlyFetchingToken) {
+                if (network && network.isOffline && val && !val.isOffline && !isCurrentlyFetchingToken && hasTokenExpired()) {
                     console.debug('[MapboxToken] Token is expired after network came online');
                     clearToken();
                 }

--- a/src/libs/actions/MapboxToken.js
+++ b/src/libs/actions/MapboxToken.js
@@ -15,10 +15,12 @@ Onyx.connect({
     },
 });
 
-let connectionID;
+let connectionIDForToken;
+let connectionIDForNetwork;
+let appStateSubscription;
 let currentToken;
 let refreshTimeoutID;
-const REFRESH_INTERVAL = 1000 * 60 * 25;
+const REFRESH_INTERVAL = 1000 * 60 * 1;
 
 const setExpirationTimer = () => {
     console.debug('[MapboxToken] refreshing token on an interval', REFRESH_INTERVAL, 'ms');
@@ -48,13 +50,13 @@ const clearToken = () => {
 };
 
 const init = () => {
-    if (connectionID) {
+    if (connectionIDForToken) {
         console.debug('[MapboxToken] init() is already listening to Onyx so returning early');
         return;
     }
 
     // When the token changes in Onyx, the expiration needs to be checked so a new token can be retrieved.
-    connectionID = Onyx.connect({
+    connectionIDForToken = Onyx.connect({
         key: ONYXKEYS.MAPBOX_ACCESS_TOKEN,
         /**
          * @param {Object} token
@@ -91,32 +93,50 @@ const init = () => {
         },
     });
 
-    AppState.addEventListener('change', (nextAppState) => {
-        // Skip getting a new token if:
-        // - The app state is not changing to active
-        // - There is no current token (which means it's not been fetch yet for the first time)
-        // - The token hasn't expired yet (this would just be a waste of an API call)
-        // - There is no authToken (which means the user has logged out)
-        if (nextAppState !== CONST.APP_STATE.ACTIVE || !currentToken || !hasTokenExpired() || !authToken) {
-            return;
-        }
-        console.debug('[MapboxToken] Token is expired after app became active');
-        clearToken();
-    });
-
-    let network;
-    Onyx.connect({
-        key: ONYXKEYS.NETWORK,
-        callback: (val) => {
-            // When the network reconnects, check if the token has expired. If it has, then clearing the token will
-            // trigger the fetch of a new one
-            if (network && network.isOffline && val && !val.isOffline) {
-                console.debug('[MapboxToken] Token is expired after network came online');
-                clearToken();
+    if (!appStateSubscription) {
+        appStateSubscription = AppState.addEventListener('change', (nextAppState) => {
+            // Skip getting a new token if:
+            // - The app state is not changing to active
+            // - There is no current token (which means it's not been fetch yet for the first time)
+            // - The token hasn't expired yet (this would just be a waste of an API call)
+            // - There is no authToken (which means the user has logged out)
+            if (nextAppState !== CONST.APP_STATE.ACTIVE || !currentToken || !hasTokenExpired() || !authToken) {
+                return;
             }
-            network = val;
-        },
-    });
+            console.debug('[MapboxToken] Token is expired after app became active');
+            clearToken();
+        });
+    }
+
+    if (!connectionIDForNetwork) {
+        let network;
+        connectionIDForNetwork = Onyx.connect({
+            key: ONYXKEYS.NETWORK,
+            callback: (val) => {
+                // When the network reconnects, check if the token has expired. If it has, then clearing the token will
+                // trigger the fetch of a new one
+                if (network && network.isOffline && val && !val.isOffline) {
+                    console.debug('[MapboxToken] Token is expired after network came online');
+                    clearToken();
+                }
+                network = val;
+            },
+        });
+    }
 };
 
-export default init;
+const stop = () => {
+    console.debug('[MapboxToken] Stopping all listeners and timers');
+    if (connectionIDForToken) {
+        Onyx.disconnect(connectionIDForToken);
+    }
+    if (connectionIDForNetwork) {
+        Onyx.disconnect(connectionIDForNetwork);
+    }
+    if (appStateSubscription) {
+        appStateSubscription.remove();
+    }
+    clearTimeout(refreshTimeoutID);
+};
+
+export {init, stop};


### PR DESCRIPTION
cc @neil-marcellini 

### Details
This PR adds the ability to stop all the listeners for the mapbox token and let's the token expire naturally. This is used for when discount requests unmount.

It also adds a listener for the network connection so that if the token has expired, it will fetch a new one.

### Fixed Issues
$ https://github.com/Expensify/App/issues/24612


### Tests
**Note: this can only be tested in web/desktop by an engineer that can modify the local code**

<details>
<summary>USE THIS DIFF FOR TESTING</summary>

```
@@ -0,0 +1,44 @@
diff --git a/src/libs/Navigation/AppNavigator/AuthScreens.js b/src/libs/Navigation/AppNavigator/AuthScreens.js
index 439c1642cc..f58d4f9694 100644
--- a/src/libs/Navigation/AppNavigator/AuthScreens.js
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.js
@@ -34,6 +34,7 @@ import FullScreenNavigator from './Navigators/FullScreenNavigator';
 import styles from '../../../styles/styles';
 import * as SessionUtils from '../../SessionUtils';
 import getNavigationModalCardStyle from '../../../styles/getNavigationModalCardStyles';
+import * as MapboxToken from '../../actions/MapboxToken';
 
 let timezone;
 let currentAccountID;
@@ -130,6 +131,9 @@ class AuthScreens extends React.Component {
             User.subscribeToUserEvents();
         });
 
+        MapboxToken.init();
+        // setTimeout(MapboxToken.stop, 2000);
+
         // If we are on this screen then we are "logged in", but the user might not have "just logged in". They could be reopening the app
         // or returning from background. If so, we'll assume they have some app data already and we can call reconnectApp() instead of openApp().
         // Note: If a Guide has enabled the memory only key mode then we do want to run OpenApp as their app will not be rehydrated with
diff --git a/src/libs/actions/MapboxToken.js b/src/libs/actions/MapboxToken.js
index 8859300478..573b75931a 100644
--- a/src/libs/actions/MapboxToken.js
+++ b/src/libs/actions/MapboxToken.js
@@ -21,7 +21,7 @@ let appStateSubscription;
 let currentToken;
 let refreshTimeoutID;
 let isCurrentlyFetchingToken = false;
-const REFRESH_INTERVAL = 1000 * 60 * 25;
+const REFRESH_INTERVAL = 1000;
 
 const setExpirationTimer = () => {
     console.debug('[MapboxToken] refreshing token on an interval', REFRESH_INTERVAL, 'ms');
@@ -118,7 +118,7 @@ const init = () => {
             callback: (val) => {
                 // When the network reconnects, check if the token has expired. If it has, then clearing the token will
                 // trigger the fetch of a new one
-                if (network && network.isOffline && val && !val.isOffline && !isCurrentlyFetchingToken && hasTokenExpired()) {
+                if (network && network.isOffline && val && !val.isOffline && !isCurrentlyFetchingToken) {
                     console.debug('[MapboxToken] Token is expired after network came online');
                     clearToken();
                 }
```

</details>

1. Modify `REFRESH_INTERVAL` to be `1000` only
1. Load the app
2. Open the JS console and filter for `[MapboxToken]`
3. Verify you see the token has initialized, been fetched once, then stopped
4. Now remove or comment out `setTimeout(MapboxToken.stop, 2000);` from `AuthScreens.js`
5. When the page refreshes, verify the token is refreshed every second
6. Go to Settings > Preferences and turn on `Force offline`
7. Verify in the JS console that the fetching of the token has stopped
8. Turn off `Force offline`
9. Verify in the JS console that the network reconnected, detected an expired token, and began fetching it again

- [ ] Verify that no errors appear in the JS console

### Offline tests
Included above

### QA Steps
None

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native **Note: this can only be tested on web**
    - [x] Android / Chrome **Note: this can only be tested on web**
    - [x] iOS / native **Note: this can only be tested on web**
    - [x] iOS / Safari **Note: this can only be tested on web**
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop **Note: this can only be tested on web**
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->
![image](https://github.com/Expensify/App/assets/1228807/067fd245-ea3c-446d-81af-4f52f77e84c8)
![image](https://github.com/Expensify/App/assets/1228807/6912ded6-058e-4dc9-838f-2ec64da3560c)

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->
 **Note: this can only be tested on web**
</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->
 **Note: this can only be tested on web**
</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->
 **Note: this can only be tested on web**
</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->
 **Note: this can only be tested on web**
</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->
 **Note: this can only be tested on web**
</details>
