### PR TITLE
Add instructions for Distance and Scan expenses

### DIFF
--- a/docs/articles/request-money/Request-and-Split-Bills.md
+++ b/docs/articles/request-money/Request-and-Split-Bills.md
@@ -17,9 +17,9 @@ These two features ensure you can live in the moment and settle up afterward.
 # How to Request Money
 - Select the Green **+** button and choose **Request Money**
 - Select the relevant option: 
-    - **Manual:** Input the amount and description manually
-    - **Scan:** Take a photo of the receipt to have the merchant/amount autofilled, and input description manually
-    - **Distance:** Input the address of your start/end points for your trip to calculate mileage 
+    - **Manual:** Enter the merchant and amount manually.
+    - **Scan:** Take a photo of the receipt to have the merchant and amount auto-filled.
+    - **Distance:** Enter the details of your trip, plus any stops along the way, and the mileage and amount will be automatically calculated.
 - Search for the user or enter their email!
 - Enter a reason for the request (optional)
 - Click **Request!**

--- a/docs/articles/request-money/Request-and-Split-Bills.md
+++ b/docs/articles/request-money/Request-and-Split-Bills.md
@@ -16,7 +16,10 @@ These two features ensure you can live in the moment and settle up afterward.
 
 # How to Request Money
 - Select the Green **+** button and choose **Request Money**
-- Enter the amount **$** they owe and click **Next**
+- Select the relevant option: 
+    - **Manual:** Input the amount and description manually
+    - **Scan:** Take a photo of the receipt to have the merchant/amount autofilled, and input description manually
+    - **Distance:** Input the address of your start/end points for your trip to calculate mileage 
 - Search for the user or enter their email!
 - Enter a reason for the request (optional)
 - Click **Request!**


### PR DESCRIPTION
### Details
We need to add instructions for requesting distance expenses to the help site. 

### Fixed Issues

$ https://github.com/Expensify/Expensify/issues/286222

### QA Steps

- Open help.expensify.com
- Click "Request money"
- Click "Request and split bills"
- Ensure that the "How to request Money" instructions contain instructions for Distance expenses in the second step. 