### PR TITLE
Fix console error by updating transaction.comment prop

### DIFF
--- a/src/components/ReportActionItem/MoneyRequestView.js
+++ b/src/components/ReportActionItem/MoneyRequestView.js
@@ -132,12 +132,13 @@ function MoneyRequestView({report, parentReport, shouldShowHorizontalRule, trans
             <OfflineWithFeedback pendingAction={lodashGet(transaction, 'pendingFields.comment') || lodashGet(transaction, 'pendingAction')}>
                 <MenuItemWithTopDescription
                     description={translate('common.description')}
-                    title={transactionDescription}
+                    title={transaction.comment ? { text: transaction.comment } : ''}
                     interactive={canEdit}
                     shouldShowRightIcon={canEdit}
                     titleStyle={styles.flex1}
                     onPress={() => Navigation.navigate(ROUTES.getEditRequestRoute(report.reportID, CONST.EDIT_REQUEST_FIELD.DESCRIPTION))}
                 />
+
             </OfflineWithFeedback>
             <OfflineWithFeedback pendingAction={lodashGet(transaction, 'pendingFields.created') || lodashGet(transaction, 'pendingAction')}>
                 <MenuItemWithTopDescription


### PR DESCRIPTION
### Details
<!-- This PR resolves the console error in the MoneyRequestView component caused by the transaction.comment prop. -->

### Fixed Issues
https://github.com/Expensify/App/issues/26382
### Code Changes
- Replaced `title={transactionDescription}` with `title={transaction.comment ? { text: transaction.comment } : ''}` to ensure correct handling of the transaction.comment prop.


