### PR TITLE
Show recent waypoints when selecting address for distance request

### DIFF
--- a/src/ONYXKEYS.ts
+++ b/src/ONYXKEYS.ts
@@ -106,6 +106,9 @@ const ONYXKEYS = {
     /** The NVP with the last payment method used per policy */
     NVP_LAST_PAYMENT_METHOD: 'nvp_lastPaymentMethod',
 
+    /** This NVP holds to most recent waypoints that a person has used when creating a distance request */
+    NVP_RECENT_WAYPOINTS: 'expensify_recentWaypoints',
+
     /** Does this user have push notifications enabled for this device? */
     PUSH_NOTIFICATIONS_ENABLED: 'pushNotificationsEnabled',
 
@@ -315,6 +318,7 @@ type OnyxValues = {
     [ONYXKEYS.NVP_BLOCKED_FROM_CONCIERGE]: OnyxTypes.BlockedFromConcierge;
     [ONYXKEYS.NVP_PRIVATE_PUSH_NOTIFICATION_ID]: string;
     [ONYXKEYS.NVP_LAST_PAYMENT_METHOD]: Record<string, string>;
+    [ONYXKEYS.NVP_RECENT_WAYPOINTS]: OnyxTypes.RecentWaypoints[];
     [ONYXKEYS.PUSH_NOTIFICATIONS_ENABLED]: boolean;
     [ONYXKEYS.PLAID_DATA]: OnyxTypes.PlaidData;
     [ONYXKEYS.IS_PLAID_DISABLED]: boolean;

--- a/src/components/AddressSearch/index.js
+++ b/src/components/AddressSearch/index.js
@@ -287,7 +287,7 @@ function AddressSearch(props) {
                     fetchDetails
                     suppressDefaultStyles
                     enablePoweredByContainer={false}
-                    predefinedPlaces={props.predefinedPlaces.length ? props.predefinedPlaces : null}
+                    predefinedPlaces={props.predefinedPlaces}
                     ListEmptyComponent={
                         props.network.isOffline ? null : (
                             <Text style={[styles.textLabel, styles.colorMuted, styles.pv4, styles.ph3, styles.overflowAuto]}>{props.translate('common.noResultsFound')}</Text>

--- a/src/components/AddressSearch/index.js
+++ b/src/components/AddressSearch/index.js
@@ -61,6 +61,26 @@ const propTypes = {
     /** Should address search be limited to results in the USA */
     isLimitedToUSA: PropTypes.bool,
 
+    /** A list of recent search results that can be shown when the user isn't searching for something */
+    recentSearchSuggestions: PropTypes.arrayOf(
+        PropTypes.shape({
+            /** A description of the location (usually the address) */
+            description: PropTypes.string,
+
+            /** Data required by the google auto complete plugin to know where to put the markers on the map */
+            geometry: PropTypes.shape({
+                /** Data about the location */
+                location: PropTypes.shape({
+                    /** Lattitude of the location */
+                    lat: PropTypes.string,
+
+                    /** Longitude of the location */
+                    lng: PropTypes.string,
+                }),
+            }),
+        }),
+    ),
+
     /** A map of inputID key names */
     renamedInputKeys: PropTypes.shape({
         street: PropTypes.string,
@@ -102,6 +122,7 @@ const defaultProps = {
         lng: 'addressLng',
     },
     maxInputLength: undefined,
+    recentSearchSuggestions: [],
 };
 
 // Do not convert to class component! It's been tried before and presents more challenges than it's worth.
@@ -250,6 +271,7 @@ function AddressSearch(props) {
                     fetchDetails
                     suppressDefaultStyles
                     enablePoweredByContainer={false}
+                    predefinedPlaces={props.recentSearchSuggestions.length ? props.recentSearchSuggestions : null}
                     ListEmptyComponent={
                         props.network.isOffline ? null : (
                             <Text style={[styles.textLabel, styles.colorMuted, styles.pv4, styles.ph3, styles.overflowAuto]}>{props.translate('common.noResultsFound')}</Text>

--- a/src/components/AddressSearch/index.js
+++ b/src/components/AddressSearch/index.js
@@ -152,9 +152,6 @@ function AddressSearch(props) {
                     lat: lodashGet(details, 'geometry.location.lat', 0),
                     lng: lodashGet(details, 'geometry.location.lng', 0),
                 });
-
-                // After we select an option, we set displayListViewBorder to false to prevent UI flickering
-                setDisplayListViewBorder(false);
             }
             return;
         }
@@ -257,9 +254,6 @@ function AddressSearch(props) {
         }
 
         props.onPress(values);
-
-        // After we select an option, we set displayListViewBorder to false to prevent UI flickering
-        setDisplayListViewBorder(false);
     };
 
     return (
@@ -293,7 +287,12 @@ function AddressSearch(props) {
                             <Text style={[styles.textLabel, styles.colorMuted, styles.pv4, styles.ph3, styles.overflowAuto]}>{props.translate('common.noResultsFound')}</Text>
                         )
                     }
-                    onPress={saveLocationDetails}
+                    onPress={(data, details) => {
+                        saveLocationDetails(data, details);
+
+                        // After we select an option, we set displayListViewBorder to false to prevent UI flickering
+                        setDisplayListViewBorder(false);
+                    }}
                     query={query}
                     requestUrl={{
                         useOnPlatform: 'all',

--- a/src/libs/actions/Transaction.js
+++ b/src/libs/actions/Transaction.js
@@ -95,8 +95,9 @@ function saveWaypoint(transactionID, index, waypoint) {
     });
     const recentWaypointAlreadyExists = _.find(recentWaypoints, (recentWaypoint) => recentWaypoint.address === waypoint.address);
     if (!recentWaypointAlreadyExists) {
-        recentWaypoints.unshift(waypoint);
-        Onyx.merge(ONYXKEYS.NVP_RECENT_WAYPOINTS, recentWaypoints.slice(0, 5));
+        const clonedWaypoints = _.clone(recentWaypoints);
+        clonedWaypoints.unshift(waypoint);
+        Onyx.merge(ONYXKEYS.NVP_RECENT_WAYPOINTS, clonedWaypoints.slice(0, 5));
     }
 }
 

--- a/src/libs/actions/Transaction.js
+++ b/src/libs/actions/Transaction.js
@@ -5,6 +5,12 @@ import ONYXKEYS from '../../ONYXKEYS';
 import * as CollectionUtils from '../CollectionUtils';
 import * as API from '../API';
 
+let recentWaypoints = [];
+Onyx.connect({
+    key: ONYXKEYS.NVP_RECENT_WAYPOINTS,
+    callback: (val) => (recentWaypoints = val || []),
+});
+
 const allTransactions = {};
 Onyx.connect({
     key: ONYXKEYS.COLLECTION.TRANSACTION,
@@ -87,6 +93,11 @@ function saveWaypoint(transactionID, index, waypoint) {
             },
         },
     });
+    const recentWaypointAlreadyExists = _.find(recentWaypoints, (recentWaypoint) => recentWaypoint.address === waypoint.address);
+    if (!recentWaypointAlreadyExists) {
+        recentWaypoints.unshift(waypoint);
+        Onyx.merge(ONYXKEYS.NVP_RECENT_WAYPOINTS, recentWaypoints.slice(0, 5));
+    }
 }
 
 function removeWaypoint(transactionID, currentIndex) {

--- a/src/pages/iou/WaypointEditor.js
+++ b/src/pages/iou/WaypointEditor.js
@@ -107,6 +107,25 @@ function WaypointEditor({transactionID, route: {params: {iouType = '', waypointI
         Navigation.goBack(ROUTES.getMoneyRequestDistanceTabRoute(iouType));
     };
 
+    const recentWaypoints = [
+        {address: '0', lat: 0, lng: 0},
+        {address: '1', lat: 0, lng: 0},
+        {address: '2', lat: 0, lng: 0},
+        {address: '3', lat: 0, lng: 0},
+        {address: '4', lat: 0, lng: 0},
+    ];
+    const recentSearchSuggestions = _.map(recentWaypoints, (waypoint) => {
+        return {
+            description: waypoint.address,
+            geometry: {
+                location: {
+                    lat: waypoint.lat,
+                    lng: waypoint.lng,
+                },
+            },
+        };
+    });
+
     return (
         <ScreenWrapper
             includeSafeAreaPaddingBottom={false}
@@ -151,6 +170,7 @@ function WaypointEditor({transactionID, route: {params: {iouType = '', waypointI
                             lng: null,
                             state: null,
                         }}
+                        recentSearchSuggestions={recentSearchSuggestions}
                     />
                 </View>
             </Form>
@@ -168,6 +188,13 @@ export default compose(
         transaction: {
             key: (props) => `${ONYXKEYS.COLLECTION.TRANSACTION}${props.transactionID}`,
             selector: (transaction) => (transaction ? {transactionID: transaction.transactionID, comment: {waypoints: lodashGet(transaction, 'comment.waypoints')}} : null),
+        },
+
+        recentWaypoints: {
+            key: ONYXKEYS.NVP_RECENT_WAYPOINTS,
+
+            // Only grab the most recent 5 waypoints because that's all that is shown in the UI
+            selector: (waypoints) => (waypoints && waypoints.length ? waypoints.slice(0, 5) : []),
         },
     }),
 )(WaypointEditor);

--- a/src/pages/iou/WaypointEditor.js
+++ b/src/pages/iou/WaypointEditor.js
@@ -53,7 +53,7 @@ const defaultProps = {
     transaction: {},
 };
 
-function WaypointEditor({transactionID, route: {params: {iouType = '', waypointIndex = ''} = {}} = {}, network, translate, transaction}) {
+function WaypointEditor({transactionID, route: {params: {iouType = '', waypointIndex = ''} = {}} = {}, network, translate, transaction, recentWaypoints}) {
     const textInput = useRef(null);
     const currentWaypoint = lodashGet(transaction, `comment.waypoints.waypoint${waypointIndex}`, {});
     const waypointAddress = lodashGet(currentWaypoint, 'address', '');
@@ -151,7 +151,7 @@ function WaypointEditor({transactionID, route: {params: {iouType = '', waypointI
                             lng: null,
                             state: null,
                         }}
-                        predefinedPlaces={props.recentWaypoints}
+                        predefinedPlaces={recentWaypoints}
                     />
                 </View>
             </Form>

--- a/src/pages/iou/WaypointEditor.js
+++ b/src/pages/iou/WaypointEditor.js
@@ -178,7 +178,7 @@ export default compose(
             // Only grab the most recent 5 waypoints because that's all that is shown in the UI. This also puts them into the format of data
             // that the google autocomplete component expects for it's "predefined places" feature.
             selector: (waypoints) =>
-                _.map(waypoints && waypoints.length ? waypoints.slice(0, 5) : [], (waypoint) => ({
+                _.map(waypoints ? waypoints.slice(0, 5) : [], (waypoint) => ({
                     description: waypoint.address,
                     geometry: {
                         location: {

--- a/src/pages/iou/WaypointEditor.js
+++ b/src/pages/iou/WaypointEditor.js
@@ -1,4 +1,5 @@
 import React, {useRef} from 'react';
+import _ from 'underscore';
 import lodashGet from 'lodash/get';
 import {View} from 'react-native';
 import PropTypes from 'prop-types';

--- a/src/pages/iou/WaypointEditor.js
+++ b/src/pages/iou/WaypointEditor.js
@@ -107,25 +107,6 @@ function WaypointEditor({transactionID, route: {params: {iouType = '', waypointI
         Navigation.goBack(ROUTES.getMoneyRequestDistanceTabRoute(iouType));
     };
 
-    const recentWaypoints = [
-        {address: '0', lat: 0, lng: 0},
-        {address: '1', lat: 0, lng: 0},
-        {address: '2', lat: 0, lng: 0},
-        {address: '3', lat: 0, lng: 0},
-        {address: '4', lat: 0, lng: 0},
-    ];
-    const recentSearchSuggestions = _.map(recentWaypoints, (waypoint) => {
-        return {
-            description: waypoint.address,
-            geometry: {
-                location: {
-                    lat: waypoint.lat,
-                    lng: waypoint.lng,
-                },
-            },
-        };
-    });
-
     return (
         <ScreenWrapper
             includeSafeAreaPaddingBottom={false}
@@ -170,7 +151,7 @@ function WaypointEditor({transactionID, route: {params: {iouType = '', waypointI
                             lng: null,
                             state: null,
                         }}
-                        recentSearchSuggestions={recentSearchSuggestions}
+                        predefinedPlaces={props.recentWaypoints}
                     />
                 </View>
             </Form>
@@ -193,8 +174,18 @@ export default compose(
         recentWaypoints: {
             key: ONYXKEYS.NVP_RECENT_WAYPOINTS,
 
-            // Only grab the most recent 5 waypoints because that's all that is shown in the UI
-            selector: (waypoints) => (waypoints && waypoints.length ? waypoints.slice(0, 5) : []),
+            // Only grab the most recent 5 waypoints because that's all that is shown in the UI. This also puts them into the format of data
+            // that the google autocomplete component expects for it's "predefined places" feature.
+            selector: (waypoints) =>
+                _.map(waypoints && waypoints.length ? waypoints.slice(0, 5) : [], (waypoint) => ({
+                    description: waypoint.address,
+                    geometry: {
+                        location: {
+                            lat: waypoint.lat,
+                            lng: waypoint.lng,
+                        },
+                    },
+                })),
         },
     }),
 )(WaypointEditor);

--- a/src/types/onyx/RecentWaypoints.ts
+++ b/src/types/onyx/RecentWaypoints.ts
@@ -1,0 +1,12 @@
+type RecentWaypoints = {
+    /** The full address of the waypoint */
+    address: string;
+
+    /** The lattitude of the waypoint */
+    lat: number;
+
+    /** The longitude of the waypoint */
+    lng: number;
+};
+
+export default RecentWaypoints;

--- a/src/types/onyx/index.ts
+++ b/src/types/onyx/index.ts
@@ -32,7 +32,6 @@ import ReimbursementAccountDraft from './ReimbursementAccountDraft';
 import WalletTransfer from './WalletTransfer';
 import ReceiptModal from './ReceiptModal';
 import MapboxAccessToken from './MapboxAccessToken';
-
 import Download from './Download';
 import PolicyMember from './PolicyMember';
 import Policy from './Policy';
@@ -41,8 +40,8 @@ import ReportAction from './ReportAction';
 import ReportActionReactions from './ReportActionReactions';
 import SecurityGroup from './SecurityGroup';
 import Transaction from './Transaction';
-
 import Form, {AddDebitCardForm} from './Form';
+import RecentWaypoints from './RecentWaypoints';
 
 export type {
     Account,
@@ -89,4 +88,5 @@ export type {
     Transaction,
     Form,
     AddDebitCardForm,
+    RecentWaypoints,
 };


### PR DESCRIPTION
### Details
This PR shows your most recently chosen waypoints when creating a distance request and selecting addresses.

### Fixed Issues
$ https://github.com/Expensify/App/issues/22714


### Tests
1. Create a distance request with valid addresses for each start and end location waypoint
2. Select a different start and end location again
3. When selecting the waypoints, verify you can see and select each of the previous addresses from step 1
8. Start typing a real address like `88 kearny`
9. Verify that the previous waypoints go away and you get address suggestions
10. Now delete the text from the input
11. Verify that you see your previous waypoints again
12. Select one of them
13. Verify that the map correctly shows that location
14. Repeat this test several times with different number of waypoints
15. Verify that it always shows the 5 most recent waypoints
16. Verify that selecting the same address more than once does not show duplicate address entries in the recent waypoints

- [ ] Verify that no errors appear in the JS console

### Offline tests
Same as the above

### QA Steps
Same as the tests above

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->
![image](https://github.com/Expensify/App/assets/1228807/f8071a8c-70ac-4034-944a-a0b71dd1e3a9)

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->
![image](https://github.com/Expensify/App/assets/1228807/68fbb4ab-f486-4bf0-bba3-35e880f8bb88)

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->
![image](https://github.com/Expensify/App/assets/1228807/3e225db7-4c0a-4bf8-a1af-b739aa512811)

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->
![image](https://github.com/Expensify/App/assets/1228807/c9f4c15f-97aa-4b8a-9b3e-338d18612c1f)

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->
![image](https://github.com/Expensify/App/assets/1228807/7dcef929-886c-4301-83c0-a91d2a8e7f1d)

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->
![image](https://github.com/Expensify/App/assets/1228807/3e2cfc87-2a8e-44b2-818b-fd38869f70d4)

</details>
