### PR TITLE
Emoji Suggestions Adjustments + Remove Duplicates

### DIFF
--- a/src/libs/EmojiTrie.js
+++ b/src/libs/EmojiTrie.js
@@ -18,26 +18,40 @@ function createTrie(lang = CONST.LOCALES.DEFAULT) {
             return;
         }
 
-        const name = isDefaultLocale ? item.name : _.get(langEmojis, [item.code, 'name']);
-        const names = isDefaultLocale ? [name] : [...new Set([name, item.name])];
-        _.forEach(names, (nm) => {
-            const node = trie.search(nm);
-            if (!node) {
-                trie.add(nm, {code: item.code, types: item.types, name: nm, suggestions: []});
-            } else {
-                trie.update(nm, {code: item.code, types: item.types, name: nm, suggestions: node.metaData.suggestions});
-            }
-        });
-
-        const keywords = _.get(langEmojis, [item.code, 'keywords'], []).concat(isDefaultLocale ? [] : _.get(localeEmojis, [CONST.LOCALES.DEFAULT, item.code, 'keywords'], []));
+        const defaultName = item.name;
+        const preferredLanguageName = _.get(langEmojis, [item.code, 'name'], defaultName);
+        
+        // Add the actual name of the emoji for the current language
+        const node = trie.search(preferredLanguageName);
+        if (!node) {
+            trie.add(preferredLanguageName, {code: item.code, types: item.types, name: preferredLanguageName, suggestions: []});
+        } else {
+            trie.update(preferredLanguageName, {code: item.code, types: item.types, name: preferredLanguageName, suggestions: node.metaData.suggestions});
+        }
+        
+        // Add keywords of both the current language and the default language, in case current language isn't the default.
+        const keywords = _.get(langEmojis, [item.code, 'keywords'], []).concat(isDefaultLocale ? [] : _.get(localeEmojis, [CONST.LOCALES.DEFAULT, item.code, 'keywords'], []));;
         for (let j = 0; j < keywords.length; j++) {
             const keywordNode = trie.search(keywords[j]);
             if (!keywordNode) {
-                trie.add(keywords[j], {suggestions: [{code: item.code, types: item.types, name}]});
+                trie.add(keywords[j], {suggestions: [{code: item.code, types: item.types, name: preferredLanguageName}]});
             } else {
                 trie.update(keywords[j], {
                     ...keywordNode.metaData,
-                    suggestions: [...keywordNode.metaData.suggestions, {code: item.code, types: item.types, name}],
+                    suggestions: [...keywordNode.metaData.suggestions, {code: item.code, types: item.types, name: preferredLanguageName}],
+                });
+            }
+        }
+
+        // If current language isn't the default, prepend the English name of the emoji in the suggestions as well.
+        if (!isDefaultLocale) {
+            const englishNode = trie.search(defaultName);
+            if (!englishNode) {
+                trie.add(defaultName, {suggestions: [{code: item.code, types: item.types, name: preferredLanguageName}]});
+            } else {
+                trie.update(defaultName, {
+                    ...englishNode.metaData,
+                    suggestions: [{code: item.code, types: item.types, name: preferredLanguageName}, ...englishNode.metaData.suggestions],
                 });
             }
         }
@@ -45,6 +59,7 @@ function createTrie(lang = CONST.LOCALES.DEFAULT) {
 
     return trie;
 }
+
 
 const emojiTrie = _.reduce(supportedLanguages, (prev, cur) => ({...prev, [cur]: createTrie(cur)}), {});
 

--- a/src/libs/EmojiTrie.js
+++ b/src/libs/EmojiTrie.js
@@ -20,7 +20,7 @@ function createTrie(lang = CONST.LOCALES.DEFAULT) {
 
         const defaultName = item.name;
         const preferredLanguageName = _.get(langEmojis, [item.code, 'name'], defaultName);
-        
+
         // Add the actual name of the emoji for the current language
         const node = trie.search(preferredLanguageName);
         if (!node) {
@@ -28,9 +28,9 @@ function createTrie(lang = CONST.LOCALES.DEFAULT) {
         } else {
             trie.update(preferredLanguageName, {code: item.code, types: item.types, name: preferredLanguageName, suggestions: node.metaData.suggestions});
         }
-        
+
         // Add keywords of both the current language and the default language, in case current language isn't the default.
-        const keywords = _.get(langEmojis, [item.code, 'keywords'], []).concat(isDefaultLocale ? [] : _.get(localeEmojis, [CONST.LOCALES.DEFAULT, item.code, 'keywords'], []));;
+        const keywords = _.get(langEmojis, [item.code, 'keywords'], []).concat(isDefaultLocale ? [] : _.get(localeEmojis, [CONST.LOCALES.DEFAULT, item.code, 'keywords'], []));
         for (let j = 0; j < keywords.length; j++) {
             const keywordNode = trie.search(keywords[j]);
             if (!keywordNode) {
@@ -59,7 +59,6 @@ function createTrie(lang = CONST.LOCALES.DEFAULT) {
 
     return trie;
 }
-
 
 const emojiTrie = _.reduce(supportedLanguages, (prev, cur) => ({...prev, [cur]: createTrie(cur)}), {});
 

--- a/src/libs/EmojiTrie.js
+++ b/src/libs/EmojiTrie.js
@@ -18,15 +18,15 @@ function createTrie(lang = CONST.LOCALES.DEFAULT) {
             return;
         }
 
-        const defaultName = item.name;
-        const preferredLanguageName = _.get(langEmojis, [item.code, 'name'], defaultName);
+        const englishName = item.name;
+        const localeName = _.get(langEmojis, [item.code, 'name'], englishName);
 
         // Add the actual name of the emoji for the current language
-        const node = trie.search(preferredLanguageName);
+        const node = trie.search(localeName);
         if (!node) {
-            trie.add(preferredLanguageName, {code: item.code, types: item.types, name: preferredLanguageName, suggestions: []});
+            trie.add(localeName, {code: item.code, types: item.types, name: localeName, suggestions: []});
         } else {
-            trie.update(preferredLanguageName, {code: item.code, types: item.types, name: preferredLanguageName, suggestions: node.metaData.suggestions});
+            trie.update(localeName, {code: item.code, types: item.types, name: localeName, suggestions: node.metaData.suggestions});
         }
 
         // Add keywords of both the current language and the default language, in case current language isn't the default.
@@ -34,24 +34,24 @@ function createTrie(lang = CONST.LOCALES.DEFAULT) {
         for (let j = 0; j < keywords.length; j++) {
             const keywordNode = trie.search(keywords[j]);
             if (!keywordNode) {
-                trie.add(keywords[j], {suggestions: [{code: item.code, types: item.types, name: preferredLanguageName}]});
+                trie.add(keywords[j], {suggestions: [{code: item.code, types: item.types, name: localeName}]});
             } else {
                 trie.update(keywords[j], {
                     ...keywordNode.metaData,
-                    suggestions: [...keywordNode.metaData.suggestions, {code: item.code, types: item.types, name: preferredLanguageName}],
+                    suggestions: [...keywordNode.metaData.suggestions, {code: item.code, types: item.types, name: localeName}],
                 });
             }
         }
 
         // If current language isn't the default, prepend the English name of the emoji in the suggestions as well.
         if (!isDefaultLocale) {
-            const englishNode = trie.search(defaultName);
+            const englishNode = trie.search(englishName);
             if (!englishNode) {
-                trie.add(defaultName, {suggestions: [{code: item.code, types: item.types, name: preferredLanguageName}]});
+                trie.add(englishName, {suggestions: [{code: item.code, types: item.types, name: localeName}]});
             } else {
-                trie.update(defaultName, {
+                trie.update(englishName, {
                     ...englishNode.metaData,
-                    suggestions: [{code: item.code, types: item.types, name: preferredLanguageName}, ...englishNode.metaData.suggestions],
+                    suggestions: [{code: item.code, types: item.types, name: localeName}, ...englishNode.metaData.suggestions],
                 });
             }
         }

--- a/src/libs/EmojiTrie.js
+++ b/src/libs/EmojiTrie.js
@@ -21,7 +21,6 @@ function createTrie(lang = CONST.LOCALES.DEFAULT) {
         const englishName = item.name;
         const localeName = _.get(langEmojis, [item.code, 'name'], englishName);
 
-        // Add the actual name of the emoji for the current language
         const node = trie.search(localeName);
         if (!node) {
             trie.add(localeName, {code: item.code, types: item.types, name: localeName, suggestions: []});
@@ -29,7 +28,7 @@ function createTrie(lang = CONST.LOCALES.DEFAULT) {
             trie.update(localeName, {code: item.code, types: item.types, name: localeName, suggestions: node.metaData.suggestions});
         }
 
-        // Add keywords of both the current language and the default language, in case current language isn't the default.
+        // Add keywords for both the locale language and English to enable users to search using either language.
         const keywords = _.get(langEmojis, [item.code, 'keywords'], []).concat(isDefaultLocale ? [] : _.get(localeEmojis, [CONST.LOCALES.DEFAULT, item.code, 'keywords'], []));
         for (let j = 0; j < keywords.length; j++) {
             const keywordNode = trie.search(keywords[j]);
@@ -44,6 +43,7 @@ function createTrie(lang = CONST.LOCALES.DEFAULT) {
         }
 
         // If current language isn't the default, prepend the English name of the emoji in the suggestions as well.
+        // We do this because when the user types the english name of the emoji, we want to show the emoji in the suggestions before all the others.
         if (!isDefaultLocale) {
             const englishNode = trie.search(englishName);
             if (!englishNode) {

--- a/src/libs/EmojiUtils.js
+++ b/src/libs/EmojiUtils.js
@@ -319,7 +319,14 @@ function replaceEmojis(text, preferredSkinTone = CONST.EMOJI_DEFAULT_SKIN_TONE, 
     }
     for (let i = 0; i < emojiData.length; i++) {
         const name = emojiData[i].slice(1, -1);
-        const checkEmoji = trie.search(name);
+        let checkEmoji = trie.search(name);
+        if ((!checkEmoji || !checkEmoji.metaData.code) && lang !== CONST.LOCALES.DEFAULT) {
+            const englishTrie = emojisTrie[CONST.LOCALES.DEFAULT];
+            if (englishTrie) {
+                const englishEmoji = englishTrie.search(name);
+                checkEmoji = englishEmoji;
+            }
+        }
         if (checkEmoji && checkEmoji.metaData.code) {
             let emojiReplacement = getEmojiCodeWithSkinColor(checkEmoji.metaData, preferredSkinTone);
             emojis.push({

--- a/src/libs/EmojiUtils.js
+++ b/src/libs/EmojiUtils.js
@@ -320,7 +320,9 @@ function replaceEmojis(text, preferredSkinTone = CONST.EMOJI_DEFAULT_SKIN_TONE, 
     for (let i = 0; i < emojiData.length; i++) {
         const name = emojiData[i].slice(1, -1);
         let checkEmoji = trie.search(name);
-        if ((!checkEmoji || !checkEmoji.metaData.code) && lang !== CONST.LOCALES.DEFAULT) {
+        // If the user has selected a language other than English, and the emoji doesn't exist in that language,
+        // we will check if the emoji exists in English.
+        if (lang !== CONST.LOCALES.DEFAULT && (!checkEmoji || !checkEmoji.metaData.code)) {
             const englishTrie = emojisTrie[CONST.LOCALES.DEFAULT];
             if (englishTrie) {
                 const englishEmoji = englishTrie.search(name);


### PR DESCRIPTION
### Details
When the user had selected Spanish as the preferred language, he was able to look for English names of the emojis as well as Spanish, but there were duplicate occurrences in many scenarios, the most obvious one being `:bomb:` and `:bomba:` , same emoji, one after the other in suggestions.

In this PR, the user will still be able to search using the English emojis, but the suggestions will only show the Spanish ones.

### Fixed Issues

$ https://github.com/Expensify/App/issues/25735
PROPOSAL: https://github.com/Expensify/App/issues/25735#issuecomment-1689144965


### Tests
1. Go to Settings -> Preferences -> Language
2. Set the Language to Spanish
3. Type in chat: `:bomb`
4. Make sure only the Spanish version of the emoji shows up on the suggestions
5. Type `:fire:`
6. Make sure the Spanish suggestion shows while you are typing it, and that it immediately gets replaced when you complete it.

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Go to Settings -> Preferences -> Language
2. Set the Language to Spanish
3. Type in chat: `:bomb`
4. Make sure only the Spanish version of the emoji shows up on the suggestions
5. Type `:fire:`
6. Make sure the Spanish suggestion shows while you are typing it, and that it immediately gets replaced when you complete it.

### QA Steps

1. Go to Settings -> Preferences -> Language
2. Set the Language to Spanish
3. Type in chat: `:bomb`
4. Make sure only the Spanish version of the emoji shows up on the suggestions
5. Type `:fire:`
6. Make sure the Spanish suggestion shows while you are typing it, and that it immediately gets replaced when you complete it.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://github.com/Expensify/App/assets/32620770/1855336a-11ca-48a6-a27d-e51ce7e596cf

</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://github.com/Expensify/App/assets/32620770/f8534be5-a208-401e-aac8-956d3f8a9086

</details>

<details>
<summary>Mobile Web - Safari</summary>

https://github.com/Expensify/App/assets/32620770/8e1f8fbd-6106-4731-a82f-ad8c51fa9c71

</details>

<details>
<summary>Desktop</summary>

https://github.com/Expensify/App/assets/32620770/1dd71977-046a-4b61-90ed-bd214d939cef

</details>

<details>
<summary>iOS</summary>

https://github.com/Expensify/App/assets/32620770/42aa9ed9-4950-4e3b-9564-ebe9942d17a8

</details>

<details>
<summary>Android</summary>

https://github.com/Expensify/App/assets/32620770/a76dd060-cfb2-45d4-8d21-6f1bbf3616f4

</details>
