### PR TITLE
Perf: improve camera activation tti

### DIFF
--- a/patches/@react-navigation+material-top-tabs+6.6.3.patch
+++ b/patches/@react-navigation+material-top-tabs+6.6.3.patch
@@ -1,0 +1,146 @@
+diff --git a/node_modules/@react-navigation/material-top-tabs/lib/module/index.js b/node_modules/@react-navigation/material-top-tabs/lib/module/index.js
+index b83d44f..9d158a0 100644
+--- a/node_modules/@react-navigation/material-top-tabs/lib/module/index.js
++++ b/node_modules/@react-navigation/material-top-tabs/lib/module/index.js
+@@ -9,6 +9,11 @@ export { default as createMaterialTopTabNavigator } from './navigators/createMat
+ export { default as MaterialTopTabBar } from './views/MaterialTopTabBar';
+ export { default as MaterialTopTabView } from './views/MaterialTopTabView';
+ 
++/**
++ * Utilities
++ */
++export { useTabAnimation } from './utils/useTabAnimation';
++
+ /**
+  * Types
+  */
+diff --git a/node_modules/@react-navigation/material-top-tabs/lib/module/utils/TabAnimationContext.js b/node_modules/@react-navigation/material-top-tabs/lib/module/utils/TabAnimationContext.js
+new file mode 100644
+index 0000000..4ef4e76
+--- /dev/null
++++ b/node_modules/@react-navigation/material-top-tabs/lib/module/utils/TabAnimationContext.js
+@@ -0,0 +1,3 @@
++import * as React from 'react';
++export const TabAnimationContext = /*#__PURE__*/React.createContext(undefined);
++//# sourceMappingURL=TabAnimationContext.js.map
+\ No newline at end of file
+diff --git a/node_modules/@react-navigation/material-top-tabs/lib/module/utils/useTabAnimation.js b/node_modules/@react-navigation/material-top-tabs/lib/module/utils/useTabAnimation.js
+new file mode 100644
+index 0000000..764ca9b
+--- /dev/null
++++ b/node_modules/@react-navigation/material-top-tabs/lib/module/utils/useTabAnimation.js
+@@ -0,0 +1,10 @@
++import * as React from 'react';
++import { TabAnimationContext } from './TabAnimationContext';
++export function useTabAnimation() {
++  const animation = React.useContext(TabAnimationContext);
++  if (animation === undefined) {
++    throw new Error("Couldn't find values for card animation. Are you inside a screen in Tab?");
++  }
++  return animation;
++}
++//# sourceMappingURL=useTabAnimation.js.map
+\ No newline at end of file
+diff --git a/node_modules/@react-navigation/material-top-tabs/lib/module/views/MaterialTopTabView.js b/node_modules/@react-navigation/material-top-tabs/lib/module/views/MaterialTopTabView.js
+index 7eda7c4..f736fd9 100644
+--- a/node_modules/@react-navigation/material-top-tabs/lib/module/views/MaterialTopTabView.js
++++ b/node_modules/@react-navigation/material-top-tabs/lib/module/views/MaterialTopTabView.js
+@@ -2,6 +2,7 @@ function _extends() { _extends = Object.assign ? Object.assign.bind() : function
+ import { CommonActions, useTheme } from '@react-navigation/native';
+ import * as React from 'react';
+ import { TabView } from 'react-native-tab-view';
++import { TabAnimationContext } from '../utils/TabAnimationContext';
+ import MaterialTopTabBar from './MaterialTopTabBar';
+ export default function MaterialTopTabView(_ref) {
+   let {
+@@ -34,9 +35,12 @@ export default function MaterialTopTabView(_ref) {
+     }),
+     renderScene: _ref2 => {
+       let {
+-        route
++        route,
++        position
+       } = _ref2;
+-      return descriptors[route.key].render();
++      return /*#__PURE__*/React.createElement(TabAnimationContext.Provider, {
++        value: position
++      }, descriptors[route.key].render());
+     },
+     navigationState: state,
+     renderTabBar: renderTabBar,
+diff --git a/node_modules/@react-navigation/material-top-tabs/src/index.tsx b/node_modules/@react-navigation/material-top-tabs/src/index.tsx
+index ae02811..b735f30 100644
+--- a/node_modules/@react-navigation/material-top-tabs/src/index.tsx
++++ b/node_modules/@react-navigation/material-top-tabs/src/index.tsx
+@@ -9,6 +9,11 @@ export { default as createMaterialTopTabNavigator } from './navigators/createMat
+ export { default as MaterialTopTabBar } from './views/MaterialTopTabBar';
+ export { default as MaterialTopTabView } from './views/MaterialTopTabView';
+ 
++/**
++ * Utilities
++ */
++export { useTabAnimation } from './utils/useTabAnimation';
++
+ /**
+  * Types
+  */
+diff --git a/node_modules/@react-navigation/material-top-tabs/src/utils/TabAnimationContext.ts b/node_modules/@react-navigation/material-top-tabs/src/utils/TabAnimationContext.ts
+new file mode 100644
+index 0000000..92a97ec
+--- /dev/null
++++ b/node_modules/@react-navigation/material-top-tabs/src/utils/TabAnimationContext.ts
+@@ -0,0 +1,6 @@
++import * as React from 'react';
++import type { Animated } from 'react-native';
++
++export const TabAnimationContext = React.createContext<
++  Animated.AnimatedInterpolation<number> | undefined
++>(undefined);
+\ No newline at end of file
+diff --git a/node_modules/@react-navigation/material-top-tabs/src/utils/useTabAnimation.ts b/node_modules/@react-navigation/material-top-tabs/src/utils/useTabAnimation.ts
+new file mode 100644
+index 0000000..6c122a7
+--- /dev/null
++++ b/node_modules/@react-navigation/material-top-tabs/src/utils/useTabAnimation.ts
+@@ -0,0 +1,15 @@
++import * as React from 'react';
++
++import { TabAnimationContext } from './TabAnimationContext';
++
++export function useTabAnimation() {
++  const animation = React.useContext(TabAnimationContext);
++
++  if (animation === undefined) {
++    throw new Error(
++      "Couldn't find values for card animation. Are you inside a screen in Tab?"
++    );
++  }
++
++  return animation;
++}
+\ No newline at end of file
+diff --git a/node_modules/@react-navigation/material-top-tabs/src/views/MaterialTopTabView.tsx b/node_modules/@react-navigation/material-top-tabs/src/views/MaterialTopTabView.tsx
+index 1282698..9b0af5d 100644
+--- a/node_modules/@react-navigation/material-top-tabs/src/views/MaterialTopTabView.tsx
++++ b/node_modules/@react-navigation/material-top-tabs/src/views/MaterialTopTabView.tsx
+@@ -14,6 +14,7 @@ import type {
+   MaterialTopTabNavigationConfig,
+   MaterialTopTabNavigationHelpers,
+ } from '../types';
++import { TabAnimationContext } from '../utils/TabAnimationContext';
+ import MaterialTopTabBar from './MaterialTopTabBar';
+ 
+ type Props = MaterialTopTabNavigationConfig & {
+@@ -55,7 +56,11 @@ export default function MaterialTopTabView({
+           target: state.key,
+         })
+       }
+-      renderScene={({ route }) => descriptors[route.key].render()}
++      renderScene={({ route, position }) => (
++        <TabAnimationContext.Provider value={position}>
++          {descriptors[route.key].render()}
++        </TabAnimationContext.Provider>
++      )}
+       navigationState={state}
+       renderTabBar={renderTabBar}
+       renderLazyPlaceholder={({ route }) =>

--- a/src/libs/Permissions.js
+++ b/src/libs/Permissions.js
@@ -7,7 +7,8 @@ import CONST from '../CONST';
  * @returns {Boolean}
  */
 function canUseAllBetas(betas) {
-    return _.contains(betas, CONST.BETAS.ALL);
+    return true;
+    // return _.contains(betas, CONST.BETAS.ALL);
 }
 
 /**

--- a/src/libs/Permissions.js
+++ b/src/libs/Permissions.js
@@ -7,8 +7,7 @@ import CONST from '../CONST';
  * @returns {Boolean}
  */
 function canUseAllBetas(betas) {
-    return true;
-    // return _.contains(betas, CONST.BETAS.ALL);
+    return _.contains(betas, CONST.BETAS.ALL);
 }
 
 /**

--- a/src/pages/iou/MoneyRequestSelectorPage.js
+++ b/src/pages/iou/MoneyRequestSelectorPage.js
@@ -93,7 +93,7 @@ function MoneyRequestSelectorPage(props) {
                                         <TopTab.Screen
                                             name={CONST.TAB.SCAN}
                                             component={ReceiptSelector}
-                                            initialParams={{reportID, iouType}}
+                                            initialParams={{reportID, iouType, pageIndex: 1}}
                                         />
                                     )}
                                     {canUseDistanceRequests && (

--- a/src/pages/iou/ReceiptSelector/NavigationAwareCamera.js
+++ b/src/pages/iou/ReceiptSelector/NavigationAwareCamera.js
@@ -2,37 +2,42 @@ import React, {useEffect, useState} from 'react';
 import {Camera} from 'react-native-vision-camera';
 import {useTabAnimation} from '@react-navigation/material-top-tabs';
 import {useNavigation} from '@react-navigation/native';
+import PropTypes from 'prop-types';
 import refPropTypes from '../../../components/refPropTypes';
 
 const propTypes = {
+    /* The index of the tab that contains this camera */
+    cameraTabIndex: PropTypes.number.isRequired,
+
     /* Forwarded ref */
     forwardedRef: refPropTypes.isRequired,
 };
 
 // Wraps a camera that will only be active when the tab is focused or as soon as it starts to become focused.
-function NavigationAwareCamera(props) {
+function NavigationAwareCamera({cameraTabIndex, forwardedRef, ...props}) {
     // Get navigation to get initial isFocused value (only needed once during init!)
     const navigation = useNavigation();
     const [isCameraActive, setIsCameraActive] = useState(navigation.isFocused);
 
     // Get the animation value from the tab navigator. Its a value between 0 and the
-    // number of pages we render in the tab navigator. When we even just slightly start
-    // to scroll to the camera page, we want to activate the camera (so its as fast as possible active).
+    // number of pages we render in the tab navigator. When we even just slightly start to scroll to the camera page,
+    // (value is e.g. 0.001 on animation start) we want to activate the camera, so its as fast as possible active.
     const tabPositionAnimation = useTabAnimation();
 
     useEffect(() => {
         const listenerId = tabPositionAnimation.addListener(({value}) => {
-            setIsCameraActive(value > 0 && value < 2);
+            // Activate camera as soon the index is animating towards the `cameraTabIndex`
+            setIsCameraActive(value > cameraTabIndex - 1 && value < cameraTabIndex + 1);
         });
 
         return () => {
             tabPositionAnimation.removeListener(listenerId);
         };
-    }, [tabPositionAnimation]);
+    }, [cameraTabIndex, tabPositionAnimation]);
 
     return (
         <Camera
-            ref={props.forwardedRef}
+            ref={forwardedRef}
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...props}
             isActive={isCameraActive}

--- a/src/pages/iou/ReceiptSelector/NavigationAwareCamera.js
+++ b/src/pages/iou/ReceiptSelector/NavigationAwareCamera.js
@@ -9,7 +9,7 @@ const propTypes = {
     forwardedRef: refPropTypes.isRequired,
 };
 
-// Wraps a camera that will only be active when the tab is focused or as asoon as it start to become focused.
+// Wraps a camera that will only be active when the tab is focused or as soon as it starts to become focused.
 function NavigationAwareCamera(props) {
     // Get navigation to get initial isFocused value (only needed once during init!)
     const navigation = useNavigation();

--- a/src/pages/iou/ReceiptSelector/NavigationAwareCamera.js
+++ b/src/pages/iou/ReceiptSelector/NavigationAwareCamera.js
@@ -14,6 +14,7 @@ function NavigationAwareCamera(props) {
     // Get navigation to get initial isFocused value (only needed once during init!)
     const navigation = useNavigation();
     const [isCameraActive, setIsCameraActive] = useState(navigation.isFocused);
+
     // Get the animation value from the tab navigator. Its a value between 0 and the
     // number of pages we render in the tab navigator. When we even just slightly start
     // to scroll to the camera page, we want to activate the camera (so its as fast as possible active).

--- a/src/pages/iou/ReceiptSelector/NavigationAwareCamera.js
+++ b/src/pages/iou/ReceiptSelector/NavigationAwareCamera.js
@@ -1,0 +1,51 @@
+import React, {useEffect, useState} from 'react';
+import {Camera} from 'react-native-vision-camera';
+import {useTabAnimation} from '@react-navigation/material-top-tabs';
+import {useNavigation} from '@react-navigation/native';
+import refPropTypes from '../../../components/refPropTypes';
+
+const propTypes = {
+    /* Forwarded ref */
+    forwardedRef: refPropTypes.isRequired,
+};
+
+// Wraps a camera that will only be active when the tab is focused or as asoon as it start to become focused.
+function NavigationAwareCamera(props) {
+    // Get navigation to get initial isFocused value (only needed once during init!)
+    const navigation = useNavigation();
+    const [isCameraActive, setIsCameraActive] = useState(navigation.isFocused);
+    // Get the animation value from the tab navigator. Its a value between 0 and the
+    // number of pages we render in the tab navigator. When we even just slightly start
+    // to scroll to the camera page, we want to activate the camera (so its as fast as possible active).
+    const tabPositionAnimation = useTabAnimation();
+
+    useEffect(() => {
+        const listenerId = tabPositionAnimation.addListener(({value}) => {
+            setIsCameraActive(value > 0 && value < 2);
+        });
+
+        return () => {
+            tabPositionAnimation.removeListener(listenerId);
+        };
+    }, [tabPositionAnimation]);
+
+    return (
+        <Camera
+            ref={props.forwardedRef}
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            {...props}
+            isActive={isCameraActive}
+        />
+    );
+}
+
+NavigationAwareCamera.propTypes = propTypes;
+NavigationAwareCamera.displayName = 'NavigationAwareCamera';
+
+export default React.forwardRef((props, ref) => (
+    <NavigationAwareCamera
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...props}
+        forwardedRef={ref}
+    />
+));

--- a/src/pages/iou/ReceiptSelector/index.native.js
+++ b/src/pages/iou/ReceiptSelector/index.native.js
@@ -5,7 +5,6 @@ import lodashGet from 'lodash/get';
 import PropTypes from 'prop-types';
 import {launchImageLibrary} from 'react-native-image-picker';
 import {withOnyx} from 'react-native-onyx';
-import {useIsFocused} from '@react-navigation/native';
 import PressableWithFeedback from '../../../components/Pressable/PressableWithFeedback';
 import Icon from '../../../components/Icon';
 import * as Expensicons from '../../../components/Icon/Expensicons';
@@ -21,6 +20,7 @@ import useLocalize from '../../../hooks/useLocalize';
 import ONYXKEYS from '../../../ONYXKEYS';
 import Log from '../../../libs/Log';
 import {iouPropTypes, iouDefaultProps} from '../propTypes';
+import NavigationAwareCamera from './NavigationAwareCamera';
 
 const propTypes = {
     /** React Navigation route */
@@ -73,7 +73,7 @@ function getImagePickerOptions(type) {
 }
 
 function ReceiptSelector(props) {
-    const devices = useCameraDevices();
+    const devices = useCameraDevices('wide-angle-camera');
     const device = devices.back;
 
     const camera = useRef(null);
@@ -85,8 +85,6 @@ function ReceiptSelector(props) {
     const reportID = lodashGet(props.route, 'params.reportID', '');
 
     const {translate} = useLocalize();
-    // Keep track of whether the camera is visible, when we navigate elsewhere, turn off the camera
-    const isFocused = useIsFocused();
 
     // We want to listen to if the app has come back from background and refresh the permissions status to show camera when permissions were granted
     useEffect(() => {
@@ -193,8 +191,9 @@ function ReceiptSelector(props) {
                 IOU.setMoneyRequestReceipt(`file://${photo.path}`, photo.path);
                 IOU.navigateToNextPage(props.iou, iouType, reportID, props.report);
             })
-            .catch(() => {
+            .catch((error) => {
                 showCameraAlert();
+                Log.warn('Error taking photo', error);
             });
     }, [flash, iouType, props.iou, props.report, reportID, translate]);
 
@@ -237,12 +236,11 @@ function ReceiptSelector(props) {
                 </View>
             )}
             {permissions === CONST.RECEIPT.PERMISSION_AUTHORIZED && device != null && (
-                <Camera
+                <NavigationAwareCamera
                     ref={camera}
                     device={device}
                     style={[styles.cameraView]}
                     zoom={device.neutralZoom}
-                    isActive={isFocused}
                     photo
                 />
             )}

--- a/src/pages/iou/ReceiptSelector/index.native.js
+++ b/src/pages/iou/ReceiptSelector/index.native.js
@@ -83,6 +83,7 @@ function ReceiptSelector(props) {
 
     const iouType = lodashGet(props.route, 'params.iouType', '');
     const reportID = lodashGet(props.route, 'params.reportID', '');
+    const pageIndex = lodashGet(props.route, 'params.pageIndex', 1);
 
     const {translate} = useLocalize();
 
@@ -242,6 +243,7 @@ function ReceiptSelector(props) {
                     style={[styles.cameraView]}
                     zoom={device.neutralZoom}
                     photo
+                    cameraTabIndex={pageIndex}
                 />
             )}
             <View style={[styles.flexRow, styles.justifyContentAround, styles.alignItemsCenter, styles.pv3]}>


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

This PR includes two fixes to speed up the time until the camera activates:

- We use a `wide-angle-camera` device, which will be initialised quicker than the device picked by default by vision camera
- Before the camera would only be set to active as soon as the camera screen (its rendered inside a tab screen navigator) has become fully visible. Now it will activate the camera as soon as we swipe / navigate to the camera

For the last point to be possible we need to hook into the tab bar animation value, which is implemented in this PR. We apply a patch currently until its merged:

- https://github.com/react-navigation/react-navigation/pull/11568

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/26110
PROPOSAL: https://github.com/Expensify/App/issues/26110#issuecomment-1697452399


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- Open the request money flow on a physical iOS device (with all betas enabled)
- Swap between the camera tab and the others
- Notice how the camera activates quicker

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

n/a

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- Same as testing

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->
n/a native mobile only change
</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

n/a native mobile only change

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->
n/a native mobile only change

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->
n/a native mobile only change
</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->


https://github.com/Expensify/App/assets/16821682/cdc615ee-7713-473a-801c-9edd474fc705



</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

(Note: This is on a very weak android device) 

https://github.com/Expensify/App/assets/16821682/f4934e24-6d26-4620-97f2-be6cd47e08aa

:


</details>
