### PR TITLE
Show header in profile pages when personal details are loading

### DIFF
--- a/src/pages/settings/Profile/PersonalDetails/AddressPage.js
+++ b/src/pages/settings/Profile/PersonalDetails/AddressPage.js
@@ -72,6 +72,7 @@ function AddressPage({privatePersonalDetails, country}) {
     const zipFormat = translate('common.zipCodeExampleFormat', {zipSampleFormat});
 
     const address = lodashGet(privatePersonalDetails, 'address') || {};
+    const isLoadingPersonalDetails = lodashGet(privatePersonalDetails, 'isLoading', true);
     const [street1, street2] = (address.street || '').split('\n');
     const [state, setState] = useState(address.state);
     /**
@@ -131,10 +132,6 @@ function AddressPage({privatePersonalDetails, country}) {
         setState(value);
     };
 
-    if (lodashGet(privatePersonalDetails, 'isLoading', true)) {
-        return <FullscreenLoadingIndicator />;
-    }
-
     return (
         <ScreenWrapper includeSafeAreaPaddingBottom={false}>
             <HeaderWithBackButton
@@ -142,92 +139,96 @@ function AddressPage({privatePersonalDetails, country}) {
                 shouldShowBackButton
                 onBackButtonPress={() => Navigation.goBack(ROUTES.SETTINGS_PERSONAL_DETAILS)}
             />
-            <Form
-                style={[styles.flexGrow1, styles.mh5]}
-                formID={ONYXKEYS.FORMS.HOME_ADDRESS_FORM}
-                validate={validate}
-                onSubmit={updateAddress}
-                submitButtonText={translate('common.save')}
-                enabledWhenOffline
-            >
-                <View>
-                    <AddressSearch
-                        inputID="addressLine1"
-                        label={translate('common.addressLine', {lineNumber: 1})}
-                        defaultValue={street1 || ''}
-                        onValueChange={handleAddressChange}
-                        renamedInputKeys={{
-                            street: 'addressLine1',
-                            street2: 'addressLine2',
-                            city: 'city',
-                            state: 'state',
-                            zipCode: 'zipPostCode',
-                            country: 'country',
-                        }}
-                        maxInputLength={CONST.FORM_CHARACTER_LIMIT}
+            {isLoadingPersonalDetails ? (
+                <FullscreenLoadingIndicator style={[styles.flex1, styles.pRelative]} />
+            ) : (
+                <Form
+                    style={[styles.flexGrow1, styles.mh5]}
+                    formID={ONYXKEYS.FORMS.HOME_ADDRESS_FORM}
+                    validate={validate}
+                    onSubmit={updateAddress}
+                    submitButtonText={translate('common.save')}
+                    enabledWhenOffline
+                >
+                    <View>
+                        <AddressSearch
+                            inputID="addressLine1"
+                            label={translate('common.addressLine', {lineNumber: 1})}
+                            defaultValue={street1 || ''}
+                            onValueChange={handleAddressChange}
+                            renamedInputKeys={{
+                                street: 'addressLine1',
+                                street2: 'addressLine2',
+                                city: 'city',
+                                state: 'state',
+                                zipCode: 'zipPostCode',
+                                country: 'country',
+                            }}
+                            maxInputLength={CONST.FORM_CHARACTER_LIMIT}
+                        />
+                    </View>
+                    <View style={styles.formSpaceVertical} />
+                    <TextInput
+                        inputID="addressLine2"
+                        label={translate('common.addressLine', {lineNumber: 2})}
+                        accessibilityLabel={translate('common.addressLine')}
+                        accessibilityRole={CONST.ACCESSIBILITY_ROLE.TEXT}
+                        defaultValue={street2 || ''}
+                        maxLength={CONST.FORM_CHARACTER_LIMIT}
+                        spellCheck={false}
                     />
-                </View>
-                <View style={styles.formSpaceVertical} />
-                <TextInput
-                    inputID="addressLine2"
-                    label={translate('common.addressLine', {lineNumber: 2})}
-                    accessibilityLabel={translate('common.addressLine')}
-                    accessibilityRole={CONST.ACCESSIBILITY_ROLE.TEXT}
-                    defaultValue={street2 || ''}
-                    maxLength={CONST.FORM_CHARACTER_LIMIT}
-                    spellCheck={false}
-                />
-                <View style={styles.formSpaceVertical} />
-                <View style={styles.mhn5}>
-                    <CountryPicker
-                        inputID="country"
-                        defaultValue={currentCountry}
-                        onValueChange={handleAddressChange}
-                    />
-                </View>
-                <View style={styles.formSpaceVertical} />
-                {isUSAForm ? (
+                    <View style={styles.formSpaceVertical} />
                     <View style={styles.mhn5}>
-                        <StatePicker
-                            inputID="state"
-                            defaultValue={state}
+                        <CountryPicker
+                            inputID="country"
+                            defaultValue={currentCountry}
                             onValueChange={handleAddressChange}
                         />
                     </View>
-                ) : (
+                    <View style={styles.formSpaceVertical} />
+                    {isUSAForm ? (
+                        <View style={styles.mhn5}>
+                            <StatePicker
+                                inputID="state"
+                                defaultValue={state}
+                                onValueChange={handleAddressChange}
+                            />
+                        </View>
+                    ) : (
+                        <TextInput
+                            inputID="state"
+                            label={translate('common.stateOrProvince')}
+                            accessibilityLabel={translate('common.stateOrProvince')}
+                            accessibilityRole={CONST.ACCESSIBILITY_ROLE.TEXT}
+                            value={state || ''}
+                            maxLength={CONST.FORM_CHARACTER_LIMIT}
+                            spellCheck={false}
+                            onValueChange={handleAddressChange}
+                        />
+                    )}
+                    <View style={styles.formSpaceVertical} />
                     <TextInput
-                        inputID="state"
-                        label={translate('common.stateOrProvince')}
-                        accessibilityLabel={translate('common.stateOrProvince')}
+                        inputID="city"
+                        label={translate('common.city')}
+                        accessibilityLabel={translate('common.city')}
                         accessibilityRole={CONST.ACCESSIBILITY_ROLE.TEXT}
-                        value={state || ''}
+                        defaultValue={address.city || ''}
                         maxLength={CONST.FORM_CHARACTER_LIMIT}
                         spellCheck={false}
-                        onValueChange={handleAddressChange}
                     />
-                )}
-                <View style={styles.formSpaceVertical} />
-                <TextInput
-                    inputID="city"
-                    label={translate('common.city')}
-                    accessibilityLabel={translate('common.city')}
-                    accessibilityRole={CONST.ACCESSIBILITY_ROLE.TEXT}
-                    defaultValue={address.city || ''}
-                    maxLength={CONST.FORM_CHARACTER_LIMIT}
-                    spellCheck={false}
-                />
-                <View style={styles.formSpaceVertical} />
-                <TextInput
-                    inputID="zipPostCode"
-                    label={translate('common.zipPostCode')}
-                    accessibilityLabel={translate('common.zipPostCode')}
-                    accessibilityRole={CONST.ACCESSIBILITY_ROLE.TEXT}
-                    autoCapitalize="characters"
-                    defaultValue={address.zip || ''}
-                    maxLength={CONST.BANK_ACCOUNT.MAX_LENGTH.ZIP_CODE}
-                    hint={zipFormat}
-                />
-            </Form>
+                    <View style={styles.formSpaceVertical} />
+                    <TextInput
+                        inputID="zipPostCode"
+                        label={translate('common.zipPostCode')}
+                        accessibilityLabel={translate('common.zipPostCode')}
+                        accessibilityRole={CONST.ACCESSIBILITY_ROLE.TEXT}
+                        autoCapitalize="characters"
+                        defaultValue={address.zip || ''}
+                        maxLength={CONST.BANK_ACCOUNT.MAX_LENGTH.ZIP_CODE}
+                        hint={zipFormat}
+                    />
+                </Form>
+            )}
         </ScreenWrapper>
     );
 }

--- a/src/pages/settings/Profile/PersonalDetails/DateOfBirthPage.js
+++ b/src/pages/settings/Profile/PersonalDetails/DateOfBirthPage.js
@@ -38,6 +38,7 @@ const defaultProps = {
 
 function DateOfBirthPage({translate, privatePersonalDetails}) {
     usePrivatePersonalDetails();
+    const isLoadingPersonalDetails = lodashGet(privatePersonalDetails, 'isLoading', true);
 
     /**
      * @param {Object} values
@@ -59,32 +60,32 @@ function DateOfBirthPage({translate, privatePersonalDetails}) {
         return errors;
     }, []);
 
-    if (lodashGet(privatePersonalDetails, 'isLoading', true)) {
-        return <FullscreenLoadingIndicator />;
-    }
-
     return (
         <ScreenWrapper includeSafeAreaPaddingBottom={false}>
             <HeaderWithBackButton
                 title={translate('common.dob')}
                 onBackButtonPress={() => Navigation.goBack(ROUTES.SETTINGS_PERSONAL_DETAILS)}
             />
-            <Form
-                style={[styles.flexGrow1, styles.ph5]}
-                formID={ONYXKEYS.FORMS.DATE_OF_BIRTH_FORM}
-                validate={validate}
-                onSubmit={PersonalDetails.updateDateOfBirth}
-                submitButtonText={translate('common.save')}
-                enabledWhenOffline
-            >
-                <NewDatePicker
-                    inputID="dob"
-                    label={translate('common.date')}
-                    defaultValue={privatePersonalDetails.dob || ''}
-                    minDate={moment().subtract(CONST.DATE_BIRTH.MAX_AGE, 'years').toDate()}
-                    maxDate={moment().subtract(CONST.DATE_BIRTH.MIN_AGE, 'years').toDate()}
-                />
-            </Form>
+            {isLoadingPersonalDetails ? (
+                <FullscreenLoadingIndicator style={[styles.flex1, styles.pRelative]} />
+            ) : (
+                <Form
+                    style={[styles.flexGrow1, styles.ph5]}
+                    formID={ONYXKEYS.FORMS.DATE_OF_BIRTH_FORM}
+                    validate={validate}
+                    onSubmit={PersonalDetails.updateDateOfBirth}
+                    submitButtonText={translate('common.save')}
+                    enabledWhenOffline
+                >
+                    <NewDatePicker
+                        inputID="dob"
+                        label={translate('common.date')}
+                        defaultValue={privatePersonalDetails.dob || ''}
+                        minDate={moment().subtract(CONST.DATE_BIRTH.MAX_AGE, 'years').toDate()}
+                        maxDate={moment().subtract(CONST.DATE_BIRTH.MIN_AGE, 'years').toDate()}
+                    />
+                </Form>
+            )}
         </ScreenWrapper>
     );
 }

--- a/src/pages/settings/Profile/PersonalDetails/LegalNamePage.js
+++ b/src/pages/settings/Profile/PersonalDetails/LegalNamePage.js
@@ -47,6 +47,7 @@ function LegalNamePage(props) {
     usePrivatePersonalDetails();
     const legalFirstName = lodashGet(props.privatePersonalDetails, 'legalFirstName', '');
     const legalLastName = lodashGet(props.privatePersonalDetails, 'legalLastName', '');
+    const isLoadingPersonalDetails = lodashGet(props.privatePersonalDetails, 'isLoading', true);
 
     const validate = useCallback((values) => {
         const errors = {};
@@ -66,10 +67,6 @@ function LegalNamePage(props) {
         return errors;
     }, []);
 
-    if (lodashGet(props.privatePersonalDetails, 'isLoading', true)) {
-        return <FullscreenLoadingIndicator />;
-    }
-
     return (
         <ScreenWrapper
             includeSafeAreaPaddingBottom={false}
@@ -79,39 +76,43 @@ function LegalNamePage(props) {
                 title={props.translate('privatePersonalDetails.legalName')}
                 onBackButtonPress={() => Navigation.goBack(ROUTES.SETTINGS_PERSONAL_DETAILS)}
             />
-            <Form
-                style={[styles.flexGrow1, styles.ph5]}
-                formID={ONYXKEYS.FORMS.LEGAL_NAME_FORM}
-                validate={validate}
-                onSubmit={updateLegalName}
-                submitButtonText={props.translate('common.save')}
-                enabledWhenOffline
-            >
-                <View style={[styles.mb4]}>
-                    <TextInput
-                        inputID="legalFirstName"
-                        name="lfname"
-                        label={props.translate('privatePersonalDetails.legalFirstName')}
-                        accessibilityLabel={props.translate('privatePersonalDetails.legalFirstName')}
-                        accessibilityRole={CONST.ACCESSIBILITY_ROLE.TEXT}
-                        defaultValue={legalFirstName}
-                        maxLength={CONST.DISPLAY_NAME.MAX_LENGTH}
-                        spellCheck={false}
-                    />
-                </View>
-                <View>
-                    <TextInput
-                        inputID="legalLastName"
-                        name="llname"
-                        label={props.translate('privatePersonalDetails.legalLastName')}
-                        accessibilityLabel={props.translate('privatePersonalDetails.legalLastName')}
-                        accessibilityRole={CONST.ACCESSIBILITY_ROLE.TEXT}
-                        defaultValue={legalLastName}
-                        maxLength={CONST.DISPLAY_NAME.MAX_LENGTH}
-                        spellCheck={false}
-                    />
-                </View>
-            </Form>
+            {isLoadingPersonalDetails ? (
+                <FullscreenLoadingIndicator style={[styles.flex1, styles.pRelative]} />
+            ) : (
+                <Form
+                    style={[styles.flexGrow1, styles.ph5]}
+                    formID={ONYXKEYS.FORMS.LEGAL_NAME_FORM}
+                    validate={validate}
+                    onSubmit={updateLegalName}
+                    submitButtonText={props.translate('common.save')}
+                    enabledWhenOffline
+                >
+                    <View style={[styles.mb4]}>
+                        <TextInput
+                            inputID="legalFirstName"
+                            name="lfname"
+                            label={props.translate('privatePersonalDetails.legalFirstName')}
+                            accessibilityLabel={props.translate('privatePersonalDetails.legalFirstName')}
+                            accessibilityRole={CONST.ACCESSIBILITY_ROLE.TEXT}
+                            defaultValue={legalFirstName}
+                            maxLength={CONST.DISPLAY_NAME.MAX_LENGTH}
+                            spellCheck={false}
+                        />
+                    </View>
+                    <View>
+                        <TextInput
+                            inputID="legalLastName"
+                            name="llname"
+                            label={props.translate('privatePersonalDetails.legalLastName')}
+                            accessibilityLabel={props.translate('privatePersonalDetails.legalLastName')}
+                            accessibilityRole={CONST.ACCESSIBILITY_ROLE.TEXT}
+                            defaultValue={legalLastName}
+                            maxLength={CONST.DISPLAY_NAME.MAX_LENGTH}
+                            spellCheck={false}
+                        />
+                    </View>
+                </Form>
+            )}
         </ScreenWrapper>
     );
 }

--- a/src/pages/settings/Profile/PersonalDetails/PersonalDetailsInitialPage.js
+++ b/src/pages/settings/Profile/PersonalDetails/PersonalDetailsInitialPage.js
@@ -60,6 +60,7 @@ function PersonalDetailsInitialPage(props) {
     const privateDetails = props.privatePersonalDetails || {};
     const address = privateDetails.address || {};
     const legalName = `${privateDetails.legalFirstName || ''} ${privateDetails.legalLastName || ''}`.trim();
+    const isLoadingPersonalDetails = lodashGet(props.privatePersonalDetails, 'isLoading', true);
 
     /**
      * Applies common formatting to each piece of an address
@@ -83,42 +84,42 @@ function PersonalDetailsInitialPage(props) {
         return formattedAddress.trim().replace(/,$/, '');
     };
 
-    if (lodashGet(props.privatePersonalDetails, 'isLoading', true)) {
-        return <FullscreenLoadingIndicator />;
-    }
-
     return (
         <ScreenWrapper>
             <HeaderWithBackButton
                 title={props.translate('privatePersonalDetails.personalDetails')}
                 onBackButtonPress={() => Navigation.goBack(ROUTES.SETTINGS_PROFILE)}
             />
-            <ScrollView>
-                <View style={styles.flex1}>
-                    <View style={[styles.ph5, styles.mb5]}>
-                        <Text>{props.translate('privatePersonalDetails.privateDataMessage')}</Text>
+            {isLoadingPersonalDetails ? (
+                <FullscreenLoadingIndicator style={[styles.flex1, styles.pRelative]} />
+            ) : (
+                <ScrollView>
+                    <View style={styles.flex1}>
+                        <View style={[styles.ph5, styles.mb5]}>
+                            <Text>{props.translate('privatePersonalDetails.privateDataMessage')}</Text>
+                        </View>
+                        <MenuItemWithTopDescription
+                            title={legalName}
+                            description={props.translate('privatePersonalDetails.legalName')}
+                            shouldShowRightIcon
+                            onPress={() => Navigation.navigate(ROUTES.SETTINGS_PERSONAL_DETAILS_LEGAL_NAME)}
+                        />
+                        <MenuItemWithTopDescription
+                            title={privateDetails.dob || ''}
+                            description={props.translate('common.dob')}
+                            shouldShowRightIcon
+                            onPress={() => Navigation.navigate(ROUTES.SETTINGS_PERSONAL_DETAILS_DATE_OF_BIRTH)}
+                            titleStyle={[styles.flex1]}
+                        />
+                        <MenuItemWithTopDescription
+                            title={getFormattedAddress()}
+                            description={props.translate('privatePersonalDetails.homeAddress')}
+                            shouldShowRightIcon
+                            onPress={() => Navigation.navigate(ROUTES.SETTINGS_PERSONAL_DETAILS_ADDRESS)}
+                        />
                     </View>
-                    <MenuItemWithTopDescription
-                        title={legalName}
-                        description={props.translate('privatePersonalDetails.legalName')}
-                        shouldShowRightIcon
-                        onPress={() => Navigation.navigate(ROUTES.SETTINGS_PERSONAL_DETAILS_LEGAL_NAME)}
-                    />
-                    <MenuItemWithTopDescription
-                        title={privateDetails.dob || ''}
-                        description={props.translate('common.dob')}
-                        shouldShowRightIcon
-                        onPress={() => Navigation.navigate(ROUTES.SETTINGS_PERSONAL_DETAILS_DATE_OF_BIRTH)}
-                        titleStyle={[styles.flex1]}
-                    />
-                    <MenuItemWithTopDescription
-                        title={getFormattedAddress()}
-                        description={props.translate('privatePersonalDetails.homeAddress')}
-                        shouldShowRightIcon
-                        onPress={() => Navigation.navigate(ROUTES.SETTINGS_PERSONAL_DETAILS_ADDRESS)}
-                    />
-                </View>
-            </ScrollView>
+                </ScrollView>
+            )}
         </ScreenWrapper>
     );
 }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/24642
PROPOSAL: https://github.com/Expensify/App/issues/24642#issuecomment-1681164078

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Logout and then login
2. Turn off network
3. Visit the personal details page `settings/profile/personal-details` and verify that it shows the loading spinner and the header is visible and clickable. 
4. Visit the personal address details page `settings/profile/personal-details/address` from deep link and verify that it shows the loading spinner and the header is visible and clickable. 
5. Visit the date of birth details page `settings/profile/personal-details/date-of-birth` from deep link and verify that it shows the loading spinner and the header is visible and clickable. 
6. Visit the legal name details page `settings/profile/personal-details/legal-name` from deep link and verify that it shows the loading spinner and the header is visible and clickable.

**Sidenote:** 
To visit the desktop deep link, right click > inspect element and add `window.location = '{The url you want to visit}'` and press enter, and to visit native mobile deep-link, use `npx uri-scheme open "new-expensify://settings/profile/personal-details/address" --android`, replace the path with the path you want to visit. For IOS, use `--ios` instead of `--android`

- [ ] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Same as the "Tests" section above (but we need to make sure that personal details are not loaded after login)

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
5. Upload an image via copy paste
6. Verify a modal appears displaying a preview of that image
--->

Same as the "Tests" section above.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

**Chrome:**

https://github.com/Expensify/App/assets/68777211/abcd964e-8213-4b8b-bb53-b037808f75e7

**Safari:**

https://github.com/Expensify/App/assets/68777211/9b91294a-16d9-4169-b796-a2b8715fe79f

</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://github.com/Expensify/App/assets/68777211/df6bddac-63cb-46d6-b2c6-227645a95c62

</details>

<details>
<summary>Mobile Web - Safari</summary>

https://github.com/Expensify/App/assets/68777211/d273de25-5c3c-43fa-9f15-82ecbd6fb0b8

</details>

<details>
<summary>Desktop</summary>

https://github.com/Expensify/App/assets/68777211/54b9b286-b2f0-4c65-a48d-48f2a7cbe3c3

</details>

<details>
<summary>iOS</summary>

https://github.com/Expensify/App/assets/68777211/1b9972e8-a08a-4e35-8373-e5dad9f0d9d5

</details>

<details>
<summary>Android</summary>

https://github.com/Expensify/App/assets/68777211/b0186a01-2c13-47d5-9fe7-54d60db25347

</details>
