### PR TITLE
[No QA] Fix markPullRequestsAsDeployed

### DIFF
--- a/.github/actions/javascript/markPullRequestsAsDeployed/index.js
+++ b/.github/actions/javascript/markPullRequestsAsDeployed/index.js
@@ -76,7 +76,7 @@ async function run() {
         message += `\n\nplatform | result\n---|---\n🤖 android 🤖|${androidResult}\n🖥 desktop 🖥|${desktopResult}`;
         message += `\n🍎 iOS 🍎|${iOSResult}\n🕸 web 🕸|${webResult}`;
 
-        if (deployVerb === 'Cherry-picked' && !/no qa/gi.test(prTitle)) {
+        if (deployVerb === 'Cherry-picked' && !/no ?qa/gi.test(prTitle)) {
             // eslint-disable-next-line max-len
             message +=
                 '\n\n@Expensify/applauseleads please QA this PR and check it off on the [deploy checklist](https://github.com/Expensify/App/issues?q=is%3Aopen+is%3Aissue+label%3AStagingDeployCash) if it passes.';

--- a/.github/actions/javascript/markPullRequestsAsDeployed/index.js
+++ b/.github/actions/javascript/markPullRequestsAsDeployed/index.js
@@ -9,16 +9,11 @@ module.exports =
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 const _ = __nccwpck_require__(2947);
-const lodashGet = __nccwpck_require__(6908);
 const core = __nccwpck_require__(2186);
 const {context} = __nccwpck_require__(5438);
 const CONST = __nccwpck_require__(4097);
 const ActionUtils = __nccwpck_require__(970);
 const GithubUtils = __nccwpck_require__(7999);
-
-const prList = ActionUtils.getJSONInput('PR_LIST', {required: true});
-const isProd = ActionUtils.getJSONInput('IS_PRODUCTION_DEPLOY', {required: true});
-const version = core.getInput('DEPLOY_VERSION', {required: true});
 
 /**
  * Return a nicely formatted message for the table based on the result of the GitHub action job
@@ -40,34 +35,6 @@ function getDeployTableMessage(platformResult) {
     }
 }
 
-const androidResult = getDeployTableMessage(core.getInput('ANDROID', {required: true}));
-const desktopResult = getDeployTableMessage(core.getInput('DESKTOP', {required: true}));
-const iOSResult = getDeployTableMessage(core.getInput('IOS', {required: true}));
-const webResult = getDeployTableMessage(core.getInput('WEB', {required: true}));
-
-const workflowURL = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
-
-/**
- * @param {String} deployer
- * @param {String} deployVerb
- * @param {String} prTitle
- * @returns {String}
- */
-function getDeployMessage(deployer, deployVerb, prTitle) {
-    let message = `🚀 [${deployVerb}](${workflowURL}) to ${isProd ? 'production' : 'staging'}`;
-    message += ` by https://github.com/${deployer} in version: ${version} 🚀`;
-    message += `\n\n platform | result \n ---|--- \n🤖 android 🤖|${androidResult} \n🖥 desktop 🖥|${desktopResult}`;
-    message += `\n🍎 iOS 🍎|${iOSResult} \n🕸 web 🕸|${webResult}`;
-
-    if (deployVerb === 'Cherry-picked' && !/no qa/gi.test(prTitle)) {
-        // eslint-disable-next-line max-len
-        message +=
-            '\n\n@Expensify/applauseleads please QA this PR and check it off on the [deploy checklist](https://github.com/Expensify/App/issues?q=is%3Aopen+is%3Aissue+label%3AStagingDeployCash) if it passes.';
-    }
-
-    return message;
-}
-
 /**
  * Comment Single PR
  *
@@ -75,87 +42,108 @@ function getDeployMessage(deployer, deployVerb, prTitle) {
  * @param {String} message
  * @returns {Promise<void>}
  */
-function commentPR(PR, message) {
-    return GithubUtils.createComment(context.repo.repo, PR, message)
-        .then(() => console.log(`Comment created on #${PR} successfully 🎉`))
-        .catch((err) => {
-            console.log(`Unable to write comment on #${PR} 😞`);
-            core.setFailed(err.message);
-        });
+async function commentPR(PR, message) {
+    try {
+        await GithubUtils.createComment(context.repo.repo, PR, message);
+        console.log(`Comment created on #${PR} successfully 🎉`);
+    } catch (err) {
+        console.log(`Unable to write comment on #${PR} 😞`);
+        core.setFailed(err.message);
+    }
 }
 
-const run = function () {
+const workflowURL = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+
+async function run() {
+    const prList = _.map(ActionUtils.getJSONInput('PR_LIST', {required: true}), (num) => Number.parseInt(num, 10));
+    const isProd = ActionUtils.getJSONInput('IS_PRODUCTION_DEPLOY', {required: true});
+    const version = core.getInput('DEPLOY_VERSION', {required: true});
+
+    const androidResult = getDeployTableMessage(core.getInput('ANDROID', {required: true}));
+    const desktopResult = getDeployTableMessage(core.getInput('DESKTOP', {required: true}));
+    const iOSResult = getDeployTableMessage(core.getInput('IOS', {required: true}));
+    const webResult = getDeployTableMessage(core.getInput('WEB', {required: true}));
+
+    /**
+     * @param {String} deployer
+     * @param {String} deployVerb
+     * @param {String} prTitle
+     * @returns {String}
+     */
+    function getDeployMessage(deployer, deployVerb, prTitle) {
+        let message = `🚀 [${deployVerb}](${workflowURL}) to ${isProd ? 'production' : 'staging'}`;
+        message += ` by https://github.com/${deployer} in version: ${version} 🚀`;
+        message += `\n\nplatform | result\n---|---\n🤖 android 🤖|${androidResult}\n🖥 desktop 🖥|${desktopResult}`;
+        message += `\n🍎 iOS 🍎|${iOSResult}\n🕸 web 🕸|${webResult}`;
+
+        if (deployVerb === 'Cherry-picked' && !/no qa/gi.test(prTitle)) {
+            // eslint-disable-next-line max-len
+            message +=
+                '\n\n@Expensify/applauseleads please QA this PR and check it off on the [deploy checklist](https://github.com/Expensify/App/issues?q=is%3Aopen+is%3Aissue+label%3AStagingDeployCash) if it passes.';
+        }
+
+        return message;
+    }
+
     if (isProd) {
-        // First find the deployer (who closed the last deploy checklist)?
-        return GithubUtils.octokit.issues
-            .listForRepo({
-                owner: CONST.GITHUB_OWNER,
-                repo: CONST.APP_REPO,
-                labels: CONST.LABELS.STAGING_DEPLOY,
-                state: 'closed',
-            })
-            .then(({data}) => _.first(data).number)
-            .then((lastDeployChecklistNumber) => GithubUtils.getActorWhoClosedIssue(lastDeployChecklistNumber))
-            .then((actor) => {
-                // Create comment on each pull request (one after another to avoid throttling issues)
-                const deployMessage = getDeployMessage(actor, 'Deployed');
-                _.reduce(prList, (promise, pr) => promise.then(() => commentPR(pr, deployMessage)), Promise.resolve());
-            });
+        // Find the previous deploy checklist
+        const {data: deployChecklists} = await GithubUtils.octokit.issues.listForRepo({
+            owner: CONST.GITHUB_OWNER,
+            repo: CONST.APP_REPO,
+            labels: CONST.LABELS.STAGING_DEPLOY,
+            state: 'closed',
+        });
+        const previousChecklistID = _.first(deployChecklists).number;
+
+        // who closed the last deploy checklist?
+        const deployer = await GithubUtils.getActorWhoClosedIssue(previousChecklistID);
+
+        // Create comment on each pull request (one at a time to avoid throttling issues)
+        const deployMessage = getDeployMessage(deployer, 'Deployed');
+        for (const pr of prList) {
+            await commentPR(pr, deployMessage);
+        }
+        return;
     }
 
     // First find out if this is a normal staging deploy or a CP by looking at the commit message on the tag
-    return GithubUtils.octokit.repos
-        .listTags({
+    const {data: recentTags} = await GithubUtils.octokit.repos.listTags({
+        owner: CONST.GITHUB_OWNER,
+        repo: CONST.APP_REPO,
+        per_page: 100,
+    });
+    const currentTag = _.find(recentTags, (tag) => tag.name === version);
+    if (!currentTag) {
+        const err = `Could not find tag matching ${version}`;
+        console.error(err);
+        core.setFailed(err);
+        return;
+    }
+    const {data: commit} = await GithubUtils.octokit.git.getCommit({
+        owner: CONST.GITHUB_OWNER,
+        repo: CONST.APP_REPO,
+        commit_sha: currentTag.commit.sha,
+    });
+    const isCP = /[\S\s]*\(cherry picked from commit .*\)/.test(commit.message);
+
+    for (const prNumber of prList) {
+        /*
+         * Determine who the deployer for the PR is. The "deployer" for staging deploys is:
+         *   1. For regular staging deploys, the person who merged the PR.
+         *   2. For CPs, the person who committed the cherry-picked commit (not necessarily the author of the commit).
+         */
+        const {data: pr} = await GithubUtils.octokit.pulls.get({
             owner: CONST.GITHUB_OWNER,
             repo: CONST.APP_REPO,
-            per_page: 100,
-        })
-        .then(({data}) => {
-            const tagSHA = _.find(data, (tag) => tag.name === version).commit.sha;
-            return GithubUtils.octokit.git.getCommit({
-                owner: CONST.GITHUB_OWNER,
-                repo: CONST.APP_REPO,
-                commit_sha: tagSHA,
-            });
-        })
-        .then(({data}) => {
-            const isCP = /Merge pull request #\d+ from Expensify\/.*-?cherry-pick-staging-\d+/.test(data.message);
-            _.reduce(
-                prList,
-                (promise, PR) =>
-                    promise
-
-                        // Then, for each PR, find out who merged it and determine the deployer
-                        .then(() =>
-                            GithubUtils.octokit.pulls.get({
-                                owner: CONST.GITHUB_OWNER,
-                                repo: CONST.APP_REPO,
-                                pull_number: PR,
-                            }),
-                        )
-                        .then((response) => {
-                            /*
-                             * The deployer for staging deploys is:
-                             *   1. For regular staging deploys, the person who merged the PR.
-                             *   2. For automatic CPs (using the label), the person who merged the PR.
-                             *   3. For manual CPs (using the GH UI), the person who triggered the workflow
-                             *      (reflected in the branch name).
-                             */
-                            let deployer = lodashGet(response, 'data.merged_by.login', '');
-                            const issueTitle = lodashGet(response, 'data.title', '');
-                            const CPActorMatches = data.message.match(/Merge pull request #\d+ from Expensify\/(.+)-cherry-pick-staging-\d+/);
-                            if (_.isArray(CPActorMatches) && CPActorMatches.length === 2 && CPActorMatches[1] !== CONST.OS_BOTIFY) {
-                                deployer = CPActorMatches[1];
-                            }
-
-                            // Finally, comment on the PR
-                            const deployMessage = getDeployMessage(deployer, isCP ? 'Cherry-picked' : 'Deployed', issueTitle);
-                            return commentPR(PR, deployMessage);
-                        }),
-                Promise.resolve(),
-            );
+            pull_number: prNumber,
         });
-};
+        const deployer = isCP ? commit.committer.name : pr.merged_by.login;
+
+        const title = pr.title;
+        const deployMessage = getDeployMessage(deployer, isCP ? 'Cherry-picked' : 'Deployed', title);
+        await commentPR(prNumber, deployMessage);
+    }
+}
 
 if (require.main === require.cache[eval('__filename')]) {
     run();
@@ -8171,7 +8159,7 @@ var modules = [
     __nccwpck_require__(9557),
     __nccwpck_require__(1155),
     __nccwpck_require__(1644),
-    __nccwpck_require__(373),
+    __nccwpck_require__(6657),
     __nccwpck_require__(1080),
     __nccwpck_require__(1012),
     __nccwpck_require__(9695),
@@ -8395,7 +8383,7 @@ InternalDecoderCesu8.prototype.end = function() {
 
 /***/ }),
 
-/***/ 373:
+/***/ 6657:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -10455,7 +10443,7 @@ module.exports = Map;
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var mapCacheClear = __nccwpck_require__(1610),
-    mapCacheDelete = __nccwpck_require__(6657),
+    mapCacheDelete = __nccwpck_require__(5991),
     mapCacheGet = __nccwpck_require__(1372),
     mapCacheHas = __nccwpck_require__(609),
     mapCacheSet = __nccwpck_require__(5582);
@@ -11297,7 +11285,7 @@ module.exports = mapCacheClear;
 
 /***/ }),
 
-/***/ 6657:
+/***/ 5991:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var getMapData = __nccwpck_require__(9980);

--- a/.github/actions/javascript/markPullRequestsAsDeployed/markPullRequestsAsDeployed.js
+++ b/.github/actions/javascript/markPullRequestsAsDeployed/markPullRequestsAsDeployed.js
@@ -1,5 +1,4 @@
 const _ = require('underscore');
-const lodashGet = require('lodash/get');
 const core = require('@actions/core');
 const {context} = require('@actions/github');
 const CONST = require('../../../libs/CONST');
@@ -65,87 +64,78 @@ function getDeployMessage(deployer, deployVerb, prTitle) {
  * @param {String} message
  * @returns {Promise<void>}
  */
-function commentPR(PR, message) {
-    return GithubUtils.createComment(context.repo.repo, PR, message)
-        .then(() => console.log(`Comment created on #${PR} successfully 🎉`))
-        .catch((err) => {
-            console.log(`Unable to write comment on #${PR} 😞`);
-            core.setFailed(err.message);
-        });
+async function commentPR(PR, message) {
+    try {
+        await GithubUtils.createComment(context.repo.report, PR, message);
+        console.log(`Comment created on #${PR} successfully 🎉`);
+    } catch (err) {
+        console.log(`Unable to write comment on #${PR} 😞`);
+        core.setFailed(err.message);
+    }
 }
 
-const run = function () {
+async function run() {
     if (isProd) {
-        // First find the deployer (who closed the last deploy checklist)?
-        return GithubUtils.octokit.issues
-            .listForRepo({
-                owner: CONST.GITHUB_OWNER,
-                repo: CONST.APP_REPO,
-                labels: CONST.LABELS.STAGING_DEPLOY,
-                state: 'closed',
-            })
-            .then(({data}) => _.first(data).number)
-            .then((lastDeployChecklistNumber) => GithubUtils.getActorWhoClosedIssue(lastDeployChecklistNumber))
-            .then((actor) => {
-                // Create comment on each pull request (one after another to avoid throttling issues)
-                const deployMessage = getDeployMessage(actor, 'Deployed');
-                _.reduce(prList, (promise, pr) => promise.then(() => commentPR(pr, deployMessage)), Promise.resolve());
-            });
+        // Find the previous deploy checklist
+        const {data: deployChecklists} = await GithubUtils.octokit.issues.listForRepo({
+            owner: CONST.GITHUB_OWNER,
+            repo: CONST.APP_REPO,
+            labels: CONST.LABELS.STAGING_DEPLOY,
+            state: 'closed',
+        });
+        const previousChecklistID = _.first(deployChecklists).number;
+
+        // who closed the last deploy checklist?
+        const deployer = await GithubUtils.getActorWhoClosedIssue(previousChecklistID);
+
+        // Create comment on each pull request (one at a time to avoid throttling issues)
+        const deployMessage = getDeployMessage(deployer, 'Deployed');
+        for (const pr of prList) {
+            await commentPR(pr, deployMessage);
+        }
+        return;
     }
 
     // First find out if this is a normal staging deploy or a CP by looking at the commit message on the tag
-    return GithubUtils.octokit.repos
-        .listTags({
+    const {data: recentTags} = await GithubUtils.octokit.repos.listTags({
+        owner: CONST.GITHUB_OWNER,
+        repo: CONST.APP_REPO,
+        per_page: 100,
+    });
+    const currentTag = _.find(recentTags, (tag) => tag.name === version);
+    if (!currentTag) {
+        const err = `Could not find tag matching ${version}`;
+        console.error(err);
+        core.setFailed(err);
+        return;
+    }
+    const commitMessage = (
+        await GithubUtils.octokit.git.getCommit({
             owner: CONST.GITHUB_OWNER,
             repo: CONST.APP_REPO,
-            per_page: 100,
+            commit_sha: currentTag.commit.sha,
         })
-        .then(({data}) => {
-            const tagSHA = _.find(data, (tag) => tag.name === version).commit.sha;
-            return GithubUtils.octokit.git.getCommit({
-                owner: CONST.GITHUB_OWNER,
-                repo: CONST.APP_REPO,
-                commit_sha: tagSHA,
-            });
-        })
-        .then(({data}) => {
-            const isCP = /Merge pull request #\d+ from Expensify\/.*-?cherry-pick-staging-\d+/.test(data.message);
-            _.reduce(
-                prList,
-                (promise, PR) =>
-                    promise
+    ).data.message;
+    const isCP = /[\S\s]*\(cherry picked from commit .*\)/.test(commitMessage);
 
-                        // Then, for each PR, find out who merged it and determine the deployer
-                        .then(() =>
-                            GithubUtils.octokit.pulls.get({
-                                owner: CONST.GITHUB_OWNER,
-                                repo: CONST.APP_REPO,
-                                pull_number: PR,
-                            }),
-                        )
-                        .then((response) => {
-                            /*
-                             * The deployer for staging deploys is:
-                             *   1. For regular staging deploys, the person who merged the PR.
-                             *   2. For automatic CPs (using the label), the person who merged the PR.
-                             *   3. For manual CPs (using the GH UI), the person who triggered the workflow
-                             *      (reflected in the branch name).
-                             */
-                            let deployer = lodashGet(response, 'data.merged_by.login', '');
-                            const issueTitle = lodashGet(response, 'data.title', '');
-                            const CPActorMatches = data.message.match(/Merge pull request #\d+ from Expensify\/(.+)-cherry-pick-staging-\d+/);
-                            if (_.isArray(CPActorMatches) && CPActorMatches.length === 2 && CPActorMatches[1] !== CONST.OS_BOTIFY) {
-                                deployer = CPActorMatches[1];
-                            }
-
-                            // Finally, comment on the PR
-                            const deployMessage = getDeployMessage(deployer, isCP ? 'Cherry-picked' : 'Deployed', issueTitle);
-                            return commentPR(PR, deployMessage);
-                        }),
-                Promise.resolve(),
-            );
+    for (const prNumber of prList) {
+        /*
+         * Determine who the deployer for the PR is. The "deployer" for staging deploys is:
+         *   1. For regular staging deploys, the person who merged the PR.
+         *   2. For CPs, the person who triggered the workflow (documented in the cherry-pick commit message)
+         */
+        const {data: pr} = await GithubUtils.octokit.pulls.get({
+            owner: CONST.GITHUB_OWNER,
+            repo: CONST.APP_REPO,
+            pull_number: prNumber,
         });
-};
+        const deployer = isCP ? commitMessage.match(/\(cherry picked from commit \w*(?: by (.*))?[)]/)[1] || CONST.OS_BOTIFY : pr.merged_by.login;
+
+        const title = pr.title;
+        const deployMessage = getDeployMessage(deployer, isCP ? 'Cherry-picked' : 'Deployed', title);
+        await commentPR(prNumber, deployMessage);
+    }
+}
 
 if (require.main === module) {
     run();

--- a/.github/actions/javascript/markPullRequestsAsDeployed/markPullRequestsAsDeployed.js
+++ b/.github/actions/javascript/markPullRequestsAsDeployed/markPullRequestsAsDeployed.js
@@ -66,7 +66,7 @@ async function run() {
         message += `\n\nplatform | result\n---|---\n🤖 android 🤖|${androidResult}\n🖥 desktop 🖥|${desktopResult}`;
         message += `\n🍎 iOS 🍎|${iOSResult}\n🕸 web 🕸|${webResult}`;
 
-        if (deployVerb === 'Cherry-picked' && !/no qa/gi.test(prTitle)) {
+        if (deployVerb === 'Cherry-picked' && !/no ?qa/gi.test(prTitle)) {
             // eslint-disable-next-line max-len
             message +=
                 '\n\n@Expensify/applauseleads please QA this PR and check it off on the [deploy checklist](https://github.com/Expensify/App/issues?q=is%3Aopen+is%3Aissue+label%3AStagingDeployCash) if it passes.';

--- a/.github/actions/javascript/markPullRequestsAsDeployed/markPullRequestsAsDeployed.js
+++ b/.github/actions/javascript/markPullRequestsAsDeployed/markPullRequestsAsDeployed.js
@@ -45,8 +45,8 @@ const workflowURL = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOS
 function getDeployMessage(deployer, deployVerb, prTitle) {
     let message = `🚀 [${deployVerb}](${workflowURL}) to ${isProd ? 'production' : 'staging'}`;
     message += ` by https://github.com/${deployer} in version: ${version} 🚀`;
-    message += `\n\n platform | result \n ---|--- \n🤖 android 🤖|${androidResult} \n🖥 desktop 🖥|${desktopResult}`;
-    message += `\n🍎 iOS 🍎|${iOSResult} \n🕸 web 🕸|${webResult}`;
+    message += `\n\nplatform | result\n---|---\n🤖 android 🤖|${androidResult}\n🖥 desktop 🖥|${desktopResult}`;
+    message += `\n🍎 iOS 🍎|${iOSResult}\n🕸 web 🕸|${webResult}`;
 
     if (deployVerb === 'Cherry-picked' && !/no qa/gi.test(prTitle)) {
         // eslint-disable-next-line max-len
@@ -66,7 +66,7 @@ function getDeployMessage(deployer, deployVerb, prTitle) {
  */
 async function commentPR(PR, message) {
     try {
-        await GithubUtils.createComment(context.repo.report, PR, message);
+        await GithubUtils.createComment(context.repo.repo, PR, message);
         console.log(`Comment created on #${PR} successfully 🎉`);
     } catch (err) {
         console.log(`Unable to write comment on #${PR} 😞`);

--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -77,6 +77,7 @@ jobs:
         id: cherryPick
         run: |
           echo "Attempting to cherry-pick ${{ steps.getCPMergeCommit.outputs.MERGE_COMMIT_SHA }}"
+          git config user.name ${{ github.actor }}
           if git cherry-pick -S -x --mainline 1 ${{ steps.getCPMergeCommit.outputs.MERGE_COMMIT_SHA }}; then
             echo "🎉 No conflicts! CP was a success, PR can be automerged 🎉"
             echo "HAS_CONFLICTS=false" >> "$GITHUB_OUTPUT"
@@ -87,6 +88,7 @@ jobs:
             GIT_MERGE_AUTOEDIT=no git cherry-pick --continue
             echo "HAS_CONFLICTS=true" >> "$GITHUB_OUTPUT"
           fi
+          git config user.name OSBotify
 
       - name: Push changes
         run: |

--- a/tests/unit/CIGitLogicTest.sh
+++ b/tests/unit/CIGitLogicTest.sh
@@ -135,8 +135,10 @@ function cherry_pick_pr {
 
   git switch staging
   git switch -c cherry-pick-staging
-  git cherry-pick -x --mainline 1 --strategy=recursive -Xtheirs "$PR_MERGE_COMMIT"
   git cherry-pick -x --mainline 1 "$VERSION_BUMP_COMMIT"
+  setup_git_as_human
+  git cherry-pick -x --mainline 1 --strategy=recursive -Xtheirs "$PR_MERGE_COMMIT"
+  setup_git_as_osbotify
 
   git switch staging
   git merge cherry-pick-staging --no-ff -m "Merge pull request #$(($1 + 1)) from Expensify/cherry-pick-staging"

--- a/tests/unit/markPullRequestsAsDeployedTest.js
+++ b/tests/unit/markPullRequestsAsDeployedTest.js
@@ -217,5 +217,22 @@ platform | result
         // Note: we import this in here so that it executes after all the mocks are set up
         run = require('../../.github/actions/javascript/markPullRequestsAsDeployed/markPullRequestsAsDeployed');
         await run();
+        expect(mockCreateComment).toHaveBeenCalledTimes(_.keys(PRList).length);
+        for (let i = 0; i < _.keys(PRList).length; i++) {
+            const PR = PRList[i + 1];
+            expect(mockCreateComment).toHaveBeenNthCalledWith(i + 1, {
+                body: `🚀 [Deployed](${workflowRunURL}) to staging by https://github.com/${PR.merged_by.login} in version: ${version} 🚀
+
+platform | result
+---|---
+🤖 android 🤖|skipped 🚫
+🖥 desktop 🖥|cancelled 🔪
+🍎 iOS 🍎|failed ❌
+🕸 web 🕸|success ✅`,
+                issue_number: PR.issue_number,
+                owner: 'Expensify',
+                repo: 'App',
+            });
+        }
     });
 });

--- a/tests/unit/markPullRequestsAsDeployedTest.js
+++ b/tests/unit/markPullRequestsAsDeployedTest.js
@@ -1,0 +1,129 @@
+/**
+ * @jest-environment node
+ */
+const core = require('@actions/core');
+const GitUtils = require('../../.github/libs/GitUtils');
+const GithubUtils = require('../../.github/libs/GithubUtils');
+const run = require('../../.github/actions/javascript/markPullRequestsAsDeployed/markPullRequestsAsDeployed');
+
+const mockGetInput = jest.fn();
+const mockListIssues = jest.fn();
+const mockListEvents = jest.fn();
+const mockCreateComment = jest.fn();
+const mockGetPullRequestsMergedBetween = jest.fn();
+let workflowRunURL;
+
+const PRList = [1, 2, 3, 4];
+
+/**
+ * @param {String} key
+ * @returns {Boolean|String}
+ * @throws {Error}
+ */
+function defaultMockGetInput(key) {
+    switch (key) {
+        case 'PR_LIST':
+            return JSON.stringify(PRList);
+        case 'IS_PRODUCTION_DEPLOY':
+            return false;
+        case 'DEPLOY_VERSION':
+            return '42.42.42-42';
+        case 'IOS':
+        case 'ANDROID':
+        case 'DESKTOP':
+        case 'WEB':
+            return 'success';
+        default:
+            throw new Error('Trying to access invalid input');
+    }
+}
+
+/**
+ * @returns {Promise<[{actor: {login: string}, event: string}]>}
+ */
+async function defaultMockListEvents() {
+    return [{event: 'closed', actor: {login: 'thor'}}];
+}
+
+beforeAll(() => {
+    // Mock core module
+    core.getInput = mockGetInput;
+    mockGetInput.mockImplementation(defaultMockGetInput);
+
+    // Mock octokit module
+    const moctokit = {
+        rest: {
+            issues: {
+                listForRepo: jest.fn().mockImplementation(async () => ({
+                    data: [
+                        {
+                            number: 5,
+                        },
+                    ],
+                })),
+                listEvents: mockListEvents,
+                createComment: mockCreateComment,
+            },
+            pulls: {
+                // Static mock for pulls.list (only used to filter out automated PRs, and that functionality is covered
+                // in the test for GithubUtils.generateStagingDeployCashBody
+                list: jest.fn().mockResolvedValue([]),
+            },
+        },
+        paginate: jest.fn().mockImplementation((objectMethod) => objectMethod().then(({data}) => data)),
+    };
+    GithubUtils.internalOctokit = moctokit;
+
+    // Mock GitUtils
+    GitUtils.getPullRequestsMergedBetween = mockGetPullRequestsMergedBetween;
+
+    // Set GH runner environment variables
+    process.env.GITHUB_SERVER_URL = 'https://github.com';
+    process.env.GITHUB_REPOSITORY = 'Expensify/App';
+    process.env.GITHUB_RUN_ID = 1234;
+    workflowRunURL = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+});
+
+afterEach(() => {
+    mockGetInput.mockClear();
+    mockListIssues.mockClear();
+    mockGetPullRequestsMergedBetween.mockClear();
+});
+
+afterAll(() => {
+    jest.clearAllMocks();
+});
+
+describe('markPullRequestsAsDeployed', () => {
+    it('comments on pull requests correctly for a standard staging deploy', async () => {});
+
+    it('comments on pull requests correctly for a standard production deploy', async () => {
+        mockGetInput.mockImplementation((key) => {
+            if (key === 'IS_PRODUCTION_DEPLOY') {
+                return true;
+            }
+            return defaultMockGetInput(key);
+        });
+
+        await run();
+        expect(mockCreateComment).toHaveBeenCalledTimes(PRList.length);
+        expect(mockCreateComment).toHaveBeenNthCalledWith(`🚀 [Deployed](${workflowRunURL}) to production `);
+    });
+
+    it('comments on pull requests correctly for a cherry pick', async () => {});
+
+    it('comments on pull requests correctly when one platform fails', async () => {
+        mockGetInput.mockImplementation((key) => {
+            if (key === 'ANDROID') {
+                return 'skipped';
+            }
+            if (key === 'IOS') {
+                return 'failed';
+            }
+            if (key === 'DESKTOP') {
+                return 'cancelled';
+            }
+            return defaultMockGetInput(key);
+        });
+    });
+});

--- a/tests/unit/markPullRequestsAsDeployedTest.js
+++ b/tests/unit/markPullRequestsAsDeployedTest.js
@@ -43,7 +43,7 @@ const defaultTags = [
  * @returns {Boolean|String}
  * @throws {Error}
  */
-function defaultMockGetInput(key) {
+function mockGetInputDefaultImplementation(key) {
     switch (key) {
         case 'PR_LIST':
             return JSON.stringify(_.keys(PRList));
@@ -84,7 +84,7 @@ beforeAll(() => {
     jest.mock('@actions/core', () => ({
         getInput: mockGetInput,
     }));
-    mockGetInput.mockImplementation(defaultMockGetInput);
+    mockGetInput.mockImplementation(mockGetInputDefaultImplementation);
 
     // Mock octokit module
     const moctokit = {
@@ -188,7 +188,7 @@ platform | result
             if (key === 'IS_PRODUCTION_DEPLOY') {
                 return true;
             }
-            return defaultMockGetInput(key);
+            return mockGetInputDefaultImplementation(key);
         });
 
         // Note: we import this in here so that it executes after all the mocks are set up
@@ -221,7 +221,7 @@ platform | result
             if (key === 'DEPLOY_VERSION') {
                 return '42.42.42-43';
             }
-            return defaultMockGetInput(key);
+            return mockGetInputDefaultImplementation(key);
         });
         mockGetPullRequest.mockImplementation(async ({pull_number}) => {
             if (pull_number === 3) {
@@ -279,7 +279,7 @@ platform | result
             if (key === 'DESKTOP') {
                 return 'cancelled';
             }
-            return defaultMockGetInput(key);
+            return mockGetInputDefaultImplementation(key);
         });
 
         // Note: we import this in here so that it executes after all the mocks are set up


### PR DESCRIPTION
### Details
This PR accomplishes three things:

1. Refactors `markPullRequestsAsDeployed` to use `async`/`await` for better clarity
1. Adds automated tests to cover `markPullRequestsAsDeployed`
1. Fixes deploy comments on cherry-picked PRs. There were two aspects to this:
    - Determining whether a deployed PR was cherry-picked or deployed via a standard staging deploy.
        - We used to rely on a regex that looked for commits like `Merge PR #\d+ from branch cherry-pick-staging-.*`. This stopped working when we implemented the branch dance and stopped using pull requests to CP code to staging.
        - Now we look at the commit message, which thanks to the `-x` flag passed to `git cherry-pick` will always contain a suffix like `(cherry picked from commit .*)`.
        
    - Determining who is the deployer for cherry-picked PRs
        - For manual CP's, we used to include `github.actor` (i.e: the person who triggered the workflow) in the branch name for cherry-picked PRs. We would use that to determine the deployer. That also stopped working when we stopped using PRs to CP stuff.
        - Now we updated the `cherryPick.yml` workflow to switch the git user with `git config user.name ${{ github.actor }}` before running the CP. Then we switch the git user back to `OSBotify` right after (because only `OSBotify` can push code to `staging`). This does mean that CP commits are unsigned (since `OSBotify` doesn't have the signing key for the `github.actor`), but that's not a problem because we lifted the signed commits requirement on staging. So this means that commits will appear as authored by the original author, committed by the `github.actor`, and pushed by `OSBotify`. Then we can look at the `commit.committer` to determine the deployer.

### Fixed Issues
$ (partial) https://github.com/Expensify/App/issues/21763

### Tests
1. Merge this PR
1. Cherry-pick it
1. The deploy comment should say that it was "cherry-picked", not just "deployed", by the person who triggers the CP.
1. Deploy comments on PRs deployed to staging via the standard methods should remain unchanged.

Also added automated tests.

- [x] Verify that no errors appear in the JS console

### Offline tests
None.

### QA Steps
None.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>
