### PR TITLE
[No QA][TS migration] Improve translations: keep translations in sync

### DIFF
--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -74,13 +74,12 @@ import type {
 } from './types';
 import * as ReportActionsUtils from '../libs/ReportActionsUtils';
 
-type States = Record<
-    keyof typeof COMMON_CONST.STATES,
-    {
-        stateISO: string;
-        stateName: string;
-    }
->;
+type StateValue = {
+    stateISO: string;
+    stateName: string;
+};
+
+type States = Record<keyof typeof COMMON_CONST.STATES, StateValue>;
 
 type AllCountries = Record<keyof typeof CONST.ALL_COUNTRIES, string>;
 

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -1,7 +1,6 @@
 import {CONST as COMMON_CONST} from 'expensify-common/lib/CONST';
 import CONST from '../CONST';
 import type {
-    Translation,
     AddressLineParams,
     CharacterLimitParams,
     MaxParticipantsReachedParams,
@@ -74,6 +73,16 @@ import type {
     RemovedTheRequestParams,
 } from './types';
 import * as ReportActionsUtils from '../libs/ReportActionsUtils';
+
+type States = Record<
+    keyof typeof COMMON_CONST.STATES,
+    {
+        stateISO: string;
+        stateName: string;
+    }
+>;
+
+type AllCountries = Record<keyof typeof CONST.ALL_COUNTRIES, string>;
 
 /* eslint-disable max-len */
 export default {
@@ -1662,8 +1671,8 @@ export default {
         createAccount: 'Create A New Account',
         logIn: 'Log In',
     },
-    allStates: COMMON_CONST.STATES,
-    allCountries: CONST.ALL_COUNTRIES,
+    allStates: COMMON_CONST.STATES as States,
+    allCountries: CONST.ALL_COUNTRIES as AllCountries,
     accessibilityHints: {
         navigateToChatsList: 'Navigate back to chats list',
         chatWelcomeMessage: 'Chat welcome message',
@@ -1757,4 +1766,4 @@ export default {
             selectSuggestedAddress: 'Please select a suggested address',
         },
     },
-} satisfies Translation;
+};

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -71,7 +71,7 @@ import type {
     SetTheRequestParams,
     UpdatedTheRequestParams,
     RemovedTheRequestParams,
-    Translation,
+    EnglishTranslation,
 } from './types';
 
 /* eslint-disable max-len */
@@ -2249,4 +2249,4 @@ export default {
             selectSuggestedAddress: 'Por favor, selecciona una dirección sugerida',
         },
     },
-} satisfies Translation;
+} satisfies EnglishTranslation;

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -1,7 +1,6 @@
 import CONST from '../CONST';
 import * as ReportActionsUtils from '../libs/ReportActionsUtils';
 import type {
-    Translation,
     AddressLineParams,
     CharacterLimitParams,
     MaxParticipantsReachedParams,
@@ -72,6 +71,7 @@ import type {
     SetTheRequestParams,
     UpdatedTheRequestParams,
     RemovedTheRequestParams,
+    Translation,
 } from './types';
 
 /* eslint-disable max-len */

--- a/src/languages/translations.ts
+++ b/src/languages/translations.ts
@@ -1,7 +1,7 @@
 import en from './en';
 import es from './es';
 import esES from './es-ES';
-import type {Translation, TranslationFlatObject} from './types';
+import type {TranslationBase, TranslationFlatObject} from './types';
 
 /**
  * Converts an object to it's flattened version.
@@ -12,10 +12,10 @@ import type {Translation, TranslationFlatObject} from './types';
  */
 // Necessary to export so that it is accessible to the unit tests
 // eslint-disable-next-line rulesdir/no-inline-named-export
-export function flattenObject(obj: Translation): TranslationFlatObject {
+export function flattenObject(obj: TranslationBase): TranslationFlatObject {
     const result: Record<string, unknown> = {};
 
-    const recursive = (data: Translation, key: string): void => {
+    const recursive = (data: TranslationBase, key: string): void => {
         // If the data is a function or not a object (eg. a string or array),
         // it's the final value for the key being built and there is no need
         // for more recursion
@@ -27,7 +27,7 @@ export function flattenObject(obj: Translation): TranslationFlatObject {
             // Recursive call to the keys and connect to the respective data
             Object.keys(data).forEach((k) => {
                 isEmpty = false;
-                recursive(data[k] as Translation, key ? `${key}.${k}` : k);
+                recursive(data[k] as TranslationBase, key ? `${key}.${k}` : k);
             });
 
             // Check for when the object is empty but a key exists, so that

--- a/src/languages/types.ts
+++ b/src/languages/types.ts
@@ -196,7 +196,7 @@ type UpdatedTheRequestParams = {valueName: string; newValueToDisplay: string; ol
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type TranslationBaseValue = string | string[] | ((...args: any[]) => string);
 
-type Translation = {[key: string]: TranslationBaseValue | Translation};
+type TranslationBase = {[key: string]: TranslationBaseValue | TranslationBase};
 
 /* Flat Translation Object types */
 // Flattens an object and returns concatenations of all the keys of nested objects
@@ -222,15 +222,16 @@ type TranslateType<TObject, TPath extends string> = TPath extends keyof TObject
         : never
     : never;
 
-type TranslationsType = typeof en;
+type Translation = typeof en;
 
-type TranslationPaths = FlattenObject<TranslationsType>;
+type TranslationPaths = FlattenObject<Translation>;
 
 type TranslationFlatObject = {
-    [TKey in TranslationPaths]: TranslateType<TranslationsType, TKey>;
+    [TKey in TranslationPaths]: TranslateType<Translation, TKey>;
 };
 
 export type {
+    TranslationBase,
     Translation,
     TranslationFlatObject,
     AddressLineParams,

--- a/src/languages/types.ts
+++ b/src/languages/types.ts
@@ -222,17 +222,17 @@ type TranslateType<TObject, TPath extends string> = TPath extends keyof TObject
         : never
     : never;
 
-type Translation = typeof en;
+type EnglishTranslation = typeof en;
 
-type TranslationPaths = FlattenObject<Translation>;
+type TranslationPaths = FlattenObject<EnglishTranslation>;
 
 type TranslationFlatObject = {
-    [TKey in TranslationPaths]: TranslateType<Translation, TKey>;
+    [TKey in TranslationPaths]: TranslateType<EnglishTranslation, TKey>;
 };
 
 export type {
     TranslationBase,
-    Translation,
+    EnglishTranslation,
     TranslationFlatObject,
     AddressLineParams,
     CharacterLimitParams,


### PR DESCRIPTION
### Details

Based on English translations (`en.ts` file) infer `Translation` type. Use the type for other translations files (`es.ts`) so that all files are kept in sync with each other, meaning that the same keys are specified for each translation file.

### Fixed Issues
$ 
PROPOSAL: N/A

### Tests
- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
N/A

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>



</details>

<details>
<summary>Mobile Web - Chrome</summary>



</details>

<details>
<summary>Mobile Web - Safari</summary>



</details>

<details>
<summary>Desktop</summary>



</details>

<details>
<summary>iOS</summary>



</details>

<details>
<summary>Android</summary>



</details>