### PR TITLE
use getReportName and getParentNavigationSubtitle from ReportUtils for reports with title or subtitle as empty string for QR code page

### DIFF
--- a/src/pages/ShareCodePage.js
+++ b/src/pages/ShareCodePage.js
@@ -42,8 +42,9 @@ class ShareCodePage extends React.Component {
 
     render() {
         const isReport = this.props.report != null && this.props.report.reportID != null;
-        const title = isReport ? this.props.report.reportName || ReportUtils.getReportName(this.props.report) : this.props.currentUserPersonalDetails.displayName;
-        const subtitle = ReportUtils.getChatRoomSubtitle(this.props.report);
+        const title = isReport ? ReportUtils.getReportName(this.props.report) : this.props.currentUserPersonalDetails.displayName;
+        const formattedEmail = this.props.formatPhoneNumber(this.props.session.email);
+        const subtitle = isReport ? ReportUtils.getChatRoomSubtitle(this.props.report) || ReportUtils.getParentNavigationSubtitle(this.props.report).rootReportName : formattedEmail;
 
         const urlWithTrailingSlash = Url.addTrailingForwardSlash(this.props.environmentURL);
         const url = isReport
@@ -52,7 +53,6 @@ class ShareCodePage extends React.Component {
 
         const platform = getPlatform();
         const isNative = platform === CONST.PLATFORM.IOS || platform === CONST.PLATFORM.ANDROID;
-        const formattedEmail = this.props.formatPhoneNumber(this.props.session.email);
 
         return (
             <ScreenWrapper>
@@ -67,7 +67,7 @@ class ShareCodePage extends React.Component {
                             ref={this.qrCodeRef}
                             url={url}
                             title={title}
-                            subtitle={isReport ? subtitle : formattedEmail}
+                            subtitle={subtitle}
                             logo={isReport ? expensifyLogo : UserUtils.getAvatarUrl(this.props.currentUserPersonalDetails.avatar, this.props.currentUserPersonalDetails.accountID)}
                             logoRatio={isReport ? CONST.QR.EXPENSIFY_LOGO_SIZE_RATIO : CONST.QR.DEFAULT_LOGO_SIZE_RATIO}
                             logoMarginRatio={isReport ? CONST.QR.EXPENSIFY_LOGO_MARGIN_RATIO : CONST.QR.DEFAULT_LOGO_MARGIN_RATIO}

--- a/src/pages/ShareCodePage.js
+++ b/src/pages/ShareCodePage.js
@@ -44,8 +44,7 @@ class ShareCodePage extends React.Component {
         const isReport = this.props.report != null && this.props.report.reportID != null;
         const title = isReport ? ReportUtils.getReportName(this.props.report) : this.props.currentUserPersonalDetails.displayName;
         const formattedEmail = this.props.formatPhoneNumber(this.props.session.email);
-        const subtitle = isReport ? ReportUtils.getChatRoomSubtitle(this.props.report) || ReportUtils.getParentNavigationSubtitle(this.props.report).rootReportName : formattedEmail;
-
+        const subtitle = isReport ? ReportUtils.getParentNavigationSubtitle(this.props.report).workspaceName || ReportUtils.getChatRoomSubtitle(this.props.report) : formattedEmail;
         const urlWithTrailingSlash = Url.addTrailingForwardSlash(this.props.environmentURL);
         const url = isReport
             ? `${urlWithTrailingSlash}${ROUTES.getReportRoute(this.props.report.reportID)}`

--- a/src/pages/ShareCodePage.js
+++ b/src/pages/ShareCodePage.js
@@ -42,6 +42,7 @@ class ShareCodePage extends React.Component {
 
     render() {
         const isReport = this.props.report != null && this.props.report.reportID != null;
+        const title = isReport && this.props.report.reportName ? this.props.report.reportName : ReportUtils.getReportName(this.props.report);
         const subtitle = ReportUtils.getChatRoomSubtitle(this.props.report);
 
         const urlWithTrailingSlash = Url.addTrailingForwardSlash(this.props.environmentURL);
@@ -65,7 +66,7 @@ class ShareCodePage extends React.Component {
                         <QRShareWithDownload
                             ref={this.qrCodeRef}
                             url={url}
-                            title={isReport ? this.props.report.reportName : this.props.currentUserPersonalDetails.displayName}
+                            title={isReport ? title : this.props.currentUserPersonalDetails.displayName}
                             subtitle={isReport ? subtitle : formattedEmail}
                             logo={isReport ? expensifyLogo : UserUtils.getAvatarUrl(this.props.currentUserPersonalDetails.avatar, this.props.currentUserPersonalDetails.accountID)}
                             logoRatio={isReport ? CONST.QR.EXPENSIFY_LOGO_SIZE_RATIO : CONST.QR.DEFAULT_LOGO_SIZE_RATIO}

--- a/src/pages/ShareCodePage.js
+++ b/src/pages/ShareCodePage.js
@@ -42,14 +42,7 @@ class ShareCodePage extends React.Component {
 
     render() {
         const isReport = this.props.report != null && this.props.report.reportID != null;
-        let title = this.props.currentUserPersonalDetails.displayName;
-        if (isReport) {
-            if (this.props.report.reportName) {
-                title = this.props.report.reportName;
-            } else {
-                title = ReportUtils.getReportName(this.props.report);
-            }
-        }
+        const title = isReport ? this.props.report.reportName || ReportUtils.getReportName(this.props.report) : this.props.currentUserPersonalDetails.displayName;
         const subtitle = ReportUtils.getChatRoomSubtitle(this.props.report);
 
         const urlWithTrailingSlash = Url.addTrailingForwardSlash(this.props.environmentURL);

--- a/src/pages/ShareCodePage.js
+++ b/src/pages/ShareCodePage.js
@@ -42,7 +42,14 @@ class ShareCodePage extends React.Component {
 
     render() {
         const isReport = this.props.report != null && this.props.report.reportID != null;
-        const title = isReport && this.props.report.reportName ? this.props.report.reportName : ReportUtils.getReportName(this.props.report);
+        let title = this.props.currentUserPersonalDetails.displayName;
+        if (isReport) {
+            if (this.props.report.reportName) {
+                title = this.props.report.reportName;
+            } else {
+                title = ReportUtils.getReportName(this.props.report);
+            }
+        }
         const subtitle = ReportUtils.getChatRoomSubtitle(this.props.report);
 
         const urlWithTrailingSlash = Url.addTrailingForwardSlash(this.props.environmentURL);
@@ -66,7 +73,7 @@ class ShareCodePage extends React.Component {
                         <QRShareWithDownload
                             ref={this.qrCodeRef}
                             url={url}
-                            title={isReport ? title : this.props.currentUserPersonalDetails.displayName}
+                            title={title}
                             subtitle={isReport ? subtitle : formattedEmail}
                             logo={isReport ? expensifyLogo : UserUtils.getAvatarUrl(this.props.currentUserPersonalDetails.avatar, this.props.currentUserPersonalDetails.accountID)}
                             logoRatio={isReport ? CONST.QR.EXPENSIFY_LOGO_SIZE_RATIO : CONST.QR.DEFAULT_LOGO_SIZE_RATIO}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/27265
PROPOSAL: https://github.com/Expensify/App/issues/27265#issuecomment-1715990945


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Test 1

1. Create a workspace
2. Go to the workspace chat created
3. Click on the header
4. Click on 'Share Code' in right hand panel
5. Verify that the workspace name is shown below the QR code


Test 2

1. Go to an archived room
2. Click on the header
3. Click on 'Share Code' in right hand panel
4. Verify that the room name is shown as "roomName (archived)" below QR code

Test 3

1. Reply to any message in the workspace to create a thread
2. Go to the chat thread in a workspace chat
3. Click on the header
4. Click on 'Share Code' in right hand panel
5. Verify that `threadName` is shown as `title` and `workSpace` is shown as `subtitle` below QR code.

Test 4

1. Create a task in a workspace chat
2. Click on the task header
3. Click on 'Share Code' in right hand panel
4. Verify that `taskName` is shown as `title` and `workSpace` is shown as `subtitle` below QR code.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
Test 1

1. Create a workspace
2. Go to the workspace chat created
3. Click on the header
4. Click on 'Share Code' in right hand panel
5. Verify that the workspace name is shown below the QR code

Test 2

1. Go to an archived room
2. Click on the header
3. Click on 'Share Code' in right hand panel
4. Verify that the room name is shown as "roomName (archived)" below QR code

Test 3

1. Reply to any message in the workspace to create a thread
2. Go to the chat thread in a workspace chat
3. Click on the header
4. Click on 'Share Code' in right hand panel
5. Verify that `threadName` is shown as `title` and `workSpace` is shown as `subtitle` below QR code.

Test 4

1. Create a task in a workspace chat
2. Click on the task header
3. Click on 'Share Code' in right hand panel
4. Verify that `taskName` is shown as `title` and `workSpace` is shown as `subtitle` below QR code.


### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
10. Upload an image via copy paste
11. Verify a modal appears displaying a preview of that image
--->
Test 1

1. Create a workspace
2. Go to the workspace chat created
3. Click on the header
4. Click on 'Share Code' in right hand panel
5. Verify that the workspace name is shown below the QR code

Test 2

1. Go to an archived room
2. Click on the header
3. Click on 'Share Code' in right hand panel
4. Verify that the room name is shown as "roomName (archived)" below QR code

Test 3

1. Reply to any message in the workspace to create a thread
2. Go to the chat thread in a workspace chat
3. Click on the header
4. Click on 'Share Code' in right hand panel
5. Verify that `threadName` is shown as `title` and `workSpace` is shown as `subtitle` below QR code.

Test 4

1. Create a task in a workspace chat
2. Click on the task header
3. Click on 'Share Code' in right hand panel
4. Verify that `taskName` is shown as `title` and `workSpace` is shown as `subtitle` below QR code.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>
Workspace Room
<img width="1431" alt="workspaceRoom" src="https://github.com/Expensify/App/assets/102477862/6dd5d2a5-17c1-4fe8-bf71-39e9c7074d1e">

Owner Workspace Chat
<img width="1431" alt="ownerWorkspaceChat" src="https://github.com/Expensify/App/assets/102477862/7edf29f4-a6db-4cc5-b84c-7b6be5fd6d7a">

Owner view of Chat of Invited Member to Workspace
<img width="1431" alt="ownerViewOfChatOfInvitedMemberToWorkspace" src="https://github.com/Expensify/App/assets/102477862/2f37f20d-c71a-4a75-a69a-955b9debf4a2">

Archived Workspace Chat
<img width="1431" alt="archivedWorkspaceChat" src="https://github.com/Expensify/App/assets/102477862/bd0a040e-6ef9-4e2c-a1e8-4bb3d8b2fe78">

Archived Room
<img width="1431" alt="archivedRoom" src="https://github.com/Expensify/App/assets/102477862/dc41c41b-c39c-4da1-a8db-107647e2d310">

Task in Room
<img width="1431" alt="taskInRoom" src="https://github.com/Expensify/App/assets/102477862/bc5ff927-78bf-4d51-b834-7e34b5bb4706">

Task in Workspace
<img width="1431" alt="taskinWorkspace-" src="https://github.com/Expensify/App/assets/102477862/1a55d355-5c58-45cc-a8b7-8c219e53f7f3">

Subtask inside Task in Workspace
<img width="1431" alt="subTaskInsideTaskInWorkspace" src="https://github.com/Expensify/App/assets/102477862/1a9499d8-994a-45f2-b988-29ad3faa192c">

Thread in Workspace
<img width="1431" alt="threadInWorkspace" src="https://github.com/Expensify/App/assets/102477862/4d4eb2f4-3713-491f-86a7-4e3e91424d39">

Thread in Room of Workspace
<img width="1431" alt="threadInRoomOfWorkspace" src="https://github.com/Expensify/App/assets/102477862/1f505511-fed9-4eb6-8474-282253a3d1b4">

Non-workspace Thread
<img width="1431" alt="nonWorkspaceThread" src="https://github.com/Expensify/App/assets/102477862/74f7b1a8-d9c6-4472-a5ed-aab5ab223f18">


</details>

<details>
<summary>Mobile Web - Chrome</summary>


https://github.com/Expensify/App/assets/102477862/c42e81b6-c6fa-4a12-a1a7-c9e50784a82f




<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>



https://github.com/Expensify/App/assets/102477862/2f064f11-a4f0-43b9-b457-5fb2a966f016




<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>



https://github.com/Expensify/App/assets/102477862/3d56262c-e071-4412-aa40-5327fe460c50





<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>



https://github.com/Expensify/App/assets/102477862/af366a44-6f2b-4a87-b0bc-f063356d7626




<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>



https://github.com/Expensify/App/assets/102477862/c5f91a01-4f53-434d-b10b-c2b644253763




<!-- add screenshots or videos here -->

</details>
