### PR TITLE
feat(selection-list): add tooltip

### DIFF
--- a/src/components/SelectionList/BaseSelectionList.js
+++ b/src/components/SelectionList/BaseSelectionList.js
@@ -266,7 +266,6 @@ function BaseSelectionList({
                 isFocused={isFocused}
                 isDisabled={isDisabled}
                 onSelectRow={() => selectRow(item, index)}
-                showTooltip={showTooltip}
             />
         );
     };

--- a/src/components/SelectionList/BaseSelectionList.js
+++ b/src/components/SelectionList/BaseSelectionList.js
@@ -11,7 +11,7 @@ import CONST from '../../CONST';
 import variables from '../../styles/variables';
 import {propTypes as selectionListPropTypes} from './selectionListPropTypes';
 import RadioListItem from './RadioListItem';
-import CheckboxListItem from './CheckboxListItem';
+import UserListItem from './UserListItem';
 import useKeyboardShortcut from '../../hooks/useKeyboardShortcut';
 import SafeAreaConsumer from '../SafeAreaConsumer';
 import withKeyboardState, {keyboardStatePropTypes} from '../withKeyboardState';
@@ -250,7 +250,7 @@ function BaseSelectionList({
 
         if (canSelectMultiple) {
             return (
-                <CheckboxListItem
+                <UserListItem
                     item={item}
                     isFocused={isFocused}
                     onSelectRow={() => selectRow(item, index)}

--- a/src/components/SelectionList/BaseSelectionList.js
+++ b/src/components/SelectionList/BaseSelectionList.js
@@ -242,8 +242,11 @@ function BaseSelectionList({
     };
 
     const renderItem = ({item, index, section}) => {
+        const normalizedIndex = index + lodashGet(section, 'indexOffset', 0);
         const isDisabled = section.isDisabled;
-        const isFocused = !isDisabled && focusedIndex === index + lodashGet(section, 'indexOffset', 0);
+        const isFocused = !isDisabled && focusedIndex === normalizedIndex;
+        // We only create tooltips for the first 10 users or so since some reports have hundreds of users, causing performance to degrade.
+        const showTooltip = normalizedIndex < 10;
 
         if (canSelectMultiple) {
             return (
@@ -252,6 +255,7 @@ function BaseSelectionList({
                     isFocused={isFocused}
                     onSelectRow={() => selectRow(item, index)}
                     onDismissError={onDismissError}
+                    showTooltip={showTooltip}
                 />
             );
         }
@@ -262,6 +266,7 @@ function BaseSelectionList({
                 isFocused={isFocused}
                 isDisabled={isDisabled}
                 onSelectRow={() => selectRow(item, index)}
+                showTooltip={showTooltip}
             />
         );
     };

--- a/src/components/SelectionList/CheckboxListItem.js
+++ b/src/components/SelectionList/CheckboxListItem.js
@@ -13,9 +13,38 @@ import * as StyleUtils from '../../styles/StyleUtils';
 import Icon from '../Icon';
 import * as Expensicons from '../Icon/Expensicons';
 import themeColors from '../../styles/themes/default';
+import Tooltip from '../Tooltip';
+import UserDetailsTooltip from '../UserDetailsTooltip';
 
-function CheckboxListItem({item, isFocused = false, onSelectRow, onDismissError = () => {}}) {
+function CheckboxListItem({item, isFocused = false, showTooltip = false, onSelectRow, onDismissError = () => {}}) {
     const hasError = !_.isEmpty(item.errors);
+
+    const avatar = (
+        <Avatar
+            containerStyles={styles.pl5}
+            source={lodashGet(item, 'avatar.source', '')}
+            name={lodashGet(item, 'avatar.name', item.text)}
+            type={lodashGet(item, 'avatar.type', CONST.ICON_TYPE_AVATAR)}
+        />
+    );
+
+    const text = (
+        <Text
+            style={[styles.optionDisplayName, isFocused ? styles.sidebarLinkActiveText : styles.sidebarLinkText, styles.sidebarLinkTextBold]}
+            numberOfLines={1}
+        >
+            {item.text}
+        </Text>
+    );
+
+    const alternateText = (
+        <Text
+            style={[isFocused ? styles.sidebarLinkActiveText : styles.sidebarLinkText, styles.optionAlternateText, styles.textLabelSupporting]}
+            numberOfLines={1}
+        >
+            {item.alternateText}
+        </Text>
+    );
 
     return (
         <OfflineWithFeedback
@@ -53,29 +82,20 @@ function CheckboxListItem({item, isFocused = false, onSelectRow, onDismissError 
                         />
                     )}
                 </View>
-                {Boolean(item.avatar) && (
-                    <Avatar
-                        containerStyles={styles.pl5}
-                        source={lodashGet(item, 'avatar.source', '')}
-                        name={lodashGet(item, 'avatar.name', item.text)}
-                        type={lodashGet(item, 'avatar.type', CONST.ICON_TYPE_AVATAR)}
-                    />
-                )}
-                <View style={[styles.flex1, styles.flexColumn, styles.justifyContentCenter, styles.alignItemsStart, styles.pl3, styles.optionRow]}>
-                    <Text
-                        style={[styles.optionDisplayName, isFocused ? styles.sidebarLinkActiveText : styles.sidebarLinkText, styles.sidebarLinkTextBold]}
-                        numberOfLines={1}
-                    >
-                        {item.text}
-                    </Text>
-                    {Boolean(item.alternateText) && (
-                        <Text
-                            style={[isFocused ? styles.sidebarLinkActiveText : styles.sidebarLinkText, styles.optionAlternateText, styles.textLabelSupporting]}
-                            numberOfLines={1}
+                {Boolean(item.avatar) &&
+                    (showTooltip ? (
+                        <UserDetailsTooltip
+                            accountID={item.accountID}
+                            shiftHorizontal={styles.pl5.paddingLeft / 2}
                         >
-                            {item.alternateText}
-                        </Text>
-                    )}
+                            <View>{avatar}</View>
+                        </UserDetailsTooltip>
+                    ) : (
+                        avatar
+                    ))}
+                <View style={[styles.flex1, styles.flexColumn, styles.justifyContentCenter, styles.alignItemsStart, styles.pl3, styles.optionRow]}>
+                    {showTooltip ? <Tooltip text={item.text}>{text}</Tooltip> : text}
+                    {Boolean(item.alternateText) && (showTooltip ? <Tooltip text={item.alternateText}>{alternateText}</Tooltip> : alternateText)}
                 </View>
                 {Boolean(item.rightElement) && item.rightElement}
             </PressableWithFeedback>

--- a/src/components/SelectionList/UserListItem.js
+++ b/src/components/SelectionList/UserListItem.js
@@ -16,7 +16,7 @@ import themeColors from '../../styles/themes/default';
 import Tooltip from '../Tooltip';
 import UserDetailsTooltip from '../UserDetailsTooltip';
 
-function UserListItem({item, isFocused = false, showTooltip = false, onSelectRow, onDismissError = () => {}}) {
+function UserListItem({item, isFocused = false, showTooltip, onSelectRow, onDismissError = () => {}}) {
     const hasError = !_.isEmpty(item.errors);
 
     const avatar = (

--- a/src/components/SelectionList/UserListItem.js
+++ b/src/components/SelectionList/UserListItem.js
@@ -5,7 +5,7 @@ import lodashGet from 'lodash/get';
 import PressableWithFeedback from '../Pressable/PressableWithFeedback';
 import styles from '../../styles/styles';
 import Text from '../Text';
-import {checkboxListItemPropTypes} from './selectionListPropTypes';
+import {userListItemPropTypes} from './selectionListPropTypes';
 import Avatar from '../Avatar';
 import OfflineWithFeedback from '../OfflineWithFeedback';
 import CONST from '../../CONST';
@@ -16,7 +16,7 @@ import themeColors from '../../styles/themes/default';
 import Tooltip from '../Tooltip';
 import UserDetailsTooltip from '../UserDetailsTooltip';
 
-function CheckboxListItem({item, isFocused = false, showTooltip = false, onSelectRow, onDismissError = () => {}}) {
+function UserListItem({item, isFocused = false, showTooltip = false, onSelectRow, onDismissError = () => {}}) {
     const hasError = !_.isEmpty(item.errors);
 
     const avatar = (
@@ -103,7 +103,7 @@ function CheckboxListItem({item, isFocused = false, showTooltip = false, onSelec
     );
 }
 
-CheckboxListItem.displayName = 'CheckboxListItem';
-CheckboxListItem.propTypes = checkboxListItemPropTypes;
+UserListItem.displayName = 'UserListItem';
+UserListItem.propTypes = userListItemPropTypes;
 
-export default CheckboxListItem;
+export default UserListItem;

--- a/src/components/SelectionList/selectionListPropTypes.js
+++ b/src/components/SelectionList/selectionListPropTypes.js
@@ -46,6 +46,9 @@ const checkboxListItemPropTypes = {
     /** Whether this item is focused (for arrow key controls) */
     isFocused: PropTypes.bool,
 
+    /** Whether this item should show Tooltip */
+    showTooltip: PropTypes.bool,
+
     /** Callback to fire when the item is pressed */
     onSelectRow: PropTypes.func.isRequired,
 

--- a/src/components/SelectionList/selectionListPropTypes.js
+++ b/src/components/SelectionList/selectionListPropTypes.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import _ from 'underscore';
 import CONST from '../../CONST';
 
-const checkboxListItemPropTypes = {
+const userListItemPropTypes = {
     /** The section list item */
     item: PropTypes.shape({
         /** Text to display */
@@ -93,7 +93,7 @@ const propTypes = {
             indexOffset: PropTypes.number,
 
             /** Array of options */
-            data: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.shape(checkboxListItemPropTypes.item), PropTypes.shape(radioListItemPropTypes.item)])),
+            data: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.shape(userListItemPropTypes.item), PropTypes.shape(radioListItemPropTypes.item)])),
 
             /** Whether this section items disabled for selection */
             isDisabled: PropTypes.bool,
@@ -161,4 +161,4 @@ const propTypes = {
     showConfirmButton: PropTypes.bool,
 };
 
-export {propTypes, radioListItemPropTypes, checkboxListItemPropTypes};
+export {propTypes, radioListItemPropTypes, userListItemPropTypes};

--- a/src/components/SelectionList/selectionListPropTypes.js
+++ b/src/components/SelectionList/selectionListPropTypes.js
@@ -47,7 +47,7 @@ const userListItemPropTypes = {
     isFocused: PropTypes.bool,
 
     /** Whether this item should show Tooltip */
-    showTooltip: PropTypes.bool,
+    showTooltip: PropTypes.bool.isRequired,
 
     /** Callback to fire when the item is pressed */
     onSelectRow: PropTypes.func.isRequired,

--- a/src/pages/workspace/WorkspaceMembersPage.js
+++ b/src/pages/workspace/WorkspaceMembersPage.js
@@ -307,7 +307,7 @@ function WorkspaceMembersPage(props) {
 
             result.push({
                 keyForList: accountID,
-                accountID,
+                accountID: Number(accountID),
                 isSelected: _.contains(selectedEmployees, Number(accountID)),
                 isDisabled: accountID === props.session.accountID || details.login === props.policy.owner || policyMember.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE,
                 text: props.formatPhoneNumber(details.displayName),

--- a/src/pages/workspace/WorkspaceMembersPage.js
+++ b/src/pages/workspace/WorkspaceMembersPage.js
@@ -307,6 +307,7 @@ function WorkspaceMembersPage(props) {
 
             result.push({
                 keyForList: accountID,
+                accountID,
                 isSelected: _.contains(selectedEmployees, Number(accountID)),
                 isDisabled: accountID === props.session.accountID || details.login === props.policy.owner || policyMember.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE,
                 text: props.formatPhoneNumber(details.displayName),


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

Add Tooltip to list items on Workspace Members Page and Workspace Invite page

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/25895
PROPOSAL: 


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

In Workspace -> Members:
- [ ] For the first 10 items: hovering over the avatar, name or email should show a tooltip. The avatar tooltip contains all info (avatar, name and email). The other 2, only their respective info
- [ ] After the 10th item, hover is disabled

In Workspace -> Members -> Invite:
- [ ] For the first 10 items: hovering over the avatar, name or email should show a tooltip. The avatar tooltip contains all info (avatar, name and email). The other 2, only their respective info
- [ ] After the 10th item, hover is disabled

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

In Workspace -> Members:
- [ ] For the first 10 items: hovering over the avatar, name or email should show a tooltip. The avatar tooltip contains all info (avatar, name and email). The other 2, only their respective info
- [ ] After the 10th item, hover is disabled

In Workspace -> Members -> Invite:
- [ ] For the first 10 items: hovering over the avatar, name or email should show a tooltip. The avatar tooltip contains all info (avatar, name and email). The other 2, only their respective info
- [ ] After the 10th item, hover is disabled

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android / native
    - [X] Android / Chrome
    - [X] iOS / native
    - [X] iOS / Safari
    - [X] MacOS / Chrome / Safari
    - [X] MacOS / Desktop
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [X] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [X] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If a new component is created I verified that:
    - [X] A similar component doesn't exist in the codebase
    - [X] All props are defined accurately and each prop has a `/** comment above it */`
    - [X] The file is named correctly
    - [X] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [X] The only data being stored in the state is data necessary for rendering and nothing else
    - [X] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [X] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [X] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [X] All JSX used for rendering exists in the render method
    - [X] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [X] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [X] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

<video src="https://github.com/Expensify/App/assets/26878038/f0e1a98c-3b8d-4d08-b96c-3c4dabab019a" /> 

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

<video src="https://github.com/Expensify/App/assets/26878038/d54c370c-c929-4021-ac95-f0736b6313b1" />

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

<video src="https://github.com/Expensify/App/assets/26878038/b2d1b791-232a-4aaf-9b43-033d8190eba8" />

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

<video src="https://github.com/Expensify/App/assets/26878038/f45d7828-5e43-4b79-9555-88199a7c8356" />

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

<video src="https://github.com/Expensify/App/assets/26878038/f3c07673-f4bd-4fbf-b61b-848127af0865" />

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

<video src="https://github.com/Expensify/App/assets/26878038/7f0a104e-74e3-499e-ad27-2901ea0e50f7" />

</details>
