### PR TITLE
Don't focus when ref composer is unmounted

### DIFF
--- a/src/pages/home/report/ReportActionCompose/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose/ReportActionCompose.js
@@ -403,7 +403,10 @@ function ReportActionCompose({
                     {DeviceCapabilities.canUseTouchScreen() && isMediumScreenWidth ? null : (
                         <EmojiPickerButton
                             isDisabled={isBlockedFromConcierge || disabled}
-                            onModalHide={() => composerRef.current.focus(true)}
+                            onModalHide={() => {
+                                if (composerRef === null || composerRef.current === null)
+                                composerRef.current.focus(true)
+                            }}
                             onEmojiSelected={(...args) => composerRef.current.replaceSelectionWithText(...args)}
                             emojiPickerID={report.reportID}
                         />

--- a/src/pages/home/report/ReportActionCompose/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose/ReportActionCompose.js
@@ -183,7 +183,7 @@ function ReportActionCompose({
         if (!isKeyboardVisibleWhenShowingModalRef.current) {
             return;
         }
-        composerRef.current.focus(true);
+        focus();
         isKeyboardVisibleWhenShowingModalRef.current = false;
     }, []);
 
@@ -270,6 +270,12 @@ function ReportActionCompose({
         isNextModalWillOpenRef.current = true;
     }, []);
 
+    const focus = () => {
+        if (composerRef === null || composerRef.current === null) {
+            return;
+        }
+        composerRef.current.focus(true);
+    }
     const onBlur = useCallback((e) => {
         setIsFocused(false);
         suggestionsRef.current.resetSuggestions();
@@ -403,12 +409,7 @@ function ReportActionCompose({
                     {DeviceCapabilities.canUseTouchScreen() && isMediumScreenWidth ? null : (
                         <EmojiPickerButton
                             isDisabled={isBlockedFromConcierge || disabled}
-                            onModalHide={() => {
-                                if (composerRef === null || composerRef.current === null) {
-                                    return;
-                                }
-                                composerRef.current.focus(true);
-                            }}
+                            onModalHide={focus}
                             onEmojiSelected={(...args) => composerRef.current.replaceSelectionWithText(...args)}
                             emojiPickerID={report.reportID}
                         />

--- a/src/pages/home/report/ReportActionCompose/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose/ReportActionCompose.js
@@ -404,7 +404,9 @@ function ReportActionCompose({
                         <EmojiPickerButton
                             isDisabled={isBlockedFromConcierge || disabled}
                             onModalHide={() => {
-                                if (composerRef === null || composerRef.current === null)
+                                if (composerRef === null || composerRef.current === null) {
+                                    return;
+                                }
                                 composerRef.current.focus(true)
                             }}
                             onEmojiSelected={(...args) => composerRef.current.replaceSelectionWithText(...args)}

--- a/src/pages/home/report/ReportActionCompose/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose/ReportActionCompose.js
@@ -276,6 +276,7 @@ function ReportActionCompose({
         }
         composerRef.current.focus(true);
     }
+
     const onBlur = useCallback((e) => {
         setIsFocused(false);
         suggestionsRef.current.resetSuggestions();

--- a/src/pages/home/report/ReportActionCompose/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose/ReportActionCompose.js
@@ -275,7 +275,7 @@ function ReportActionCompose({
             return;
         }
         composerRef.current.focus(true);
-    }
+    };
 
     const onBlur = useCallback((e) => {
         setIsFocused(false);

--- a/src/pages/home/report/ReportActionCompose/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose/ReportActionCompose.js
@@ -178,6 +178,13 @@ function ReportActionCompose({
         return translate('reportActionCompose.writeSomething');
     }, [report, blockedFromConcierge, translate, conciergePlaceholderRandomIndex]);
 
+    const focus = () => {
+        if (composerRef === null || composerRef.current === null) {
+            return;
+        }
+        composerRef.current.focus(true);
+    };
+
     const isKeyboardVisibleWhenShowingModalRef = useRef(false);
     const restoreKeyboardState = useCallback(() => {
         if (!isKeyboardVisibleWhenShowingModalRef.current) {
@@ -269,13 +276,6 @@ function ReportActionCompose({
         }
         isNextModalWillOpenRef.current = true;
     }, []);
-
-    const focus = () => {
-        if (composerRef === null || composerRef.current === null) {
-            return;
-        }
-        composerRef.current.focus(true);
-    };
 
     const onBlur = useCallback((e) => {
         setIsFocused(false);

--- a/src/pages/home/report/ReportActionCompose/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose/ReportActionCompose.js
@@ -183,7 +183,7 @@ function ReportActionCompose({
         if (!isKeyboardVisibleWhenShowingModalRef.current) {
             return;
         }
-        composerRef?.current?.focus(true);
+        composerRef.current.focus(true);
         isKeyboardVisibleWhenShowingModalRef.current = false;
     }, []);
 
@@ -197,9 +197,9 @@ function ReportActionCompose({
 
     const onAddActionPressed = useCallback(() => {
         if (!willBlurTextInputOnTapOutside) {
-            isKeyboardVisibleWhenShowingModalRef.current = composerRef?.current?.isFocused();
+            isKeyboardVisibleWhenShowingModalRef.current = composerRef.current.isFocused();
         }
-        composerRef?.current?.blur();
+        composerRef.current.blur();
     }, []);
 
     const updateShouldShowSuggestionMenuToFalse = useCallback(() => {
@@ -218,7 +218,7 @@ function ReportActionCompose({
             // We don't really care about saving the draft the user was typing
             // We need to make sure an empty draft gets saved instead
             debouncedSaveReportComment.cancel();
-            const newComment = composerRef?.current?.prepareCommentAndResetComposer();
+            const newComment = composerRef.current.prepareCommentAndResetComposer();
             Report.addAttachment(reportID, file, newComment);
             setTextInputShouldClear(false);
         },
@@ -250,7 +250,7 @@ function ReportActionCompose({
             // We need to make sure an empty draft gets saved instead
             debouncedSaveReportComment.cancel();
 
-            const newComment = composerRef?.current?.prepareCommentAndResetComposer();
+            const newComment = composerRef.current.prepareCommentAndResetComposer();
             if (!newComment) {
                 return;
             }
@@ -403,8 +403,13 @@ function ReportActionCompose({
                     {DeviceCapabilities.canUseTouchScreen() && isMediumScreenWidth ? null : (
                         <EmojiPickerButton
                             isDisabled={isBlockedFromConcierge || disabled}
-                            onModalHide={() => composerRef?.current?.focus(true)}
-                            onEmojiSelected={(...args) => composerRef?.current?.replaceSelectionWithText(...args)}
+                            onModalHide={() => {
+                                if (composerRef === null || composerRef.current === null) {
+                                    return;
+                                }
+                                composerRef.current.focus(true);
+                            }}
+                            onEmojiSelected={(...args) => composerRef.current.replaceSelectionWithText(...args)}
                             emojiPickerID={report.reportID}
                         />
                     )}

--- a/src/pages/home/report/ReportActionCompose/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose/ReportActionCompose.js
@@ -183,7 +183,7 @@ function ReportActionCompose({
         if (!isKeyboardVisibleWhenShowingModalRef.current) {
             return;
         }
-        composerRef.current.focus(true);
+        composerRef?.current?.focus(true);
         isKeyboardVisibleWhenShowingModalRef.current = false;
     }, []);
 
@@ -197,9 +197,9 @@ function ReportActionCompose({
 
     const onAddActionPressed = useCallback(() => {
         if (!willBlurTextInputOnTapOutside) {
-            isKeyboardVisibleWhenShowingModalRef.current = composerRef.current.isFocused();
+            isKeyboardVisibleWhenShowingModalRef.current = composerRef?.current?.isFocused();
         }
-        composerRef.current.blur();
+        composerRef?.current?.blur();
     }, []);
 
     const updateShouldShowSuggestionMenuToFalse = useCallback(() => {
@@ -218,7 +218,7 @@ function ReportActionCompose({
             // We don't really care about saving the draft the user was typing
             // We need to make sure an empty draft gets saved instead
             debouncedSaveReportComment.cancel();
-            const newComment = composerRef.current.prepareCommentAndResetComposer();
+            const newComment = composerRef?.current?.prepareCommentAndResetComposer();
             Report.addAttachment(reportID, file, newComment);
             setTextInputShouldClear(false);
         },
@@ -250,7 +250,7 @@ function ReportActionCompose({
             // We need to make sure an empty draft gets saved instead
             debouncedSaveReportComment.cancel();
 
-            const newComment = composerRef.current.prepareCommentAndResetComposer();
+            const newComment = composerRef?.current?.prepareCommentAndResetComposer();
             if (!newComment) {
                 return;
             }
@@ -403,13 +403,8 @@ function ReportActionCompose({
                     {DeviceCapabilities.canUseTouchScreen() && isMediumScreenWidth ? null : (
                         <EmojiPickerButton
                             isDisabled={isBlockedFromConcierge || disabled}
-                            onModalHide={() => {
-                                if (composerRef === null || composerRef.current === null) {
-                                    return;
-                                }
-                                composerRef.current.focus(true);
-                            }}
-                            onEmojiSelected={(...args) => composerRef.current.replaceSelectionWithText(...args)}
+                            onModalHide={() => composerRef?.current?.focus(true)}
+                            onEmojiSelected={(...args) => composerRef?.current?.replaceSelectionWithText(...args)}
                             emojiPickerID={report.reportID}
                         />
                     )}

--- a/src/pages/home/report/ReportActionCompose/ReportActionCompose.js
+++ b/src/pages/home/report/ReportActionCompose/ReportActionCompose.js
@@ -407,7 +407,7 @@ function ReportActionCompose({
                                 if (composerRef === null || composerRef.current === null) {
                                     return;
                                 }
-                                composerRef.current.focus(true)
+                                composerRef.current.focus(true);
                             }}
                             onEmojiSelected={(...args) => composerRef.current.replaceSelectionWithText(...args)}
                             emojiPickerID={report.reportID}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Fixed a regression caused by https://github.com/Expensify/App/pull/25758.
cc: @mountiny @mountiny 
### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://expensify.slack.com/archives/C049HHMV9SM/p1692991483808169
PROPOSAL: https://expensify.slack.com/archives/C049HHMV9SM/p1692997508379109?thread_ts=1692991483.808169&cid=C049HHMV9SM


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Open a report A, then open report B
2. Click on the emoji picker from the composer
3. Click on the browser's back button
4. Verify that the app doesn't crash
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/29673073/6abe360b-5c7f-4da3-b5c4-c1888c8dd14d

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/29673073/1481d14a-9006-405d-a5b0-51f6a087112f



</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/29673073/f222f58f-ef9f-487a-9327-192efd6e9d7f

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/29673073/3c04e0e0-f2fc-4978-ad53-260fabd26de3


</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/29673073/899ffa15-a9b1-4e9f-887c-4b1c39d286a5


</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/29673073/6015762a-17e0-46bb-9573-3ef5e44dbf31


</details>
