### PR TITLE
[22523] Fix path calculation

### DIFF
--- a/src/libs/Url.js
+++ b/src/libs/Url.js
@@ -19,7 +19,7 @@ function addTrailingForwardSlash(url) {
 function getPathFromURL(url) {
     try {
         const parsedUrl = new URL(url);
-        const path = parsedUrl.pathname + parsedUrl.search;
+        const path = parsedUrl.pathname + parsedUrl.search + parsedUrl.hash;
         return path.substring(1); // Remove the leading '/'
     } catch (error) {
         console.error('Error parsing URL:', error);

--- a/src/libs/Url.js
+++ b/src/libs/Url.js
@@ -18,7 +18,8 @@ function addTrailingForwardSlash(url) {
  */
 function getPathFromURL(url) {
     try {
-        const path = new URL(url).pathname;
+        const parsedUrl = new URL(url);
+        const path = parsedUrl.pathname + parsedUrl.search;
         return path.substring(1); // Remove the leading '/'
     } catch (error) {
         console.error('Error parsing URL:', error);

--- a/tests/unit/UrlTest.js
+++ b/tests/unit/UrlTest.js
@@ -30,7 +30,9 @@ describe('Url', () => {
             expect(Url.getPathFromURL('http://necolas.github.io/react-native-web/docs/?path=/docs/components-pressable--disabled ')).toEqual(
                 'react-native-web/docs/?path=/docs/components-pressable--disabled',
             );
-            expect(Url.getPathFromURL('https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash ')).toEqual('Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash');
+            expect(Url.getPathFromURL('https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash ')).toEqual(
+                'Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash',
+            );
             expect(Url.getPathFromURL('mm..food ')).toEqual('');
             expect(Url.getPathFromURL('https://upwork.com/jobs/~016781e062ce860b84 ')).toEqual('jobs/~016781e062ce860b84');
             expect(
@@ -38,7 +40,9 @@ describe('Url', () => {
                     // eslint-disable-next-line max-len
                     "https://bastion1.sjc/logs/app/kibana#/discover?_g=()&_a=(columns:!(_source),index:'2125cbe0-28a9-11e9-a79c-3de0157ed580',interval:auto,query:(language:lucene,query:''),sort:!(timestamp,desc))",
                 ),
-            ).toEqual('logs/app/kibana#/discover?_g=()&_a=(columns:!(_source),index:\'2125cbe0-28a9-11e9-a79c-3de0157ed580\',interval:auto,query:(language:lucene,query:\'\'),sort:!(timestamp,desc))');
+            ).toEqual(
+                "logs/app/kibana#/discover?_g=()&_a=(columns:!(_source),index:'2125cbe0-28a9-11e9-a79c-3de0157ed580',interval:auto,query:(language:lucene,query:''),sort:!(timestamp,desc))",
+            );
             expect(
                 Url.getPathFromURL("https://google.com/maps/place/The+Flying'+Saucer/@42.4043314,-86.2742418,15z/data=!4m5!3m4!1s0x0:0xe28f6108670216bc!8m2!3d42.4043316!4d-86.2742121"),
             ).toEqual("maps/place/The+Flying'+Saucer/@42.4043314,-86.2742418,15z/data=!4m5!3m4!1s0x0:0xe28f6108670216bc!8m2!3d42.4043316!4d-86.2742121");

--- a/tests/unit/UrlTest.js
+++ b/tests/unit/UrlTest.js
@@ -59,9 +59,13 @@ describe('Url', () => {
             ).toEqual(
                 'maps/place/Taj+Mahal+@is~%22Awesome%22/@27.1751496,78.0399535,17z/data=!4m12!1m6!3m5!1s0x39747121d702ff6d:0xdd2ae4803f767dde!2sTaj+Mahal!8m2!3d27.1751448!4d78.0421422!3m4!1s0x39747121d702ff6d:0xdd2ae4803f767dde!8m2!3d27.1751448!4d78.0421422',
             );
+            expect(
+                Url.getPathFromURL(
+                    'https://new.expensify.com/r/443044983936732/attachment?source=https://www.expensify.com/chat-attachments/3915228701265930556/w_a758d3c8444a64f98d37205b17141388064d458e.jpg',
+                ),
+            ).toEqual('r/443044983936732/attachment?source=https://www.expensify.com/chat-attachments/3915228701265930556/w_a758d3c8444a64f98d37205b17141388064d458e.jpg');
         });
     });
-
     describe('hasSameExpensifyOrigin()', () => {
         describe('happy path', () => {
             it('It should work correctly', () => {

--- a/tests/unit/UrlTest.js
+++ b/tests/unit/UrlTest.js
@@ -6,12 +6,12 @@ describe('Url', () => {
             expect(Url.getPathFromURL('http://www.foo.com')).toEqual('');
             expect(Url.getPathFromURL('http://foo.com/blah_blah')).toEqual('blah_blah');
             expect(Url.getPathFromURL('http://foo.com/blah_blah_(wikipedia)')).toEqual('blah_blah_(wikipedia)');
-            expect(Url.getPathFromURL('http://www.example.com/wpstyle/?p=364')).toEqual('wpstyle/');
-            expect(Url.getPathFromURL('https://www.example.com/foo/?bar=baz&inga=42&quux')).toEqual('foo/');
-            expect(Url.getPathFromURL('http://foo.com/(something)?after=parens')).toEqual('(something)');
+            expect(Url.getPathFromURL('http://www.example.com/wpstyle/?p=364')).toEqual('wpstyle/?p=364');
+            expect(Url.getPathFromURL('https://www.example.com/foo/?bar=baz&inga=42&quux')).toEqual('foo/?bar=baz&inga=42&quux');
+            expect(Url.getPathFromURL('http://foo.com/(something)?after=parens')).toEqual('(something)?after=parens');
             expect(Url.getPathFromURL('http://code.google.com/events/#&product=browser')).toEqual('events/');
-            expect(Url.getPathFromURL('http://foo.bar/?q=Test%20URL-encoded%20stuff')).toEqual('');
-            expect(Url.getPathFromURL('http://www.test.com/path?param=123#123')).toEqual('path');
+            expect(Url.getPathFromURL('http://foo.bar/?q=Test%20URL-encoded%20stuff')).toEqual('?q=Test%20URL-encoded%20stuff');
+            expect(Url.getPathFromURL('http://www.test.com/path?param=123#123')).toEqual('path?param=123');
             expect(Url.getPathFromURL('http://1337.net')).toEqual('');
             expect(Url.getPathFromURL('http://a.b-c.de/')).toEqual('');
             expect(Url.getPathFromURL('https://sd1.sd2.docs.google.com/')).toEqual('');
@@ -27,7 +27,9 @@ describe('Url', () => {
                     'https://www.expensify.com/_devportal/tools/logSearch/#query=request_id:(%22Ufjjim%22)+AND+timestamp:[2021-01-08T03:48:10.389Z+TO+2021-01-08T05:48:10.389Z]&index=logs_expensify-008878)',
                 ),
             ).toEqual('_devportal/tools/logSearch/');
-            expect(Url.getPathFromURL('http://necolas.github.io/react-native-web/docs/?path=/docs/components-pressable--disabled ')).toEqual('react-native-web/docs/');
+            expect(Url.getPathFromURL('http://necolas.github.io/react-native-web/docs/?path=/docs/components-pressable--disabled ')).toEqual(
+                'react-native-web/docs/?path=/docs/components-pressable--disabled',
+            );
             expect(Url.getPathFromURL('https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash ')).toEqual('Expensify/Expensify.cash/issues/123');
             expect(Url.getPathFromURL('https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash ')).toEqual('Expensify/Expensify.cash/issues/123');
             expect(Url.getPathFromURL('mm..food ')).toEqual('');

--- a/tests/unit/UrlTest.js
+++ b/tests/unit/UrlTest.js
@@ -9,13 +9,13 @@ describe('Url', () => {
             expect(Url.getPathFromURL('http://www.example.com/wpstyle/?p=364')).toEqual('wpstyle/?p=364');
             expect(Url.getPathFromURL('https://www.example.com/foo/?bar=baz&inga=42&quux')).toEqual('foo/?bar=baz&inga=42&quux');
             expect(Url.getPathFromURL('http://foo.com/(something)?after=parens')).toEqual('(something)?after=parens');
-            expect(Url.getPathFromURL('http://code.google.com/events/#&product=browser')).toEqual('events/');
+            expect(Url.getPathFromURL('http://code.google.com/events/#&product=browser')).toEqual('events/#&product=browser');
             expect(Url.getPathFromURL('http://foo.bar/?q=Test%20URL-encoded%20stuff')).toEqual('?q=Test%20URL-encoded%20stuff');
-            expect(Url.getPathFromURL('http://www.test.com/path?param=123#123')).toEqual('path?param=123');
+            expect(Url.getPathFromURL('http://www.test.com/path?param=123#123')).toEqual('path?param=123#123');
             expect(Url.getPathFromURL('http://1337.net')).toEqual('');
             expect(Url.getPathFromURL('http://a.b-c.de/')).toEqual('');
             expect(Url.getPathFromURL('https://sd1.sd2.docs.google.com/')).toEqual('');
-            expect(Url.getPathFromURL('https://expensify.cash/#/r/1234')).toEqual('');
+            expect(Url.getPathFromURL('https://expensify.cash/#/r/1234')).toEqual('#/r/1234');
             expect(Url.getPathFromURL('https://github.com/Expensify/ReactNativeChat/pull/6.45')).toEqual('Expensify/ReactNativeChat/pull/6.45');
             expect(Url.getPathFromURL('https://github.com/Expensify/Expensify/issues/143,231')).toEqual('Expensify/Expensify/issues/143,231');
             expect(Url.getPathFromURL('testRareTLDs.beer')).toEqual('');
@@ -26,12 +26,11 @@ describe('Url', () => {
                     // eslint-disable-next-line max-len
                     'https://www.expensify.com/_devportal/tools/logSearch/#query=request_id:(%22Ufjjim%22)+AND+timestamp:[2021-01-08T03:48:10.389Z+TO+2021-01-08T05:48:10.389Z]&index=logs_expensify-008878)',
                 ),
-            ).toEqual('_devportal/tools/logSearch/');
+            ).toEqual('_devportal/tools/logSearch/#query=request_id:(%22Ufjjim%22)+AND+timestamp:[2021-01-08T03:48:10.389Z+TO+2021-01-08T05:48:10.389Z]&index=logs_expensify-008878)');
             expect(Url.getPathFromURL('http://necolas.github.io/react-native-web/docs/?path=/docs/components-pressable--disabled ')).toEqual(
                 'react-native-web/docs/?path=/docs/components-pressable--disabled',
             );
-            expect(Url.getPathFromURL('https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash ')).toEqual('Expensify/Expensify.cash/issues/123');
-            expect(Url.getPathFromURL('https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash ')).toEqual('Expensify/Expensify.cash/issues/123');
+            expect(Url.getPathFromURL('https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash ')).toEqual('Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash');
             expect(Url.getPathFromURL('mm..food ')).toEqual('');
             expect(Url.getPathFromURL('https://upwork.com/jobs/~016781e062ce860b84 ')).toEqual('jobs/~016781e062ce860b84');
             expect(
@@ -39,7 +38,7 @@ describe('Url', () => {
                     // eslint-disable-next-line max-len
                     "https://bastion1.sjc/logs/app/kibana#/discover?_g=()&_a=(columns:!(_source),index:'2125cbe0-28a9-11e9-a79c-3de0157ed580',interval:auto,query:(language:lucene,query:''),sort:!(timestamp,desc))",
                 ),
-            ).toEqual('logs/app/kibana');
+            ).toEqual('logs/app/kibana#/discover?_g=()&_a=(columns:!(_source),index:\'2125cbe0-28a9-11e9-a79c-3de0157ed580\',interval:auto,query:(language:lucene,query:\'\'),sort:!(timestamp,desc))');
             expect(
                 Url.getPathFromURL("https://google.com/maps/place/The+Flying'+Saucer/@42.4043314,-86.2742418,15z/data=!4m5!3m4!1s0x0:0xe28f6108670216bc!8m2!3d42.4043316!4d-86.2742121"),
             ).toEqual("maps/place/The+Flying'+Saucer/@42.4043314,-86.2742418,15z/data=!4m5!3m4!1s0x0:0xe28f6108670216bc!8m2!3d42.4043316!4d-86.2742121");


### PR DESCRIPTION


### Details
This PR is an extension of https://github.com/Expensify/App/pull/24483 since we are using query parameters in attachment URLs and the previous implementation only catered pretty URLs and removed any query params in the path.

### Fixed Issues

$ https://github.com/Expensify/App/issues/22523
$ https://github.com/Expensify/App/pull/24483#issuecomment-1683071524

PROPOSAL: 
Original Proposal: https://github.com/Expensify/App/issues/22523#issuecomment-1629939138
Proposal for this PR: https://github.com/Expensify/App/pull/24483#issuecomment-1683087171


### Tests

1. Open a chat and send an attachment.
2. Open the attachment preview and copy the URL then send it in the chat.
3. Click the URL you send it in step 2.
4. The attachment should be previewed internally.

- [ ] Verify that no errors appear in the JS console

### Offline tests

Same as above

### QA Steps

Same as above

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://github.com/Expensify/App/assets/36226639/daab198c-3e8e-4fe1-9f0c-e349891104c2



<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>


https://github.com/Expensify/App/assets/36226639/2ef3f10c-5494-4104-a6ac-ebd714b3cb49



<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>


https://github.com/Expensify/App/assets/36226639/7b1ed450-598d-4179-a853-d29b8eb3906d



<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>


https://github.com/Expensify/App/assets/36226639/86233889-9109-44d7-8e92-5061dcd419b6





<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>


https://github.com/Expensify/App/assets/36226639/50402547-fbee-45de-a127-cbe679220cdb



<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>

Android build is stuck locally and taking a long time.Will update once it is done.

<!-- add screenshots or videos here -->

</details>
