### PR TITLE
Add log when we try to deep link redirect while not authenticated. Don't crash the app.

### DIFF
--- a/src/libs/actions/App.js
+++ b/src/libs/actions/App.js
@@ -453,6 +453,11 @@ function beginDeepLinkRedirect(shouldAuthenticateWithCurrentAccount = true) {
 
     // eslint-disable-next-line rulesdir/no-api-side-effects-method
     API.makeRequestWithSideEffects('OpenOldDotLink', {shouldRetry: false}, {}).then((response) => {
+        if (!response) {
+            Log.alert('Trying to redirect via deep link, but the response is empty', {response}, true);
+            return;
+        }
+
         Browser.openRouteInDesktopApp(response.shortLivedAuthToken, currentUserEmail);
     });
 }

--- a/src/libs/actions/App.js
+++ b/src/libs/actions/App.js
@@ -454,7 +454,7 @@ function beginDeepLinkRedirect(shouldAuthenticateWithCurrentAccount = true) {
     // eslint-disable-next-line rulesdir/no-api-side-effects-method
     API.makeRequestWithSideEffects('OpenOldDotLink', {shouldRetry: false}, {}).then((response) => {
         if (!response) {
-            Log.alert('Trying to redirect via deep link, but the response is empty', {response}, true);
+            Log.alert('Trying to redirect via deep link, but the response is empty', {response, shouldAuthenticateWithCurrentAccount, currentUserAccountID}, true);
             return;
         }
 

--- a/src/libs/actions/App.js
+++ b/src/libs/actions/App.js
@@ -454,7 +454,7 @@ function beginDeepLinkRedirect(shouldAuthenticateWithCurrentAccount = true) {
     // eslint-disable-next-line rulesdir/no-api-side-effects-method
     API.makeRequestWithSideEffects('OpenOldDotLink', {shouldRetry: false}, {}).then((response) => {
         if (!response) {
-            Log.alert('Trying to redirect via deep link, but the response is empty', {response, shouldAuthenticateWithCurrentAccount, currentUserAccountID}, true);
+            Log.alert('Trying to redirect via deep link, but the response is empty. User likely not authenticated.', {response, shouldAuthenticateWithCurrentAccount, currentUserAccountID}, true);
             return;
         }
 

--- a/src/libs/actions/App.js
+++ b/src/libs/actions/App.js
@@ -454,7 +454,11 @@ function beginDeepLinkRedirect(shouldAuthenticateWithCurrentAccount = true) {
     // eslint-disable-next-line rulesdir/no-api-side-effects-method
     API.makeRequestWithSideEffects('OpenOldDotLink', {shouldRetry: false}, {}).then((response) => {
         if (!response) {
-            Log.alert('Trying to redirect via deep link, but the response is empty. User likely not authenticated.', {response, shouldAuthenticateWithCurrentAccount, currentUserAccountID}, true);
+            Log.alert(
+                'Trying to redirect via deep link, but the response is empty. User likely not authenticated.',
+                {response, shouldAuthenticateWithCurrentAccount, currentUserAccountID},
+                true,
+            );
             return;
         }
 


### PR DESCRIPTION
### Details

Not sure how @davidcardoza got into this state, but the app is crashing for him and he is hitting the deep link redirect code flow. At a minimum, I think we are clearly doing a bad access on an empty `response` variable. Doesn't answer the question of why we are hitting that code yet. But does explain the JS error in the console logs shared.

### Fixed Issues (Add logs for)
https://github.com/Expensify/Expensify/issues/312304

### Tests

1. Set this diff in Web-E to emulate expired session
```diff
diff --git a/lib/UserAPI.php b/lib/UserAPI.php
index c748595048a..659263536c1 100644
--- a/lib/UserAPI.php
+++ b/lib/UserAPI.php
@@ -2203,7 +2203,7 @@ class UserAPI
     {
         try {
             return [
-                'shortLivedAuthToken' => Auth::getShortLivedAuthToken($authToken),
+                'jsonCode' => 407
             ];
         } catch (Throwable $e) {
```
3. Set this diff in App so we can force calling the method from the web app
```diff
diff --git a/src/libs/actions/App.js b/src/libs/actions/App.js
index e77fb98c28..057e3aa4b5 100644
--- a/src/libs/actions/App.js
+++ b/src/libs/actions/App.js
@@ -462,6 +462,8 @@ function beginDeepLinkRedirect(shouldAuthenticateWithCurrentAccount = true) {
     });
 }

+window.beginDeepLinkRedirect = beginDeepLinkRedirect;
+
 /**
  * @param {boolean} shouldAuthenticateWithCurrentAccount Optional, indicates whether default authentication method (shortLivedAuthToken) should be used
  */
```
4. Call method from JS console
5. Verify that the alert happens

![2023-09-05_16-09-49](https://github.com/Expensify/App/assets/32969087/983063f6-d3aa-4d8a-93a7-6b490380a491)


- [ ] Verify that no errors appear in the JS console

### Offline tests

N/A

### QA Steps

1. Navigate to NewDot on staging web
2. Install the staging desktop app
3. Sign into NewDot on staging web
4. Refresh the page to trigger the deep link flow to the desktop app (if Chrome asks to open the page in the desktop app allow it to do so)
8. Verify you get redirected and the desktop app opens
10. Back in staging web invalidate credentials via the preferences pane
11. Refresh the page again to trigger the deep link flow
12. Verify the app does not crash and there are no errors in the JS console.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

not relevant to other platforms besides web

![2023-09-05_16-09-49](https://github.com/Expensify/App/assets/32969087/4e69c7f1-a7d3-4002-909b-f6093f705361)

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>
