### PR TITLE
Fix receipt image modal logic

### DIFF
--- a/src/components/ReportActionItem/ReportActionItemImage.js
+++ b/src/components/ReportActionItem/ReportActionItemImage.js
@@ -23,7 +23,7 @@ const propTypes = {
 };
 
 const defaultProps = {
-    thumbnail: '',
+    thumbnail: null,
     enablePreviewModal: false,
 };
 
@@ -35,8 +35,8 @@ const defaultProps = {
 
 function ReportActionItemImage({thumbnail, image, enablePreviewModal}) {
     const {translate} = useLocalize();
-    const imageSource = tryResolveUrlFromApiRoot(image);
-    const thumbnailSource = tryResolveUrlFromApiRoot(thumbnail);
+    const imageSource = tryResolveUrlFromApiRoot(image || '');
+    const thumbnailSource = tryResolveUrlFromApiRoot(thumbnail || '');
 
     const receiptImageComponent = thumbnail ? (
         <ThumbnailImage

--- a/src/components/ReportActionItem/ReportActionItemImage.js
+++ b/src/components/ReportActionItem/ReportActionItemImage.js
@@ -23,7 +23,7 @@ const propTypes = {
 };
 
 const defaultProps = {
-    thumbnail: null,
+    thumbnail: '',
     enablePreviewModal: false,
 };
 
@@ -35,47 +35,44 @@ const defaultProps = {
 
 function ReportActionItemImage({thumbnail, image, enablePreviewModal}) {
     const {translate} = useLocalize();
+    const imageSource = tryResolveUrlFromApiRoot(image);
+    const thumbnailSource = tryResolveUrlFromApiRoot(thumbnail);
 
-    if (thumbnail) {
-        const imageSource = tryResolveUrlFromApiRoot(image);
-        const thumbnailSource = tryResolveUrlFromApiRoot(thumbnail);
-        const thumbnailComponent = (
-            <ThumbnailImage
-                previewSourceURL={thumbnailSource}
-                style={[styles.w100, styles.h100]}
-                isAuthTokenRequired
-                shouldDynamicallyResize={false}
-            />
-        );
-
-        if (enablePreviewModal) {
-            return (
-                <ShowContextMenuContext.Consumer>
-                    {({report}) => (
-                        <PressableWithoutFocus
-                            style={[styles.noOutline, styles.w100, styles.h100]}
-                            onPress={() => {
-                                const route = ROUTES.getReportAttachmentRoute(report.reportID, imageSource);
-                                Navigation.navigate(route);
-                            }}
-                            accessibilityRole={CONST.ACCESSIBILITY_ROLE.IMAGEBUTTON}
-                            accessibilityLabel={translate('accessibilityHints.viewAttachment')}
-                        >
-                            {thumbnailComponent}
-                        </PressableWithoutFocus>
-                    )}
-                </ShowContextMenuContext.Consumer>
-            );
-        }
-        return thumbnailComponent;
-    }
-
-    return (
+    const receiptImageComponent = thumbnail ? (
+        <ThumbnailImage
+            previewSourceURL={thumbnailSource}
+            style={[styles.w100, styles.h100]}
+            isAuthTokenRequired
+            shouldDynamicallyResize={false}
+        />
+    ) : (
         <Image
             source={{uri: image}}
             style={[styles.w100, styles.h100]}
         />
     );
+
+    if (enablePreviewModal) {
+        return (
+            <ShowContextMenuContext.Consumer>
+                {({report}) => (
+                    <PressableWithoutFocus
+                        style={[styles.noOutline, styles.w100, styles.h100]}
+                        onPress={() => {
+                            const route = ROUTES.getReportAttachmentRoute(report.reportID, imageSource);
+                            Navigation.navigate(route);
+                        }}
+                        accessibilityRole={CONST.ACCESSIBILITY_ROLE.IMAGEBUTTON}
+                        accessibilityLabel={translate('accessibilityHints.viewAttachment')}
+                    >
+                        {receiptImageComponent}
+                    </PressableWithoutFocus>
+                )}
+            </ShowContextMenuContext.Consumer>
+        );
+    }
+
+    return receiptImageComponent;
 }
 
 ReportActionItemImage.propTypes = propTypes;


### PR DESCRIPTION
### Details
Allows users to tap on the receipt image right away, without the need for a thumbnail url

### Fixed Issues
$ https://github.com/Expensify/App/issues/26590

### Tests
1. Log into NewDot and create a new Workspace
2. Navigate to a workspace chat
3. Tap "+" and select "Request money" > "Scan"
4. Scan a receipt and submit a request
5. Open the request in the chat and tap the scanned receipt image
6. Verify that the image modal opens and the receipt image loads
7. Go to `Settings > Preferences` and turn on `Force offline` 
8. Repeat steps 3-6

- [x] Verify that no errors appear in the JS console

### Offline tests
Covered above

### QA Steps
Same as test

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://github.com/Expensify/App/assets/22219519/71b02fd0-fdc7-44fc-93a9-99358c29dacd


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://github.com/Expensify/App/assets/22219519/fa5133b5-67a2-4f4b-84b4-a2909292bce6


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

https://github.com/Expensify/App/assets/22219519/14ffe52c-c8e2-4a5f-90ce-27cec555836b


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>

https://github.com/Expensify/App/assets/22219519/6b9d67c1-97c3-4466-a137-fe3d6b022a02


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/22219519/29f3bfe2-fef8-449a-81df-0b321c3064ca

</details>

<details>
<summary>Android</summary>

https://github.com/Expensify/App/assets/22219519/324e9b26-8989-4c26-90a9-5c248880005f


<!-- add screenshots or videos here -->

</details>
