### PR TITLE
fix(task-pages): Force task page editions only for task reports

### DIFF
--- a/src/pages/tasks/TaskAssigneeSelectorModal.js
+++ b/src/pages/tasks/TaskAssigneeSelectorModal.js
@@ -126,7 +126,7 @@ function TaskAssigneeSelectorModal(props) {
 
     if (report && !ReportUtils.isTaskReport(report)) {
         Navigation.isNavigationReady().then(() => {
-            Navigation.dismissModal();
+            Navigation.dismissModal(report.reportID);
         });
     }
 

--- a/src/pages/tasks/TaskAssigneeSelectorModal.js
+++ b/src/pages/tasks/TaskAssigneeSelectorModal.js
@@ -18,7 +18,7 @@ import compose from '../../libs/compose';
 import personalDetailsPropType from '../personalDetailsPropType';
 import reportPropTypes from '../reportPropTypes';
 import ROUTES from '../../ROUTES';
-
+import * as ReportUtils from '../../libs/ReportUtils';
 import * as Task from '../../libs/actions/Task';
 
 const propTypes = {
@@ -123,6 +123,12 @@ function TaskAssigneeSelectorModal(props) {
         }
         return props.reports[`${ONYXKEYS.COLLECTION.REPORT}${props.route.params.reportID}`];
     }, [props.reports, props.route.params]);
+
+    if (!ReportUtils.isTaskReport(report)) {
+        Navigation.isNavigationReady().then(() => {
+            Navigation.dismissModal();
+        });
+    }
 
     const sections = useMemo(() => {
         const sectionsList = [];

--- a/src/pages/tasks/TaskAssigneeSelectorModal.js
+++ b/src/pages/tasks/TaskAssigneeSelectorModal.js
@@ -124,7 +124,7 @@ function TaskAssigneeSelectorModal(props) {
         return props.reports[`${ONYXKEYS.COLLECTION.REPORT}${props.route.params.reportID}`];
     }, [props.reports, props.route.params]);
 
-    if (!ReportUtils.isTaskReport(report)) {
+    if (report && !ReportUtils.isTaskReport(report)) {
         Navigation.isNavigationReady().then(() => {
             Navigation.dismissModal();
         });

--- a/src/pages/tasks/TaskDescriptionPage.js
+++ b/src/pages/tasks/TaskDescriptionPage.js
@@ -50,7 +50,7 @@ function TaskDescriptionPage(props) {
 
     if (!ReportUtils.isTaskReport(props.report)) {
         Navigation.isNavigationReady().then(() => {
-            Navigation.dismissModal();
+            Navigation.dismissModal(props.report.reportID);
         });
     }
     const inputRef = useRef(null);

--- a/src/pages/tasks/TaskDescriptionPage.js
+++ b/src/pages/tasks/TaskDescriptionPage.js
@@ -15,6 +15,8 @@ import * as Task from '../../libs/actions/Task';
 import CONST from '../../CONST';
 import focusAndUpdateMultilineInputRange from '../../libs/focusAndUpdateMultilineInputRange';
 import * as Browser from '../../libs/Browser';
+import * as ReportUtils from '../../libs/ReportUtils';
+import Navigation from '../../libs/Navigation/Navigation';
 
 const propTypes = {
     /** Current user session */
@@ -46,6 +48,11 @@ function TaskDescriptionPage(props) {
         [props],
     );
 
+    if (!ReportUtils.isTaskReport(props.report)) {
+        Navigation.isNavigationReady().then(() => {
+            Navigation.dismissModal();
+        });
+    }
     const inputRef = useRef(null);
 
     return (

--- a/src/pages/tasks/TaskTitlePage.js
+++ b/src/pages/tasks/TaskTitlePage.js
@@ -14,6 +14,8 @@ import reportPropTypes from '../reportPropTypes';
 import compose from '../../libs/compose';
 import * as Task from '../../libs/actions/Task';
 import CONST from '../../CONST';
+import * as ReportUtils from '../../libs/ReportUtils';
+import Navigation from '../../libs/Navigation/Navigation';
 
 const propTypes = {
     /** The report currently being looked at */
@@ -57,6 +59,12 @@ function TaskTitlePage(props) {
         },
         [props],
     );
+
+    if (!ReportUtils.isTaskReport(props.report)) {
+        Navigation.isNavigationReady().then(() => {
+            Navigation.dismissModal();
+        });
+    }
 
     const inputRef = useRef(null);
 

--- a/src/pages/tasks/TaskTitlePage.js
+++ b/src/pages/tasks/TaskTitlePage.js
@@ -62,7 +62,7 @@ function TaskTitlePage(props) {
 
     if (!ReportUtils.isTaskReport(props.report)) {
         Navigation.isNavigationReady().then(() => {
-            Navigation.dismissModal();
+            Navigation.dismissModal(props.report.reportID);
         });
     }
 


### PR DESCRIPTION
### Details

Only allow edition of task report attributes for task reports.

### Fixed Issues
$ https://github.com/Expensify/App/issues/25950
PROPOSAL: https://github.com/Expensify/App/issues/25950#issuecomment-1693561752


### Tests
All
1. Create an IOU report or use an existing one so you have a URL like: `https://staging.new.expensify.com/r/{requestReportID}`
2. The edit description of a request report is: `https://staging.new.expensify.com/r/{requestReportID}/edit/description` and for a task report it is `https://staging.new.expensify.com/r/{taskReportID}/description` since you have a request report the second should not work

Web-mWeb

3. In a browser input the URL  `https://staging.new.expensify.com/r/{requestReportID}/description` you should be sent to `https://staging.new.expensify.com/r/{requestReportID}` since this URL only applies for task reports.
4. Repeat step 3 for title and description they should only work for tasks reports, in the request report the user should be redirected to request report page

Native (iOS/Android)

3. Send a mail or a link to the device with deeplink including this 3 cases: `https://staging.new.expensify.com/r/{requestReportID}/{description/title/assignee}`
4. The application should open directly the request report page. This 3 URL only apply for task reports.

### Offline tests

same as tests

### QA Steps
same as tests

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

[Web Desc - 9_7_2023, 8_04_53 PM.webm](https://github.com/Expensify/App/assets/13544910/3e06c005-612e-4434-b8b1-58f6f8c3238f)

</details>

<details>
<summary>Mobile Web - Chrome</summary>

[mWeb Chrome Desc- 9_7_2023, 8_06_46 PM.webm](https://github.com/Expensify/App/assets/13544910/0153dc37-c812-4738-a40f-75606acb0087)

</details>

<details>
<summary>Mobile Web - Safari</summary>

https://github.com/Expensify/App/assets/13544910/09189700-4a33-4533-a940-96e817f8dc5e

</details>

<details>
<summary>Desktop</summary>

[Desktop desc - 9_7_2023, 8_13_23 PM.webm](https://github.com/Expensify/App/assets/13544910/e9343799-3c52-4132-8bec-c84fd1dee2b0)

</details>

<details>
<summary>iOS</summary>

[iOS Desc - 9_7_2023, 8_30_19 PM.webm](https://github.com/Expensify/App/assets/13544910/de363688-2aca-430e-9370-3d0a789076ee)

</details>

<details>
<summary>Android</summary>

[Android desc - 9_7_2023, 9_02_21 PM.webm](https://github.com/Expensify/App/assets/13544910/6099b232-5658-4124-9a9a-6f32562871e7)

</details>
