### PR TITLE
Fix undefined color keys

### DIFF
--- a/src/components/FormHelpMessage.js
+++ b/src/components/FormHelpMessage.js
@@ -42,7 +42,7 @@ function FormHelpMessage(props) {
             {props.isError && (
                 <Icon
                     src={Expensicons.DotIndicator}
-                    fill={themeColors.success}
+                    fill={themeColors.danger}
                 />
             )}
             <View style={[styles.flex1, props.isError && styles.ml2]}>

--- a/src/components/TabSelector/TabSelector.js
+++ b/src/components/TabSelector/TabSelector.js
@@ -79,10 +79,10 @@ const getBackgroundColor = (position, routesLength, tabIndex) => {
 
         return position.interpolate({
             inputRange,
-            outputRange: _.map(inputRange, (i) => (i === tabIndex ? themeColors.midtone : themeColors.appBG)),
+            outputRange: _.map(inputRange, (i) => (i === tabIndex ? themeColors.border : themeColors.appBG)),
         });
     }
-    return themeColors.midtone;
+    return themeColors.border;
 };
 
 function TabSelector({state, navigation, onTabPress, position}) {

--- a/src/pages/ReimbursementAccount/BankAccountStep.js
+++ b/src/pages/ReimbursementAccount/BankAccountStep.js
@@ -164,7 +164,7 @@ function BankAccountStep(props) {
                             <View style={[styles.ml1]}>
                                 <Icon
                                     src={Expensicons.Lock}
-                                    fill={themeColors.heroCard}
+                                    fill={themeColors.link}
                                 />
                             </View>
                         </PressableWithoutFeedback>

--- a/src/pages/ReimbursementAccount/BankAccountStep.js
+++ b/src/pages/ReimbursementAccount/BankAccountStep.js
@@ -164,7 +164,7 @@ function BankAccountStep(props) {
                             <View style={[styles.ml1]}>
                                 <Icon
                                     src={Expensicons.Lock}
-                                    fill={themeColors.BRAND_COLORS.blue400}
+                                    fill={themeColors.heroCard}
                                 />
                             </View>
                         </PressableWithoutFeedback>

--- a/src/pages/settings/Profile/CustomStatus/StatusPage.js
+++ b/src/pages/settings/Profile/CustomStatus/StatusPage.js
@@ -68,7 +68,7 @@ function StatusPage({draftStatus, currentUserPersonalDetails}) {
         <StaticHeaderPageLayout
             title={localize.translate('statusPage.status')}
             onBackButtonPress={navigateBackToSettingsPage}
-            backgroundColor={themeColors.border}
+            backgroundColor={themeColors.PAGE_BACKGROUND_COLORS[ROUTES.SETTINGS_STATUS]}
             image={MobileBackgroundImage}
             footer={footerComponent}
         >

--- a/src/pages/settings/Profile/CustomStatus/StatusPage.js
+++ b/src/pages/settings/Profile/CustomStatus/StatusPage.js
@@ -68,7 +68,7 @@ function StatusPage({draftStatus, currentUserPersonalDetails}) {
         <StaticHeaderPageLayout
             title={localize.translate('statusPage.status')}
             onBackButtonPress={navigateBackToSettingsPage}
-            backgroundColor={themeColors.midtone}
+            backgroundColor={themeColors.border}
             image={MobileBackgroundImage}
             footer={footerComponent}
         >

--- a/src/styles/themes/default.js
+++ b/src/styles/themes/default.js
@@ -88,6 +88,7 @@ darkTheme.PAGE_BACKGROUND_COLORS = {
     [SCREENS.HOME]: darkTheme.sidebar,
     [SCREENS.SETTINGS.PREFERENCES]: colors.blue500,
     [SCREENS.SETTINGS.WORKSPACES]: colors.pink800,
+    [ROUTES.SETTINGS_STATUS]: colors.green700,
     [ROUTES.I_KNOW_A_TEACHER]: colors.tangerine800,
     [ROUTES.SETTINGS_SECURITY]: colors.ice500,
 };

--- a/src/styles/themes/light.js
+++ b/src/styles/themes/light.js
@@ -87,6 +87,7 @@ lightTheme.PAGE_BACKGROUND_COLORS = {
     [SCREENS.HOME]: lightTheme.sidebar,
     [SCREENS.SETTINGS.PREFERENCES]: colors.blue500,
     [SCREENS.SETTINGS.WORKSPACES]: colors.pink800,
+    [ROUTES.SETTINGS_STATUS]: colors.green700,
     [ROUTES.I_KNOW_A_TEACHER]: colors.tangerine800,
     [ROUTES.SETTINGS_SECURITY]: colors.ice500,
 };


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

We need to merge this before https://github.com/Expensify/App/pull/22986 is deployed to staging. Otherwise it will need to be CP to staging because it becomes a deploy blocker fix

I removed the `colors.midtone` key in https://github.com/Expensify/App/pull/22986 but missed a few uses after a merge. Let's replace it with borders instead for theme support.

I fixed a case of using `colors.success` instead of `colors.danger` for the form error red dots
I fixed a case of referencing a brand key that did not exist for the lock icon  <img width="36" alt="image" src="https://github.com/Expensify/App/assets/38015950/a4c15b30-09e2-4443-9a72-04e7f52ddc08"> on the bank account page



### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/27487
$ https://github.com/Expensify/App/issues/27488



### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

`Go to a chat`
`Request Money to open the Tab Selector. Click on Manual Request or Scan Receipt: `
- [ ] Verify that colors match this screenshot: 
<img width="369" alt="image" src="https://github.com/Expensify/App/assets/38015950/96eaafd2-f6a8-4d81-9123-05efcadb6631">

`Go to /settings/profile/status`
- [ ] Verify that colors match this screenshot: 
<img width="379" alt="image" src="https://github.com/Expensify/App/assets/38015950/c8e30ff6-0375-4423-aac9-237eb05cb4f3">

`Create a workspace`
`Go to add bank account page`
- [ ] Verify that colors for copy at the bottom matches this screenshot: 
<img width="445" alt="image" src="https://github.com/Expensify/App/assets/38015950/a3471d93-9b46-4199-9549-9060aa421327">

`Click "add manually" to go to Connect Bank Account - Step 1 (Routing Number)`
`Click submit with empty fields`
**Note: you can do these steps with any form**
- [ ] Verify that color of red dot matches this screenshot: 
<img width="456" alt="image" src="https://github.com/Expensify/App/assets/38015950/fdc84b94-68fa-4f43-860f-e3b915778b98">


### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

<img width="1354" alt="image" src="https://github.com/Expensify/App/assets/38015950/a68d4cb0-9b16-4527-92e8-6cb15022f3a9">
<img width="1834" alt="image" src="https://github.com/Expensify/App/assets/38015950/0c6e655c-79d8-4d1d-881b-05c87e91b3cf">

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->
<img width="502" alt="image" src="https://github.com/Expensify/App/assets/38015950/764412e1-82b5-4733-8e64-bfe1069e54a9">
<img width="546" alt="image" src="https://github.com/Expensify/App/assets/38015950/f6de6b1a-ba94-4409-a221-b4a5dc208094">


</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->
<img width="583" alt="image" src="https://github.com/Expensify/App/assets/38015950/0ba38275-95b9-432e-a81a-2d50b80bcaa8">
<img width="583" alt="image" src="https://github.com/Expensify/App/assets/38015950/c1bd0110-6583-4d16-8e8d-3627c7753280">


</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->
<img width="1312" alt="image" src="https://github.com/Expensify/App/assets/38015950/1900f04a-1ed5-4f68-b174-04bd28046cae">
<img width="1312" alt="image" src="https://github.com/Expensify/App/assets/38015950/0c4addba-32bb-4158-9d75-97d3141e45ba">


</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->
<img width="583" alt="image" src="https://github.com/Expensify/App/assets/38015950/6aa15290-0205-4e60-be14-52e2f4608c11">
<img width="583" alt="image" src="https://github.com/Expensify/App/assets/38015950/1e11ca0b-5b6d-4216-8a7f-c0c97f4dce6b">

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->
emulator not working right now :(

</details>
