### PR TITLE
Rewrite WalletStatementModal to functional component

### DIFF
--- a/src/components/WalletStatementModal/index.js
+++ b/src/components/WalletStatementModal/index.js
@@ -20,20 +20,20 @@ function WalletStatementModal({statementPageURL, session}) {
     /**
      * Handles in-app navigation for iframe links
      *
-     * @param {MessageEvent} e
+     * @param {MessageEvent} event
      */
-    const navigate = (e) => {
-        if (!e.data || !e.data.type || (e.data.type !== 'STATEMENT_NAVIGATE' && e.data.type !== 'CONCIERGE_NAVIGATE')) {
+    const navigate = (event) => {
+        if (!event.data || !event.data.type || (event.data.type !== 'STATEMENT_NAVIGATE' && event.data.type !== 'CONCIERGE_NAVIGATE')) {
             return;
         }
 
-        if (e.data.type === 'CONCIERGE_NAVIGATE') {
+        if (event.data.type === 'CONCIERGE_NAVIGATE') {
             Report.navigateToConciergeChat();
         }
 
-        if (e.data.type === 'STATEMENT_NAVIGATE' && e.data.url) {
+        if (event.data.type === 'STATEMENT_NAVIGATE' && event.data.url) {
             const iouRoutes = [ROUTES.IOU_REQUEST, ROUTES.IOU_SEND, ROUTES.IOU_BILL];
-            const navigateToIOURoute = _.find(iouRoutes, (iouRoute) => e.data.url.includes(iouRoute));
+            const navigateToIOURoute = _.find(iouRoutes, (iouRoute) => event.data.url.includes(iouRoute));
             if (navigateToIOURoute) {
                 Navigation.navigate(navigateToIOURoute);
             }

--- a/src/components/WalletStatementModal/index.js
+++ b/src/components/WalletStatementModal/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {withOnyx} from 'react-native-onyx';
 import lodashGet from 'lodash/get';
 import {View} from 'react-native';
@@ -13,21 +13,16 @@ import ROUTES from '../../ROUTES';
 import Navigation from '../../libs/Navigation/Navigation';
 import * as Report from '../../libs/actions/Report';
 
-class WalletStatementModal extends React.Component {
-    constructor(props) {
-        super(props);
-
-        this.state = {
-            isLoading: true,
-        };
-    }
+function WalletStatementModal({statementPageURL, session}) {
+    const [isLoading, setIsLoading] = useState(true);
+    const authToken = lodashGet(session, 'authToken', null);
 
     /**
      * Handles in-app navigation for iframe links
      *
      * @param {MessageEvent} e
      */
-    navigate(e) {
+    const navigate = (e) => {
         if (!e.data || !e.data.type || (e.data.type !== 'STATEMENT_NAVIGATE' && e.data.type !== 'CONCIERGE_NAVIGATE')) {
             return;
         }
@@ -45,31 +40,28 @@ class WalletStatementModal extends React.Component {
         }
     }
 
-    render() {
-        const authToken = lodashGet(this.props, 'session.authToken', null);
-        return (
-            <>
-                {this.state.isLoading && <FullScreenLoadingIndicator />}
-                <View style={[styles.flex1]}>
-                    <iframe
-                        src={`${this.props.statementPageURL}&authToken=${authToken}`}
-                        title="Statements"
-                        height="100%"
-                        width="100%"
-                        seamless="seamless"
-                        frameBorder="0"
-                        onLoad={() => {
-                            this.setState({isLoading: false});
+    return (
+        <>
+            {isLoading && <FullScreenLoadingIndicator />}
+            <View style={[styles.flex1]}>
+                <iframe
+                    src={`${statementPageURL}&authToken=${authToken}`}
+                    title="Statements"
+                    height="100%"
+                    width="100%"
+                    seamless="seamless"
+                    frameBorder="0"
+                    onLoad={() => {
+                        setIsLoading(false);
 
-                            // We listen to a message sent from the iframe to the parent component when a link is clicked.
-                            // This lets us handle navigation in the app, outside of the iframe.
-                            window.onmessage = (e) => this.navigate(e);
-                        }}
-                    />
-                </View>
-            </>
-        );
-    }
+                        // We listen to a message sent from the iframe to the parent component when a link is clicked.
+                        // This lets us handle navigation in the app, outside of the iframe.
+                        window.onmessage = (e) => navigate(e);
+                    }}
+                />
+            </View>
+        </>
+    );
 }
 
 WalletStatementModal.propTypes = walletStatementPropTypes;

--- a/src/components/WalletStatementModal/index.js
+++ b/src/components/WalletStatementModal/index.js
@@ -56,7 +56,7 @@ function WalletStatementModal({statementPageURL, session}) {
 
                         // We listen to a message sent from the iframe to the parent component when a link is clicked.
                         // This lets us handle navigation in the app, outside of the iframe.
-                        window.onmessage = (e) => navigate(e);
+                        window.onmessage = navigate;
                     }}
                 />
             </View>

--- a/src/components/WalletStatementModal/index.js
+++ b/src/components/WalletStatementModal/index.js
@@ -38,7 +38,7 @@ function WalletStatementModal({statementPageURL, session}) {
                 Navigation.navigate(navigateToIOURoute);
             }
         }
-    }
+    };
 
     return (
         <>


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/16216
PROPOSAL: https://github.com/Expensify/App/issues/16216#issuecomment-1695133842


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Go to http://localhost:8082/statements/202308
- [x] Verify that there is only one error in the console in local environment:
```
Refused to frame 'https://www.expensify.com/' because an ancestor violates the following Content Security Policy directive: "frame-ancestors https://we.are.expensify.com www.expensify.com chrome-extension://oiicpdkmeclmgmlmbajefnkalcfageek chrome-extension://eeibfofdhodcjojmbookcpigoaeilkek https://new.expensify.com".
```
- [x] Due to CSP policy, your browser will block you from seeing `www.expensify.com` iframe, as `localhost` is not whitelisted in the CSP headers coming from `www.expensify.com`. I disabled CSP protection in my chrome by downloading https://chrome.google.com/webstore/detail/always-disable-content-se/ffelghdomoehpceihalcnbmnodohkibj/related but still, even though the iframe is now loading, it's loading `https://www.expensify.com/statement.php?period=202201&authToken=<HIDDEN>` that loads no content at all (empty <head> and <body>) - this might be because I am navigating to this URL by directly going to `/statements/202308` but I have no card added to my wallet? I have no card added since I don't know how to do it/getting errors when adding a test mastercard card.

This is the header I'm getting from `www.expensify.com` that sets the allowed ancestors for iframe:
```
Content-Security-Policy:
frame-ancestors https://we.are.expensify.com www.expensify.com chrome-extension://oiicpdkmeclmgmlmbajefnkalcfageek chrome-extension://eeibfofdhodcjojmbookcpigoaeilkek https://new.expensify.com
```

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

You should see `You appear to be offline.This feature requires an active internet connection to be used.` instead of the iframe when you are offline.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

In Staging, the iframe should load without any problems.

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://github.com/Expensify/App/assets/85628901/82dd9089-9897-464f-98b5-9854681ea7f0

</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://github.com/Expensify/App/assets/85628901/5d553d53-9440-40a9-a350-ae2468a64cb8

</details>

<details>
<summary>Mobile Web - Safari</summary>

https://github.com/Expensify/App/assets/85628901/7c0ac949-8288-4218-915d-1745eb38e1aa

</details>

<details>
<summary>Desktop</summary>

https://github.com/Expensify/App/assets/85628901/62c49cb8-cfc9-42ed-b860-32774123be48

</details>

<details>
<summary>iOS</summary>

https://github.com/Expensify/App/assets/85628901/9edf8ea2-6129-4236-9d08-0625d7bdd842

</details>

<details>
<summary>Android</summary>

https://github.com/Expensify/App/assets/85628901/c6b5c827-9cd4-4884-8538-19989dcc5474

</details>
