### PR TITLE
Update empty field check logic

### DIFF
--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -666,6 +666,7 @@ const CONST = {
     TRANSACTION: {
         DEFAULT_MERCHANT: 'Request',
         UNKNOWN_MERCHANT: 'Unknown Merchant',
+        PARTIAL_TRANSACTION_MERCHANT: '(none)',
         TYPE: {
             CUSTOM_UNIT: 'customUnit',
         },

--- a/src/libs/TransactionUtils.js
+++ b/src/libs/TransactionUtils.js
@@ -90,10 +90,13 @@ function hasReceipt(transaction) {
  * @returns {Boolean}
  */
 function areRequiredFieldsEmpty(transaction) {
-    return (transaction.modifiedMerchant === CONST.TRANSACTION.UNKNOWN_MERCHANT
-        || (transaction.modifiedMerchant === '' && (transaction.merchant === CONST.TRANSACTION.UNKNOWN_MERCHANT || transaction.merchant === '' || transaction.merchant === CONST.TRANSACTION.PARTIAL_TRANSACTION_MERCHANT))
-        || (transaction.modifiedAmount === 0 && transaction.amount === 0)
-        || (transaction.modifiedCreated === '' && transaction.created === ''));
+    return (
+        transaction.modifiedMerchant === CONST.TRANSACTION.UNKNOWN_MERCHANT ||
+        (transaction.modifiedMerchant === '' &&
+            (transaction.merchant === CONST.TRANSACTION.UNKNOWN_MERCHANT || transaction.merchant === '' || transaction.merchant === CONST.TRANSACTION.PARTIAL_TRANSACTION_MERCHANT)) ||
+        (transaction.modifiedAmount === 0 && transaction.amount === 0) ||
+        (transaction.modifiedCreated === '' && transaction.created === '')
+    );
 }
 
 /**

--- a/src/libs/TransactionUtils.js
+++ b/src/libs/TransactionUtils.js
@@ -89,8 +89,11 @@ function hasReceipt(transaction) {
  * @param {Object} transaction
  * @returns {Boolean}
  */
-function areModifiedFieldsPopulated(transaction) {
-    return transaction.modifiedMerchant !== CONST.TRANSACTION.UNKNOWN_MERCHANT && transaction.modifiedAmount !== 0 && transaction.modifiedCreated !== '';
+function areRequiredFieldsEmpty(transaction) {
+    return (transaction.modifiedMerchant === CONST.TRANSACTION.UNKNOWN_MERCHANT
+        || (transaction.modifiedMerchant === '' && (transaction.merchant === CONST.TRANSACTION.UNKNOWN_MERCHANT || transaction.merchant === '' || transaction.merchant === CONST.TRANSACTION.PARTIAL_TRANSACTION_MERCHANT))
+        || (transaction.modifiedAmount === 0 && transaction.amount === 0)
+        || (transaction.modifiedCreated === '' && transaction.created === ''));
 }
 
 /**
@@ -262,7 +265,7 @@ function isReceiptBeingScanned(transaction) {
  * @returns {Boolean}
  */
 function hasMissingSmartscanFields(transaction) {
-    return hasReceipt(transaction) && !isDistanceRequest(transaction) && !isReceiptBeingScanned(transaction) && !areModifiedFieldsPopulated(transaction);
+    return hasReceipt(transaction) && !isDistanceRequest(transaction) && !isReceiptBeingScanned(transaction) && areRequiredFieldsEmpty(transaction);
 }
 
 /**


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/Expensify/issues/313812

Coming from [this comment](https://github.com/Expensify/App/pull/26155#issuecomment-1704779263)

### Tests
- Follow the steps in https://github.com/Expensify/App/pull/26155. Try requesting money both from another individual and a workspace. 
- Follow the steps again, but populating all fields when smartscanning. Confirm no red dot displays in that case.

- [ ] Verify that no errors appear in the JS console

### Offline tests
None

### QA Steps
- Same as https://github.com/Expensify/App/pull/26155
- Try the same steps, but with a receipt with all fields visible, so it smartscans correctly. No red dot should show in that case.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<img width="1441" alt="Screenshot 2023-08-29 at 3 18 44 PM" src="https://github.com/Expensify/App/assets/19366280/49ce3c07-2059-489c-9f75-50c4304cbb7d">

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<img width="385" alt="Screenshot 2023-08-30 at 12 59 10 PM" src="https://github.com/Expensify/App/assets/19366280/cf4b81eb-96e7-43c3-b230-ba0f9d8336e2">
<img width="391" alt="Screenshot 2023-08-30 at 12 59 21 PM" src="https://github.com/Expensify/App/assets/19366280/cb32f362-bb31-428c-b568-41426f91a4b5">
<img width="393" alt="Screenshot 2023-08-30 at 12 59 30 PM" src="https://github.com/Expensify/App/assets/19366280/e1e99028-b171-4b22-af3d-03e2536637dd">


</details>

<details>
<summary>Mobile Web - Safari</summary>

<img width="415" alt="Screenshot 2023-08-30 at 12 26 51 PM" src="https://github.com/Expensify/App/assets/19366280/97d79d53-6cf6-43b8-8577-e0de5eb64d23">
<img width="420" alt="Screenshot 2023-08-30 at 12 26 58 PM" src="https://github.com/Expensify/App/assets/19366280/ba0055ec-8a01-4b87-9b31-a6520466176f">
<img width="417" alt="Screenshot 2023-08-30 at 12 27 04 PM" src="https://github.com/Expensify/App/assets/19366280/cdee3e6f-c190-4642-8838-9b092a1aefd6">


</details>

<details>
<summary>Desktop</summary>

<img width="1206" alt="Screenshot 2023-08-30 at 11 20 36 AM" src="https://github.com/Expensify/App/assets/19366280/8a3774d4-1b48-4e89-829c-5059d527d200">


</details>

<details>
<summary>iOS</summary>

<img width="416" alt="Screenshot 2023-08-30 at 12 23 04 PM" src="https://github.com/Expensify/App/assets/19366280/afbae402-e0bf-415a-9e30-9499c8fd72cf">
<img width="417" alt="Screenshot 2023-08-30 at 12 23 15 PM" src="https://github.com/Expensify/App/assets/19366280/91cf3ba2-f6a5-4917-99ed-99b6b780eb88">
<img width="409" alt="Screenshot 2023-08-30 at 12 23 27 PM" src="https://github.com/Expensify/App/assets/19366280/a5ae0744-427e-4135-8e2e-69d8048f1aaf">


</details>

<details>
<summary>Android</summary>

<img width="387" alt="Screenshot 2023-08-30 at 12 46 06 PM" src="https://github.com/Expensify/App/assets/19366280/ba9b8a9b-01b6-4dac-91f5-1d7b5b5bc764">
<img width="382" alt="Screenshot 2023-08-30 at 12 46 14 PM" src="https://github.com/Expensify/App/assets/19366280/1a9c0408-22a1-4c8f-8006-c750c220acfd">
<img width="391" alt="Screenshot 2023-08-30 at 12 46 21 PM" src="https://github.com/Expensify/App/assets/19366280/01beaa5b-160f-4c2d-99cd-226fe74398f6">


</details>

