### PR TITLE
disable "Didn't receive magic code" while loading

### DIFF
--- a/src/pages/settings/Profile/Contacts/ValidateCodeForm/BaseValidateCodeForm.js
+++ b/src/pages/settings/Profile/Contacts/ValidateCodeForm/BaseValidateCodeForm.js
@@ -76,6 +76,7 @@ function BaseValidateCodeForm(props) {
     const loginData = props.loginList[props.contactMethod];
     const inputValidateCodeRef = useRef();
     const validateLoginError = ErrorUtils.getEarliestErrorField(loginData, 'validateLogin');
+    const shouldDisableMagicCodeNotReceived = props.network.isOffline || props.account.isLoading;
 
     useImperativeHandle(props.innerRef, () => ({
         focus() {
@@ -170,7 +171,7 @@ function BaseValidateCodeForm(props) {
             >
                 <View style={[styles.mt2, styles.dFlex, styles.flexColumn, styles.alignItemsStart]}>
                     <PressableWithFeedback
-                        disabled={props.network.isOffline || props.account.isLoading}
+                        disabled={shouldDisableMagicCodeNotReceived}
                         style={[styles.mr1]}
                         onPress={resendValidateCode}
                         underlayColor={themeColors.componentBG}
@@ -179,7 +180,7 @@ function BaseValidateCodeForm(props) {
                         accessibilityRole={CONST.ACCESSIBILITY_ROLE.BUTTON}
                         accessibilityLabel={props.translate('validateCodeForm.magicCodeNotReceived')}
                     >
-                        <Text style={[StyleUtils.getDisabledLinkStyles(props.network.isOffline || props.account.isLoading)]}>{props.translate('validateCodeForm.magicCodeNotReceived')}</Text>
+                        <Text style={[StyleUtils.getDisabledLinkStyles(shouldDisableMagicCodeNotReceived)]}>{props.translate('validateCodeForm.magicCodeNotReceived')}</Text>
                     </PressableWithFeedback>
                     {props.hasMagicCodeBeenSent && (
                         <DotIndicatorMessage

--- a/src/pages/settings/Profile/Contacts/ValidateCodeForm/BaseValidateCodeForm.js
+++ b/src/pages/settings/Profile/Contacts/ValidateCodeForm/BaseValidateCodeForm.js
@@ -76,7 +76,7 @@ function BaseValidateCodeForm(props) {
     const loginData = props.loginList[props.contactMethod];
     const inputValidateCodeRef = useRef();
     const validateLoginError = ErrorUtils.getEarliestErrorField(loginData, 'validateLogin');
-    const shouldDisableDidntReceiveMagicCode = props.network.isOffline || props.account.isLoading;
+    const shouldDisableResendValidateCode = props.network.isOffline || props.account.isLoading;
 
     useImperativeHandle(props.innerRef, () => ({
         focus() {
@@ -171,7 +171,7 @@ function BaseValidateCodeForm(props) {
             >
                 <View style={[styles.mt2, styles.dFlex, styles.flexColumn, styles.alignItemsStart]}>
                     <PressableWithFeedback
-                        disabled={shouldDisableDidntReceiveMagicCode}
+                        disabled={shouldDisableResendValidateCode}
                         style={[styles.mr1]}
                         onPress={resendValidateCode}
                         underlayColor={themeColors.componentBG}
@@ -180,7 +180,7 @@ function BaseValidateCodeForm(props) {
                         accessibilityRole={CONST.ACCESSIBILITY_ROLE.BUTTON}
                         accessibilityLabel={props.translate('validateCodeForm.magicCodeNotReceived')}
                     >
-                        <Text style={[StyleUtils.getDisabledLinkStyles(shouldDisableDidntReceiveMagicCode)]}>{props.translate('validateCodeForm.magicCodeNotReceived')}</Text>
+                        <Text style={[StyleUtils.getDisabledLinkStyles(shouldDisableResendValidateCode)]}>{props.translate('validateCodeForm.magicCodeNotReceived')}</Text>
                     </PressableWithFeedback>
                     {props.hasMagicCodeBeenSent && (
                         <DotIndicatorMessage

--- a/src/pages/settings/Profile/Contacts/ValidateCodeForm/BaseValidateCodeForm.js
+++ b/src/pages/settings/Profile/Contacts/ValidateCodeForm/BaseValidateCodeForm.js
@@ -76,7 +76,7 @@ function BaseValidateCodeForm(props) {
     const loginData = props.loginList[props.contactMethod];
     const inputValidateCodeRef = useRef();
     const validateLoginError = ErrorUtils.getEarliestErrorField(loginData, 'validateLogin');
-    const shouldDisableMagicCodeNotReceived = props.network.isOffline || props.account.isLoading;
+    const shouldDisableDidntReceiveMagicCode = props.network.isOffline || props.account.isLoading;
 
     useImperativeHandle(props.innerRef, () => ({
         focus() {
@@ -171,7 +171,7 @@ function BaseValidateCodeForm(props) {
             >
                 <View style={[styles.mt2, styles.dFlex, styles.flexColumn, styles.alignItemsStart]}>
                     <PressableWithFeedback
-                        disabled={shouldDisableMagicCodeNotReceived}
+                        disabled={shouldDisableDidntReceiveMagicCode}
                         style={[styles.mr1]}
                         onPress={resendValidateCode}
                         underlayColor={themeColors.componentBG}
@@ -180,7 +180,7 @@ function BaseValidateCodeForm(props) {
                         accessibilityRole={CONST.ACCESSIBILITY_ROLE.BUTTON}
                         accessibilityLabel={props.translate('validateCodeForm.magicCodeNotReceived')}
                     >
-                        <Text style={[StyleUtils.getDisabledLinkStyles(shouldDisableMagicCodeNotReceived)]}>{props.translate('validateCodeForm.magicCodeNotReceived')}</Text>
+                        <Text style={[StyleUtils.getDisabledLinkStyles(shouldDisableDidntReceiveMagicCode)]}>{props.translate('validateCodeForm.magicCodeNotReceived')}</Text>
                     </PressableWithFeedback>
                     {props.hasMagicCodeBeenSent && (
                         <DotIndicatorMessage

--- a/src/pages/settings/Profile/Contacts/ValidateCodeForm/BaseValidateCodeForm.js
+++ b/src/pages/settings/Profile/Contacts/ValidateCodeForm/BaseValidateCodeForm.js
@@ -170,7 +170,7 @@ function BaseValidateCodeForm(props) {
             >
                 <View style={[styles.mt2, styles.dFlex, styles.flexColumn, styles.alignItemsStart]}>
                     <PressableWithFeedback
-                        disabled={props.network.isOffline}
+                        disabled={props.network.isOffline || props.account.isLoading}
                         style={[styles.mr1]}
                         onPress={resendValidateCode}
                         underlayColor={themeColors.componentBG}
@@ -179,7 +179,7 @@ function BaseValidateCodeForm(props) {
                         accessibilityRole={CONST.ACCESSIBILITY_ROLE.BUTTON}
                         accessibilityLabel={props.translate('validateCodeForm.magicCodeNotReceived')}
                     >
-                        <Text style={[StyleUtils.getDisabledLinkStyles(props.network.isOffline)]}>{props.translate('validateCodeForm.magicCodeNotReceived')}</Text>
+                        <Text style={[StyleUtils.getDisabledLinkStyles(props.network.isOffline || props.account.isLoading)]}>{props.translate('validateCodeForm.magicCodeNotReceived')}</Text>
                     </PressableWithFeedback>
                     {props.hasMagicCodeBeenSent && (
                         <DotIndicatorMessage

--- a/src/pages/signin/ValidateCodeForm/BaseValidateCodeForm.js
+++ b/src/pages/signin/ValidateCodeForm/BaseValidateCodeForm.js
@@ -87,6 +87,7 @@ function BaseValidateCodeForm(props) {
 
     const hasError = Boolean(props.account) && !_.isEmpty(props.account.errors);
     const isLoadingResendValidationForm = props.account.loadingForm === CONST.FORMS.RESEND_VALIDATE_CODE_FORM;
+    const shouldDisableMagicCodeNotReceived = props.network.isOffline || props.account.isLoading;
 
     useEffect(() => {
         if (!(inputValidateCodeRef.current && hasError && (props.session.autoAuthState === CONST.AUTO_AUTH_STATE.FAILED || props.account.isLoading))) {
@@ -279,13 +280,13 @@ function BaseValidateCodeForm(props) {
                                 style={[styles.mt2]}
                                 onPress={resendValidateCode}
                                 underlayColor={themeColors.componentBG}
-                                disabled={props.network.isOffline || props.account.isLoading}
+                                disabled={shouldDisableMagicCodeNotReceived}
                                 hoverDimmingValue={1}
                                 pressDimmingValue={0.2}
                                 accessibilityRole={CONST.ACCESSIBILITY_ROLE.BUTTON}
                                 accessibilityLabel={props.translate('validateCodeForm.magicCodeNotReceived')}
                             >
-                                <Text style={[StyleUtils.getDisabledLinkStyles(props.network.isOffline || props.account.isLoading)]}>
+                                <Text style={[StyleUtils.getDisabledLinkStyles(shouldDisableMagicCodeNotReceived)]}>
                                     {hasError ? props.translate('validateCodeForm.requestNewCodeAfterErrorOccurred') : props.translate('validateCodeForm.magicCodeNotReceived')}
                                 </Text>
                             </PressableWithFeedback>

--- a/src/pages/signin/ValidateCodeForm/BaseValidateCodeForm.js
+++ b/src/pages/signin/ValidateCodeForm/BaseValidateCodeForm.js
@@ -87,7 +87,7 @@ function BaseValidateCodeForm(props) {
 
     const hasError = Boolean(props.account) && !_.isEmpty(props.account.errors);
     const isLoadingResendValidationForm = props.account.loadingForm === CONST.FORMS.RESEND_VALIDATE_CODE_FORM;
-    const shouldDisableMagicCodeNotReceived = props.network.isOffline || props.account.isLoading;
+    const shouldDisableDidntReceiveMagicCode = props.network.isOffline || props.account.isLoading;
 
     useEffect(() => {
         if (!(inputValidateCodeRef.current && hasError && (props.session.autoAuthState === CONST.AUTO_AUTH_STATE.FAILED || props.account.isLoading))) {
@@ -280,13 +280,13 @@ function BaseValidateCodeForm(props) {
                                 style={[styles.mt2]}
                                 onPress={resendValidateCode}
                                 underlayColor={themeColors.componentBG}
-                                disabled={shouldDisableMagicCodeNotReceived}
+                                disabled={shouldDisableDidntReceiveMagicCode}
                                 hoverDimmingValue={1}
                                 pressDimmingValue={0.2}
                                 accessibilityRole={CONST.ACCESSIBILITY_ROLE.BUTTON}
                                 accessibilityLabel={props.translate('validateCodeForm.magicCodeNotReceived')}
                             >
-                                <Text style={[StyleUtils.getDisabledLinkStyles(shouldDisableMagicCodeNotReceived)]}>
+                                <Text style={[StyleUtils.getDisabledLinkStyles(shouldDisableDidntReceiveMagicCode)]}>
                                     {hasError ? props.translate('validateCodeForm.requestNewCodeAfterErrorOccurred') : props.translate('validateCodeForm.magicCodeNotReceived')}
                                 </Text>
                             </PressableWithFeedback>

--- a/src/pages/signin/ValidateCodeForm/BaseValidateCodeForm.js
+++ b/src/pages/signin/ValidateCodeForm/BaseValidateCodeForm.js
@@ -87,7 +87,7 @@ function BaseValidateCodeForm(props) {
 
     const hasError = Boolean(props.account) && !_.isEmpty(props.account.errors);
     const isLoadingResendValidationForm = props.account.loadingForm === CONST.FORMS.RESEND_VALIDATE_CODE_FORM;
-    const shouldDisableDidntReceiveMagicCode = props.network.isOffline || props.account.isLoading;
+    const shouldDisableResendValidateCode = props.network.isOffline || props.account.isLoading;
 
     useEffect(() => {
         if (!(inputValidateCodeRef.current && hasError && (props.session.autoAuthState === CONST.AUTO_AUTH_STATE.FAILED || props.account.isLoading))) {
@@ -280,13 +280,13 @@ function BaseValidateCodeForm(props) {
                                 style={[styles.mt2]}
                                 onPress={resendValidateCode}
                                 underlayColor={themeColors.componentBG}
-                                disabled={shouldDisableDidntReceiveMagicCode}
+                                disabled={shouldDisableResendValidateCode}
                                 hoverDimmingValue={1}
                                 pressDimmingValue={0.2}
                                 accessibilityRole={CONST.ACCESSIBILITY_ROLE.BUTTON}
                                 accessibilityLabel={props.translate('validateCodeForm.magicCodeNotReceived')}
                             >
-                                <Text style={[StyleUtils.getDisabledLinkStyles(shouldDisableDidntReceiveMagicCode)]}>
+                                <Text style={[StyleUtils.getDisabledLinkStyles(shouldDisableResendValidateCode)]}>
                                     {hasError ? props.translate('validateCodeForm.requestNewCodeAfterErrorOccurred') : props.translate('validateCodeForm.magicCodeNotReceived')}
                                 </Text>
                             </PressableWithFeedback>

--- a/src/pages/signin/ValidateCodeForm/BaseValidateCodeForm.js
+++ b/src/pages/signin/ValidateCodeForm/BaseValidateCodeForm.js
@@ -279,13 +279,13 @@ function BaseValidateCodeForm(props) {
                                 style={[styles.mt2]}
                                 onPress={resendValidateCode}
                                 underlayColor={themeColors.componentBG}
-                                disabled={props.network.isOffline}
+                                disabled={props.network.isOffline || props.account.isLoading}
                                 hoverDimmingValue={1}
                                 pressDimmingValue={0.2}
                                 accessibilityRole={CONST.ACCESSIBILITY_ROLE.BUTTON}
                                 accessibilityLabel={props.translate('validateCodeForm.magicCodeNotReceived')}
                             >
-                                <Text style={[StyleUtils.getDisabledLinkStyles(props.network.isOffline)]}>
+                                <Text style={[StyleUtils.getDisabledLinkStyles(props.network.isOffline || props.account.isLoading)]}>
                                     {hasError ? props.translate('validateCodeForm.requestNewCodeAfterErrorOccurred') : props.translate('validateCodeForm.magicCodeNotReceived')}
                                 </Text>
                             </PressableWithFeedback>


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Disable "Didn't receive magic code" while loading in `BaseValidateCodeForm` of signin and contacts.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/25932
PROPOSAL: https://github.com/Expensify/App/issues/25932#issuecomment-1693349003


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Test 1 for SignIn Magic Code page
1. Go to sign in page
2. Input phone or email and click 'Continue'
3. Wait till the 'Didn't receive magic code' link becomes active
4. Input the magic code received
5. Verify that the 'Didn't receive magic code' link is disabled while the page is loading

Test 2 for Secondary Contact Magic Code page
1. Sign in
2. Go to Settings > Profile > Contact Method
3. Add a new contact method
4. Click on this newly added contact method
5. Input the magic code received
6. Verify that the 'Didn't receive magic code' link is disabled while the page is loading


- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
NA
### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
7. Upload an image via copy paste
8. Verify a modal appears displaying a preview of that image
--->
Test 1 for SignIn Magic Code page
1. Go to sign in page
2. Input phone or email and click 'Continue'
3. Wait till the 'Didn't receive magic code' link becomes active
4. Input the magic code received
5. Verify that the 'Didn't receive magic code' link is disabled while the page is loading

Test 2 for Secondary Contact Magic Code page
1. Sign in
2. Go to Settings > Profile > Contact Method
3. Add a new contact method
4. Click on this newly added contact method
5. Input the magic code received
6. Verify that the 'Didn't receive magic code' link is disabled while the page is loading
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://github.com/Expensify/App/assets/102477862/4233e978-bb98-4d0d-9860-35d40a8e33ba





https://github.com/Expensify/App/assets/102477862/a9bf64a7-d0fc-482a-ab60-d7cf0c28f1f2



<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>


https://github.com/Expensify/App/assets/102477862/1a151b35-0958-4ea4-b1da-2db5745b7bc5



https://github.com/Expensify/App/assets/102477862/8fbfb1ef-c458-4368-b7ae-f01066840069





<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>


https://github.com/Expensify/App/assets/102477862/d1555369-ce0b-4844-ac95-eb6fcd013c1b





https://github.com/Expensify/App/assets/102477862/bca7d9d6-4bb4-47b3-aa04-c6c9ecdf6021



<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>




https://github.com/Expensify/App/assets/102477862/fd375a92-84d9-4bd8-aabe-bab50793cfaf




https://github.com/Expensify/App/assets/102477862/b4461bdf-374a-4f9d-a591-7d1873605922





<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>



https://github.com/Expensify/App/assets/102477862/821b98f2-2c94-4891-8b36-af07e6e66ff9




https://github.com/Expensify/App/assets/102477862/13ac4506-5844-4003-bc5a-76ea33958e97






<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>

https://github.com/Expensify/App/assets/102477862/448aaa7b-6f3c-4915-a941-dbc20ff45a71




https://github.com/Expensify/App/assets/102477862/c2073b9e-651e-4e86-9486-78087c73fd28




<!-- add screenshots or videos here -->

</details>
