### PR TITLE
Fixing the race condition on `history.go` due to buggy queue async callbacks

### DIFF
--- a/patches/@react-navigation+native+6.1.6.patch
+++ b/patches/@react-navigation+native+6.1.6.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@react-navigation/native/lib/module/createMemoryHistory.js b/node_modules/@react-navigation/native/lib/module/createMemoryHistory.js
-index 16fdbef..bc2c96a 100644
+index 16fdbef..8fca56f 100644
 --- a/node_modules/@react-navigation/native/lib/module/createMemoryHistory.js
 +++ b/node_modules/@react-navigation/native/lib/module/createMemoryHistory.js
 @@ -1,8 +1,23 @@
@@ -73,6 +73,15 @@ index 16fdbef..bc2c96a 100644
      // `history.go(n)` is asynchronous, there are couple of things to keep in mind:
      // - it won't do anything if we can't go `n` steps, the `popstate` event won't fire.
      // - each `history.go(n)` call will trigger a separate `popstate` event with correct location.
+@@ -133,7 +156,7 @@ export default function createMemoryHistory() {
+         index = nextIndex;
+       }
+       if (n === 0) {
+-        return;
++        return Promise.resolve();
+       }
+ 
+       // When we call `history.go`, `popstate` will fire when there's history to go back to
 @@ -175,20 +198,17 @@ export default function createMemoryHistory() {
          // But on Firefox, it seems to take much longer, around 50ms from our testing
          // We're using a hacky timeout since there doesn't seem to be way to know for sure
@@ -133,7 +142,7 @@ index 0000000..16da117
 +//# sourceMappingURL=findFocusedRouteKey.js.map
 \ No newline at end of file
 diff --git a/node_modules/@react-navigation/native/lib/module/useLinking.js b/node_modules/@react-navigation/native/lib/module/useLinking.js
-index 5bf2a88..a6d0670 100644
+index 5bf2a88..da708ba 100644
 --- a/node_modules/@react-navigation/native/lib/module/useLinking.js
 +++ b/node_modules/@react-navigation/native/lib/module/useLinking.js
 @@ -2,6 +2,7 @@ import { findFocusedRoute, getActionFromState as getActionFromStateDefault, getP
@@ -144,7 +153,37 @@ index 5bf2a88..a6d0670 100644
  import ServerContext from './ServerContext';
  /**
   * Find the matching navigation state that changed between 2 navigation states
-@@ -60,6 +61,44 @@ const series = cb => {
+@@ -34,32 +35,53 @@ const findMatchingState = (a, b) => {
+ /**
+  * Run async function in series as it's called.
+  */
+-const series = cb => {
+-  // Whether we're currently handling a callback
+-  let handling = false;
+-  let queue = [];
+-  const callback = async () => {
+-    try {
+-      if (handling) {
+-        // If we're currently handling a previous event, wait before handling this one
+-        // Add the callback to the beginning of the queue
+-        queue.unshift(callback);
+-        return;
+-      }
+-      handling = true;
+-      await cb();
+-    } finally {
+-      handling = false;
+-      if (queue.length) {
+-        // If we have queued items, handle the last one
+-        const last = queue.pop();
+-        last === null || last === void 0 ? void 0 : last();
+-      }
+-    }
++const series = (cb) => {
++  let queue = Promise.resolve();
++  const callback = () => {
++    queue = queue.then(cb);
+   };
    return callback;
  };
  let linkingHandlers = [];
@@ -172,6 +211,7 @@ index 5bf2a88..a6d0670 100644
 +  }
 +  return -1;
 +};
++
 +const getHistoryDeltaByKeys = (focusedState, previousFocusedState) => {
 +  const focusedStateKeys = focusedState.routes.map(r => r.key);
 +  const previousFocusedStateKeys = previousFocusedState.routes.map(r => r.key);
@@ -189,17 +229,15 @@ index 5bf2a88..a6d0670 100644
  export default function useLinking(ref, _ref) {
    let {
      independent,
-@@ -251,6 +290,9 @@ export default function useLinking(ref, _ref) {
+@@ -251,6 +273,7 @@ export default function useLinking(ref, _ref) {
        // Otherwise it's likely a change triggered by `popstate`
        path !== pendingPath) {
          const historyDelta = (focusedState.history ? focusedState.history.length : focusedState.routes.length) - (previousFocusedState.history ? previousFocusedState.history.length : previousFocusedState.routes.length);
 +
-+        // The historyDelta and historyDeltaByKeys may differ if the new state has an entry that didn't exist in previous state
-+        const historyDeltaByKeys = getHistoryDeltaByKeys(focusedState, previousFocusedState);
          if (historyDelta > 0) {
            // If history length is increased, we should pushState
            // Note that path might not actually change here, for example, drawer open should pushState
-@@ -262,34 +304,55 @@ export default function useLinking(ref, _ref) {
+@@ -262,34 +285,63 @@ export default function useLinking(ref, _ref) {
            // If history length is decreased, i.e. entries were removed, we want to go back
  
            const nextIndex = history.backIndex({
@@ -212,6 +250,7 @@ index 5bf2a88..a6d0670 100644
              if (nextIndex !== -1 && nextIndex < currentIndex) {
                // An existing entry for this path exists and it's less than current index, go back to that
                await history.go(nextIndex - currentIndex);
++              // Store the updated state as well as fix the path if incorrect
 +              history.replace({
 +                path,
 +                state
@@ -221,6 +260,15 @@ index 5bf2a88..a6d0670 100644
                // This won't be correct if multiple routes were pushed in one go before
                // Usually this shouldn't happen and this is a fallback for that
 -              await history.go(historyDelta);
+-            }
+ 
+-            // Store the updated state as well as fix the path if incorrect
+-            history.replace({
+-              path,
+-              state
+-            });
++              // The historyDelta and historyDeltaByKeys may differ if the new state has an entry that didn't exist in previous state
++              const historyDeltaByKeys = getHistoryDeltaByKeys(focusedState, previousFocusedState);
 +              await history.go(historyDeltaByKeys);
 +              if (historyDeltaByKeys + 1 === historyDelta) {
 +                history.push({
@@ -233,13 +281,7 @@ index 5bf2a88..a6d0670 100644
 +                  state
 +                });
 +              }
-             }
--
--            // Store the updated state as well as fix the path if incorrect
--            history.replace({
--              path,
--              state
--            });
++            }
            } catch (e) {
              // The navigation was interrupted
            }
@@ -258,11 +300,15 @@ index 5bf2a88..a6d0670 100644
 +              state
 +            });
 +          } else {
-+            await history.go(-staleHistoryDiff);
-+            history.push({
-+              path,
-+              state
-+            });
++            try {
++              await history.go(-staleHistoryDiff);
++              history.push({
++                path,
++                state
++              });
++            } catch (e) {
++              // The navigation was interrupted
++            }
 +          }
          }
        } else {

--- a/patches/@react-navigation+native+6.1.6.patch
+++ b/patches/@react-navigation+native+6.1.6.patch
@@ -133,7 +133,7 @@ index 0000000..16da117
 +//# sourceMappingURL=findFocusedRouteKey.js.map
 \ No newline at end of file
 diff --git a/node_modules/@react-navigation/native/lib/module/useLinking.js b/node_modules/@react-navigation/native/lib/module/useLinking.js
-index 5bf2a88..abfa7d7 100644
+index 5bf2a88..a4318ef 100644
 --- a/node_modules/@react-navigation/native/lib/module/useLinking.js
 +++ b/node_modules/@react-navigation/native/lib/module/useLinking.js
 @@ -2,6 +2,7 @@ import { findFocusedRoute, getActionFromState as getActionFromStateDefault, getP
@@ -229,7 +229,7 @@ index 5bf2a88..abfa7d7 100644
          if (historyDelta > 0) {
            // If history length is increased, we should pushState
            // Note that path might not actually change here, for example, drawer open should pushState
-@@ -262,34 +286,56 @@ export default function useLinking(ref, _ref) {
+@@ -262,34 +286,55 @@ export default function useLinking(ref, _ref) {
            // If history length is decreased, i.e. entries were removed, we want to go back
  
            const nextIndex = history.backIndex({
@@ -251,13 +251,6 @@ index 5bf2a88..abfa7d7 100644
                // This won't be correct if multiple routes were pushed in one go before
                // Usually this shouldn't happen and this is a fallback for that
 -              await history.go(historyDelta);
--            }
- 
--            // Store the updated state as well as fix the path if incorrect
--            history.replace({
--              path,
--              state
--            });
 +              await history.go(historyDeltaByKeys);
 +              if (historyDeltaByKeys + 1 === historyDelta) {
 +                history.push({
@@ -270,7 +263,13 @@ index 5bf2a88..abfa7d7 100644
 +                  state
 +                });
 +              }
-+            }
+             }
+-
+-            // Store the updated state as well as fix the path if incorrect
+-            history.replace({
+-              path,
+-              state
+-            });
            } catch (e) {
              // The navigation was interrupted
            }

--- a/patches/@react-navigation+native+6.1.6.patch
+++ b/patches/@react-navigation+native+6.1.6.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@react-navigation/native/lib/module/createMemoryHistory.js b/node_modules/@react-navigation/native/lib/module/createMemoryHistory.js
-index 16fdbef..8fca56f 100644
+index 16fdbef..bc2c96a 100644
 --- a/node_modules/@react-navigation/native/lib/module/createMemoryHistory.js
 +++ b/node_modules/@react-navigation/native/lib/module/createMemoryHistory.js
 @@ -1,8 +1,23 @@
@@ -73,15 +73,6 @@ index 16fdbef..8fca56f 100644
      // `history.go(n)` is asynchronous, there are couple of things to keep in mind:
      // - it won't do anything if we can't go `n` steps, the `popstate` event won't fire.
      // - each `history.go(n)` call will trigger a separate `popstate` event with correct location.
-@@ -133,7 +156,7 @@ export default function createMemoryHistory() {
-         index = nextIndex;
-       }
-       if (n === 0) {
--        return;
-+        return Promise.resolve();
-       }
- 
-       // When we call `history.go`, `popstate` will fire when there's history to go back to
 @@ -175,20 +198,17 @@ export default function createMemoryHistory() {
          // But on Firefox, it seems to take much longer, around 50ms from our testing
          // We're using a hacky timeout since there doesn't seem to be way to know for sure
@@ -142,7 +133,7 @@ index 0000000..16da117
 +//# sourceMappingURL=findFocusedRouteKey.js.map
 \ No newline at end of file
 diff --git a/node_modules/@react-navigation/native/lib/module/useLinking.js b/node_modules/@react-navigation/native/lib/module/useLinking.js
-index 5bf2a88..da708ba 100644
+index 5bf2a88..abfa7d7 100644
 --- a/node_modules/@react-navigation/native/lib/module/useLinking.js
 +++ b/node_modules/@react-navigation/native/lib/module/useLinking.js
 @@ -2,6 +2,7 @@ import { findFocusedRoute, getActionFromState as getActionFromStateDefault, getP
@@ -153,7 +144,7 @@ index 5bf2a88..da708ba 100644
  import ServerContext from './ServerContext';
  /**
   * Find the matching navigation state that changed between 2 navigation states
-@@ -34,32 +35,53 @@ const findMatchingState = (a, b) => {
+@@ -34,32 +35,52 @@ const findMatchingState = (a, b) => {
  /**
   * Run async function in series as it's called.
   */
@@ -211,7 +202,6 @@ index 5bf2a88..da708ba 100644
 +  }
 +  return -1;
 +};
-+
 +const getHistoryDeltaByKeys = (focusedState, previousFocusedState) => {
 +  const focusedStateKeys = focusedState.routes.map(r => r.key);
 +  const previousFocusedStateKeys = previousFocusedState.routes.map(r => r.key);
@@ -229,15 +219,17 @@ index 5bf2a88..da708ba 100644
  export default function useLinking(ref, _ref) {
    let {
      independent,
-@@ -251,6 +273,7 @@ export default function useLinking(ref, _ref) {
+@@ -251,6 +272,9 @@ export default function useLinking(ref, _ref) {
        // Otherwise it's likely a change triggered by `popstate`
        path !== pendingPath) {
          const historyDelta = (focusedState.history ? focusedState.history.length : focusedState.routes.length) - (previousFocusedState.history ? previousFocusedState.history.length : previousFocusedState.routes.length);
 +
++        // The historyDelta and historyDeltaByKeys may differ if the new state has an entry that didn't exist in previous state
++        const historyDeltaByKeys = getHistoryDeltaByKeys(focusedState, previousFocusedState);
          if (historyDelta > 0) {
            // If history length is increased, we should pushState
            // Note that path might not actually change here, for example, drawer open should pushState
-@@ -262,34 +285,63 @@ export default function useLinking(ref, _ref) {
+@@ -262,34 +286,56 @@ export default function useLinking(ref, _ref) {
            // If history length is decreased, i.e. entries were removed, we want to go back
  
            const nextIndex = history.backIndex({
@@ -250,7 +242,6 @@ index 5bf2a88..da708ba 100644
              if (nextIndex !== -1 && nextIndex < currentIndex) {
                // An existing entry for this path exists and it's less than current index, go back to that
                await history.go(nextIndex - currentIndex);
-+              // Store the updated state as well as fix the path if incorrect
 +              history.replace({
 +                path,
 +                state
@@ -267,8 +258,6 @@ index 5bf2a88..da708ba 100644
 -              path,
 -              state
 -            });
-+              // The historyDelta and historyDeltaByKeys may differ if the new state has an entry that didn't exist in previous state
-+              const historyDeltaByKeys = getHistoryDeltaByKeys(focusedState, previousFocusedState);
 +              await history.go(historyDeltaByKeys);
 +              if (historyDeltaByKeys + 1 === historyDelta) {
 +                history.push({
@@ -300,15 +289,11 @@ index 5bf2a88..da708ba 100644
 +              state
 +            });
 +          } else {
-+            try {
-+              await history.go(-staleHistoryDiff);
-+              history.push({
-+                path,
-+                state
-+              });
-+            } catch (e) {
-+              // The navigation was interrupted
-+            }
++            await history.go(-staleHistoryDiff);
++            history.push({
++              path,
++              state
++            });
 +          }
          }
        } else {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/25527
PROPOSAL: https://github.com/Expensify/App/issues/25527#issuecomment-1686303349


### Tests / QA Steps
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Open the app
2. Click CTRL+K
3. Click CTRL+SHIFT+K
4. Again click CTRL+K

- [x] Verify that no errors appear in the JS console
- [x] Verify that the search page should be open at last

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://github.com/Expensify/App/assets/58412969/e8a7ddde-6062-44a7-8e09-711395d12ed8

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->
NA

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->
NA

</details>

<details>
<summary>Desktop</summary>


https://github.com/Expensify/App/assets/58412969/3665d87f-4d52-4e82-9711-60ffa6065df7


</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->
NA

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->
NA

</details>
