### PR TITLE
fix: empty checking of report

### DIFF
--- a/src/libs/ReportUtils.js
+++ b/src/libs/ReportUtils.js
@@ -2821,7 +2821,7 @@ function shouldReportBeInOptionList(report, currentReportId, isInGSDMode, betas,
     }
 
     const lastVisibleMessage = ReportActionsUtils.getLastVisibleMessage(report.reportID);
-    const isEmptyChat = !lastVisibleMessage.lastMessageText && !lastVisibleMessage.lastMessageTranslationKey;
+    const isEmptyChat = !report.lastMessageText && !report.lastMessageTranslationKey && !lastVisibleMessage.lastMessageText && !lastVisibleMessage.lastMessageTranslationKey;
 
     // Hide only chat threads that haven't been commented on (other threads are actionable)
     if (isChatThread(report) && isEmptyChat) {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

Check the report.lastMessagText and report.lastMessageTranslationKey as well when checking if the report is empty

### Fixed Issues

$ https://github.com/Expensify/App/issues/25727
PROPOSAL: https://github.com/Expensify/App/issues/25727#issuecomment-1691776494


### Tests
1. Open ND and log in with account A and account B on different browsers
2. As account A, initiate a new chat with account B
3. As account A, assign a task to account A and share it in the chat with account B
4. As account A, complete the task
5. Verify that account B can see the new chat with account A
6. As account B, log out while leaving the chat unread(don't open it)
7. As account B, log in on a different platform(mweb, native, desktop, or incognito web)
8. Verify that the new chat with account A remains in LHN


_**Tests from https://github.com/Expensify/App/pull/19321**_

#### Empty chat shouldn't stay in LNH
1. Sign into newDot
2. Start a new chat with an account.
3. Make sure the new chat opens and is shown in the LNH
4. [WEB ONLY]: Copy the chat's `reportID` (last number in the chat's URL)
5. Open another existing chat (like concierge), make sure the chat disappears from the LNH
6. Start a chat again with that same account, make sure the account shows up in the Options list since you already had a chat with it before
7. Make sure the chat opens and has the same `reportID` (has the same URL)

#### Chat should stay in LNH if it has a Draft
1. In the same chat of used in the previous test, type some text into the composer but do not send the message
2. Open another existing chat (like concierge), make sure the chat stays in the LNH and shows the draft icon

#### Not-Empty chat should stay in LNH
1. Send a message in the same chat from the previous test.
2. Open another existing chat (like concierge), make sure the chat stays in the LNH.

#### Deleting messages and leaving chat empty should remove it from LNH
1. Open a chat that has a message sent inside it
2. Delete that message so the chat becomes empty
3. Open another existing chat (like concierge), make sure the chat disappears from the LNH.

#### Same tests w/ Group Chat
1. Start a new group chat with two accounts "B" and "C"
2. Make sure the new chat opens and is shown in the LNH
3. [WEB ONLY]: Copy the chat's `reportID` (last number in the chat's URL)
4. Open another existing chat (like concierge), make sure the chat disappears from the LNH
5. Start a group chat again with account B and C
6. Make sure the chat opens and has the same `reportID` (has the same URL)

#### Money request should stay in LNH
1. Start a new empty chat as userA with existing account userB
2. Sign in as userB and send a message back to userA so you become known
3. As userA, send new Money Request to userB inside the chat
4. As userB, delete the message sent in step 2 so the chat becomes empty
5. As userA, Open another existing chat (like concierge), make sure the reports don't disappear from the LNH
6. Make sure both the Money Request and the original report stay in the LNH

#### Workspace Chats should stay in LNH
1. Create a new Workspace in an account
2. Make sure the `#admins`, `#announce` and a workspace chats are created
3. Open another existing chat (like concierge), make sure none of the workspace related chats disappear from the LNH
4. Invite another user to the workspace, make sure another workspace chat is created for the invited user
5. Open another existing chat (like concierge), make sure none of the workspace related chats disappear from the LNH

- [x] Verify that no errors appear in the JS console

### Offline tests

_**Tests from https://github.com/Expensify/App/pull/19321**_

1. Sign into newDot
2. Turn connectivity off
3. Start a new chat with an account.
4. Make sure the new chat opens and is shown in the LNH
5. [WEB ONLY]: Copy that chat's `reportID` (last number in the chat's URL)
6. Open another existing chat (like concierge), make sure the chat disappears from the LNH
7. Start a chat again with that same account, make sure the account shows up in the Options list since you already had a chat with it before
8. [WEB ONLY]: That chat's `reportID` will not be the same as the first attempt because we are offline, but make note of that `reportID` as well
9. Open another existing chat (like concierge), make sure the chat disappears from the LNH
10. [WEB ONLY]: Toggle connectivity back on
11. [WEB ONLY]: Start a chat again with that same account
12. [WEB ONLY]: Make sure that chat's `reportID` is the same as the from step 5 (and not step 8)

### QA Steps
1. Open ND and log in with account A and account B on different browsers
2. As account A, initiate a new chat with account B
3. As account A, assign a task to account A and share it in the chat with account B
4. As account A, complete the task
5. Verify that account B can see the new chat with account A
6. As account B, log out while leaving the chat unread(don't open it)
7. As account B, log in on a different platform(mweb, native, desktop, or incognito web)
8. Verify that the new chat with account A remains in LHN


_**Tests from https://github.com/Expensify/App/pull/19321**_

#### Empty chat shouldn't stay in LNH
1. Sign into newDot
2. Start a new chat with an account.
3. Make sure the new chat opens and is shown in the LNH
4. [WEB ONLY]: Copy the chat's `reportID` (last number in the chat's URL)
5. Open another existing chat (like concierge), make sure the chat disappears from the LNH
6. Start a chat again with that same account, make sure the account shows up in the Options list since you already had a chat with it before
7. Make sure the chat opens and has the same `reportID` (has the same URL)

#### Chat should stay in LNH if it has a Draft
1. In the same chat of used in the previous test, type some text into the composer but do not send the message
2. Open another existing chat (like concierge), make sure the chat stays in the LNH and shows the draft icon

#### Not-Empty chat should stay in LNH
1. Send a message in the same chat from the previous test.
2. Open another existing chat (like concierge), make sure the chat stays in the LNH.

#### Deleting messages and leaving chat empty should remove it from LNH
1. Open a chat that has a message sent inside it
2. Delete that message so the chat becomes empty
3. Open another existing chat (like concierge), make sure the chat disappears from the LNH.

#### Same tests w/ Group Chat
1. Start a new group chat with two accounts "B" and "C"
2. Make sure the new chat opens and is shown in the LNH
3. [WEB ONLY]: Copy the chat's `reportID` (last number in the chat's URL)
4. Open another existing chat (like concierge), make sure the chat disappears from the LNH
5. Start a group chat again with account B and C
6. Make sure the chat opens and has the same `reportID` (has the same URL)

#### Money request should stay in LNH
1. Start a new empty chat as userA with existing account userB
2. Sign in as userB and send a message back to userA so you become known
3. As userA, send new Money Request to userB inside the chat
4. As userB, delete the message sent in step 2 so the chat becomes empty
5. As userA, Open another existing chat (like concierge), make sure the reports don't disappear from the LNH
6. Make sure both the Money Request and the original report stay in the LNH

#### Workspace Chats should stay in LNH
1. Create a new Workspace in an account
2. Make sure the `#admins`, `#announce` and a workspace chats are created
3. Open another existing chat (like concierge), make sure none of the workspace related chats disappear from the LNH
4. Invite another user to the workspace, make sure another workspace chat is created for the invited user
5. Open another existing chat (like concierge), make sure none of the workspace related chats disappear from the LNH

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Tests from https://github.com/Expensify/App/pull/19321</summary>

https://github.com/Expensify/App/assets/126839717/bd6cfb64-27ec-41c6-9579-c789818c21b0


https://github.com/Expensify/App/assets/126839717/7b7174fc-09e2-4ab7-bd33-51cb0d232648

</details>

<details>
<summary>Web</summary>


https://github.com/Expensify/App/assets/126839717/8ce0ee4e-bdc8-4100-910a-574e1993f284


</details>

<details>
<summary>Mobile Web - Chrome</summary>


https://github.com/Expensify/App/assets/126839717/3f3b0988-6798-40e8-9ad6-5fe138ab7372


</details>

<details>
<summary>Mobile Web - Safari</summary>


https://github.com/Expensify/App/assets/126839717/2f973205-1dea-4bd0-ac4d-0b1acf543d32


</details>

<details>
<summary>Desktop</summary>


https://github.com/Expensify/App/assets/126839717/cbc30583-5e29-4d5c-95be-b04fd476af57


</details>

<details>
<summary>iOS</summary>


https://github.com/Expensify/App/assets/126839717/78b6e738-e452-4744-9ed6-4a182f5310f9


</details>

<details>
<summary>Android</summary>


https://github.com/Expensify/App/assets/126839717/b44e78c9-7f98-48e2-8b52-7c1a93f708ef


</details>
