### PR TITLE
 [TS migration] Migrate 'writingDirection.js' style to TypeScript #24689 

### DIFF
--- a/src/styles/utilities/writingDirection.ts
+++ b/src/styles/utilities/writingDirection.ts
@@ -3,7 +3,13 @@
  * Note: writingDirection isn't supported on Android. Unicode controls are being used for Android
  * https://www.w3.org/International/questions/qa-bidi-unicode-controls
  */
-export default {
+
+type Direction = {
+    writingDirection: 'rtl' | 'ltr';
+
+};
+
+const writingDirection: Record<'rtl' | 'ltr', Direction> = {
     rtl: {
         writingDirection: 'rtl',
     },
@@ -11,3 +17,5 @@ export default {
         writingDirection: 'ltr',
     },
 };
+
+export default writingDirection;


### PR DESCRIPTION
### Details
- Created a new type for Directions `rtl` | `ltr` 
- restricting `writingDirection` to have some other key, by allowing only `rtl` and `ltr` in the Record
- I choose camelCase for a variable name , as it is mentioned in the Guidelines that `type` should be in PascalCase but there nothing for variable name

### Fixed Issues

$ https://github.com/Expensify/App/issues/24689
